### PR TITLE
ci(desktop): add Azure Trusted Signing release gate

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,125 @@
+name: Desktop Release
+
+on:
+  push:
+    tags:
+      - 'desktop-v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: desktop-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sign-and-publish:
+    name: Sign and publish Windows Desktop
+    if: startsWith(github.ref, 'refs/tags/desktop-v')
+    runs-on: windows-2025
+    timeout-minutes: 45
+    environment: desktop-release
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Validate protected release configuration
+        shell: pwsh
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ vars.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          WINDOWS_SIGNING_PUBLISHER_NAME: ${{ vars.WINDOWS_SIGNING_PUBLISHER_NAME }}
+        run: |
+          $required = @(
+            'AZURE_TENANT_ID',
+            'AZURE_CLIENT_ID',
+            'AZURE_CLIENT_SECRET',
+            'AZURE_TRUSTED_SIGNING_ENDPOINT',
+            'AZURE_TRUSTED_SIGNING_ACCOUNT_NAME',
+            'AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME',
+            'WINDOWS_SIGNING_PUBLISHER_NAME'
+          )
+          foreach ($name in $required) {
+            if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+              throw "Protected desktop-release value '$name' is missing."
+            }
+          }
+          node apps/desktop/scripts/validate-release-tag.mjs "$env:GITHUB_REF_NAME"
+          $tagType = git cat-file -t "$env:GITHUB_REF_NAME"
+          if ($tagType -ne 'tag') {
+            throw "Desktop releases require an annotated tag; found '$tagType'."
+          }
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run release configuration tests
+        run: node --test apps/desktop/scripts/validate-release-tag.test.mjs apps/desktop/scripts/release-config.test.cjs
+
+      - name: Build signed NSIS and MSI artifacts
+        working-directory: apps/desktop
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ vars.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          WINDOWS_SIGNING_PUBLISHER_NAME: ${{ vars.WINDOWS_SIGNING_PUBLISHER_NAME }}
+          HERMES_DESKTOP_RELEASE_SIGNING: '1'
+        run: npm run dist:win:release
+
+      - name: Verify publisher, timestamp, and trust chain
+        shell: pwsh
+        env:
+          WINDOWS_SIGNING_PUBLISHER_NAME: ${{ vars.WINDOWS_SIGNING_PUBLISHER_NAME }}
+        run: |
+          ./apps/desktop/scripts/verify-windows-signatures.ps1 `
+            -ReleaseDirectory ./apps/desktop/release `
+            -PublisherName $env:WINDOWS_SIGNING_PUBLISHER_NAME
+
+      - name: Upload verified workflow artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hermes-desktop-${{ github.ref_name }}
+          path: |
+            apps/desktop/release/Hermes-*.exe
+            apps/desktop/release/Hermes-*.exe.blockmap
+            apps/desktop/release/Hermes-*.msi
+            apps/desktop/release/latest.yml
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish verified GitHub release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $artifacts = @(
+            Get-ChildItem ./apps/desktop/release -File |
+              Where-Object {
+                $_.Name -like 'Hermes-*.exe' -or
+                $_.Name -like 'Hermes-*.exe.blockmap' -or
+                $_.Name -like 'Hermes-*.msi' -or
+                $_.Name -eq 'latest.yml'
+              } |
+              Select-Object -ExpandProperty FullName
+          )
+          if ($artifacts.Count -lt 3) {
+            throw 'Expected verified NSIS, MSI, and update metadata artifacts.'
+          }
+          gh release create "$env:GITHUB_REF_NAME" @artifacts `
+            --repo "$env:GITHUB_REPOSITORY" `
+            --verify-tag `
+            --generate-notes `
+            --title "Hermes Desktop $env:GITHUB_REF_NAME"

--- a/apps/desktop/electron-builder.release.cjs
+++ b/apps/desktop/electron-builder.release.cjs
@@ -1,0 +1,40 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'))
+
+const releaseVariables = {
+  endpoint: 'AZURE_TRUSTED_SIGNING_ENDPOINT',
+  codeSigningAccountName: 'AZURE_TRUSTED_SIGNING_ACCOUNT_NAME',
+  certificateProfileName: 'AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME',
+  publisherName: 'WINDOWS_SIGNING_PUBLISHER_NAME'
+}
+
+const azureSignOptions = Object.fromEntries(
+  Object.entries(releaseVariables).map(([property, environmentName]) => {
+    const value = process.env[environmentName]?.trim()
+    if (!value) {
+      throw new Error(`Official Windows release signing requires ${environmentName}`)
+    }
+    return [property, value]
+  })
+)
+
+module.exports = {
+  ...packageJson.build,
+  forceCodeSigning: true,
+  win: {
+    ...packageJson.build.win,
+    signAndEditExecutable: true,
+    azureSignOptions: {
+      ...azureSignOptions,
+      fileDigest: 'SHA256',
+      timestampDigest: 'SHA256',
+      timestampRfc3161: 'http://timestamp.acs.microsoft.com'
+    }
+  },
+  nsis: {
+    ...packageJson.build.nsis,
+    warningsAsErrors: true
+  }
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -36,6 +36,7 @@
     "dist:win": "npm run build && npm run builder -- --win",
     "dist:win:msi": "npm run build && npm run builder -- --win msi",
     "dist:win:nsis": "npm run build && npm run builder -- --win nsis",
+    "dist:win:release": "npm run build && npm run builder -- --config electron-builder.release.cjs --win nsis msi",
     "dist:linux": "npm run build && npm run builder -- --linux AppImage deb rpm",
     "perf": "node scripts/perf/run.mjs",
     "perf:serve": "node scripts/perf/serve.mjs",

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -9,9 +9,10 @@
  * install.ps1, which the update path doesn't use).
  *
  * Windows-only: rcedit edits PE resources, irrelevant on macOS/Linux where the
- * app identity comes from the bundle Info.plist / desktop entry. Best-effort:
- * a stamp failure must never fail an otherwise-good build (worst case is the
- * stock icon, not a broken app), so we log and resolve rather than throw.
+ * app identity comes from the bundle Info.plist / desktop entry. Local builds
+ * remain best-effort. Official release builds set
+ * HERMES_DESKTOP_RELEASE_SIGNING=1 and fail closed: signing a stock Electron
+ * binary would permanently bind the wrong identity into a published artifact.
  *
  * electron-builder passes a context with:
  *   - electronPlatformName: 'win32' | 'darwin' | 'linux'
@@ -35,7 +36,9 @@ export default async function afterPack(context) {
   try {
     await stampExeIdentity(exe, desktopRoot)
   } catch (err) {
-    // Never fail the build over a cosmetic stamp.
+    if (process.env.HERMES_DESKTOP_RELEASE_SIGNING === '1') {
+      throw new Error(`release exe identity stamp failed: ${err.message}`, { cause: err })
+    }
     console.warn(`[after-pack] exe identity stamp failed (${err.message}); Hermes.exe keeps the stock Electron icon`)
   }
 }

--- a/apps/desktop/scripts/after-pack.test.mjs
+++ b/apps/desktop/scripts/after-pack.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import afterPack from './after-pack.mjs'
+
+const missingExecutableContext = {
+  electronPlatformName: 'win32',
+  appOutDir: 'Z:\\hermes-release-test\\missing',
+  packager: {
+    appInfo: {
+      productFilename: 'Hermes'
+    }
+  }
+}
+
+test('Windows branding is best-effort locally and mandatory for releases', async () => {
+  const previous = process.env.HERMES_DESKTOP_RELEASE_SIGNING
+
+  try {
+    delete process.env.HERMES_DESKTOP_RELEASE_SIGNING
+    await assert.doesNotReject(afterPack(missingExecutableContext))
+
+    process.env.HERMES_DESKTOP_RELEASE_SIGNING = '1'
+    await assert.rejects(afterPack(missingExecutableContext), /release exe identity stamp failed/)
+  } finally {
+    if (previous === undefined) {
+      delete process.env.HERMES_DESKTOP_RELEASE_SIGNING
+    } else {
+      process.env.HERMES_DESKTOP_RELEASE_SIGNING = previous
+    }
+  }
+})

--- a/apps/desktop/scripts/release-config.test.cjs
+++ b/apps/desktop/scripts/release-config.test.cjs
@@ -1,0 +1,43 @@
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const test = require('node:test')
+
+const configPath = path.resolve(__dirname, '..', 'electron-builder.release.cjs')
+const requiredEnvironment = {
+  AZURE_TRUSTED_SIGNING_ENDPOINT: 'https://example.codesigning.azure.net/',
+  AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: 'nous-signing',
+  AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: 'hermes-release',
+  WINDOWS_SIGNING_PUBLISHER_NAME: 'Nous Research'
+}
+
+test('release config enables mandatory Azure signing without changing local config', () => {
+  Object.assign(process.env, requiredEnvironment)
+  delete require.cache[configPath]
+  const config = require(configPath)
+
+  assert.equal(config.forceCodeSigning, true)
+  assert.equal(config.win.signAndEditExecutable, true)
+  assert.deepEqual(config.win.azureSignOptions, {
+    endpoint: requiredEnvironment.AZURE_TRUSTED_SIGNING_ENDPOINT,
+    codeSigningAccountName: requiredEnvironment.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME,
+    certificateProfileName: requiredEnvironment.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME,
+    publisherName: requiredEnvironment.WINDOWS_SIGNING_PUBLISHER_NAME,
+    fileDigest: 'SHA256',
+    timestampDigest: 'SHA256',
+    timestampRfc3161: 'http://timestamp.acs.microsoft.com'
+  })
+
+  const packageJson = require('../package.json')
+  assert.equal(packageJson.build.win.signAndEditExecutable, false)
+  assert.equal(packageJson.build.win.azureSignOptions, undefined)
+})
+
+test('release config rejects a missing signing variable', () => {
+  const previous = process.env.WINDOWS_SIGNING_PUBLISHER_NAME
+  delete process.env.WINDOWS_SIGNING_PUBLISHER_NAME
+  delete require.cache[configPath]
+
+  assert.throws(() => require(configPath), /requires WINDOWS_SIGNING_PUBLISHER_NAME/)
+
+  process.env.WINDOWS_SIGNING_PUBLISHER_NAME = previous
+})

--- a/apps/desktop/scripts/set-exe-identity.mjs
+++ b/apps/desktop/scripts/set-exe-identity.mjs
@@ -34,6 +34,10 @@
 // stampExeIdentity() resolves on success and rejects on failure; the caller
 // (after-pack.mjs) swallows the rejection so a stamp failure never fails an
 // otherwise-good build (worst case: stock icon, not a broken app).
+//
+// Official releases are the deliberate exception. The release-only builder
+// overlay enables signing on a controlled CI runner after this afterPack stamp
+// and makes any branding failure fatal.
 
 import { resolve, join } from 'node:path'
 import { existsSync } from 'node:fs'

--- a/apps/desktop/scripts/validate-release-tag.mjs
+++ b/apps/desktop/scripts/validate-release-tag.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { isMain } from './utils.mjs'
+
+export function expectedDesktopTag(version) {
+  return `desktop-v${version}`
+}
+
+export function validateDesktopReleaseTag(tag, version) {
+  const expected = expectedDesktopTag(version)
+  if (tag !== expected) {
+    throw new Error(`Desktop release tag must be ${expected}; received ${tag || '<empty>'}`)
+  }
+  return expected
+}
+
+if (isMain(import.meta.url)) {
+  const packageJson = JSON.parse(fs.readFileSync(path.resolve(import.meta.dirname, '..', 'package.json'), 'utf8'))
+
+  try {
+    const tag = process.argv[2] || process.env.GITHUB_REF_NAME || ''
+    console.log(`[release] validated ${validateDesktopReleaseTag(tag, packageJson.version)}`)
+  } catch (error) {
+    console.error(`[release] ${error.message}`)
+    process.exit(1)
+  }
+}

--- a/apps/desktop/scripts/validate-release-tag.test.mjs
+++ b/apps/desktop/scripts/validate-release-tag.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { expectedDesktopTag, validateDesktopReleaseTag } from './validate-release-tag.mjs'
+
+test('expectedDesktopTag uses the dedicated Desktop release namespace', () => {
+  assert.equal(expectedDesktopTag('0.17.0'), 'desktop-v0.17.0')
+})
+
+test('validateDesktopReleaseTag accepts only the package version tag', () => {
+  assert.equal(validateDesktopReleaseTag('desktop-v0.17.0', '0.17.0'), 'desktop-v0.17.0')
+  assert.throws(() => validateDesktopReleaseTag('v0.17.0', '0.17.0'), /must be desktop-v0\.17\.0/)
+  assert.throws(() => validateDesktopReleaseTag('desktop-v0.18.0', '0.17.0'), /must be desktop-v0\.17\.0/)
+})

--- a/apps/desktop/scripts/verify-windows-signatures.ps1
+++ b/apps/desktop/scripts/verify-windows-signatures.ps1
@@ -1,0 +1,73 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReleaseDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PublisherName
+)
+
+$ErrorActionPreference = 'Stop'
+$releaseRoot = (Resolve-Path -LiteralPath $ReleaseDirectory).Path
+$packagedExecutable = Join-Path $releaseRoot 'win-unpacked\Hermes.exe'
+$installers = @(
+    Get-ChildItem -LiteralPath $releaseRoot -File |
+        Where-Object { $_.Extension -in '.exe', '.msi' }
+)
+$targets = @($packagedExecutable) + @($installers.FullName)
+
+if (-not (Test-Path -LiteralPath $packagedExecutable -PathType Leaf)) {
+    throw "Packaged executable not found: $packagedExecutable"
+}
+if (-not ($installers.Extension -contains '.exe')) {
+    throw "Signed NSIS installer was not produced under $releaseRoot"
+}
+if (-not ($installers.Extension -contains '.msi')) {
+    throw "Signed MSI installer was not produced under $releaseRoot"
+}
+
+$signtool = Get-Command signtool.exe -ErrorAction SilentlyContinue
+if (-not $signtool) {
+    $kitsRoot = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits\10\bin'
+    $signtool = Get-ChildItem -LiteralPath $kitsRoot -Filter signtool.exe -Recurse |
+        Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+        Sort-Object FullName -Descending |
+        Select-Object -First 1
+}
+if (-not $signtool) {
+    throw 'signtool.exe was not found on the release runner'
+}
+$signtoolPath = if ($signtool.Source) {
+    $signtool.Source
+} else {
+    $signtool.FullName
+}
+
+foreach ($target in $targets) {
+    $signature = Get-AuthenticodeSignature -LiteralPath $target
+    if ($signature.Status -ne 'Valid') {
+        throw "Invalid Authenticode signature on $target ($($signature.Status))"
+    }
+
+    $actualPublisher = $signature.SignerCertificate.GetNameInfo(
+        [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName,
+        $false
+    )
+    if (-not [string]::Equals(
+        $actualPublisher,
+        $PublisherName,
+        [System.StringComparison]::Ordinal
+    )) {
+        throw "Unexpected publisher on $target. Expected '$PublisherName', found '$actualPublisher'"
+    }
+    if (-not $signature.TimeStamperCertificate) {
+        throw "Authenticode timestamp missing on $target"
+    }
+
+    & $signtoolPath verify /pa /all /v $target
+    if ($LASTEXITCODE -ne 0) {
+        throw "signtool verification failed for $target"
+    }
+}
+
+Write-Host "Verified $($targets.Count) signed Hermes artifact(s) for publisher '$PublisherName'."

--- a/docs/release/windows-desktop-signing.md
+++ b/docs/release/windows-desktop-signing.md
@@ -1,0 +1,43 @@
+# Windows Desktop Signing
+
+Official Windows Desktop releases use Azure Trusted Signing through the
+protected GitHub environment `desktop-release`. Ordinary local builds remain
+unsigned and keep `build.win.signAndEditExecutable` disabled.
+
+## Maintainer setup
+
+Create the `desktop-release` environment and require a Nous release maintainer
+to approve deployments. Configure these environment secrets:
+
+- `AZURE_TENANT_ID`
+- `AZURE_CLIENT_ID`
+- `AZURE_CLIENT_SECRET`
+
+Configure these environment variables:
+
+- `AZURE_TRUSTED_SIGNING_ENDPOINT`
+- `AZURE_TRUSTED_SIGNING_ACCOUNT_NAME`
+- `AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME`
+- `WINDOWS_SIGNING_PUBLISHER_NAME`
+
+`WINDOWS_SIGNING_PUBLISHER_NAME` must exactly match the certificate Common Name.
+Grant the Azure service principal the **Trusted Signing Certificate Profile
+Signer** role for the Nous Research signing profile.
+
+## Release
+
+1. Update `apps/desktop/package.json` to the intended version.
+2. Create and push the matching annotated tag: `desktop-v<version>`.
+3. Approve the `desktop-release` environment deployment.
+4. Confirm the workflow verifies Authenticode publisher, timestamp, and trust
+   chain before it uploads or publishes any artifact.
+
+The workflow publishes only after both `Get-AuthenticodeSignature` and
+`signtool verify /pa /all /v` pass for `win-unpacked\Hermes.exe`, the NSIS
+installer, and the MSI.
+
+If the controlled GitHub runner fails specifically while extracting
+`winCodeSign`, replace the release overlay with an Azure signing
+`afterPack`/artifact hook. Keep `forceCodeSigning`, the strict branding gate,
+and the same post-build signature verification; never weaken the workflow to
+publish unsigned artifacts.


### PR DESCRIPTION
## Summary
- add a release-only electron-builder overlay for Azure Trusted Signing
- keep ordinary local/Desktop updater builds unsigned with `signAndEditExecutable: false`
- make Windows branding fatal only for official releases, then sign the packaged executable, NSIS installer, and MSI
- verify exact publisher, Authenticode timestamp, and `signtool /pa /all /v` before any artifact upload or GitHub release
- gate releases on an exact annotated `desktop-v<package version>` tag and the protected `desktop-release` environment

## Security properties
- Azure credentials are scoped only to preflight and signing steps; `npm ci`, tests, verification, and publishing do not receive the client secret
- `forceCodeSigning: true` prevents unsigned release output
- no artifact is uploaded before signature verification passes
- default local packaging remains on the direct-rcedit path and does not enable winCodeSign extraction

## Verification
- 5 release configuration/tag/branding tests passed
- release workflow asserts the winCodeSign/symlink precondition on the runner before exposing signing secrets
- Desktop TypeScript typecheck passed
- workflow YAML and PowerShell verifier parse checks passed
- electron-builder accepted the release overlay in an unsigned schema/package smoke
- ordinary unsigned Windows NSIS packaging still succeeds
- staged diff contains no local machine paths

## Maintainer setup required before merge
Create a protected `desktop-release` environment with required reviewers, then configure:

Secrets: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`

Variables: `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT_NAME`, `AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME`, `WINDOWS_SIGNING_PUBLISHER_NAME`

The Azure service principal needs the `Trusted Signing Certificate Profile Signer` role. This PR must remain draft until a Nous maintainer supplies those values and validates one real signed artifact. See [electron-builder Azure signing](https://www.electron.build/docs/features/code-signing/code-signing-win/) and [GitHub deployment environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments).

If the controlled runner fails specifically on winCodeSign extraction, the documented fallback is an Azure post-pack/artifact signing hook with the same mandatory post-sign verification. It is not acceptable to weaken `forceCodeSigning` or publish unsigned artifacts.
