### PR TITLE
fix(windows): isolate ACP environment probes from stdin

### DIFF
--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -162,6 +162,23 @@ class TestGitBashExternalProgramProbe:
 
         assert local_mod._bash_starts(r"C:\Git\bin\bash.exe") is True
         assert calls[0][0][-1] == "/usr/bin/true; /usr/bin/cat --version >/dev/null"
+        assert calls[0][1]["stdin"] is subprocess.DEVNULL
+
+    def test_mandatory_aslr_probe_detaches_stdin(self, monkeypatch):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_mandatory_aslr_enabled_cache", None)
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return subprocess.CompletedProcess(argv, 0, stdout="ON\n", stderr="")
+
+        monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(local_mod.shutil, "which", lambda _name: "powershell.exe")
+
+        assert local_mod._mandatory_aslr_enabled() is True
+        assert calls[0][1]["stdin"] is subprocess.DEVNULL
 
     def test_aslr_failure_surfaces_targeted_windows_command(
         self, tmp_path, monkeypatch

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -740,6 +740,7 @@ def _mandatory_aslr_enabled() -> "bool | None":
                 "-Command",
                 "(Get-ProcessMitigation -System).Aslr.ForceRelocateImages.ToString()",
             ],
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             timeout=10,
@@ -806,6 +807,7 @@ def _bash_starts(bash: str) -> bool:
     try:
         result = subprocess.run(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             timeout=15,


### PR DESCRIPTION
## What does this PR do?

Prevents two non-interactive Windows environment probes from inheriting the parent process's stdin.

Under ACP stdio, stdin is a long-lived pipe owned by the client. The Git Bash and Mandatory ASLR probes used `subprocess.run(..., capture_output=True)` without isolating stdin, so their child processes could inherit that pipe and deadlock during the first file-tool environment initialization.

Both probes now use `stdin=subprocess.DEVNULL`, matching the existing isolation used by the real Git Bash session.

## Related Issue

Fixes #69732

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/local.py`: detach stdin for the Git Bash external-program probe and the Windows Mandatory ASLR probe.
- `tests/tools/test_find_shell.py`: assert both non-interactive probes pass `subprocess.DEVNULL`.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_find_shell.py tests/tools/test_local_env_windows_msys.py tests/tools/test_subprocess_stdin_guard.py -q`.
2. Confirm all 60 tests pass.
3. Run `ruff check tools/environments/local.py tests/tools/test_find_shell.py`.
4. Run `python scripts/check-windows-footguns.py tools/environments/local.py tests/tools/test_find_shell.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full Python test suite; all 60 branch-relevant tests pass (the local full-suite run had unrelated environment/baseline failures)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), N/A because behavior and configuration contracts are unchanged
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior, N/A

## Screenshots / Logs

TDD evidence:

- Before the production change, both focused assertions failed with `KeyError: 'stdin'`.
- After the change, the relevant shell and subprocess suites passed: `60 passed, 0 failed`.
- The full Python suite completed locally: `39,826 passed, 4,871 failed`; the failures were unrelated environment/baseline failures (including missing async/optional dependencies and sandbox restrictions), with a representative failure reproduced on clean `upstream/main`.
- Ruff passed for both changed files.
- The Windows footgun scan passed for both changed files.
- `git diff --check upstream/main...HEAD` passed.

The fix was validated through focused unit and cross-platform shell tests on macOS. A native Windows ACP end-to-end run was not available in this environment.
