### PR TITLE
fix(windows): resolve active profile home and architecture

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3358,6 +3358,12 @@ async def get_system_stats():
     """
     import platform as _platform
 
+    architecture = (
+        _platform.machine()
+        or os.environ.get("PROCESSOR_ARCHITEW6432")
+        or os.environ.get("PROCESSOR_ARCHITECTURE")
+        or "unknown"
+    )
     info: Dict[str, Any] = {
         **_display_system_platform(
             system=_platform.system(),
@@ -3365,7 +3371,7 @@ async def get_system_stats():
             version=_platform.version(),
             platform_label=_platform.platform(),
         ),
-        "arch": _platform.machine(),
+        "arch": architecture,
         "hostname": _platform.node(),
         "python_version": _platform.python_version(),
         "python_impl": _platform.python_implementation(),

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -152,6 +152,14 @@ def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
 T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+_IMPORT_DEFAULT_DB_PATH = DEFAULT_DB_PATH
+
+
+def _resolve_default_db_path() -> Path:
+    """Resolve the active home while preserving explicit legacy overrides."""
+    if DEFAULT_DB_PATH != _IMPORT_DEFAULT_DB_PATH:
+        return DEFAULT_DB_PATH
+    return get_hermes_home() / "state.db"
 
 SCHEMA_VERSION = 23
 
@@ -1421,7 +1429,7 @@ class SessionDB:
     _IMPORT_MAX_TOTAL_BYTES = 25 * 1024 * 1024
 
     def __init__(self, db_path: Path = None, read_only: bool = False):
-        self.db_path = db_path or DEFAULT_DB_PATH
+        self.db_path = db_path if db_path is not None else _resolve_default_db_path()
         self.read_only = read_only
 
         self._lock = threading.Lock()

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -653,6 +653,20 @@ class TestSystemStatsEndpoint:
         # psutil flag tells the UI whether the richer metrics are populated.
         assert "psutil" in s
 
+    def test_stats_architecture_uses_windows_environment_fallback(
+        self, monkeypatch
+    ):
+        import platform
+
+        monkeypatch.setattr(platform, "machine", lambda: "")
+        monkeypatch.setenv("PROCESSOR_ARCHITEW6432", "ARM64")
+        monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "AMD64")
+
+        r = self.client.get("/api/system/stats")
+
+        assert r.status_code == 200
+        assert r.json()["arch"] == "ARM64"
+
 
 class TestCuratorEndpoints:
     @pytest.fixture(autouse=True)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -77,6 +77,28 @@ def db(tmp_path):
     session_db.close()
 
 
+def test_implicit_path_resolves_active_home_at_construction(tmp_path, monkeypatch):
+    active_home = tmp_path / "active-home"
+    monkeypatch.setenv("HERMES_HOME", str(active_home))
+
+    session_db = SessionDB()
+    try:
+        assert session_db.db_path == active_home / "state.db"
+    finally:
+        session_db.close()
+
+
+def test_implicit_path_preserves_explicit_default_override(tmp_path, monkeypatch):
+    overridden_path = tmp_path / "overridden.db"
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", overridden_path)
+
+    session_db = SessionDB()
+    try:
+        assert session_db.db_path == overridden_path
+    finally:
+        session_db.close()
+
+
 # =========================================================================
 # Session lifecycle
 # =========================================================================
@@ -7155,4 +7177,3 @@ class TestLoneSurrogatePersistence:
         db.create_session("s1", source="cli")
         assert db.set_session_title("s1", "title \ud835 bad") is True
         assert db.get_session("s1")["title"] == "title \ufffd bad"
-


### PR DESCRIPTION
## Summary
- resolve the implicit `SessionDB()` path from the active `HERMES_HOME` at construction time
- preserve the existing `DEFAULT_DB_PATH` override seam used by tests and embedders
- report Windows architecture from `PROCESSOR_ARCHITEW6432` / `PROCESSOR_ARCHITECTURE` when `platform.machine()` is empty

## Why
Profile selection can change `HERMES_HOME` after `hermes_state` is imported. Freezing the default database path at import time can then write sessions to the wrong profile. Separately, some Windows Python environments return an empty machine architecture even though the process architecture variables are populated.

## Verification
- 558 state/gateway tests passed
- 3 focused home/architecture regressions passed
- Ruff passed
- `compileall` passed
- `git diff --check` passed