### PR TITLE
fix(kanban): reconcile post-release pickup ordering

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2115,18 +2115,24 @@ def _cmd_block(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
-            if not kb.block_task(
-                conn,
-                tid,
-                reason=reason,
-                kind=kind,
-                expected_run_id=_worker_run_id_for(tid),
-            ):
+            try:
+                ok = kb.block_task(
+                    conn,
+                    tid,
+                    reason=reason,
+                    kind=kind,
+                    expected_run_id=_worker_run_id_for(tid),
+                )
+            except kb.ReviewHandoffBlockError as exc:
+                failed.append(tid)
+                print(str(exc), file=sys.stderr)
+                continue
+            if not ok:
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
             else:
+                if reason:
+                    kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
                 # Report where the task actually landed — dependency blocks go
                 # to todo, and a tripped unblock-loop breaker routes to triage.
                 landed = kb.get_task(conn, tid)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2329,16 +2329,57 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         max_in_progress_per_profile = None
         max_in_progress = None
         max_spawn = getattr(args, "max", None)
-    with kb.connect_closing() as conn:
-        res = kb.dispatch_once(
-            conn,
-            dry_run=args.dry_run,
-            max_spawn=max_spawn,
-            max_in_progress=max_in_progress,
-            failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
-            default_assignee=default_assignee,
-            max_in_progress_per_profile=max_in_progress_per_profile,
+    exact_task_id = getattr(args, "task_id", None)
+    if exact_task_id and getattr(args, "dry_run", False):
+        print(
+            "kanban: dispatch <task_id> does not support --dry-run; "
+            "drop --dry-run to spawn the exact task",
+            file=sys.stderr,
         )
+        return 2
+    exact: Optional[kb.ExactDispatchResult] = None
+    res: Optional[kb.DispatchResult] = None
+    with kb.connect_closing() as conn:
+        if exact_task_id:
+            exact = kb.dispatch_task(
+                conn,
+                exact_task_id,
+                failure_limit=getattr(
+                    args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT
+                ),
+            )
+        else:
+            res = kb.dispatch_once(
+                conn,
+                dry_run=args.dry_run,
+                max_spawn=max_spawn,
+                max_in_progress=max_in_progress,
+                failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
+                default_assignee=default_assignee,
+                max_in_progress_per_profile=max_in_progress_per_profile,
+            )
+    if exact_task_id:
+        assert exact is not None
+        payload = {
+            "task_id": exact.task_id,
+            "state": exact.state,
+            "spawned": exact.spawned,
+            "run_id": exact.run_id,
+            "pid": exact.pid,
+            "assignee": exact.assignee,
+            "workspace": exact.workspace,
+            "reason": exact.reason,
+            "capacity": exact.capacity,
+        }
+        if getattr(args, "json", False):
+            print(json.dumps(payload, indent=2))
+        else:
+            print(
+                f"{exact.task_id}: {exact.state}"
+                + (f" ({exact.reason})" if exact.reason else "")
+            )
+        return 0 if exact.state in {"spawned", "already_running", "capacity"} else 1
+    assert res is not None
     if getattr(args, "json", False):
         print(json.dumps({
             "reclaimed": res.reclaimed,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -659,6 +659,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "dispatch",
         help="One dispatcher pass: reclaim stale, promote ready, spawn workers",
     )
+    p_disp.add_argument("task_id", nargs="?",
+                        help="Dispatch this task only; never falls back to another ready task")
     p_disp.add_argument("--dry-run", action="store_true",
                         help="Don't actually spawn processes; just print what would happen")
     p_disp.add_argument("--max", type=int, default=None,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4697,8 +4697,6 @@ def complete_task(
     # just tracks "is there a current pathology the breaker should
     # care about", and a success resets that question.
     _clear_failure_counter(conn, task_id)
-    # Recompute ready status for dependents (separate txn so children see done).
-    recompute_ready(conn)
     # Clean up the scratch workspace and any stale tmux session for the worker.
     _cleanup_workspace(conn, task_id)
     _done_task = get_task(conn, task_id)
@@ -4716,6 +4714,9 @@ def complete_task(
         release_run_id=run_id,
         assignee=_done_task.assignee if _done_task else None,
     )
+    # Recompute ready status for any dependents that were not selected by the
+    # same-profile pickup path.
+    recompute_ready(conn)
     return True
 
 
@@ -5344,8 +5345,8 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
-    routed_to = "blocked"
-    recurrences = 0
+    run_id: Optional[int] = None
+    _blocked_task: Optional[Task] = None
     with write_txn(conn):
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
@@ -5395,73 +5396,19 @@ def block_task(
                 conn, task_id, "dependency_wait",
                 {"reason": reason, "kind": kind}, run_id=run_id,
             )
-            routed_to = "todo"
             _blocked_task = get_task(conn, task_id)
-            _fire_kanban_lifecycle_hook(
-                "kanban_task_blocked",
-                task_id,
-                board=get_current_board(),
-                assignee=_blocked_task.assignee if _blocked_task else None,
-                run_id=run_id,
-                reason=reason,
-            )
-            return True
-
-        # Truly-blocked kinds. Increment the unblock-loop counter when this is a
-        # re-block for the SAME reason after a prior unblock. block_task only
-        # fires from running/ready (i.e. AFTER an unblock returned the task to
-        # the work pool), so a stored block_kind that matches the incoming kind
-        # means: blocked → unblocked → about-to-re-block for the same cause.
-        # An un-typed (None) block compares as "same" to a prior un-typed block.
-        same_cause = prev_kind == kind
-        recurrences = prev_recurrences + 1 if same_cause else 1
-
-        if recurrences >= BLOCK_RECURRENCE_LIMIT:
-            # Loop detected — stop letting the unblocker spin this task. Route
-            # to triage for a human-in-the-loop decision instead of blocked.
-            cur = conn.execute(
-                """
-                UPDATE tasks
-                   SET status        = 'triage',
-                       claim_lock    = NULL,
-                       claim_expires = NULL,
-                       worker_pid    = NULL,
-                       block_kind    = ?,
-                       block_recurrences = ?
-                 WHERE id = ?
-                   AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, recurrences, task_id) if expected_run_id is None
-                else (kind, recurrences, task_id, int(expected_run_id)),
-            )
-            if cur.rowcount != 1:
-                return False
-            run_id = _end_run(
-                conn, task_id,
-                outcome="blocked", status="blocked",
-                summary=reason,
-            )
-            if run_id is None and reason:
-                run_id = _synthesize_ended_run(
-                    conn, task_id, outcome="blocked", summary=reason,
-                )
-            _append_event(
-                conn, task_id, "block_loop_detected",
-                {
-                    "reason": reason,
-                    "kind": kind,
-                    "recurrences": recurrences,
-                    "limit": BLOCK_RECURRENCE_LIMIT,
-                },
-                run_id=run_id,
-            )
-            routed_to = "triage"
         else:
-            if expected_run_id is None:
+            # Truly-blocked kinds. Increment the unblock-loop counter when this
+            # is a re-block for the SAME reason after a prior unblock.
+            same_cause = prev_kind == kind
+            recurrences = prev_recurrences + 1 if same_cause else 1
+
+            if recurrences >= BLOCK_RECURRENCE_LIMIT:
+                # Loop detected — stop letting the unblocker spin this task.
                 cur = conn.execute(
                     """
                     UPDATE tasks
-                       SET status        = 'blocked',
+                       SET status        = 'triage',
                            claim_lock    = NULL,
                            claim_expires = NULL,
                            worker_pid    = NULL,
@@ -5469,46 +5416,84 @@ def block_task(
                            block_recurrences = ?
                      WHERE id = ?
                        AND status IN ('running', 'ready')
-                    """,
-                    (kind, recurrences, task_id),
+                    """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
+                    (kind, recurrences, task_id) if expected_run_id is None
+                    else (kind, recurrences, task_id, int(expected_run_id)),
                 )
-            else:
-                cur = conn.execute(
-                    """
-                    UPDATE tasks
-                       SET status        = 'blocked',
-                           claim_lock    = NULL,
-                           claim_expires = NULL,
-                           worker_pid    = NULL,
-                           block_kind    = ?,
-                           block_recurrences = ?
-                     WHERE id = ?
-                       AND status IN ('running', 'ready')
-                       AND current_run_id = ?
-                    """,
-                    (kind, recurrences, task_id, int(expected_run_id)),
-                )
-            if cur.rowcount != 1:
-                return False
-            run_id = _end_run(
-                conn, task_id,
-                outcome="blocked", status="blocked",
-                summary=reason,
-            )
-            # Synthesize a run when blocking a never-claimed task so the
-            # reason is preserved in attempt history.
-            if run_id is None and reason:
-                run_id = _synthesize_ended_run(
+                if cur.rowcount != 1:
+                    return False
+                run_id = _end_run(
                     conn, task_id,
-                    outcome="blocked",
+                    outcome="blocked", status="blocked",
                     summary=reason,
                 )
-            _append_event(
-                conn, task_id, "blocked",
-                {"reason": reason, "kind": kind, "recurrences": recurrences},
-                run_id=run_id,
-            )
-        _blocked_task = get_task(conn, task_id)
+                if run_id is None and reason:
+                    run_id = _synthesize_ended_run(
+                        conn, task_id, outcome="blocked", summary=reason,
+                    )
+                _append_event(
+                    conn, task_id, "block_loop_detected",
+                    {
+                        "reason": reason,
+                        "kind": kind,
+                        "recurrences": recurrences,
+                        "limit": BLOCK_RECURRENCE_LIMIT,
+                    },
+                    run_id=run_id,
+                )
+            else:
+                if expected_run_id is None:
+                    cur = conn.execute(
+                        """
+                        UPDATE tasks
+                           SET status        = 'blocked',
+                               claim_lock    = NULL,
+                               claim_expires = NULL,
+                               worker_pid    = NULL,
+                               block_kind    = ?,
+                               block_recurrences = ?
+                         WHERE id = ?
+                           AND status IN ('running', 'ready')
+                        """,
+                        (kind, recurrences, task_id),
+                    )
+                else:
+                    cur = conn.execute(
+                        """
+                        UPDATE tasks
+                           SET status        = 'blocked',
+                               claim_lock    = NULL,
+                               claim_expires = NULL,
+                               worker_pid    = NULL,
+                               block_kind    = ?,
+                               block_recurrences = ?
+                         WHERE id = ?
+                           AND status IN ('running', 'ready')
+                           AND current_run_id = ?
+                        """,
+                        (kind, recurrences, task_id, int(expected_run_id)),
+                    )
+                if cur.rowcount != 1:
+                    return False
+                run_id = _end_run(
+                    conn, task_id,
+                    outcome="blocked", status="blocked",
+                    summary=reason,
+                )
+                # Synthesize a run when blocking a never-claimed task so the
+                # reason is preserved in attempt history.
+                if run_id is None and reason:
+                    run_id = _synthesize_ended_run(
+                        conn, task_id,
+                        outcome="blocked",
+                        summary=reason,
+                    )
+                _append_event(
+                    conn, task_id, "blocked",
+                    {"reason": reason, "kind": kind, "recurrences": recurrences},
+                    run_id=run_id,
+                )
+            _blocked_task = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
         "kanban_task_blocked",
         task_id,
@@ -6550,6 +6535,8 @@ class PostReleasePickupResult:
     reason: Optional[str] = None
     boards_checked: list[str] = field(default_factory=list)
     capacity: list[dict[str, Any]] = field(default_factory=list)
+    blocker: Optional[dict[str, Any]] = None
+    todo: Optional[dict[str, Any]] = None
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -7772,6 +7759,8 @@ def _record_post_release_pickup(
         "reason": result.reason,
         "boards_checked": result.boards_checked,
         "capacity": result.capacity,
+        "blocker": result.blocker,
+        "todo": result.todo,
     }
     with write_txn(conn):
         if _post_release_pickup_event_exists(
@@ -7835,6 +7824,215 @@ def _same_profile_candidates(
     return candidates, boards_checked
 
 
+def _same_profile_rows(
+    assignee: str,
+    status: str,
+    *,
+    exclude_task_id: Optional[str] = None,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    candidates: list[dict[str, Any]] = []
+    boards_checked: list[str] = []
+    for meta in list_boards(include_archived=False):
+        board = meta["slug"]
+        path = kanban_db_path(board=board)
+        if not path.exists():
+            continue
+        boards_checked.append(board)
+        with connect_closing(board=board) as board_conn:
+            rows = board_conn.execute(
+                "SELECT id, priority, created_at, block_kind, block_recurrences "
+                "FROM tasks WHERE status = ? AND assignee = ? "
+                "AND claim_lock IS NULL AND current_run_id IS NULL",
+                (status, assignee),
+            ).fetchall()
+        for row in rows:
+            if exclude_task_id and row["id"] == exclude_task_id:
+                continue
+            candidates.append({
+                "board": board,
+                "task_id": row["id"],
+                "priority": int(row["priority"] or 0),
+                "created_at": int(row["created_at"] or 0),
+                "block_kind": row["block_kind"],
+                "block_recurrences": int(row["block_recurrences"] or 0),
+            })
+    candidates.sort(
+        key=lambda item: (
+            -int(item["priority"]),
+            int(item["created_at"]),
+            str(item["board"]),
+            str(item["task_id"]),
+        )
+    )
+    return candidates, boards_checked
+
+
+def _has_unsatisfied_parents(conn: sqlite3.Connection, task_id: str) -> bool:
+    return conn.execute(
+        "SELECT 1 FROM task_links l JOIN tasks p ON p.id = l.parent_id "
+        "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+        (task_id,),
+    ).fetchone() is not None
+
+
+def _latest_block_event(conn: sqlite3.Connection, task_id: str) -> Optional[sqlite3.Row]:
+    return conn.execute(
+        "SELECT id, kind, payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('blocked', 'dependency_wait') "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+
+
+def _post_release_reconciliation_exists(
+    conn: sqlite3.Connection,
+    task_id: str,
+    event_kind: str,
+    source_event_id: Optional[int],
+) -> bool:
+    if source_event_id is None:
+        return False
+    needle = f'"source_event_id": {int(source_event_id)}'
+    return conn.execute(
+        "SELECT 1 FROM task_events WHERE task_id = ? AND kind = ? "
+        "AND payload LIKE ? LIMIT 1",
+        (task_id, event_kind, f"%{needle}%"),
+    ).fetchone() is not None
+
+
+def _append_post_release_reconciliation_event(
+    conn: sqlite3.Connection,
+    task_id: str,
+    event_kind: str,
+    payload: dict[str, Any],
+) -> bool:
+    source_event_id = payload.get("source_event_id")
+    with write_txn(conn):
+        if _post_release_reconciliation_exists(
+            conn,
+            task_id,
+            event_kind,
+            int(source_event_id) if source_event_id else None,
+        ):
+            return False
+        _append_event(conn, task_id, event_kind, payload)
+    return True
+
+
+def _reconcile_same_profile_blocker(
+    profile: str,
+    *,
+    exclude_task_id: Optional[str],
+) -> tuple[Optional[dict[str, Any]], list[str]]:
+    blocked, boards_checked = _same_profile_rows(
+        profile, "blocked", exclude_task_id=exclude_task_id,
+    )
+    for selected in blocked:
+        with connect_closing(board=selected["board"]) as selected_conn:
+            event = _latest_block_event(selected_conn, selected["task_id"])
+            source_event_id = int(event["id"]) if event else None
+            if _post_release_reconciliation_exists(
+                selected_conn,
+                selected["task_id"],
+                "post_release_blocker_waiting",
+                source_event_id,
+            ) or _post_release_reconciliation_exists(
+                selected_conn,
+                selected["task_id"],
+                "post_release_blocker_reconciled",
+                source_event_id,
+            ):
+                continue
+            block_kind = selected.get("block_kind")
+            base = {
+                "board": selected["board"],
+                "task_id": selected["task_id"],
+                "block_kind": block_kind,
+                "source_event_id": source_event_id,
+            }
+            if block_kind in {"dependency", "transient"}:
+                if _has_unsatisfied_parents(selected_conn, selected["task_id"]):
+                    emitted = _append_post_release_reconciliation_event(
+                        selected_conn,
+                        selected["task_id"],
+                        "post_release_blocker_waiting",
+                        {
+                            **base,
+                            "outcome": "waiting_on_dependency",
+                            "owner": "dependency",
+                        },
+                    )
+                    return {
+                        **base,
+                        "outcome": "waiting_on_dependency",
+                        "emitted": emitted,
+                    }, boards_checked
+                if unblock_task(selected_conn, selected["task_id"]):
+                    _append_post_release_reconciliation_event(
+                        selected_conn,
+                        selected["task_id"],
+                        "post_release_blocker_reconciled",
+                        {**base, "outcome": "unblocked_to_ready"},
+                    )
+                    return {**base, "outcome": "unblocked_to_ready"}, boards_checked
+            owner = "operator" if block_kind is None else block_kind
+            emitted = _append_post_release_reconciliation_event(
+                selected_conn,
+                selected["task_id"],
+                "post_release_blocker_waiting",
+                {**base, "outcome": "waiting_on_owner", "owner": owner},
+            )
+            return {
+                **base,
+                "outcome": "waiting_on_owner",
+                "owner": owner,
+                "emitted": emitted,
+            }, boards_checked
+    return None, boards_checked
+
+
+def _promote_next_same_profile_todo(
+    profile: str,
+    *,
+    exclude_task_id: Optional[str],
+) -> tuple[Optional[dict[str, Any]], list[str]]:
+    todos, boards_checked = _same_profile_rows(
+        profile, "todo", exclude_task_id=exclude_task_id,
+    )
+    if not todos:
+        return None, boards_checked
+    selected = todos[0]
+    with connect_closing(board=selected["board"]) as selected_conn:
+        event = _latest_block_event(selected_conn, selected["task_id"])
+        source_event_id = int(event["id"]) if event else None
+        base = {
+            "board": selected["board"],
+            "task_id": selected["task_id"],
+            "source_event_id": source_event_id,
+        }
+        if _has_unsatisfied_parents(selected_conn, selected["task_id"]):
+            emitted = _append_post_release_reconciliation_event(
+                selected_conn,
+                selected["task_id"],
+                "post_release_todo_waiting",
+                {**base, "outcome": "waiting_on_dependency"},
+            )
+            return {
+                **base,
+                "outcome": "waiting_on_dependency",
+                "emitted": emitted,
+            }, boards_checked
+        promoted, reason = promote_task(
+            selected_conn,
+            selected["task_id"],
+            actor="post_release_pickup",
+            reason="parents satisfied during post-release pickup",
+        )
+        if promoted:
+            return {**base, "outcome": "promoted_to_ready"}, boards_checked
+        return {**base, "outcome": "promotion_refused", "reason": reason}, boards_checked
+
+
 def attempt_post_release_pickup(
     conn: sqlite3.Connection,
     release_task_id: str,
@@ -7888,16 +8086,33 @@ def attempt_post_release_pickup(
         return result
 
     try:
-        candidates, boards_checked = _same_profile_candidates(
+        blocker, blocked_boards = _reconcile_same_profile_blocker(
             profile, exclude_task_id=release_task_id,
         )
+        candidates, ready_boards = _same_profile_candidates(
+            profile, exclude_task_id=release_task_id,
+        )
+        todo: Optional[dict[str, Any]] = None
+        todo_boards: list[str] = []
+        if not candidates:
+            todo, todo_boards = _promote_next_same_profile_todo(
+                profile, exclude_task_id=release_task_id,
+            )
+            if todo and todo.get("outcome") == "promoted_to_ready":
+                candidates, ready_boards = _same_profile_candidates(
+                    profile, exclude_task_id=release_task_id,
+                )
+        boards_checked = sorted(set(blocked_boards + ready_boards + todo_boards))
         if not candidates:
             result = PostReleasePickupResult(
                 outcome="no_eligible_work",
                 release_task_id=release_task_id,
                 release_run_id=release_run_id,
                 assignee=profile,
+                reason=(todo or blocker or {}).get("outcome"),
                 boards_checked=boards_checked,
+                blocker=blocker,
+                todo=todo,
             )
             _record_post_release_pickup(conn, result)
             return result
@@ -7915,6 +8130,8 @@ def attempt_post_release_pickup(
                 reason="profile_occupied",
                 boards_checked=boards_checked,
                 capacity=occupied,
+                blocker=blocker,
+                todo=todo,
             )
             _record_post_release_pickup(conn, result)
             return result
@@ -7947,6 +8164,8 @@ def attempt_post_release_pickup(
             reason=exact.reason or exact.state,
             boards_checked=boards_checked,
             capacity=exact.capacity,
+            blocker=blocker,
+            todo=todo,
         )
         _record_post_release_pickup(conn, result)
         return result

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4710,6 +4710,12 @@ def complete_task(
         run_id=run_id,
         summary=(summary if summary is not None else result),
     )
+    attempt_post_release_pickup(
+        conn,
+        task_id,
+        release_run_id=run_id,
+        assignee=_done_task.assignee if _done_task else None,
+    )
     return True
 
 
@@ -5510,6 +5516,12 @@ def block_task(
         assignee=_blocked_task.assignee if _blocked_task else None,
         run_id=run_id,
         reason=reason,
+    )
+    attempt_post_release_pickup(
+        conn,
+        task_id,
+        release_run_id=run_id,
+        assignee=_blocked_task.assignee if _blocked_task else None,
     )
     return True
 
@@ -6522,6 +6534,24 @@ class ExactDispatchResult:
     capacity: list[dict[str, Any]] = field(default_factory=list)
 
 
+@dataclass
+class PostReleasePickupResult:
+    """Structured receipt for one same-profile pickup attempt after release."""
+
+    outcome: str
+    release_task_id: str
+    release_run_id: Optional[int]
+    assignee: Optional[str]
+    selected_board: Optional[str] = None
+    selected_task_id: Optional[str] = None
+    spawned_run_id: Optional[int] = None
+    pid: Optional[int] = None
+    workspace: Optional[str] = None
+    reason: Optional[str] = None
+    boards_checked: list[str] = field(default_factory=list)
+    capacity: list[dict[str, Any]] = field(default_factory=list)
+
+
 # Bounded registry of recently-reaped worker child exits, populated by the
 # reap loop at the top of ``dispatch_once`` and consulted by
 # ``detect_crashed_workers`` to classify a dead-pid task.
@@ -7016,7 +7046,7 @@ def detect_stale_running(
     reclaimed: list[str] = []
 
     rows = conn.execute(
-        "SELECT t.id, t.worker_pid, t.last_heartbeat_at, t.claim_lock, "
+        "SELECT t.id, t.assignee, t.worker_pid, t.last_heartbeat_at, t.claim_lock, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
@@ -7094,6 +7124,13 @@ def detect_stale_running(
                 conn, tid, "stale", payload, run_id=run_id,
             )
             reclaimed.append(tid)
+
+        attempt_post_release_pickup(
+            conn,
+            tid,
+            release_run_id=run_id,
+            assignee=row["assignee"],
+        )
 
         # Intentionally NOT calling _record_task_failure here. Stale reclaim
         # is dispatcher-side detection of an absent heartbeat; the task is
@@ -7700,6 +7737,229 @@ def _profile_occupancy(assignee: str) -> list[dict[str, Any]]:
                     "pid": pid,
                 })
     return occupied
+
+
+def _post_release_pickup_event_exists(
+    conn: sqlite3.Connection,
+    task_id: str,
+    run_id: Optional[int],
+) -> bool:
+    if run_id is None:
+        return False
+    row = conn.execute(
+        "SELECT 1 FROM task_events "
+        "WHERE task_id = ? AND run_id = ? AND kind = 'post_release_pickup' "
+        "LIMIT 1",
+        (task_id, int(run_id)),
+    ).fetchone()
+    return row is not None
+
+
+def _record_post_release_pickup(
+    conn: sqlite3.Connection,
+    result: PostReleasePickupResult,
+) -> None:
+    payload: dict[str, Any] = {
+        "outcome": result.outcome,
+        "release_task_id": result.release_task_id,
+        "release_run_id": result.release_run_id,
+        "assignee": result.assignee,
+        "selected_board": result.selected_board,
+        "selected_task_id": result.selected_task_id,
+        "spawned_run_id": result.spawned_run_id,
+        "pid": result.pid,
+        "workspace": result.workspace,
+        "reason": result.reason,
+        "boards_checked": result.boards_checked,
+        "capacity": result.capacity,
+    }
+    with write_txn(conn):
+        if _post_release_pickup_event_exists(
+            conn, result.release_task_id, result.release_run_id,
+        ):
+            return
+        _append_event(
+            conn,
+            result.release_task_id,
+            "post_release_pickup",
+            payload,
+            run_id=result.release_run_id,
+        )
+
+
+def _same_profile_candidates(
+    assignee: str,
+    *,
+    exclude_task_id: Optional[str] = None,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    candidates: list[dict[str, Any]] = []
+    boards_checked: list[str] = []
+    for meta in list_boards(include_archived=False):
+        board = meta["slug"]
+        path = kanban_db_path(board=board)
+        if not path.exists():
+            continue
+        boards_checked.append(board)
+        with connect_closing(board=board) as board_conn:
+            rows = board_conn.execute(
+                "SELECT t.id, t.priority, t.created_at FROM tasks t "
+                "WHERE t.status = 'ready' "
+                "  AND t.assignee = ? "
+                "  AND t.claim_lock IS NULL "
+                "  AND t.current_run_id IS NULL "
+                "  AND NOT EXISTS ("
+                "      SELECT 1 FROM task_links l "
+                "      JOIN tasks p ON p.id = l.parent_id "
+                "      WHERE l.child_id = t.id "
+                "        AND p.status NOT IN ('done', 'archived')"
+                "  )",
+                (assignee,),
+            ).fetchall()
+        for row in rows:
+            if exclude_task_id and row["id"] == exclude_task_id:
+                continue
+            candidates.append({
+                "board": board,
+                "task_id": row["id"],
+                "priority": int(row["priority"] or 0),
+                "created_at": int(row["created_at"] or 0),
+            })
+    candidates.sort(
+        key=lambda item: (
+            -int(item["priority"]),
+            int(item["created_at"]),
+            str(item["board"]),
+            str(item["task_id"]),
+        )
+    )
+    return candidates, boards_checked
+
+
+def attempt_post_release_pickup(
+    conn: sqlite3.Connection,
+    release_task_id: str,
+    *,
+    release_run_id: Optional[int],
+    assignee: Optional[str],
+    spawn_fn=None,
+    failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
+) -> PostReleasePickupResult:
+    """Try to spawn one next ready task for the just-released profile.
+
+    The releasing task is already terminal/reclaimed and its claim/PID has
+    been cleared before this is called. The function records exactly one
+    release-side ``post_release_pickup`` event per releasing run id; pickup
+    failures are evidence, never reasons to roll back the release.
+    """
+    if release_run_id is not None and _post_release_pickup_event_exists(
+        conn, release_task_id, release_run_id,
+    ):
+        return PostReleasePickupResult(
+            outcome="already_recorded",
+            release_task_id=release_task_id,
+            release_run_id=release_run_id,
+            assignee=assignee,
+            reason="duplicate_release_event",
+        )
+    profile = (assignee or "").strip()
+    if not profile:
+        result = PostReleasePickupResult(
+            outcome="owner_unavailable",
+            release_task_id=release_task_id,
+            release_run_id=release_run_id,
+            assignee=assignee,
+            reason="missing_assignee",
+        )
+        _record_post_release_pickup(conn, result)
+        return result
+    try:
+        from hermes_cli.profiles import profile_exists
+    except Exception:
+        profile_exists = None  # type: ignore[assignment]
+    if profile_exists is not None and not profile_exists(profile):
+        result = PostReleasePickupResult(
+            outcome="owner_unavailable",
+            release_task_id=release_task_id,
+            release_run_id=release_run_id,
+            assignee=profile,
+            reason="assignee_not_spawnable",
+        )
+        _record_post_release_pickup(conn, result)
+        return result
+
+    try:
+        candidates, boards_checked = _same_profile_candidates(
+            profile, exclude_task_id=release_task_id,
+        )
+        if not candidates:
+            result = PostReleasePickupResult(
+                outcome="no_eligible_work",
+                release_task_id=release_task_id,
+                release_run_id=release_run_id,
+                assignee=profile,
+                boards_checked=boards_checked,
+            )
+            _record_post_release_pickup(conn, result)
+            return result
+
+        occupied = _profile_occupancy(profile)
+        if occupied:
+            selected = candidates[0]
+            result = PostReleasePickupResult(
+                outcome="profile_occupied",
+                release_task_id=release_task_id,
+                release_run_id=release_run_id,
+                assignee=profile,
+                selected_board=selected["board"],
+                selected_task_id=selected["task_id"],
+                reason="profile_occupied",
+                boards_checked=boards_checked,
+                capacity=occupied,
+            )
+            _record_post_release_pickup(conn, result)
+            return result
+
+        selected = candidates[0]
+        with connect_closing(board=selected["board"]) as selected_conn:
+            exact = dispatch_task(
+                selected_conn,
+                selected["task_id"],
+                spawn_fn=spawn_fn,
+                failure_limit=failure_limit,
+                board=selected["board"],
+            )
+        if exact.state == "spawned" and exact.spawned and exact.run_id and exact.pid:
+            outcome = "spawned"
+        elif exact.state == "capacity":
+            outcome = "profile_occupied" if exact.reason == "profile_occupied" else "capacity_queued"
+        else:
+            outcome = "exact_refused"
+        result = PostReleasePickupResult(
+            outcome=outcome,
+            release_task_id=release_task_id,
+            release_run_id=release_run_id,
+            assignee=profile,
+            selected_board=selected["board"],
+            selected_task_id=selected["task_id"],
+            spawned_run_id=exact.run_id,
+            pid=exact.pid,
+            workspace=exact.workspace,
+            reason=exact.reason or exact.state,
+            boards_checked=boards_checked,
+            capacity=exact.capacity,
+        )
+        _record_post_release_pickup(conn, result)
+        return result
+    except Exception as exc:
+        result = PostReleasePickupResult(
+            outcome="pickup_error",
+            release_task_id=release_task_id,
+            release_run_id=release_run_id,
+            assignee=profile,
+            reason=str(exc)[:500],
+        )
+        _record_post_release_pickup(conn, result)
+        return result
 
 
 def dispatch_task(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6507,6 +6507,21 @@ class DispatchResult:
     actively preventing two dispatchers from racing on ``kanban.db``."""
 
 
+@dataclass
+class ExactDispatchResult:
+    """Machine-readable outcome for dispatching one requested task only."""
+
+    task_id: str
+    state: str
+    spawned: bool = False
+    run_id: Optional[int] = None
+    pid: Optional[int] = None
+    assignee: Optional[str] = None
+    workspace: Optional[str] = None
+    reason: Optional[str] = None
+    capacity: list[dict[str, Any]] = field(default_factory=list)
+
+
 # Bounded registry of recently-reaped worker child exits, populated by the
 # reap loop at the top of ``dispatch_once`` and consulted by
 # ``detect_crashed_workers`` to classify a dead-pid task.
@@ -7648,6 +7663,193 @@ def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
         _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
 
 
+def _profile_occupancy(assignee: str) -> list[dict[str, Any]]:
+    """Return live current runs for ``assignee`` across visible boards."""
+    now = int(time.time())
+    occupied: list[dict[str, Any]] = []
+    for meta in list_boards(include_archived=False):
+        board = meta["slug"]
+        path = kanban_db_path(board=board)
+        if not path.exists():
+            continue
+        with connect_closing(board=board) as other:
+            rows = other.execute(
+                "SELECT t.id, t.worker_pid, t.claim_expires, t.last_heartbeat_at, "
+                "       t.started_at, t.current_run_id "
+                "FROM tasks t JOIN task_runs r ON r.id = t.current_run_id "
+                "WHERE t.status = 'running' AND t.assignee = ? "
+                "  AND r.ended_at IS NULL",
+                (assignee,),
+            ).fetchall()
+        for row in rows:
+            pid = int(row["worker_pid"]) if row["worker_pid"] is not None else None
+            if pid is not None:
+                started_at = int(row["started_at"] or 0)
+                live = _pid_alive(pid) or now - started_at < _resolve_crash_grace_seconds()
+            else:
+                heartbeat = int(row["last_heartbeat_at"] or 0)
+                live = int(row["claim_expires"] or 0) > now or (
+                    heartbeat > 0
+                    and now - heartbeat <= DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
+                )
+            if live:
+                occupied.append({
+                    "board": board,
+                    "task_id": row["id"],
+                    "run_id": int(row["current_run_id"]),
+                    "pid": pid,
+                })
+    return occupied
+
+
+def dispatch_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    spawn_fn=None,
+    ttl_seconds: Optional[int] = None,
+    failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
+    board: Optional[str] = None,
+) -> ExactDispatchResult:
+    """Dispatch exactly ``task_id`` or return a fail-closed structured result."""
+    requested = (task_id or "").strip()
+    if not requested:
+        return ExactDispatchResult(task_id=requested, state="refused", reason="task_id_required")
+
+    with _dispatch_tick_lock(kanban_db_path(board=board)) as held:
+        if not held:
+            return ExactDispatchResult(
+                task_id=requested, state="capacity", reason="dispatcher_locked"
+            )
+
+        reap_worker_zombies()
+        release_stale_claims(conn)
+        detect_crashed_workers(conn)
+        enforce_max_runtime(conn)
+        recompute_ready(conn, failure_limit=failure_limit)
+
+        task = get_task(conn, requested)
+        if task is None:
+            return ExactDispatchResult(task_id=requested, state="refused", reason="not_found")
+        base = {
+            "task_id": requested,
+            "assignee": task.assignee,
+            "workspace": task.workspace_path,
+        }
+        if task.status == "running" and task.current_run_id is not None:
+            return ExactDispatchResult(
+                **base,
+                state="already_running",
+                run_id=task.current_run_id,
+                pid=task.worker_pid,
+            )
+        if task.status != "ready":
+            return ExactDispatchResult(
+                **base, state="refused", reason=f"state:{task.status}"
+            )
+        undone = conn.execute(
+            "SELECT 1 FROM task_links l JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            (requested,),
+        ).fetchone()
+        if undone:
+            return ExactDispatchResult(
+                **base, state="refused", reason="parents_not_done"
+            )
+        if not task.assignee:
+            return ExactDispatchResult(**base, state="refused", reason="unassigned")
+        try:
+            from hermes_cli.profiles import profile_exists
+        except Exception:
+            profile_exists = None  # type: ignore[assignment]
+        if profile_exists is not None and not profile_exists(task.assignee):
+            return ExactDispatchResult(
+                **base, state="refused", reason="assignee_not_spawnable"
+            )
+
+        try:
+            resolved_branch_name = None
+            if task.workspace_kind == "worktree":
+                workspace, resolved_branch_name = _resolve_worktree_workspace(task, board=board)
+            else:
+                workspace = resolve_workspace(task, board=board)
+        except Exception as exc:
+            return ExactDispatchResult(
+                **base, state="refused", reason=f"workspace:{exc}"
+            )
+
+        occupied = _profile_occupancy(task.assignee)
+        if occupied:
+            return ExactDispatchResult(
+                task_id=requested,
+                state="capacity",
+                assignee=task.assignee,
+                workspace=str(workspace),
+                reason="profile_occupied",
+                capacity=occupied,
+            )
+
+        claimed = claim_task(conn, requested, ttl_seconds=ttl_seconds)
+        if claimed is None:
+            current = get_task(conn, requested)
+            if current and current.status == "running" and current.current_run_id is not None:
+                return ExactDispatchResult(
+                    task_id=requested,
+                    state="already_running",
+                    assignee=current.assignee,
+                    workspace=current.workspace_path,
+                    run_id=current.current_run_id,
+                    pid=current.worker_pid,
+                )
+            return ExactDispatchResult(
+                **base, state="refused", reason="claim_failed"
+            )
+
+        set_workspace_path(conn, claimed.id, str(workspace))
+        if claimed.workspace_kind == "worktree":
+            set_branch_name(
+                conn,
+                claimed.id,
+                resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}",
+            )
+        _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
+        _spawn = spawn_fn if spawn_fn is not None else _default_spawn
+        try:
+            import inspect
+            try:
+                sig = inspect.signature(_spawn)
+                if "board" in sig.parameters:
+                    pid = _spawn(claimed, str(workspace), board=board)
+                else:
+                    pid = _spawn(claimed, str(workspace))
+            except (TypeError, ValueError):
+                pid = _spawn(claimed, str(workspace))
+            if not pid:
+                raise RuntimeError("spawn returned no PID")
+            _set_worker_pid(conn, claimed.id, int(pid))
+        except Exception as exc:
+            _record_spawn_failure(
+                conn, claimed.id, str(exc), failure_limit=failure_limit,
+            )
+            return ExactDispatchResult(
+                task_id=requested,
+                state="refused",
+                assignee=claimed.assignee,
+                workspace=str(workspace),
+                reason=f"spawn:{exc}",
+            )
+        current = get_task(conn, requested)
+        return ExactDispatchResult(
+            task_id=requested,
+            state="spawned",
+            spawned=True,
+            run_id=current.current_run_id if current else None,
+            pid=int(pid),
+            assignee=claimed.assignee,
+            workspace=str(workspace),
+        )
+
+
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
     """Reset the unified consecutive-failures counter.
 
@@ -8003,40 +8205,32 @@ def _dispatch_once_locked(
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
-    # Count tasks already running so max_spawn enforces concurrency rather
-    # than a per-tick spawn budget. See the docstring above for the full
-    # rationale; the short version is that a 60-second tick interval with a
-    # per-tick budget of N would grow concurrency by N every tick on a busy
-    # board, since "running" tasks aren't reclaimed by completion alone —
-    # they sit in status='running' until the worker calls
-    # kanban_complete/kanban_block (or the dispatcher TTL-reclaims them).
+    # Count tasks already running so max_spawn/max_in_progress enforce live
+    # concurrency rather than per-tick spawn budgets. Treat both knobs as caps
+    # on the same board-wide worker pool and honor the stricter one. The old
+    # implementation first converted max_in_progress into a *remaining-slot*
+    # value, then still compared it against ``running_count + spawned``; when
+    # both caps were set, existing running tasks were double-counted and an
+    # available slot could be skipped entirely.
+    concurrency_limits = [
+        limit for limit in (max_spawn, max_in_progress) if limit is not None
+    ]
+    concurrency_limit = min(concurrency_limits) if concurrency_limits else None
     running_count = 0
-    if max_spawn is not None:
+    if concurrency_limit is not None:
         running_count = int(
             conn.execute(
                 "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
             ).fetchone()[0]
         )
+        if running_count >= concurrency_limit:
+            return result
 
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
-    # Honour kanban.max_in_progress: if the board already has enough running
-    # tasks, skip spawning this tick so slow workers (local LLMs,
-    # resource-constrained hosts) can finish what they have before more tasks
-    # pile up and time out.
-    if max_in_progress is not None and ready_rows:
-        in_progress = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
-        ).fetchone()[0]
-        if in_progress >= max_in_progress:
-            return result
-        # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = max_in_progress - in_progress
-        if max_spawn is None or max_spawn > remaining:
-            max_spawn = remaining
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn
@@ -8075,7 +8269,10 @@ def _dispatch_once_locked(
             # there, with the existing diagnostic.
             _default_assignee_resolved = True
     for row in ready_rows:
-        if max_spawn is not None and running_count + spawned >= max_spawn:
+        if (
+            concurrency_limit is not None
+            and running_count + spawned >= concurrency_limit
+        ):
             break
         row_assignee = row["assignee"]
         if not row_assignee:
@@ -8180,6 +8377,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
+            spawned += 1
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
             # Without this, dry_run reports every task as spawnable and
@@ -8266,7 +8464,10 @@ def _dispatch_once_locked(
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
     for row in review_rows:
-        if max_spawn is not None and running_count + spawned >= max_spawn:
+        if (
+            concurrency_limit is not None
+            and running_count + spawned >= concurrency_limit
+        ):
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
@@ -8278,8 +8479,20 @@ def _dispatch_once_locked(
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
             continue
+        if _per_profile_cap is not None:
+            current = _per_profile_running.get(row["assignee"], 0)
+            if current >= _per_profile_cap:
+                result.skipped_per_profile_capped.append(
+                    (row["id"], row["assignee"], current)
+                )
+                continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            spawned += 1
+            if _per_profile_cap is not None and row["assignee"]:
+                _per_profile_running[row["assignee"]] = (
+                    _per_profile_running.get(row["assignee"], 0) + 1
+                )
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -8324,6 +8537,10 @@ def _dispatch_once_locked(
                 _set_worker_pid(conn, claimed.id, int(pid))
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
+            if _per_profile_cap is not None and claimed.assignee:
+                _per_profile_running[claimed.assignee] = (
+                    _per_profile_running.get(claimed.assignee, 0) + 1
+                )
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -124,6 +124,84 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
 VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 
+_REVIEW_HANDOFF_KIND_TOKENS = {
+    "review-required",
+    "review_required",
+    "review required",
+    "review-only",
+    "review_only",
+    "needs-review",
+    "needs_review",
+    "needs review",
+}
+
+_REVIEW_HANDOFF_REASON_RE = re.compile(
+    r"\b("
+    r"review[-_ ]?required|"
+    r"review[-_ ]?only|"
+    r"needs[-_ ]?review|"
+    r"ready[-_ ]?for[-_ ]?review|"
+    r"awaiting[-_ ]?review|"
+    r"qa[-_ ]?review|"
+    r"eve[-_ ]?review"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+class ReviewHandoffBlockError(ValueError):
+    """Raised when a normal review handoff is attempted as a blocker."""
+
+    code = "review_handoff_not_blocker"
+
+    def __init__(self, *, task_id: str, reason: Optional[str], kind: Optional[str]):
+        self.task_id = task_id
+        self.reason = reason
+        self.kind = kind
+        super().__init__(review_handoff_block_message(task_id=task_id))
+
+
+def is_review_handoff_block(reason: Optional[str], kind: Optional[str] = None) -> bool:
+    """Return True for normal review/QA handoff language, not real blockers."""
+
+    kind_text = (kind or "").strip().casefold().replace("_", "-")
+    if kind_text in {token.replace("_", "-") for token in _REVIEW_HANDOFF_KIND_TOKENS}:
+        return True
+    reason_text = (reason or "").strip()
+    if not reason_text:
+        return False
+    return bool(_REVIEW_HANDOFF_REASON_RE.search(reason_text))
+
+
+def review_handoff_block_instruction(task_id: str) -> dict[str, Any]:
+    """Structured recovery instruction for rejected review-handoff blocks."""
+
+    return {
+        "code": ReviewHandoffBlockError.code,
+        "task_id": task_id,
+        "state_mutated": False,
+        "instruction": (
+            "Normal review-required/QA handoff is not a blocker. Create or "
+            "recover the exact artifact-bound successor first (use an "
+            "idempotency key derived from immutable artifact evidence), verify "
+            "the successor task id and status, then complete the producer with "
+            "structured artifact/test/successor/dispatch facts. If dispatch "
+            "capacity is unavailable, leave the successor Ready/Todo with a "
+            "capacity receipt; do not block the producer merely because review "
+            "is queued."
+        ),
+        "required_actions": [
+            "create_or_recover_artifact_bound_successor",
+            "verify_successor_id_and_status",
+            "complete_producer_with_structured_handoff",
+        ],
+    }
+
+
+def review_handoff_block_message(*, task_id: str) -> str:
+    payload = review_handoff_block_instruction(task_id)
+    return f"{payload['code']}: {payload['instruction']}"
+
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
 # unblocker (usually a cron) and routes the task to ``triage`` instead of back
@@ -5242,6 +5320,20 @@ def block_task(
     Returns True on any successful transition (to ``blocked``, ``todo``, or
     ``triage``), False when the task wasn't in a blockable state.
     """
+    if is_review_handoff_block(reason, kind):
+        with write_txn(conn):
+            _append_event(
+                conn,
+                task_id,
+                "block_rejected_review_handoff",
+                {
+                    "reason": reason,
+                    "kind": kind,
+                    "contract": review_handoff_block_instruction(task_id),
+                },
+            )
+        raise ReviewHandoffBlockError(task_id=task_id, reason=reason, kind=kind)
+
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -192,6 +192,88 @@ def test_invalid_kind_rejected(kanban_home: Path) -> None:
             kb.block_task(conn, tid, reason="x", kind="bogus")
 
 
+def test_review_required_block_rejected_without_task_state_mutation(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        before = kb.get_task(conn, tid)
+        assert before is not None
+
+        with pytest.raises(kb.ReviewHandoffBlockError) as exc:
+            kb.block_task(
+                conn,
+                tid,
+                reason="review-required: implementation complete",
+                kind="needs_input",
+                expected_run_id=before.current_run_id,
+            )
+
+        after = kb.get_task(conn, tid)
+        assert after is not None
+        assert exc.value.task_id == tid
+        assert after.status == before.status == "running"
+        assert after.current_run_id == before.current_run_id
+        assert after.block_kind == before.block_kind
+        assert after.block_recurrences == before.block_recurrences
+
+
+def test_review_kind_alias_rejected_before_invalid_kind_error(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+
+        with pytest.raises(kb.ReviewHandoffBlockError):
+            kb.block_task(conn, tid, reason="done", kind="review_required")
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "running"
+
+
+def test_producer_handoff_successor_is_idempotent_and_not_parent_suppressed(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        producer = _running_task(conn, title="producer")
+        key = "review:artifact:sha256:abc123"
+
+        successor_1 = kb.create_task(
+            conn,
+            title="EVE review exact artifact abc123",
+            assignee="eve",
+            body="Review immutable artifact sha256:abc123 from producer.",
+            idempotency_key=key,
+        )
+        successor_2 = kb.create_task(
+            conn,
+            title="duplicate EVE review exact artifact abc123",
+            assignee="eve",
+            idempotency_key=key,
+        )
+        assert successor_2 == successor_1
+
+        successor = kb.get_task(conn, successor_1)
+        assert successor is not None
+        assert successor.status == "ready"
+
+        assert kb.complete_task(
+            conn,
+            producer,
+            summary="Producer complete; exact artifact successor queued.",
+            metadata={
+                "artifact_sha256": "abc123",
+                "successor_task_id": successor_1,
+                "successor_status": successor.status,
+                "dispatch_receipt": {"status": "queued_capacity"},
+            },
+        )
+
+        producer_task = kb.get_task(conn, producer)
+        successor_task = kb.get_task(conn, successor_1)
+        assert producer_task is not None
+        assert successor_task is not None
+        assert producer_task.status == "done"
+        assert successor_task.status == "ready"
+
+
 def test_block_without_kind_is_backward_compatible(kanban_home: Path) -> None:
     """Existing callers that pass no kind keep the old single-block behaviour."""
     with kb.connect_closing() as conn:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -54,16 +54,17 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path) -> None:
-    """A standalone task that a worker explicitly blocks for review
+    """A standalone task that a worker explicitly blocks for human input
     must stay blocked across an arbitrary number of dispatcher ticks.
     Before #28712's fix, ``recompute_ready`` would silently flip it
     back to ``ready`` on the very next tick."""
     with kb.connect() as conn:
-        tid = kb.create_task(conn, title="needs human review")
+        tid = kb.create_task(conn, title="needs human approval")
         kb.claim_task(conn, tid)
         assert kb.block_task(
             conn, tid,
-            reason="review-required: please verify ACL change",
+            reason="auth-required: please approve ACL change",
+            kind="needs_input",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.get_task(conn, tid).status == "blocked"
@@ -89,7 +90,8 @@ def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Pa
         kb.claim_task(conn, child)
         kb.block_task(
             conn, child,
-            reason="review-required: child needs sign-off",
+            reason="auth-required: child needs sign-off",
+            kind="needs_input",
             expected_run_id=kb.get_task(conn, child).current_run_id,
         )
         assert kb.get_task(conn, child).status == "blocked"
@@ -185,7 +187,8 @@ def test_unblock_clears_sticky_state_and_lets_block_recover(kanban_home: Path) -
         kb.claim_task(conn, tid)
         kb.block_task(
             conn, tid,
-            reason="review-required: ...",
+            reason="auth-required: device consent needed",
+            kind="needs_input",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.unblock_task(conn, tid)
@@ -236,7 +239,8 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
         kb.claim_task(conn, tid)
         kb.block_task(
             conn, tid,
-            reason="review-required: human eyes please",
+            reason="auth-required: human approval needed",
+            kind="needs_input",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.get_task(conn, tid).status == "blocked"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1793,6 +1793,58 @@ def test_dispatch_max_spawn_fills_remaining_capacity(
         assert kb.get_task(conn, ready_b).status == "ready"
 
 
+def test_dispatch_combines_max_spawn_and_max_in_progress_without_double_counting(
+    kanban_home, all_assignees_spawnable
+):
+    """Global caps share one live worker pool and only count running tasks once."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        running_a = kb.create_task(conn, title="running-a", assignee="alice")
+        running_b = kb.create_task(conn, title="running-b", assignee="bob")
+        ready_a = kb.create_task(conn, title="ready-a", assignee="carol")
+        ready_b = kb.create_task(conn, title="ready-b", assignee="dave")
+        kb.claim_task(conn, running_a)
+        kb.claim_task(conn, running_b)
+
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=fake_spawn,
+            max_spawn=5,
+            max_in_progress=3,
+        )
+
+        assert len(res.spawned) == 1
+        assert spawns == [ready_a]
+        assert kb.get_task(conn, ready_a).status == "running"
+        assert kb.get_task(conn, ready_b).status == "ready"
+
+
+def test_dispatch_max_in_progress_blocks_review_without_ready_rows(
+    kanban_home, all_assignees_spawnable
+):
+    """kanban.max_in_progress caps review dispatch even when no ready task exists."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        running = kb.create_task(conn, title="running", assignee="alice")
+        review = kb.create_task(conn, title="review", assignee="bob")
+        kb.claim_task(conn, running)
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review,))
+
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_in_progress=1)
+
+        assert res.spawned == []
+        assert spawns == []
+        assert kb.get_task(conn, review).status == "review"
+
+
 def test_dispatch_reclaims_stale_before_spawning(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="alice")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1907,6 +1907,184 @@ def test_post_release_pickup_is_idempotent_per_released_run(
     assert len([event for event in events if event.kind == "post_release_pickup"]) == 1
 
 
+def test_post_release_pickup_reconciles_self_resolvable_blocked_before_ready(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    spawns = []
+    monkeypatch.setattr(
+        kb, "_default_spawn", lambda task, workspace: spawns.append(task.id) or 4242
+    )
+
+    with kb.connect() as conn:
+        releasing = kb.create_task(conn, title="release", assignee="alice")
+        blocked = kb.create_task(conn, title="blocked", assignee="alice", priority=100)
+        ready = kb.create_task(conn, title="ready", assignee="alice", priority=10)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'blocked', block_kind = 'transient' "
+                "WHERE id = ?",
+                (blocked,),
+            )
+            kb._append_event(
+                conn, blocked, "blocked", {"reason": "retry later", "kind": "transient"}
+            )
+        kb.claim_task(conn, releasing)
+
+        assert kb.complete_task(conn, releasing, result="done") is True
+
+        blocked_task = kb.get_task(conn, blocked)
+        ready_task = kb.get_task(conn, ready)
+        pickup = [
+            event for event in kb.list_events(conn, releasing)
+            if event.kind == "post_release_pickup"
+        ][0]
+        reconciled = [
+            event for event in kb.list_events(conn, blocked)
+            if event.kind == "post_release_blocker_reconciled"
+        ]
+
+    assert spawns == [blocked]
+    assert blocked_task is not None
+    assert ready_task is not None
+    assert blocked_task.status == "running"
+    assert ready_task.status == "ready"
+    assert pickup.payload is not None
+    assert pickup.payload["selected_task_id"] == blocked
+    assert pickup.payload["blocker"]["outcome"] == "unblocked_to_ready"
+    assert len(reconciled) == 1
+
+
+def test_post_release_pickup_external_blocker_routes_once_then_ready(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    spawns = []
+    monkeypatch.setattr(
+        kb, "_default_spawn", lambda task, workspace: spawns.append(task.id) or 4242
+    )
+
+    with kb.connect() as conn:
+        blocked = kb.create_task(conn, title="needs-human", assignee="alice", priority=100)
+        releasing_1 = kb.create_task(conn, title="release-1", assignee="alice")
+        ready_1 = kb.create_task(conn, title="ready-1", assignee="alice", priority=10)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'blocked', block_kind = 'needs_input' "
+                "WHERE id = ?",
+                (blocked,),
+            )
+            kb._append_event(
+                conn,
+                blocked,
+                "blocked",
+                {"reason": "needs human", "kind": "needs_input"},
+            )
+        kb.claim_task(conn, releasing_1)
+
+        assert kb.complete_task(conn, releasing_1, result="done") is True
+        waiting_after_first = [
+            event for event in kb.list_events(conn, blocked)
+            if event.kind == "post_release_blocker_waiting"
+        ]
+
+        # Same unchanged blocker is skipped on a later release; ready work still runs.
+        releasing_2 = kb.create_task(conn, title="release-2", assignee="alice")
+        ready_2 = kb.create_task(conn, title="ready-2", assignee="alice", priority=10)
+        conn.execute(
+            "UPDATE tasks SET status = 'done', current_run_id = NULL, worker_pid = NULL "
+            "WHERE id = ?",
+            (ready_1,),
+        )
+        kb.claim_task(conn, releasing_2)
+
+        assert kb.complete_task(conn, releasing_2, result="done") is True
+        waiting_after_second = [
+            event for event in kb.list_events(conn, blocked)
+            if event.kind == "post_release_blocker_waiting"
+        ]
+        blocked_task = kb.get_task(conn, blocked)
+        ready_2_task = kb.get_task(conn, ready_2)
+
+    assert spawns == [ready_1, ready_2]
+    assert blocked_task is not None
+    assert ready_2_task is not None
+    assert blocked_task.status == "blocked"
+    assert ready_2_task.status == "running"
+    assert len(waiting_after_first) == 1
+    assert len(waiting_after_second) == 1
+    assert waiting_after_first[0].payload is not None
+    assert waiting_after_first[0].payload["owner"] == "needs_input"
+
+
+def test_post_release_pickup_ready_beats_promotable_todo(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    spawns = []
+    monkeypatch.setattr(
+        kb, "_default_spawn", lambda task, workspace: spawns.append(task.id) or 4242
+    )
+
+    with kb.connect() as conn:
+        releasing = kb.create_task(conn, title="release", assignee="alice")
+        todo = kb.create_task(conn, title="todo", assignee="alice", priority=100)
+        ready = kb.create_task(conn, title="ready", assignee="alice", priority=10)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (todo,))
+        kb.claim_task(conn, releasing)
+
+        assert kb.complete_task(conn, releasing, result="done") is True
+
+        todo_task = kb.get_task(conn, todo)
+        ready_task = kb.get_task(conn, ready)
+        pickup = [
+            event for event in kb.list_events(conn, releasing)
+            if event.kind == "post_release_pickup"
+        ][0]
+
+    assert spawns == [ready]
+    assert todo_task is not None
+    assert ready_task is not None
+    assert todo_task.status == "ready"
+    assert ready_task.status == "running"
+    assert pickup.payload is not None
+    assert pickup.payload["selected_task_id"] == ready
+    assert pickup.payload["todo"] is None
+
+
+def test_post_release_pickup_promotes_todo_only_after_dependencies(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    spawns = []
+    monkeypatch.setattr(
+        kb, "_default_spawn", lambda task, workspace: spawns.append(task.id) or 4242
+    )
+
+    with kb.connect() as conn:
+        releasing = kb.create_task(conn, title="release", assignee="alice")
+        parent = kb.create_task(conn, title="parent", assignee="bob")
+        waiting = kb.create_task(conn, title="waiting", assignee="alice", parents=[parent])
+        kb.claim_task(conn, releasing)
+
+        assert kb.complete_task(conn, releasing, result="done") is True
+
+        waiting_task = kb.get_task(conn, waiting)
+        pickup = [
+            event for event in kb.list_events(conn, releasing)
+            if event.kind == "post_release_pickup"
+        ][0]
+        waiting_events = [
+            event for event in kb.list_events(conn, waiting)
+            if event.kind == "post_release_todo_waiting"
+        ]
+
+    assert spawns == []
+    assert waiting_task is not None
+    assert waiting_task.status == "todo"
+    assert pickup.payload is not None
+    assert pickup.payload["outcome"] == "no_eligible_work"
+    assert pickup.payload["todo"]["outcome"] == "waiting_on_dependency"
+    assert len(waiting_events) == 1
+
+
 def test_dispatch_spawn_failure_releases_claim(kanban_home, all_assignees_spawnable):
     def boom(task, workspace):
         raise RuntimeError("spawn failed")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import subprocess
@@ -1728,6 +1729,182 @@ def test_dispatch_promotes_ready_and_spawns(kanban_home, all_assignees_spawnable
     # c is now running
     with kb.connect() as conn:
         assert kb.get_task(conn, c).status == "running"
+
+
+def test_complete_task_picks_up_next_same_profile_ready_task(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    """A terminal worker release immediately claims one successor for the
+    same profile and leaves structured evidence on the releasing run."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append((task.id, workspace))
+        return 4242
+
+    monkeypatch.setattr(kb, "_default_spawn", fake_spawn)
+
+    with kb.connect() as conn:
+        releasing = kb.create_task(conn, title="release", assignee="alice")
+        successor = kb.create_task(conn, title="successor", assignee="alice")
+        other_profile = kb.create_task(conn, title="other", assignee="bob")
+        kb.claim_task(conn, releasing)
+        releasing_task = kb.get_task(conn, releasing)
+        assert releasing_task is not None
+        release_run_id = releasing_task.current_run_id
+
+        assert kb.complete_task(conn, releasing, result="done") is True
+
+        successor_task = kb.get_task(conn, successor)
+        other_task = kb.get_task(conn, other_profile)
+        events = kb.list_events(conn, releasing)
+
+    assert spawns and spawns[0][0] == successor
+    assert successor_task is not None
+    assert other_task is not None
+    assert successor_task.status == "running"
+    assert successor_task.worker_pid == 4242
+    assert other_task.status == "ready"
+    pickup_events = [event for event in events if event.kind == "post_release_pickup"]
+    assert len(pickup_events) == 1
+    assert pickup_events[0].payload is not None
+    assert pickup_events[0].run_id == release_run_id
+    assert pickup_events[0].payload["outcome"] == "spawned"
+    assert pickup_events[0].payload["release_task_id"] == releasing
+    assert pickup_events[0].payload["selected_task_id"] == successor
+    assert pickup_events[0].payload["spawned_run_id"] == successor_task.current_run_id
+
+
+def test_complete_task_pickup_records_capacity_when_profile_already_running(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    """Post-release pickup is fail-closed when another same-profile run still
+    occupies the profile; the queued task remains ready with an evidence event."""
+    spawns = []
+    monkeypatch.setattr(
+        kb, "_default_spawn", lambda task, workspace: spawns.append(task.id) or 4242
+    )
+
+    with kb.connect() as conn:
+        releasing = kb.create_task(conn, title="release", assignee="alice")
+        occupied = kb.create_task(conn, title="occupied", assignee="alice")
+        successor = kb.create_task(conn, title="successor", assignee="alice")
+        kb.claim_task(conn, releasing)
+        kb.claim_task(conn, occupied)
+
+        assert kb.complete_task(conn, releasing, result="done") is True
+
+        successor_task = kb.get_task(conn, successor)
+        occupied_task = kb.get_task(conn, occupied)
+        events = kb.list_events(conn, releasing)
+
+    assert spawns == []
+    assert successor_task is not None
+    assert occupied_task is not None
+    assert successor_task.status == "ready"
+    assert occupied_task.status == "running"
+    pickup_events = [event for event in events if event.kind == "post_release_pickup"]
+    assert len(pickup_events) == 1
+    assert pickup_events[0].payload is not None
+    assert pickup_events[0].payload["outcome"] == "profile_occupied"
+    assert pickup_events[0].payload["selected_task_id"] == successor
+    assert pickup_events[0].payload["capacity"][0]["task_id"] == occupied
+
+
+def test_block_task_picks_up_next_same_profile_ready_task(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    spawns = []
+    monkeypatch.setattr(
+        kb, "_default_spawn", lambda task, workspace: spawns.append(task.id) or 4242
+    )
+
+    with kb.connect() as conn:
+        releasing = kb.create_task(conn, title="blocked", assignee="alice")
+        successor = kb.create_task(conn, title="successor", assignee="alice")
+        kb.claim_task(conn, releasing)
+
+        assert kb.block_task(conn, releasing, reason="needs human", kind="needs_input") is True
+
+        releasing_task = kb.get_task(conn, releasing)
+        successor_task = kb.get_task(conn, successor)
+        events = kb.list_events(conn, releasing)
+
+    assert spawns == [successor]
+    assert releasing_task is not None
+    assert successor_task is not None
+    assert releasing_task.status == "blocked"
+    assert successor_task.status == "running"
+    pickup_events = [event for event in events if event.kind == "post_release_pickup"]
+    assert len(pickup_events) == 1
+    assert pickup_events[0].payload is not None
+    assert pickup_events[0].payload["outcome"] == "spawned"
+    assert pickup_events[0].payload["selected_task_id"] == successor
+
+
+def test_complete_task_pickup_records_no_eligible_for_other_profile_only(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    spawns = []
+    monkeypatch.setattr(
+        kb, "_default_spawn", lambda task, workspace: spawns.append(task.id) or 4242
+    )
+
+    with kb.connect() as conn:
+        releasing = kb.create_task(conn, title="release", assignee="alice")
+        other_profile = kb.create_task(conn, title="other", assignee="bob")
+        unassigned = kb.create_task(conn, title="unassigned")
+        kb.claim_task(conn, releasing)
+
+        assert kb.complete_task(conn, releasing, result="done") is True
+
+        other_task = kb.get_task(conn, other_profile)
+        unassigned_task = kb.get_task(conn, unassigned)
+        events = kb.list_events(conn, releasing)
+
+    assert spawns == []
+    assert other_task is not None
+    assert unassigned_task is not None
+    assert other_task.status == "ready"
+    assert unassigned_task.status == "ready"
+    pickup_events = [event for event in events if event.kind == "post_release_pickup"]
+    assert len(pickup_events) == 1
+    assert pickup_events[0].payload is not None
+    assert pickup_events[0].payload["outcome"] == "no_eligible_work"
+    assert pickup_events[0].payload["selected_task_id"] is None
+
+
+def test_post_release_pickup_is_idempotent_per_released_run(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    spawns = []
+    monkeypatch.setattr(
+        kb, "_default_spawn", lambda task, workspace: spawns.append(task.id) or 4242
+    )
+
+    with kb.connect() as conn:
+        releasing = kb.create_task(conn, title="release", assignee="alice")
+        successor = kb.create_task(conn, title="successor", assignee="alice")
+        kb.claim_task(conn, releasing)
+        release_task = kb.get_task(conn, releasing)
+        assert release_task is not None
+        release_run_id = release_task.current_run_id
+
+        assert kb.complete_task(conn, releasing, result="done") is True
+        duplicate = kb.attempt_post_release_pickup(
+            conn,
+            releasing,
+            release_run_id=release_run_id,
+            assignee="alice",
+        )
+        events = kb.list_events(conn, releasing)
+        successor_task = kb.get_task(conn, successor)
+
+    assert spawns == [successor]
+    assert duplicate.outcome == "already_recorded"
+    assert successor_task is not None
+    assert successor_task.status == "running"
+    assert len([event for event in events if event.kind == "post_release_pickup"]) == 1
 
 
 def test_dispatch_spawn_failure_releases_claim(kanban_home, all_assignees_spawnable):

--- a/tests/hermes_cli/test_kanban_exact_dispatch.py
+++ b/tests/hermes_cli/test_kanban_exact_dispatch.py
@@ -1,0 +1,210 @@
+"""Focused regressions for native exact-task Kanban dispatch."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def test_exact_dispatch_success_is_idempotent_and_structured(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="exact", assignee="alice")
+        result = kb.dispatch_task(conn, task_id, spawn_fn=lambda *_: os.getpid())
+
+        assert result == kb.ExactDispatchResult(
+            task_id=task_id,
+            state="spawned",
+            spawned=True,
+            run_id=kb.get_task(conn, task_id).current_run_id,
+            pid=os.getpid(),
+            assignee="alice",
+            workspace=str(kb.workspaces_root() / task_id),
+        )
+
+        repeated = kb.dispatch_task(conn, task_id, spawn_fn=lambda *_: 99999)
+        assert repeated.state == "already_running"
+        assert repeated.spawned is False
+        assert repeated.run_id == result.run_id
+        assert repeated.pid == result.pid
+
+
+def test_exact_dispatch_never_falls_back(kanban_home, all_assignees_spawnable):
+    calls = []
+    with kb.connect() as conn:
+        requested = kb.create_task(conn, title="blocked", assignee="alice")
+        other = kb.create_task(conn, title="ready", assignee="bob", priority=100)
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (requested,))
+
+        result = kb.dispatch_task(
+            conn, requested, spawn_fn=lambda task, workspace: calls.append(task.id)
+        )
+
+        assert result.state == "refused"
+        assert result.reason == "state:done"
+        assert calls == []
+        assert kb.get_task(conn, other).status == "ready"
+
+
+def test_exact_dispatch_refuses_dependencies_and_bad_workspace(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="alice")
+        child = kb.create_task(
+            conn, title="child", assignee="bob", parents=[parent]
+        )
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child,))
+        dependency = kb.dispatch_task(conn, child, spawn_fn=lambda *_: 123)
+        assert dependency.reason == "parents_not_done"
+        assert kb.get_task(conn, child).status == "ready"
+
+        bad_workspace = kb.create_task(
+            conn,
+            title="bad workspace",
+            assignee="carol",
+            workspace_kind="dir",
+            workspace_path="relative/path",
+        )
+        workspace = kb.dispatch_task(conn, bad_workspace, spawn_fn=lambda *_: 123)
+        assert workspace.state == "refused"
+        assert workspace.reason.startswith("workspace:")
+        assert kb.get_task(conn, bad_workspace).status == "ready"
+
+
+def test_exact_dispatch_reports_cross_board_profile_capacity(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: True)
+    kb.create_board("other", name="Other")
+    with kb.connect(board="other") as other_conn:
+        occupied_id = kb.create_task(other_conn, title="occupied", assignee="alice")
+        occupied = kb.claim_task(other_conn, occupied_id)
+        kb._set_worker_pid(other_conn, occupied_id, 4242)
+        occupied_run = occupied.current_run_id
+
+    with kb.connect(board="default") as conn:
+        target = kb.create_task(conn, title="target", assignee="alice")
+        result = kb.dispatch_task(
+            conn, target, board="default", spawn_fn=lambda *_: 9999
+        )
+        assert result.state == "capacity"
+        assert result.reason == "profile_occupied"
+        assert result.capacity == [{
+            "board": "other",
+            "task_id": occupied_id,
+            "run_id": occupied_run,
+            "pid": 4242,
+        }]
+        assert kb.get_task(conn, target).status == "ready"
+
+
+def test_exact_dispatch_reclaims_dead_target_and_retries(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid == 2222)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="retry", assignee="alice")
+        kb.claim_task(conn, task_id)
+        kb._set_worker_pid(conn, task_id, 1111)
+        conn.execute(
+            "UPDATE tasks SET started_at = ? WHERE id = ?",
+            (int(time.time()) - kb.DEFAULT_CRASH_GRACE_SECONDS - 1, task_id),
+        )
+
+        result = kb.dispatch_task(conn, task_id, spawn_fn=lambda *_: 2222)
+
+        assert result.state == "spawned"
+        assert result.pid == 2222
+        assert kb.get_task(conn, task_id).status == "running"
+        assert [run.outcome for run in kb.list_runs(conn, task_id)] == ["crashed", None]
+
+
+def test_exact_dispatch_cli_parser_accepts_one_task_id():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    kanban_cli.build_parser(subparsers)
+
+    args = parser.parse_args(["kanban", "dispatch", "t_exact", "--json"])
+    assert args.task_id == "t_exact"
+    assert args.json is True
+
+
+def test_exact_dispatch_cli_rejects_dry_run_without_side_effects(
+    kanban_home, all_assignees_spawnable, monkeypatch, capsys
+):
+    calls = []
+
+    def fail_dispatch(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("dry-run exact dispatch must not call dispatch_task")
+
+    monkeypatch.setattr(kb, "dispatch_task", fail_dispatch)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="dry exact", assignee="alice")
+
+    args = argparse.Namespace(
+        task_id=task_id, dry_run=True, max=None, failure_limit=2, json=True
+    )
+
+    assert kanban_cli._cmd_dispatch(args) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "does not support --dry-run" in captured.err
+    assert calls == []
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert task.worker_pid is None
+    assert task.current_run_id is None
+
+
+def test_exact_dispatch_cli_json_shape(monkeypatch, capsys):
+    expected = kb.ExactDispatchResult(
+        task_id="t_exact",
+        state="spawned",
+        spawned=True,
+        run_id=7,
+        pid=1234,
+        assignee="alice",
+        workspace="/tmp/exact",
+    )
+    monkeypatch.setattr(kb, "dispatch_task", lambda *args, **kwargs: expected)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+
+    args = argparse.Namespace(
+        task_id="t_exact", dry_run=False, max=None, failure_limit=2, json=True
+    )
+    assert kanban_cli._cmd_dispatch(args) == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "task_id": "t_exact",
+        "state": "spawned",
+        "spawned": True,
+        "run_id": 7,
+        "pid": 1234,
+        "assignee": "alice",
+        "workspace": "/tmp/exact",
+        "reason": None,
+        "capacity": [],
+    }

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -157,6 +157,36 @@ def test_capped_tasks_dispatched_on_subsequent_tick(isolated_kanban_home_with_pr
     assert res2.spawned[0][0] != spawned_id  # different task this time
 
 
+def test_cap_applies_to_review_dispatch(isolated_kanban_home_with_profiles):
+    """Review workers share the same per-profile cap as ready workers."""
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        running_alpha = kb.create_task(conn, title="running alpha", assignee="alpha")
+        review_alpha = kb.create_task(conn, title="review alpha", assignee="alpha")
+        review_beta = kb.create_task(conn, title="review beta", assignee="beta")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'running', claim_lock = 'test:1' WHERE id = ?",
+                (running_alpha,),
+            )
+            conn.execute(
+                "UPDATE tasks SET status = 'review' WHERE id IN (?, ?)",
+                (review_alpha, review_beta),
+            )
+
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            max_in_progress_per_profile=1,
+        )
+
+    assert [s[1] for s in res.spawned] == ["beta"]
+    assert res.skipped_per_profile_capped == [(review_alpha, "alpha", 1)]
+
+
 def test_dispatch_result_has_skipped_per_profile_capped_field():
     """Schema-level invariant: DispatchResult exposes the
     skipped_per_profile_capped field as a list of

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -742,6 +742,37 @@ def test_block_rejects_empty_reason(worker_env):
         assert json.loads(out).get("error")
 
 
+def test_block_rejects_review_required_handoff_without_state_change(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        before = kb.get_task(conn, worker_env)
+        assert before is not None
+    finally:
+        conn.close()
+
+    out = kt._handle_block({
+        "reason": "review-required: implementation complete",
+        "kind": "needs_input",
+    })
+    d = json.loads(out)
+    assert d.get("code") == "review_handoff_not_blocker"
+    assert d.get("state_mutated") is False
+    assert "create_or_recover_artifact_bound_successor" in d.get("required_actions", [])
+
+    conn = kb.connect()
+    try:
+        after = kb.get_task(conn, worker_env)
+        assert after is not None
+        assert after.status == before.status == "running"
+        assert after.current_run_id == before.current_run_id
+        assert after.block_kind == before.block_kind
+    finally:
+        conn.close()
+
+
 def _make_goal_mode_worker_env(monkeypatch, tmp_path):
     """Set up an isolated HERMES_HOME with one claimed goal_mode task,
     matching the pattern used by the kanban_complete judge gate tests."""
@@ -1554,6 +1585,14 @@ def test_worker_complete_rejects_foreign_task_id(worker_env):
     d = json.loads(out)
     assert d.get("ok") is not True
     assert "refusing to mutate" in d.get("error", "")
+    assert d.get("code") == "cross_task_mutation_refused"
+    receipt = d.get("board_operator_request")
+    assert receipt["source_task_id"] == worker_env
+    assert receipt["target_task_ids"] == [other]
+    assert receipt["requested_terminal_actions"]
+    assert "kanban_complete your own evidence/reconciliation task" in d.get(
+        "worker_lifecycle_guidance", ""
+    )
 
     # Sibling task must be untouched.
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -157,9 +157,24 @@ def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
         return None
     if tid != env_tid:
         return tool_error(
-            f"worker is scoped to task {env_tid}; refusing to mutate "
-            f"{tid}. Use kanban_comment to hand off information to other "
-            f"tasks, or kanban_create to spawn follow-up work."
+            f"worker is scoped to task {env_tid}; refusing to mutate {tid}.",
+            code="cross_task_mutation_refused",
+            board_operator_request={
+                "source_task_id": env_tid,
+                "target_task_ids": [tid],
+                "requested_terminal_actions": [
+                    "review the source task's comment/run evidence",
+                    "apply the requested terminal state changes from an operator/orchestrator context",
+                ],
+                "evidence_references": [],
+            },
+            worker_lifecycle_guidance=(
+                "Do not block this task just because cross-task mutation was "
+                "refused. Add a kanban_comment with the target task ids, "
+                "requested terminal actions, and evidence references, then "
+                "kanban_complete your own evidence/reconciliation task with "
+                "that structured operator receipt."
+            ),
         )
     return None
 
@@ -695,6 +710,12 @@ def _handle_block(args: dict, **kw) -> str:
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
+        if kb.is_review_handoff_block(reason, kind):
+            conn.close()
+            return tool_error(
+                kb.review_handoff_block_message(task_id=tid),
+                **kb.review_handoff_block_instruction(tid),
+            )
         if kind is not None and kind not in kb.VALID_BLOCK_KINDS:
             conn.close()
             return tool_error(
@@ -725,12 +746,18 @@ def _handle_block(args: dict, **kw) -> str:
                 f"completion judge will evaluate it."
             )
         try:
-            ok = kb.block_task(
-                conn, tid,
-                reason=reason,
-                kind=kind,
-                expected_run_id=_worker_run_id(tid),
-            )
+            try:
+                ok = kb.block_task(
+                    conn, tid,
+                    reason=reason,
+                    kind=kind,
+                    expected_run_id=_worker_run_id(tid),
+                )
+            except kb.ReviewHandoffBlockError as review_err:
+                return tool_error(
+                    str(review_err),
+                    **kb.review_handoff_block_instruction(tid),
+                )
             if not ok:
                 return tool_error(
                     f"could not block {tid} (unknown id or not in "
@@ -1443,7 +1470,11 @@ KANBAN_COMPLETE_SCHEMA = {
         "in ``artifacts`` — the gateway notifier will upload them as "
         "native attachments to the human who subscribed to the task, "
         "so the deliverable lands in their chat alongside the summary "
-        "instead of being a path they have to fetch by hand."
+        "instead of being a path they have to fetch by hand. Normal "
+        "review-required producer handoff is a completion path, not a "
+        "blocker: create/recover the artifact-bound successor first, "
+        "verify its id/status, then include successor/dispatch/test facts "
+        "here."
     ),
     "parameters": {
         "type": "object",
@@ -1533,7 +1564,9 @@ KANBAN_BLOCK_SCHEMA = {
         "``reason`` is shown to the human on the board. If a task keeps "
         "getting unblocked and re-blocked for the same reason, it is "
         "auto-escalated to triage. Use for genuine blockers only — don't "
-        "block on things you can resolve yourself."
+        "block on things you can resolve yourself. Do not use this for "
+        "normal review-required/QA handoff; that is handled by creating "
+        "the review successor and completing the producer with evidence."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## Summary
- Reconcile released blocked/completed kanban work before picking up queued same-profile work after release.
- Add exact task dispatch behavior that fails closed instead of falling back when a requested task cannot be dispatched.
- Guard `review-required`/QA handoff misuse as a blocker before state mutation while preserving dependent readiness recomputation after completion.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_exact_dispatch.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/tools/test_kanban_tools.py -q`
- `python -m compileall -q hermes_cli tests/hermes_cli tests/tools`
- `python -m ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_exact_dispatch.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/tools/test_kanban_tools.py`
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- `git verify-commit HEAD`

## Boundary
- Scope is limited to kanban post-release pickup ordering, exact-dispatch fail-closed behavior, review-required blocker validation, and focused tests for those paths.
- No scheduler, auth, UI, provider, plugin, gateway, deployment, or release-cutover changes.
- Reviewed exact signed head: `a5aa4f2d38d717f308559a066d57448cc75f55da`.
