### PR TITLE
fix(desktop): stop idle animation frame loops

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -1,0 +1,122 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PersistentTerminal, TerminalSlot } from './persistent'
+
+vi.mock('./terminals', () => ({ ensureTerminal: vi.fn() }))
+vi.mock('./workspace', () => ({ TerminalWorkspace: () => <div data-testid="terminal-workspace" /> }))
+
+const resizeObservers = new Set<TestResizeObserver>()
+
+class TestResizeObserver {
+  constructor(private readonly callback: ResizeObserverCallback) {
+    resizeObservers.add(this)
+  }
+
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {
+    resizeObservers.delete(this)
+  }
+
+  notify(target: Element) {
+    this.callback([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver)
+  }
+}
+
+const rect = (left: number, top: number, width: number, height: number): DOMRect =>
+  ({
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    top,
+    width,
+    x: left,
+    y: top,
+    toJSON: () => ({})
+  }) as DOMRect
+
+describe('PersistentTerminal geometry tracking', () => {
+  const frames = new Map<number, FrameRequestCallback>()
+  let nextFrame = 1
+
+  beforeEach(() => {
+    frames.clear()
+    resizeObservers.clear()
+    nextFrame = 1
+
+    vi.stubGlobal('ResizeObserver', TestResizeObserver)
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      const id = nextFrame++
+
+      frames.set(id, callback)
+
+      return id
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      frames.delete(id)
+    })
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect(20, 30, 640, 360))
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('stays dormant while geometry is unchanged and coalesces observer updates to one frame', () => {
+    const { container, unmount } = render(
+      <>
+        <TerminalSlot />
+        <PersistentTerminal onAddSelectionToChat={() => {}} />
+      </>
+    )
+
+    const slot = container.firstElementChild!
+    const overlay = container.lastElementChild as HTMLElement
+
+    expect(overlay.style.left).toBe('20px')
+    expect(overlay.style.top).toBe('30px')
+    expect(frames.size).toBe(0)
+    expect(resizeObservers.size).toBe(1)
+
+    vi.spyOn(slot, 'getBoundingClientRect').mockReturnValue(rect(40, 50, 600, 320))
+
+    act(() => {
+      for (const observer of resizeObservers) {
+        observer.notify(slot)
+        observer.notify(slot)
+      }
+    })
+
+    expect(frames.size).toBe(1)
+
+    act(() => {
+      const [id, callback] = [...frames.entries()][0]!
+
+      frames.delete(id)
+      callback(performance.now())
+    })
+
+    expect(overlay.style.left).toBe('40px')
+    expect(overlay.style.top).toBe('50px')
+    expect(frames.size).toBe(0)
+
+    act(() => {
+      for (const observer of resizeObservers) {
+        observer.notify(slot)
+      }
+    })
+
+    expect(frames.size).toBe(1)
+
+    unmount()
+
+    expect(frames.size).toBe(0)
+    expect(resizeObservers.size).toBe(0)
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -84,7 +84,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     let prev: Rect | null = null
     let frame = 0
 
-    const tick = () => {
+    const measure = () => {
       const r = slot.getBoundingClientRect()
       // floor top/left + ceil right/bottom: overlay always covers the slot's
       // full pixel footprint, so half-pixel rects can't leak page bg through.
@@ -100,13 +100,56 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
           setReady(true)
         }
       }
-
-      frame = requestAnimationFrame(tick)
     }
 
-    tick()
+    const scheduleMeasure = () => {
+      if (document.hidden || frame) {
+        return
+      }
 
-    return () => cancelAnimationFrame(frame)
+      frame = requestAnimationFrame(() => {
+        frame = 0
+        measure()
+      })
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        if (frame) {
+          cancelAnimationFrame(frame)
+          frame = 0
+        }
+
+        return
+      }
+
+      scheduleMeasure()
+    }
+
+    const observer = new ResizeObserver(scheduleMeasure)
+
+    measure()
+    observer.observe(slot)
+    window.addEventListener('pointermove', scheduleMeasure, true)
+    window.addEventListener('resize', scheduleMeasure)
+    window.addEventListener('scroll', scheduleMeasure, true)
+    document.addEventListener('animationend', scheduleMeasure, true)
+    document.addEventListener('transitionend', scheduleMeasure, true)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('pointermove', scheduleMeasure, true)
+      window.removeEventListener('resize', scheduleMeasure)
+      window.removeEventListener('scroll', scheduleMeasure, true)
+      document.removeEventListener('animationend', scheduleMeasure, true)
+      document.removeEventListener('transitionend', scheduleMeasure, true)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+
+      if (frame) {
+        cancelAnimationFrame(frame)
+      }
+    }
   }, [slot])
 
   const visible = Boolean(rect && rect.width > 0 && rect.height > 0)

--- a/apps/desktop/src/components/pet/use-pet-roam.test.tsx
+++ b/apps/desktop/src/components/pet/use-pet-roam.test.tsx
@@ -1,0 +1,115 @@
+import { act, cleanup, fireEvent, renderHook } from '@testing-library/react'
+import type { RefObject } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePetRoam } from './use-pet-roam'
+
+const rect = (left: number, top: number, width: number, height: number): DOMRect =>
+  ({
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    top,
+    width,
+    x: left,
+    y: top,
+    toJSON: () => ({})
+  }) as DOMRect
+
+describe('usePetRoam scheduling', () => {
+  let visibilityDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    visibilityDescriptor = Object.getOwnPropertyDescriptor(window.document, 'hidden')
+    Object.defineProperty(window.document, 'hidden', { configurable: true, value: false })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+
+    if (visibilityDescriptor) {
+      Object.defineProperty(window.document, 'hidden', visibilityDescriptor)
+    } else {
+      Reflect.deleteProperty(window.document, 'hidden')
+    }
+  })
+
+  it('uses a timeout while paused and requests frames only when movement resumes', () => {
+    const frames: FrameRequestCallback[] = []
+    let interacting = false
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback)
+
+      return frames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    const element = window.document.createElement('div')
+
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(rect(100, window.innerHeight - 40 + 4, 40, 40))
+
+    const { unmount } = renderHook(() =>
+      usePetRoam({
+        commit: vi.fn(),
+        containerRef: { current: element } as RefObject<HTMLDivElement>,
+        enabled: true,
+        isInteracting: () => interacting,
+        loopMs: 800,
+        overlayOpen: false,
+        petH: 40,
+        petW: 40
+      })
+    )
+
+    expect(frames).toHaveLength(0)
+
+    act(() => {
+      vi.advanceTimersByTime(399)
+    })
+    expect(frames).toHaveLength(0)
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(frames).toHaveLength(1)
+
+    act(() => {
+      frames.shift()!(performance.now())
+    })
+
+    // Math.random() = 0 selects another rest beat, which should return to a
+    // timeout instead of starting a permanent frame loop.
+    expect(frames).toHaveLength(0)
+    expect(vi.getTimerCount()).toBe(1)
+
+    interacting = true
+    fireEvent.pointerDown(window)
+
+    expect(frames).toHaveLength(1)
+    expect(vi.getTimerCount()).toBe(0)
+
+    act(() => {
+      frames.shift()!(performance.now())
+    })
+    expect(frames).toHaveLength(1)
+
+    interacting = false
+
+    act(() => {
+      frames.shift()!(performance.now())
+    })
+
+    expect(frames).toHaveLength(0)
+    expect(vi.getTimerCount()).toBe(1)
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/apps/desktop/src/components/pet/use-pet-roam.ts
+++ b/apps/desktop/src/components/pet/use-pet-roam.ts
@@ -114,6 +114,7 @@ export function usePetRoam({
     let pauseUntil = performance.now() + rand(400, 1200)
     let last = performance.now()
     let raf = 0
+    let timer: null | ReturnType<typeof setTimeout> = null
 
     let walkTargetX = cur.x
     let curLedge: Ledge | null = null
@@ -208,6 +209,64 @@ export function usePetRoam({
       signal('run', signDir(walkTargetX - cur.x))
     }
 
+    const cancelScheduled = () => {
+      if (raf) {
+        cancelAnimationFrame(raf)
+        raf = 0
+      }
+
+      if (timer !== null) {
+        clearTimeout(timer)
+        timer = null
+      }
+    }
+
+    const scheduleFrame = () => {
+      if (document.hidden || raf) {
+        return
+      }
+
+      raf = requestAnimationFrame(now => {
+        raf = 0
+        step(now)
+      })
+    }
+
+    const schedulePause = (now: number) => {
+      if (document.hidden || timer !== null) {
+        return
+      }
+
+      timer = setTimeout(
+        () => {
+          timer = null
+          scheduleFrame()
+        },
+        Math.max(0, pauseUntil - now)
+      )
+    }
+
+    const scheduleNext = (now: number) => {
+      if (phase === 'pause' && !isInteracting()) {
+        schedulePause(now)
+      } else {
+        scheduleFrame()
+      }
+    }
+
+    const wakeForInteraction = () => {
+      if (phase !== 'pause' || !isInteracting()) {
+        return
+      }
+
+      if (timer !== null) {
+        clearTimeout(timer)
+        timer = null
+      }
+
+      scheduleFrame()
+    }
+
     const step = (now: number) => {
       const dt = Math.min(MAX_DT_S, (now - last) / 1000)
       last = now
@@ -223,7 +282,7 @@ export function usePetRoam({
         // Short settle so the pet falls right after you drop it, not seconds later.
         pauseUntil = now + DROP_SETTLE_MS
         signal(null, 0)
-        raf = requestAnimationFrame(step)
+        scheduleFrame()
 
         return
       }
@@ -300,13 +359,30 @@ export function usePetRoam({
         }
       }
 
-      raf = requestAnimationFrame(step)
+      scheduleNext(now)
     }
 
-    raf = requestAnimationFrame(step)
+    const handleVisibilityChange = () => {
+      cancelScheduled()
+
+      if (!document.hidden) {
+        const now = performance.now()
+
+        last = now
+        scheduleNext(now)
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('pointerdown', wakeForInteraction)
+    window.addEventListener('pointermove', wakeForInteraction)
+    scheduleNext(performance.now())
 
     return () => {
-      cancelAnimationFrame(raf)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('pointerdown', wakeForInteraction)
+      window.removeEventListener('pointermove', wakeForInteraction)
+      cancelScheduled()
       signal(null, 0)
       // Hand the final position back to React so its `style` matches the DOM once
       // the loop stops re-asserting it.


### PR DESCRIPTION
## Summary
- replace the persistent terminal's lifetime geometry polling loop with event-driven observation and frame-coalesced updates
- let pet roaming sleep on a timeout during pause phases while preserving frame updates for movement and drag recovery
- suspend both schedulers while the document is hidden and add behavior-focused regression coverage

## Root cause
The terminal overlay re-read its slot geometry and scheduled another animation frame for its entire mounted lifetime, even when the rectangle never changed. The pet state machine likewise requested another frame during long pause phases that performed no movement.

## Validation
- `npm test -- --project ui src/components/pet src/app/right-sidebar/terminal` ? 44 passed
- `npm run typecheck` ? passed
- `npm run lint` ? passed with 0 errors (17 existing warnings outside the touched files)
- targeted ESLint + Prettier checks for all four touched files ? passed with 0 warnings
- `npm run build` ? passed
- GitHub CI after rebasing to current `main` ? all required checks passed, including Desktop UI, desktop/platform tests, lint, E2E, security, and amd64/arm64 Docker builds.

Tested on Windows 11.

Fixes #69645
