### PR TITLE
fix(compress): tell the user when /compress no-ops because another compression holds the lock

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1282,6 +1282,12 @@ def compress_context(
     _try_acquire_lock = None
     _lock_lookup_error: Optional[Exception] = None
     _legacy_session_db_without_lock_api = False
+    # Clear any stale lock-skip signal from a prior call so this call's
+    # outcome alone determines what callers see.  Without this an
+    # auto-compress lock-skip followed by a successful manual /compress
+    # would falsely report "Compression already in progress" and discard
+    # the compression results.
+    agent._compression_skipped_due_to_lock = None
     if _lock_db is not None:
         try:
             _legacy_session_db_without_lock_api = _lock_api_is_absent_on_session_db(

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1369,6 +1369,11 @@ def compress_context(
                 _lock_sid, existing,
             )
             _lock_holder = None  # don't release a lock we don't own
+            # Signal to callers that this no-op is due to a concurrent lock,
+            # not a genuine "nothing to compress" or aux-model failure.
+            # Manual /compress callers can surface a clear status message
+            # instead of the misleading "No changes from compression" text.
+            agent._compression_skipped_due_to_lock = existing or True
             # Surface to the user once — quiet for downstream auto-compress loops
             if getattr(agent, "_last_compression_lock_warning_sid", None) != _lock_sid:
                 agent._last_compression_lock_warning_sid = _lock_sid

--- a/agent/manual_compression_feedback.py
+++ b/agent/manual_compression_feedback.py
@@ -7,6 +7,36 @@ from typing import Any, Sequence
 from agent.redact import redact_sensitive_text
 
 
+def describe_compression_lock_skip(lock_signal: Any) -> str:
+    """User-facing text for a manual /compress skipped by the compression lock.
+
+    ``lock_signal`` is ``agent._compression_skipped_due_to_lock`` (or the
+    ``holder`` carried by the TUI's ``CompressionLockHeld``): a descriptive
+    holder string when another compressor CONFIRMED holds the lock, or
+    ``True``/``None`` when acquisition failed without a confirmed holder
+    (``hermes_state.try_acquire_compression_lock`` catches ``sqlite3.Error``
+    internally and returns ``False``, so a failed acquire is NOT proof that
+    another compression is running). The two cases must be worded
+    differently: claiming "already in progress" on an unconfirmed failure
+    misdirects the user when the real problem is a broken lock subsystem.
+    """
+    holder = (
+        lock_signal
+        if isinstance(lock_signal, str) and lock_signal.strip()
+        else None
+    )
+    if holder:
+        return (
+            f"⏳ Compression already in progress for this session "
+            f"(holder: {holder}). Please wait for it to finish."
+        )
+    return (
+        "⏳ Compression skipped: could not acquire this session's "
+        "compression lock. Another compression may still be running, or "
+        "the lock check failed — try again shortly."
+    )
+
+
 def summarize_manual_compression(
     before_messages: Sequence[dict[str, Any]],
     after_messages: Sequence[dict[str, Any]],

--- a/cli.py
+++ b/cli.py
@@ -10076,6 +10076,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     force=True,
                     defer_context_engine_notification=True,
                 )
+
+                # If _compress_context returned unchanged because a
+                # concurrent compression lock is held, tell the user
+                # clearly instead of showing the misleading
+                # "No changes from compression" no-op text.
+                if getattr(self.agent, "_compression_skipped_due_to_lock", None):
+                    holder = self.agent._compression_skipped_due_to_lock
+                    if isinstance(holder, str):
+                        print(f"  ⏳ Compression already in progress for this "
+                              f"session (holder: {holder}). "
+                              f"Please wait for it to finish.")
+                    else:
+                        print(f"  ⏳ Compression already in progress for this "
+                              f"session. Please wait for it to finish.")
+                    self.agent._compression_skipped_due_to_lock = None
+                    return
+
                 if partial and tail:
                     compressed = rejoin_compressed_head_and_tail(compressed, tail)
                 self.conversation_history = compressed

--- a/cli.py
+++ b/cli.py
@@ -10080,17 +10080,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # If _compress_context returned unchanged because a
                 # concurrent compression lock is held, tell the user
                 # clearly instead of showing the misleading
-                # "No changes from compression" no-op text.
+                # "No changes from compression" no-op text. The wording
+                # distinguishes a confirmed holder from an unconfirmed
+                # acquisition failure (describe_compression_lock_skip).
                 if getattr(self.agent, "_compression_skipped_due_to_lock", None):
-                    holder = self.agent._compression_skipped_due_to_lock
-                    if isinstance(holder, str):
-                        print(f"  ⏳ Compression already in progress for this "
-                              f"session (holder: {holder}). "
-                              f"Please wait for it to finish.")
-                    else:
-                        print(f"  ⏳ Compression already in progress for this "
-                              f"session. Please wait for it to finish.")
+                    from agent.manual_compression_feedback import (
+                        describe_compression_lock_skip,
+                    )
+                    print(
+                        "  "
+                        + describe_compression_lock_skip(
+                            self.agent._compression_skipped_due_to_lock
+                        )
+                    )
                     self.agent._compression_skipped_due_to_lock = None
+                    # No boundary was committed on a lock-skip; discard the
+                    # deferred context-engine notification (exactly-once).
+                    finalize_context_engine_compression_notification(
+                        self.agent,
+                        committed=False,
+                    )
                     return
 
                 if partial and tail:

--- a/cli.py
+++ b/cli.py
@@ -10083,7 +10083,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # "No changes from compression" no-op text. The wording
                 # distinguishes a confirmed holder from an unconfirmed
                 # acquisition failure (describe_compression_lock_skip).
-                if getattr(self.agent, "_compression_skipped_due_to_lock", None):
+                # Type-pinned check (is True / str): the flag's only real
+                # values are None/True/holder-string, and a bare getattr
+                # truthiness test is fooled by MagicMock auto-attributes on
+                # test-double agents (skill pitfall: MagicMock vs hasattr).
+                _lock_skip_signal = getattr(
+                    self.agent, "_compression_skipped_due_to_lock", None
+                )
+                if _lock_skip_signal is True or isinstance(_lock_skip_signal, str):
                     from agent.manual_compression_feedback import (
                         describe_compression_lock_skip,
                     )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3563,6 +3563,19 @@ class GatewaySlashCommandsMixin:
                         defer_context_engine_notification=True,
                     )
                 )
+
+                # If _compress_context returned unchanged because a
+                # concurrent compression lock is held, tell the user
+                # clearly instead of showing the misleading
+                # "No changes from compression" no-op text.
+                _lock_skipped = getattr(tmp_agent, "_compression_skipped_due_to_lock", None)
+                if _lock_skipped:
+                    holder = _lock_skipped if isinstance(_lock_skipped, str) else "unknown"
+                    return (
+                        f"⏳ Compression already in progress for this session "
+                        f"(holder: {holder}). Please wait for it to finish."
+                    )
+
                 if partial and tail:
                     compressed = rejoin_compressed_head_and_tail(compressed, tail)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3573,7 +3573,7 @@ class GatewaySlashCommandsMixin:
                 # The deferred context-engine notification is discarded by
                 # the finally block below (finalize committed=False).
                 _lock_skipped = getattr(tmp_agent, "_compression_skipped_due_to_lock", None)
-                if _lock_skipped:
+                if _lock_skipped is True or isinstance(_lock_skipped, str):
                     from agent.manual_compression_feedback import (
                         describe_compression_lock_skip,
                     )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3567,15 +3567,17 @@ class GatewaySlashCommandsMixin:
                 # If _compress_context returned unchanged because a
                 # concurrent compression lock is held, tell the user
                 # clearly instead of showing the misleading
-                # "No changes from compression" no-op text.
+                # "No changes from compression" no-op text. The wording
+                # distinguishes a confirmed holder from an unconfirmed
+                # acquisition failure (describe_compression_lock_skip).
+                # The deferred context-engine notification is discarded by
+                # the finally block below (finalize committed=False).
                 _lock_skipped = getattr(tmp_agent, "_compression_skipped_due_to_lock", None)
                 if _lock_skipped:
-                    holder = _lock_skipped if isinstance(_lock_skipped, str) else None
-                    holder_clause = f" (holder: {holder})" if holder else ""
-                    return (
-                        f"⏳ Compression already in progress for this session"
-                        f"{holder_clause}. Please wait for it to finish."
+                    from agent.manual_compression_feedback import (
+                        describe_compression_lock_skip,
                     )
+                    return describe_compression_lock_skip(_lock_skipped)
 
                 if partial and tail:
                     compressed = rejoin_compressed_head_and_tail(compressed, tail)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3570,10 +3570,11 @@ class GatewaySlashCommandsMixin:
                 # "No changes from compression" no-op text.
                 _lock_skipped = getattr(tmp_agent, "_compression_skipped_due_to_lock", None)
                 if _lock_skipped:
-                    holder = _lock_skipped if isinstance(_lock_skipped, str) else "unknown"
+                    holder = _lock_skipped if isinstance(_lock_skipped, str) else None
+                    holder_clause = f" (holder: {holder})" if holder else ""
                     return (
-                        f"⏳ Compression already in progress for this session "
-                        f"(holder: {holder}). Please wait for it to finish."
+                        f"⏳ Compression already in progress for this session"
+                        f"{holder_clause}. Please wait for it to finish."
                     )
 
                 if partial and tail:

--- a/tests/agent/test_compress_signal_leak.py
+++ b/tests/agent/test_compress_signal_leak.py
@@ -1,0 +1,60 @@
+"""Invariant: stale signal leak between consecutive compress_context calls."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_signal_cleared_on_entry_between_calls(monkeypatch):
+    """Call 1: lock held → signal set. Call 2: lock available → signal must
+    be None after call 2 because the entry code cleared it. This prevents
+    a prior auto-compress lock-skip from causing a subsequent successful
+    manual /compress to falsely report 'Compression already in progress'."""
+    from agent.conversation_compression import compress_context
+
+    agent = MagicMock()
+    agent._cached_system_prompt = ""
+    agent.tools = None
+    agent._memory_manager = None
+    agent._build_system_prompt = MagicMock(return_value="sys prompt")
+    agent._emit_warning = MagicMock()
+
+    msgs = [
+        {"role": "user", "content": "a"}, {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"}, {"role": "assistant", "content": "d"},
+    ]
+
+    monkeypatch.setattr(
+        "agent.conversation_compression._compression_lock_holder",
+        lambda a: "pid=test:holder",
+    )
+
+    # --- Call 1: lock held ---
+    db1 = MagicMock()
+    db1.try_acquire_compression_lock.return_value = False
+    db1.get_compression_lock_holder.return_value = "pid=holder1"
+    agent._session_db = db1
+
+    compress_context(agent, msgs, "", approx_tokens=100, force=True)
+
+    # Call 1: signal set (lock was held).
+    assert agent._compression_skipped_due_to_lock is not None
+
+    # --- Call 2: lock available, compressor succeeds ---
+    db2 = MagicMock()
+    db2.try_acquire_compression_lock.return_value = True
+    agent._session_db = db2
+    agent.context_compressor = MagicMock()
+    compressed = [
+        {"role": "user", "content": "[summary]"},
+        {"role": "assistant", "content": "ok"},
+    ]
+    agent.context_compressor.compress = MagicMock(return_value=compressed)
+    agent.context_compressor.compression_count = 0
+    agent.context_compressor.last_compression_rough_tokens = 0
+
+    compress_context(agent, msgs, "", approx_tokens=100, force=True)
+
+    # Call 2: signal must be None — entry code cleared stale Call 1 signal.
+    assert agent._compression_skipped_due_to_lock is None, (
+        "stale signal from lock-skip call 1 leaked into successful call 2"
+    )

--- a/tests/agent/test_manual_compression_feedback.py
+++ b/tests/agent/test_manual_compression_feedback.py
@@ -2,7 +2,10 @@
 
 from types import SimpleNamespace
 
-from agent.manual_compression_feedback import summarize_manual_compression
+from agent.manual_compression_feedback import (
+    describe_compression_lock_skip,
+    summarize_manual_compression,
+)
 
 
 def _messages(count: int) -> list[dict[str, str]]:
@@ -82,3 +85,27 @@ def test_fallback_compression_reports_dropped_message_count():
     assert feedback["headline"] == "Compressed with fallback: 12 → 4 messages"
     assert "removed 8 message(s)" in feedback["note"]
     assert "invalid response" in feedback["note"]
+
+
+def test_lock_skip_with_confirmed_holder_names_it():
+    """A descriptive holder string means another compressor CONFIRMED holds
+    the lock — say so and name the holder."""
+    text = describe_compression_lock_skip("pid=12345:tid=7:agent=1:nonce=ab")
+
+    assert "Compression already in progress" in text
+    assert "pid=12345:tid=7:agent=1:nonce=ab" in text
+    assert "wait for it to finish" in text
+
+
+def test_lock_skip_without_confirmed_holder_does_not_claim_concurrency():
+    """signal=True / None / '' / whitespace: acquisition failed but the
+    holder is unconfirmed (hermes_state.try_acquire_compression_lock catches
+    sqlite3.Error internally and returns False). The message must not assert
+    another compression is definitely running."""
+    for signal in (True, None, "", "   "):
+        text = describe_compression_lock_skip(signal)
+
+        assert "already in progress" not in text, f"signal={signal!r}"
+        assert "Compression skipped" in text
+        assert "could not acquire" in text
+        assert "try again" in text

--- a/tests/cli/test_compress_here.py
+++ b/tests/cli/test_compress_here.py
@@ -26,6 +26,7 @@ def _wire_agent(shell, compressed_head):
     shell.agent.session_id = None
     shell.agent.tools = None
     shell.agent._compress_context.return_value = (compressed_head, "")
+    shell.agent._compression_skipped_due_to_lock = False
 
 
 def test_compress_here_compresses_head_only(capsys):

--- a/tests/cli/test_manual_compress.py
+++ b/tests/cli/test_manual_compress.py
@@ -53,6 +53,9 @@ def test_manual_compress_reports_noop_without_success_banner(capsys):
     shell.agent.tools = None
     shell.agent.session_id = shell.session_id  # no-op compression: no split
     shell.agent._compress_context.return_value = (list(history), "")
+    # Explicitly signal this is NOT a lock-skip to avoid MagicMock
+    # getattr returning a truthy mock for unset attributes.
+    shell.agent._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         assert messages == history
@@ -108,6 +111,7 @@ def test_manual_compress_explains_when_token_estimate_rises(capsys):
     shell.agent.tools = None
     shell.agent.session_id = shell.session_id  # no-op: no split
     shell.agent._compress_context.return_value = (compressed, "")
+    shell.agent._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         if messages == history:
@@ -152,6 +156,7 @@ def test_manual_compress_syncs_session_id_after_split():
         shell.agent.session_id = new_child_id
         return (compressed, "")
     shell.agent._compress_context.side_effect = _fake_compress
+    shell.agent._compression_skipped_due_to_lock = False
     shell.agent.session_id = old_id  # starts in sync
     shell._pending_title = "stale title"
 
@@ -194,6 +199,7 @@ def test_manual_compress_flushes_compressed_history_to_child_session_db():
         return (compressed, "")
 
     shell.agent._compress_context.side_effect = _fake_compress
+    shell.agent._compression_skipped_due_to_lock = False
 
     with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=100):
         shell._manual_compress()
@@ -210,6 +216,7 @@ def test_manual_compress_does_not_flush_full_history_when_session_id_unchanged()
     shell.agent._cached_system_prompt = ""
     shell.agent.session_id = shell.session_id
     shell.agent._compress_context.return_value = (list(history), "")
+    shell.agent._compression_skipped_due_to_lock = False
 
     with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=100):
         shell._manual_compress()
@@ -264,6 +271,7 @@ def test_manual_compress_no_sync_when_session_id_unchanged():
     shell.agent.tools = None
     shell.agent.session_id = shell.session_id
     shell.agent._compress_context.return_value = (list(history), "")
+    shell.agent._compression_skipped_due_to_lock = False
     shell._pending_title = "keep me"
 
     with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
@@ -271,3 +279,61 @@ def test_manual_compress_no_sync_when_session_id_unchanged():
 
     # No split → pending title untouched.
     assert shell._pending_title == "keep me"
+
+
+def test_manual_compress_shows_lock_in_progress_when_skipped_due_to_lock(capsys):
+    """When _compress_context skips due to a concurrent compression lock,
+    _manual_compress must print a clear "already in progress" message,
+    NOT show the misleading "No changes from compression" no-op text."""
+    shell = _make_cli()
+    history = _make_history()
+    shell.conversation_history = history
+    shell.agent = MagicMock()
+    shell.agent.compression_enabled = True
+    shell.agent._cached_system_prompt = ""
+    shell.agent.tools = None
+    shell.agent.session_id = shell.session_id
+
+    # Simulate _compress_context setting the lock-skip signal and
+    # returning unchanged messages.
+    def _fake_compress(*args, **kwargs):
+        shell.agent._compression_skipped_due_to_lock = True
+        return (list(history), "")
+
+    shell.agent._compress_context.side_effect = _fake_compress
+
+    with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
+        shell._manual_compress()
+
+    output = capsys.readouterr().out
+    assert "Compression already in progress" in output
+    assert "No changes from compression" not in output
+    # Signal should be cleared after use.
+    assert shell.agent._compression_skipped_due_to_lock is None
+
+
+def test_manual_compress_shows_lock_in_progress_with_holder(capsys):
+    """When the lock holder is a descriptive string, include it in the
+    status message so the user knows which process to investigate."""
+    shell = _make_cli()
+    history = _make_history()
+    shell.conversation_history = history
+    shell.agent = MagicMock()
+    shell.agent.compression_enabled = True
+    shell.agent._cached_system_prompt = ""
+    shell.agent.tools = None
+    shell.agent.session_id = shell.session_id
+
+    def _fake_compress(*args, **kwargs):
+        shell.agent._compression_skipped_due_to_lock = "pid=12345"
+        return (list(history), "")
+
+    shell.agent._compress_context.side_effect = _fake_compress
+
+    with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
+        shell._manual_compress()
+
+    output = capsys.readouterr().out
+    assert "Compression already in progress" in output
+    assert "pid=12345" in output
+    assert "No changes from compression" not in output

--- a/tests/cli/test_manual_compress.py
+++ b/tests/cli/test_manual_compress.py
@@ -85,6 +85,8 @@ def test_manual_compress_reports_aborted_summary_without_success_banner(capsys):
         "Provider 'opencode-zen' is set in config.yaml but no API key was found."
     )
     shell.agent._compress_context.return_value = (list(history), "")
+    # Explicit non-lock-skip: MagicMock getattr would return a truthy mock.
+    shell.agent._compression_skipped_due_to_lock = False
 
     with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
         shell._manual_compress()
@@ -246,6 +248,8 @@ def test_manual_compress_runs_when_auto_compaction_disabled(capsys):
     shell.agent.tools = None
     shell.agent.session_id = shell.session_id
     shell.agent._compress_context.return_value = (compressed, "")
+    # Explicit non-lock-skip: MagicMock getattr would return a truthy mock.
+    shell.agent._compression_skipped_due_to_lock = False
 
     with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
         shell._manual_compress()
@@ -281,10 +285,13 @@ def test_manual_compress_no_sync_when_session_id_unchanged():
     assert shell._pending_title == "keep me"
 
 
-def test_manual_compress_shows_lock_in_progress_when_skipped_due_to_lock(capsys):
-    """When _compress_context skips due to a concurrent compression lock,
-    _manual_compress must print a clear "already in progress" message,
-    NOT show the misleading "No changes from compression" no-op text."""
+def test_manual_compress_shows_lock_skip_without_confirmed_holder(capsys):
+    """When _compress_context skips due to the compression lock WITHOUT a
+    confirmed holder (signal=True — acquisition failed but
+    get_compression_lock_holder returned nothing, e.g. a SQLite error made
+    try_acquire return False), _manual_compress must print the unconfirmed
+    lock-skip wording, NOT claim another compression is definitely running,
+    and NOT show the misleading "No changes from compression" no-op text."""
     shell = _make_cli()
     history = _make_history()
     shell.conversation_history = history
@@ -306,7 +313,10 @@ def test_manual_compress_shows_lock_in_progress_when_skipped_due_to_lock(capsys)
         shell._manual_compress()
 
     output = capsys.readouterr().out
-    assert "Compression already in progress" in output
+    assert "Compression skipped" in output
+    assert "could not acquire" in output
+    # No confirmed holder → must not assert one is running.
+    assert "already in progress" not in output
     assert "No changes from compression" not in output
     # Signal should be cleared after use.
     assert shell.agent._compression_skipped_due_to_lock is None

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -70,6 +70,7 @@ async def test_compress_command_reports_noop_without_success_banner():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         assert messages == history
@@ -149,6 +150,7 @@ async def test_compress_command_explains_when_token_estimate_rises():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         if messages == history:
@@ -199,6 +201,7 @@ async def test_compress_command_appends_warning_when_compression_aborts():
     )
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         if messages == history:
@@ -261,6 +264,7 @@ async def test_compress_command_surfaces_aux_model_failure_even_when_recovered()
     )
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         if messages == history:
@@ -319,6 +323,7 @@ async def test_compress_command_passes_session_db_and_persists_rotated_session()
         return compressed, ""
 
     agent_instance._compress_context.side_effect = _compress
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         if messages == history:
@@ -385,6 +390,7 @@ async def test_compress_command_does_not_repoint_session_when_transcript_write_f
         return compressed, ""
 
     agent_instance._compress_context.side_effect = _compress
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         return 100
@@ -440,6 +446,7 @@ async def test_compress_command_in_place_skips_destructive_rewrite():
     agent_instance._last_compaction_in_place = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         if messages == history:
@@ -482,6 +489,7 @@ async def test_compress_command_preserves_platform_and_gateway_session_key():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     with (
         patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
@@ -517,6 +525,7 @@ async def test_compress_command_overrides_stale_resolver_identity():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     # Resolver injects a WRONG platform and a stale session key.
     runtime = {"api_key": "test-key", "platform": "discord", "gateway_session_key": "stale-key"}
@@ -581,3 +590,32 @@ async def test_compress_command_passes_tool_messages_to_compressor():
     # Assistant tool_calls stubs (content=None) must survive too, or the
     # tool message would dangle without its call.
     assert any(m.get("tool_calls") for m in passed), "assistant tool_calls stub dropped"
+
+
+@pytest.mark.asyncio
+async def test_compress_command_surfaces_lock_skip():
+    """When _compress_context skips due to a concurrent lock, the gateway
+    handler must surface a clear message, not the misleading no-op text."""
+    history = _make_history()
+    runner = _make_runner(history)
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = "pid=99999"
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+        patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+    ):
+        result = await runner._handle_compress_command(_make_event())
+
+    assert "Compression already in progress" in result
+    assert "pid=99999" in result
+    assert "No changes from compression" not in result

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -115,6 +115,8 @@ async def test_compress_command_works_when_auto_compaction_disabled():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    # Explicit non-lock-skip: MagicMock getattr would return a truthy mock.
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         return 100 if messages == history else 60

--- a/tests/gateway/test_compress_focus.py
+++ b/tests/gateway/test_compress_focus.py
@@ -68,6 +68,7 @@ async def test_compress_focus_topic_passed_to_agent():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages):
         return 100
@@ -98,6 +99,7 @@ async def test_compress_no_focus_passes_none():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     with (
         patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),

--- a/tests/gateway/test_compress_plugin_engine.py
+++ b/tests/gateway/test_compress_plugin_engine.py
@@ -127,6 +127,7 @@ async def test_compress_works_with_plugin_context_engine():
     agent_instance.context_compressor = plugin_engine
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     with (
         patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -82,6 +82,18 @@ VISIBLE_COMPRESSION_MESSAGES = [
         "⚠ Compression returned an empty transcript. No session split was "
         "performed; conversation continues unchanged."
     ),
+    # Manual /compress lock-skip feedback (issue #57631): both the
+    # confirmed-holder and unconfirmed-acquire wordings must reach the user.
+    (
+        "⏳ Compression already in progress for this session "
+        "(holder: pid=12345:tid=7:agent=1:nonce=ab). Please wait for it to "
+        "finish."
+    ),
+    (
+        "⏳ Compression skipped: could not acquire this session's "
+        "compression lock. Another compression may still be running, or "
+        "the lock check failed — try again shortly."
+    ),
 ]
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5982,6 +5982,8 @@ def test_compress_session_history_passes_force():
     agent.context_compressor = None  # keep _get_usage on the simple path
     compressed = [{"role": "user", "content": "summary"}]
     agent._compress_context.return_value = (compressed, "")
+    # Explicit non-lock-skip: MagicMock getattr would return a truthy mock.
+    agent._compression_skipped_due_to_lock = False
     session = _session(
         agent=agent,
         history=[
@@ -6012,6 +6014,8 @@ def test_compress_session_history_works_when_auto_compaction_disabled():
     agent.context_compressor = None  # keep _get_usage on the simple path
     compressed = [{"role": "user", "content": "summary"}]
     agent._compress_context.return_value = (compressed, "")
+    # Explicit non-lock-skip: MagicMock getattr would return a truthy mock.
+    agent._compression_skipped_due_to_lock = False
     session = _session(
         agent=agent,
         history=[

--- a/tests/tui_gateway/test_compress_lock_skip.py
+++ b/tests/tui_gateway/test_compress_lock_skip.py
@@ -1,0 +1,84 @@
+"""Tests for TUI gateway /compress lock-hold signalling."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_compress_session_history_raises_on_lock_skip():
+    """When _compression_skipped_due_to_lock is set on the agent,
+    _compress_session_history must raise CompressionLockHeld with
+    the holder string so callers can surface a clear message."""
+    from tui_gateway.server import _compress_session_history, CompressionLockHeld
+
+    history = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+        {"role": "assistant", "content": "d"},
+    ]
+    agent = MagicMock()
+    agent._cached_system_prompt = ""
+    agent.tools = None
+    agent._compression_skipped_due_to_lock = "pid=99999:tid=1:agent=1:nonce=abc"
+
+    def _fake_compress(msgs=None, *_args, **_kwargs):
+        return (msgs or history, "")
+
+    agent._compress_context.side_effect = _fake_compress
+
+    session = {
+        "agent": agent,
+        "history_lock": MagicMock(),
+        "history": history,
+        "history_version": 1,
+    }
+
+    with (
+        patch(
+            "agent.model_metadata.estimate_request_tokens_rough", return_value=100
+        ),
+        pytest.raises(CompressionLockHeld) as exc_info,
+    ):
+        _compress_session_history(session)
+
+    assert exc_info.value.holder == "pid=99999:tid=1:agent=1:nonce=abc"
+
+
+def test_compress_session_history_clears_signal_after_raise():
+    """The signal attribute must be cleared when the exception is raised
+    so stale signals don't leak into subsequent operations."""
+    from tui_gateway.server import _compress_session_history, CompressionLockHeld
+
+    history = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+        {"role": "assistant", "content": "d"},
+    ]
+    agent = MagicMock()
+    agent._cached_system_prompt = ""
+    agent.tools = None
+    agent._compression_skipped_due_to_lock = True
+
+    def _fake_compress(msgs=None, *_args, **_kwargs):
+        return (msgs or history, "")
+
+    agent._compress_context.side_effect = _fake_compress
+
+    session = {
+        "agent": agent,
+        "history_lock": MagicMock(),
+        "history": history,
+        "history_version": 1,
+    }
+
+    with (
+        patch(
+            "agent.model_metadata.estimate_request_tokens_rough", return_value=100
+        ),
+        pytest.raises(CompressionLockHeld),
+    ):
+        _compress_session_history(session)
+
+    # Signal must be cleared after the raise.
+    assert agent._compression_skipped_due_to_lock is None

--- a/tests/tui_gateway/test_compress_lock_skip.py
+++ b/tests/tui_gateway/test_compress_lock_skip.py
@@ -1,7 +1,53 @@
-"""Tests for TUI gateway /compress lock-hold signalling."""
+"""Tests for TUI gateway /compress lock-hold signalling.
+
+Covers the shared _compress_session_history choke point plus ALL THREE
+in-process manual-compress consumers (session.compress RPC, the
+command.dispatch compress branch, and the slash.exec mirror via
+_mirror_slash_side_effects) — each must surface the lock-skip reason
+instead of the misleading "No changes from compression" no-op text or a
+generic "compress failed" error.
+"""
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+def _make_history():
+    return [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+        {"role": "assistant", "content": "d"},
+    ]
+
+
+def _make_lock_skip_agent(signal):
+    """Agent double whose _compress_context no-ops and sets the lock signal."""
+    agent = MagicMock()
+    agent._cached_system_prompt = ""
+    agent.tools = None
+    agent.session_id = "sess-lock"
+    # Deferred-notify contract: no pending notification exists.
+    agent._pending_context_engine_compression_notification = None
+
+    def _fake_compress(msgs=None, *_args, **_kwargs):
+        agent._compression_skipped_due_to_lock = signal
+        return (list(msgs) if msgs is not None else _make_history(), "")
+
+    agent._compress_context.side_effect = _fake_compress
+    return agent
+
+
+def _make_session(agent, history):
+    return {
+        "agent": agent,
+        "history_lock": threading.Lock(),
+        "history": history,
+        "history_version": 1,
+        "running": False,
+        "session_key": "sess-lock",
+    }
 
 
 def test_compress_session_history_raises_on_lock_skip():
@@ -10,28 +56,9 @@ def test_compress_session_history_raises_on_lock_skip():
     the holder string so callers can surface a clear message."""
     from tui_gateway.server import _compress_session_history, CompressionLockHeld
 
-    history = [
-        {"role": "user", "content": "a"},
-        {"role": "assistant", "content": "b"},
-        {"role": "user", "content": "c"},
-        {"role": "assistant", "content": "d"},
-    ]
-    agent = MagicMock()
-    agent._cached_system_prompt = ""
-    agent.tools = None
-    agent._compression_skipped_due_to_lock = "pid=99999:tid=1:agent=1:nonce=abc"
-
-    def _fake_compress(msgs=None, *_args, **_kwargs):
-        return (msgs or history, "")
-
-    agent._compress_context.side_effect = _fake_compress
-
-    session = {
-        "agent": agent,
-        "history_lock": MagicMock(),
-        "history": history,
-        "history_version": 1,
-    }
+    history = _make_history()
+    agent = _make_lock_skip_agent("pid=99999:tid=1:agent=1:nonce=abc")
+    session = _make_session(agent, history)
 
     with (
         patch(
@@ -42,6 +69,9 @@ def test_compress_session_history_raises_on_lock_skip():
         _compress_session_history(session)
 
     assert exc_info.value.holder == "pid=99999:tid=1:agent=1:nonce=abc"
+    # The history must be untouched by the lock-skip.
+    assert session["history"] == history
+    assert session["history_version"] == 1
 
 
 def test_compress_session_history_clears_signal_after_raise():
@@ -49,28 +79,9 @@ def test_compress_session_history_clears_signal_after_raise():
     so stale signals don't leak into subsequent operations."""
     from tui_gateway.server import _compress_session_history, CompressionLockHeld
 
-    history = [
-        {"role": "user", "content": "a"},
-        {"role": "assistant", "content": "b"},
-        {"role": "user", "content": "c"},
-        {"role": "assistant", "content": "d"},
-    ]
-    agent = MagicMock()
-    agent._cached_system_prompt = ""
-    agent.tools = None
-    agent._compression_skipped_due_to_lock = True
-
-    def _fake_compress(msgs=None, *_args, **_kwargs):
-        return (msgs or history, "")
-
-    agent._compress_context.side_effect = _fake_compress
-
-    session = {
-        "agent": agent,
-        "history_lock": MagicMock(),
-        "history": history,
-        "history_version": 1,
-    }
+    history = _make_history()
+    agent = _make_lock_skip_agent(True)
+    session = _make_session(agent, history)
 
     with (
         patch(
@@ -82,3 +93,147 @@ def test_compress_session_history_clears_signal_after_raise():
 
     # Signal must be cleared after the raise.
     assert agent._compression_skipped_due_to_lock is None
+
+
+def test_compress_session_history_unconfirmed_signal_yields_none_holder():
+    """signal=True (acquisition failed, holder unconfirmed — e.g. SQLite
+    error made try_acquire return False) must map to holder=None, NOT a
+    fabricated holder, so downstream wording doesn't claim a concurrent
+    compression is definitely running."""
+    from tui_gateway.server import _compress_session_history, CompressionLockHeld
+
+    agent = _make_lock_skip_agent(True)
+    session = _make_session(agent, _make_history())
+
+    with (
+        patch(
+            "agent.model_metadata.estimate_request_tokens_rough", return_value=100
+        ),
+        pytest.raises(CompressionLockHeld) as exc_info,
+    ):
+        _compress_session_history(session)
+
+    assert exc_info.value.holder is None
+
+
+# ── Consumer 1: session.compress RPC ───────────────────────────────────
+
+
+def test_session_compress_rpc_returns_lock_held_payload():
+    from tui_gateway import server
+
+    agent = _make_lock_skip_agent("pid=4242")
+    session = _make_session(agent, _make_history())
+    sid = "sid-lock-rpc"
+    server._sessions[sid] = session
+    try:
+        with (
+            patch.object(server, "_sess", return_value=(session, None)),
+            patch.object(server, "_session_uses_compute_host", return_value=False),
+            patch.object(server, "_status_update"),
+            patch(
+                "agent.model_metadata.estimate_request_tokens_rough",
+                return_value=100,
+            ),
+        ):
+            r = server._methods["session.compress"]("r1", {"session_id": sid})
+    finally:
+        server._sessions.pop(sid, None)
+
+    result = r["result"]
+    assert result["lock_held"] is True
+    assert result["compressed"] is False
+    assert "Compression already in progress" in result["message"]
+    assert "pid=4242" in result["message"]
+    assert "No changes from compression" not in result["message"]
+
+
+# ── Consumer 2: command.dispatch compress branch ───────────────────────
+
+
+def test_command_dispatch_compress_reports_lock_skip_as_output_not_error():
+    """CompressionLockHeld must NOT fall through to the generic
+    'compress failed' error handler — it's a clean no-op with feedback."""
+    from tui_gateway import server
+
+    agent = _make_lock_skip_agent("pid=5150")
+    session = _make_session(agent, _make_history())
+    sid = "sid-lock-dispatch"
+    server._sessions[sid] = session
+    try:
+        with (
+            patch.object(server, "_session_uses_compute_host", return_value=False),
+            patch(
+                "agent.model_metadata.estimate_request_tokens_rough",
+                return_value=100,
+            ),
+        ):
+            r = server._methods["command.dispatch"](
+                "r2", {"name": "compress", "arg": "", "session_id": sid}
+            )
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert "error" not in r, f"lock-skip surfaced as error: {r.get('error')}"
+    output = r["result"]["output"]
+    assert r["result"]["type"] == "exec"
+    assert "Compression already in progress" in output
+    assert "pid=5150" in output
+    assert "compress failed" not in output
+    assert "No changes from compression" not in output
+
+
+# ── Consumer 3: slash.exec mirror (_mirror_slash_side_effects) ─────────
+
+
+def test_mirror_slash_side_effects_reports_lock_skip():
+    from tui_gateway import server
+
+    agent = _make_lock_skip_agent("pid=6161")
+    session = _make_session(agent, _make_history())
+    sid = "sid-lock-mirror"
+    server._sessions[sid] = session
+    try:
+        with (
+            patch.object(server, "_sync_session_key_after_compress"),
+            patch.object(server, "_emit"),
+            patch(
+                "agent.model_metadata.estimate_request_tokens_rough",
+                return_value=100,
+            ),
+        ):
+            output = server._mirror_slash_side_effects(sid, session, "/compress")
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert "Compression already in progress" in output
+    assert "pid=6161" in output
+    assert "No changes from compression" not in output
+    assert "live session sync failed" not in output
+
+
+def test_mirror_slash_side_effects_unconfirmed_lock_skip_wording():
+    """signal=True (no confirmed holder) must use the 'could not acquire'
+    wording rather than claiming another compression is running."""
+    from tui_gateway import server
+
+    agent = _make_lock_skip_agent(True)
+    session = _make_session(agent, _make_history())
+    sid = "sid-lock-mirror-unconfirmed"
+    server._sessions[sid] = session
+    try:
+        with (
+            patch.object(server, "_sync_session_key_after_compress"),
+            patch.object(server, "_emit"),
+            patch(
+                "agent.model_metadata.estimate_request_tokens_rough",
+                return_value=100,
+            ),
+        ):
+            output = server._mirror_slash_side_effects(sid, session, "/compress")
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert "Compression skipped" in output
+    assert "could not acquire" in output
+    assert "already in progress" not in output

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3745,8 +3745,10 @@ def _compress_session_history(
     # If _compress_context returned unchanged because a concurrent
     # compression lock is held, raise so callers can surface a clear
     # message instead of the misleading "No changes from compression" text.
+    # Type-pinned (is True / str): real values are None/True/holder-string;
+    # bare truthiness is fooled by MagicMock auto-attrs on test doubles.
     _lock_skipped = getattr(agent, "_compression_skipped_due_to_lock", None)
-    if _lock_skipped:
+    if _lock_skipped is True or isinstance(_lock_skipped, str):
         agent._compression_skipped_due_to_lock = None
         # No boundary was committed on a lock-skip; discard any pending
         # deferred context-engine notification (exactly-once, no-op safe).

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9372,11 +9372,13 @@ def _(rid, params: dict) -> dict:
             _status_update(sid, "ready")
     except CompressionLockHeld as e:
         _status_update(sid, "ready")
-        holder_msg = f" (holder: {e.holder})" if e.holder else ""
+        from agent.manual_compression_feedback import (
+            describe_compression_lock_skip,
+        )
         return _ok(rid, {
             "compressed": False,
             "lock_held": True,
-            "message": f"Compression already in progress for this session{holder_msg}. Please wait for it to finish."
+            "message": describe_compression_lock_skip(e.holder),
         })
     except Exception as e:
         finalize_context_engine_compression_notification(
@@ -14474,6 +14476,19 @@ def _(rid, params: dict) -> dict:
                     ),
                 },
             )
+        except CompressionLockHeld as e:
+            # Lock-skip is a clean no-op, not a failure: report it as
+            # normal command output (matching the slash-mirror and
+            # session.compress RPC), never as a "compress failed" error.
+            # _compress_session_history already discarded the deferred
+            # context-engine notification before raising.
+            from agent.manual_compression_feedback import (
+                describe_compression_lock_skip,
+            )
+            return _ok(
+                rid,
+                {"type": "exec", "output": describe_compression_lock_skip(e.holder)},
+            )
         except Exception as exc:
             finalize_context_engine_compression_notification(
                 session["agent"],
@@ -15535,8 +15550,10 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             try:
                 _compress_session_history(session, arg)
             except CompressionLockHeld as e:
-                holder_msg = f" (holder: {e.holder})" if e.holder else ""
-                return f"⏳ Compression already in progress for this session{holder_msg}. Please wait for it to finish."
+                from agent.manual_compression_feedback import (
+                    describe_compression_lock_skip,
+                )
+                return describe_compression_lock_skip(e.holder)
             _sync_session_key_after_compress(sid, session)
 
             with session["history_lock"]:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3642,6 +3642,14 @@ def _sync_agent_model_with_config(sid: str, session: dict) -> None:
         )
 
 
+class CompressionLockHeld(Exception):
+    """Raised by _compress_session_history when compression skipped due
+    to a concurrent lock on the session's compression_locks row."""
+    def __init__(self, holder: str | None = None):
+        self.holder = holder
+        super().__init__(f"Compression lock held: {holder or 'unknown'}")
+
+
 def _compress_session_history(
     session: dict,
     focus_topic: str | None = None,
@@ -3734,6 +3742,22 @@ def _compress_session_history(
             committed=False,
         )
         raise
+    # If _compress_context returned unchanged because a concurrent
+    # compression lock is held, raise so callers can surface a clear
+    # message instead of the misleading "No changes from compression" text.
+    _lock_skipped = getattr(agent, "_compression_skipped_due_to_lock", None)
+    if _lock_skipped:
+        agent._compression_skipped_due_to_lock = None
+        # No boundary was committed on a lock-skip; discard any pending
+        # deferred context-engine notification (exactly-once, no-op safe).
+        finalize_context_engine_compression_notification(
+            agent,
+            committed=False,
+        )
+        raise CompressionLockHeld(
+            _lock_skipped if isinstance(_lock_skipped, str) else None
+        )
+
     if partial and tail:
         compressed = rejoin_compressed_head_and_tail(compressed, tail)
     with session["history_lock"]:
@@ -9346,6 +9370,14 @@ def _(rid, params: dict) -> dict:
             # reverts to neutral whether compaction succeeded, was a
             # no-op, or raised.
             _status_update(sid, "ready")
+    except CompressionLockHeld as e:
+        _status_update(sid, "ready")
+        holder_msg = f" (holder: {e.holder})" if e.holder else ""
+        return _ok(rid, {
+            "compressed": False,
+            "lock_held": True,
+            "message": f"Compression already in progress for this session{holder_msg}. Please wait for it to finish."
+        })
     except Exception as e:
         finalize_context_engine_compression_notification(
             session["agent"],
@@ -15500,7 +15532,11 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             # (the choke point shared by all three manual-compress routes)
             # parses the boundary-aware forms (here [N], up to here, --keep N)
             # and does the partial head/tail split there (#35533).
-            _compress_session_history(session, arg)
+            try:
+                _compress_session_history(session, arg)
+            except CompressionLockHeld as e:
+                holder_msg = f" (holder: {e.holder})" if e.holder else ""
+                return f"⏳ Compression already in progress for this session{holder_msg}. Please wait for it to finish."
             _sync_session_key_after_compress(sid, session)
 
             with session["history_lock"]:


### PR DESCRIPTION
## Summary
Manual `/compress` during a concurrent compression now tells the user the real reason for the no-op — including who holds the lock — instead of the misleading "No changes from compression" text. Root cause: the lock-acquisition failure path in `compress_context` returns messages unchanged with no signal, so every manual-compress feedback surface read it as a genuine no-op (issue #57631).

## Changes
- `agent/conversation_compression.py`: lock-skip sets `agent._compression_skipped_due_to_lock` (holder string when confirmed, `True` otherwise); cleared at entry of every call so a stale auto-compress signal can't leak into a later successful manual `/compress`.
- `agent/manual_compression_feedback.py`: new `describe_compression_lock_skip()` — single source of truth for the wording. **Classification fix over the original PR:** a confirmed holder string says "already in progress (holder: …)"; `True`/`None` (acquisition failed but `hermes_state.try_acquire_compression_lock` catches `sqlite3.Error` internally and returns `False`, so no concurrent compressor is proven) says "could not acquire this session's compression lock … or the lock check failed" instead of falsely asserting another compression is running.
- `cli.py` `_manual_compress`: prints the lock-skip message, clears the signal, and discards the deferred context-engine notification (`finalize(committed=False)`, #69324 contract) before returning.
- `gateway/slash_commands.py` `/compress`: returns the shared wording (deferred notification discarded by the existing `finally`).
- `tui_gateway/server.py`: `_compress_session_history` raises `CompressionLockHeld` (and discards the deferred notification first); **all three** in-process consumers handle it — `session.compress` RPC (`lock_held: true` payload), the `command.dispatch` compress branch (**new** — previously fell into the generic "compress failed: …" error), and the `slash.exec` mirror. Compute-host isolated routes inherit via `_mirror_slash_side_effects` running inside the host child.
- Tests: per-surface wording pins (CLI/gateway/TUI×3 + helper), unconfirmed-vs-confirmed wording contract, stale-signal-leak invariant, `VISIBLE_COMPRESSION_MESSAGES` noise-filter carve-outs for both wordings, and MagicMock signal opt-outs for sibling tests added on main after the original PR.

## Validation
| | Before | After |
|---|---|---|
| `/compress` while another compression holds the lock | "No changes from compression: N messages" | "⏳ Compression already in progress for this session (holder: pid=…). Please wait for it to finish." |
| Lock acquire fails without a confirmed holder (SQLite error → `False`) | claimed "another compressor running" (`existing or True` defect) | "⏳ Compression skipped: could not acquire this session's compression lock… try again shortly." |
| TUI `command.dispatch` compress during lock hold | error `5009 compress failed: Compression lock held` | clean exec output with the lock-skip message |

Targeted tests: `bash scripts/run_tests.sh tests/ -q -k 'lock and compress'` → 80 passed, 0 failed; manual-compress feedback suite (13 files incl. `test_manual_compress.py`, `test_compress_command.py`, `test_compress_lock_skip.py`, `test_telegram_noise_filter.py`, `test_tui_gateway_server.py`, `test_compression_concurrent_fork.py`) → 1190 passed, 0 failed.

## Credit
Salvaged from #57634 by @0xLeathery. Fixes #57631.

## Infographic
![compress-lock-reason](https://v3b.fal.media/files/b/0aa35cbb/8nrHOzL6Mvttu0weCdp6u_a33TUGnc.png)
