### PR TITLE
feat(desktop): show credit-usage notices as toasts (#69808)

### DIFF
--- a/agent/credits_tracker.py
+++ b/agent/credits_tracker.py
@@ -316,12 +316,21 @@ def evaluate_credits_notices(
             active.discard(CREDITS_USAGE_KEY)
         if target_band is not None:
             # Belt-and-suspenders: a producer could set subscription_limit_micros
-            # without subscription_limit_usd. Render "$? cap" rather than "$None cap".
+            # without subscription_limit_usd. Render "$?" rather than "$None".
             _cap_usd = state.subscription_limit_usd or "?"
             _level = current_band[1]  # type: ignore[index]  (current_band set when target_band set)
+            # Report absolute dollars used, not a bare "N% used": the percentage is
+            # only meaningful against a Nous subscription cap (no cap → never fires),
+            # so dollars are clearer and don't imply a universal %. Used = cap −
+            # remaining (micros, money-safe), clamped to [0, cap]. Re-emits on band
+            # change (50 → 75 → 90), not every turn — a snapshot, not a live ticker.
+            _lim = state.subscription_limit_micros or 0
+            _used_micros = max(0, min(_lim, _lim - state.subscription_micros))
+            _used_usd = f"{_used_micros / 1_000_000:.2f}" if _lim else "?"
+            _glyph = "⚠" if _level == "warn" else "•"
             to_show.append(
                 AgentNotice(
-                    text=f"{'⚠' if _level == 'warn' else '•'} Credits {target_band}% used · ${_cap_usd} cap",
+                    text=f"{_glyph} You've used ${_used_usd} of your ${_cap_usd} cap",
                     level=_level,
                     kind=CREDITS_NOTICE_KIND,
                     key=CREDITS_USAGE_KEY,

--- a/apps/desktop/src/app/contrib/dev/credits-notice-demo.ts
+++ b/apps/desktop/src/app/contrib/dev/credits-notice-demo.ts
@@ -1,0 +1,128 @@
+// Dev-only: drive the credit-notice UX without a backend that can hit real
+// usage bands. Each trigger emits ONE synthetic `notification.show` /
+// `notification.clear` gateway event through the real fan-out
+// (`emitLocalGatewayEvent`), so it exercises the actual dispatcher branch in
+// `use-message-stream/gateway-event.ts` — toast render, key-replacement
+// escalation, TTL self-dismiss, native OS notification, and billing re-poll.
+//
+// Installed only under `import.meta.env.DEV` (see contrib/wiring.tsx), so none
+// of this ships in a production build.
+
+import type { GatewayEvent } from '@hermes/shared'
+
+import { PALETTE_AREA, type PaletteContribution } from '@/app/command-palette/contrib'
+import { registry } from '@/contrib/registry'
+import { CreditCard } from '@/lib/icons'
+import { emitLocalGatewayEvent } from '@/store/gateway'
+import { $activeSessionId } from '@/store/session'
+
+interface NoticeStep {
+  key: string
+  level: string
+  kind: 'sticky' | 'ttl'
+  text: string
+  ttl_ms?: number
+}
+
+// Walks the same lifecycle the Nous credits tracker drives: usage escalates in
+// place (50→75→90, one key), then grant-spent, then the depleted/restored pair.
+// Wraps around. These are all separate SHOW steps; the stepper auto-clears the
+// previous notice when the key changes, so the demo shows one toast at a time
+// (real usage CAN stack these, but that's noise when you're eyeballing a single
+// transition). The same-key usage steps still demonstrate in-place escalation.
+const STEPS: readonly NoticeStep[] = [
+  { key: 'credits.usage', kind: 'sticky', level: 'info', text: "• You've used $110.00 of your $220.00 cap" },
+  { key: 'credits.usage', kind: 'sticky', level: 'warn', text: "⚠ You've used $165.00 of your $220.00 cap" },
+  { key: 'credits.usage', kind: 'sticky', level: 'warn', text: "⚠ You've used $198.00 of your $220.00 cap" },
+  { key: 'credits.grant_spent', kind: 'sticky', level: 'info', text: '• Grant spent · $12.00 top-up left' },
+  { key: 'credits.depleted', kind: 'sticky', level: 'error', text: '✕ Credit access paused · run /topup to top up' },
+  { key: 'credits.restored', kind: 'ttl', level: 'success', text: '✓ Credit access restored', ttl_ms: 8000 }
+]
+
+let cursor = 0
+let lastShownKey: null | string = null
+
+function clearNotice(key: string): void {
+  emitLocalGatewayEvent({
+    payload: { key },
+    session_id: $activeSessionId.get() ?? '',
+    type: 'notification.clear'
+  } as GatewayEvent)
+}
+
+function showNotice(step: NoticeStep): void {
+  emitLocalGatewayEvent({
+    payload: {
+      id: `${step.key}:${Date.now()}`,
+      key: step.key,
+      kind: step.kind,
+      level: step.level,
+      text: step.text,
+      ttl_ms: step.ttl_ms ?? null
+    },
+    session_id: $activeSessionId.get() ?? '',
+    type: 'notification.show'
+  } as GatewayEvent)
+}
+
+/** Fire the next notice in the scripted sequence, wrapping at the end. */
+export function stepCreditsNoticeDemo(): void {
+  const step = STEPS[cursor % STEPS.length]
+
+  // One toast at a time: retire the previous notice when we move to a new key.
+  // (Same-key steps skip this, so the usage line still escalates in place.)
+  if (lastShownKey && lastShownKey !== step.key) {
+    clearNotice(lastShownKey)
+  }
+
+  showNotice(step)
+  lastShownKey = step.key
+  cursor += 1
+}
+
+// The hotkey: Ctrl+Shift+C on every platform (Ctrl, not Cmd, so it can't clash
+// with a system Cmd chord and works the same on Windows/Linux). Matched on
+// `code` so it's keyboard-layout independent, and captured before the composer
+// so a focused input can't swallow it.
+function isTriggerChord(e: KeyboardEvent): boolean {
+  return e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey && e.code === 'KeyC'
+}
+
+/**
+ * Install the dev trigger: a capture-phase hotkey (Ctrl+Shift+C), a ⌘K palette
+ * entry, and a `window.__creditsDemo()` console hook. Returns a disposer.
+ */
+export function installCreditsNoticeDemo(): () => void {
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (!isTriggerChord(e)) {
+      return
+    }
+
+    e.preventDefault()
+    e.stopPropagation()
+    stepCreditsNoticeDemo()
+  }
+
+  window.addEventListener('keydown', onKeyDown, { capture: true })
+  ;(window as unknown as { __creditsDemo?: () => void }).__creditsDemo = stepCreditsNoticeDemo
+
+  const disposePalette = registry.register({
+    id: 'dev.creditsNotice',
+    area: PALETTE_AREA,
+    data: {
+      id: 'dev.creditsNotice',
+      icon: CreditCard,
+      keywords: ['credits', 'notice', 'toast', 'billing', 'dev', 'demo'],
+      label: 'Dev: cycle credit notices',
+      run: stepCreditsNoticeDemo
+    } satisfies PaletteContribution
+  })
+
+  console.info('[dev] credit-notice demo ready — press Ctrl+Shift+C, or run window.__creditsDemo()')
+
+  return () => {
+    window.removeEventListener('keydown', onKeyDown, { capture: true })
+    disposePalette()
+    delete (window as unknown as { __creditsDemo?: () => void }).__creditsDemo
+  }
+}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -272,6 +272,23 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     return () => window.removeEventListener('hermes:open-keybinds', onOpenKeybinds)
   }, [navigate])
 
+  // Dev-only: install the credit-notice demo trigger (Ctrl+Shift+C / ⌘K palette
+  // / window.__creditsDemo). Dynamic import inside the DEV guard so the module
+  // is dropped from production builds.
+  useEffect(() => {
+    if (!import.meta.env.DEV) {
+      return
+    }
+
+    let dispose: (() => void) | undefined
+
+    void import('./dev/credits-notice-demo').then(m => {
+      dispose = m.installCreditsNoticeDemo()
+    })
+
+    return () => dispose?.()
+  }, [])
+
   // Post-turn rehydrate from stored history (same behavior as DesktopController,
   // including finished-todos restoration).
   const hydrateFromStoredSession = useCallback(

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -15,6 +15,7 @@ import { resolveGatewayEventSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
+import { type AgentNoticePayload, clearAgentNotice, showAgentNotice } from '@/store/agent-notices'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { billingCtaLabel, clearBillingBlock, runBillingRecovery, setBillingBlock } from '@/store/billing-block'
 import { clearClarifyRequest, normalizeChoices, setClarifyRequest, warnDroppedChoices } from '@/store/clarify'
@@ -865,6 +866,19 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             ]
           }))
         }
+      } else if (event.type === 'notification.show') {
+        // Driver-agnostic agent notice (credits usage/grant/depleted/restored
+        // from `agent/credits_tracker.py`). The Ink TUI renders these in its
+        // status bar; the desktop renders them as toasts. The notice key doubles
+        // as the toast id, so the escalating 50→75→90 credits line replaces in
+        // place instead of stacking. Account-wide signal — shown regardless of
+        // which session is focused.
+        showAgentNotice(event.payload as AgentNoticePayload | undefined)
+      } else if (event.type === 'notification.clear') {
+        // Key-matched dismissal (e.g. credits restored clears the depleted
+        // notice). notify() keys the toast by the notice key, so this maps
+        // straight to dismissNotification(key).
+        clearAgentNotice((event.payload as AgentNoticePayload | undefined)?.key)
       } else if (event.type === 'error') {
         const errorMessage = payload?.message || 'Hermes reported an error'
         const looksLikeProviderSetup = isProviderSetupErrorMessage(errorMessage)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -15,7 +15,7 @@ import { resolveGatewayEventSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
-import { type AgentNoticePayload, clearAgentNotice, showAgentNotice } from '@/store/agent-notices'
+import { type AgentNoticePayload, clearAgentNotice, nativeNoticeInput, showAgentNotice } from '@/store/agent-notices'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { billingCtaLabel, clearBillingBlock, runBillingRecovery, setBillingBlock } from '@/store/billing-block'
 import { clearClarifyRequest, normalizeChoices, setClarifyRequest, warnDroppedChoices } from '@/store/clarify'
@@ -873,7 +873,25 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // as the toast id, so the escalating 50→75→90 credits line replaces in
         // place instead of stacking. Account-wide signal — shown regardless of
         // which session is focused.
-        showAgentNotice(event.payload as AgentNoticePayload | undefined)
+        const notice = event.payload as AgentNoticePayload | undefined
+
+        showAgentNotice(notice)
+
+        // The urgent pair (access paused / restored) also breaks through as a
+        // native OS notification when Hermes is backgrounded; dispatch is gated
+        // by the user's notification prefs + backgrounded check.
+        const native = nativeNoticeInput(notice, translateNow('notifications.native.creditsTitle'))
+
+        if (native) {
+          dispatchNativeNotification(native)
+        }
+
+        // A credits crossing moves the account balance. Settings → Billing polls
+        // `billing.state` every 30s; nudge it so the page reflects the crossing
+        // immediately instead of up to 30s late.
+        if (notice?.key?.startsWith('credits.')) {
+          void queryClient.invalidateQueries({ queryKey: ['billing', 'state'] })
+        }
       } else if (event.type === 'notification.clear') {
         // Key-matched dismissal (e.g. credits restored clears the depleted
         // notice). notify() keys the toast by the notice key, so this maps

--- a/apps/desktop/src/app/settings/billing/use-billing-state.ts
+++ b/apps/desktop/src/app/settings/billing/use-billing-state.ts
@@ -11,15 +11,22 @@ export const EMPTY_BILLING_VALUE = '—'
 export const FALLBACK_PORTAL_BILLING_URL = 'https://portal.nousresearch.com/billing'
 export const FALLBACK_PORTAL_URL = 'https://portal.nousresearch.com'
 
-// Billing polls on its own while the page is mounted (react-query only ticks an
-// active observer), so the view stays live without a manual refresh control —
-// matching every other data view in the app. It pauses when the window is
-// backgrounded (refetchIntervalInBackground defaults to false).
+// The billing endpoint is the authoritative source of truth for balance / cap /
+// plan — the inference `x-nous-credits-*` headers are best-effort and can drift
+// out of sync (notably in team/org accounts where another member's spend moves
+// the shared balance without ever touching THIS client's headers). So the page
+// never trusts a cache: `staleTime: 0` + `refetchOnMount: 'always'` force a
+// fresh fetch every time it opens or regains focus, and it keeps polling every
+// 30s while mounted (react-query only ticks an active observer; it pauses when
+// the window is backgrounded — refetchIntervalInBackground defaults to false).
+// A `credits.*` notice crossing additionally invalidates ['billing','state'] to
+// pull the change in immediately rather than waiting for the next poll tick.
 const BILLING_QUERY_OPTIONS = {
   refetchInterval: 30_000,
+  refetchOnMount: 'always',
   refetchOnWindowFocus: true,
   retry: false,
-  staleTime: 30_000
+  staleTime: 0
 } as const
 
 export interface BillingSummaryItemView {

--- a/apps/desktop/src/components/notifications.tsx
+++ b/apps/desktop/src/components/notifications.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { type CSSProperties, type ReactNode, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -162,12 +162,42 @@ function BottomRightStack({
   )
 }
 
+// Emphasize only the leading money figure ("$16.00" — the amount used) with the
+// accent color (semibold), leaving the rest of the line in its default muted
+// tone. No accent, or no figure in the message → render the text untouched.
+function renderMessage(message: string, accent?: string): ReactNode {
+  const match = accent ? /\$\d+(?:\.\d{2})?/.exec(message) : null
+
+  if (!match) {
+    return message
+  }
+
+  const start = match.index
+  const end = start + match[0].length
+
+  return (
+    <>
+      {message.slice(0, start)}
+      <span className="font-semibold" style={{ color: accent }}>
+        {match[0]}
+      </span>
+      {message.slice(end)}
+    </>
+  )
+}
+
 function NotificationItem({ notification }: { notification: AppNotification }) {
   const styles = tone[notification.kind]
   const Icon = styles.icon
   const hasDetail = Boolean(notification.detail && notification.detail !== notification.message)
   const { t } = useI18n()
   const copy = t.notifications
+
+  // Nudge the icon down to sit on the first text line, in `ch` so it tracks the
+  // toast's font size instead of a fixed rem. `accentColor` (when set) tints the
+  // icon + message as a severity ramp, overriding the kind's default color.
+  const accent = notification.accentColor
+  const iconStyle: CSSProperties = { marginTop: '0.42ch', ...(accent ? { color: accent } : {}) }
 
   return (
     <Alert
@@ -177,14 +207,17 @@ function NotificationItem({ notification }: { notification: AppNotification }) {
       variant={styles.variant}
     >
       {notification.icon ? (
-        <Codicon className={styles.iconClass} name={notification.icon} size="1rem" />
+        <Codicon className={styles.iconClass} name={notification.icon} size="1rem" style={iconStyle} />
       ) : (
-        <Icon className={styles.iconClass} />
+        <Icon className={styles.iconClass} style={iconStyle} />
       )}
       <div className="col-start-2 min-w-0">
         {notification.title && <AlertTitle className="col-start-auto">{notification.title}</AlertTitle>}
         <AlertDescription className="col-start-auto">
-          <p className="m-0">{notification.message}</p>
+          <p className="m-0">{renderMessage(notification.message, accent)}</p>
+          {notification.meta && (
+            <p className="m-0 text-xs text-muted-foreground tabular-nums">{notification.meta}</p>
+          )}
           {hasDetail && <NotificationDetail detail={notification.detail || ''} />}
           {notification.action && (
             <Button

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -168,7 +168,8 @@ export const en: Translations = {
       turnDoneBody: 'The response is ready.',
       turnErrorTitle: 'Turn failed',
       backgroundDoneTitle: 'Background task finished',
-      backgroundFailedTitle: 'Background task failed'
+      backgroundFailedTitle: 'Background task failed',
+      creditsTitle: 'Credits'
     }
   },
 
@@ -378,6 +379,10 @@ export const en: Translations = {
         backgroundDone: {
           label: 'Background task finished',
           description: 'A backgrounded terminal command completed.'
+        },
+        credits: {
+          label: 'Credit alerts',
+          description: 'Credit access is paused or restored.'
         }
       },
       test: 'Send test notification',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -169,7 +169,8 @@ export const ja = defineLocale({
       turnDoneBody: '応答の準備ができました。',
       turnErrorTitle: 'ターンが失敗しました',
       backgroundDoneTitle: 'バックグラウンドタスクが完了しました',
-      backgroundFailedTitle: 'バックグラウンドタスクが失敗しました'
+      backgroundFailedTitle: 'バックグラウンドタスクが失敗しました',
+      creditsTitle: 'クレジット'
     }
   },
 
@@ -262,6 +263,10 @@ export const ja = defineLocale({
         backgroundDone: {
           label: 'バックグラウンドタスク完了',
           description: 'バックグラウンドのターミナルコマンドが完了しました。'
+        },
+        credits: {
+          label: 'クレジット通知',
+          description: 'クレジットの利用が停止または復旧しました。'
         }
       },
       test: 'テスト通知を送信',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -211,6 +211,7 @@ export interface Translations {
       turnErrorTitle: string
       backgroundDoneTitle: string
       backgroundFailedTitle: string
+      creditsTitle: string
     }
   }
 
@@ -314,7 +315,7 @@ export interface Translations {
       enableAllDesc: string
       focusedHint: string
       kinds: Record<
-        'approval' | 'backgroundDone' | 'input' | 'turnDone' | 'turnError',
+        'approval' | 'backgroundDone' | 'credits' | 'input' | 'turnDone' | 'turnError',
         { label: string; description: string }
       >
       test: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -164,7 +164,8 @@ export const zhHant = defineLocale({
       turnDoneBody: '回覆已就緒。',
       turnErrorTitle: '本輪失敗',
       backgroundDoneTitle: '背景工作已完成',
-      backgroundFailedTitle: '背景工作失敗'
+      backgroundFailedTitle: '背景工作失敗',
+      creditsTitle: '額度'
     }
   },
 
@@ -256,6 +257,10 @@ export const zhHant = defineLocale({
         backgroundDone: {
           label: '背景工作完成',
           description: '背景終端機指令已完成。'
+        },
+        credits: {
+          label: '額度提醒',
+          description: '額度存取被暫停或恢復。'
         }
       },
       test: '傳送測試通知',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -164,7 +164,8 @@ export const zh: Translations = {
       turnDoneBody: '回复已就绪。',
       turnErrorTitle: '本轮失败',
       backgroundDoneTitle: '后台任务已完成',
-      backgroundFailedTitle: '后台任务失败'
+      backgroundFailedTitle: '后台任务失败',
+      creditsTitle: '额度'
     }
   },
 
@@ -368,6 +369,10 @@ export const zh: Translations = {
         backgroundDone: {
           label: '后台任务完成',
           description: '后台终端命令已完成。'
+        },
+        credits: {
+          label: '额度提醒',
+          description: '额度访问被暂停或恢复。'
         }
       },
       test: '发送测试通知',

--- a/apps/desktop/src/store/agent-notices.test.ts
+++ b/apps/desktop/src/store/agent-notices.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, expect, test } from 'vitest'
+
+import {
+  type AgentNoticePayload,
+  clearAgentNotice,
+  noticeToToast,
+  showAgentNotice
+} from './agent-notices'
+import { $notifications, clearNotifications } from './notifications'
+
+function usage(overrides: Partial<AgentNoticePayload> = {}): AgentNoticePayload {
+  return {
+    key: 'credits.usage',
+    kind: 'sticky',
+    level: 'info',
+    text: '• Credits 50% used · $220.00 cap',
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  clearNotifications()
+})
+
+// ── noticeToToast: the whole mapping contract ────────────────────────────────
+
+test('drops a notice with no text', () => {
+  expect(noticeToToast(undefined)).toBeNull()
+  expect(noticeToToast({ text: '' })).toBeNull()
+  expect(noticeToToast({ text: '   ' })).toBeNull()
+})
+
+test('level maps to toast kind (warn → warning)', () => {
+  expect(noticeToToast(usage({ level: 'info' }))?.kind).toBe('info')
+  expect(noticeToToast(usage({ level: 'warn' }))?.kind).toBe('warning')
+  expect(noticeToToast(usage({ level: 'error' }))?.kind).toBe('error')
+  expect(noticeToToast(usage({ level: 'success' }))?.kind).toBe('success')
+})
+
+test('unknown / missing level falls back to info', () => {
+  expect(noticeToToast({ text: 'x', level: 'bogus' })?.kind).toBe('info')
+  expect(noticeToToast({ text: 'x' })?.kind).toBe('info')
+})
+
+test('sticky notices never auto-dismiss', () => {
+  expect(noticeToToast(usage({ kind: 'sticky' }))?.durationMs).toBe(0)
+})
+
+test('ttl notice carries its ttl_ms as the duration', () => {
+  const toast = noticeToToast({ key: 'credits.restored', kind: 'ttl', level: 'success', text: '✓ restored', ttl_ms: 8000 })
+  expect(toast?.durationMs).toBe(8000)
+})
+
+test('ttl notice without a usable ttl_ms defers to notify()’s default', () => {
+  expect(noticeToToast({ text: 'x', kind: 'ttl' })?.durationMs).toBeUndefined()
+  expect(noticeToToast({ text: 'x', kind: 'ttl', ttl_ms: 0 })?.durationMs).toBeUndefined()
+})
+
+test('the notice key is the toast id, falling back to id', () => {
+  expect(noticeToToast(usage({ key: 'credits.usage' }))?.id).toBe('credits.usage')
+  expect(noticeToToast({ text: 'x', id: 'n1', key: undefined })?.id).toBe('n1')
+})
+
+test('the glyph-bearing text passes through verbatim as the message', () => {
+  expect(noticeToToast(usage())?.message).toBe('• Credits 50% used · $220.00 cap')
+})
+
+// ── show / clear: rendered through the notifications store ────────────────────
+
+test('showAgentNotice renders a toast; empty text is a no-op', () => {
+  showAgentNotice(usage())
+  expect($notifications.get()).toHaveLength(1)
+  expect($notifications.get()[0]?.id).toBe('credits.usage')
+
+  showAgentNotice({ text: '' })
+  expect($notifications.get()).toHaveLength(1)
+})
+
+test('re-emitting the same key replaces the toast instead of stacking (50→75→90)', () => {
+  showAgentNotice(usage({ level: 'info', text: '• Credits 50% used' }))
+  showAgentNotice(usage({ level: 'warn', text: '• Credits 75% used' }))
+  showAgentNotice(usage({ level: 'warn', text: '• Credits 90% used' }))
+
+  const toasts = $notifications.get().filter(item => item.id === 'credits.usage')
+  expect(toasts).toHaveLength(1)
+  expect(toasts[0]?.message).toBe('• Credits 90% used')
+  expect(toasts[0]?.kind).toBe('warning')
+})
+
+test('clearAgentNotice dismisses only the matching key', () => {
+  showAgentNotice(usage())
+  showAgentNotice({ key: 'credits.depleted', kind: 'sticky', level: 'error', text: '✕ paused' })
+  expect($notifications.get()).toHaveLength(2)
+
+  clearAgentNotice('credits.usage')
+  const ids = $notifications.get().map(item => item.id)
+  expect(ids).toContain('credits.depleted')
+  expect(ids).not.toContain('credits.usage')
+
+  clearAgentNotice(undefined)
+  expect($notifications.get()).toHaveLength(1)
+})

--- a/apps/desktop/src/store/agent-notices.test.ts
+++ b/apps/desktop/src/store/agent-notices.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, expect, test } from 'vitest'
 import {
   type AgentNoticePayload,
   clearAgentNotice,
+  nativeNoticeInput,
   noticeToToast,
   showAgentNotice
 } from './agent-notices'
@@ -99,4 +100,35 @@ test('clearAgentNotice dismisses only the matching key', () => {
 
   clearAgentNotice(undefined)
   expect($notifications.get()).toHaveLength(1)
+})
+
+// ── nativeNoticeInput: only the urgent credit pair breaks through the OS ──────
+
+test('only credits.depleted and credits.restored map to a native notification', () => {
+  expect(nativeNoticeInput(usage({ key: 'credits.usage' }), 'Credits')).toBeNull()
+  expect(nativeNoticeInput(usage({ key: 'credits.grant_spent' }), 'Credits')).toBeNull()
+  expect(nativeNoticeInput({ text: 'x', key: undefined }, 'Credits')).toBeNull()
+  expect(nativeNoticeInput({ text: '', key: 'credits.depleted' }, 'Credits')).toBeNull()
+})
+
+test('the urgent pair maps to a global native input carrying the text as its body', () => {
+  const depleted = nativeNoticeInput(
+    { key: 'credits.depleted', kind: 'sticky', level: 'error', text: '✕ Credit access paused · run /topup to top up' },
+    'Credits'
+  )
+
+  expect(depleted).toEqual({
+    body: '✕ Credit access paused · run /topup to top up',
+    global: true,
+    kind: 'credits',
+    title: 'Credits'
+  })
+
+  const restored = nativeNoticeInput(
+    { key: 'credits.restored', kind: 'ttl', level: 'success', text: '✓ Credit access restored', ttl_ms: 8000 },
+    'Credits'
+  )
+
+  expect(restored?.kind).toBe('credits')
+  expect(restored?.body).toBe('✓ Credit access restored')
 })

--- a/apps/desktop/src/store/agent-notices.test.ts
+++ b/apps/desktop/src/store/agent-notices.test.ts
@@ -4,8 +4,12 @@ import {
   type AgentNoticePayload,
   clearAgentNotice,
   nativeNoticeInput,
+  noticeAccent,
   noticeToToast,
-  showAgentNotice
+  showAgentNotice,
+  splitMeta,
+  stripGlyph,
+  usageFraction
 } from './agent-notices'
 import { $notifications, clearNotifications } from './notifications'
 
@@ -14,7 +18,7 @@ function usage(overrides: Partial<AgentNoticePayload> = {}): AgentNoticePayload 
     key: 'credits.usage',
     kind: 'sticky',
     level: 'info',
-    text: '• Credits 50% used · $220.00 cap',
+    text: "• You've used $110.00 of your $220.00 cap",
     ...overrides
   }
 }
@@ -62,8 +66,76 @@ test('the notice key is the toast id, falling back to id', () => {
   expect(noticeToToast({ text: 'x', id: 'n1', key: undefined })?.id).toBe('n1')
 })
 
-test('the glyph-bearing text passes through verbatim as the message', () => {
-  expect(noticeToToast(usage())?.message).toBe('• Credits 50% used · $220.00 cap')
+test('the leading severity glyph is stripped from the toast message', () => {
+  // The toast renders a kind icon, so the message must not double up on a glyph.
+  expect(noticeToToast(usage())?.message).toBe("You've used $110.00 of your $220.00 cap")
+  expect(noticeToToast(usage({ level: 'error', text: '✕ Credit access paused' }))?.message).toBe('Credit access paused')
+  expect(noticeToToast(usage({ level: 'success', text: '✓ Credit access restored' }))?.message).toBe(
+    'Credit access restored'
+  )
+})
+
+test('the trailing "· detail" is split off as a secondary meta line, not inlined', () => {
+  // grant_spent still carries a `· detail` tail.
+  const grant = noticeToToast({ key: 'credits.grant_spent', level: 'info', text: '• Grant spent · $12.00 top-up left' })
+  expect(grant?.message).toBe('Grant spent')
+  expect(grant?.meta).toBe('$12.00 top-up left')
+
+  // The usage line has no middot → whole line is the message, no meta.
+  const plain = noticeToToast(usage())
+  expect(plain?.message).toBe("You've used $110.00 of your $220.00 cap")
+  expect(plain?.meta).toBeUndefined()
+})
+
+test('splitMeta splits on the first space-middot-space only', () => {
+  expect(splitMeta('Grant spent · $12.00 top-up left')).toEqual(['Grant spent', '$12.00 top-up left'])
+  expect(splitMeta('Credit access restored')).toEqual(['Credit access restored', undefined])
+  // Interior middots after the first split stay in the meta.
+  expect(splitMeta('a · b · c')).toEqual(['a', 'b · c'])
+})
+
+test('stripGlyph removes only a single leading severity glyph', () => {
+  expect(stripGlyph('• Credits 50% used')).toBe('Credits 50% used')
+  expect(stripGlyph('⚠ warn')).toBe('warn')
+  expect(stripGlyph('✕ paused')).toBe('paused')
+  expect(stripGlyph('✓ ok')).toBe('ok')
+  // No leading glyph → unchanged; interior glyphs are preserved.
+  expect(stripGlyph('Credits 50% used')).toBe('Credits 50% used')
+  expect(stripGlyph('spent · $12.00 • top-up left')).toBe('spent · $12.00 • top-up left')
+})
+
+// ── noticeAccent: severity color ramp keyed off $used / $cap ─────────────────
+
+test('usageFraction derives $used / $cap from the notice text', () => {
+  expect(usageFraction("You've used $15.00 of your $20.00 cap")).toBeCloseTo(0.75)
+  expect(usageFraction("You've used $198.00 of your $220.00 cap")).toBeCloseTo(0.9)
+  // Fewer than two amounts, or a zero cap → no fraction.
+  expect(usageFraction('Grant spent')).toBeNull()
+  expect(usageFraction("You've used $5.00 of your $0.00 cap")).toBeNull()
+  expect(usageFraction(undefined)).toBeNull()
+})
+
+test('usage accent stays muted below 75%, then ramps orange → red', () => {
+  expect(noticeAccent(usage({ text: "• You've used $10.00 of your $20.00 cap" }))).toBeUndefined() // 50%
+  expect(noticeAccent(usage({ text: "• You've used $14.80 of your $20.00 cap" }))).toBeUndefined() // 74%
+  expect(noticeAccent(usage({ level: 'warn', text: "⚠ You've used $15.00 of your $20.00 cap" }))).toBe('var(--ui-orange)') // 75%
+  expect(noticeAccent(usage({ level: 'warn', text: "⚠ You've used $17.80 of your $20.00 cap" }))).toBe('var(--ui-orange)') // 89%
+  expect(noticeAccent(usage({ level: 'warn', text: "⚠ You've used $18.00 of your $20.00 cap" }))).toBe('var(--ui-red)') // 90%
+  expect(noticeAccent(usage({ level: 'warn', text: "⚠ You've used $20.00 of your $20.00 cap" }))).toBe('var(--ui-red)') // 100%
+})
+
+test('terminal credit states carry their own accent; others stay default', () => {
+  expect(noticeAccent({ key: 'credits.depleted', text: '✕ paused' })).toBe('var(--ui-red)')
+  expect(noticeAccent({ key: 'credits.restored', text: '✓ restored' })).toBe('var(--ui-green)')
+  expect(noticeAccent({ key: 'credits.grant_spent', text: '• Grant spent' })).toBeUndefined()
+  expect(noticeAccent(undefined)).toBeUndefined()
+})
+
+test('noticeToToast attaches the band accent to the toast', () => {
+  expect(noticeToToast(usage({ level: 'warn', text: "⚠ You've used $15.00 of your $20.00 cap" }))?.accentColor).toBe(
+    'var(--ui-orange)'
+  )
+  expect(noticeToToast(usage({ text: "• You've used $10.00 of your $20.00 cap" }))?.accentColor).toBeUndefined()
 })
 
 // ── show / clear: rendered through the notifications store ────────────────────
@@ -78,13 +150,13 @@ test('showAgentNotice renders a toast; empty text is a no-op', () => {
 })
 
 test('re-emitting the same key replaces the toast instead of stacking (50→75→90)', () => {
-  showAgentNotice(usage({ level: 'info', text: '• Credits 50% used' }))
-  showAgentNotice(usage({ level: 'warn', text: '• Credits 75% used' }))
-  showAgentNotice(usage({ level: 'warn', text: '• Credits 90% used' }))
+  showAgentNotice(usage({ level: 'info', text: "• You've used $10.00 of your $20.00 cap" }))
+  showAgentNotice(usage({ level: 'warn', text: "⚠ You've used $15.00 of your $20.00 cap" }))
+  showAgentNotice(usage({ level: 'warn', text: "⚠ You've used $18.00 of your $20.00 cap" }))
 
   const toasts = $notifications.get().filter(item => item.id === 'credits.usage')
   expect(toasts).toHaveLength(1)
-  expect(toasts[0]?.message).toBe('• Credits 90% used')
+  expect(toasts[0]?.message).toBe("You've used $18.00 of your $20.00 cap")
   expect(toasts[0]?.kind).toBe('warning')
 })
 

--- a/apps/desktop/src/store/agent-notices.ts
+++ b/apps/desktop/src/store/agent-notices.ts
@@ -1,0 +1,78 @@
+import { dismissNotification, type NotificationInput, type NotificationKind, notify } from '@/store/notifications'
+
+/**
+ * Wire shape of a `notification.show` payload — the driver-agnostic
+ * `AgentNotice` spine (`agent/credits_tracker.py`) as forwarded by
+ * `tui_gateway/server.py`. Snake_case to match the wire; the `text` already
+ * carries its own leading glyph (• ⚠ ✕ ✓) from the Python policy, so a toast
+ * NEVER adds another icon on top.
+ *
+ * - `level` is severity: info | warn | error | success.
+ * - `kind` is lifetime: `sticky` (stays until an explicit clear) or `ttl`
+ *   (self-expires after `ttl_ms`).
+ */
+export interface AgentNoticePayload {
+  text?: string
+  level?: string
+  kind?: string
+  ttl_ms?: null | number
+  key?: string
+  id?: string
+}
+
+const LEVEL_TO_TOAST_KIND: Record<string, NotificationKind> = {
+  error: 'error',
+  info: 'info',
+  success: 'success',
+  warn: 'warning'
+}
+
+/**
+ * Map an agent notice to a toast input, or `null` when it carries no text.
+ *
+ * Pure and side-effect free so it can be unit-tested directly. The mapping is
+ * the whole contract:
+ * - `level` → toast kind (info/warn/error/success, warn→warning).
+ * - `sticky` → `durationMs: 0` (persists); `ttl` → `durationMs: ttl_ms`.
+ * - the notice `key` doubles as the toast `id`, so re-emitting the same key
+ *   REPLACES the prior toast — the credits 50→75→90 line escalates in place
+ *   instead of stacking, and a key-matched `notification.clear` can dismiss it.
+ */
+export function noticeToToast(payload: AgentNoticePayload | undefined): NotificationInput | null {
+  const text = payload?.text?.trim()
+
+  if (!text) {
+    return null
+  }
+
+  const isTtl = payload?.kind === 'ttl'
+  const ttl = isTtl && typeof payload?.ttl_ms === 'number' && payload.ttl_ms > 0 ? payload.ttl_ms : undefined
+
+  return {
+    // sticky → 0 (never auto-dismiss); ttl with a ttl_ms → that value; a ttl
+    // without a usable ttl_ms falls back to notify()'s per-kind default.
+    durationMs: isTtl ? ttl : 0,
+    id: payload?.key || payload?.id,
+    kind: LEVEL_TO_TOAST_KIND[payload?.level ?? 'info'] ?? 'info',
+    message: text
+  }
+}
+
+/** Render a `notification.show` notice as a toast (no-op when it has no text). */
+export function showAgentNotice(payload: AgentNoticePayload | undefined): void {
+  const toast = noticeToToast(payload)
+
+  if (toast) {
+    notify(toast)
+  }
+}
+
+/**
+ * Dismiss the toast a `notification.clear` targets. The clear only ever names a
+ * `key`, which we used as the toast id, so this is a key-matched dismissal.
+ */
+export function clearAgentNotice(key: string | undefined): void {
+  if (key) {
+    dismissNotification(key)
+  }
+}

--- a/apps/desktop/src/store/agent-notices.ts
+++ b/apps/desktop/src/store/agent-notices.ts
@@ -1,3 +1,4 @@
+import type { NativeNotificationInput } from '@/store/native-notifications'
 import { dismissNotification, type NotificationInput, type NotificationKind, notify } from '@/store/notifications'
 
 /**
@@ -74,5 +75,37 @@ export function showAgentNotice(payload: AgentNoticePayload | undefined): void {
 export function clearAgentNotice(key: string | undefined): void {
   if (key) {
     dismissNotification(key)
+  }
+}
+
+// Only these two credit notices are urgent enough to break through as a native
+// OS notification (when Hermes is backgrounded). The escalating usage line
+// (`credits.usage`) and the grant-spent notice stay in-app toasts only — they
+// aren't worth interrupting the user's OS for.
+const NATIVE_NOTICE_KEYS = new Set(['credits.depleted', 'credits.restored'])
+
+/**
+ * Map a notice to a native OS notification input, or `null` when it isn't one of
+ * the urgent credit notices. Pure — the caller passes the localized `title` and
+ * decides whether to dispatch. `global: true` because credit state is
+ * account-wide, not tied to a chat session, so it should fire whenever the user
+ * is away regardless of which session (if any) is focused. The notice `text`
+ * already carries its glyph and is passed through as the raw body.
+ */
+export function nativeNoticeInput(
+  payload: AgentNoticePayload | undefined,
+  title: string
+): NativeNotificationInput | null {
+  const text = payload?.text?.trim()
+
+  if (!text || !payload?.key || !NATIVE_NOTICE_KEYS.has(payload.key)) {
+    return null
+  }
+
+  return {
+    body: text,
+    global: true,
+    kind: 'credits',
+    title
   }
 }

--- a/apps/desktop/src/store/agent-notices.ts
+++ b/apps/desktop/src/store/agent-notices.ts
@@ -4,9 +4,14 @@ import { dismissNotification, type NotificationInput, type NotificationKind, not
 /**
  * Wire shape of a `notification.show` payload — the driver-agnostic
  * `AgentNotice` spine (`agent/credits_tracker.py`) as forwarded by
- * `tui_gateway/server.py`. Snake_case to match the wire; the `text` already
- * carries its own leading glyph (• ⚠ ✕ ✓) from the Python policy, so a toast
- * NEVER adds another icon on top.
+ * `tui_gateway/server.py`. Snake_case to match the wire.
+ *
+ * The `text` carries its own leading severity glyph (• ⚠ ✕ ✓) from the Python
+ * policy — that's how the CLI/TUI render it (glyph in a status line, no separate
+ * icon). The desktop toast is different: every toast renders a kind icon, so we
+ * strip the leading glyph and let that icon carry severity (see `stripGlyph`),
+ * otherwise the toast shows two markers. The native OS notification keeps the
+ * glyph (it has no icon of ours).
  *
  * - `level` is severity: info | warn | error | success.
  * - `kind` is lifetime: `sticky` (stays until an explicit clear) or `ttl`
@@ -28,6 +33,70 @@ const LEVEL_TO_TOAST_KIND: Record<string, NotificationKind> = {
   warn: 'warning'
 }
 
+// The severity glyphs the Python notice policy prefixes (`•` `⚠` `✕`/`✗` `✓`),
+// optionally with a variation selector, plus trailing space. Stripped for the
+// desktop toast because the toast already renders a kind icon.
+const LEADING_GLYPH = /^[•⚠✕✗✓]\uFE0F?\s*/u
+
+/** Drop a single leading severity glyph so the toast doesn't double up on it. */
+export function stripGlyph(text: string): string {
+  return text.replace(LEADING_GLYPH, '')
+}
+
+/** A `$12.34` money token, as the Nous notice policy formats amounts. */
+const MONEY = /\$(\d+(?:\.\d{2})?)/g
+
+/**
+ * Used fraction of the cap derived from a "You've used $X of your $Y cap" notice
+ * — the first two money tokens are (used, cap). Returns a value in [0, 1], or
+ * `null` when the line has no usable pair.
+ */
+export function usageFraction(text: string | undefined): null | number {
+  const amounts = [...(text ?? '').matchAll(MONEY)].map(m => Number(m[1]))
+
+  if (amounts.length < 2 || !(amounts[1] > 0)) {
+    return null
+  }
+
+  return amounts[0] / amounts[1]
+}
+
+/**
+ * Accent color for a credit notice, as a range/severity ramp. The usage gauge
+ * keys off how much of the cap is spent ($used / $cap): it stays on the toast's
+ * default muted color under 75%, then escalates to orange, then red, as the cap
+ * nears. `credits.depleted` is red (paused) and `credits.restored` green.
+ *
+ * Returns a CSS color token or `undefined` (= keep the default muted color).
+ * These reuse the app's existing usage palette (`--ui-*`; see the
+ * `--context-usage-*` block in styles.css) — no new colors are introduced.
+ */
+export function noticeAccent(payload: AgentNoticePayload | undefined): string | undefined {
+  if (payload?.key === 'credits.depleted') {
+    return 'var(--ui-red)'
+  }
+
+  if (payload?.key === 'credits.restored') {
+    return 'var(--ui-green)'
+  }
+
+  const frac = usageFraction(payload?.text)
+
+  if (frac === null) {
+    return undefined
+  }
+
+  if (frac >= 0.9) {
+    return 'var(--ui-red)'
+  }
+
+  if (frac >= 0.75) {
+    return 'var(--ui-orange)'
+  }
+
+  return undefined
+}
+
 /**
  * Map an agent notice to a toast input, or `null` when it carries no text.
  *
@@ -47,16 +116,42 @@ export function noticeToToast(payload: AgentNoticePayload | undefined): Notifica
   }
 
   const isTtl = payload?.kind === 'ttl'
-  const ttl = isTtl && typeof payload?.ttl_ms === 'number' && payload.ttl_ms > 0 ? payload.ttl_ms : undefined
+  const ttl = typeof payload?.ttl_ms === 'number' && payload.ttl_ms > 0 ? payload.ttl_ms : undefined
+
+  // The Python notice text packs a trailing detail after a middot
+  // (`… used · $220.00 cap`, `Grant spent · $12.00 top-up left`). On one CLI/TUI
+  // status line that reads fine, but the toast follows the title-plus-description
+  // convention (Sonner/shadcn): the primary status is the message and the detail
+  // drops to a muted second line, instead of inlining a `·` separator.
+  const [primary, meta] = splitMeta(stripGlyph(text))
 
   return {
+    // Icon + text tint by usage band (muted → orange → red); undefined keeps
+    // the default muted color.
+    accentColor: noticeAccent(payload),
     // sticky → 0 (never auto-dismiss); ttl with a ttl_ms → that value; a ttl
     // without a usable ttl_ms falls back to notify()'s per-kind default.
     durationMs: isTtl ? ttl : 0,
     id: payload?.key || payload?.id,
     kind: LEVEL_TO_TOAST_KIND[payload?.level ?? 'info'] ?? 'info',
-    message: text
+    message: primary,
+    meta
   }
+}
+
+/**
+ * Split a notice line into its primary status and a trailing detail on the first
+ * ` · ` (space-middot-space). No middot → the whole line is the primary and
+ * there's no meta.
+ */
+export function splitMeta(text: string): [primary: string, meta: string | undefined] {
+  const at = text.indexOf(' · ')
+
+  if (at === -1) {
+    return [text, undefined]
+  }
+
+  return [text.slice(0, at), text.slice(at + 3) || undefined]
 }
 
 /** Render a `notification.show` notice as a toast (no-op when it has no text). */

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -35,6 +35,17 @@ export function configureGatewayRegistry(cfg: RegistryConfig): void {
   config = cfg
 }
 
+/**
+ * Feed a synthetic event through the exact same fan-out a real socket frame
+ * takes (`config.onEvent` → the desktop's `handleGatewayEvent`). Used by
+ * dev-only tooling to exercise the real event branches (e.g. the credit-notice
+ * demo) without a backend that can produce the event on demand. No-op until a
+ * registry is configured.
+ */
+export function emitLocalGatewayEvent(event: GatewayEvent): void {
+  config?.onEvent(event)
+}
+
 // ── Primary (window) backend ───────────────────────────────────────────────
 let primaryGateway: HermesGateway | null = null
 let primaryProfile = 'default'

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -8,14 +8,15 @@ import { $activeSessionId } from './session'
 
 // Native OS notifications (Electron `Notification`), separate from the in-app
 // toast feed in `notifications.ts`. Each kind toggles independently.
-export type NativeNotificationKind = 'approval' | 'backgroundDone' | 'input' | 'turnDone' | 'turnError'
+export type NativeNotificationKind = 'approval' | 'backgroundDone' | 'credits' | 'input' | 'turnDone' | 'turnError'
 
 export const NATIVE_NOTIFICATION_KINDS: readonly NativeNotificationKind[] = [
   'approval',
   'input',
   'turnDone',
   'turnError',
-  'backgroundDone'
+  'backgroundDone',
+  'credits'
 ]
 
 // Blocking prompts — surface even while focused if they're for another session.
@@ -30,7 +31,7 @@ const STORAGE_KEY = 'hermes:native-notifications'
 
 const DEFAULT_PREFS: NativeNotificationPrefs = {
   enabled: true,
-  kinds: { approval: true, backgroundDone: true, input: true, turnDone: true, turnError: true }
+  kinds: { approval: true, backgroundDone: true, credits: true, input: true, turnDone: true, turnError: true }
 }
 
 function readPrefs(): NativeNotificationPrefs {

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -16,6 +16,10 @@ export interface AppNotification {
   kind: NotificationKind
   /** When set, renders this codicon instead of the default kind icon. */
   icon?: string
+  /** When set, tints the icon and message with this CSS color (severity ramp). */
+  accentColor?: string
+  /** Secondary detail line rendered below the message, muted (e.g. "$220.00 cap"). */
+  meta?: string
   title?: string
   message: string
   detail?: string
@@ -29,6 +33,8 @@ export interface NotificationInput {
   id?: string
   kind?: NotificationKind
   icon?: string
+  accentColor?: string
+  meta?: string
   title?: string
   message: string
   detail?: string
@@ -130,6 +136,8 @@ export function notify(input: NotificationInput): string {
     id,
     kind,
     icon: input.icon,
+    accentColor: input.accentColor,
+    meta: input.meta,
     title: input.title,
     message: input.message,
     detail: input.detail,

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -25,7 +25,7 @@ export interface AppNotification {
   placement?: NotificationPlacement
 }
 
-interface NotificationInput {
+export interface NotificationInput {
   id?: string
   kind?: NotificationKind
   icon?: string

--- a/tests/agent/test_credits_policy.py
+++ b/tests/agent/test_credits_policy.py
@@ -569,7 +569,8 @@ class TestTopUpSuppression:
         assert latch["usage_band"] is None
         to_show, _ = evaluate_credits_notices(state_with_fraction(0.95), latch)
         n = next(n for n in to_show if n.key == "credits.usage")
-        assert "90%" in n.text
+        # uf 0.95 of a $20 cap → used = $19.00 (cap − remaining, clamped).
+        assert "$19.00" in n.text
         assert latch["usage_band"] == 90
 
     def test_grant_spent_still_fires_with_topup(self):
@@ -645,7 +646,8 @@ class TestUsageBands:
         evaluate_credits_notices(state_with_fraction(0.10), latch)  # prime
         to_show, _ = evaluate_credits_notices(state_with_fraction(0.55), latch)
         n = next(n for n in to_show if n.key == "credits.usage")
-        assert "50%" in n.text and n.level == "info"
+        # uf 0.55 of a $20 cap → used = $11.00; band 50 fires at info level.
+        assert "$11.00" in n.text and n.level == "info"
         assert latch["usage_band"] == 50
 
     def test_75_band_fires_warn(self):
@@ -653,7 +655,8 @@ class TestUsageBands:
         evaluate_credits_notices(state_with_fraction(0.10), latch)
         to_show, _ = evaluate_credits_notices(state_with_fraction(0.80), latch)
         n = next(n for n in to_show if n.key == "credits.usage")
-        assert "75%" in n.text and n.level == "warn"
+        # uf 0.80 of a $20 cap → used = $16.00; band 75 fires at warn level.
+        assert "$16.00" in n.text and n.level == "warn"
         assert latch["usage_band"] == 75
 
     def test_climb_replaces_band(self):
@@ -663,15 +666,15 @@ class TestUsageBands:
         # 55% → 50 band
         evaluate_credits_notices(state_with_fraction(0.55), latch)
         assert latch["usage_band"] == 50
-        # 80% → climbs to 75, clearing the 50 line
+        # 80% → climbs to 75, clearing the 50 line (used = $16.00 of $20)
         to_show, to_clear = evaluate_credits_notices(state_with_fraction(0.80), latch)
         assert "credits.usage" in to_clear
-        assert "75%" in self._band_text(to_show)
+        assert "$16.00" in self._band_text(to_show)
         assert latch["usage_band"] == 75
-        # 95% → climbs to 90
+        # 95% → climbs to 90 (used = $19.00 of $20)
         to_show, to_clear = evaluate_credits_notices(state_with_fraction(0.95), latch)
         assert "credits.usage" in to_clear
-        assert "90%" in self._band_text(to_show)
+        assert "$19.00" in self._band_text(to_show)
         assert latch["usage_band"] == 90
 
     def test_step_down_on_recovery(self):
@@ -680,13 +683,13 @@ class TestUsageBands:
         evaluate_credits_notices(state_with_fraction(0.10), latch)
         evaluate_credits_notices(state_with_fraction(0.95), latch)
         assert latch["usage_band"] == 90
-        # drop to 80% → steps down to 75
+        # drop to 80% → steps down to 75 (used = $16.00 of $20)
         to_show, to_clear = evaluate_credits_notices(state_with_fraction(0.80), latch)
         assert "credits.usage" in to_clear
-        assert "75%" in self._band_text(to_show)
-        # drop to 55% → steps down to 50
+        assert "$16.00" in self._band_text(to_show)
+        # drop to 55% → steps down to 50 (used = $11.00 of $20)
         to_show, _ = evaluate_credits_notices(state_with_fraction(0.55), latch)
-        assert "50%" in self._band_text(to_show)
+        assert "$11.00" in self._band_text(to_show)
         # drop below 50% → clears entirely
         to_show, to_clear = evaluate_credits_notices(state_with_fraction(0.10), latch)
         assert "credits.usage" in to_clear


### PR DESCRIPTION
Closes #69808.

## Problem

The desktop app never showed credit-usage warnings. The backend already emits them — `agent/credits_tracker.py` parses the `x-nous-credits-*` headers, evaluates the 50/75/90% bands, and `tui_gateway/server.py` turns each `AgentNotice` into a `notification.show` / `notification.clear` WS event. The Ink TUI renders them in its status bar, but the desktop renderer's event dispatcher (`use-message-stream/gateway-event.ts`) had **no branch** for either event and no fallback, so they were silently dropped.

This is distinct from the out-of-credits *billing wall* (#69655): that fires reactively when a turn fails (`message.complete` → `billing_block`). These notices are the proactive band signals, on a separate wire.

## What's here

The full issue (core + both optional pieces), plus a copy change and UI polish that came out of review.

### 1. Render notices as toasts (core)

- **`store/agent-notices.ts`** (new) — a small, pure, unit-tested module. `noticeToToast(payload)` maps a notice to a toast: `level` → toast kind (`warn`→`warning`), `sticky` → `durationMs: 0`, `ttl` → `ttl_ms`.
  - The notice `key` becomes the toast `id`, so re-emitting the same key **replaces** the toast — the credits `50→75→90` line escalates in place instead of stacking, and `notification.clear` maps straight to `dismissNotification(key)`.
- **`gateway-event.ts`** — `notification.show` / `notification.clear` branches. Notices are account-wide, so the toast shows regardless of the focused session.

### 2. Toast rendering fixes

The CLI/TUI render a notice as one status line with a leading glyph and no separate icon; the desktop toast always draws a kind icon, so the raw text collided with it. Fixes:

- **De-dupe the icon** — strip the leading severity glyph (`•` `⚠` `✕` `✓`) from the toast message and let the kind icon carry severity. The native OS notification keeps the glyph (it draws no icon of ours).
- **Icon margin** — `0.42ch` (font-relative) instead of a fixed rem.
- **Band-color the figure** — the `$used` amount is semibold and tinted by `$used/$cap`: muted `<75%`, `--ui-orange` `≥75%`, `--ui-red` `≥90%` (depleted red, restored green), reusing the existing `--ui-*` usage palette. The icon shares the accent.
- **Split the trailing detail** — a `· $X …` tail (grant-spent / depleted) drops to a muted second line (title-plus-description convention) instead of an inline middot.

These are generic `accentColor` + `meta` slots on the notification and degrade gracefully when a notice has no figure.

### 3. Usage copy: `$used of $cap` instead of a bare `%`

`agent/credits_tracker.py` now says **`You've used $16.00 of your $20.00 cap`** rather than `Credits 75% used · $20.00 cap`. The gauge is Nous subscription-cap-only in the first place (`used_fraction` needs a cap; non-Nous providers send no headers, so no notice fires), so a bare percentage implied a universal unit that doesn't exist. `used = cap − remaining`, from micros (money-safe), clamped to `[0, cap]`. It stays a snapshot at band-crossing — re-emitted on band change, not every turn — so the single escalating line is preserved and append-only surfaces (messaging pushes one message per crossing) stay quiet.

### 4. Native OS notification for the urgent pair (optional)

`credits.depleted` / `credits.restored` also fire an Electron notification when Hermes is backgrounded, via a new `credits` `NativeNotificationKind` with its own toggle in **Settings → Notifications** (the panel is data-driven off `NATIVE_NOTIFICATION_KINDS`, so the toggle appears automatically). `nativeNoticeInput()` is a pure, unit-tested mapping; the gateway-event branch does the localized-title lookup and the gated `dispatchNativeNotification()`. The escalating usage line and grant-spent notice stay in-app only.

### 5. Billing page always fetches fresh

A `credits.*` crossing invalidates `['billing','state']` so **Settings → Billing** reflects a change immediately instead of waiting for its poll. On top of that (per review), the page no longer trusts a cache: `staleTime: 0` + `refetchOnMount: 'always'` force a fresh fetch on every open and focus (still polling 30s while mounted). The `x-nous-credits-*` headers are best-effort and can drift out of sync — notably in team/org accounts where another member's spend moves the shared balance without ever touching this client's headers — so the page treats the billing endpoint as the source of truth.

### 6. Dev-only demo

`Ctrl+Shift+C` (and `window.__creditsDemo()`) steps the whole lifecycle (usage `50→75→90`, grant-spent, depleted/restored) through the real gateway event fan-out via a new `emitLocalGatewayEvent`, so the toast / native / billing-invalidation paths are exercisable without hitting real usage bands. Installed only under `import.meta.env.DEV`, so it's tree-shaken from production.

## Done when (from the issue)

- ✅ Crossing the 50% band mid-session shows a toast.
- ✅ The 75% warning replaces the 50% toast instead of stacking (same `key` → same toast id).
- ✅ `✓ Credit access restored` disappears on its own after ~8s (`ttl` → `ttl_ms`).
- ✅ `notification.clear` dismisses the matching toast.
- ✅ Optional: native OS notification for `credits.depleted` / `credits.restored`.
- ✅ Optional: Billing page reflects a notice immediately.

## Tests

- `agent/credits_tracker.py` copy change is covered by `tests/agent/test_credits_policy.py` (band → `$used` assertions); notice-rendering, notice-spine, and cold-start suites pass unchanged.
- `apps/desktop/src/store/agent-notices.test.ts` covers the toast mapping (level→kind, sticky/ttl duration, key→id fallback), glyph stripping, the `$used/$cap` accent ramp (`usageFraction`), the detail split, the store side-effects (render, key-replacement escalation, key-matched clear), and the native-input mapping.

```
scripts/run_tests.sh tests/agent/test_credits_policy.py …   # 84 passed
cd apps/desktop
npx vitest run src/store/agent-notices.test.ts src/app/settings/billing   # 127 passed
npm run typecheck   # clean
npx eslint <changed files>   # clean
```

i18n added for all four locales (en / ja / zh / zh-hant).
