### PR TITLE
fix(serve): register shell hooks for dashboard/serve startup (#69825)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13190,6 +13190,28 @@ def cmd_dashboard(args):
             exc_info=True,
         )
 
+    # Register declarative shell hooks from config.yaml (#69825).  ``serve``
+    # (the desktop app's chat backend) and ``dashboard`` are not in
+    # ``_AGENT_COMMANDS``, so ``_prepare_agent_startup()`` never wires shell
+    # hooks for this process — configured hooks passed ``hermes hooks
+    # doctor`` yet silently never fired in desktop-app chats.  Mirror the
+    # gateway's call site (gateway/run.py): pass ``accept_hooks=False`` and
+    # let ``register_from_config`` resolve consent from ``--accept-hooks``-less
+    # channels itself (HERMES_ACCEPT_HOOKS env var, ``hooks_auto_accept`` in
+    # config.yaml, or the interactive TTY prompt when one exists).  Runs
+    # after ``discover_plugins()`` because registration attaches to the
+    # plugin manager.  Failures must never block server startup.
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at dashboard/serve startup",
+            exc_info=True,
+        )
+
     from hermes_cli.web_server import start_server
 
     # Interactive auth setup: if this bind will engage the auth gate but no

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12525,6 +12525,15 @@ def cmd_dashboard(args):
         # the missing-provider state if it matters.
         print(f"⚠ Plugin discovery failed: {exc}", file=sys.stderr)
 
+    try:
+        from agent.shell_hooks import register_from_config
+        from hermes_cli.config import load_config
+
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception as exc:
+        print(f"Error: shell-hook registration failed: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
     # Desktop chat uses the dashboard's in-process /api/ws gateway, which builds
     # agents via tui_gateway.server._make_agent.  That path only snapshots the
     # tool registry — it never starts MCP discovery (the stdio TUI does that in

--- a/tests/hermes_cli/test_dashboard_shell_hooks.py
+++ b/tests/hermes_cli/test_dashboard_shell_hooks.py
@@ -1,0 +1,144 @@
+"""Regression tests for #69825: ``hermes serve`` / ``hermes dashboard`` must
+register declarative shell hooks from config.yaml.
+
+``serve`` (the desktop app's chat backend) is not in ``_AGENT_COMMANDS``, so
+``_prepare_agent_startup()`` never runs for it.  Before the fix, configured
+shell hooks passed ``hermes hooks doctor`` but silently never fired during
+desktop-app chat activity because ``agent.shell_hooks.register_from_config()``
+was never called in the serve process.  ``cmd_dashboard`` (the shared handler
+for ``dashboard`` and ``serve``) now mirrors the gateway's call site.
+"""
+
+import sys
+import types
+from argparse import Namespace
+
+import pytest
+
+import hermes_cli.main as main_mod
+
+
+def _serve_args(**overrides):
+    base = {
+        "ssh_session_token_file": None,
+        "ssh_owner_nonce": None,
+        "status": False,
+        "stop": False,
+        "headless_backend": True,  # the `serve` path: no UI build
+        "isolated": False,
+        "open_profile": "",
+        "host": "127.0.0.1",
+        "port": 9119,
+        "no_open": True,
+        "insecure": False,
+        "skip_build": False,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+@pytest.fixture()
+def _stubbed_dashboard_env(monkeypatch):
+    """Stub every side-effecting collaborator of ``cmd_dashboard`` and record
+    the calls that matter for the shell-hook registration contract."""
+    calls = {"order": [], "register_kwargs": None, "register_cfg": None}
+    sentinel_cfg = {"hooks": {"pre_tool_call": [{"command": "/tmp/hook.sh"}]}}
+
+    # Touch the env var through monkeypatch first so its mutation inside
+    # cmd_dashboard (headless sets HERMES_SERVE_HEADLESS=1) is restored.
+    monkeypatch.setenv("HERMES_SERVE_HEADLESS", "0")
+
+    def _register_from_config(cfg, *, accept_hooks=False):
+        calls["order"].append("register_from_config")
+        calls["register_cfg"] = cfg
+        calls["register_kwargs"] = {"accept_hooks": accept_hooks}
+        return []
+
+    def _discover_plugins(*a, **k):
+        calls["order"].append("discover_plugins")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.profiles",
+        types.SimpleNamespace(get_active_profile_name=lambda: "default"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=_discover_plugins),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.mcp_startup",
+        types.SimpleNamespace(
+            start_background_mcp_discovery=lambda **_k: calls["order"].append(
+                "mcp_discovery"
+            ),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            load_config=lambda: sentinel_cfg,
+            apply_terminal_config_to_env=lambda: None,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=_register_from_config),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(
+            start_server=lambda **_k: calls["order"].append("start_server"),
+        ),
+    )
+    monkeypatch.setattr(main_mod, "_sync_bundled_skills_quietly", lambda: None)
+    monkeypatch.setattr(
+        main_mod, "_maybe_setup_dashboard_auth_interactively", lambda _a: None
+    )
+    return calls, sentinel_cfg
+
+
+def test_serve_registers_shell_hooks_before_start_server(_stubbed_dashboard_env):
+    calls, sentinel_cfg = _stubbed_dashboard_env
+
+    main_mod.cmd_dashboard(_serve_args())
+
+    assert "register_from_config" in calls["order"], (
+        "serve/dashboard startup must register shell hooks — configured hooks "
+        "otherwise silently never fire in desktop-app chats (#69825)"
+    )
+    # The loaded config dict is passed through untouched, and consent
+    # resolution is delegated to register_from_config (mirrors gateway).
+    assert calls["register_cfg"] is sentinel_cfg
+    assert calls["register_kwargs"] == {"accept_hooks": False}
+    # Registration attaches hooks to the plugin manager, so plugin discovery
+    # must have happened first; and the server boots afterwards.
+    order = calls["order"]
+    assert order.index("discover_plugins") < order.index("register_from_config")
+    assert order.index("register_from_config") < order.index("start_server")
+
+
+def test_serve_hook_registration_failure_does_not_block_startup(
+    _stubbed_dashboard_env, monkeypatch
+):
+    calls, _ = _stubbed_dashboard_env
+
+    def _boom(_cfg, *, accept_hooks=False):
+        calls["order"].append("register_from_config")
+        raise RuntimeError("registration exploded")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=_boom),
+    )
+
+    main_mod.cmd_dashboard(_serve_args())
+
+    # The failure is swallowed (logged) and the server still starts.
+    assert "start_server" in calls["order"]

--- a/tests/hermes_cli/test_dashboard_shell_hooks.py
+++ b/tests/hermes_cli/test_dashboard_shell_hooks.py
@@ -1,0 +1,149 @@
+"""Dashboard/serve startup registers configured shell hooks before MCP."""
+
+from __future__ import annotations
+
+import shlex
+import sys
+import types
+from argparse import Namespace
+
+import pytest
+import yaml
+
+
+def _args() -> Namespace:
+    return Namespace(
+        headless_backend=True,
+        host="127.0.0.1",
+        ignore_user_config=False,
+        insecure=False,
+        isolated=False,
+        no_open=True,
+        open_profile="",
+        port=0,
+        skip_build=False,
+        ssh_owner_nonce=None,
+        ssh_session_token_file=None,
+        status=False,
+        stop=False,
+    )
+
+
+def _wire_dashboard_boundaries(monkeypatch, main_mod, order):
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+    )
+    monkeypatch.setattr(
+        "hermes_cli.resource_limits.apply_nofile_soft_limit", lambda: None
+    )
+    monkeypatch.setattr(main_mod, "_sync_bundled_skills_quietly", lambda: None)
+    monkeypatch.setattr(
+        main_mod, "_maybe_setup_dashboard_auth_interactively", lambda _args: None
+    )
+    monkeypatch.setitem(sys.modules, "fastapi", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "uvicorn", types.SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_logging",
+        types.SimpleNamespace(setup_logging=lambda **_kwargs: None),
+    )
+    monkeypatch.setattr("hermes_cli.config.apply_terminal_config_to_env", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.start_background_mcp_discovery",
+        lambda **_kwargs: order.append("mcp"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(start_server=lambda **_kwargs: order.append("server")),
+    )
+
+
+@pytest.fixture()
+def dashboard_runtime(monkeypatch, tmp_path):
+    from agent import shell_hooks
+    from hermes_cli import main as main_mod
+    from hermes_cli import plugins
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_SAFE_MODE", raising=False)
+    monkeypatch.delenv("HERMES_ACCEPT_HOOKS", raising=False)
+
+    manager = plugins.PluginManager()
+    monkeypatch.setattr(plugins, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins, "_plugin_managers_by_home", {})
+    shell_hooks.reset_for_tests()
+    yield main_mod, plugins, manager, shell_hooks, tmp_path
+    shell_hooks.reset_for_tests()
+
+
+def test_dashboard_registers_allowlisted_hook_before_mcp_and_server(
+    dashboard_runtime, monkeypatch
+):
+    main_mod, plugins, manager, shell_hooks, home = dashboard_runtime
+    hook_script = home / "block_hook.py"
+    hook_script.write_text(
+        "import json\nprint(json.dumps({'decision': 'block', "
+        "'reason': 'blocked by dashboard hook'}))\n",
+        encoding="utf-8",
+    )
+    command = f"{shlex.quote(sys.executable)} {shlex.quote(str(hook_script))}"
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "hooks": {"pre_tool_call": [{"matcher": "terminal", "command": command}]}
+        }),
+        encoding="utf-8",
+    )
+    shell_hooks._record_approval("pre_tool_call", command)
+
+    order = []
+    _wire_dashboard_boundaries(monkeypatch, main_mod, order)
+    monkeypatch.setattr(
+        manager,
+        "_discover_and_load_inner",
+        lambda: order.append("plugins"),
+    )
+    real_register = shell_hooks.register_from_config
+
+    def recording_register(config, *, accept_hooks=False):
+        order.append(("shell-hooks", accept_hooks))
+        return real_register(config, accept_hooks=accept_hooks)
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", recording_register)
+
+    main_mod.cmd_dashboard(_args())
+
+    assert order == ["plugins", ("shell-hooks", False), "mcp", "server"]
+    assert plugins.get_plugin_manager() is manager
+    block_message = plugins.get_pre_tool_call_block_message(
+        "terminal", {"command": "echo allowed-to-reach-hook"}
+    )
+    assert block_message == "blocked by dashboard hook"
+
+
+def test_dashboard_shell_hook_registration_failure_stops_startup(
+    dashboard_runtime, monkeypatch, capsys
+):
+    main_mod, _plugins, manager, shell_hooks, _home = dashboard_runtime
+    order = []
+    _wire_dashboard_boundaries(monkeypatch, main_mod, order)
+    monkeypatch.setattr(
+        manager,
+        "_discover_and_load_inner",
+        lambda: order.append("plugins"),
+    )
+
+    def fail_registration(_config, *, accept_hooks=False):
+        assert accept_hooks is False
+        raise RuntimeError("registration exploded")
+
+    monkeypatch.setattr(shell_hooks, "register_from_config", fail_registration)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod.cmd_dashboard(_args())
+
+    assert exc_info.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "Error:" in stderr
+    assert "shell-hook registration" in stderr
+    assert order == ["plugins"]

--- a/tests/hermes_cli/test_dashboard_web_dist_validation.py
+++ b/tests/hermes_cli/test_dashboard_web_dist_validation.py
@@ -52,6 +52,11 @@ def _wire_common(main_mod, monkeypatch):
         "hermes_cli.plugins",
         types.SimpleNamespace(discover_plugins=lambda: None),
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=lambda *_a, **_k: None),
+    )
     monkeypatch.setattr(
         "hermes_cli.mcp_startup.start_background_mcp_discovery",
         lambda **_k: None,


### PR DESCRIPTION
Fixes #69825

## Root cause

`serve` (the Desktop backend) and `dashboard` share `cmd_dashboard()`, but neither enters `_prepare_agent_startup()`. The live startup path therefore discovers plugins and can start MCP plus the mutation-serving web backend without ever calling `agent.shell_hooks.register_from_config()`. Configuration diagnostics still pass because they parse config directly; they do not prove runtime registration.

## Fix

Register configured shell hooks at the runtime-owned boundary in `cmd_dashboard()`:

- after synchronous `discover_plugins()`, preserving plugin-before-shell-hook precedence;
- before dashboard MCP discovery and before `start_server()`;
- through the existing native `register_from_config(load_config(), accept_hooks=False)` primitive.

If hook policy cannot be realized, startup uses the adjacent CLI fail-closed shape: report the error on stderr and exit with code `2` before MCP discovery or socket bind.

I deliberately did **not** add `serve` or `dashboard` to `_AGENT_COMMANDS`; doing so would route lifecycle-only commands through unrelated generic startup and duplicate the dashboard-owned MCP path. This patch adds no helper, registry, retry layer, outbound-webhook behavior, or unrelated refactor.

## Regression coverage

`tests/hermes_cli/test_dashboard_shell_hooks.py` drives the real `cmd_dashboard()` entry with a temporary `HERMES_HOME`, the real config loader, real `register_from_config()`, a fresh real `PluginManager`, and an allowlisted subprocess hook. It proves that:

- the hook actually blocks a real `pre_tool_call` through the public plugin helper;
- startup order is plugins → shell hooks → MCP → server;
- consent remains delegated with `accept_hooks=False`;
- registration failure exits `2` and reaches neither MCP discovery nor server startup.

One pre-existing web-dist test fixture now stubs the newly introduced collaborator instead of letting its intentionally fake plugin module leak into the real hook parser.

## Verification

RED on unpatched current `main`:

```text
2 failed: shell-hook registration was absent and the failure path was unreachable
```

Current branch:

```text
2 passed   tests/hermes_cli/test_dashboard_shell_hooks.py
36 passed  dashboard lifecycle, unified launch, web-dist, config-guard, and MCP startup neighborhood
62 passed  existing shell-hook parser, consent, and process-tree neighborhood
1 passed   public pre-tool-call block dispatch neighborhood
Review     independent PASS; no security concerns or logic errors
Ruff       changed files clean
Format     new test clean; existing legacy drift does not overlap changed lines
git diff --check clean
```

## Concurrent refactor

If #102117 lands first, this remains a mechanical forward-port into its bounded dashboard/serve owner; the ordering and regressions stay unchanged.

---

*NL: de oude PR is opnieuw opgebouwd op actuele `main`, met een echte runtime-regressietest en zonder nieuwe infrastructuur.*
