### PR TITLE
fix(windows): hide console flashes in GUI-reachable exec paths and provider transports (#56747)

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -503,6 +503,10 @@ class CopilotACPClient:
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
         try:
+            # Hide the console the CLI child would otherwise flash on Windows
+            # (#56747). Hide-only — stdio pipes stay intact for the ACP wire.
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
             proc = subprocess.Popen(
                 [self._acp_command] + self._acp_args,
                 stdin=subprocess.PIPE,
@@ -512,6 +516,7 @@ class CopilotACPClient:
                 bufsize=1,
                 cwd=self._acp_cwd,
                 env=_build_subprocess_env(),
+                creationflags=windows_hide_flags(),
             )
         except FileNotFoundError as exc:
             raise RuntimeError(

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -127,6 +127,10 @@ class CodexAppServerClient:
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.
         spawn_env.setdefault("RUST_LOG", "warn")
 
+        # Hide the console the codex child would otherwise flash on Windows
+        # (#56747). Hide-only — stdio pipes stay intact for the app-server wire.
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         self._proc = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -134,6 +138,7 @@ class CodexAppServerClient:
             stderr=subprocess.PIPE,
             bufsize=0,
             env=spawn_env,
+            creationflags=windows_hide_flags(),
         )
         self._next_id = 1
         self._pending: dict[int, _Pending] = {}

--- a/cli.py
+++ b/cli.py
@@ -9374,9 +9374,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             # has all API keys in os.environ.
                             from tools.environments.local import _sanitize_subprocess_env
                             sanitized_env = _sanitize_subprocess_env(os.environ.copy())
+                            from hermes_cli._subprocess_compat import windows_hide_flags
                             result = subprocess.run(
                                 exec_cmd, shell=True, capture_output=True,
-                                text=True, timeout=30, env=sanitized_env
+                                text=True, timeout=30, env=sanitized_env,
+                                # No console flash on Windows (#56747).
+                                creationflags=windows_hide_flags(),
                             )
                             output = result.stdout.strip() or result.stderr.strip()
                             if output:

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -653,3 +653,187 @@ def test_tui_slash_worker_hides_python_window(monkeypatch):
 
     assert captured[0][0][:3] == [server.sys.executable, "-m", "tui_gateway.slash_worker"]
     assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW
+
+
+# ── #56747 GUI-reachable exec paths + provider transports (PR #56877) ──────
+#
+# These six sites are the desktop-GUI-reachable spawns that still flashed a
+# console on Windows after the #54220 sweep: the TUI gateway's cli.exec /
+# shell.exec / quick-command exec RPCs, the interactive CLI's quick-command
+# exec handler, and the Copilot ACP + Codex app-server stdio transports.
+# All are hide-only (creationflags) — PIPE stdio must stay intact.
+
+
+def _patch_hide_flags(monkeypatch):
+    import hermes_cli._subprocess_compat as subprocess_compat
+
+    monkeypatch.setattr(subprocess_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(subprocess_compat, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+
+
+def test_tui_cli_exec_rpc_hides_python_window(monkeypatch):
+    from tui_gateway import server
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="hermes 0.0-test\n")
+
+    _patch_hide_flags(monkeypatch)
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "cli.exec", "params": {"argv": ["version"]}}
+    )
+    assert resp["result"]["code"] == 0
+
+    spawns = _spawns(captured, "hermes_cli.main")
+    assert len(spawns) == 1, captured
+    cmd, kwargs = spawns[0]
+    assert cmd[:3] == [server.sys.executable, "-m", "hermes_cli.main"]
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_tui_shell_exec_rpc_hides_console_window(monkeypatch):
+    from tui_gateway import server
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="ok\n")
+
+    _patch_hide_flags(monkeypatch)
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+
+    resp = server.handle_request(
+        {"id": "2", "method": "shell.exec", "params": {"command": "echo shellexec-56747"}}
+    )
+    assert resp["result"]["code"] == 0
+
+    spawns = _spawns(captured, "shellexec-56747")
+    assert len(spawns) == 1, captured
+    assert spawns[0][1]["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_tui_quick_command_exec_hides_console_window(monkeypatch):
+    from tui_gateway import server
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="qc ok\n")
+
+    _patch_hide_flags(monkeypatch)
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"quick_commands": {"qtest": {"type": "exec", "command": "echo qc-56747"}}},
+    )
+
+    resp = server.handle_request(
+        {"id": "3", "method": "command.dispatch", "params": {"name": "qtest"}}
+    )
+    assert resp["result"]["type"] == "exec"
+
+    spawns = _spawns(captured, "qc-56747")
+    assert len(spawns) == 1, captured
+    assert spawns[0][1]["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_cli_quick_command_exec_hides_console_window(monkeypatch):
+    import cli as cli_mod
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="qc ok\n")
+
+    _patch_hide_flags(monkeypatch)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    inst = object.__new__(cli_mod.HermesCLI)
+    inst.config = {"quick_commands": {"qtest": {"type": "exec", "command": "echo cli-qc-56747"}}}
+    inst._pending_resume_sessions = None
+    inst._console_print = lambda *a, **k: None
+
+    assert inst.process_command("/qtest") is True
+
+    spawns = _spawns(captured, "cli-qc-56747")
+    assert len(spawns) == 1, captured
+    assert spawns[0][1]["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_copilot_acp_transport_hides_console_window(monkeypatch):
+    from agent import copilot_acp_client
+
+    captured = []
+
+    class _FakeProc:
+        stdin = None
+        stdout = None
+
+        def kill(self):
+            pass
+
+    def fake_popen(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _FakeProc()
+
+    _patch_hide_flags(monkeypatch)
+    monkeypatch.setattr(copilot_acp_client.subprocess, "Popen", fake_popen)
+
+    client = copilot_acp_client.CopilotACPClient(
+        acp_command="copilot-acp-test", acp_args=["--stdio"]
+    )
+    # stdin/stdout None → the transport raises after spawn; the spawn contract
+    # is what's under test here.
+    try:
+        client._run_prompt("hi", timeout_seconds=1.0)
+    except RuntimeError:
+        pass
+
+    assert len(captured) == 1, captured
+    cmd, kwargs = captured[0]
+    assert cmd == ["copilot-acp-test", "--stdio"]
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+    # Hide-only: the ACP wire still needs its pipes.
+    assert kwargs["stdin"] == subprocess.PIPE
+    assert kwargs["stdout"] == subprocess.PIPE
+
+
+def test_codex_app_server_transport_hides_console_window(monkeypatch):
+    from agent.transports import codex_app_server
+
+    captured = []
+
+    class _FakeProc:
+        stdin = SimpleNamespace(write=lambda *a: None, flush=lambda: None)
+        stdout = SimpleNamespace(readline=lambda: b"")
+        stderr = SimpleNamespace(readline=lambda: b"")
+
+    def fake_popen(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _FakeProc()
+
+    _patch_hide_flags(monkeypatch)
+    monkeypatch.setattr(codex_app_server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        codex_app_server.threading,
+        "Thread",
+        lambda *a, **k: SimpleNamespace(start=lambda: None),
+    )
+
+    codex_app_server.CodexAppServerClient(codex_bin="codex-test")
+
+    assert len(captured) == 1, captured
+    cmd, kwargs = captured[0]
+    assert cmd[:2] == ["codex-test", "app-server"]
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+    # Hide-only: the app-server wire still needs its pipes.
+    assert kwargs["stdin"] == subprocess.PIPE
+    assert kwargs["stdout"] == subprocess.PIPE

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13755,6 +13755,10 @@ def _(rid, params: dict) -> dict:
     if hint:
         return _ok(rid, {"blocked": True, "hint": hint, "code": -1, "output": ""})
     try:
+        # CREATE_NO_WINDOW on Windows — under the desktop GUI's windowless
+        # parent, this spawn otherwise flashes a console (#56747).
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         r = subprocess.run(
             [sys.executable, "-m", "hermes_cli.main", *argv],
             capture_output=True,
@@ -13765,6 +13769,7 @@ def _(rid, params: dict) -> dict:
             # needs provider credentials. Tier-1 secrets still stripped (#29157).
             env=hermes_subprocess_env(inherit_credentials=True),
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         parts = [r.stdout or "", r.stderr or ""]
         out = "\n".join(p for p in parts if p).strip() or "(no output)"
@@ -13824,6 +13829,8 @@ def _(rid, params: dict) -> dict:
             # has all API keys in os.environ.
             from tools.environments.local import _sanitize_subprocess_env
             sanitized_env = _sanitize_subprocess_env(os.environ.copy())
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
             r = subprocess.run(
                 qc.get("command", ""),
                 shell=True,
@@ -13832,6 +13839,7 @@ def _(rid, params: dict) -> dict:
                 timeout=30,
                 stdin=subprocess.DEVNULL,
                 env=sanitized_env,
+                creationflags=windows_hide_flags(),
             )
             output = (
                 (r.stdout or "")
@@ -16894,9 +16902,12 @@ def _(rid, params: dict) -> dict:
     except ImportError:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         return _ok(
             rid,


### PR DESCRIPTION
## Summary

Salvages PR #56877 by @basilalshukaili onto current `main`: adds `creationflags=windows_hide_flags()` to the six GUI-reachable subprocess spawn paths that still flashed a console window on Windows desktop during agent command execution (#56747).

## Changes

- `tui_gateway/server.py`: hide flags on the `cli.exec` RPC, `shell.exec` RPC, and quick-command `exec` dispatch spawns
- `cli.py`: hide flags on the interactive CLI quick-command `exec` handler
- `agent/copilot_acp_client.py`: hide flags on the ACP `Popen` transport (hide-only, PIPE stdio intact)
- `agent/transports/codex_app_server.py`: hide flags on the app-server `Popen` transport (hide-only, PIPE stdio intact)
- `tests/test_windows_subprocess_no_window_flags.py`: +6 mocked-subprocess regression tests, one per site, following the file's existing pattern (our follow-up commit — the original PR's only gap)

## Validation

| | Before (fix reverted) | After |
|---|---|---|
| `tests/test_windows_subprocess_no_window_flags.py` | 25 pass / 6 fail | 31/31 pass |
| ACP + codex transport + TUI protocol suites | — | 155/155 pass |

Contributor also validated on native Windows 11 (345 tests, `CREATE_NO_WINDOW` resolution confirmed) per #56877.

Scope discipline preserved from the original: hide-only (no `DETACHED_PROCESS`/breakaway flags), no Electron changes, no updater-handoff legs.

Authorship: cherry-picked from #56877 with @basilalshukaili's commit preserved; rebase-merge.

Closes #56877. Addresses #56747.

## Infographic

![windows-console-flash-56747](https://v3b.fal.media/files/b/0aa35c29/64Ysjd2O822z7PCp0BttD_4yMacqow.png)
