### PR TITLE
fix(model-tools): pass custom_providers to context-length resolver in tool-search gate (#69807)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -589,6 +589,21 @@ def _resolve_active_context_length() -> int:
         # CLI startup.  See issue #46620.
         raw_ctx = model_cfg.get("context_length")
         config_ctx = raw_ctx if isinstance(raw_ctx, int) and raw_ctx > 0 else None
+        # Also pass the custom_providers list so the per-model
+        # ``context_length`` override (get_model_context_length step 0b,
+        # added for #15779) is reachable from this call path too.  Without
+        # it, a custom provider with an explicitly configured per-model
+        # context_length still fell through to the endpoint /models probe —
+        # which blocks CLI startup for the full HTTP timeout (×2 attempts)
+        # when the endpoint has no /models route at all, e.g. Anthropic-mode
+        # gateways with ``api_mode: anthropic_messages`` (#69807).  Mirrors
+        # the gateway's call site (gateway/run.py).
+        try:
+            from hermes_cli.config import get_compatible_custom_providers
+            custom_provs = get_compatible_custom_providers(cfg)
+        except Exception:
+            raw_provs = cfg.get("custom_providers")
+            custom_provs = raw_provs if isinstance(raw_provs, list) else None
         # Provider-aware resolution: providers like Codex OAuth enforce a
         # different (lower) window than the direct API for the same slug, and
         # their resolvers key off provider/base_url/api_key. Without these,
@@ -619,6 +634,7 @@ def _resolve_active_context_length() -> int:
             api_key=api_key,
             config_context_length=config_ctx,
             provider=provider,
+            custom_providers=custom_provs,
         ) or 0)
     except Exception as e:
         logger.debug("Could not resolve active context length: %s", e)

--- a/tests/tools/test_tool_search_context_provider.py
+++ b/tests/tools/test_tool_search_context_provider.py
@@ -30,7 +30,7 @@ class TestResolveActiveContextLengthProviderAware:
 
         captured = {}
 
-        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider=""):
+        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
             captured.update(
                 model=model_id, base_url=base_url, api_key=api_key,
                 config_ctx=config_context_length, provider=provider,
@@ -60,7 +60,7 @@ class TestResolveActiveContextLengthProviderAware:
 
         captured = {}
 
-        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider=""):
+        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
             captured.update(base_url=base_url, api_key=api_key, provider=provider)
             return 272_000
 
@@ -83,7 +83,7 @@ class TestResolveActiveContextLengthProviderAware:
 
         captured = {}
 
-        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider=""):
+        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
             captured.update(base_url=base_url, provider=provider)
             return 200_000
 
@@ -103,7 +103,7 @@ class TestResolveActiveContextLengthProviderAware:
 
         captured = {}
 
-        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider=""):
+        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
             captured["config_ctx"] = config_context_length
             return config_context_length or 0
 
@@ -117,3 +117,67 @@ class TestResolveActiveContextLengthProviderAware:
 
         assert ctx == 150_000
         assert captured["config_ctx"] == 150_000
+
+
+class TestResolveActiveContextLengthCustomProviders:
+    def test_custom_providers_reach_the_resolver(self):
+        """The configured custom_providers list must be passed through so the
+        per-model context_length override (step 0b, #15779) is reachable —
+        otherwise an Anthropic-mode endpoint with no /models route pays the
+        full probe timeout at every CLI startup despite an explicitly
+        configured context length (#69807)."""
+        import model_tools
+
+        captured = {}
+
+        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
+            captured["custom_providers"] = custom_providers
+            return 256_000
+
+        provs = [{
+            "name": "qianwen-tp",
+            "base_url": "https://token-plan.example/apps/anthropic",
+            "api_mode": "anthropic_messages",
+            "models": {"qwen3.8-max-preview": {"context_length": 256_000}},
+        }]
+        cfg = {
+            "model": {"model": "qwen3.8-max-preview", "provider": "custom:qianwen-tp"},
+            "custom_providers": provs,
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("hermes_cli.config.get_compatible_custom_providers",
+                   return_value=provs) as mock_compat, \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value={"base_url": "https://token-plan.example/apps/anthropic",
+                                 "api_key": "sk-x"}), \
+             patch("agent.model_metadata.get_model_context_length", side_effect=fake_get_ctx):
+            ctx = model_tools._resolve_active_context_length()
+
+        assert ctx == 256_000
+        assert captured["custom_providers"] == provs
+        mock_compat.assert_called_once_with(cfg)
+
+    def test_compat_helper_failure_falls_back_to_raw_config_list(self):
+        """If get_compatible_custom_providers raises, the raw
+        cfg['custom_providers'] list still reaches the resolver."""
+        import model_tools
+
+        captured = {}
+
+        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
+            captured["custom_providers"] = custom_providers
+            return 256_000
+
+        provs = [{"name": "x", "base_url": "https://x.example",
+                  "models": {"m": {"context_length": 256_000}}}]
+        cfg = {"model": {"model": "m"}, "custom_providers": provs}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("hermes_cli.config.get_compatible_custom_providers",
+                   side_effect=RuntimeError("boom")), \
+             patch("agent.model_metadata.get_model_context_length", side_effect=fake_get_ctx):
+            ctx = model_tools._resolve_active_context_length()
+
+        assert ctx == 256_000
+        assert captured["custom_providers"] == provs

--- a/tests/tools/test_tool_search_context_provider.py
+++ b/tests/tools/test_tool_search_context_provider.py
@@ -158,6 +158,34 @@ class TestResolveActiveContextLengthCustomProviders:
         assert captured["custom_providers"] == provs
         mock_compat.assert_called_once_with(cfg)
 
+    def test_per_model_override_short_circuits_endpoint_metadata_fetch(self):
+        import model_tools
+
+        base_url = "https://token-plan.example/apps/anthropic"
+        provs = [{
+            "name": "qianwen-tp",
+            "base_url": base_url,
+            "models": {"qwen3.8-max-preview": {"context_length": 256_000}},
+        }]
+        cfg = {
+            "model": {
+                "model": "qwen3.8-max-preview",
+                "provider": "custom:qianwen-tp",
+                "base_url": base_url,
+            },
+            "custom_providers": provs,
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value={"base_url": base_url, "api_key": "sk-x"}), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata",
+                   side_effect=AssertionError("endpoint metadata fetch attempted")) as mock_fetch:
+            ctx = model_tools._resolve_active_context_length()
+
+        assert ctx == 256_000
+        mock_fetch.assert_not_called()
+
     def test_compat_helper_failure_falls_back_to_raw_config_list(self):
         """If get_compatible_custom_providers raises, the raw
         cfg['custom_providers'] list still reaches the resolver."""


### PR DESCRIPTION
Fixes #69807

## Root cause

`_resolve_active_context_length()` in `model_tools.py` (the tool-search gate) never passes the configured `custom_providers` list into `get_model_context_length()`. That makes resolution **step 0b** — the per-model `context_length` override added for #15779 — unreachable from this call path: only the top-level `model.context_length` is forwarded, not the provider-level per-model value.

For custom providers whose endpoint has no `/models` route (e.g. Anthropic-compatible gateways with `api_mode: anthropic_messages`, like the reporter's Alibaba Token Plan setup), the resolver falls through to `fetch_endpoint_model_metadata()` and blocks CLI startup for the full HTTP timeout — twice — at every launch, despite the context length being explicitly configured. **Sibling of #15779 for the tool-search-gate call path.**

## Fix

Mirror the gateway's call site (`gateway/run.py`): resolve the list via `get_compatible_custom_providers(cfg)` (raw `cfg['custom_providers']` as fallback if the helper raises) and pass it through as the `custom_providers` kwarg, so step 0b short-circuits before any endpoint probe.

Deliberately scoped to the reported primary case ("context_length is already configured — the probe is unnecessary"). The issue's two broader asks — skipping the OpenAI-style `/models` probe entirely for `api_mode: anthropic_messages` endpoints, and negative-caching 404 probe results — change probe semantics for *unconfigured* models and deserve their own review; happy to follow up on either if maintainers want them.

## Tests

Extended `tests/tools/test_tool_search_context_provider.py`:

- `custom_providers` reach the resolver (config passed through `get_compatible_custom_providers`, asserted called with the loaded cfg)
- helper-failure path falls back to the raw config list
- existing mock signatures updated to include the `custom_providers` kwarg the real `get_model_context_length` accepts (mocks brought to reality, not behavior changed)

Verified **RED on the unpatched `_resolve_active_context_length`** (git stash → both new tests fail with `custom_providers=None` → stash pop → green). Neighborhood run: 102 passed (`-k "tool_search or context"` across tests/tools).

---

*NL: sibling-fix van #15779 — zelfde lookup-gap, andere call-site, gespiegeld aan het gateway-patroon.*