### PR TITLE
fix(compression): reset in-place compaction state on every abort path

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -730,7 +730,11 @@ def replay_compression_warning(agent: Any) -> None:
             pass
 
 
-def conversation_history_after_compression(agent: Any, messages: list) -> Optional[list]:
+def conversation_history_after_compression(
+    agent: Any,
+    messages: list,
+    previous_history: Optional[list] = None,
+) -> Optional[list]:
     """Return the correct flush baseline after a compression boundary.
 
     Legacy compression rotates to a fresh child session. That child has not
@@ -747,7 +751,19 @@ def conversation_history_after_compression(agent: Any, messages: list) -> Option
 
     A shallow copy is intentional: it captures the current compacted dict
     identities as history while allowing later same-turn appends to remain new.
+
+    An aborted or no-op attempt after an earlier in-place compaction must retain
+    the pre-attempt baseline.  Treating all current messages as persisted would
+    drop any later, unflushed turns on restart; clearing the baseline would
+    append the already-persisted compacted rows a second time.
     """
+    if bool(getattr(agent, "_last_compression_attempt_recorded", False)):
+        attempt_in_place = getattr(agent, "_last_compression_attempt_in_place", None)
+        if attempt_in_place is True:
+            return list(messages)
+        if attempt_in_place is False:
+            return None
+        return previous_history
     if bool(getattr(agent, "_last_compaction_in_place", False)):
         return list(messages)
     return None
@@ -1007,6 +1023,13 @@ def compress_context(
         and callable(getattr(agent, _PENDING_CONTEXT_ENGINE_NOTIFICATION, None))
     ):
         raise RuntimeError("a compression notification is already pending")
+
+    # ``conversation_history_after_compression()`` needs the latest attempt's
+    # outcome, while ``_last_compaction_in_place`` remains the run-level signal
+    # read by gateway callers. ``None`` means this attempt aborted or made no
+    # boundary, so the previous flush baseline remains authoritative.
+    agent._last_compression_attempt_recorded = True
+    agent._last_compression_attempt_in_place = None
 
     _attempt_started_at = time.monotonic()
     _attempt_id = uuid.uuid4().hex
@@ -1823,6 +1846,7 @@ def compress_context(
         # via a rotation-independent flag. The gateway uses this — NOT an
         # id-change diff — to re-baseline transcript handling (history_offset=0 +
         # rewrite on the same id) when compaction happened in place. See #38763.
+        agent._last_compression_attempt_in_place = compacted_in_place
         agent._last_compaction_in_place = compacted_in_place
 
         # Keep the post-compression rough estimate for diagnostics, but do not

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -710,6 +710,13 @@ def run_conversation(
         except Exception:
             pass
 
+    # The gateway caches agents across user turns.  Compression state is
+    # per-turn: carrying a prior in-place boundary forward would make a later
+    # uncompressed result look like a compacted transcript to gateway writers.
+    agent._last_compaction_in_place = False
+    agent._last_compression_attempt_recorded = False
+    agent._last_compression_attempt_in_place = None
+
     # ── Per-turn setup (the prologue) ──
     # All once-per-turn setup — stdio guarding, retry-counter resets, user
     # message sanitization, todo/nudge hydration, system-prompt restore-or-
@@ -1340,7 +1347,7 @@ def run_conversation(
             # and preflight compaction sites; see
             # conversation_history_after_compression().
             conversation_history = conversation_history_after_compression(
-                agent, messages
+                agent, messages, conversation_history
             )
             api_call_count -= 1
             agent._api_call_count = api_call_count
@@ -3523,7 +3530,7 @@ def run_conversation(
                             task_id=effective_task_id,
                         )
                         conversation_history = conversation_history_after_compression(
-                            agent, messages
+                            agent, messages, conversation_history
                         )
                         if len(messages) < original_len or old_ctx > _reduced_ctx:
                             agent._buffer_status(
@@ -3778,7 +3785,7 @@ def run_conversation(
                         task_id=effective_task_id,
                     )
                     conversation_history = conversation_history_after_compression(
-                        agent, messages
+                        agent, messages, conversation_history
                     )
 
                     # Re-estimate tokens after compression.  Same-message-count
@@ -4019,7 +4026,7 @@ def run_conversation(
                         task_id=effective_task_id,
                     )
                     conversation_history = conversation_history_after_compression(
-                        agent, messages
+                        agent, messages, conversation_history
                     )
 
                     # Re-estimate tokens after compression.  Same-message-count
@@ -5408,7 +5415,7 @@ def run_conversation(
                         task_id=effective_task_id,
                     )
                     conversation_history = conversation_history_after_compression(
-                        agent, messages
+                        agent, messages, conversation_history
                     )
                 
                 # Save session log incrementally (so progress is visible even if interrupted)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -805,7 +805,7 @@ def build_turn_context(
                     _preflight_compression_blocked = True
                     break  # Cannot compress further: neither rows nor tokens moved
                 conversation_history = conversation_history_after_compression(
-                    agent, messages
+                    agent, messages, conversation_history
                 )
                 agent._empty_content_retries = 0
                 agent._thinking_prefill_retries = 0

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -680,7 +680,7 @@ def build_turn_context(
                 # untouched.
                 if messages is not _idle_input:
                     conversation_history = conversation_history_after_compression(
-                        agent, messages
+                        agent, messages, conversation_history
                     )
                     # Compaction rebuilt the list, so the index of this turn's
                     # just-appended user message is stale — re-anchor it the

--- a/tests/run_agent/test_compression_abort_state_reset.py
+++ b/tests/run_agent/test_compression_abort_state_reset.py
@@ -1,0 +1,196 @@
+"""Regression tests for #58630: every compression abort path must reset
+per-attempt in-place compaction state.
+
+After a successful in-place compaction sets ``_last_compaction_in_place=True``
+(run-level gateway signal), a later attempt that aborts or skips through ANY
+early-return path in ``compress_context`` must NOT reuse that stale flag as
+the flush baseline: ``conversation_history_after_compression()`` would then
+treat all current messages (including unflushed new turns) as persisted, and a
+restart would lose them.
+
+The fix records a per-attempt outcome (``_last_compression_attempt_recorded``/
+``_last_compression_attempt_in_place``) at the very top of
+``compress_context`` — before the codex-app-server route, breaker gates, lock
+acquisition, rotated-parent skips, compressor-abort, no-progress and
+empty-transcript returns — so every abort path leaves the attempt outcome
+``None`` and callers retain the previous flush baseline.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _make_agent(session_db):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id="abort-state-session",
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    return agent
+
+
+class _InPlaceSuccessCompressor:
+    _last_compress_aborted = False
+    _last_summary_error = None
+    compression_count = 1
+    _last_compression_made_progress = True
+    _last_summary_fallback_used = False
+    last_compression_rough_tokens = 0
+    last_prompt_tokens = 0
+    last_completion_tokens = 0
+    awaiting_real_usage_after_compression = False
+
+    def compress(self, _messages, **_kwargs):
+        return [
+            {"role": "user", "content": "[summary] earlier state"},
+            {"role": "assistant", "content": "retained tail"},
+        ]
+
+
+class _BreakerBlockedCompressor(_InPlaceSuccessCompressor):
+    """Trips the pre-lock automatic-compression breaker gate."""
+
+    def _automatic_compression_blocked(self):
+        return True
+
+    def compress(self, messages, **_kwargs):  # pragma: no cover - must not run
+        raise AssertionError("compress() must not be reached when blocked")
+
+
+class _NoProgressCompressor(_InPlaceSuccessCompressor):
+    """Returns a semantically-equal transcript (no-op attempt)."""
+
+    _last_compression_made_progress = False
+
+    def compress(self, messages, **_kwargs):
+        return [dict(m) for m in messages]
+
+
+class TestAbortPathsResetPerAttemptState:
+    def _in_place_success(self, agent, messages):
+        from agent.conversation_compression import (
+            compress_context,
+            conversation_history_after_compression,
+        )
+        agent.context_compressor = _InPlaceSuccessCompressor()
+        compacted, _ = compress_context(
+            agent, messages, "system", approx_tokens=100_000
+        )
+        assert agent._last_compaction_in_place is True
+        assert agent._last_compression_attempt_in_place is True
+        return compacted, conversation_history_after_compression(
+            agent, compacted, None
+        )
+
+    def test_breaker_blocked_skip_retains_previous_baseline(self):
+        """Pre-lock breaker skip after an in-place success must keep baseline."""
+        from agent.conversation_compression import (
+            compress_context,
+            conversation_history_after_compression,
+        )
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = True
+            original = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(original, [])
+            compacted, history = self._in_place_success(agent, original)
+
+            messages = compacted + [
+                {"role": "user", "content": "new request"},
+                {"role": "assistant", "content": "new answer"},
+            ]
+            agent.context_compressor = _BreakerBlockedCompressor()
+            returned, _ = compress_context(
+                agent, messages, "system", approx_tokens=100_000
+            )
+            assert returned is messages
+            # Per-attempt outcome must be reset even though this attempt
+            # returned before acquiring the lock.
+            assert agent._last_compression_attempt_recorded is True
+            assert agent._last_compression_attempt_in_place is None
+            new_history = conversation_history_after_compression(
+                agent, returned, history
+            )
+            # Skip = previous baseline stays authoritative: not all-persisted
+            # (would drop the new pair on restart), not None (would re-append
+            # the compacted rows).
+            assert new_history is history
+            db.close()
+
+    def test_no_progress_attempt_retains_previous_baseline(self):
+        """A semantic no-op attempt must not reuse the stale in-place flag."""
+        from agent.conversation_compression import (
+            compress_context,
+            conversation_history_after_compression,
+        )
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = True
+            original = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(original, [])
+            compacted, history = self._in_place_success(agent, original)
+
+            messages = compacted + [
+                {"role": "user", "content": "new request"},
+                {"role": "assistant", "content": "new answer"},
+            ]
+            agent.context_compressor = _NoProgressCompressor()
+            returned, _ = compress_context(
+                agent, messages, "system", approx_tokens=100_000
+            )
+            assert agent._last_compression_attempt_in_place is None
+            new_history = conversation_history_after_compression(
+                agent, returned, history
+            )
+            assert new_history is history
+            # Run-level gateway signal is untouched by the aborted attempt.
+            assert agent._last_compaction_in_place is True
+            db.close()
+
+    def test_rotation_boundary_still_clears_baseline(self):
+        """A completed rotation attempt must still return None (full rewrite)."""
+        from agent.conversation_compression import (
+            compress_context,
+            conversation_history_after_compression,
+        )
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = False
+            original = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(original, [])
+            agent.context_compressor = _InPlaceSuccessCompressor()
+            compacted, _ = compress_context(
+                agent, original, "system", approx_tokens=100_000
+            )
+            assert agent._last_compression_attempt_in_place is False
+            assert conversation_history_after_compression(
+                agent, compacted, list(original)
+            ) is None
+            db.close()

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -19,7 +19,6 @@ Bug scenario (pre-fix):
 import os
 import tempfile
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import patch
 
 
@@ -271,45 +270,6 @@ class TestFlushAfterCompression:
                 "new request",
                 "new answer",
             ]
-
-    def test_new_run_clears_stale_in_place_compaction_state(self, monkeypatch):
-        """A cached agent must not report a prior turn's compaction boundary."""
-        import agent.conversation_loop as loop
-
-        observed = {}
-
-        def fake_build_turn_context(agent, *_args, **_kwargs):
-            observed["in_place"] = agent._last_compaction_in_place
-            observed["attempt_recorded"] = agent._last_compression_attempt_recorded
-            observed["attempt_in_place"] = agent._last_compression_attempt_in_place
-            return SimpleNamespace(
-                user_message="hello",
-                original_user_message="hello",
-                messages=[],
-                conversation_history=[],
-                active_system_prompt="system",
-                effective_task_id="default",
-                turn_id="turn-1",
-                current_turn_user_idx=0,
-                should_review_memory=False,
-                plugin_user_context={},
-                ext_prefetch_cache=None,
-            )
-
-        agent = SimpleNamespace(
-            api_mode="codex_app_server",
-            _last_compaction_in_place=True,
-            _last_compression_attempt_recorded=True,
-            _last_compression_attempt_in_place=True,
-        )
-        agent._run_codex_app_server_turn = lambda **_kwargs: dict(observed)
-        monkeypatch.setattr(loop, "build_turn_context", fake_build_turn_context)
-
-        assert loop.run_conversation(agent, "hello") == {
-            "in_place": False,
-            "attempt_recorded": False,
-            "attempt_in_place": None,
-        }
 
     def test_rotation_child_session_flushes_full_compressed_transcript_with_markers(self):
         """Regression for #57491: live cached-agent markers must not block child flush."""

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -192,7 +192,7 @@ class TestFlushAfterCompression:
             ]
 
     def test_abort_after_in_place_compaction_preserves_flush_baseline(self):
-        """An aborted retry must retain both compacted rows and new turns."""
+        """An aborted retry must survive flush, restart, and resume."""
         from agent.conversation_compression import (
             compress_context,
             conversation_history_after_compression,
@@ -232,7 +232,8 @@ class TestFlushAfterCompression:
                 return messages
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
             agent = self._make_agent(db)
             agent.compression_in_place = True
             original = [
@@ -262,7 +263,9 @@ class TestFlushAfterCompression:
             )
             agent._flush_messages_to_session_db(returned, history)
 
-            assert [message["content"] for message in db.get_messages_as_conversation(
+            db.close()
+            resumed_db = SessionDB(db_path=db_path)
+            assert [message["content"] for message in resumed_db.get_messages_as_conversation(
                 agent.session_id
             )] == [
                 "[summary] earlier state",
@@ -270,6 +273,7 @@ class TestFlushAfterCompression:
                 "new request",
                 "new answer",
             ]
+            resumed_db.close()
 
     def test_rotation_child_session_flushes_full_compressed_transcript_with_markers(self):
         """Regression for #57491: live cached-agent markers must not block child flush."""

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -19,6 +19,7 @@ Bug scenario (pre-fix):
 import os
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 
@@ -190,6 +191,125 @@ class TestFlushAfterCompression:
                 "tool result",
                 "final answer",
             ]
+
+    def test_abort_after_in_place_compaction_preserves_flush_baseline(self):
+        """An aborted retry must retain both compacted rows and new turns."""
+        from agent.conversation_compression import (
+            compress_context,
+            conversation_history_after_compression,
+        )
+        from hermes_state import SessionDB
+
+        class SuccessCompressor:
+            _last_compress_aborted = False
+            _last_summary_error = None
+            compression_count = 1
+            _last_compression_made_progress = True
+            _last_summary_fallback_used = False
+            last_compression_rough_tokens = 0
+            last_prompt_tokens = 0
+            last_completion_tokens = 0
+            awaiting_real_usage_after_compression = False
+
+            def compress(self, _messages, **_kwargs):
+                return [
+                    {"role": "user", "content": "[summary] earlier state"},
+                    {"role": "assistant", "content": "retained tail"},
+                ]
+
+        class AbortCompressor:
+            _last_compress_aborted = False
+            _last_summary_error = "simulated auxiliary timeout"
+            compression_count = 2
+            _last_compression_made_progress = False
+            _last_summary_fallback_used = False
+            last_compression_rough_tokens = 0
+            last_prompt_tokens = 0
+            last_completion_tokens = 0
+            awaiting_real_usage_after_compression = False
+
+            def compress(self, messages, **_kwargs):
+                self._last_compress_aborted = True
+                return messages
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            agent.compression_in_place = True
+            original = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(original, [])
+
+            agent.context_compressor = SuccessCompressor()
+            compacted, _ = compress_context(
+                agent, original, "system", approx_tokens=100_000
+            )
+            history = conversation_history_after_compression(
+                agent, compacted, None
+            )
+
+            messages = compacted + [
+                {"role": "user", "content": "new request"},
+                {"role": "assistant", "content": "new answer"},
+            ]
+            agent.context_compressor = AbortCompressor()
+            returned, _ = compress_context(
+                agent, messages, "system", approx_tokens=100_000
+            )
+            history = conversation_history_after_compression(
+                agent, returned, history
+            )
+            agent._flush_messages_to_session_db(returned, history)
+
+            assert [message["content"] for message in db.get_messages_as_conversation(
+                agent.session_id
+            )] == [
+                "[summary] earlier state",
+                "retained tail",
+                "new request",
+                "new answer",
+            ]
+
+    def test_new_run_clears_stale_in_place_compaction_state(self, monkeypatch):
+        """A cached agent must not report a prior turn's compaction boundary."""
+        import agent.conversation_loop as loop
+
+        observed = {}
+
+        def fake_build_turn_context(agent, *_args, **_kwargs):
+            observed["in_place"] = agent._last_compaction_in_place
+            observed["attempt_recorded"] = agent._last_compression_attempt_recorded
+            observed["attempt_in_place"] = agent._last_compression_attempt_in_place
+            return SimpleNamespace(
+                user_message="hello",
+                original_user_message="hello",
+                messages=[],
+                conversation_history=[],
+                active_system_prompt="system",
+                effective_task_id="default",
+                turn_id="turn-1",
+                current_turn_user_idx=0,
+                should_review_memory=False,
+                plugin_user_context={},
+                ext_prefetch_cache=None,
+            )
+
+        agent = SimpleNamespace(
+            api_mode="codex_app_server",
+            _last_compaction_in_place=True,
+            _last_compression_attempt_recorded=True,
+            _last_compression_attempt_in_place=True,
+        )
+        agent._run_codex_app_server_turn = lambda **_kwargs: dict(observed)
+        monkeypatch.setattr(loop, "build_turn_context", fake_build_turn_context)
+
+        assert loop.run_conversation(agent, "hello") == {
+            "in_place": False,
+            "attempt_recorded": False,
+            "attempt_in_place": None,
+        }
 
     def test_rotation_child_session_flushes_full_compressed_transcript_with_markers(self):
         """Regression for #57491: live cached-agent markers must not block child flush."""


### PR DESCRIPTION
## Summary
After a successful in-place compaction, any later compression attempt that aborts (aux summary failure, breaker skip, no-progress, lock contention, rotated-parent skip) reused the stale `_last_compaction_in_place=True` flag as the flush baseline, so `conversation_history_after_compression()` treated unflushed new turns as already persisted — a restart then lost them. The abort early-returns exit `compress_context()` before the flag assignment, so the previous attempt's run-level signal leaked into the next attempt's baseline decision.

## Changes
- `agent/conversation_compression.py`: record a per-attempt outcome (`_last_compression_attempt_recorded` / `_last_compression_attempt_in_place`) at the very top of `compress_context()` — before the codex-app-server route, breaker gates, lock acquisition, and every abort/no-op/empty early return — set to the real `compacted_in_place` verdict only when a boundary completes. `conversation_history_after_compression()` distinguishes completed in-place (`list(messages)`) vs completed rotation (`None`) vs aborted/skipped attempt (retain the previous baseline).
- `agent/conversation_loop.py`: reset run-scoped compression signals at turn start (gateway caches agents across turns) and thread `conversation_history` through all five compression call sites.
- `agent/turn_context.py`: thread the previous baseline through the preflight caller (contributor) and the idle-compaction caller (follow-up — that call site postdates the PR).
- `tests/run_agent/test_compression_persistence.py`: contributor's end-to-end regression — real `SessionDB`, in-place success → append → abort → flush → close → reopen → exact resumed transcript.
- `tests/run_agent/test_compression_abort_state_reset.py` (follow-up): abort-path audit coverage — breaker-blocked skip and semantic no-op attempts retain the previous baseline after an in-place success; completed rotation still clears it; run-level gateway flag untouched by aborted attempts.

## Validation
| | Before | After |
|---|---|---|
| Abort after in-place compaction, then restart | New user/assistant turns baselined as persisted → lost on resume | Compacted rows + new turns resumed exactly once |
| Breaker/no-progress skip after in-place success | Stale flag rebaselined all current messages | Previous flush baseline retained |

Targeted tests: `tests/ -k 'abort and (flush or baseline or in_place)'` → 4 passed, 0 failed; `test_compression_abort_state_reset.py` + `test_compression_persistence.py` + `test_in_place_compaction.py` → 21 passed; `test_idle_compaction*` + `test_compression_rotation_state.py` → 39 passed. Premise verified on current main first: the contributor's regression test fails on origin/main, passes with the fix.

## Credit
Salvaged from #58629 by @bbopen. Fixes #58630.

## Infographic
![compression-abort-state-reset](https://v3b.fal.media/files/b/0aa35c28/cBsE_r1MynuUIj7gFUIyd_soPNC4W0.png)
