### PR TITLE
Recognize Ollama Cloud's multimodal tool-content rejection message

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -231,6 +231,16 @@ _MULTIMODAL_TOOL_CONTENT_PATTERNS = [
     "expected string, got array",
     # Alibaba/DashScope variant
     "tool_call.content must be string",
+    # Ollama Cloud-proxied models (e.g. gemma-family "-cloud" variants
+    # via a local `ollama serve` at 127.0.0.1:11434/v1): the cloud-side
+    # backend validates the request with what looks like a Pydantic
+    # schema and rejects list-type tool-message content with a bare
+    # "Input should be a valid string (ref: <uuid>)" — no mention of
+    # "tool" or "content" at all, so it needs its own narrow pattern.
+    # Confirmed by reproducing the failure: it fires on the turn right
+    # after `vision_analyze`'s native fast path embeds an image into a
+    # tool-result message.
+    "input should be a valid string",
 ]
 
 # Context overflow patterns


### PR DESCRIPTION
## Summary
- Gemma-family `-cloud` models proxied through a local `ollama serve` (`127.0.0.1:11434/v1`) reject list-type tool-result content (e.g. the image parts `vision_analyze`'s native fast path embeds) with a bare `Input should be a valid string (ref: <uuid>)` — a Pydantic-style message from the cloud-side backend.
- That phrasing wasn't in `_MULTIMODAL_TOOL_CONTENT_PATTERNS`, so the classifier fell through to a non-retryable `format_error` and hard-aborted instead of stripping the image parts and retrying via the existing `multimodal_tool_content_unsupported` recovery path.
- Adds `"input should be a valid string"` to the pattern list so this case now routes into the existing strip-and-retry recovery.

## Test plan
- [x] Reproduced locally against a live session log (`gemma4:31b-cloud` via local Ollama proxy) — the failing turn now classifies as `multimodal_tool_content_unsupported` / `retryable=True` instead of `format_error` / `retryable=False`.
- [x] `pytest tests/run_agent/ -k "multimodal or classif"` — 63 passed.