### PR TITLE
fix(update): self-heal venv after failed lazy backend refresh (salvage #58004)

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -1,0 +1,226 @@
+"""Dependency-light venv recovery that runs BEFORE hermes_cli.main's imports.
+
+The ``hermes`` console entry point is ``hermes_cli.main:main``.  Importing
+``hermes_cli.main`` pulls in third-party packages at module level (``dotenv``
+via ``hermes_cli.env_loader``, ``yaml`` via ``hermes_cli.config``, ...).  In
+the exact failure state the update-recovery markers exist for — a failed lazy
+backend refresh or interrupted core install that wiped a core package's
+import files (#57828) — a normal launch crashes *while importing main.py*,
+before ``_recover_from_interrupted_install()`` can run.  The marker system is
+unreachable precisely when it is needed most.
+
+This module is deliberately **stdlib-only** so importing it can never fail on
+a corrupted venv.  ``hermes_cli.main`` imports and calls
+:func:`recover_if_needed` at the very top of its module body, before any
+third-party import.
+
+Scope: this early pass only repairs enough for ``hermes_cli.main`` to become
+importable again (force-reinstall of the known-fragile core packages, using
+the pins from pyproject.toml).  It NEVER clears the recovery markers — the
+full, confirmed marker lifecycle stays with ``_recover_from_interrupted_install()``
+in main.py, which runs right after import succeeds.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Core packages a failed lazy ``uv pip install`` is known to leave with intact
+# distribution metadata but wiped import files (#57828).  ``module`` is what we
+# probe via a real import; ``attr`` guards against an empty/stub module.
+# main.py's marker-recovery path reuses these tables — keep them here (the
+# dependency-light module) so both layers probe and repair the same set.
+LAZY_REFRESH_IMPORT_PROBES: tuple[tuple[str, str], ...] = (
+    ("yaml", "SafeDumper"),
+    ("dotenv", "load_dotenv"),
+    ("click", "Command"),
+    ("certifi", "contents"),
+    ("rich", "print"),
+    ("cryptography", "__version__"),
+    ("jwt", "encode"),
+)
+
+LAZY_REFRESH_REPAIR_PACKAGES: dict[str, str] = {
+    "yaml": "PyYAML",
+    "dotenv": "python-dotenv",
+    "click": "click",
+    "certifi": "certifi",
+    "rich": "rich",
+    "cryptography": "cryptography",
+    "jwt": "PyJWT",
+}
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _pinned_specs(packages: list[str], project_root: Path) -> list[str]:
+    """Map bare package names to their pinned specs from pyproject.toml.
+
+    Stdlib-only (tomllib + naive requirement-head parsing — ``packaging`` may
+    itself be broken in the failure state this module exists for).  Unknown
+    packages fall back to their bare name.
+    """
+    pyproject = project_root / "pyproject.toml"
+    if not pyproject.is_file():
+        return packages
+    try:
+        import tomllib
+
+        with open(pyproject, "rb") as f:
+            raw_deps = tomllib.load(f).get("project", {}).get("dependencies", []) or []
+    except Exception:
+        return packages
+
+    name_to_spec: dict[str, str] = {}
+    for spec in raw_deps:
+        head = spec.split(";", 1)[0].strip()
+        bare = head
+        for op in ("==", ">=", "<=", "~=", ">", "<", "!="):
+            if op in bare:
+                bare = bare.split(op, 1)[0]
+                break
+        key = bare.strip().split("[", 1)[0].strip().lower()
+        if key:
+            name_to_spec[key] = head
+    return [name_to_spec.get(pkg.lower(), pkg) for pkg in packages]
+
+
+def _probe_broken_packages() -> list[str]:
+    """Import-probe the fragile core packages in THIS process.
+
+    Returns repair package names (deduped, probe order) for modules that fail
+    to import or lack their sentinel attribute.  Failed imports leave nothing
+    in ``sys.modules``, so a post-repair retry in the same process works.
+    """
+    broken: list[str] = []
+    for mod_name, attr in LAZY_REFRESH_IMPORT_PROBES:
+        try:
+            mod = importlib.import_module(mod_name)
+            if not hasattr(mod, attr):
+                raise ImportError(f"{mod_name} missing {attr}")
+        except Exception:
+            pkg = LAZY_REFRESH_REPAIR_PACKAGES.get(mod_name)
+            if pkg and pkg not in broken:
+                broken.append(pkg)
+    return broken
+
+
+def _run_repair_install(specs: list[str], project_root: Path) -> bool:
+    """ensurepip + ``pip install --force-reinstall`` the given specs.
+
+    Streams nothing to stdout (``hermes acp`` speaks JSON-RPC on stdout);
+    output is captured and replayed to stderr only on failure.  Never raises.
+    """
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
+            cwd=project_root,
+            capture_output=True,
+        )
+    except Exception:
+        pass
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--force-reinstall", *specs],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+        )
+    except Exception as exc:
+        print(f"  ✗ Early venv repair could not run pip: {exc}", file=sys.stderr)
+        return False
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout or "")[-2000:]
+        if tail:
+            print(tail, file=sys.stderr)
+        return False
+    return True
+
+
+def recover_if_needed(
+    project_root: Path | None = None,
+    argv: list[str] | None = None,
+) -> None:
+    """Repair wiped core packages so ``hermes_cli.main`` can import at all.
+
+    Fast path (no marker present) is two ``lstat`` calls.  Only acts when a
+    recovery marker from a prior ``hermes update`` exists AND an import probe
+    confirms a core package is actually broken.  Markers are intentionally
+    NOT cleared here — ``_recover_from_interrupted_install()`` in main.py owns
+    the confirmed marker lifecycle and runs immediately after import succeeds.
+
+    Never raises: on any failure the import of main.py proceeds and surfaces
+    the real error.
+    """
+    try:
+        args = sys.argv[1:] if argv is None else argv
+        # Same deliberately-loose match as main(): the real update flow writes
+        # and clears its own markers — a recovery install must not race it.
+        if "update" in args:
+            return
+        root = _project_root() if project_root is None else project_root
+        core_marker = root / ".update-incomplete"
+        lazy_marker = root / ".lazy-refresh-incomplete"
+        if not core_marker.exists() and not lazy_marker.exists():
+            return
+        # Managed/Docker/PyPI installs have no source tree here — the marker
+        # is not ours to act on; main.py's recovery clears it.
+        if not (root / "pyproject.toml").is_file():
+            return
+
+        broken = _probe_broken_packages()
+        if not broken:
+            # Imports are fine — main.py will load and run full recovery.
+            return
+
+        # Single-flight: share main.py's recovery lock so an early repair
+        # never races a concurrent full recovery into the same shared venv.
+        lock_path = root / ".update-incomplete.lock"
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.write(fd, f"{os.getpid()}\n".encode())
+            os.close(fd)
+        except FileExistsError:
+            try:
+                if time.time() - lock_path.stat().st_mtime > 3600:
+                    lock_path.unlink()
+            except OSError:
+                pass
+            return
+        except OSError:
+            pass  # read-only fs / perms — proceed unlocked, install surfaces it
+
+        try:
+            specs = _pinned_specs(broken, root)
+            print(
+                "⚠ Core package(s) broken by an interrupted update — "
+                f"repairing before launch: {', '.join(broken)}",
+                file=sys.stderr,
+            )
+            if _run_repair_install(specs, root) and not _probe_broken_packages():
+                print("  ✓ Core packages repaired.", file=sys.stderr)
+            else:
+                print(
+                    "  ✗ Automatic repair incomplete. Recover manually with:",
+                    file=sys.stderr,
+                )
+                print(
+                    f"    {sys.executable} -m pip install --force-reinstall "
+                    + " ".join(specs),
+                    file=sys.stderr,
+                )
+        finally:
+            try:
+                lock_path.unlink()
+            except OSError:
+                pass
+    except Exception:
+        # Never block launch — the import of main.py will surface the truth.
+        pass

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8178,7 +8178,187 @@ def _cleanup_quarantined_exes(scripts_dir: Path | None = None) -> None:
         pass
 
 
-def _refresh_active_lazy_features() -> None:
+# Import probes for venv corruption after a failed lazy ``uv pip install``.
+# Metadata can look fine while ``.py`` files were removed mid-install (#57828).
+_LAZY_REFRESH_IMPORT_PROBES: tuple[tuple[str, str], ...] = (
+    ("yaml", "SafeDumper"),
+    ("dotenv", "load_dotenv"),
+    ("click", "Command"),
+    ("certifi", "contents"),
+    ("rich", "print"),
+    ("cryptography", "__version__"),
+    ("jwt", "encode"),
+)
+
+_LAZY_REFRESH_REPAIR_PACKAGES: dict[str, str] = {
+    "yaml": "PyYAML",
+    "dotenv": "python-dotenv",
+    "click": "click",
+    "certifi": "certifi",
+    "rich": "rich",
+    "cryptography": "cryptography",
+    "jwt": "PyJWT",
+}
+
+
+def _run_package_only_install(
+    cmd: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Run a package-only pip/uv install without quarantining entry-point shims.
+
+    ``pip install --upgrade pip`` and ``--force-reinstall <pkg>`` do not
+    rewrite ``hermes.exe``. The editable-install quarantine path would rename
+    shims without uv recreating them on Windows (#57828).
+    """
+    _run_install_with_heartbeat(cmd, env=env)
+
+
+def _lazy_refresh_repair_specs(packages: list[str]) -> list[str]:
+    """Map repair package names to their declared pin specs in pyproject.toml."""
+    try:
+        import tomllib  # Python 3.11+
+    except ImportError:  # pragma: no cover
+        return packages
+
+    pyproject = PROJECT_ROOT / "pyproject.toml"
+    if not pyproject.is_file():
+        return packages
+
+    try:
+        with open(pyproject, "rb") as f:
+            raw_deps = tomllib.load(f).get("project", {}).get("dependencies", []) or []
+    except Exception as exc:
+        logger.debug("lazy refresh repair spec lookup failed: %s", exc)
+        return packages
+
+    name_to_spec: dict[str, str] = {}
+    try:
+        from packaging.requirements import Requirement  # type: ignore
+
+        for spec in raw_deps:
+            try:
+                req = Requirement(spec)
+                name_to_spec[req.name.lower()] = spec.split(";", 1)[0].strip()
+            except Exception:
+                continue
+    except Exception:
+        for spec in raw_deps:
+            head = spec.split(";", 1)[0].strip()
+            bare = head
+            for op in ("==", ">=", "<=", "~=", ">", "<", "!="):
+                if op in bare:
+                    bare = bare.split(op, 1)[0]
+                    break
+            key = bare.strip().split("[", 1)[0].strip().lower()
+            if key:
+                name_to_spec[key] = head
+
+    return [name_to_spec.get(pkg.lower(), pkg) for pkg in packages]
+
+
+def _upgrade_pip_before_lazy_refresh(
+    install_cmd_prefix: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Upgrade pip before lazy-backend refreshes.
+
+    Older pip (e.g. 24.0 on Python 3.11) can fail setuptools-backed source
+    builds during lazy installs and leave a partially-written venv (#57828).
+    Never raises.
+    """
+    try:
+        _run_package_only_install(
+            install_cmd_prefix + ["install", "--upgrade", "pip"],
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.debug("pip upgrade before lazy refresh failed: %s", exc)
+
+
+def _detect_broken_lazy_refresh_imports(
+    install_cmd_prefix: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> list[str]:
+    """Return pip distribution names whose import probes fail."""
+    venv_python = _resolve_install_target_python(install_cmd_prefix, env)
+    if venv_python is None:
+        return []
+
+    probe_lines = "\n".join(
+        f"    ({mod!r}, {attr!r})," for mod, attr in _LAZY_REFRESH_IMPORT_PROBES
+    )
+    check_script = (
+        "import sys\n"
+        "probes = [\n"
+        f"{probe_lines}\n"
+        "]\n"
+        "broken = []\n"
+        "for mod, attr in probes:\n"
+        "    try:\n"
+        "        imported = __import__(mod)\n"
+        "        if not hasattr(imported, attr):\n"
+        "            broken.append(mod)\n"
+        "    except Exception:\n"
+        "        broken.append(mod)\n"
+        "print('\\n'.join(broken))\n"
+    )
+    try:
+        result = subprocess.run(
+            [str(venv_python), "-c", check_script],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+    except Exception as exc:
+        logger.debug("lazy refresh import probe failed: %s", exc)
+        return []
+
+    broken_modules = [
+        line.strip() for line in result.stdout.splitlines() if line.strip()
+    ]
+    packages: list[str] = []
+    seen: set[str] = set()
+    for mod in broken_modules:
+        pkg = _LAZY_REFRESH_REPAIR_PACKAGES.get(mod)
+        if pkg and pkg not in seen:
+            seen.add(pkg)
+            packages.append(pkg)
+    return packages
+
+
+def _repair_broken_lazy_refresh_imports(
+    install_cmd_prefix: list[str],
+    packages: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> bool:
+    """Force-reinstall ``packages`` and re-probe imports. Never raises."""
+    if not packages:
+        return True
+
+    specs = _lazy_refresh_repair_specs(packages)
+    try:
+        _run_package_only_install(
+            install_cmd_prefix + ["install", "--force-reinstall", *specs],
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.warning("lazy refresh venv repair failed: %s", exc)
+        return False
+
+    return not _detect_broken_lazy_refresh_imports(install_cmd_prefix, env=env)
+
+
+def _refresh_active_lazy_features(
+    install_cmd_prefix: list[str] | None = None,
+    *,
+    env: dict[str, str] | None = None,
+) -> bool:
     """Refresh lazy-installed backends after a code update.
 
     When pyproject.toml's ``[all]`` extra was slimmed down (May 2026), most
@@ -8192,22 +8372,27 @@ def _refresh_active_lazy_features() -> None:
     activated and reinstalls them under the current pins. Features the
     user never enabled stay quiet — no churn for cold backends.
 
+    Returns True when the venv is safe to use (refresh succeeded, or no
+    active lazy backends, or post-failure import repair succeeded). Returns
+    False when a failed lazy install left broken core imports that automatic
+    repair could not fix (#57828).
+
     Never raises. A failure here must not block the rest of the update.
     """
     try:
         from tools import lazy_deps
     except Exception as exc:
         logger.debug("Lazy refresh skipped (import failed): %s", exc)
-        return
+        return True
 
     try:
         active = lazy_deps.active_features()
     except Exception as exc:
         logger.debug("Lazy refresh skipped (active_features failed): %s", exc)
-        return
+        return True
 
     if not active:
-        return
+        return True
 
     print()
     print(f"→ Refreshing {len(active)} active lazy backend(s)...")
@@ -8218,7 +8403,7 @@ def _refresh_active_lazy_features() -> None:
         # refresh_active_features is documented as never-raise, but defend
         # the update flow against future regressions.
         print(f"  ⚠ Lazy refresh failed unexpectedly: {exc}")
-        return
+        results = {}
 
     refreshed = [f for f, s in results.items() if s == "refreshed"]
     current = [f for f, s in results.items() if s == "current"]
@@ -8242,8 +8427,37 @@ def _refresh_active_lazy_features() -> None:
             if len(reason) > 200:
                 reason = reason[:200] + "..."
             print(f"  ⚠ {feature} failed to refresh: {reason}")
-        print("  Backends keep their previously-installed version; rerun")
-        print("  `hermes update` once the upstream issue is resolved.")
+
+        if install_cmd_prefix is None:
+            print("  ⚠ Lazy refresh failed; rerun `hermes update` once resolved.")
+            return False
+
+        broken = _detect_broken_lazy_refresh_imports(
+            install_cmd_prefix, env=env
+        )
+        if broken:
+            print("  → Detected corrupted venv packages; repairing...")
+            if _repair_broken_lazy_refresh_imports(
+                install_cmd_prefix, broken, env=env
+            ):
+                print("  ✓ Venv repair succeeded")
+                print("  Lazy backend(s) keep their previous version until refresh succeeds.")
+                return True
+
+            manual = " ".join(
+                repr(p) for p in broken
+            )
+            print("  ⚠ Venv repair incomplete. Run manually, then `hermes update`:")
+            print(
+                f"    {' '.join(install_cmd_prefix)} install --force-reinstall {manual}"
+            )
+            return False
+
+        print("  Lazy backend(s) keep their previous version; core venv looks intact.")
+        print("  Rerun `hermes update` once the upstream issue is resolved.")
+        return True
+
+    return True
 
 
 def _install_python_dependencies_with_optional_fallback(
@@ -10746,13 +10960,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _install_psutil_android_compat(pip_cmd)
             _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
 
-        # Core Python deps installed AND verified (the fallback helper runs
-        # _verify_core_dependencies_installed). Clear the interrupted-install
-        # breadcrumb now — the remaining steps (lazy refresh, node deps, web
-        # UI, desktop rebuild) are non-core and can't brick the venv.
-        _clear_update_incomplete_marker()
+        install_prefix = [uv_bin, "pip"] if uv_bin else pip_cmd
+        lazy_env = uv_env if uv_bin else None
 
-        _refresh_active_lazy_features()
+        # Upgrade pip before lazy refreshes — stale pip can fail source builds
+        # and leave partially-written packages (#57828).
+        _upgrade_pip_before_lazy_refresh(install_prefix, env=lazy_env)
+
+        # Lazy refresh can corrupt the venv when a backend install fails.
+        # Keep the interrupted-install marker until refresh + repair succeed.
+        lazy_ok = _refresh_active_lazy_features(install_prefix, env=lazy_env)
+        if lazy_ok:
+            _clear_update_incomplete_marker()
+        else:
+            print(
+                "  ⚠ Update incomplete — run `hermes` again to finish venv recovery."
+            )
 
         node_failures = _update_node_dependencies()
         _build_web_ui(PROJECT_ROOT / "web")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -64,6 +64,25 @@ except ModuleNotFoundError:
 import os
 import sys
 
+# Early venv self-heal — MUST run before any third-party import below.  When
+# a prior ``hermes update`` left a recovery marker and a core package's import
+# files were wiped (#57828 — failed lazy backend refresh), the module-level
+# ``from hermes_cli.env_loader import ...`` / ``from hermes_cli.config import
+# ...`` imports further down would crash before ``main()`` ever reaches
+# ``_recover_from_interrupted_install()``.  ``_early_recovery`` is stdlib-only
+# (safe to import on a corrupted venv), repairs just enough for this module to
+# finish importing, and leaves the marker lifecycle to the full recovery path.
+# The module import itself is unguarded on purpose: it lives in this same
+# package directory, so if IT can't import, nothing else in hermes_cli can
+# either. It is also the canonical home of the probe/repair tables reused by
+# the full recovery path below.
+from hermes_cli import _early_recovery as _early_recovery_mod
+
+try:
+    _early_recovery_mod.recover_if_needed()
+except Exception:
+    pass
+
 
 def _exit_after_oneshot(rc: object) -> None:
     """Exit one-shot mode without letting late native finalizers change rc.
@@ -7724,9 +7743,12 @@ def _recover_lazy_refresh_marker_locked() -> None:
             "Leaving `.lazy-refresh-incomplete` for the next launch."
         )
         print("  Recover manually with:")
+        all_specs = _lazy_refresh_repair_specs(
+            sorted(set(_LAZY_REFRESH_REPAIR_PACKAGES.values()))
+        )
         print(
             f"    {' '.join(install_prefix)} install --force-reinstall "
-            "PyYAML python-dotenv click certifi rich cryptography PyJWT"
+            + " ".join(shlex.quote(s) for s in all_specs)
         )
 
 
@@ -8283,25 +8305,16 @@ def _cleanup_quarantined_exes(scripts_dir: Path | None = None) -> None:
 
 # Import probes for venv corruption after a failed lazy ``uv pip install``.
 # Metadata can look fine while ``.py`` files were removed mid-install (#57828).
+# Canonical tables live in the stdlib-only ``_early_recovery`` module (which
+# also probes/repairs BEFORE this module's third-party imports can run) so the
+# early and full recovery layers can never drift apart.
 _LAZY_REFRESH_IMPORT_PROBES: tuple[tuple[str, str], ...] = (
-    ("yaml", "SafeDumper"),
-    ("dotenv", "load_dotenv"),
-    ("click", "Command"),
-    ("certifi", "contents"),
-    ("rich", "print"),
-    ("cryptography", "__version__"),
-    ("jwt", "encode"),
+    _early_recovery_mod.LAZY_REFRESH_IMPORT_PROBES
 )
 
-_LAZY_REFRESH_REPAIR_PACKAGES: dict[str, str] = {
-    "yaml": "PyYAML",
-    "dotenv": "python-dotenv",
-    "click": "click",
-    "certifi": "certifi",
-    "rich": "rich",
-    "cryptography": "cryptography",
-    "jwt": "PyJWT",
-}
+_LAZY_REFRESH_REPAIR_PACKAGES: dict[str, str] = (
+    _early_recovery_mod.LAZY_REFRESH_REPAIR_PACKAGES
+)
 
 
 def _run_package_only_install(
@@ -8508,7 +8521,9 @@ def _repair_venv_via_import_probes(
     ):
         print("  ✓ Venv repair succeeded")
         return "repaired"
-    manual = " ".join(repr(p) for p in broken)
+    manual = " ".join(
+        shlex.quote(s) for s in _lazy_refresh_repair_specs(broken)
+    )
     print("  ⚠ Venv repair incomplete. Run manually, then `hermes update`:")
     print(
         f"    {' '.join(install_cmd_prefix)} install --force-reinstall {manual}"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7551,62 +7551,93 @@ def _load_installable_optional_extras(group: str = "all") -> list[str]:
     return referenced
 
 
-# Install-scoped breadcrumb dropped right before ``hermes update`` mutates the
-# venv and cleared only after the dependency install verifies clean.  If a user
-# kills the update mid-install (Ctrl-C, terminal close, WSL OOM), the marker
-# survives and the next ``hermes`` launch finishes the install instead of
-# limping along on a half-built venv (e.g. pip wiped, a core dep like Pillow
-# never landed).  Lives next to the venv (not under $HERMES_HOME) because the
-# venv is shared across all profiles, so a single marker covers every profile.
+# Install-scoped breadcrumbs live next to the venv (not under $HERMES_HOME)
+# because the venv is shared across profiles.
+#
+# ``.update-incomplete`` — generic core ``.[all]`` install was interrupted.
+# Cleared only after a confirmed full dependency reinstall/recovery.
+#
+# ``.lazy-refresh-incomplete`` — lazy-backend refresh phase may have corrupted
+# packages. Cleared only after import-probe repair confirms healthy (not when
+# probes are unavailable/indeterminate). Narrow lazy probes must NEVER clear
+# the generic core marker (#58004 review).
 def _update_marker_path() -> Path:
     return PROJECT_ROOT / ".update-incomplete"
 
 
-def _write_update_incomplete_marker() -> None:
-    """Drop the interrupted-install breadcrumb. Never raises."""
+def _lazy_refresh_marker_path() -> Path:
+    return PROJECT_ROOT / ".lazy-refresh-incomplete"
+
+
+def _write_marker_file(path: Path, *, label: str) -> None:
+    """Drop an update-recovery breadcrumb. Never raises."""
     try:
-        _update_marker_path().write_text(
+        path.write_text(
             f"started={_time.time()}\npid={os.getpid()}\n", encoding="utf-8"
         )
     except OSError as exc:
-        logger.debug("Could not write update-incomplete marker: %s", exc)
+        logger.debug("Could not write %s marker: %s", label, exc)
 
 
-def _clear_update_incomplete_marker() -> None:
-    """Remove the interrupted-install breadcrumb. Never raises."""
+def _clear_marker_file(path: Path, *, label: str) -> None:
+    """Remove an update-recovery breadcrumb. Never raises."""
     try:
-        _update_marker_path().unlink()
+        path.unlink()
     except FileNotFoundError:
         pass
     except OSError as exc:
-        logger.debug("Could not clear update-incomplete marker: %s", exc)
+        logger.debug("Could not clear %s marker: %s", label, exc)
+
+
+def _write_update_incomplete_marker() -> None:
+    """Drop the interrupted core-install breadcrumb. Never raises."""
+    _write_marker_file(_update_marker_path(), label="update-incomplete")
+
+
+def _clear_update_incomplete_marker() -> None:
+    """Remove the interrupted core-install breadcrumb. Never raises."""
+    _clear_marker_file(_update_marker_path(), label="update-incomplete")
+
+
+def _write_lazy_refresh_incomplete_marker() -> None:
+    """Drop the interrupted lazy-refresh breadcrumb. Never raises."""
+    _write_marker_file(_lazy_refresh_marker_path(), label="lazy-refresh-incomplete")
+
+
+def _clear_lazy_refresh_incomplete_marker() -> None:
+    """Remove the interrupted lazy-refresh breadcrumb. Never raises."""
+    _clear_marker_file(_lazy_refresh_marker_path(), label="lazy-refresh-incomplete")
 
 
 def _recover_from_interrupted_install() -> None:
-    """Finish a dependency install that a prior ``hermes update`` left half-done.
+    """Finish update work left half-done by a prior ``hermes update``.
 
-    Triggered on launch when ``.update-incomplete`` is present — meaning the
-    code was pulled but the dep install was killed before it verified clean.
-    Unconditionally bootstraps pip via ``ensurepip`` (a killed ``pip install``
-    can wipe pip from the venv entirely, which blocks the venv from recovering
-    on its own), then re-runs the editable ``.[all]`` install + core-dependency
-    verification, then clears the marker.
+    Handles two independent breadcrumbs:
+
+    - ``.update-incomplete`` — core ``.[all]`` install interrupted. Recovers
+      via full quarantined reinstall. Never cleared by the narrow lazy-refresh
+      import probes alone.
+    - ``.lazy-refresh-incomplete`` — lazy-backend refresh may have corrupted
+      packages. Recovers via package-only import probes; cleared only when
+      probes confirm healthy/repaired (indeterminate keeps the marker).
 
     Never raises: a recovery failure must not block launch.  If it can't
-    self-heal it prints the one-line manual command and leaves the marker so
+    self-heal it prints the manual command and leaves the relevant marker so
     the next launch tries again.
 
-    Concurrency: the marker lives next to the shared venv, so a gateway start
-    plus a CLI launch (or two profiles starting at once) can both see it.  An
-    ``O_EXCL`` lockfile ensures only one process runs the reinstall; the
-    others skip and let the winner clear the marker.
+    Concurrency: markers live next to the shared venv, so a gateway start
+    plus a CLI launch (or two profiles starting at once) can both see them.
+    An ``O_EXCL`` lockfile ensures only one process runs recovery; the
+    others skip and let the winner clear markers.
 
     Output: everything — our status lines AND the streamed pip/uv install
     (which inherits fd 1) — is routed to stderr.  Launches whose stdout is a
     protocol stream (``hermes acp`` speaks JSON-RPC on stdout) must never get
     install noise on stdout.
     """
-    if not _update_marker_path().exists():
+    core_marker = _update_marker_path().exists()
+    lazy_marker = _lazy_refresh_marker_path().exists()
+    if not core_marker and not lazy_marker:
         return
 
     # Skip in managed/Docker installs and on PyPI installs with no git checkout:
@@ -7614,6 +7645,7 @@ def _recover_from_interrupted_install() -> None:
     # to act on. Just clear it.
     if not (PROJECT_ROOT / "pyproject.toml").is_file():
         _clear_update_incomplete_marker()
+        _clear_lazy_refresh_incomplete_marker()
         return
 
     # Single-flight guard: atomically claim the recovery lock. If another
@@ -7650,90 +7682,11 @@ def _recover_from_interrupted_install() -> None:
             saved_stdout_fd = None
         sys.stdout = sys.stderr
 
-        print(
-            "⚠ A previous `hermes update` was interrupted mid-install — "
-            "finishing dependency installation now..."
-        )
+        if lazy_marker:
+            _recover_lazy_refresh_marker_locked()
 
-        # Windows: a normal ``hermes.exe`` launch always has the launcher as an
-        # ancestor. Full editable reinstall may fail with WinError 32 when it
-        # tries to replace that live shim (#45542). Package-only import repair
-        # does not rewrite entry-point shims, so heal the #57828 corruption
-        # class first — and NEVER clear ``.update-incomplete`` merely because
-        # the launcher is running (that previously aborted recovery on every
-        # normal Windows launch).
-        self_locked = _windows_running_hermes_launcher_locked()
-        if self_locked:
-            install_prefix, install_env = _default_venv_install_target()
-            print(
-                "  → Running from hermes.exe; attempting package-only "
-                "import repair (no launcher rewrite)..."
-            )
-            if _repair_venv_via_import_probes(install_prefix, env=install_env):
-                _clear_update_incomplete_marker()
-                print(
-                    "✓ Venv package repair succeeded — your install is healthy again."
-                )
-                return
-            print(
-                "  ⚠ Package-only repair did not fully heal the venv; "
-                "trying quarantined reinstall next..."
-            )
-
-        try:
-            from hermes_cli.managed_uv import ensure_uv
-
-            # Always bootstrap pip first: a killed install can leave the venv with
-            # no pip module at all, and uv may also be gone. ensurepip restores a
-            # known-good pip so at least the plain-pip path below can proceed.
-            try:
-                subprocess.run(
-                    [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                )
-            except Exception as exc:
-                logger.debug("ensurepip during install recovery failed: %s", exc)
-
-            uv_bin = ensure_uv()
-            if uv_bin:
-                uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
-                if _is_termux_env(uv_env):
-                    uv_env.pop("PYTHONPATH", None)
-                    uv_env.pop("PYTHONHOME", None)
-                _install_python_dependencies_with_optional_fallback(
-                    [uv_bin, "pip"],
-                    env=uv_env,
-                    group="termux-all" if _is_termux_env(uv_env) else "all",
-                )
-            else:
-                _install_python_dependencies_with_optional_fallback(
-                    [sys.executable, "-m", "pip"],
-                    group="termux-all" if _is_termux_env() else "all",
-                )
-
-            _clear_update_incomplete_marker()
-            print("✓ Dependency installation recovered — your install is healthy again.")
-        except Exception as exc:
-            # Leave the marker in place so the next launch retries. Give the user
-            # the exact manual recovery command in the meantime.
-            logger.debug("Interrupted-install recovery failed: %s", exc)
-            print("✗ Could not auto-recover the interrupted install.")
-            if self_locked:
-                print(
-                    "  Hermes is still running from the launcher that needs "
-                    "replacing. Close other Hermes windows, restart from a "
-                    "different terminal, then run:"
-                )
-                print(f'    cd /d "{PROJECT_ROOT}"')
-                print(
-                    f'    "{sys.executable}" -m pip install -e ".[all]"'
-                )
-            else:
-                print("  Recover manually with:")
-                print(f"    cd {PROJECT_ROOT}")
-                print(f"    {sys.executable} -m ensurepip --upgrade")
-                print(f"    {sys.executable} -m pip install -e '.[all]'")
+        if _update_marker_path().exists():
+            _recover_core_update_marker_locked()
     finally:
         sys.stdout = saved_sys_stdout
         if saved_stdout_fd is not None:
@@ -7746,6 +7699,117 @@ def _recover_from_interrupted_install() -> None:
             lock_path.unlink()
         except OSError:
             pass
+
+
+def _recover_lazy_refresh_marker_locked() -> None:
+    """Heal ``.lazy-refresh-incomplete`` via confirmed import-probe repair."""
+    print(
+        "⚠ A previous lazy-backend refresh may have left the venv unhealthy — "
+        "running import-based package repair..."
+    )
+    install_prefix, install_env = _default_venv_install_target()
+    status = _repair_venv_via_import_probes(install_prefix, env=install_env)
+    if status in ("healthy", "repaired"):
+        _clear_lazy_refresh_incomplete_marker()
+        print("✓ Lazy-refresh venv recovery confirmed — install is healthy again.")
+        return
+    if status == "indeterminate":
+        print(
+            "  ⚠ Import probes unavailable — cannot confirm venv health. "
+            "Leaving `.lazy-refresh-incomplete` for the next launch."
+        )
+    else:
+        print(
+            "  ⚠ Lazy-refresh package repair incomplete. "
+            "Leaving `.lazy-refresh-incomplete` for the next launch."
+        )
+        print("  Recover manually with:")
+        print(
+            f"    {' '.join(install_prefix)} install --force-reinstall "
+            "PyYAML python-dotenv click certifi rich cryptography PyJWT"
+        )
+
+
+def _recover_core_update_marker_locked() -> None:
+    """Heal ``.update-incomplete`` via full ``.[all]`` reinstall only.
+
+    Narrow lazy-refresh import probes are not sufficient proof that a generic
+    interrupted core install finished — a missing dep outside that probe set
+    would otherwise look healthy and clear the breadcrumb too early.
+    """
+    print(
+        "⚠ A previous `hermes update` was interrupted mid-install — "
+        "finishing dependency installation now..."
+    )
+
+    # Windows: a normal ``hermes.exe`` launch always has the launcher as an
+    # ancestor. Full editable reinstall uses quarantine so the live shim can
+    # still be replaced. Package-only import repair may help as first aid but
+    # must NEVER clear this core marker on its own (#58004 review).
+    self_locked = _windows_running_hermes_launcher_locked()
+    if self_locked:
+        install_prefix, install_env = _default_venv_install_target()
+        print(
+            "  → Running from hermes.exe; applying package-only first aid, "
+            "then quarantined full reinstall (core marker stays until that "
+            "succeeds)..."
+        )
+        _repair_venv_via_import_probes(install_prefix, env=install_env)
+
+    try:
+        from hermes_cli.managed_uv import ensure_uv
+
+        # Always bootstrap pip first: a killed install can leave the venv with
+        # no pip module at all, and uv may also be gone. ensurepip restores a
+        # known-good pip so at least the plain-pip path below can proceed.
+        try:
+            subprocess.run(
+                [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+            )
+        except Exception as exc:
+            logger.debug("ensurepip during install recovery failed: %s", exc)
+
+        uv_bin = ensure_uv()
+        if uv_bin:
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            if _is_termux_env(uv_env):
+                uv_env.pop("PYTHONPATH", None)
+                uv_env.pop("PYTHONHOME", None)
+            _install_python_dependencies_with_optional_fallback(
+                [uv_bin, "pip"],
+                env=uv_env,
+                group="termux-all" if _is_termux_env(uv_env) else "all",
+            )
+        else:
+            _install_python_dependencies_with_optional_fallback(
+                [sys.executable, "-m", "pip"],
+                group="termux-all" if _is_termux_env() else "all",
+            )
+
+        _clear_update_incomplete_marker()
+        print("✓ Dependency installation recovered — your install is healthy again.")
+    except Exception as exc:
+        # Leave the marker in place so the next launch retries. Give the user
+        # the exact manual recovery command in the meantime.
+        logger.debug("Interrupted-install recovery failed: %s", exc)
+        print("✗ Could not auto-recover the interrupted install.")
+        if self_locked:
+            print(
+                "  Hermes is still running from the launcher that needs "
+                "replacing. Close other Hermes windows, restart from a "
+                "different terminal, then run:"
+            )
+            print(f'    cd /d "{PROJECT_ROOT}"')
+            print(
+                f'    "{sys.executable}" -m pip install -e ".[all]"'
+            )
+        else:
+            print("  Recover manually with:")
+            print(f"    cd {PROJECT_ROOT}")
+            print(f"    {sys.executable} -m ensurepip --upgrade")
+            print(f"    {sys.executable} -m pip install -e '.[all]'")
 
 
 def _windows_running_hermes_launcher_locked() -> bool:
@@ -8321,11 +8385,18 @@ def _detect_broken_lazy_refresh_imports(
     install_cmd_prefix: list[str],
     *,
     env: dict[str, str] | None = None,
-) -> list[str]:
-    """Return pip distribution names whose import probes fail."""
+) -> list[str] | None:
+    """Probe lazy-refresh packages via real imports.
+
+    Returns:
+      - ``[]`` when probes ran and every package imported cleanly
+      - ``[dist, ...]`` when probes ran and some packages failed
+      - ``None`` when the probe could not run (missing venv Python, subprocess
+        failure, non-zero probe exit) — this is *indeterminate*, not healthy
+    """
     venv_python = _resolve_install_target_python(install_cmd_prefix, env)
     if venv_python is None:
-        return []
+        return None
 
     probe_lines = "\n".join(
         f"    ({mod!r}, {attr!r})," for mod, attr in _LAZY_REFRESH_IMPORT_PROBES
@@ -8355,7 +8426,15 @@ def _detect_broken_lazy_refresh_imports(
         )
     except Exception as exc:
         logger.debug("lazy refresh import probe failed: %s", exc)
-        return []
+        return None
+
+    if result.returncode != 0:
+        logger.debug(
+            "lazy refresh import probe exited %s: %s",
+            result.returncode,
+            (result.stderr or "")[:200],
+        )
+        return None
 
     broken_modules = [
         line.strip() for line in result.stdout.splitlines() if line.strip()
@@ -8390,25 +8469,36 @@ def _repair_broken_lazy_refresh_imports(
         logger.warning("lazy refresh venv repair failed: %s", exc)
         return False
 
-    return not _detect_broken_lazy_refresh_imports(install_cmd_prefix, env=env)
+    after = _detect_broken_lazy_refresh_imports(install_cmd_prefix, env=env)
+    # Indeterminate re-probe is not confirmed success.
+    return after == []
 
 
 def _repair_venv_via_import_probes(
     install_cmd_prefix: list[str],
     *,
     env: dict[str, str] | None = None,
-) -> bool:
-    """Probe core imports and force-reinstall any broken packages.
+) -> str:
+    """Probe imports and force-reinstall any broken lazy-refresh packages.
 
     Uses real ``import`` checks (not distribution metadata) so a venv where
     METADATA remains but ``.py`` files were wiped mid-install is still
     detected (#57828). Package-only reinstall — never rewrites ``hermes.exe``.
-    Never raises. Returns True when probes are clean after repair (or already
-    were).
+
+    Never raises. Returns one of:
+      - ``"healthy"`` — probes ran and found nothing broken
+      - ``"repaired"`` — probes found breakage and force-reinstall confirmed clean
+      - ``"failed"`` — probes found breakage and repair did not confirm clean
+      - ``"indeterminate"`` — probes could not run; do NOT treat as healthy
     """
     broken = _detect_broken_lazy_refresh_imports(install_cmd_prefix, env=env)
+    if broken is None:
+        print(
+            "  ⚠ Import probes unavailable — cannot confirm venv package health."
+        )
+        return "indeterminate"
     if not broken:
-        return True
+        return "healthy"
     print(
         "  → Detected corrupted venv packages via import probes: "
         f"{', '.join(broken)}; repairing..."
@@ -8417,13 +8507,13 @@ def _repair_venv_via_import_probes(
         install_cmd_prefix, broken, env=env
     ):
         print("  ✓ Venv repair succeeded")
-        return True
+        return "repaired"
     manual = " ".join(repr(p) for p in broken)
     print("  ⚠ Venv repair incomplete. Run manually, then `hermes update`:")
     print(
         f"    {' '.join(install_cmd_prefix)} install --force-reinstall {manual}"
     )
-    return False
+    return "failed"
 
 
 def _refresh_active_lazy_features(
@@ -8511,21 +8601,24 @@ def _refresh_active_lazy_features(
 
     # Immediate import-based recovery — metadata-only verifiers miss the case
     # where DISTRIBUTION-INFO remains but import files were wiped (#57828).
-    broken_before = _detect_broken_lazy_refresh_imports(
-        install_cmd_prefix, env=env
-    )
-    if not _repair_venv_via_import_probes(install_cmd_prefix, env=env):
-        return False
-    if broken_before:
+    # Unavailable probes are indeterminate, not healthy — keep the lazy marker.
+    status = _repair_venv_via_import_probes(install_cmd_prefix, env=env)
+    if status == "repaired":
         print(
             "  Lazy backend(s) keep their previous version until refresh succeeds."
         )
-    else:
+        return True
+    if status == "healthy":
         print(
-            "  Lazy backend(s) keep their previous version; core venv looks intact."
+            "  Lazy backend(s) keep their previous version; probed packages look intact."
         )
         print("  Rerun `hermes update` once the upstream issue is resolved.")
-    return True
+        return True
+    if status == "indeterminate":
+        print(
+            "  ⚠ Leaving `.lazy-refresh-incomplete` until import probes can confirm health."
+        )
+    return False
 
 
 def _install_python_dependencies_with_optional_fallback(
@@ -10969,11 +11062,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # breaks on this machine, keep base deps and reinstall the remaining extras
         # individually so update does not silently strip working capabilities.
         #
-        # Drop the interrupted-install breadcrumb BEFORE touching the venv. If
-        # the install is killed mid-flight (Ctrl-C, terminal close, WSL OOM),
-        # the marker survives and the next ``hermes`` launch finishes the
-        # install via ``_recover_from_interrupted_install``. Cleared only after
-        # the install + core-dependency verification completes below.
+        # Drop the core-install breadcrumb BEFORE touching the venv. If the
+        # install is killed mid-flight (Ctrl-C, terminal close, WSL OOM), the
+        # marker survives and the next ``hermes`` launch finishes the install
+        # via ``_recover_from_interrupted_install``. Cleared after the core
+        # ``.[all]`` install completes — lazy refresh uses a separate marker.
         _write_update_incomplete_marker()
         print("→ Updating Python dependencies...")
         from hermes_cli.managed_uv import ensure_uv, update_managed_uv
@@ -11031,18 +11124,26 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_prefix = [uv_bin, "pip"] if uv_bin else pip_cmd
         lazy_env = uv_env if uv_bin else None
 
+        # Core ``.[all]`` install finished. Clear the generic core breadcrumb
+        # before the lazy-refresh phase — that phase uses its own marker so a
+        # later lazy failure cannot be "healed" by clearing the core marker
+        # based on a narrow 7-package import probe (#58004 review).
+        _clear_update_incomplete_marker()
+
         # Upgrade pip before lazy refreshes — stale pip can fail source builds
         # and leave partially-written packages (#57828).
+        _write_lazy_refresh_incomplete_marker()
         _upgrade_pip_before_lazy_refresh(install_prefix, env=lazy_env)
 
         # Lazy refresh can corrupt the venv when a backend install fails.
-        # Keep the interrupted-install marker until refresh + repair succeed.
+        # Clear the lazy marker only when refresh/repair is confirmed healthy.
         lazy_ok = _refresh_active_lazy_features(install_prefix, env=lazy_env)
         if lazy_ok:
-            _clear_update_incomplete_marker()
+            _clear_lazy_refresh_incomplete_marker()
         else:
             print(
-                "  ⚠ Update incomplete — run `hermes` again to finish venv recovery."
+                "  ⚠ Lazy-refresh recovery incomplete — run `hermes` again "
+                "to finish import-based venv repair."
             )
 
         node_failures = _update_node_dependencies()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7638,55 +7638,6 @@ def _recover_from_interrupted_install() -> None:
         # the install itself will surface the real problem.
         logger.debug("Could not create install-recovery lock: %s", exc)
 
-    # Windows self-lock guard: if hermes.exe is the launcher that spawned
-    # this Python process, any attempt to pip-install will fail with
-    # "拒绝访问 / WinError 32" because the running .exe cannot be replaced.
-    # Rather than entering the permanent retry loop described in issue
-    # #45542, clear the marker and give the user an offline recovery command.
-    if _is_windows():
-        scripts_dir = _venv_scripts_dir()
-        if scripts_dir is not None:
-            shims = _hermes_exe_shims(scripts_dir)
-            if shims:
-                _shim_set: set[str] = set()
-                for _s in shims:
-                    try:
-                        _shim_set.add(str(_s.resolve()).lower())
-                    except OSError:
-                        _shim_set.add(str(_s).lower())
-                try:
-                    import psutil
-                    _me = psutil.Process()
-                    for _anc in [_me] + list(_me.parents()):
-                        try:
-                            _anc_exe = _anc.exe()
-                            _anc_norm = str(Path(_anc_exe).resolve()).lower()
-                        except Exception:
-                            continue
-                        if _anc_norm in _shim_set:
-                            print(
-                                "✗ Hermes is running from the binary that "
-                                "needs to be replaced — the auto-recovery "
-                                "cannot overwrite a running executable."
-                            )
-                            print(
-                                "  Restart Hermes from a different terminal, "
-                                "then run the manual recovery command below:"
-                            )
-                            print(f'    cd /d "{PROJECT_ROOT}"')
-                            print(
-                                f'    "{sys.executable}" -m pip install '
-                                '-e ".[all]"'
-                            )
-                            _clear_update_incomplete_marker()
-                            try:
-                                lock_path.unlink()
-                            except OSError:
-                                pass
-                            return
-                except Exception:
-                    pass  # psutil is best-effort; fall through to install
-
     saved_stdout_fd = None
     saved_sys_stdout = sys.stdout
     try:
@@ -7703,6 +7654,31 @@ def _recover_from_interrupted_install() -> None:
             "⚠ A previous `hermes update` was interrupted mid-install — "
             "finishing dependency installation now..."
         )
+
+        # Windows: a normal ``hermes.exe`` launch always has the launcher as an
+        # ancestor. Full editable reinstall may fail with WinError 32 when it
+        # tries to replace that live shim (#45542). Package-only import repair
+        # does not rewrite entry-point shims, so heal the #57828 corruption
+        # class first — and NEVER clear ``.update-incomplete`` merely because
+        # the launcher is running (that previously aborted recovery on every
+        # normal Windows launch).
+        self_locked = _windows_running_hermes_launcher_locked()
+        if self_locked:
+            install_prefix, install_env = _default_venv_install_target()
+            print(
+                "  → Running from hermes.exe; attempting package-only "
+                "import repair (no launcher rewrite)..."
+            )
+            if _repair_venv_via_import_probes(install_prefix, env=install_env):
+                _clear_update_incomplete_marker()
+                print(
+                    "✓ Venv package repair succeeded — your install is healthy again."
+                )
+                return
+            print(
+                "  ⚠ Package-only repair did not fully heal the venv; "
+                "trying quarantined reinstall next..."
+            )
 
         try:
             from hermes_cli.managed_uv import ensure_uv
@@ -7743,10 +7719,21 @@ def _recover_from_interrupted_install() -> None:
             # the exact manual recovery command in the meantime.
             logger.debug("Interrupted-install recovery failed: %s", exc)
             print("✗ Could not auto-recover the interrupted install.")
-            print("  Recover manually with:")
-            print(f"    cd {PROJECT_ROOT}")
-            print(f"    {sys.executable} -m ensurepip --upgrade")
-            print(f"    {sys.executable} -m pip install -e '.[all]'")
+            if self_locked:
+                print(
+                    "  Hermes is still running from the launcher that needs "
+                    "replacing. Close other Hermes windows, restart from a "
+                    "different terminal, then run:"
+                )
+                print(f'    cd /d "{PROJECT_ROOT}"')
+                print(
+                    f'    "{sys.executable}" -m pip install -e ".[all]"'
+                )
+            else:
+                print("  Recover manually with:")
+                print(f"    cd {PROJECT_ROOT}")
+                print(f"    {sys.executable} -m ensurepip --upgrade")
+                print(f"    {sys.executable} -m pip install -e '.[all]'")
     finally:
         sys.stdout = saved_sys_stdout
         if saved_stdout_fd is not None:
@@ -7759,6 +7746,58 @@ def _recover_from_interrupted_install() -> None:
             lock_path.unlink()
         except OSError:
             pass
+
+
+def _windows_running_hermes_launcher_locked() -> bool:
+    """True when a venv ``hermes*.exe`` shim is this process or an ancestor.
+
+    Best-effort: returns False when psutil is unavailable or inspection fails.
+    """
+    if not _is_windows():
+        return False
+    scripts_dir = _venv_scripts_dir()
+    if scripts_dir is None:
+        return False
+    shims = _hermes_exe_shims(scripts_dir)
+    if not shims:
+        return False
+    shim_set: set[str] = set()
+    for shim in shims:
+        try:
+            shim_set.add(str(shim.resolve()).lower())
+        except OSError:
+            shim_set.add(str(shim).lower())
+    try:
+        import psutil
+
+        me = psutil.Process()
+        for proc in [me] + list(me.parents()):
+            try:
+                exe_norm = str(Path(proc.exe()).resolve()).lower()
+            except Exception:
+                continue
+            if exe_norm in shim_set:
+                return True
+    except Exception:
+        return False
+    return False
+
+
+def _default_venv_install_target() -> tuple[list[str], dict[str, str] | None]:
+    """Return ``(install_cmd_prefix, env)`` for the project venv when possible."""
+    try:
+        from hermes_cli.managed_uv import ensure_uv
+
+        uv_bin = ensure_uv()
+    except Exception:
+        uv_bin = None
+    if uv_bin:
+        env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        if _is_termux_env(env):
+            env.pop("PYTHONPATH", None)
+            env.pop("PYTHONHOME", None)
+        return [uv_bin, "pip"], env
+    return [sys.executable, "-m", "pip"], None
 
 
 def _run_install_with_heartbeat(
@@ -8354,6 +8393,39 @@ def _repair_broken_lazy_refresh_imports(
     return not _detect_broken_lazy_refresh_imports(install_cmd_prefix, env=env)
 
 
+def _repair_venv_via_import_probes(
+    install_cmd_prefix: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> bool:
+    """Probe core imports and force-reinstall any broken packages.
+
+    Uses real ``import`` checks (not distribution metadata) so a venv where
+    METADATA remains but ``.py`` files were wiped mid-install is still
+    detected (#57828). Package-only reinstall — never rewrites ``hermes.exe``.
+    Never raises. Returns True when probes are clean after repair (or already
+    were).
+    """
+    broken = _detect_broken_lazy_refresh_imports(install_cmd_prefix, env=env)
+    if not broken:
+        return True
+    print(
+        "  → Detected corrupted venv packages via import probes: "
+        f"{', '.join(broken)}; repairing..."
+    )
+    if _repair_broken_lazy_refresh_imports(
+        install_cmd_prefix, broken, env=env
+    ):
+        print("  ✓ Venv repair succeeded")
+        return True
+    manual = " ".join(repr(p) for p in broken)
+    print("  ⚠ Venv repair incomplete. Run manually, then `hermes update`:")
+    print(
+        f"    {' '.join(install_cmd_prefix)} install --force-reinstall {manual}"
+    )
+    return False
+
+
 def _refresh_active_lazy_features(
     install_cmd_prefix: list[str] | None = None,
     *,
@@ -8397,6 +8469,7 @@ def _refresh_active_lazy_features(
     print()
     print(f"→ Refreshing {len(active)} active lazy backend(s)...")
 
+    unexpected_failure = False
     try:
         results = lazy_deps.refresh_active_features(prompt=False)
     except Exception as exc:
@@ -8404,6 +8477,7 @@ def _refresh_active_lazy_features(
         # the update flow against future regressions.
         print(f"  ⚠ Lazy refresh failed unexpectedly: {exc}")
         results = {}
+        unexpected_failure = True
 
     refreshed = [f for f, s in results.items() if s == "refreshed"]
     current = [f for f, s in results.items() if s == "current"]
@@ -8420,43 +8494,37 @@ def _refresh_active_lazy_features(
         names = ", ".join(f for f, _ in skipped)
         reason = skipped[0][1].split(": ", 1)[-1]
         print(f"  · {len(skipped)} skipped ({reason}): {names}")
-    if failed:
-        for feature, status in failed:
-            reason = status.split(": ", 1)[-1]
-            # Clip noisy pip stderr to keep update output legible.
-            if len(reason) > 200:
-                reason = reason[:200] + "..."
-            print(f"  ⚠ {feature} failed to refresh: {reason}")
 
-        if install_cmd_prefix is None:
-            print("  ⚠ Lazy refresh failed; rerun `hermes update` once resolved.")
-            return False
-
-        broken = _detect_broken_lazy_refresh_imports(
-            install_cmd_prefix, env=env
-        )
-        if broken:
-            print("  → Detected corrupted venv packages; repairing...")
-            if _repair_broken_lazy_refresh_imports(
-                install_cmd_prefix, broken, env=env
-            ):
-                print("  ✓ Venv repair succeeded")
-                print("  Lazy backend(s) keep their previous version until refresh succeeds.")
-                return True
-
-            manual = " ".join(
-                repr(p) for p in broken
-            )
-            print("  ⚠ Venv repair incomplete. Run manually, then `hermes update`:")
-            print(
-                f"    {' '.join(install_cmd_prefix)} install --force-reinstall {manual}"
-            )
-            return False
-
-        print("  Lazy backend(s) keep their previous version; core venv looks intact.")
-        print("  Rerun `hermes update` once the upstream issue is resolved.")
+    if not failed and not unexpected_failure:
         return True
 
+    for feature, status in failed:
+        reason = status.split(": ", 1)[-1]
+        # Clip noisy pip stderr to keep update output legible.
+        if len(reason) > 200:
+            reason = reason[:200] + "..."
+        print(f"  ⚠ {feature} failed to refresh: {reason}")
+
+    if install_cmd_prefix is None:
+        print("  ⚠ Lazy refresh failed; rerun `hermes update` once resolved.")
+        return False
+
+    # Immediate import-based recovery — metadata-only verifiers miss the case
+    # where DISTRIBUTION-INFO remains but import files were wiped (#57828).
+    broken_before = _detect_broken_lazy_refresh_imports(
+        install_cmd_prefix, env=env
+    )
+    if not _repair_venv_via_import_probes(install_cmd_prefix, env=env):
+        return False
+    if broken_before:
+        print(
+            "  Lazy backend(s) keep their previous version until refresh succeeds."
+        )
+    else:
+        print(
+            "  Lazy backend(s) keep their previous version; core venv looks intact."
+        )
+        print("  Rerun `hermes update` once the upstream issue is resolved.")
     return True
 
 

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -1,0 +1,277 @@
+"""Tests for hermes_cli._early_recovery — the dependency-light bootstrap
+repair that runs BEFORE hermes_cli.main's third-party imports (#57828 / #58004).
+
+Covers:
+- entry-point lifecycle: a broken core import (dotenv) crashes the import of
+  hermes_cli.main WITHOUT early recovery, and imports fine when recovery runs
+  first (proving main.py invokes recovery before its third-party imports)
+- recover_if_needed unit behavior: fast path, marker gating, update-argv skip,
+  lock single-flight, no marker clearing, pinned repair specs
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import _early_recovery as er
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Entry-point lifecycle (subprocess, real imports)
+# ---------------------------------------------------------------------------
+
+def _make_broken_dotenv_shadow(tmp_path: Path) -> Path:
+    """A sys.path dir shadowing ``dotenv`` with the #57828 failure state:
+    distribution metadata intact, import files wiped/broken."""
+    shadow = tmp_path / "shadow"
+    shadow.mkdir()
+    (shadow / "dotenv.py").write_text(
+        "raise ImportError('import files wiped mid-install (#57828)')\n",
+        encoding="utf-8",
+    )
+    return shadow
+
+
+def _run_lifecycle_subprocess(tmp_path: Path, *, repair: bool) -> subprocess.CompletedProcess:
+    shadow = _make_broken_dotenv_shadow(tmp_path)
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    script = tmp_path / "lifecycle.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            import sys
+
+            shadow = {str(shadow)!r}
+            sys.path.insert(0, shadow)
+
+            # _early_recovery must be importable on the corrupted venv
+            # (stdlib-only) — this import itself is part of the contract.
+            import hermes_cli._early_recovery as er
+
+            REPAIR = {repair!r}
+
+            def recorder(*args, **kwargs):
+                print("EARLY_RECOVERY_CALLED", flush=True)
+                if REPAIR:
+                    sys.path.remove(shadow)
+                    sys.modules.pop("dotenv", None)
+
+            er.recover_if_needed = recorder
+
+            import hermes_cli.main  # noqa: F401
+            print("MAIN_IMPORTED_OK", flush=True)
+            """
+        ),
+        encoding="utf-8",
+    )
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(REPO_ROOT),
+        "HERMES_HOME": str(hermes_home),
+    }
+    return subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=env,
+        timeout=120,
+    )
+
+
+def test_broken_dotenv_crashes_main_import_without_repair(tmp_path):
+    """Negative control: the shadow really breaks importing hermes_cli.main,
+    and recovery was invoked BEFORE the crash (i.e. before third-party
+    imports) — so a real repair at that point can save the launch."""
+    result = _run_lifecycle_subprocess(tmp_path, repair=False)
+    assert result.returncode != 0
+    assert "EARLY_RECOVERY_CALLED" in result.stdout
+    assert "MAIN_IMPORTED_OK" not in result.stdout
+    assert "wiped mid-install" in result.stderr
+
+
+def test_early_recovery_runs_before_main_imports_and_saves_launch(tmp_path):
+    """When recovery repairs the broken package, hermes_cli.main imports
+    cleanly — proving the recovery hook fires before env_loader/dotenv."""
+    result = _run_lifecycle_subprocess(tmp_path, repair=True)
+    assert "EARLY_RECOVERY_CALLED" in result.stdout
+    assert "MAIN_IMPORTED_OK" in result.stdout, result.stderr
+    assert result.returncode == 0
+
+
+def test_early_recovery_module_is_stdlib_only(tmp_path):
+    """The module must import in a process where every non-stdlib import
+    fails — that is the whole point of its existence."""
+    script = tmp_path / "stdlib_only.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            import builtins
+            import sys
+
+            STDLIB = set(sys.stdlib_module_names) | {"hermes_cli"}
+            real_import = builtins.__import__
+
+            def guard(name, *args, **kwargs):
+                top = name.split(".")[0]
+                if top not in STDLIB:
+                    raise ImportError(f"non-stdlib import blocked: {name}")
+                return real_import(name, *args, **kwargs)
+
+            builtins.__import__ = guard
+            import hermes_cli._early_recovery  # noqa: F401
+            print("STDLIB_ONLY_OK")
+            """
+        ),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        timeout=60,
+    )
+    assert "STDLIB_ONLY_OK" in result.stdout, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# recover_if_needed unit behavior
+# ---------------------------------------------------------------------------
+
+def _project(tmp_path: Path, *, pyproject: bool = True) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir(exist_ok=True)
+    if pyproject:
+        (root / "pyproject.toml").write_text(
+            '[project]\nname = "x"\ndependencies = [\n'
+            '  "PyYAML==6.0.2",\n'
+            '  "python-dotenv==1.2.2",\n'
+            '  "PyJWT[crypto]==2.13.0",\n'
+            "]\n",
+            encoding="utf-8",
+        )
+    return root
+
+
+def test_fast_path_no_marker_never_probes(tmp_path, monkeypatch):
+    root = _project(tmp_path)
+    probed = []
+    monkeypatch.setattr(er, "_probe_broken_packages", lambda: probed.append(1) or [])
+    er.recover_if_needed(project_root=root, argv=[])
+    assert probed == []
+
+
+def test_update_argv_skips_recovery(tmp_path, monkeypatch):
+    root = _project(tmp_path)
+    (root / ".lazy-refresh-incomplete").write_text("x", encoding="utf-8")
+    probed = []
+    monkeypatch.setattr(er, "_probe_broken_packages", lambda: probed.append(1) or [])
+    er.recover_if_needed(project_root=root, argv=["update"])
+    assert probed == []
+
+
+def test_no_pyproject_skips_and_preserves_marker(tmp_path, monkeypatch):
+    root = _project(tmp_path, pyproject=False)
+    marker = root / ".update-incomplete"
+    marker.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(er, "_probe_broken_packages", lambda: ["PyYAML"])
+    installs = []
+    monkeypatch.setattr(er, "_run_repair_install", lambda specs, r: installs.append(specs) or True)
+    er.recover_if_needed(project_root=root, argv=[])
+    assert installs == []
+    assert marker.exists()
+
+
+def test_marker_plus_broken_probe_repairs_with_pinned_specs(tmp_path, monkeypatch):
+    root = _project(tmp_path)
+    marker = root / ".lazy-refresh-incomplete"
+    marker.write_text("x", encoding="utf-8")
+
+    probe_results = iter([["PyYAML", "python-dotenv"], []])
+    monkeypatch.setattr(er, "_probe_broken_packages", lambda: next(probe_results))
+    installs = []
+    monkeypatch.setattr(
+        er, "_run_repair_install", lambda specs, r: installs.append(specs) or True
+    )
+
+    er.recover_if_needed(project_root=root, argv=[])
+
+    assert installs == [["PyYAML==6.0.2", "python-dotenv==1.2.2"]]
+    # Marker lifecycle belongs to main.py's full recovery — never cleared here.
+    assert marker.exists()
+    # Lock released for the full recovery pass.
+    assert not (root / ".update-incomplete.lock").exists()
+
+
+def test_healthy_probe_skips_install(tmp_path, monkeypatch):
+    root = _project(tmp_path)
+    (root / ".update-incomplete").write_text("x", encoding="utf-8")
+    monkeypatch.setattr(er, "_probe_broken_packages", lambda: [])
+    installs = []
+    monkeypatch.setattr(er, "_run_repair_install", lambda specs, r: installs.append(specs) or True)
+    er.recover_if_needed(project_root=root, argv=[])
+    assert installs == []
+
+
+def test_lock_held_skips_repair(tmp_path, monkeypatch):
+    root = _project(tmp_path)
+    (root / ".lazy-refresh-incomplete").write_text("x", encoding="utf-8")
+    (root / ".update-incomplete.lock").write_text("123\n", encoding="utf-8")
+    monkeypatch.setattr(er, "_probe_broken_packages", lambda: ["PyYAML"])
+    installs = []
+    monkeypatch.setattr(er, "_run_repair_install", lambda specs, r: installs.append(specs) or True)
+    er.recover_if_needed(project_root=root, argv=[])
+    assert installs == []
+    # Fresh (non-stale) lock is left for its owner.
+    assert (root / ".update-incomplete.lock").exists()
+
+
+def test_failed_repair_prints_manual_command_with_pins(tmp_path, monkeypatch, capsys):
+    root = _project(tmp_path)
+    (root / ".lazy-refresh-incomplete").write_text("x", encoding="utf-8")
+    monkeypatch.setattr(er, "_probe_broken_packages", lambda: ["PyJWT"])
+    monkeypatch.setattr(er, "_run_repair_install", lambda specs, r: False)
+    er.recover_if_needed(project_root=root, argv=[])
+    err = capsys.readouterr().err
+    assert "--force-reinstall" in err
+    assert "PyJWT[crypto]==2.13.0" in err
+
+
+def test_pinned_specs_falls_back_to_bare_names_without_pyproject(tmp_path):
+    root = _project(tmp_path, pyproject=False)
+    assert er._pinned_specs(["PyYAML", "unknown-pkg"], root) == ["PyYAML", "unknown-pkg"]
+
+
+def test_pinned_specs_strips_env_markers_and_matches_extras(tmp_path):
+    root = _project(tmp_path)
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "x"\ndependencies = [\n'
+        '  "cryptography==46.0.7; python_version >= \'3.11\'",\n'
+        '  "PyJWT[crypto]==2.13.0",\n'
+        "]\n",
+        encoding="utf-8",
+    )
+    assert er._pinned_specs(["cryptography", "PyJWT"], root) == [
+        "cryptography==46.0.7",
+        "PyJWT[crypto]==2.13.0",
+    ]
+
+
+def test_probe_tables_shared_with_main():
+    """The full recovery layer in main.py must probe/repair the same set as
+    the early layer — the tables have one canonical home."""
+    import hermes_cli.main as m
+
+    assert m._LAZY_REFRESH_IMPORT_PROBES == er.LAZY_REFRESH_IMPORT_PROBES
+    assert m._LAZY_REFRESH_REPAIR_PACKAGES == er.LAZY_REFRESH_REPAIR_PACKAGES

--- a/tests/hermes_cli/test_lazy_refresh_venv_repair.py
+++ b/tests/hermes_cli/test_lazy_refresh_venv_repair.py
@@ -1,4 +1,4 @@
-"""Tests for lazy-backend refresh venv repair (#57828)."""
+"""Tests for lazy-backend refresh venv repair (#57828 / #58004)."""
 
 from __future__ import annotations
 
@@ -35,6 +35,53 @@ def test_detect_broken_imports_returns_repair_package_names(
         ["python", "-m", "pip"], env={"VIRTUAL_ENV": str(tmp_path)}
     )
     assert broken == ["PyYAML", "click"]
+
+
+def test_detect_returns_none_when_venv_python_unresolved(monkeypatch):
+    monkeypatch.setattr(m, "_resolve_install_target_python", lambda *a, **k: None)
+    assert m._detect_broken_lazy_refresh_imports(["uv", "pip"]) is None
+
+
+def test_detect_returns_none_when_probe_subprocess_fails(tmp_path, monkeypatch):
+    python = tmp_path / "python"
+    python.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        m, "_resolve_install_target_python", lambda *a, **k: python
+    )
+    monkeypatch.setattr(
+        m.subprocess,
+        "run",
+        MagicMock(side_effect=OSError("exec failed")),
+    )
+    assert m._detect_broken_lazy_refresh_imports(["uv", "pip"]) is None
+
+
+def test_detect_returns_none_when_probe_exits_nonzero(tmp_path, monkeypatch):
+    python = tmp_path / "python"
+    python.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        m, "_resolve_install_target_python", lambda *a, **k: python
+    )
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stdout = ""
+        result.stderr = "boom"
+        result.returncode = 1
+        return result
+
+    monkeypatch.setattr(m.subprocess, "run", fake_run)
+    assert m._detect_broken_lazy_refresh_imports(["uv", "pip"]) is None
+
+
+def test_repair_via_probes_indeterminate_is_not_success(monkeypatch, capsys):
+    monkeypatch.setattr(
+        m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: None
+    )
+    status = m._repair_venv_via_import_probes(["uv", "pip"])
+    out = capsys.readouterr().out
+    assert status == "indeterminate"
+    assert "cannot confirm" in out
 
 
 def test_repair_runs_force_reinstall_with_pyproject_pins(
@@ -140,6 +187,26 @@ def test_refresh_returns_false_when_repair_fails(tmp_path, monkeypatch, capsys):
     assert "Venv repair incomplete" in out
 
 
+def test_refresh_returns_false_when_probes_indeterminate(
+    tmp_path, monkeypatch, capsys
+):
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "active_features", lambda: ["platform.matrix"])
+    monkeypatch.setattr(
+        lazy_deps_mod,
+        "refresh_active_features",
+        lambda **kw: {"platform.matrix": "failed: pip install failed"},
+    )
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: None)
+
+    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
+    out = capsys.readouterr().out
+
+    assert ok is False
+    assert "lazy-refresh-incomplete" in out
+
+
 def test_refresh_repairs_on_unexpected_lazy_exception(tmp_path, monkeypatch, capsys):
     import tools.lazy_deps as lazy_deps_mod
 
@@ -162,9 +229,10 @@ def test_refresh_repairs_on_unexpected_lazy_exception(tmp_path, monkeypatch, cap
     assert "Venv repair succeeded" in out
 
 
-def test_marker_stays_until_lazy_repair_succeeds(tmp_path, monkeypatch):
-    """Update path must not clear ``.update-incomplete`` while repair fails."""
+def test_lazy_marker_stays_until_repair_confirmed(tmp_path, monkeypatch):
+    """Lazy marker is independent of the generic core ``.update-incomplete``."""
     monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    m._write_lazy_refresh_incomplete_marker()
     m._write_update_incomplete_marker()
 
     import tools.lazy_deps as lazy_deps_mod
@@ -182,15 +250,8 @@ def test_marker_stays_until_lazy_repair_succeeds(tmp_path, monkeypatch):
 
     ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
     assert ok is False
-    assert m._update_marker_path().exists(), "caller clears marker only when lazy_ok"
-
-    monkeypatch.setattr(
-        m, "_repair_broken_lazy_refresh_imports", lambda *a, **k: True
-    )
-    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
-    assert ok is True
-    # Marker lifecycle is owned by _cmd_update_impl — refresh only reports health.
-    assert m._update_marker_path().exists()
+    assert m._lazy_refresh_marker_path().exists()
+    assert m._update_marker_path().exists(), "core marker must not be touched by lazy refresh"
 
 
 def test_upgrade_pip_before_lazy_refresh_never_raises(monkeypatch):

--- a/tests/hermes_cli/test_lazy_refresh_venv_repair.py
+++ b/tests/hermes_cli/test_lazy_refresh_venv_repair.py
@@ -1,0 +1,219 @@
+"""Tests for lazy-backend refresh venv repair (#57828)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import hermes_cli.main as m
+
+
+def test_detect_broken_imports_returns_repair_package_names(
+    tmp_path, monkeypatch
+):
+    venv_bin = tmp_path / "bin"
+    venv_bin.mkdir(parents=True)
+    python = venv_bin / "python"
+    python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(
+        m,
+        "_resolve_install_target_python",
+        lambda prefix, env: python,
+    )
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stdout = "yaml\nclick\n"
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr(m.subprocess, "run", fake_run)
+
+    broken = m._detect_broken_lazy_refresh_imports(
+        ["python", "-m", "pip"], env={"VIRTUAL_ENV": str(tmp_path)}
+    )
+    assert broken == ["PyYAML", "click"]
+
+
+def test_repair_runs_force_reinstall_with_pyproject_pins(
+    tmp_path, monkeypatch
+):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "fake"
+            version = "0.0.0"
+            dependencies = [
+              "pyyaml==6.0.3",
+              "click==8.2.1",
+            ]
+        """
+        )
+    )
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+
+    calls: list[list[str]] = []
+
+    def fake_install(cmd, **kwargs):
+        calls.append(cmd)
+
+    detect_calls = {"count": 0}
+
+    def fake_detect(prefix, *, env=None):
+        detect_calls["count"] += 1
+        return []
+
+    monkeypatch.setattr(m, "_run_package_only_install", fake_install)
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", fake_detect)
+
+    ok = m._repair_broken_lazy_refresh_imports(
+        ["uv", "pip"],
+        ["PyYAML", "click"],
+        env={"VIRTUAL_ENV": str(tmp_path)},
+    )
+    assert ok is True
+    assert calls == [
+        [
+            "uv",
+            "pip",
+            "install",
+            "--force-reinstall",
+            "pyyaml==6.0.3",
+            "click==8.2.1",
+        ]
+    ]
+    assert detect_calls["count"] == 1
+
+
+def test_refresh_repairs_venv_after_lazy_failure(tmp_path, monkeypatch, capsys):
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "active_features", lambda: ["platform.matrix"])
+    monkeypatch.setattr(
+        lazy_deps_mod,
+        "refresh_active_features",
+        lambda **kw: {"platform.matrix": "failed: pip install failed"},
+    )
+
+    repair_calls: list[list[str]] = []
+
+    def fake_repair(prefix, packages, *, env=None):
+        repair_calls.append(packages)
+        return True
+
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: ["PyYAML"])
+    monkeypatch.setattr(m, "_repair_broken_lazy_refresh_imports", fake_repair)
+
+    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
+    out = capsys.readouterr().out
+
+    assert ok is True
+    assert repair_calls == [["PyYAML"]]
+    assert "Venv repair succeeded" in out
+    assert "Backends keep their previously-installed version" not in out
+
+
+def test_refresh_returns_false_when_repair_fails(tmp_path, monkeypatch, capsys):
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "active_features", lambda: ["platform.matrix"])
+    monkeypatch.setattr(
+        lazy_deps_mod,
+        "refresh_active_features",
+        lambda **kw: {"platform.matrix": "failed: pip install failed"},
+    )
+
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: ["PyYAML"])
+    monkeypatch.setattr(
+        m, "_repair_broken_lazy_refresh_imports", lambda *a, **k: False
+    )
+
+    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
+    out = capsys.readouterr().out
+
+    assert ok is False
+    assert "Venv repair incomplete" in out
+
+
+def test_upgrade_pip_before_lazy_refresh_never_raises(monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "_run_package_only_install",
+        MagicMock(side_effect=m.subprocess.CalledProcessError(1, "pip")),
+    )
+    m._upgrade_pip_before_lazy_refresh(["uv", "pip"])
+
+
+def test_package_only_repair_does_not_quarantine_shims_on_windows(
+    tmp_path, monkeypatch
+):
+    """Regression: package-only repairs must not rename hermes.exe on Windows."""
+    fake_scripts = tmp_path / "venv" / "Scripts"
+    fake_scripts.mkdir(parents=True)
+
+    install_calls: list[list[str]] = []
+
+    def fake_install(cmd, **kwargs):
+        install_calls.append(cmd)
+
+    monkeypatch.setattr(m, "_is_windows", lambda: True)
+    monkeypatch.setattr(m, "_venv_scripts_dir", lambda: fake_scripts)
+    monkeypatch.setattr(m, "_run_package_only_install", fake_install)
+    monkeypatch.setattr(
+        m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: []
+    )
+
+    with patch("hermes_cli.main._quarantine_running_hermes_exe") as mock_quar:
+        m._repair_broken_lazy_refresh_imports(
+            ["uv", "pip"],
+            ["PyYAML"],
+            env={"VIRTUAL_ENV": str(tmp_path / "venv")},
+        )
+
+    mock_quar.assert_not_called()
+    assert install_calls
+
+
+def test_upgrade_pip_does_not_quarantine_shims_on_windows(tmp_path, monkeypatch):
+    fake_scripts = tmp_path / "venv" / "Scripts"
+    fake_scripts.mkdir(parents=True)
+
+    install_calls: list[list[str]] = []
+
+    def fake_install(cmd, **kwargs):
+        install_calls.append(cmd)
+
+    monkeypatch.setattr(m, "_is_windows", lambda: True)
+    monkeypatch.setattr(m, "_venv_scripts_dir", lambda: fake_scripts)
+    monkeypatch.setattr(m, "_run_package_only_install", fake_install)
+
+    with patch("hermes_cli.main._quarantine_running_hermes_exe") as mock_quar:
+        m._upgrade_pip_before_lazy_refresh(["uv", "pip"])
+
+    mock_quar.assert_not_called()
+    assert install_calls == [["uv", "pip", "install", "--upgrade", "pip"]]
+
+
+def test_lazy_refresh_repair_specs_resolves_extras(tmp_path, monkeypatch):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "fake"
+            version = "0.0.0"
+            dependencies = [
+              "PyJWT[crypto]==2.13.0",
+              "cryptography==46.0.7",
+            ]
+        """
+        )
+    )
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+
+    specs = m._lazy_refresh_repair_specs(["PyJWT", "cryptography"])
+    assert specs == ["PyJWT[crypto]==2.13.0", "cryptography==46.0.7"]

--- a/tests/hermes_cli/test_lazy_refresh_venv_repair.py
+++ b/tests/hermes_cli/test_lazy_refresh_venv_repair.py
@@ -114,6 +114,7 @@ def test_refresh_repairs_venv_after_lazy_failure(tmp_path, monkeypatch, capsys):
     assert ok is True
     assert repair_calls == [["PyYAML"]]
     assert "Venv repair succeeded" in out
+    assert "import probes" in out
     assert "Backends keep their previously-installed version" not in out
 
 
@@ -137,6 +138,59 @@ def test_refresh_returns_false_when_repair_fails(tmp_path, monkeypatch, capsys):
 
     assert ok is False
     assert "Venv repair incomplete" in out
+
+
+def test_refresh_repairs_on_unexpected_lazy_exception(tmp_path, monkeypatch, capsys):
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "active_features", lambda: ["platform.matrix"])
+
+    def boom(**kw):
+        raise RuntimeError("refresh registry broke")
+
+    monkeypatch.setattr(lazy_deps_mod, "refresh_active_features", boom)
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: ["click"])
+    monkeypatch.setattr(
+        m, "_repair_broken_lazy_refresh_imports", lambda *a, **k: True
+    )
+
+    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
+    out = capsys.readouterr().out
+
+    assert ok is True
+    assert "Lazy refresh failed unexpectedly" in out
+    assert "Venv repair succeeded" in out
+
+
+def test_marker_stays_until_lazy_repair_succeeds(tmp_path, monkeypatch):
+    """Update path must not clear ``.update-incomplete`` while repair fails."""
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    m._write_update_incomplete_marker()
+
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "active_features", lambda: ["platform.matrix"])
+    monkeypatch.setattr(
+        lazy_deps_mod,
+        "refresh_active_features",
+        lambda **kw: {"platform.matrix": "failed: pip install failed"},
+    )
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: ["PyYAML"])
+    monkeypatch.setattr(
+        m, "_repair_broken_lazy_refresh_imports", lambda *a, **k: False
+    )
+
+    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
+    assert ok is False
+    assert m._update_marker_path().exists(), "caller clears marker only when lazy_ok"
+
+    monkeypatch.setattr(
+        m, "_repair_broken_lazy_refresh_imports", lambda *a, **k: True
+    )
+    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
+    assert ok is True
+    # Marker lifecycle is owned by _cmd_update_impl — refresh only reports health.
+    assert m._update_marker_path().exists()
 
 
 def test_upgrade_pip_before_lazy_refresh_never_raises(monkeypatch):

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -393,7 +393,8 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     monkeypatch.setattr(hermes_config, "get_missing_config_fields", lambda: [])
     monkeypatch.setattr(hermes_config, "check_config_version", lambda: (5, 5))
     monkeypatch.setattr(hermes_config, "migrate_config", lambda **kw: {"env_added": [], "config_added": []})
-    monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", lambda: None)
+    monkeypatch.setattr(hermes_main, "_upgrade_pip_before_lazy_refresh", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", lambda *a, **kw: True)
 
 
 def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_update_interrupted_recovery.py
+++ b/tests/hermes_cli/test_update_interrupted_recovery.py
@@ -52,6 +52,7 @@ def test_recovery_clears_stray_marker_without_pyproject(tmp_path, monkeypatch):
     # act on; recovery should just clear it without trying to install.
     monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
     m._write_update_incomplete_marker()
+    m._write_lazy_refresh_incomplete_marker()
     called = {"install": False}
     monkeypatch.setattr(
         m,
@@ -61,6 +62,7 @@ def test_recovery_clears_stray_marker_without_pyproject(tmp_path, monkeypatch):
     m._recover_from_interrupted_install()
     assert called["install"] is False
     assert not m._update_marker_path().exists()
+    assert not m._lazy_refresh_marker_path().exists()
 
 
 def test_recovery_runs_install_and_clears_marker(tmp_path, monkeypatch):
@@ -139,11 +141,13 @@ def _stub_install_env(monkeypatch, m, seen):
     )
 
 
-def test_recovery_self_lock_import_repair_clears_marker(tmp_path, monkeypatch):
-    # Windows self-lock: hermes.exe is an ancestor on every normal launch.
-    # Package-only import repair must still heal #57828 corruption and clear
-    # the marker — clearing the marker without repairing (old behavior) made
-    # the update-incomplete breadcrumb useless on Windows (#58004 review).
+def test_recovery_self_lock_does_not_clear_core_marker_via_import_probes(
+    tmp_path, monkeypatch
+):
+    # ``.update-incomplete`` is the generic core-install marker. Healthy
+    # lazy-refresh import probes alone must NOT clear it and skip full
+    # reinstall — a missing dep outside the 7-probe set would look healthy
+    # (#58004 review blocker).
     monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
     (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
     m._write_update_incomplete_marker()
@@ -157,9 +161,13 @@ def test_recovery_self_lock_import_repair_clears_marker(tmp_path, monkeypatch):
     monkeypatch.setattr(m, "_venv_scripts_dir", lambda: scripts_dir)
     monkeypatch.setattr(m, "_hermes_exe_shims", lambda d: [shim])
     monkeypatch.setattr(
-        m, "_default_venv_install_target", lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")})
+        m,
+        "_default_venv_install_target",
+        lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")}),
     )
-    monkeypatch.setattr(m, "_repair_venv_via_import_probes", lambda *a, **k: True)
+    monkeypatch.setattr(
+        m, "_repair_venv_via_import_probes", lambda *a, **k: "healthy"
+    )
 
     class FakeProc:
         def __init__(self, exe_path):
@@ -178,16 +186,15 @@ def test_recovery_self_lock_import_repair_clears_marker(tmp_path, monkeypatch):
 
     m._recover_from_interrupted_install()
 
-    assert seen["install"] is False, "successful import repair skips full reinstall"
-    assert not m._update_marker_path().exists(), "marker cleared after successful repair"
+    assert seen["install"] is True, "core marker still requires full reinstall"
+    assert not m._update_marker_path().exists(), "cleared only after full reinstall"
 
 
-def test_recovery_self_lock_keeps_marker_when_repair_and_install_fail(
+def test_recovery_self_lock_keeps_core_marker_when_install_fails(
     tmp_path, monkeypatch
 ):
-    # If import repair cannot heal and the quarantined full install also fails,
-    # the marker must remain so the next launch retries — never clear it solely
-    # because hermes.exe is an ancestor.
+    # Quarantined full install failed under self-lock — keep the core marker.
+    # Never clear it solely because hermes.exe is an ancestor.
     monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
     (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
     m._write_update_incomplete_marker()
@@ -201,9 +208,13 @@ def test_recovery_self_lock_keeps_marker_when_repair_and_install_fail(
     monkeypatch.setattr(m, "_venv_scripts_dir", lambda: scripts_dir)
     monkeypatch.setattr(m, "_hermes_exe_shims", lambda d: [shim])
     monkeypatch.setattr(
-        m, "_default_venv_install_target", lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")})
+        m,
+        "_default_venv_install_target",
+        lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")}),
     )
-    monkeypatch.setattr(m, "_repair_venv_via_import_probes", lambda *a, **k: False)
+    monkeypatch.setattr(
+        m, "_repair_venv_via_import_probes", lambda *a, **k: "failed"
+    )
 
     class FakeProc:
         def __init__(self, exe_path):
@@ -233,7 +244,84 @@ def test_recovery_self_lock_keeps_marker_when_repair_and_install_fail(
 
     m._recover_from_interrupted_install()
 
-    assert m._update_marker_path().exists(), "marker kept for retry when self-locked recovery fails"
+    assert m._update_marker_path().exists(), (
+        "core marker kept for retry when self-locked recovery fails"
+    )
+
+
+def test_lazy_marker_cleared_only_after_confirmed_import_repair(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    m._write_lazy_refresh_incomplete_marker()
+
+    monkeypatch.setattr(
+        m,
+        "_default_venv_install_target",
+        lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")}),
+    )
+    monkeypatch.setattr(
+        m, "_repair_venv_via_import_probes", lambda *a, **k: "repaired"
+    )
+
+    seen = {"install": False}
+    _stub_install_env(monkeypatch, m, seen)
+
+    m._recover_from_interrupted_install()
+
+    assert seen["install"] is False, "lazy marker does not require full .[all] reinstall"
+    assert not m._lazy_refresh_marker_path().exists()
+
+
+def test_lazy_marker_kept_when_probes_indeterminate(tmp_path, monkeypatch):
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    m._write_lazy_refresh_incomplete_marker()
+
+    monkeypatch.setattr(
+        m,
+        "_default_venv_install_target",
+        lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")}),
+    )
+    monkeypatch.setattr(
+        m, "_repair_venv_via_import_probes", lambda *a, **k: "indeterminate"
+    )
+
+    seen = {"install": False}
+    _stub_install_env(monkeypatch, m, seen)
+
+    m._recover_from_interrupted_install()
+
+    assert seen["install"] is False
+    assert m._lazy_refresh_marker_path().exists(), (
+        "indeterminate probes must not clear the lazy marker"
+    )
+
+
+def test_lazy_and_core_markers_recover_independently(tmp_path, monkeypatch):
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    m._write_lazy_refresh_incomplete_marker()
+    m._write_update_incomplete_marker()
+
+    monkeypatch.setattr(
+        m,
+        "_default_venv_install_target",
+        lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")}),
+    )
+    monkeypatch.setattr(
+        m, "_repair_venv_via_import_probes", lambda *a, **k: "healthy"
+    )
+
+    seen = {"install": False}
+    _stub_install_env(monkeypatch, m, seen)
+
+    m._recover_from_interrupted_install()
+
+    assert not m._lazy_refresh_marker_path().exists()
+    assert seen["install"] is True, "core marker still drives full reinstall"
+    assert not m._update_marker_path().exists()
 
 
 def sys_executable_path():

--- a/tests/hermes_cli/test_update_interrupted_recovery.py
+++ b/tests/hermes_cli/test_update_interrupted_recovery.py
@@ -139,11 +139,11 @@ def _stub_install_env(monkeypatch, m, seen):
     )
 
 
-def test_recovery_self_lock_guard_clears_marker_without_install(tmp_path, monkeypatch):
-    # Windows self-lock: hermes.exe is an ancestor of this Python process, so a
-    # pip-install would fail trying to replace the running launcher (WinError 32
-    # / 拒绝访问). Recovery must short-circuit — clear the marker, skip install,
-    # break the loop (#45542 / #52378) — instead of retrying forever.
+def test_recovery_self_lock_import_repair_clears_marker(tmp_path, monkeypatch):
+    # Windows self-lock: hermes.exe is an ancestor on every normal launch.
+    # Package-only import repair must still heal #57828 corruption and clear
+    # the marker — clearing the marker without repairing (old behavior) made
+    # the update-incomplete breadcrumb useless on Windows (#58004 review).
     monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
     (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
     m._write_update_incomplete_marker()
@@ -156,6 +156,10 @@ def test_recovery_self_lock_guard_clears_marker_without_install(tmp_path, monkey
     monkeypatch.setattr(m, "_is_windows", lambda: True)
     monkeypatch.setattr(m, "_venv_scripts_dir", lambda: scripts_dir)
     monkeypatch.setattr(m, "_hermes_exe_shims", lambda d: [shim])
+    monkeypatch.setattr(
+        m, "_default_venv_install_target", lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")})
+    )
+    monkeypatch.setattr(m, "_repair_venv_via_import_probes", lambda *a, **k: True)
 
     class FakeProc:
         def __init__(self, exe_path):
@@ -174,8 +178,62 @@ def test_recovery_self_lock_guard_clears_marker_without_install(tmp_path, monkey
 
     m._recover_from_interrupted_install()
 
-    assert seen["install"] is False, "self-lock must skip the install"
-    assert not m._update_marker_path().exists(), "marker cleared to break the loop"
+    assert seen["install"] is False, "successful import repair skips full reinstall"
+    assert not m._update_marker_path().exists(), "marker cleared after successful repair"
+
+
+def test_recovery_self_lock_keeps_marker_when_repair_and_install_fail(
+    tmp_path, monkeypatch
+):
+    # If import repair cannot heal and the quarantined full install also fails,
+    # the marker must remain so the next launch retries — never clear it solely
+    # because hermes.exe is an ancestor.
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    m._write_update_incomplete_marker()
+
+    scripts_dir = tmp_path / "venv" / "Scripts"
+    scripts_dir.mkdir(parents=True)
+    shim = scripts_dir / "hermes.exe"
+    shim.write_text("")
+
+    monkeypatch.setattr(m, "_is_windows", lambda: True)
+    monkeypatch.setattr(m, "_venv_scripts_dir", lambda: scripts_dir)
+    monkeypatch.setattr(m, "_hermes_exe_shims", lambda d: [shim])
+    monkeypatch.setattr(
+        m, "_default_venv_install_target", lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")})
+    )
+    monkeypatch.setattr(m, "_repair_venv_via_import_probes", lambda *a, **k: False)
+
+    class FakeProc:
+        def __init__(self, exe_path):
+            self._exe = exe_path
+
+        def exe(self):
+            return self._exe
+
+        def parents(self):
+            return [FakeProc(str(shim))]
+
+    monkeypatch.setattr("psutil.Process", lambda: FakeProc(sys_executable_path()))
+
+    class R:
+        returncode = 0
+
+    monkeypatch.setattr(m.subprocess, "run", lambda *a, **k: R())
+    monkeypatch.setattr(m, "_is_termux_env", lambda *a, **k: False)
+    monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: None)
+
+    def boom(*a, **k):
+        raise RuntimeError("WinError 32")
+
+    monkeypatch.setattr(
+        m, "_install_python_dependencies_with_optional_fallback", boom
+    )
+
+    m._recover_from_interrupted_install()
+
+    assert m._update_marker_path().exists(), "marker kept for retry when self-locked recovery fails"
 
 
 def sys_executable_path():


### PR DESCRIPTION
## Summary
`hermes update` now self-heals a venv corrupted by a failed lazy backend refresh — including the worst case where the corruption prevents `hermes` itself from launching. Salvages PR #58004 by @HexLab98 onto current main and closes the final review blocker: recovery previously lived inside `hermes_cli.main`, whose own module-level imports (`dotenv` via `env_loader`, `yaml` via `config`) crash first in exactly the failure state the recovery exists for (#57828).

## Changes
**Cherry-picked from #58004 (@HexLab98, authorship preserved):**
- Upgrade pip before lazy backend refreshes (stale pip source-build failures were the corruption trigger)
- Import-probe repair: after a failed lazy `uv pip install`, probe 7 core packages via real imports (metadata can survive while `.py` files are wiped) and `--force-reinstall` broken ones with pyproject pins
- Two-marker lifecycle: `.update-incomplete` (interrupted core `.[all]` install → full quarantined reinstall) split from `.lazy-refresh-incomplete` (refresh phase → package-only import repair); narrow probes can never clear the core marker
- Indeterminate probes (unresolvable venv Python, probe subprocess failure) are never treated as healthy
- Package-only installs bypass the shim-quarantine path so Windows `hermes.exe` launchers survive pip upgrades
- Windows `hermes.exe`-ancestor launches get package-only first aid, with the core marker retained until the full reinstall succeeds

**Follow-up (ours):**
- `hermes_cli/_early_recovery.py` — stdlib-only bootstrap repair invoked at the very top of `main.py`, before any third-party import. Probes the fragile core packages in-process, force-reinstalls broken ones with pyproject pins, shares the single-flight recovery lock, and never clears markers (the confirmed lifecycle stays with `_recover_from_interrupted_install()`, which runs right after import succeeds)
- Probe/repair tables moved to one canonical home in `_early_recovery`, re-exported by `main.py` so the two layers cannot drift
- Manual `--force-reinstall` fallback commands now print pinned specs via `_lazy_refresh_repair_specs()` instead of bare names

## Validation
| | Before | After |
|---|---|---|
| Failed lazy refresh wipes dotenv | `hermes` crashes importing `main.py`; markers unreachable; every update fails | Early bootstrap repairs before import; launch proceeds |
| Interrupted core install | Marker cleared by 7-package probe (false-healthy) | Core marker only cleared by confirmed full reinstall |
| Probe can't run | Treated as healthy, marker cleared | Indeterminate — marker retained |

- `scripts/run_tests.sh` — 78/78 across `test_early_recovery.py` (13, new), `test_lazy_refresh_venv_repair.py` (15), `test_update_interrupted_recovery.py` (16), `test_update_autostash.py` (34)
- Entry-point lifecycle test proves a broken `dotenv` crashes the `hermes_cli.main` import without repair and imports cleanly with it; a stdlib-only import guard proves `_early_recovery` loads on a corrupted venv
- Live E2E: real venv, real pip, `dotenv` import files deleted with metadata intact, marker present → early recovery detected + force-reinstalled `python-dotenv==1.2.2`, import restored, marker preserved for the full recovery pass

Closes #58004 (salvaged, @HexLab98's commits cherry-picked with authorship preserved). Closes #58246 (superseded — its metadata-only verifier misses the metadata-survives/imports-gone case this PR's import probes catch; thanks @tianma-if). Fixes #57828.

## Infographic

![self-healing-venv-recovery](https://v3b.fal.media/files/b/0aa35c80/62Or4DWx8JtJkQjh4GM2x_91zROrLX.png)
