### PR TITLE
fix(gateway): stay alive on mixed retryable + non-retryable startup failures

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7981,7 +7981,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         if connected_count == 0:
-            if startup_nonretryable_errors:
+            if startup_nonretryable_errors and not startup_retryable_errors:
                 reason = "; ".join(startup_nonretryable_errors)
                 logger.error("Gateway hit a non-retryable startup conflict: %s", reason)
                 try:
@@ -7993,6 +7993,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._request_clean_exit(reason)
                 self._startup_restore_in_progress = False
                 return True
+            if startup_nonretryable_errors:
+                # Mixed failure mode (NS-609): some platforms are fatally
+                # misconfigured (e.g. WhatsApp enabled but never paired) while
+                # others hit merely transient errors (e.g. Telegram TimedOut
+                # during polling startup).  Exiting with
+                # GATEWAY_FATAL_CONFIG_EXIT_CODE here is wrong in both
+                # supervision worlds: under supervisors that honor the
+                # exit-78 contract (systemd RestartPreventExitStatus, s6
+                # finish→125 since #51228) the gateway goes PERMANENTLY down
+                # over a network blip; under anything else it crash-loops.
+                # Either way the retryable platforms never get their retry.
+                # Log the fatal side loudly, then fall through to the
+                # degraded/retry path below: the reconnect watcher recovers
+                # the retryable platforms; the non-retryable ones remain
+                # fatal-parked and visible in runtime status.
+                logger.error(
+                    "%d platform(s) fatally misconfigured and parked: %s. "
+                    "Staying alive so retryable platforms can recover.",
+                    len(startup_nonretryable_errors),
+                    "; ".join(startup_nonretryable_errors),
+                )
             if enabled_platform_count > 0:
                 if startup_retryable_errors:
                     # All enabled platforms hit retryable failures (network

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -513,6 +513,60 @@ async def test_runner_exits_with_ex_config_on_nonretryable_startup_error(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_runner_stays_alive_on_mixed_retryable_and_nonretryable_errors(
+    monkeypatch, tmp_path, caplog
+):
+    """Mixed startup failures — one platform fatally misconfigured, another
+    merely transiently failing — must NOT exit with EX_CONFIG (NS-609).
+
+    Real-world shape: WhatsApp enabled but never paired (non-retryable
+    ``whatsapp_not_paired``) while Telegram hits a startup TimedOut
+    (retryable). Exiting 78 here either takes the gateway permanently down
+    (supervisors honoring the exit-78 contract) or crash-loops it (anything
+    else) — and in both cases Telegram never gets its retry even though
+    nothing is wrong with its config. The gateway must stay alive in
+    degraded mode, park the fatal platform, and queue the retryable one."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    def _make_adapter(platform, platform_config):
+        if platform == Platform.DISCORD:
+            return _NonRetryableFailureAdapter()
+        return _RetryableFailureAdapter()
+
+    monkeypatch.setattr(runner, "_create_adapter", _make_adapter)
+
+    import logging
+    with caplog.at_level(logging.ERROR):
+        ok = await runner.start()
+
+    # Gateway stays alive — no clean-exit request, no EX_CONFIG.
+    assert ok is True
+    assert runner.should_exit_cleanly is False
+    assert runner.exit_code is None
+    state = read_runtime_status()
+    assert state["gateway_state"] in {"degraded", "running"}
+    # The retryable platform is queued for reconnection…
+    assert Platform.TELEGRAM in runner._failed_platforms
+    assert state["platforms"]["telegram"]["state"] == "retrying"
+    # …while the misconfigured one is parked as fatal, not retried.
+    assert Platform.DISCORD not in runner._failed_platforms
+    assert state["platforms"]["discord"]["state"] == "fatal"
+    # The fatal side is still surfaced loudly for the operator.
+    assert any(
+        "fatally misconfigured" in record.message
+        for record in caplog.records
+    ), "Expected an error log calling out the parked platform(s)"
+
+
+@pytest.mark.asyncio
 async def test_start_gateway_propagates_fatal_config_exit_code(monkeypatch, tmp_path):
     """A clean exit carrying GATEWAY_FATAL_CONFIG_EXIT_CODE must surface as a
     process-level SystemExit(78) — NOT a truthy return — so main() exits 78


### PR DESCRIPTION
## What does this PR do?

Fixes a hosted-gateway crash-loop / permanent-down edge in gateway startup: when `connected_count == 0` and at least one platform failed **non-retryably**, the runner exited with `GATEWAY_FATAL_CONFIG_EXIT_CODE` (78) even when *other* platforms failed for merely **retryable** reasons.

Real-world shape (Linear NS-609, hosted Fly instance): WhatsApp enabled but never paired (non-retryable `whatsapp_not_paired`) + Telegram `TimedOut` during polling startup (retryable) → exit 78. Depending on the supervisor this either crash-loops the gateway or takes it permanently down (s6 `finish` → 125 from #51228, systemd `RestartPreventExitStatus=78`). Either way Telegram never gets its retry and the dashboard drops with every exit — a single unpaired platform plus one network blip disconnected every channel on the instance.

After this change, exit 78 is reserved for the case where **all** startup failures are non-retryable (true config error, nothing to wait for). With mixed failures the gateway stays alive in `degraded` state: the reconnect watcher recovers the retryable platforms, and the misconfigured ones stay fatal-parked and visible in runtime status (`gateway_state.json`).

## Related Issue

Linear NS-609 (hosted gateway disconnects after enabling WhatsApp alongside Telegram). Diagnosed on a live hosted instance: repeated `asyncio.run.SystemExit code=78` in `gateway-exit-diag.log` correlating with Telegram startup timeouts while WhatsApp sat unpaired.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- `gateway/run.py`: the `connected_count == 0` exit-78 branch now requires `startup_nonretryable_errors and not startup_retryable_errors`. A new mixed-failure branch logs the fatally-parked platforms loudly and falls through to the existing degraded/retry path (reconnect watcher takes over).
- `tests/gateway/test_runner_startup_failures.py`: new regression test `test_runner_stays_alive_on_mixed_retryable_and_nonretryable_errors` — one fatal platform + one retryable platform must leave the gateway alive (`should_exit_cleanly is False`, `exit_code is None`), queue the retryable platform, park the fatal one, and log the parked platform(s).

## How to Test

1. `pytest tests/gateway/test_runner_startup_failures.py -q` → 13 passed (includes the new mixed-failure regression test).
2. `pytest tests/gateway/test_whatsapp_connect.py -q` → 29 passed (fatal-park path unchanged).
3. Manual repro: enable WhatsApp without pairing (no `creds.json`) alongside a Telegram token that hits a transient startup failure → gateway must stay up in `degraded`, Telegram reconnects when the network recovers, WhatsApp shows `fatal` / `whatsapp_not_paired` in runtime status.

Behavior matrix after the fix:

| Startup failures | Before | After |
|---|---|---|
| all non-retryable | exit 78 | exit 78 (unchanged) |
| all retryable | degraded, retry | degraded, retry (unchanged) |
| mixed | **exit 78** | **degraded; retryables retried, fatals parked** |

## Checklist

### Code
- [x] I have read the contributing guidelines
- [x] Commit messages follow conventional commits
- [x] This is not a duplicate of an existing PR
- [x] Tests pass locally
- [x] Tested on macOS (gateway test suite)

### Documentation & Housekeeping
- [x] N/A — no user-facing docs affected (behavioral bug fix; comments in code explain the contract)
- [x] N/A — no config example changes
- [x] Cross-platform: pure Python control-flow change, no platform-specific code

## Screenshots / Logs

Diagnostic signature from the affected hosted instance (`profiles/<p>/logs/gateway-exit-diag.log`):

```
{"tag":"asyncio.run.SystemExit","code":78}   # repeated, seconds apart, s6 restarting each time
```

with `gateway.log` showing `✗ whatsapp failed to connect` (`whatsapp_not_paired`) and Telegram `TimedOut` / polling-degraded warnings in the same startup windows.
