### PR TITLE
fix(compression): merge the todo snapshot into the trailing user turn

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1509,11 +1509,29 @@ def compress_context(
 
         todo_snapshot = agent._todo_store.format_for_injection()
         if todo_snapshot:
-            compressed.append({
-                "role": "user",
-                "content": todo_snapshot,
-                "_todo_snapshot_synthetic": True,
-            })
+            # Fold the snapshot into a trailing user message so compression
+            # never introduces a synthetic user/user pair. When it must stand
+            # alone, retain the marker so the real-user preservation pass does
+            # not mistake todo scaffolding for human intent.
+            if compressed and compressed[-1].get("role") == "user":
+                from agent.context_compressor import _append_text_to_content
+
+                _tail = compressed[-1]
+                _tail_content = _tail.get("content")
+                _snapshot_text = (
+                    f"\n\n{todo_snapshot}"
+                    if isinstance(_tail_content, str) and _tail_content
+                    else todo_snapshot
+                )
+                _tail["content"] = _append_text_to_content(
+                    _tail_content, _snapshot_text
+                )
+            else:
+                compressed.append({
+                    "role": "user",
+                    "content": todo_snapshot,
+                    "_todo_snapshot_synthetic": True,
+                })
         _ensure_compressed_has_user_turn(messages, compressed)
 
         cached_system_prompt = agent._cached_system_prompt

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -806,6 +806,37 @@ def _is_real_user_message(message: Any) -> bool:
     return not ContextCompressor._is_synthetic_compression_user_turn(message)
 
 
+def _strip_stale_todo_snapshot(content: Any) -> Any:
+    """Remove a previously merged todo-snapshot block from message content.
+
+    Snapshot merges (see the injection site in ``compress_context``) always
+    append the block at the end of the trailing user turn, so a surviving
+    header marks stale todo state from an earlier compaction boundary.
+    Stripping before re-injection keeps repeated boundaries from
+    accumulating outdated snapshots (#26981).
+    """
+    from tools.todo_tool import TODO_INJECTION_HEADER
+
+    if isinstance(content, str):
+        idx = content.find(TODO_INJECTION_HEADER)
+        if idx == -1:
+            return content
+        return content[:idx].rstrip()
+    if isinstance(content, list):
+        return [
+            part
+            for part in content
+            if not (
+                isinstance(part, dict)
+                and part.get("type") == "text"
+                and str(part.get("text") or "")
+                .lstrip()
+                .startswith(TODO_INJECTION_HEADER)
+            )
+        ]
+    return content
+
+
 def _merge_anchor_into_user_message(target: dict, anchor: dict) -> None:
     """Fold the human anchor into an existing user-role scaffolding turn.
 
@@ -1509,24 +1540,49 @@ def compress_context(
 
         todo_snapshot = agent._todo_store.format_for_injection()
         if todo_snapshot:
-            # Fold the snapshot into a trailing user message so compression
-            # never introduces a synthetic user/user pair. When it must stand
-            # alone, retain the marker so the real-user preservation pass does
-            # not mistake todo scaffolding for human intent.
-            if compressed and compressed[-1].get("role") == "user":
-                from agent.context_compressor import _append_text_to_content
+            # Fold the snapshot into a trailing REAL user message so
+            # compression never introduces a synthetic user/user pair. Any
+            # snapshot merged at an earlier boundary is stripped first so
+            # repeated compactions refresh rather than accumulate todo state
+            # (#26981). Scaffolding tails (continuation marker, summary
+            # handoff, a bare stale snapshot row) must never absorb the
+            # snapshot: merging would upgrade them to "real user" evidence
+            # and break zero-user provenance (#69292), so those keep the
+            # flagged standalone append and the real-user preservation pass
+            # continues to see todo scaffolding, not human intent.
+            from agent.context_compressor import _append_text_to_content
 
-                _tail = compressed[-1]
-                _tail_content = _tail.get("content")
-                _snapshot_text = (
-                    f"\n\n{todo_snapshot}"
-                    if isinstance(_tail_content, str) and _tail_content
-                    else todo_snapshot
-                )
-                _tail["content"] = _append_text_to_content(
-                    _tail_content, _snapshot_text
-                )
-            else:
+            merged = False
+            _tail = (
+                compressed[-1]
+                if compressed and isinstance(compressed[-1], dict)
+                else None
+            )
+            if _tail is not None and _tail.get("role") == "user":
+                _stripped = _strip_stale_todo_snapshot(_tail.get("content"))
+                _probe = {
+                    key: value for key, value in _tail.items() if key != "content"
+                }
+                _probe["content"] = _stripped
+                if _is_real_user_message(_probe):
+                    _snapshot_text = (
+                        f"\n\n{todo_snapshot}"
+                        if isinstance(_stripped, str) and _stripped
+                        else todo_snapshot
+                    )
+                    _tail["content"] = _append_text_to_content(
+                        _stripped, _snapshot_text
+                    )
+                    merged = True
+                elif _stripped != _tail.get("content") and not _message_text(
+                    {"role": "user", "content": _stripped}
+                ).strip():
+                    # The tail was nothing but an earlier snapshot row —
+                    # refresh it in place instead of stacking a duplicate.
+                    _tail["content"] = todo_snapshot
+                    _tail["_todo_snapshot_synthetic"] = True
+                    merged = True
+            if not merged:
                 compressed.append({
                     "role": "user",
                     "content": todo_snapshot,

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -804,3 +804,191 @@ class TestTodoSnapshotMergedNotDuplicated:
             previous.get("role") == current.get("role") == "user"
             for previous, current in zip(db_msgs, db_msgs[1:])
         )
+
+
+class TestTodoSnapshotScaffoldingTails:
+    """Scaffolding tails must never absorb the todo snapshot (#69292)."""
+
+    @staticmethod
+    def _agent_with_todo(db: SessionDB, session_id: str, tail: dict):
+        db.create_session(session_id, source="cli")
+        agent = _build_agent_with_db(db, session_id, platform="cli")
+        agent.context_compressor.compress.return_value = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "assistant", "content": "acknowledged"},
+            tail,
+        ]
+        agent._todo_store.write(
+            [{"id": "t1", "content": "task A", "status": "pending"}]
+        )
+        return agent
+
+    def test_snapshot_stays_standalone_after_continuation_marker(
+        self, tmp_path: Path
+    ):
+        from agent.context_compressor import (
+            COMPRESSION_CONTINUATION_USER_CONTENT,
+            ContextCompressor,
+        )
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        agent = self._agent_with_todo(
+            db,
+            "PARENT_TODO_MARKER_TAIL",
+            {
+                "role": "user",
+                "content": COMPRESSION_CONTINUATION_USER_CONTENT,
+            },
+        )
+
+        compressed, _ = agent._compress_context(
+            _msgs(), "sys", approx_tokens=120_000
+        )
+
+        tail = compressed[-1]
+        assert tail["role"] == "user"
+        assert tail.get("_todo_snapshot_synthetic") is True
+        assert "task A" in tail["content"]
+        # The continuation marker keeps its exact text so it stays
+        # recognizable as scaffolding after SessionDB projection.
+        marker_rows = [
+            message
+            for message in compressed
+            if message.get("content") == COMPRESSION_CONTINUATION_USER_CONTENT
+        ]
+        assert len(marker_rows) == 1
+        # Zero-user provenance: neither the marker nor the snapshot may read
+        # as a real user turn once SessionDB projection strips the flags
+        # (#69292). The fixture's stub summary text is not a real handoff
+        # prefix, so assert on the projected scaffolding rows directly.
+        assert not ContextCompressor._transcript_has_real_user_turn(
+            [
+                {"role": "user", "content": marker_rows[0]["content"]},
+                {"role": "user", "content": tail["content"]},
+            ]
+        )
+
+    def test_snapshot_stays_standalone_after_summary_as_user_tail(
+        self, tmp_path: Path
+    ):
+        from agent.context_compressor import SUMMARY_PREFIX, ContextCompressor
+
+        summary_as_user = f"{SUMMARY_PREFIX}\nzero-user summary body"
+        db = SessionDB(db_path=tmp_path / "state.db")
+        agent = self._agent_with_todo(
+            db,
+            "PARENT_TODO_SUMMARY_TAIL",
+            {"role": "user", "content": summary_as_user},
+        )
+
+        compressed, _ = agent._compress_context(
+            _msgs(), "sys", approx_tokens=120_000
+        )
+
+        tail = compressed[-1]
+        assert tail.get("_todo_snapshot_synthetic") is True
+        assert "task A" in tail["content"]
+        # The summary handoff prefix must stay at the START of its own
+        # message for downstream summary detection.
+        summary_rows = [
+            message
+            for message in compressed
+            if str(message.get("content") or "").startswith(SUMMARY_PREFIX)
+        ]
+        assert len(summary_rows) == 1
+        # Zero-user provenance (#69292): after SessionDB projection strips
+        # the flags, both the summary-as-user handoff and the standalone
+        # snapshot must still classify as synthetic — the merge would have
+        # buried the header/prefix markers mid-content.
+        assert not ContextCompressor._transcript_has_real_user_turn(
+            [
+                {"role": "user", "content": summary_rows[0]["content"]},
+                {"role": "user", "content": tail["content"]},
+            ]
+        )
+
+    def test_stale_snapshot_row_is_refreshed_not_stacked(self, tmp_path: Path):
+        from tools.todo_tool import TODO_INJECTION_HEADER
+
+        stale = f"{TODO_INJECTION_HEADER}\n- [ ] t0. old finished task (pending)"
+        db = SessionDB(db_path=tmp_path / "state.db")
+        agent = self._agent_with_todo(
+            db,
+            "PARENT_TODO_STALE_ROW",
+            {"role": "user", "content": stale},
+        )
+
+        compressed, _ = agent._compress_context(
+            _msgs(), "sys", approx_tokens=120_000
+        )
+
+        tail = compressed[-1]
+        assert tail.get("_todo_snapshot_synthetic") is True
+        assert "task A" in tail["content"]
+        assert "old finished task" not in tail["content"]
+        snapshot_rows = [
+            message
+            for message in compressed
+            if str(message.get("content") or "").startswith(TODO_INJECTION_HEADER)
+        ]
+        assert len(snapshot_rows) == 1
+
+    def test_previously_merged_snapshot_is_stripped_before_reinjection(
+        self, tmp_path: Path
+    ):
+        from tools.todo_tool import TODO_INJECTION_HEADER
+
+        previously_merged = (
+            "please fix the login bug\n\n"
+            f"{TODO_INJECTION_HEADER}\n- [ ] t0. old finished task (pending)"
+        )
+        db = SessionDB(db_path=tmp_path / "state.db")
+        agent = self._agent_with_todo(
+            db,
+            "PARENT_TODO_RESTRIP",
+            {"role": "user", "content": previously_merged},
+        )
+
+        compressed, _ = agent._compress_context(
+            _msgs(), "sys", approx_tokens=120_000
+        )
+
+        tail = compressed[-1]
+        assert tail["role"] == "user"
+        assert "please fix the login bug" in tail["content"]
+        assert "task A" in tail["content"]
+        assert "old finished task" not in tail["content"]
+        assert tail["content"].count(TODO_INJECTION_HEADER) == 1
+        assert not any(
+            previous.get("role") == current.get("role") == "user"
+            for previous, current in zip(compressed, compressed[1:])
+        )
+
+    def test_empty_todo_store_injects_nothing(self, tmp_path: Path):
+        from tools.todo_tool import TODO_INJECTION_HEADER
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        session_id = "PARENT_TODO_EMPTY"
+        db.create_session(session_id, source="cli")
+        agent = _build_agent_with_db(db, session_id, platform="cli")
+        expected = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "assistant", "content": "acknowledged"},
+            {"role": "user", "content": "tail"},
+        ]
+        agent.context_compressor.compress.return_value = [
+            dict(message) for message in expected
+        ]
+        agent._todo_store.write(
+            [{"id": "t1", "content": "done thing", "status": "completed"}]
+        )
+
+        compressed, _ = agent._compress_context(
+            _msgs(), "sys", approx_tokens=120_000
+        )
+
+        assert compressed == expected
+        assert not any(
+            TODO_INJECTION_HEADER in str(message.get("content") or "")
+            for message in compressed
+        )

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -636,3 +636,170 @@ class TestCooldownPersistFailureIsNotAClearedRow:
             side_effect=AssertionError("nothing durable to refresh"),
         ):
             assert compressor._automatic_compression_blocked() is True
+
+
+class TestTodoSnapshotMergedNotDuplicated:
+    """Todo snapshots preserve tail content without duplicate user turns."""
+
+    def test_snapshot_merges_into_trailing_user(self, tmp_path: Path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_TODO_MERGE"
+        db.create_session(parent, source="cli")
+        agent = _build_agent_with_db(db, parent, platform="cli")
+
+        agent.context_compressor.compress.return_value = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "assistant", "content": "acknowledged"},
+            {"role": "user", "content": "tail"},
+        ]
+        agent._todo_store._todos = [
+            {"id": "t1", "content": "task A", "status": "pending"}
+        ]
+        agent._todo_store.format_for_injection = (
+            lambda: "## Current Tasks\n- [ ] task A"
+        )
+
+        compressed, _ = agent._compress_context(
+            _msgs(), "sys", approx_tokens=120_000
+        )
+
+        assert len(compressed) == 3
+        tail = compressed[-1]
+        assert tail["role"] == "user"
+        assert "tail" in tail["content"]
+        assert "task A" in tail["content"]
+        assert not any(
+            previous.get("role") == current.get("role") == "user"
+            for previous, current in zip(compressed, compressed[1:])
+        )
+
+    def test_multimodal_snapshot_merges_into_trailing_user_on_rotation(
+        self, tmp_path: Path
+    ):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_TODO_MULTIMODAL_ROTATION"
+        db.create_session(parent, source="cli")
+        agent = _build_agent_with_db(db, parent, platform="cli")
+
+        original_parts = [
+            {"type": "text", "text": "tail text"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/context.png"},
+            },
+        ]
+        agent.context_compressor.compress.return_value = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "assistant", "content": "acknowledged"},
+            {"role": "user", "content": list(original_parts)},
+        ]
+        agent._todo_store._todos = [
+            {"id": "t1", "content": "inspect image", "status": "pending"}
+        ]
+        agent._todo_store.format_for_injection = (
+            lambda: "## Current Tasks\n- [ ] inspect image"
+        )
+
+        compressed, _ = agent._compress_context(
+            _msgs(), "sys", approx_tokens=120_000
+        )
+
+        assert len(compressed) == 3
+        tail = compressed[-1]
+        assert tail["role"] == "user"
+        assert isinstance(tail["content"], list)
+        assert tail["content"][: len(original_parts)] == original_parts
+        assert any(
+            isinstance(part, dict) and "inspect image" in (part.get("text") or "")
+            for part in tail["content"]
+        )
+        assert not any(
+            previous.get("role") == current.get("role") == "user"
+            for previous, current in zip(compressed, compressed[1:])
+        )
+
+    def test_snapshot_merge_is_persisted_in_place(self, tmp_path: Path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_TODO_INPLACE"
+        db.create_session(parent, source="cli")
+        agent = _build_agent_with_db(db, parent, platform="cli")
+        agent.compression_in_place = True
+        agent.context_compressor.compress.return_value = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "last user msg"},
+        ]
+        agent._todo_store._todos = [
+            {"id": "t1", "content": "do thing", "status": "in_progress"}
+        ]
+        agent._todo_store.format_for_injection = (
+            lambda: "## Current Tasks\n- [ ] do thing"
+        )
+
+        agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+
+        db_msgs = db.get_messages(agent.session_id)
+        assert not any(
+            previous.get("role") == current.get("role") == "user"
+            for previous, current in zip(db_msgs, db_msgs[1:])
+        )
+        last_user = [message for message in db_msgs if message["role"] == "user"][-1]
+        assert "last user msg" in last_user["content"]
+        assert "do thing" in last_user["content"]
+
+    def test_multimodal_snapshot_merge_is_persisted_in_place(self, tmp_path: Path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_TODO_MULTIMODAL_INPLACE"
+        db.create_session(parent, source="cli")
+        agent = _build_agent_with_db(db, parent, platform="cli")
+        agent.compression_in_place = True
+
+        original_parts = [
+            {"type": "text", "text": "last user msg"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/context.png"},
+            },
+        ]
+        agent.context_compressor.compress.return_value = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": list(original_parts)},
+        ]
+        agent._todo_store._todos = [
+            {"id": "t1", "content": "inspect image", "status": "in_progress"}
+        ]
+        agent._todo_store.format_for_injection = (
+            lambda: "## Current Tasks\n- [ ] inspect image"
+        )
+
+        compressed, _ = agent._compress_context(
+            _msgs(), "sys", approx_tokens=120_000
+        )
+
+        assert len(compressed) == 3
+        tail = compressed[-1]
+        assert tail["role"] == "user"
+        assert isinstance(tail["content"], list)
+        assert tail["content"][: len(original_parts)] == original_parts
+        assert any(
+            isinstance(part, dict) and "inspect image" in (part.get("text") or "")
+            for part in tail["content"]
+        )
+        assert not any(
+            previous.get("role") == current.get("role") == "user"
+            for previous, current in zip(compressed, compressed[1:])
+        )
+
+        db_msgs = db.get_messages(agent.session_id)
+        persisted_tail = db_msgs[-1]
+        assert persisted_tail["role"] == "user"
+        assert persisted_tail["content"][: len(original_parts)] == original_parts
+        assert any(
+            isinstance(part, dict) and "inspect image" in (part.get("text") or "")
+            for part in persisted_tail["content"]
+        )
+        assert not any(
+            previous.get("role") == current.get("role") == "user"
+            for previous, current in zip(db_msgs, db_msgs[1:])
+        )

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -718,6 +718,7 @@ class TestTodoSnapshotMergedNotDuplicated:
             for previous, current in zip(compressed, compressed[1:])
         )
 
+
     def test_snapshot_merge_is_persisted_in_place(self, tmp_path: Path):
         db = SessionDB(db_path=tmp_path / "state.db")
         parent = "PARENT_TODO_INPLACE"


### PR DESCRIPTION
## Summary
After context compression, the preserved todo snapshot is no longer appended as a standalone synthetic `{role:"user"}` message that can read as a fresh user instruction — it is folded into the trailing *real* user turn instead (mirroring the summary merged-into-tail precedent), preserving role alternation and injection authority. Root cause: `compress_context` unconditionally appended the todo snapshot as a new user-role row after the compressed transcript, so the todo text became the tail user turn (#26979) and — when the tail was already a user message — created consecutive user/user turns some providers reject.

## Changes
- `agent/conversation_compression.py`: fold the todo snapshot into a trailing user message when one exists (blank-line separated for strings, appended text block for multimodal lists via `_append_text_to_content`); fall back to the flagged standalone append otherwise (salvaged from #53890).
- `agent/conversation_compression.py` (follow-up hardening): merge only into REAL user tails — a `_is_real_user_message` probe keeps scaffolding tails (continuation marker, summary-as-user handoff, bare stale snapshot rows) on the flagged standalone path, because merging would bury the `TODO_INJECTION_HEADER` / summary-prefix content markers mid-content and upgrade those rows to "real user" evidence after SessionDB projection strips the underscore flags, breaking #69292's zero-user provenance (`_is_synthetic_compression_user_turn` keys on those start-of-content markers).
- `agent/conversation_compression.py`: new `_strip_stale_todo_snapshot` — a snapshot merged at an earlier boundary is stripped before re-injection so repeated compactions refresh rather than accumulate todo state, and a bare stale snapshot row is refreshed in place instead of stacking a duplicate (empty/stale-skip semantics from #26981; the empty-store skip itself lives in `TodoStore.format_for_injection`, which returns `None` for empty or all-completed lists — now pinned by test).
- `tests/agent/test_compression_rotation_state.py`: contributor tests (merge into trailing user, multimodal tails, in-place persistence, no user/user adjacency) plus follow-up tests (scaffolding tails stay standalone with provenance verified via `_transcript_has_real_user_turn`, stale-row refresh, strip-before-reinject, empty-store no-op).

## Validation
| | Before | After |
|---|---|---|
| Compressed transcript tail with active todos | Standalone synthetic user turn carrying todo text (reads as a fresh instruction; user/user adjacency when tail is user) | Snapshot folded into the trailing real user turn; alternation preserved |
| Tail is scaffolding (continuation marker / summary-as-user) | Merge would erase synthetic classification after DB projection | Flagged standalone append retained; `_is_synthetic_compression_user_turn` classifies both shapes; zero-user provenance (#69292) intact |
| Repeated compaction boundaries | Snapshots accumulate | Previous snapshot stripped/refreshed; exactly one snapshot block |

Targeted tests: `tests/agent/ -k 'todo and (snapshot or inject)'` → 11 passed; `tests/agent/test_context_compressor_zero_user_provenance.py` → 10 passed; `tests/agent/test_compression_rotation_state.py` → 25 passed; `tests/agent/test_context_compressor.py` + `tests/agent/test_compression_concurrent_fork.py` + `tests/run_agent/test_run_agent.py` → 674 passed. 0 failed.

Note on the longer-term direction: #58162 by @0xLeathery (draft) proposes preserving todos as tool state (tool-call/tool-result pair) rather than any user-role row — the architecturally cleaner endgame. This PR keeps the user-visible fix shippable now without blocking that direction.

## Credit
Salvaged from #53890 by @yingliang-zhang; empty-snapshot handling from #26981 by @YLChen-007; #58162 by @0xLeathery notes the longer-term tool-state direction. Fixes #26979.

## Infographic
![todo-snapshot-merge](https://v3b.fal.media/files/b/0aa35c4f/Z_iPHiYqOFeCi5yJTSaA7_cRF1N8lh.png)
