### PR TITLE
fix(credential-pool): attribute failures to the key that failed, not the shared current() pointer (#58738 salvage)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -922,12 +922,17 @@ def recover_with_credential_pool(
             )
             return False, has_retried_429
 
-    # Capture the current API key before any rotation — needed to
-    # identify which credential actually failed when
-    # mark_exhausted_and_rotate is called.  Without this hint the
-    # pool falls back to current() or _select_unlocked(), which may
-    # return the NEXT (healthy) entry after a prior rotation, marking
-    # the wrong credential as exhausted (#43747).
+    # Attribute the failure to the API key the agent actually dispatched the
+    # request with, not to pool.current(). The current() pointer is shared,
+    # mutable state — round-robin select() advances it on every call, and
+    # concurrent turns or a second process (gateway/dashboard) reloading the
+    # pool reset it to None — so by the time recovery runs it routinely points
+    # at a DIFFERENT, healthy entry. Marking that entry exhausted copies this
+    # request's error/reset time onto it and can take the whole pool offline
+    # from a single rate-limited key (#43747). ``_swap_credential`` keeps
+    # ``agent.api_key`` in sync with the entry in use, so it identifies the
+    # failing entry exactly; fall back to current()'s key only when the agent
+    # carries no key at all.
     _api_key_hint = getattr(agent, "api_key", None) or None
     if not _api_key_hint:
         _cur = pool.current()
@@ -987,7 +992,16 @@ def recover_with_credential_pool(
         # rotate immediately. This prevents the "cancel-between-429s" trap
         # where has_retried_429 (a local var) gets reset on each new prompt,
         # causing the pool to retry the same exhausted credential forever.
-        current_entry = pool.current()
+        # Prefer the entry matching the failing key over the shared current()
+        # pointer, for the same attribution reason as above.
+        current_entry = None
+        if _api_key_hint:
+            current_entry = next(
+                (e for e in pool.entries() if e.runtime_api_key == _api_key_hint),
+                None,
+            )
+        if current_entry is None:
+            current_entry = pool.current()
         current_last_status = getattr(current_entry, "last_status", None) if current_entry else None
         if current_last_status == STATUS_EXHAUSTED:
             _ra().logger.info(
@@ -995,7 +1009,11 @@ def recover_with_credential_pool(
                 current_last_status,
             )
             rotate_status = status_code if status_code is not None else 429
-            next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, api_key_hint=_api_key_hint)
+            next_entry = pool.mark_exhausted_and_rotate(
+                status_code=rotate_status,
+                error_context=error_context,
+                api_key_hint=_api_key_hint,
+            )
             if next_entry is not None:
                 _ra().logger.info(
                     "Credential %s (rate limit, pre-exhausted) — rotated to pool entry %s",
@@ -1019,7 +1037,11 @@ def recover_with_credential_pool(
         if not has_retried_429 and not usage_limit_reached:
             return False, True
         rotate_status = status_code if status_code is not None else 429
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, api_key_hint=_api_key_hint)
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=rotate_status,
+            error_context=error_context,
+            api_key_hint=_api_key_hint,
+        )
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (rate limit) — rotated to pool entry %s",
@@ -1119,7 +1141,11 @@ def recover_with_credential_pool(
         # Refresh failed — rotate to next credential instead of giving up.
         # The failed entry is already marked exhausted by try_refresh_current().
         rotate_status = status_code if status_code is not None else 401
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, api_key_hint=_api_key_hint)
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=rotate_status,
+            error_context=error_context,
+            api_key_hint=_api_key_hint,
+        )
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (auth refresh failed) — rotated to pool entry %s",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1056,7 +1056,7 @@ def recover_with_credential_pool(
         # Subscription/entitlement 403s look like auth failures on the wire
         # but refresh cannot fix them — the OAuth token is already valid,
         # the account simply lacks the entitlement.  Without this guard,
-        # ``try_refresh_current()`` keeps minting fresh tokens against the
+        # the refresh path keeps minting fresh tokens against the
         # same unsubscribed account and the main agent loop spins re-issuing
         # the same 403 until the user Ctrl+C's.
         #
@@ -1109,9 +1109,13 @@ def recover_with_credential_pool(
                 agent.provider or "provider",
             )
             return False, has_retried_429
-        refreshed = pool.try_refresh_current()
+        # Refresh the entry that supplied the failing key, not current():
+        # the shared pointer can reference a different, healthy entry, and
+        # refreshing it would consume that entry's single-use refresh token
+        # (or mark it exhausted on failure) for a failure it never had.
+        refreshed = pool.try_refresh_matching(api_key_hint=_api_key_hint)
         if refreshed is not None:
-            # ``try_refresh_current()`` re-mints a fresh OAuth token and reports
+            # ``try_refresh_matching()`` re-mints a fresh OAuth token and reports
             # success even when the upstream keeps rejecting it — a single-entry
             # pool (common for OAuth/Max subscribers) has nothing to rotate to,
             # so a bare "refreshed → retry" loop spins forever on the same dead
@@ -1139,7 +1143,7 @@ def recover_with_credential_pool(
             agent._swap_credential(refreshed)
             return True, has_retried_429
         # Refresh failed — rotate to next credential instead of giving up.
-        # The failed entry is already marked exhausted by try_refresh_current().
+        # The failed entry is already marked exhausted by the refresh attempt.
         rotate_status = status_code if status_code is not None else 401
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=rotate_status,

--- a/contributors/emails/schattenan@kagaku.eu
+++ b/contributors/emails/schattenan@kagaku.eu
@@ -1,0 +1,1 @@
+schattenan

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -6,8 +6,12 @@ Covers:
 3. Eager fallback deferred when credential pool has credentials
 4. Eager fallback fires when no credential pool exists
 5. Full 429 rotation cycle: retry-same → rotate → exhaust → fallback
+6. Failure attribution: the entry matching the failing API key is marked
+   exhausted, not whatever pool.current() happens to point at
 """
 
+import json
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -352,3 +356,127 @@ class TestApiKeyHintRealPool:
         statuses = {e.id: e.last_status for e in pool._entries}
         assert statuses["cred-healthy"] == "exhausted"
         assert statuses["cred-failed"] in (None, "ok")
+
+
+# ---------------------------------------------------------------------------
+# 7. Failure attribution — mark the key that failed, not pool.current()
+# ---------------------------------------------------------------------------
+
+class TestFailureAttribution:
+    """Regression: recover_with_credential_pool must mark the entry whose API
+    key actually produced the failure.
+
+    pool.current() is shared mutable state: round-robin select() advances it,
+    concurrent turns move it, and a freshly loaded pool (second process) has
+    current() == None — in which case the old code fell through to
+    _select_unlocked() and exhausted the NEXT (healthy) entry, copying the
+    failing key's error/reset time onto it until the whole pool went offline.
+    """
+
+    def _make_pool(self, tmp_path, monkeypatch, entries):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "auth.json").write_text(
+            json.dumps({"version": 1, "credential_pool": {"anthropic": entries}})
+        )
+        from agent.credential_pool import load_pool
+
+        return load_pool("anthropic")
+
+    def _entry(self, idx, key, **overrides):
+        entry = {
+            "id": f"cred-{idx}",
+            "label": f"key-{idx}",
+            "auth_type": "api_key",
+            "priority": idx,
+            "source": "manual",
+            "access_token": key,
+        }
+        entry.update(overrides)
+        return entry
+
+    def _agent(self, pool, failing_key):
+        return SimpleNamespace(
+            provider="anthropic",
+            api_key=failing_key,
+            _credential_pool=pool,
+            _swap_credential=MagicMock(),
+        )
+
+    def _statuses(self, pool):
+        return {e.id: e.last_status for e in pool.entries()}
+
+    def test_billing_marks_failing_key_not_pointer(self, tmp_path, monkeypatch):
+        """Freshly loaded pool (current() is None): a 402 on key B must mark
+        entry B exhausted, not entry A (which _select_unlocked would return)."""
+        pool = self._make_pool(
+            tmp_path, monkeypatch,
+            [self._entry(0, "key-a"), self._entry(1, "key-b")],
+        )
+        assert pool.current() is None
+        agent = self._agent(pool, failing_key="key-b")
+
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=402, has_retried_429=False
+        )
+
+        assert recovered is True
+        statuses = self._statuses(pool)
+        assert statuses["cred-1"] == "exhausted"
+        assert statuses["cred-0"] != "exhausted"
+        swapped = agent._swap_credential.call_args[0][0]
+        assert swapped.id == "cred-0"
+
+    def test_rate_limit_marks_failing_key_not_pointer(self, tmp_path, monkeypatch):
+        """Same attribution for the 429 rotation path (second consecutive 429)."""
+        pool = self._make_pool(
+            tmp_path, monkeypatch,
+            [self._entry(0, "key-a"), self._entry(1, "key-b")],
+        )
+        agent = self._agent(pool, failing_key="key-b")
+
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        recovered, has_retried = recover_with_credential_pool(
+            agent, status_code=429, has_retried_429=True
+        )
+
+        assert recovered is True
+        assert has_retried is False
+        statuses = self._statuses(pool)
+        assert statuses["cred-1"] == "exhausted"
+        assert statuses["cred-0"] != "exhausted"
+
+    def test_pre_exhausted_check_uses_failing_key(self, tmp_path, monkeypatch):
+        """The 'already exhausted → rotate immediately' check must inspect the
+        failing entry, not pool.current(): first 429 on an already-exhausted
+        key rotates without burning a retry."""
+        pool = self._make_pool(
+            tmp_path, monkeypatch,
+            [
+                self._entry(0, "key-a"),
+                self._entry(
+                    1, "key-b",
+                    last_status="exhausted",
+                    last_status_at=time.time(),
+                    last_error_code=429,
+                ),
+            ],
+        )
+        agent = self._agent(pool, failing_key="key-b")
+
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        recovered, has_retried = recover_with_credential_pool(
+            agent, status_code=429, has_retried_429=False
+        )
+
+        assert recovered is True
+        assert has_retried is False
+        statuses = self._statuses(pool)
+        assert statuses["cred-0"] != "exhausted"
+        swapped = agent._swap_credential.call_args[0][0]
+        assert swapped.id == "cred-0"

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -480,3 +480,35 @@ class TestFailureAttribution:
         assert statuses["cred-0"] != "exhausted"
         swapped = agent._swap_credential.call_args[0][0]
         assert swapped.id == "cred-0"
+
+    def test_auth_refresh_targets_failing_key_not_pointer(self, tmp_path, monkeypatch):
+        """The auth path must refresh the entry that supplied the failing key,
+        not current(). With current() pointing at healthy A while key B failed,
+        try_refresh_current() force-refreshes A — for non-OAuth entries a
+        forced refresh marks the entry exhausted outright — so healthy A dies,
+        the hinted rotation then exhausts B, and the pool has nothing left."""
+        pool = self._make_pool(
+            tmp_path, monkeypatch,
+            [self._entry(0, "key-a"), self._entry(1, "key-b")],
+        )
+        # Point the shared cursor at the healthy entry, as a concurrent
+        # turn's select() would.
+        selected = pool.select()
+        assert selected.id == "cred-0"
+        assert pool.current().id == "cred-0"
+
+        agent = self._agent(pool, failing_key="key-b")
+        agent._is_entitlement_failure = MagicMock(return_value=False)
+
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=401, has_retried_429=False
+        )
+
+        assert recovered is True
+        statuses = self._statuses(pool)
+        assert statuses["cred-1"] == "exhausted"
+        assert statuses["cred-0"] != "exhausted"
+        swapped = agent._swap_credential.call_args[0][0]
+        assert swapped.id == "cred-0"

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -706,7 +706,7 @@ def test_recover_with_credential_pool_skips_refresh_on_entitlement_403():
     refresh_calls = {"n": 0}
 
     class _FakePool:
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             return MagicMock(id="should_not_be_called")
 
@@ -756,7 +756,7 @@ def test_recover_with_credential_pool_rotates_on_xai_spending_limit_403():
     class _FakePool:
         provider = "xai-oauth"
 
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             return MagicMock(id="should_not_be_called")
 
@@ -816,7 +816,7 @@ def test_recover_with_credential_pool_skips_refresh_on_bare_403_for_xai_oauth():
     refresh_calls = {"n": 0}
 
     class _FakePool:
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             return MagicMock(id="should_not_be_called")
 
@@ -857,7 +857,7 @@ def test_recover_with_credential_pool_still_refreshes_genuine_auth_failure():
     refresh_calls = {"n": 0}
 
     class _FakePool:
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             # Return a fake refreshed entry — semantically "refresh worked"
             entry = MagicMock()
@@ -1038,7 +1038,7 @@ def test_recover_with_credential_pool_refreshes_on_xai_bad_credentials_403():
     refresh_calls = {"n": 0}
 
     class _FakePool:
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             entry = MagicMock()
             entry.id = "entry_refreshed_after_stale"
@@ -1094,7 +1094,7 @@ def test_recover_with_credential_pool_still_blocks_real_entitlement():
     refresh_calls = {"n": 0}
 
     class _FakePool:
-        def try_refresh_current(self):
+        def try_refresh_matching(self, api_key_hint=None):
             refresh_calls["n"] += 1
             return MagicMock(id="should_not_be_called")
 

--- a/tests/run_agent/test_credential_pool_interrupt.py
+++ b/tests/run_agent/test_credential_pool_interrupt.py
@@ -25,7 +25,7 @@ def _make_entry(idx, **overrides):
 
 def _make_pool(entries):
     pool = MagicMock()
-    pool.entries = entries
+    pool.entries = MagicMock(return_value=entries)
     pool.current.return_value = entries[0]
     # Must be set explicitly — MagicMock.provider returns a truthy
     # child mock, which would trigger the provider-mismatch guard.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6413,6 +6413,9 @@ class TestCredentialPoolRecovery:
             def current(self):
                 return SimpleNamespace(label="primary")
 
+            def entries(self):
+                return []
+
             def mark_exhausted_and_rotate(
                 self, *, status_code, error_context=None, api_key_hint=None
             ):
@@ -6626,6 +6629,9 @@ class TestCredentialPoolRecovery:
         class _Pool:
             def current(self):
                 return SimpleNamespace(label="primary")
+
+            def entries(self):
+                return []
 
             def mark_exhausted_and_rotate(
                 self, *, status_code, error_context=None, api_key_hint=None

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6449,7 +6449,7 @@ class TestCredentialPoolRecovery:
         refreshed_entry = SimpleNamespace(label="refreshed-primary", id="abc")
 
         class _Pool:
-            def try_refresh_current(self):
+            def try_refresh_matching(self, api_key_hint=None):
                 return refreshed_entry
 
         agent._credential_pool = _Pool()
@@ -6467,7 +6467,7 @@ class TestCredentialPoolRecovery:
         """Repeated same-entry auth refreshes must eventually fall through.
 
         A single-entry OAuth pool re-mints a fresh token on every 401, so
-        ``try_refresh_current()`` reports success forever. The cap (#26080)
+        ``try_refresh_matching()`` reports success forever. The cap (#26080)
         must let the third consecutive same-entry refresh fall through
         (return not-recovered) so the fallback chain can activate instead of
         looping on the same dead credential.
@@ -6475,7 +6475,7 @@ class TestCredentialPoolRecovery:
         refreshed_entry = SimpleNamespace(label="primary", id="abc")
 
         class _Pool:
-            def try_refresh_current(self):
+            def try_refresh_matching(self, api_key_hint=None):
                 return refreshed_entry
 
         agent._credential_pool = _Pool()
@@ -6499,7 +6499,7 @@ class TestCredentialPoolRecovery:
         sequence = [entry_a, entry_a, entry_b, entry_b]
 
         class _Pool:
-            def try_refresh_current(self):
+            def try_refresh_matching(self, api_key_hint=None):
                 return sequence.pop(0)
 
         agent._credential_pool = _Pool()
@@ -6521,7 +6521,7 @@ class TestCredentialPoolRecovery:
         next_entry = SimpleNamespace(label="secondary", id="def")
 
         class _Pool:
-            def try_refresh_current(self):
+            def try_refresh_matching(self, api_key_hint=None):
                 return None  # refresh failed
 
             def mark_exhausted_and_rotate(
@@ -6548,7 +6548,7 @@ class TestCredentialPoolRecovery:
         """401 with failed refresh and no other credentials returns not recovered."""
 
         class _Pool:
-            def try_refresh_current(self):
+            def try_refresh_matching(self, api_key_hint=None):
                 return None
 
             def mark_exhausted_and_rotate(


### PR DESCRIPTION
## Summary

Salvage of #58738 by @schattenan: credential-pool failure recovery now attributes every failure to the API key that actually issued the failed request, instead of trusting the shared `pool.current()` pointer. Extends the just-merged #69553 to the two remaining `current()`-dependent sites: the pre-exhausted rate-limit check and the 401 refresh path.

Root cause: `current()` is shared mutable state — round-robin `select()` advances it, concurrent turns move it, and a second process reloading the pool resets it to `None`. By recovery time it routinely points at a different, healthy entry: the pre-exhausted check then inspects the wrong entry, and `try_refresh_current()` force-refreshes the healthy entry (consuming its single-use refresh token, or marking it exhausted outright for API-key entries) for a failure it never had.

## Changes

- `agent/agent_runtime_helpers.py` (contributor commits, cherry-picked):
  - Pre-exhausted rate-limit check resolves the entry matching the failing key via `pool.entries()` before falling back to `current()`.
  - 401 auth path uses `try_refresh_matching(api_key_hint=...)` (already on main) instead of `try_refresh_current()`, so the refresh targets the failing entry.
  - Merged with #69553's hint capture (`agent.api_key` → fallback `current().runtime_api_key`), one variable feeding all sites.
- Tests (contributor): `TestFailureAttribution` — 4 real-pool tests driving `recover_with_credential_pool()` end-to-end (402 fresh-pool attribution, 429 rotation, pre-exhausted lookup, 401 refresh targeting); `test_codex_xai_oauth_recovery.py` doubles migrated to `try_refresh_matching`.
- Tests (follow-up): `test_credential_pool_interrupt.py` pool double exposes `entries` as callable.

## Validation

| | Before | After |
|---|---|---|
| 401 on key B while `current()` is key A | Key A force-refreshed/killed, then B exhausted — pool empty | Key B refreshed/quarantined, key A keeps serving |
| Pre-exhausted check after interrupt | Inspected `current()` (wrong entry) | Inspects the failing entry |

- 611 targeted tests green across 7 files (`test_credential_pool_routing.py`, `test_run_agent.py`, `test_codex_xai_oauth_recovery.py`, `test_fallback_credential_isolation.py`, `test_credential_pool_interrupt.py`, `test_switch_model_pool_reload_52727.py`, `test_credential_pool.py`).
- Live E2E with real pools in a temp `HERMES_HOME`: 402 fresh-pool (current()=None) quarantines the failing key; 401 with current() on the healthy key refreshes/quarantines only the failing key and swaps to the healthy one.

Complements #69553 / #69494 (both halves of #43747). Closes #58738's scope.

## Credit

Both substantive commits by @schattenan (#58738), cherry-picked with authorship preserved. Conflict resolution + one test-double follow-up on top.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa35bf1/nyvRZxfsZxEPcfolAEGwS_WCVyG1EC.png)
