### PR TITLE
fix(desktop): refresh auxiliary model catalog on demand

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -29,7 +29,7 @@ let profileSwitchHandler: (() => void) | null = null
 
 vi.mock('@/hermes', () => ({
   getGlobalModelInfo: () => getGlobalModelInfo(),
-  getGlobalModelOptions: () => getGlobalModelOptions(),
+  getGlobalModelOptions: (options?: unknown) => getGlobalModelOptions(options),
   getAuxiliaryModels: () => getAuxiliaryModels(),
   getMoaModels: () => getMoaModels(),
   setModelAssignment: (body: unknown) => setModelAssignment(body),
@@ -250,6 +250,50 @@ describe('ModelSettings', () => {
 
     expect(await screen.findByText('Vision')).toBeTruthy()
     expect(screen.getAllByText('auto · use main model').length).toBeGreaterThan(0)
+  })
+
+  it('refreshes the provider catalog before choosing an auxiliary model', async () => {
+    getGlobalModelOptions
+      .mockResolvedValueOnce({
+        providers: [
+          {
+            name: 'Local Gateway',
+            slug: 'custom:work',
+            models: ['cached-model'],
+            authenticated: true,
+            is_user_defined: true
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        providers: [
+          {
+            name: 'Local Gateway',
+            slug: 'custom:work',
+            models: ['cached-model', 'live-model'],
+            authenticated: true,
+            is_user_defined: true
+          }
+        ]
+      })
+    getAuxiliaryModels.mockResolvedValueOnce({
+      main: { provider: 'nous', model: 'hermes-4' },
+      tasks: [{ task: 'vision', provider: 'custom:work', model: 'cached-model', base_url: '' }]
+    })
+
+    await renderModelSettings()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refresh Models' }))
+
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalledWith({ refresh: true }))
+
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Change' }))[0])
+
+    const auxiliaryModelSelect = screen.getAllByRole('combobox').at(-1)
+    expect(auxiliaryModelSelect).toBeTruthy()
+    fireEvent.click(auxiliaryModelSelect!)
+
+    expect(await screen.findByRole('option', { name: 'live-model' })).toBeTruthy()
   })
 
   it('assigns an auxiliary task to the main model via setModelAssignment', async () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -208,6 +208,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   const [applying, setApplying] = useState(false)
   const [editingAuxTask, setEditingAuxTask] = useState<null | string>(null)
   const [auxDraft, setAuxDraft] = useState<{ model: string; provider: string }>({ model: '', provider: '' })
+  const [refreshingAuxiliaryModels, setRefreshingAuxiliaryModels] = useState(false)
   // Aux slots reported stale by the backend immediately after a main-model
   // switch (provider differs from the new main). Cleared on next switch/reset.
   const [switchStaleAux, setSwitchStaleAux] = useState<StaleAuxAssignment[]>([])
@@ -292,6 +293,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     setSelectedProvider('')
     setSelectedModel('')
     setApiKeyDraft('')
+    setRefreshingAuxiliaryModels(false)
     void refresh({ replaceSelection: true })
   })
 
@@ -700,6 +702,30 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     [auxiliary, mainModel]
   )
 
+  const refreshAuxiliaryModelOptions = useCallback(async () => {
+    const epoch = profileEpoch.current
+    setRefreshingAuxiliaryModels(true)
+    setError('')
+
+    try {
+      const modelOptions = await getGlobalModelOptions({ refresh: true })
+
+      if (profileEpoch.current !== epoch) {
+        return
+      }
+
+      setProviders(modelOptions.providers || [])
+    } catch (err) {
+      if (profileEpoch.current === epoch) {
+        setError(err instanceof Error ? err.message : String(err))
+      }
+    } finally {
+      if (profileEpoch.current === epoch) {
+        setRefreshingAuxiliaryModels(false)
+      }
+    }
+  }, [])
+
   const resetAuxiliaryModels = useCallback(async () => {
     if (!mainModel) {
       return
@@ -858,14 +884,25 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       <section>
         <div className="mb-2.5 flex items-center justify-between">
           <SectionHeading icon={Cpu} title={m.auxiliaryTitle} />
-          <Button
-            disabled={!mainModel || applying}
-            onClick={() => void resetAuxiliaryModels()}
-            size="sm"
-            variant="textStrong"
-          >
-            {m.resetAllToMain}
-          </Button>
+          <div className="flex items-center gap-1.5">
+            <Button
+              disabled={loading || applying || refreshingAuxiliaryModels}
+              onClick={() => void refreshAuxiliaryModelOptions()}
+              size="sm"
+              variant="text"
+            >
+              {refreshingAuxiliaryModels && <Loader2 className="animate-spin" />}
+              {t.shell.modelMenu.refreshModels}
+            </Button>
+            <Button
+              disabled={!mainModel || applying || refreshingAuxiliaryModels}
+              onClick={() => void resetAuxiliaryModels()}
+              size="sm"
+              variant="textStrong"
+            >
+              {m.resetAllToMain}
+            </Button>
+          </div>
         </div>
         <p className="mb-2 text-xs text-muted-foreground">{m.auxiliaryDesc}</p>
         {switchStaleAux.length === 0 && persistentStaleAux.length > 0 && (


### PR DESCRIPTION
## What does this PR do?

Desktop Settings loads the model catalog without a live refresh, and the Auxiliary Models selectors reuse that catalog. A non-current custom provider can therefore show only its cached or configured models, with no Auxiliary action that asks the backend to discover its current catalog.

This adds an explicit `Refresh Models` action to the Auxiliary Models section. The action uses the existing `getGlobalModelOptions({ refresh: true })` boundary, so live custom-provider probing remains user-driven instead of slowing every ordinary Settings load. It also guards the response with the active profile epoch so a refresh started under one profile cannot repaint another profile after a switch.

## Related Issue

Reported in [Discord support](https://discord.com/channels/1053877538025386074/1529386853436751982). No GitHub issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add an explicit Auxiliary Models catalog refresh action in `apps/desktop/src/app/settings/model-settings.tsx`.
- Reuse the backend's bounded `refresh=true` path rather than probing custom endpoints on every Settings load.
- Discard a refresh response if the active profile changes while it is in flight.
- Add a behavioral regression test proving that a live-discovered model becomes selectable after refresh.

## How to Test

1. Configure a custom provider whose live endpoint exposes a model that is not present in the currently loaded catalog.
2. Open Desktop Settings → Models and use `Refresh Models` in the Auxiliary Models section.
3. Edit an auxiliary task and confirm the newly discovered model is selectable.

Focused validation run on Windows 11:

`npx vitest run src/app/settings/model-settings.test.tsx`

`tsc -p . --noEmit`

`eslint src/app/settings/model-settings.tsx src/app/settings/model-settings.test.tsx`

`prettier --check src/app/settings/model-settings.tsx src/app/settings/model-settings.test.tsx`

`python scripts/check-windows-footguns.py --diff origin/main`

The focused Vitest file passed all 17 tests. The renderer TypeScript check, targeted ESLint, Prettier check, diff check, and Windows-footgun check also passed. Full-suite validation is left to GitHub CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, focused Desktop tests and static checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. The regression is covered by the focused Desktop behavior test described above.
