### PR TITLE
feat(context-engine): let engines suppress or customize routine compaction status

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -53,6 +53,39 @@ def sanitize_memory_context(memory_context: str) -> str:
     )
 
 
+def automatic_compaction_status_message(
+    engine: Any,
+    *,
+    phase: str,
+    default_message: str,
+    **context: Any,
+) -> str | None:
+    """Resolve host-visible status for an automatic compaction event.
+
+    Engines can suppress routine automatic status with
+    ``emit_automatic_compaction_status = False`` or customize it by defining
+    ``get_automatic_compaction_status_message(...)``. Empty strings and
+    ``None`` mean "do not emit a lifecycle status".
+    """
+    if not getattr(engine, "emit_automatic_compaction_status", True):
+        return None
+
+    formatter = getattr(engine, "get_automatic_compaction_status_message", None)
+    if callable(formatter):
+        message = formatter(
+            phase=phase,
+            default_message=default_message,
+            **context,
+        )
+    else:
+        message = default_message
+
+    if message is None:
+        return None
+    message = str(message).strip()
+    return message or None
+
+
 class ContextEngine(ABC):
     """Base class all context engines must implement."""
 
@@ -88,6 +121,12 @@ class ContextEngine(ABC):
     threshold_percent: float = 0.75
     protect_first_n: int = 3
     protect_last_n: int = 6
+
+    # User-visible lifecycle status for automatic host-triggered compaction.
+    # Alternative engines that treat compaction as routine background
+    # maintenance can set this false to keep successful automatic passes silent;
+    # warnings, errors, and explicit manual commands should still surface.
+    emit_automatic_compaction_status: bool = True
 
     # -- Core interface ----------------------------------------------------
 
@@ -155,6 +194,27 @@ class ContextEngine(ABC):
         engines can ignore it safely.
         """
         return False
+
+    def get_automatic_compaction_status_message(
+        self,
+        *,
+        phase: str,
+        default_message: str,
+        **context: Any,
+    ) -> str | None:
+        """Return user-visible status for automatic host-triggered compaction.
+
+        Return ``None`` to suppress successful automatic lifecycle status for
+        this compaction event. ``phase`` identifies the host call site (for
+        example ``"preflight"`` or ``"compress"``). ``context`` contains
+        best-effort fields such as ``approx_tokens`` and ``threshold_tokens``.
+
+        This hook does not control warning/error messages or explicit manual
+        commands such as ``/compress``.
+        """
+        if not self.emit_automatic_compaction_status:
+            return None
+        return default_message
 
     # -- Optional: manual /compress preflight ------------------------------
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -42,7 +42,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Tuple
 
-from agent.context_engine import sanitize_memory_context
+from agent.context_engine import (
+    automatic_compaction_status_message,
+    sanitize_memory_context,
+)
 from agent.model_metadata import estimate_request_tokens_rough
 
 logger = logging.getLogger(__name__)
@@ -1089,7 +1092,20 @@ def compress_context(
         f"{approx_tokens:,}" if approx_tokens else "unknown", agent.model,
         focus_topic,
     )
-    agent._emit_status(COMPACTION_STATUS)
+    _compaction_status = COMPACTION_STATUS
+    if not force:
+        _compaction_status = automatic_compaction_status_message(
+            agent.context_compressor,
+            phase="compress",
+            default_message=_compaction_status,
+            approx_tokens=approx_tokens,
+            message_count=_pre_msg_count,
+            model=agent.model,
+            focus_topic=focus_topic,
+        )
+    _compaction_status_emitted = bool(_compaction_status)
+    if _compaction_status:
+        agent._emit_status(_compaction_status)
     _compaction_done_emitted = False
 
     def _complete_compaction_lifecycle() -> None:
@@ -1097,7 +1113,11 @@ def compress_context(
         if _compaction_done_emitted:
             return
         _compaction_done_emitted = True
-        _emit_compaction_done(agent)
+        # A suppressed start (quiet context engine) opened no visible
+        # compaction phase — emit no terminal edge either. Failure warnings
+        # go through agent._emit_warning and are never suppressed here.
+        if _compaction_status_emitted:
+            _emit_compaction_done(agent)
 
     # ── Compression lock ────────────────────────────────────────────────
     # Atomic, state.db-backed lock per session_id.  Without this, two

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -36,6 +36,7 @@ from agent.conversation_compression import (
     PRE_API_COMPRESSION_STATUS_TEMPLATE,
     conversation_history_after_compression,
 )
+from agent.context_engine import automatic_compaction_status_message
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1311,11 +1311,25 @@ def run_conversation(
                 compression_attempts,
                 max_compression_attempts,
             )
-            agent._emit_status(
-                PRE_API_COMPRESSION_STATUS_TEMPLATE.format(
+            _pre_api_status = automatic_compaction_status_message(
+                _compressor,
+                phase="pre_api",
+                default_message=PRE_API_COMPRESSION_STATUS_TEMPLATE.format(
                     tokens=request_pressure_tokens
-                )
+                ),
+                approx_tokens=request_pressure_tokens,
+                threshold_tokens=int(
+                    getattr(_compressor, "threshold_tokens", 0) or 0
+                ),
+                context_length=int(
+                    getattr(_compressor, "context_length", 0) or 0
+                ),
+                model=agent.model,
+                attempt=compression_attempts,
+                max_attempts=max_compression_attempts,
             )
+            if _pre_api_status:
+                agent._emit_status(_pre_api_status)
             _last_preflight_pressure = request_pressure_tokens
             messages, active_system_prompt = agent._compress_context(
                 messages,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -36,6 +36,7 @@ from agent.conversation_compression import (
     PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
     conversation_history_after_compression,
 )
+from agent.context_engine import automatic_compaction_status_message
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
 from agent.model_metadata import (
@@ -771,12 +772,20 @@ def build_turn_context(
                 agent.model,
                 f"{_compressor.context_length:,}",
             )
-            agent._emit_status(
-                PREFLIGHT_COMPRESSION_STATUS_TEMPLATE.format(
+            _preflight_status = automatic_compaction_status_message(
+                _compressor,
+                phase="preflight",
+                default_message=PREFLIGHT_COMPRESSION_STATUS_TEMPLATE.format(
                     tokens=_preflight_tokens,
                     threshold=_compressor.threshold_tokens,
-                )
+                ),
+                approx_tokens=_preflight_tokens,
+                threshold_tokens=_compressor.threshold_tokens,
+                context_length=_compressor.context_length,
+                model=agent.model,
             )
+            if _preflight_status:
+                agent._emit_status(_preflight_status)
             # Preflight passes honor the same configured per-turn cap
             # (compression.max_attempts) as the loop's compression sites;
             # default 3 preserves the prior hardcoded behavior.

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -663,11 +663,18 @@ def build_turn_context(
                     f"{_idle_floor:,}",
                     agent.session_id or "none",
                 )
-                agent._emit_status(
-                    IDLE_COMPACTION_STATUS_TEMPLATE.format(
+                _idle_status = automatic_compaction_status_message(
+                    _compressor,
+                    phase="idle",
+                    default_message=IDLE_COMPACTION_STATUS_TEMPLATE.format(
                         idle_seconds=int(_idle_gap), tokens=_idle_tokens
-                    )
+                    ),
+                    approx_tokens=_idle_tokens,
+                    idle_seconds=int(_idle_gap),
+                    model=agent.model,
                 )
+                if _idle_status:
+                    agent._emit_status(_idle_status)
                 _idle_input = messages
                 messages, active_system_prompt = agent._compress_context(
                     messages, system_message, approx_tokens=_idle_tokens,

--- a/tests/agent/test_idle_compaction_lock_and_guards.py
+++ b/tests/agent/test_idle_compaction_lock_and_guards.py
@@ -115,6 +115,53 @@ def test_idle_compaction_runs_through_guarded_path_and_releases_lock(
     assert ctx.messages[ctx.current_turn_user_idx].get("role") == "user"
 
 
+def test_idle_compaction_status_suppressed_when_engine_opts_out(
+    tmp_path: Path,
+) -> None:
+    """Quiet context engines silence the 💤 idle-resume status line too.
+
+    The idle emit routes through ``automatic_compaction_status_message``
+    (phase="idle") the same way the preflight and pre-API emits do — an
+    engine with ``emit_automatic_compaction_status = False`` gets a fully
+    silent idle compaction, while the compaction itself still runs.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "IDLE_QUIET"
+    db.create_session(sid, source="cli")
+    agent = _prep_idle_agent(db, sid)
+    agent.context_compressor.emit_automatic_compaction_status = False
+    events = []
+    agent.status_callback = lambda ev, msg: events.append((ev, msg))
+
+    _run_prologue(agent, _history())
+
+    agent.context_compressor.compress.assert_called_once()
+    assert not any(
+        "Resumed after" in str(msg) for _ev, msg in events
+    ), f"idle status leaked despite quiet engine: {events}"
+
+
+def test_idle_compaction_status_emitted_by_default(tmp_path: Path) -> None:
+    """Control: the default engine keeps the 💤 idle-resume status line."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "IDLE_LOUD"
+    db.create_session(sid, source="cli")
+    agent = _prep_idle_agent(db, sid)
+    # MagicMock would auto-create the hook attributes as truthy mocks; pin
+    # the default-engine surface explicitly.
+    agent.context_compressor.emit_automatic_compaction_status = True
+    del agent.context_compressor.get_automatic_compaction_status_message
+    events = []
+    agent.status_callback = lambda ev, msg: events.append((ev, msg))
+
+    _run_prologue(agent, _history())
+
+    agent.context_compressor.compress.assert_called_once()
+    assert any(
+        ev == "lifecycle" and "Resumed after" in str(msg) for ev, msg in events
+    ), f"expected idle status line, got: {events}"
+
+
 def test_idle_compaction_defers_to_held_compression_lock(tmp_path: Path) -> None:
     """An idle-triggered compress racing another path must sit the round out.
 

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -776,6 +776,9 @@ class TestPreflightCompression:
 
     def test_compress_context_suppresses_automatic_status_when_engine_opts_out(self, agent):
         """Plugin engines can make successful automatic compaction silent."""
+        # Keep this isolated from the lazy aux-provider feasibility warning,
+        # which is unrelated to automatic compaction lifecycle status.
+        agent.compression_enabled = False
         events = []
         agent.status_callback = lambda ev, msg: events.append((ev, msg))
         agent.context_compressor.emit_automatic_compaction_status = False
@@ -801,6 +804,9 @@ class TestPreflightCompression:
 
     def test_compress_context_force_keeps_manual_status_when_engine_opts_out(self, agent):
         """Manual /compress remains visible even for quiet automatic engines."""
+        # Keep this isolated from the lazy aux-provider feasibility warning,
+        # which is unrelated to manual compression lifecycle status.
+        agent.compression_enabled = False
         events = []
         agent.status_callback = lambda ev, msg: events.append((ev, msg))
         agent.context_compressor.emit_automatic_compaction_status = False

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -907,6 +907,7 @@ class TestPreflightCompression:
             return 114_000 if _rough_calls["n"] == 1 else 40_000
 
         with (
+            patch("agent.turn_context.estimate_request_tokens_rough", side_effect=_rough_estimate),
             patch("agent.conversation_loop.estimate_request_tokens_rough", side_effect=_rough_estimate),
             patch.object(agent, "_compress_context") as mock_compress,
             patch.object(agent, "_persist_session"),
@@ -957,6 +958,7 @@ class TestPreflightCompression:
             return 114_000 if _rough_calls["n"] == 1 else 40_000
 
         with (
+            patch("agent.turn_context.estimate_request_tokens_rough", side_effect=_rough_estimate),
             patch("agent.conversation_loop.estimate_request_tokens_rough", side_effect=_rough_estimate),
             patch.object(agent, "_compress_context") as mock_compress,
             patch.object(agent, "_persist_session"),

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -774,6 +774,57 @@ class TestPreflightCompression:
         assert new_system_prompt == "rebuilt without memory"
         build_prompt.assert_called_once_with("system prompt")
 
+    def test_compress_context_suppresses_automatic_status_when_engine_opts_out(self, agent):
+        """Plugin engines can make successful automatic compaction silent."""
+        events = []
+        agent.status_callback = lambda ev, msg: events.append((ev, msg))
+        agent.context_compressor.emit_automatic_compaction_status = False
+
+        def _fake_compress(messages, current_tokens=None, focus_topic=None):
+            events.append(("compress", "started"))
+            return [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+
+        with (
+            patch.object(agent.context_compressor, "compress", side_effect=_fake_compress),
+            patch.object(agent, "_build_system_prompt", return_value="new system prompt"),
+            patch("run_agent.estimate_request_tokens_rough", return_value=42),
+        ):
+            compressed, new_system_prompt = agent._compress_context(
+                [{"role": "user", "content": "hello"}],
+                "system prompt",
+                approx_tokens=1234,
+            )
+
+        assert compressed == [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+        assert new_system_prompt == "new system prompt"
+        assert events == [("compress", "started")]
+
+    def test_compress_context_force_keeps_manual_status_when_engine_opts_out(self, agent):
+        """Manual /compress remains visible even for quiet automatic engines."""
+        events = []
+        agent.status_callback = lambda ev, msg: events.append((ev, msg))
+        agent.context_compressor.emit_automatic_compaction_status = False
+
+        def _fake_compress(messages, current_tokens=None, focus_topic=None, force=False):
+            events.append(("compress", "started"))
+            return [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+
+        with (
+            patch.object(agent.context_compressor, "compress", side_effect=_fake_compress),
+            patch.object(agent, "_build_system_prompt", return_value="new system prompt"),
+            patch("run_agent.estimate_request_tokens_rough", return_value=42),
+        ):
+            agent._compress_context(
+                [{"role": "user", "content": "hello"}],
+                "system prompt",
+                approx_tokens=1234,
+                force=True,
+            )
+
+        assert events[0][0] == "lifecycle"
+        assert "Compacting context" in events[0][1]
+        assert events[1] == ("compress", "started")
+
     def test_preflight_compresses_oversized_history(self, agent):
         """When loaded history exceeds the model's context threshold, compress before API call."""
         agent.compression_enabled = True
@@ -825,6 +876,98 @@ class TestPreflightCompression:
             ev == "lifecycle" and "Preflight compression" in msg
             for ev, msg in status_messages
         )
+
+    def test_preflight_suppresses_status_when_context_engine_opts_out(self, agent):
+        """LCM-style engines can keep routine automatic preflight maintenance silent."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+        agent.context_compressor.emit_automatic_compaction_status = False
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i} padded"})
+            big_history.append({"role": "assistant", "content": f"Response {i} padded"})
+
+        ok_resp = _mock_response(content="After quiet preflight", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+        status_messages = []
+        agent.status_callback = lambda ev, msg: status_messages.append((ev, msg))
+
+        _rough_calls = {"n": 0}
+
+        def _rough_estimate(*_args, **_kwargs):
+            _rough_calls["n"] += 1
+            return 114_000 if _rough_calls["n"] == 1 else 40_000
+
+        with (
+            patch("agent.conversation_loop.estimate_request_tokens_rough", side_effect=_rough_estimate),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}],
+                "new system prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        mock_compress.assert_called_once()
+        assert result["completed"] is True
+        assert not any(
+            ev == "lifecycle" and "Preflight compression" in msg
+            for ev, msg in status_messages
+        )
+
+    def test_preflight_uses_context_engine_custom_status_message(self, agent):
+        """Plugin engines can replace generic built-in-compressor wording."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+
+        def _custom_status(**kwargs):
+            assert kwargs["phase"] == "preflight"
+            assert kwargs["approx_tokens"] == 114_000
+            assert kwargs["threshold_tokens"] == 100_000
+            return "🔧 LCM context maintenance: preparing compacted context."
+
+        agent.context_compressor.get_automatic_compaction_status_message = _custom_status
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i} padded"})
+            big_history.append({"role": "assistant", "content": f"Response {i} padded"})
+
+        ok_resp = _mock_response(content="After custom preflight", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+        status_messages = []
+        agent.status_callback = lambda ev, msg: status_messages.append((ev, msg))
+
+        _rough_calls = {"n": 0}
+
+        def _rough_estimate(*_args, **_kwargs):
+            _rough_calls["n"] += 1
+            return 114_000 if _rough_calls["n"] == 1 else 40_000
+
+        with (
+            patch("agent.conversation_loop.estimate_request_tokens_rough", side_effect=_rough_estimate),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}],
+                "new system prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        mock_compress.assert_called_once()
+        assert result["completed"] is True
+        lifecycle_messages = [msg for ev, msg in status_messages if ev == "lifecycle"]
+        assert "🔧 LCM context maintenance: preparing compacted context." in lifecycle_messages
+        assert not any("Preflight compression" in msg for msg in lifecycle_messages)
 
     def test_preflight_defers_when_recent_real_usage_fit(self, agent):
         """A noisy rough estimate should not re-compact a recently fitting request."""

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -783,7 +783,13 @@ class TestPreflightCompression:
         agent.status_callback = lambda ev, msg: events.append((ev, msg))
         agent.context_compressor.emit_automatic_compaction_status = False
 
-        def _fake_compress(messages, current_tokens=None, focus_topic=None):
+        def _fake_compress(
+            messages,
+            current_tokens=None,
+            focus_topic=None,
+            force=False,
+            memory_context="",
+        ):
             events.append(("compress", "started"))
             return [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
 
@@ -798,8 +804,16 @@ class TestPreflightCompression:
                 approx_tokens=1234,
             )
 
-        assert compressed == [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
-        assert new_system_prompt == "new system prompt"
+        # The compressor returned only the user-role summary; the human-anchor
+        # repair restores the real user turn after it (same contract as
+        # test_compress_context_emits_lifecycle_status_before_work above).
+        assert compressed == [
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"},
+            {"role": "user", "content": "hello"},
+        ]
+        # Memory snapshot unchanged → the cached prompt is retained (same
+        # contract as test_compress_context_emits_lifecycle_status_before_work).
+        assert new_system_prompt == "You are helpful."
         assert events == [("compress", "started")]
 
     def test_compress_context_force_keeps_manual_status_when_engine_opts_out(self, agent):
@@ -830,6 +844,117 @@ class TestPreflightCompression:
         assert events[0][0] == "lifecycle"
         assert "Compacting context" in events[0][1]
         assert events[1] == ("compress", "started")
+
+    def test_compress_context_abort_warning_is_never_suppressed(self, agent):
+        """Failure warnings stay visible even when a quiet engine suppresses
+        routine automatic status — only ROUTINE lifecycle lines are quiet."""
+        agent.compression_enabled = False
+        agent.context_compressor.emit_automatic_compaction_status = False
+        events = []
+        agent.status_callback = lambda event, message: events.append((event, message))
+        messages = [{"role": "user", "content": "hello"}]
+
+        def _abort_compression(current_messages, **_kwargs):
+            agent.context_compressor._last_compress_aborted = True
+            agent.context_compressor._last_summary_error = "auxiliary model unavailable"
+            return current_messages
+
+        with patch.object(agent.context_compressor, "compress", side_effect=_abort_compression):
+            compressed, prompt = agent._compress_context(messages, "system prompt")
+
+        assert compressed is messages
+        assert prompt == "You are helpful."
+        # Routine lifecycle + structured compacted edges are suppressed (the
+        # quiet engine opened no visible phase), but the abort warning fires.
+        assert [event for event, _ in events] == ["warn"]
+        assert "Compression aborted" in events[0][1]
+
+    def test_pre_api_compression_status_suppressed_when_engine_opts_out(self, agent):
+        """The mid-turn pre-API pressure emit routes through the resolver too.
+
+        Regression guard for the #35191 review gap: with
+        ``emit_automatic_compaction_status = False`` the 📦 Pre-API line must
+        not leak even though compaction itself still runs.
+        """
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 130_000
+        agent.context_compressor.emit_automatic_compaction_status = False
+
+        history = [
+            {"role": "user", "content": "earlier question"},
+            {"role": "assistant", "content": "earlier answer"},
+        ]
+        ok_resp = _mock_response(content="After quiet pre-API", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+        status_messages = []
+        agent.status_callback = lambda ev, msg: status_messages.append((ev, msg))
+
+        with (
+            # Keep the turn-prologue preflight quiet-by-size so only the
+            # in-loop pre-API pressure gate fires.
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=10_000),
+            patch("agent.conversation_loop.estimate_request_tokens_rough", return_value=144_669),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                return_value=144_669,
+            ),
+            patch.object(
+                agent,
+                "_compress_context",
+                side_effect=lambda msgs, *a, **k: (msgs, agent._cached_system_prompt),
+            ) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=history)
+
+        assert result["completed"] is True
+        assert mock_compress.call_count >= 1, "pre-API compression never ran"
+        assert not any(
+            "Pre-API compression" in msg for _ev, msg in status_messages
+        )
+
+    def test_pre_api_compression_status_emitted_by_default(self, agent):
+        """Control: the default (non-quiet) engine keeps the pre-API line."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 130_000
+
+        history = [
+            {"role": "user", "content": "earlier question"},
+            {"role": "assistant", "content": "earlier answer"},
+        ]
+        ok_resp = _mock_response(content="After pre-API", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+        status_messages = []
+        agent.status_callback = lambda ev, msg: status_messages.append((ev, msg))
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=10_000),
+            patch("agent.conversation_loop.estimate_request_tokens_rough", return_value=144_669),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                return_value=144_669,
+            ),
+            patch.object(
+                agent,
+                "_compress_context",
+                side_effect=lambda msgs, *a, **k: (msgs, agent._cached_system_prompt),
+            ) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=history)
+
+        assert result["completed"] is True
+        assert mock_compress.call_count >= 1
+        assert any(
+            ev == "lifecycle" and "Pre-API compression" in msg
+            for ev, msg in status_messages
+        )
 
     def test_preflight_compresses_oversized_history(self, agent):
         """When loaded history exceeds the model's context threshold, compress before API call."""


### PR DESCRIPTION
## Summary
Alternative context engines (e.g. hermes-lcm) can now suppress or reword the ROUTINE automatic compaction status lines (`🗜️ Compacting context…`, `📦 Pre-API compression…`, `📦 Preflight compression…`, `💤 Resumed after Ns idle…`) via a context-engine hook, keeping background maintenance fully silent for engines that treat compaction as routine. Default behavior is unchanged, manual `/compress` stays visible, and failure warnings are never suppressible.

## Changes
- `agent/context_engine.py`: new `automatic_compaction_status_message(engine, phase=..., default_message=..., **context)` resolver + `ContextEngine.emit_automatic_compaction_status` (default `True`) and overridable `get_automatic_compaction_status_message(...)` hook. `None`/empty → emit nothing.
- `agent/conversation_compression.py`: `compress_context()` routes the `COMPACTION_STATUS` start line through the resolver for automatic (`force=False`) passes only; a suppressed start also skips the #69546 structured `compacted` terminal edge (no phantom "phase closed" event for a phase that never opened). Manual `force=True` bypasses the resolver entirely.
- `agent/conversation_loop.py`: the mid-turn pre-API pressure emit (the review-gap leak from #35191) now routes through the resolver (`phase="pre_api"`), keeping the #69550 `PRE_API_COMPRESSION_STATUS_TEMPLATE` as the default wording.
- `agent/turn_context.py`: preflight (`phase="preflight"`) and idle-resume (`phase="idle"`) emits route through the resolver, defaults still formatted from the #69550 template constants.
- Tests: PR's suppression/custom-wording/manual-visibility tests (updated to main's human-anchor repair + cached-prompt contracts), plus new pins: pre-API line suppressed when engine opts out + emitted by default, idle line suppressed/emitted, abort warning (`⚠ Compression aborted`) NEVER suppressed by a quiet engine, quiet engine emits no `compacted` structured edge.

## Validation
| | Before | After |
|---|---|---|
| Engine sets `emit_automatic_compaction_status = False` | 🗜️/📦/💤 routine lines still stream to the host on every automatic compaction | All routine automatic compaction status (compress start, pre-API, preflight, idle) fully silent; no structured `compacted` edge for the suppressed phase |
| Default engine / manual `/compress` | visible | unchanged — visible |
| Compression failure warnings | visible | unchanged — never suppressible |

Targeted tests: `tests/ -k 'quiet or compaction_status or preflight_status'` → 46 passed; test_413_compression (46) + idle lock/guards (7) + telegram noise filter + tui compaction status + preflight cap e2e + post-tool cap + codex compaction: 634 passed, 0 failed; sibling compression suites (concurrent fork, rotation state, feasibility, max-attempts config): 89 passed.

## Credit
Salvaged from #35191 by @stephenschoettler. Fixes #25115.

## Infographic
![quiet-compaction-status](https://v3b.fal.media/files/b/0aa35c4a/KBTg_jstFNjxMzgsCIas5_61pIUUIt.png)
