### PR TITLE
fix(desktop): harden canonical Windows backend startup

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3494,39 +3494,46 @@ function uploadLocalWindowsSessionTokenFile(backend, token) {
 
   const ownershipId = crypto.randomBytes(16).toString('hex')
   const spawnNonce = crypto.randomBytes(8).toString('hex')
-  const output = execFileSync(
-    backend.command,
-    ['-m', 'hermes_cli.windows_ssh_runtime', 'upload-token', ownershipId, spawnNonce],
-    hiddenWindowsChildOptions({
-      cwd: backend.root || resolveHermesCwd(),
-      env: {
-        ...process.env,
-        HERMES_HOME,
-        ...backend.env
-      },
-      input: token,
-      encoding: 'utf8',
-      timeout: 10_000,
-      stdio: ['pipe', 'pipe', 'pipe']
-    })
-  )
-  const lines = String(output || '')
-    .replace(/^\uFEFF/, '')
-    .trim()
-    .split(/\r?\n/)
-    .filter(Boolean)
-  const parsed = JSON.parse(lines[lines.length - 1] || 'null')
+  try {
+    const output = execFileSync(
+      backend.command,
+      ['-m', 'hermes_cli.windows_ssh_runtime', 'upload-token', ownershipId, spawnNonce],
+      hiddenWindowsChildOptions({
+        cwd: backend.root || resolveHermesCwd(),
+        env: {
+          ...process.env,
+          HERMES_HOME,
+          ...backend.env
+        },
+        input: token,
+        encoding: 'utf8',
+        timeout: 10_000,
+        stdio: ['pipe', 'pipe', 'pipe']
+      })
+    )
+    const lines = String(output || '')
+      .replace(/^\uFEFF/, '')
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+    const parsed = JSON.parse(lines[lines.length - 1] || 'null')
 
-  if (!parsed?.path || typeof parsed.path !== 'string') {
-    throw new Error('Hermes did not return a Windows session token file path.')
-  }
+    if (!parsed?.path || typeof parsed.path !== 'string') {
+      throw new Error('Hermes did not return a Windows session token file path.')
+    }
 
-  rememberLog('[boot] Using Windows one-shot session token file for local Hermes backend')
+    rememberLog('[boot] Using Windows one-shot session token file for local Hermes backend')
 
-  return {
-    path: parsed.path,
-    ownershipId,
-    spawnNonce
+    return {
+      path: parsed.path,
+      ownershipId,
+      spawnNonce
+    }
+  } catch {
+    // A newer Desktop can briefly launch against an older CLI during update
+    // handoff. Keep startup compatible by using the process-local env token.
+    rememberLog('[boot] Windows one-shot session token helper unavailable; using process-local token')
+    return null
   }
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2820,7 +2820,7 @@ async function handOffWindowsBootstrapRecovery(reason) {
 // Resolve the hermes CLI to drive an in-app update: prefer the venv shim in
 // the install we're updating, fall back to `hermes` on PATH.
 function resolveHermesCliBinary(updateRoot) {
-  const venvHermes = path.join(updateRoot, 'venv', 'bin', 'hermes')
+  const venvHermes = venvHermesShimPath(updateRoot)
 
   if (fileExists(venvHermes)) {
     return venvHermes
@@ -3483,6 +3483,79 @@ function createActiveBackend(backendArgs) {
   }
 }
 
+function backendUsesHeadlessServe(backend) {
+  return Array.isArray(backend?.args) && backend.args.includes('serve')
+}
+
+function uploadLocalWindowsSessionTokenFile(backend, token) {
+  if (!IS_WINDOWS || !backendUsesHeadlessServe(backend)) {
+    return null
+  }
+
+  const ownershipId = crypto.randomBytes(16).toString('hex')
+  const spawnNonce = crypto.randomBytes(8).toString('hex')
+  const output = execFileSync(
+    backend.command,
+    ['-m', 'hermes_cli.windows_ssh_runtime', 'upload-token', ownershipId, spawnNonce],
+    hiddenWindowsChildOptions({
+      cwd: backend.root || resolveHermesCwd(),
+      env: {
+        ...process.env,
+        HERMES_HOME,
+        ...backend.env
+      },
+      input: token,
+      encoding: 'utf8',
+      timeout: 10_000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+  )
+  const lines = String(output || '')
+    .replace(/^\uFEFF/, '')
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+  const parsed = JSON.parse(lines[lines.length - 1] || 'null')
+
+  if (!parsed?.path || typeof parsed.path !== 'string') {
+    throw new Error('Hermes did not return a Windows session token file path.')
+  }
+
+  rememberLog('[boot] Using Windows one-shot session token file for local Hermes backend')
+
+  return {
+    path: parsed.path,
+    ownershipId,
+    spawnNonce
+  }
+}
+
+function removeLocalWindowsSessionTokenFile(backend, tokenFile) {
+  if (!IS_WINDOWS || !tokenFile) {
+    return
+  }
+
+  try {
+    execFileSync(
+      backend.command,
+      ['-m', 'hermes_cli.windows_ssh_runtime', 'remove-token', tokenFile.ownershipId, tokenFile.spawnNonce],
+      hiddenWindowsChildOptions({
+        cwd: backend.root || resolveHermesCwd(),
+        env: {
+          ...process.env,
+          HERMES_HOME,
+          ...backend.env
+        },
+        stdio: 'ignore',
+        timeout: 10_000
+      })
+    )
+  } catch {
+    // Best effort only. If the backend consumed the file, Windows deletes it on
+    // close; if startup failed before read, the next helper cleanup can remove it.
+  }
+}
+
 function resolveHermesBackend(backendArgs) {
   // 1. Explicit override -- HERMES_DESKTOP_HERMES_ROOT points at a developer
   //    checkout. Honour it as-is (no bootstrap; the user is driving).
@@ -3508,13 +3581,20 @@ function resolveHermesBackend(backendArgs) {
     }
   }
 
-  // 3. Bootstrap-complete ACTIVE_HERMES_ROOT -- the canonical install at
+  // 3. Usable ACTIVE_HERMES_ROOT -- the canonical install at
   //    %LOCALAPPDATA%\hermes\hermes-agent (Windows) or ~/.hermes/hermes-agent.
-  //    The bootstrap marker means install.ps1 stages finished and the user
-  //    completed initial configuration; we trust the install and go straight
-  //    to spawning hermes. Updates flow through the in-app update path
-  //    (applyUpdates -> git pull) or `hermes update` from the CLI.
-  if (isBootstrapComplete()) {
+  //    Prefer this before any `hermes` found on PATH, even when the desktop
+  //    bootstrap marker is missing. A CLI-installed or marker-lost but runnable
+  //    active install is still the install we own; falling through to PATH can
+  //    select a stale shim and trigger a needless bootstrap/update loop.
+  const bootstrapComplete = isBootstrapComplete()
+  const activeRuntimeUsable = bootstrapComplete || isActiveRuntimeUsable()
+
+  if (activeRuntimeUsable) {
+    if (!bootstrapComplete) {
+      rememberLog('[boot] Using active Hermes install without bootstrap marker; runtime probe passed')
+    }
+
     return createActiveBackend(backendArgs)
   }
 
@@ -4668,6 +4748,23 @@ async function waitForHermes(baseUrl, token, signal?) {
   }
 
   throw new Error(`Hermes backend did not become ready: ${lastError?.message || 'timeout'}`)
+}
+
+async function assertHermesWebSocketReady(wsUrl, label) {
+  if (typeof globalThis.WebSocket !== 'function') {
+    throw new Error(`${label} cannot verify /api/ws because WebSocket is unavailable in the Electron main process.`)
+  }
+
+  const probe = await probeGatewayWebSocket(wsUrl, { WebSocketImpl: globalThis.WebSocket })
+
+  if (!probe.ok) {
+    throw new Error(
+      `${label} passed HTTP readiness, but /api/ws rejected the Desktop session: ` +
+        `${probe.reason || 'unknown WebSocket failure'}`
+    )
+  }
+
+  rememberLog(`[boot] ${label} WebSocket probe succeeded`)
 }
 
 function getWindowButtonPosition() {
@@ -7592,7 +7689,7 @@ async function spawnPoolBackend(profile, entry) {
     }
   }
 
-  const token = crypto.randomBytes(32).toString('base64url')
+  const token = crypto.randomBytes(32).toString('hex')
   // --profile wins over the inherited HERMES_HOME env (see _apply_profile_override
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
   // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
@@ -7600,6 +7697,16 @@ async function spawnPoolBackend(profile, entry) {
   const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
   backend.args = getBackendArgsForRuntime(backend)
+  const localTokenFile = uploadLocalWindowsSessionTokenFile(backend, token)
+
+  if (localTokenFile) {
+    backend.args.push(
+      '--ssh-session-token-file',
+      localTokenFile.path,
+      '--ssh-owner-nonce',
+      localTokenFile.spawnNonce
+    )
+  }
   const hermesCwd = resolveHermesCwd()
   const webDist = resolveWebDist()
   const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
@@ -7645,11 +7752,15 @@ async function spawnPoolBackend(profile, entry) {
   })
 
   child.once('error', error => {
+    removeLocalWindowsSessionTokenFile(backend, localTokenFile)
     rememberLog(`Hermes backend for profile "${profile}" failed to start: ${error.message}`)
     backendPool.delete(profile)
     rejectStart?.(error)
   })
   child.once('exit', (code, signal) => {
+    if (!ready) {
+      removeLocalWindowsSessionTokenFile(backend, localTokenFile)
+    }
     rememberLog(`Hermes backend for profile "${profile}" exited (${signal || code})`)
     backendPool.delete(profile)
 
@@ -7671,7 +7782,6 @@ async function spawnPoolBackend(profile, entry) {
 
   const baseUrl = `http://127.0.0.1:${port}`
   await Promise.race([waitForHermes(baseUrl, token), startFailed])
-  ready = true
 
   const authToken = await adoptServedDashboardToken(baseUrl, token, {
     childAlive: () => child.exitCode === null && !child.killed,
@@ -7679,6 +7789,12 @@ async function spawnPoolBackend(profile, entry) {
     rememberLog
   })
 
+  const wsUrl = `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`
+  await Promise.race([
+    assertHermesWebSocketReady(wsUrl, `Hermes backend for profile "${profile}"`),
+    startFailed
+  ])
+  ready = true
   entry.token = authToken
 
   return {
@@ -7688,7 +7804,7 @@ async function spawnPoolBackend(profile, entry) {
     authMode: 'token',
     token: authToken,
     profile,
-    wsUrl: `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`,
+    wsUrl,
     logs: hermesLog.slice(-80),
     ...getWindowState()
   }
@@ -7839,7 +7955,7 @@ async function startHermes() {
     // connections returned above and never touch the install tree.
     await waitForUpdateToFinish()
 
-    const token = crypto.randomBytes(32).toString('base64url')
+    const token = crypto.randomBytes(32).toString('hex')
     // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
     const backendArgs = ['serve', '--host', '127.0.0.1', '--port', '0']
     // Pin the desktop's chosen profile via the global --profile flag. This is
@@ -7857,6 +7973,16 @@ async function startHermes() {
     const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
     // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
     backend.args = getBackendArgsForRuntime(backend)
+    const localTokenFile = uploadLocalWindowsSessionTokenFile(backend, token)
+
+    if (localTokenFile) {
+      backend.args.push(
+        '--ssh-session-token-file',
+        localTokenFile.path,
+        '--ssh-owner-nonce',
+        localTokenFile.spawnNonce
+      )
+    }
     const hermesCwd = resolveHermesCwd()
     const webDist = resolveWebDist()
     const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
@@ -7897,6 +8023,7 @@ async function startHermes() {
     const processOwner = backendConnectionState.attachProcess(connectionAttempt, hermesProcess)
 
     if (!processOwner) {
+      removeLocalWindowsSessionTokenFile(backend, localTokenFile)
       stopBackendChild(hermesProcess)
       throw new Error('Hermes backend start was superseded by a newer connection attempt.')
     }
@@ -7911,6 +8038,7 @@ async function startHermes() {
     })
 
     hermesProcess.once('error', error => {
+      removeLocalWindowsSessionTokenFile(backend, localTokenFile)
       if (!backendConnectionState.clearForCurrentProcess(processOwner)) {
         rememberLog(`Ignoring stale Hermes backend error: ${error.message}`)
         rejectBackendStart?.(new Error('Hermes backend start was superseded by a newer connection attempt.'))
@@ -7932,6 +8060,9 @@ async function startHermes() {
       rejectBackendStart?.(error)
     })
     hermesProcess.once('exit', (code, signal) => {
+      if (!backendReady) {
+        removeLocalWindowsSessionTokenFile(backend, localTokenFile)
+      }
       if (!backendConnectionState.clearForCurrentProcess(processOwner)) {
         rememberLog(`Ignoring stale Hermes backend exit (${signal || code})`)
 
@@ -7979,13 +8110,16 @@ async function startHermes() {
     const baseUrl = `http://127.0.0.1:${port}`
     await advanceBootProgress('backend.wait', 'Waiting for Hermes backend to become ready', 90)
     await Promise.race([waitForHermes(baseUrl, token), backendStartFailed])
-    backendReady = true
-    backendStartFailure = null
 
     const authToken = await adoptServedDashboardToken(baseUrl, token, {
       childAlive: () => hermesProcess.exitCode === null && !hermesProcess.killed,
       rememberLog
     })
+
+    const wsUrl = `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`
+    await Promise.race([assertHermesWebSocketReady(wsUrl, 'Hermes backend'), backendStartFailed])
+    backendReady = true
+    backendStartFailure = null
 
     updateBootProgress({
       phase: 'backend.ready',
@@ -8001,7 +8135,7 @@ async function startHermes() {
       source: 'local',
       authMode: 'token',
       token: authToken,
-      wsUrl: `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`,
+      wsUrl,
       logs: hermesLog.slice(-80),
       ...getWindowState()
     }

--- a/apps/desktop/electron/windows-hermes-path.test.ts
+++ b/apps/desktop/electron/windows-hermes-path.test.ts
@@ -168,13 +168,14 @@ test('getVenvSitePackagesEntries: returns empty on Windows when site-packages do
 })
 
 test('getVenvSitePackagesEntries: reads pyvenv.cfg version on POSIX and resolves lib/pythonX.Y/site-packages', () => {
+  const expected = path.join('/venv', 'lib', 'python3.12', 'site-packages')
   const result = getVenvSitePackagesEntries('/venv', {
     isWindows: false,
-    directoryExists: p => p === '/venv/lib/python3.12/site-packages',
+    directoryExists: p => p === expected,
     readFile: () => 'version_info = 3.12.1\n'
   })
 
-  assert.deepEqual(result, ['/venv/lib/python3.12/site-packages'])
+  assert.deepEqual(result, [expected])
 })
 
 test('getVenvSitePackagesEntries: returns empty on POSIX when pyvenv.cfg is missing', () => {

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -18,6 +18,12 @@ from utils import atomic_replace, fast_safe_load
 # pure ASCII (they become HTTP header values).
 _CREDENTIAL_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_KEY")
 
+# Process-owned credentials are minted for one runtime and must never be
+# sourced from a persistent .env file. Desktop supplies this token when it
+# launches the local backend; allowing the user's .env to overwrite it splits
+# HTTP/WS authentication between two different credentials.
+_PROCESS_OWNED_ENV_KEYS = frozenset({"HERMES_DASHBOARD_SESSION_TOKEN"})
+
 # Names we've already warned about during this process, so repeated
 # load_hermes_dotenv() calls (user env + project env, gateway hot-reload,
 # tests) don't spam the same warning multiple times.
@@ -173,10 +179,21 @@ def _sanitize_loaded_credentials() -> None:
 
 
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
+    process_owned = {
+        key: (key in os.environ, os.environ.get(key))
+        for key in _PROCESS_OWNED_ENV_KEYS
+    }
     try:
-        load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
-    except UnicodeDecodeError:
-        load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+        try:
+            load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
+        except UnicodeDecodeError:
+            load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+    finally:
+        for key, (was_present, value) in process_owned.items():
+            if was_present:
+                os.environ[key] = value or ""
+            else:
+                os.environ.pop(key, None)
     # Strip non-ASCII characters from credential env vars that were just
     # loaded.  API keys must be pure ASCII since they're sent as HTTP
     # header values (httpx encodes headers as ASCII).  Non-ASCII chars

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -20,6 +20,36 @@ def test_user_env_overrides_stale_shell_values(tmp_path, monkeypatch):
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
 
 
+def test_user_env_cannot_override_process_owned_dashboard_token(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text(
+        "HERMES_DASHBOARD_SESSION_TOKEN=persisted-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "desktop-token")
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("HERMES_DASHBOARD_SESSION_TOKEN") == "desktop-token"
+
+
+def test_user_env_does_not_create_process_owned_dashboard_token(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text(
+        "HERMES_DASHBOARD_SESSION_TOKEN=persisted-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("HERMES_DASHBOARD_SESSION_TOKEN", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert "HERMES_DASHBOARD_SESSION_TOKEN" not in os.environ
+
+
 def test_project_env_overrides_stale_shell_values_when_user_env_missing(tmp_path, monkeypatch):
     home = tmp_path / "hermes"
     project_env = tmp_path / ".env"


### PR DESCRIPTION
## Summary
- resolve the updater CLI from the canonical Windows `venv\Scripts\hermes.exe`
- accept a runnable canonical install even when the Desktop bootstrap marker is missing
- hand local `hermes serve` an ACL-protected one-shot token file and prevent persistent `.env` values from replacing the process-owned token
- fall back to the existing process-local token when a newer Desktop briefly encounters an older CLI without the token-file helper
- require an authenticated `/api/ws` probe before declaring the backend ready

## Why
On Windows, the old POSIX updater path skipped the installed CLI, a missing marker could send a healthy install back through bootstrap, and HTTP readiness could succeed even when Desktop and the backend disagreed about the session token. The result was repeated repair/update loops or a visible "Could not connect to Hermes gateway" failure despite a listening backend.

## Verification
- `uv run --isolated --extra dev pytest -q tests/hermes_cli/test_env_loader.py` (19 passed)
- focused Electron matrix before the compatibility follow-up: 70 passed
- post-review Desktop TypeScript typecheck: passed
- post-review Electron project on native Windows: 675 passed, 2 skipped, 18 existing POSIX-path/permission failures
- focused Ruff and `compileall`: passed
- `git diff --check`: passed

A broader web-server selection reached 489 passes and 25 skips but also hit four existing Windows machine-isolation failures involving host Honcho config and inherited temp-directory ACLs; those files are unchanged here.