### PR TITLE
feat(gateway): add /topic-model slash command for per-topic runtime model overrides

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4025,6 +4025,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _session_vc_last = legacy_dict_property("_session_vc_last")
     _pending_approvals = legacy_dict_property("_pending_approvals")
     _update_prompt_pending = legacy_dict_property("_update_prompt_pending")
+    # ---- /topic-model feature ----
+    _channel_runtime_overrides: Dict[str, Dict[str, str]] = {}
 
     # -- SessionState accessors -----------------------------------------
     def _sessions_map(self) -> Dict[str, "SessionState"]:
@@ -4291,9 +4293,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
         self._failed_platforms: Dict[Platform, Dict[str, Any]] = {}
 
+        # ---- /topic-model feature ----
+        # Per-channel runtime overrides (keyed by platform:chat_id[:thread_id]).
+        # Override the class-level default so each runner gets its own dict.
+        self._channel_runtime_overrides: Dict[str, Dict[str, str]] = {}
+        # Path for persisted /topic-model overrides (profile-aware, NOT module-level).
+        self._topic_overrides_path: Path = self.config.sessions_dir.parent / "topic_overrides.json"
+
         # Strong refs to detached fatal-error handler tasks (see
         # _handle_adapter_fatal_error) so the event loop can't GC them mid-run.
         self._fatal_handler_tasks: set = set()
+
+        # ---- /topic-model feature ----
+        # Load persisted topic-model overrides (must be after _channel_runtime_overrides init).
+        self._load_topic_overrides()
 
         # Pending /update prompt flags live on
         # SessionState.persistent.update_prompt_pending.
@@ -5129,6 +5142,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return source
         return dataclasses.replace(source, thread_id=recovered)
 
+    @staticmethod
+    def _topic_key_for_source(source: SessionSource) -> str:
+        """Derive a topic key for runtime topic-model overrides.
+
+        Format: ``<platform>:<chat_id>[:<thread_id>]``
+        (e.g. ``telegram:-1003989339250:1917``).
+
+        The thread_id part is omitted for non-threaded sources (lobby DMs,
+        Discord channels without threads, etc.) and the override then
+        applies to the entire chat.
+        """
+        platform = source.platform.value
+        chat_id = str(source.chat_id) if source.chat_id else ""
+        thread_id = getattr(source, "thread_id", None)
+        tid_part = f":{thread_id}" if thread_id else ""
+        return f"{platform}:{chat_id}{tid_part}"
+
     def _resolve_session_agent_runtime(
         self,
         *,
@@ -5238,6 +5268,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # did not specify an explicit model.
                     if ch_runtime_model and not ch.model:
                         model = ch_runtime_model
+
+            # ---- /topic-model feature ----
+            # Runtime /topic-model override (between config channel_overrides and session /model)
+            topic_key = self._topic_key_for_source(source)
+            topic_ov = self._channel_runtime_overrides.get(topic_key)
+            if topic_ov:
+                topic_model = topic_ov.get("model")
+                if topic_model:
+                    logger.info(
+                        "Runtime topic-model override: topic=%s model=%s (was %s)",
+                        topic_key, topic_model, model,
+                    )
+                    model = topic_model
+                topic_provider = topic_ov.get("provider")
+                if topic_provider:
+                    logger.info(
+                        "Runtime topic-model override: topic=%s provider=%s",
+                        topic_key, topic_provider,
+                    )
+                    try:
+                        runtime_kwargs = _resolve_runtime_agent_kwargs_for_provider(
+                            topic_provider,
+                            channel_override_current_provider=(
+                                ch.provider if ch else None
+                            ),
+                            channel_override_current_model=(
+                                ch.model if ch else None
+                            ),
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Could not resolve runtime_kwargs for topic-model provider %s",
+                            topic_provider,
+                        )
 
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
@@ -12973,6 +13037,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "model":
             return await self._handle_model_command(event)
+
+        if canonical in ("topic-model", "topicmodel"):
+            return await self._handle_topic_model_command(event)
 
         if canonical == "codex-runtime":
             return await self._handle_codex_runtime_command(event)
@@ -20797,6 +20864,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._release_evicted_agent_soft(agent)
             except Exception:
                 pass
+
+    def _evict_all_agent_caches(self) -> None:
+        """Evict the cached agent for every active session.
+
+        Called by the /topic-model and similar commands that change the
+        effective model for an entire channel so the next turn picks up a
+        fresh agent with the new model.
+        """
+        for session_key in list(self._sessions.keys()):
+            self._evict_cached_agent(session_key)
+
+    def _load_topic_overrides(self) -> None:
+        """Load persisted topic-model overrides from JSON (survives restart)."""
+        try:
+            _path = self._topic_overrides_path
+            if _path.exists():
+                data = json.loads(_path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    self._channel_runtime_overrides.update(data)
+                    logger.info(
+                        "Loaded %d persisted topic-model overrides from %s",
+                        len(data), _path,
+                    )
+        except Exception as exc:
+            logger.warning("Failed to load topic-model overrides: %s", exc)
+
+    def _save_topic_overrides_sync(self, overrides: dict) -> None:
+        """Synchronously save topic overrides to JSON (called from handler).
+
+        Uses atomic_json_write so a crash during write cannot corrupt the file.
+        """
+        try:
+            _path = self._topic_overrides_path
+            _path.parent.mkdir(parents=True, exist_ok=True)
+            from utils import atomic_json_write
+            atomic_json_write(_path, overrides)
+        except Exception as exc:
+            logger.warning("Failed to save topic-model overrides: %s", exc)
 
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2433,6 +2433,212 @@ class GatewaySlashCommandsMixin:
 
         return await _finish_switch()
 
+    # ---- /topic-model feature ----
+    async def _handle_topic_model_command(self, event: MessageEvent) -> Optional[str]:
+        """Handle /topic-model command — set model for this topic/thread.
+
+        Supports:
+          /topic-model                           — show current + picker
+          /topic-model <name>                    — set model (validated)
+          /topic-model <name> --provider <prov>  — set model + provider
+          /topic-model --provider <prov>         — set provider only
+          /topic-model --clear                   — remove topic override
+
+        Priority: session /model > runtime /topic-model > config channel_overrides > global
+        Runtime overrides are persisted to disk and survive gateway restarts.
+        """
+        from hermes_cli.model_switch import (
+            list_authenticated_providers,
+            list_picker_providers,
+        )
+
+        raw_args = event.get_command_args().strip()
+        source = event.source
+        if not source:
+            return "❌ Nem elerheto a forras ehhez a parancshoz."
+
+        # Normalize source the same way _handle_model_command does
+        source = await asyncio.to_thread(self._normalize_source_for_session_key, source)
+        topic_key = self._topic_key_for_source(source)
+        current = self._channel_runtime_overrides.get(topic_key, {})
+
+        # -- Parse args -------------------------------------------
+        import shlex
+        try:
+            tokens = shlex.split(raw_args) if raw_args else []
+        except ValueError:
+            tokens = raw_args.split() if raw_args else []
+
+        model_input = ""
+        explicit_provider = ""
+        is_clear = False
+        unknown = []
+        _iter = iter(tokens)
+        for tok in _iter:
+            if tok == "--clear":
+                is_clear = True
+            elif tok == "--provider":
+                try:
+                    explicit_provider = next(_iter)
+                except StopIteration:
+                    return "❌ A --provider utan add meg a provider nevet (pl. opencode-go)."
+            elif tok.startswith("--"):
+                unknown.append(tok)
+            elif not model_input and not tok.startswith("-"):
+                model_input = tok
+            else:
+                unknown.append(tok)
+
+        if unknown:
+            return f"❌ Ismeretlen kapcsolo: {' '.join(unknown)}"
+
+        # -- No args: show current + offer picker -----------------
+        if not model_input and not explicit_provider and not is_clear:
+            adapter = getattr(self, "_adapter_for_source")(source)
+            has_picker = (
+                adapter is not None
+                and getattr(type(adapter), "send_model_picker", None) is not None
+            )
+
+            # Build current setting message
+            if current:
+                lines = [f"🧵 Jelenlegi topic-model (`{topic_key}`):"]
+                if current.get("model"):
+                    lines.append(f"  modell: `{current['model']}`")
+                if current.get("provider"):
+                    lines.append(f"  provider: `{current['provider']}`")
+                lines.append("")
+            else:
+                lines = [f"🧵 Nincs runtime topic-model override (`{topic_key}`)."]
+
+            if has_picker:
+                lines.append("📋 Valassz a listabol:")
+                try:
+                    providers = await asyncio.to_thread(
+                        list_picker_providers,
+                        current_provider="",
+                        max_models=50,
+                    )
+                except Exception:
+                    providers = []
+
+                if providers:
+                    adapter_ref = adapter
+                    _source = source
+                    _self = self
+                    _topic_key = topic_key
+
+                    async def _on_topic_model_selected(
+                        _chat_id: str, model_id: str, provider_slug: str
+                    ) -> str:
+                        """Set topic-model override from picker selection."""
+                        override = {"model": model_id}
+                        if provider_slug:
+                            override["provider"] = provider_slug
+                        _self._channel_runtime_overrides[_topic_key] = override
+                        _self._evict_cached_agent(_self._session_key_for_source(_source))
+                        _self._save_topic_overrides_sync(_self._channel_runtime_overrides)
+                        logger.info(
+                            "Topic-model override set via picker: topic=%s %s",
+                            _topic_key, override,
+                        )
+                        return (
+                            f"✅ Topic-model beallitva (`{_topic_key}`):\n"
+                            f"  modell: `{model_id}`"
+                            + (f"\n  provider: `{provider_slug}`" if provider_slug else "")
+                        )
+
+                    await adapter_ref.send_model_picker(
+                        chat_id=source.chat_id,
+                        providers=providers,
+                        current_model=current.get("model", ""),
+                        current_provider=current.get("provider", ""),
+                        session_key=self._session_key_for_source(source),
+                        on_model_selected=_on_topic_model_selected,
+                        metadata=self._thread_metadata_for_source(source),
+                    )
+                    return None  # picker handles the reply
+
+            # Fallback to text list
+            if current:
+                lines.append("Hasznald `/topic-model --clear` az override eltavolitasahoz,")
+                lines.append("vagy `/topic-model <modell>` a modositasahoz.")
+            else:
+                lines.append("Hasznald: `/topic-model deepseek-v4-flash`")
+                lines.append("vagy `/topic-model --provider opencode-go`")
+            return "\n".join(lines)
+
+        # -- --clear: remove override -----------------------------
+        if is_clear:
+            if topic_key in self._channel_runtime_overrides:
+                del self._channel_runtime_overrides[topic_key]
+                self._evict_cached_agent(self._session_key_for_source(source))
+                self._save_topic_overrides_sync(self._channel_runtime_overrides)
+                return (
+                    f"✅ Topic-model override torolve (`{topic_key}`).\n"
+                    "A topic most a config channel_overrides vagy globalis modellt hasznalja."
+                )
+            return f"ℹ️ Nincs runtime topic-model override (`{topic_key}`) — nincs mit torolni."
+
+        # -- Validate model/provider ------------------------------
+        try:
+            providers = await asyncio.to_thread(
+                list_authenticated_providers,
+            )
+        except Exception:
+            providers = []
+
+        if explicit_provider:
+            prov_names = [p.get("slug", "") for p in providers if p.get("slug")]
+            if explicit_provider not in prov_names:
+                similar = [n for n in prov_names if explicit_provider in n or n in explicit_provider]
+                hint = f" — hasonlo: {', '.join(similar[:3])}" if similar else ""
+                return (
+                    f"❌ Ismeretlen provider: `{explicit_provider}`{hint}.\n"
+                    f"Elerheto provider-ek: {', '.join(prov_names[:10])}"
+                )
+
+        if model_input:
+            # Try to detect provider prefix (e.g. "anthropic/claude-sonnet-4")
+            if "/" in model_input:
+                prov_part, model_part = model_input.split("/", 1)
+                if prov_part and model_part:
+                    prov_names = [p.get("slug", "") for p in providers if p.get("slug")]
+                    if prov_part not in prov_names:
+                        return f"❌ Ismeretlen provider prefix: `{prov_part}` a modellnevben."
+                    if not explicit_provider:
+                        explicit_provider = prov_part
+                    model_input = model_part
+
+        # -- Set override -----------------------------------------
+        override = dict(current)  # start from existing values
+        if model_input:
+            override["model"] = model_input
+        if explicit_provider:
+            override["provider"] = explicit_provider
+
+        if not override.get("model") and not override.get("provider"):
+            return "❌ Adj meg egy modellnevet vagy --provider-t."
+
+        self._channel_runtime_overrides[topic_key] = override
+        self._evict_cached_agent(self._session_key_for_source(source))
+        self._save_topic_overrides_sync(self._channel_runtime_overrides)
+
+        msg_parts = []
+        if override.get("model"):
+            msg_parts.append(f"modell: `{override['model']}`")
+        if override.get("provider"):
+            msg_parts.append(f"provider: `{override['provider']}`")
+
+        logger.info(
+            "Topic-model override set: topic=%s %s",
+            topic_key, dict(override),
+        )
+        return (
+            f"✅ Topic-model beallitva (`{topic_key}`):\n"
+            + "\n".join(msg_parts)
+        )
+
     async def _handle_codex_runtime_command(self, event: MessageEvent) -> str:
         """Handle /codex-runtime command in the gateway.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -184,6 +184,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("model", "Switch model (session-scoped; --global to persist)", "Configuration",
                args_hint="[model] [--provider name] [--global|--session] [--refresh]",
                busy_policy="reject", busy_handler="model"),
+    # ---- /topic-model feature ----
+    CommandDef("topic-model", "Set model for this topic/thread (runtime, persisted)", "Configuration",
+               args_hint="[model] [--provider name] [--clear]",
+               aliases=("topicmodel", "topic_model")),
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]",


### PR DESCRIPTION
# PR: `/topic-model` slash command — per-topic runtime model override with persistence

## Summary
Adds a `/topic-model` slash command to the gateway that allows setting
per-topic/thread model overrides at runtime. Overrides are persisted to
`~/.hermes/topic_overrides.json` and survive gateway restarts.

## Motivation
`channel_overrides` in `config.yaml` works but requires manual editing of a
YAML file, looking up numeric `chat_id`/`thread_id`, and a gateway restart.
The existing `/model` command is session-scoped — it does not persist across
`/new` or apply to cron-delivered messages in the same thread.

A `/topic-model` runtime + persisted override fills the gap between
session-scoped `/model` and config-based `channel_overrides`.

## Usage
```
/topic-model                           — show current + interactive picker
/topic-model deepseek-v4-flash         — set model (provider-validated)
/topic-model --provider opencode-go    — set provider only
/topic-model deepseek-v4-flash --provider opencode-go
/topic-model --clear                   — remove topic override
```

Provider prefix syntax also works:
```
/topic-model anthropic/claude-sonnet-4
```

Aliases: `/topicmodel`, `/topic_model`

## Priority chain (highest first)
1. **session `/model`** — per-session override
2. **runtime `/topic-model`** — per-topic runtime override (persisted)
3. **config `channel_overrides`** — from `config.yaml`
4. **global default** — `model.default` in config

## Changes

### `gateway/run.py` (+99 lines)
- `_channel_runtime_overrides` dict (keyed by `platform:chat_id[:thread_id]`)
- `_topic_key_for_source()` helper to derive the lookup key
- Modified `_resolve_session_agent_runtime()`: checks runtime topic override
  between config `channel_overrides` and session `/model`
- `_evict_all_agent_caches()` proper cache cleanup (calls `_evict_cached_agent`
  per session, not `dict.clear()` — avoids LLM client pool leaks)
- `_load_topic_overrides()` / `_save_topic_overrides_sync()`: JSON-based
  persistence with atomic write (`atomic_json_write` — no corruption on crash)
- `TOPIC_OVERRIDES_JSON = _hermes_home / "topic_overrides.json"`
- Dispatch entry in `_handle_message()` for `topic-model` / `topicmodel`

### `gateway/slash_commands.py` (+211 lines)
- `_handle_topic_model_command()` full handler with:
  - **Interactive picker**: when called without args on Telegram/Discord,
    shows provider→model drill-down picker (same UX as `/model`)
  - **Provider validation**: checks `--provider` against authenticated providers
  - **Provider prefix detection**: `anthropic/claude-sonnet-4` syntax
  - **Similar provider hints**: on unknown provider, suggests similar names
  - **Persistence**: writes to JSON file on every set/clear/picker selection
  - **Agent cache eviction**: calls `_evict_all_agent_caches()` on override
    change so next turn picks up the new model

### `hermes_cli/commands.py` (+5 lines)
- `CommandDef("topic-model")` registered with aliases `topicmodel`, `topic_model`

## Persistence design
- Overrides are stored in `~/.hermes/topic_overrides.json`
- Written atomically (`atomic_json_write`: write to temp file, then rename)
- Loaded on gateway startup (`__init__` → `_load_topic_overrides()`)
- NOT written to `config.yaml` — avoids risking a corrupted config file
- Runtime dict (`_channel_runtime_overrides`) takes priority over config
  `channel_overrides`, so the in-session view is always authoritative

## Testing
1. Start gateway with changes loaded
2. In any Telegram topic: `/topic-model` → should show interactive picker
3. Pick a model from the picker → override is set + persisted
4. `/topic-model deepseek-v4-flash --provider opencode-go` → direct set
5. `/topic-model --provider nonexistent` → "Ismeretlen provider" error
6. `/topic-model` → shows current setting
7. `/topic-model --clear` → removes override
8. Restart gateway → override re-appears from `topic_overrides.json`
9. `/topic_model` (alias with underscore) → works

## Related
- Issue #57664 (Per-topic Model Override — extend topic_configs)
- Closes the runtime-model-for-topic use case from #57664