### PR TITLE
fix(desktop): let clarify choices + overlays keep their keys from type-to-focus

### DIFF
--- a/apps/desktop/src/app/overlays/overlay-view.tsx
+++ b/apps/desktop/src/app/overlays/overlay-view.tsx
@@ -66,6 +66,13 @@ export function OverlayView({
         'p-[calc(var(--titlebar-height)+0.625rem)]',
         'sm:p-[calc(var(--titlebar-height)+0.875rem)]'
       )}
+      // Every OverlayView-based overlay (settings, command-center, agents, cron,
+      // profiles, star map, …) covers the chat while the composer stays mounted
+      // beneath it. This marker tells `composerFocusBlockedBySurface` to stand
+      // the global type-to-focus / soft `/` / Enter down, so keystrokes don't
+      // leak into the hidden composer (and the overlay's own bare-key shortcuts,
+      // e.g. star map's Space, keep working).
+      data-overlay-surface=""
       onClick={event => {
         if (event.target === event.currentTarget) {
           closeOverlay()

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -296,3 +296,45 @@ describe('ClarifyTool keyboard navigation', () => {
     expect(request).not.toHaveBeenCalled()
   })
 })
+
+describe('ClarifyTool pending marker', () => {
+  it('marks a live choices card so type-to-focus yields its shortcut keys', () => {
+    renderLiveClarify()
+
+    // The marker is what `composerFocusBlockedBySurface` keys off of, so the
+    // global type-to-focus listener stands down and A/B/C… + 1-9 + Enter reach
+    // the card instead of the composer.
+    expect(document.querySelector('[data-clarify-choices]')).toBeTruthy()
+  })
+
+  it('does not mark a free-text (no-choice) pending card', () => {
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn().mockResolvedValue({ ok: true }) } as never)
+    setClarifyRequest({
+      choices: null,
+      question: 'Anything else?',
+      requestId: 'request-1',
+      sessionId: 'session-1'
+    })
+
+    const args = { question: 'Anything else?' }
+    renderClarify(
+      <ClarifyTool
+        addResult={vi.fn()}
+        args={args}
+        argsText={JSON.stringify(args)}
+        isError={false}
+        respondToApproval={vi.fn()}
+        result={undefined}
+        resume={vi.fn()}
+        status={{ type: 'running' }}
+        toolCallId="clarify-free"
+        toolName="clarify"
+        type="tool-call"
+      />
+    )
+
+    // No shortcuts → nothing to protect → composer type-to-focus stays live.
+    expect(document.querySelector('[data-clarify-choices]')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -538,7 +538,11 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   }
 
   return (
-    <ClarifyShell className="grid gap-2 px-2.5 py-2">
+    // `data-clarify-choices` marks the panel as owning printable/Enter keys
+    // while its A/B/C… shortcuts are live, so the global type-to-focus listener
+    // (`composerFocusBlockedBySurface`) stands down and the letters reach this
+    // card instead of being redirected into the composer.
+    <ClarifyShell className="grid gap-2 px-2.5 py-2" data-clarify-choices={hasChoices ? '' : undefined}>
       <div className="flex items-start gap-2">
         <span className="flex-1 whitespace-pre-wrap font-medium leading-(--conversation-line-height)">{question}</span>
         <MessageQuestion aria-hidden className="mt-px size-4 shrink-0 text-(--ui-text-tertiary)" />

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
@@ -72,6 +72,22 @@ describe('composerFocusBlockedBySurface', () => {
     expect(composerFocusBlockedBySurface()).toBe(true)
   })
 
+  it('blocks while an overlay covers the chat (composer sits behind it)', () => {
+    const overlay = document.createElement('div')
+    overlay.setAttribute('data-overlay-surface', '')
+    document.body.append(overlay)
+
+    expect(composerFocusBlockedBySurface()).toBe(true)
+  })
+
+  it('blocks while a live clarify choices card owns its letter keys', () => {
+    const card = document.createElement('div')
+    card.setAttribute('data-clarify-choices', '')
+    document.body.append(card)
+
+    expect(composerFocusBlockedBySurface()).toBe(true)
+  })
+
   it('blocks when focus is inside a terminal', () => {
     const term = document.createElement('div')
     term.setAttribute('data-terminal', '')
@@ -145,5 +161,17 @@ describe('composerFocusKeysAllowed', () => {
     document.body.append(dialog)
 
     expect(composerFocusKeysAllowed(keydown({ key: 'a', code: 'KeyA', target: document.body }), 'type')).toBe(false)
+  })
+
+  it('yields letter + Enter keys to a live clarify choices card', () => {
+    const card = document.createElement('div')
+    card.setAttribute('data-clarify-choices', '')
+    document.body.append(card)
+
+    // The clarify card's own A/B/C… + Enter shortcuts must win over type-to-focus.
+    expect(composerFocusKeysAllowed(keydown({ key: 'a', code: 'KeyA', target: document.body }), 'type')).toBe(false)
+    expect(composerFocusKeysAllowed(keydown({ key: 'Enter', code: 'Enter', target: document.body }), 'enter')).toBe(
+      false
+    )
   })
 })

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
@@ -38,7 +38,7 @@ const ENTER_ACTIVATES = [
 ].join(',')
 
 const BLOCKING_SURFACE =
-  '[role="dialog"],[role="alertdialog"],[role="menu"],[role="listbox"],[data-radix-popper-content-wrapper]'
+  '[role="dialog"],[role="alertdialog"],[role="menu"],[role="listbox"],[data-radix-popper-content-wrapper],[data-overlay-surface],[data-clarify-choices]'
 
 /** True when the focused control would normally handle Enter itself. */
 export function isActivateOnEnterTarget(target: EventTarget | null): boolean {
@@ -47,7 +47,13 @@ export function isActivateOnEnterTarget(target: EventTarget | null): boolean {
   return Boolean(el && el !== document.body && el !== document.documentElement && el.closest(ENTER_ACTIVATES))
 }
 
-/** Dialogs, menus, terminal, full pages, session switcher — they keep their keys. */
+/**
+ * Dialogs, menus, terminal, full pages, session switcher, any open overlay
+ * (settings / command-center / star map / …), and a live clarify choices card —
+ * they keep their keys, so type-to-focus / soft `/` / Enter stand down rather
+ * than stealing keystrokes those surfaces own (or leaking them into the composer
+ * mounted behind an overlay).
+ */
 export function composerFocusBlockedBySurface(): boolean {
   return (
     switcherActive() ||


### PR DESCRIPTION
## What

The recent type-to-focus change (a global capture-phase `keydown` listener in `useKeybinds` that redirects any unbound printable key into the composer) is great, but it shadows two in-app surfaces that own bare printable keys.

### 1. Clarify multichoice hotkeys (the reported regression)
A pending `clarify` card with choices binds `A`/`B`/`C`… to pick an option, the trailing letter to jump into "Other", and Enter to confirm. Its listener runs in the **bubble** phase and bails on `event.defaultPrevented`. The `useKeybinds` listener runs in the **capture** phase and `preventDefault()`s the key first, so the composer stole `a`/`b`/`c` before clarify ever saw them.

### 2. Any open overlay
`settings`, `command-center`, `agents`, `cron`, `profiles`, and the star map all render through `OverlayView` (`role="presentation"`) with the chat — and its composer — still mounted **behind** them. Overlays aren't "pages" (`$workspaceIsPage` stays `false`) and `role="presentation"` isn't a blocking surface, so type-to-focus / soft `/` / Enter leaked into the hidden composer. The star map's Space play/pause was one concrete symptom.

## How

`composerFocusBlockedBySurface()` is the single resolver for "should composer focus keys stand down." Extend the `BLOCKING_SURFACE` selector so it also matches:

- `[data-clarify-choices]` — set on a live clarify card that has choices (letters + Enter are live).
- `[data-overlay-surface]` — set once on the shared `OverlayView` root, covering every overlay.

Both are DOM markers, matching the existing `[data-terminal]` / dialog / menu pattern in that function. When one is present the global listener yields, so the key reaches the surface that owns it (or simply does nothing behind an overlay) instead of the composer.

## Tests

- `composer-focus-keys.test.ts`: a `[data-overlay-surface]` and a `[data-clarify-choices]` element each block composer focus keys; letters + Enter are refused when a clarify choices card is present.
- `clarify-tool.test.tsx`: the live pending card emits `data-clarify-choices` only when it has choices (free-text pending does not).

`npm run typecheck` + targeted `vitest` green; eslint clean on changed files.