### PR TITLE
chore(deps): clear desktop npm advisories

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -100,7 +100,7 @@
     "cmdk": "^1.1.1",
     "d3-force": "^3.0.0",
     "dnd-core": "^14.0.1",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "fflate": "^0.8.3",
     "hast-util-from-html-isomorphic": "^2.0.0",
     "hast-util-to-text": "^4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,7 @@
         "cmdk": "^1.1.1",
         "d3-force": "^3.0.0",
         "dnd-core": "^14.0.1",
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.12",
         "fflate": "^0.8.3",
         "hast-util-from-html-isomorphic": "^2.0.0",
         "hast-util-to-text": "^4.0.2",
@@ -9585,9 +9585,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -10965,9 +10965,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -17240,9 +17240,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17921,9 +17921,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.17",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.17.tgz",
-      "integrity": "sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,11 @@
     "agent-browser": "^0.26.0"
   },
   "overrides": {
+    "dompurify": "3.4.12",
+    "fast-uri": "3.1.4",
     "lodash": "4.18.1",
+    "shell-quote": "1.10.0",
+    "tar": "7.5.21",
     "yauzl": "^3.3.1",
     "protobufjs": "^8.7.1"
   },


### PR DESCRIPTION
## Summary
- override `tar` to 7.5.21, `fast-uri` to 3.1.4, and `shell-quote` to 1.10.0
- update DOMPurify to 3.4.12 after its new low-severity production advisory
- regenerate only the affected lockfile nodes

## Verification
- clean `npm ci`
- `npm audit`: 0 production/development findings
- `npm audit --omit=dev`: 0 production findings
- `concurrently` two-process smoke passed with the shell-quote override
- Desktop typecheck passed
- focused messaging UI tests passed (2/2)
- production Desktop build passed
- unsigned Windows NSIS packaging passed (`Hermes-0.17.0-win-x64.exe`)
- `git diff --check` passed

## Existing test noise
The full Electron project on native Windows reached 674 passes and 2 skips with 19 pre-existing POSIX-path/permission assumptions. The full UI project reached 1950 passes and 1 skip with two order-dependent messaging failures; that same file passes 2/2 in isolation on this branch.