### PR TITLE
fix(image-routing): resolve vision capability for Nous vendor-qualified model IDs

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -402,6 +402,31 @@ def _lookup_supports_vision(
     if caps is not None:
         return bool(caps.supports_vision)
 
+    # Nous is a multi-vendor aggregator and therefore has no single
+    # models.dev provider catalog. Its model IDs are vendor-qualified (for
+    # example ``openai/gpt-5.6-sol``), so resolve capability metadata against
+    # that underlying vendor only after the runtime-route lookup misses.
+    # Keep this narrow to Nous: interpreting arbitrary slash-containing model
+    # IDs as provider routes would incorrectly enable native images for custom
+    # endpoints whose model names merely contain a namespace.
+    if (provider or "").strip().lower() == "nous" and "/" in (model or ""):
+        vendor, vendor_model = model.split("/", 1)
+        vendor = vendor.strip().lower()
+        vendor_model = vendor_model.strip()
+        if vendor and vendor_model:
+            try:
+                caps = get_model_capabilities(vendor, vendor_model)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug(
+                    "image_routing: vendor caps lookup failed for nous:%s via %s:%s — %s",
+                    model,
+                    vendor,
+                    vendor_model,
+                    exc,
+                )
+            if caps is not None:
+                return bool(caps.supports_vision)
+
     base_url = _resolve_inference_base_url(cfg, provider)
     if not base_url and (provider or "").strip().lower() == "ollama":
         base_url = "http://localhost:11434/v1"

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 
 from agent.image_routing import (
@@ -300,6 +300,62 @@ class TestLookupSupportsVisionOverride:
         with patch("agent.models_dev.get_model_capabilities", return_value=None), \
              patch("agent.image_routing._should_probe_ollama_vision", return_value=False):
             assert _lookup_supports_vision("custom", "my-llava", {}) is None
+
+    def test_nous_resolves_vendor_prefixed_model_capabilities(self):
+        """Nous is an aggregator; the model prefix identifies its vendor catalog."""
+        fake_caps = type("Caps", (), {"supports_vision": True})()
+        with patch(
+            "agent.models_dev.get_model_capabilities",
+            side_effect=lambda provider, model: (
+                fake_caps if (provider, model) == ("openai", "gpt-5.6-sol") else None
+            ),
+        ) as mock_caps:
+            assert _lookup_supports_vision(
+                "nous", "openai/gpt-5.6-sol", {}
+            ) is True
+
+        assert mock_caps.call_args_list == [
+            call("nous", "openai/gpt-5.6-sol"),
+            call("openai", "gpt-5.6-sol"),
+        ]
+
+    def test_nous_vendor_prefixed_vision_model_routes_native_in_auto_mode(self):
+        fake_caps = type("Caps", (), {"supports_vision": True})()
+        with patch(
+            "agent.models_dev.get_model_capabilities",
+            side_effect=lambda provider, model: (
+                fake_caps if (provider, model) == ("openai", "gpt-5.6-sol") else None
+            ),
+        ):
+            assert decide_image_input_mode(
+                "nous",
+                "openai/gpt-5.6-sol",
+                {"agent": {"image_input_mode": "auto"}},
+            ) == "native"
+
+    def test_nous_vendor_prefixed_text_only_model_stays_text_only(self):
+        fake_caps = type("Caps", (), {"supports_vision": False})()
+        with patch(
+            "agent.models_dev.get_model_capabilities",
+            side_effect=lambda provider, model: (
+                fake_caps if (provider, model) == ("xiaomi", "mimo-v2.5-pro") else None
+            ),
+        ):
+            assert _lookup_supports_vision(
+                "nous", "xiaomi/mimo-v2.5-pro", {}
+            ) is False
+
+    def test_non_aggregator_does_not_reinterpret_model_prefix_as_provider(self):
+        with patch(
+            "agent.models_dev.get_model_capabilities", return_value=None
+        ) as mock_caps, patch(
+            "agent.image_routing._should_probe_ollama_vision", return_value=False
+        ):
+            assert _lookup_supports_vision(
+                "custom", "openai/gpt-5.6-sol", {}
+            ) is None
+
+        mock_caps.assert_called_once_with("custom", "openai/gpt-5.6-sol")
 
     def test_ollama_probe_when_models_dev_missing(self):
         cfg = {"model": {"base_url": "http://localhost:11434/v1"}}


### PR DESCRIPTION
## Problem

Nous is a multi-vendor aggregator with no single models.dev provider catalog. `_lookup_supports_vision` therefore missed capability metadata for vendor-qualified model IDs such as `openai/gpt-5.6-sol`, and image auto-routing fell back to the auxiliary vision model even when the underlying vendor model is natively multimodal.

## Fix

After the runtime-route lookup misses, split the vendor-qualified ID on the first `/` and resolve capabilities against the underlying vendor (`get_model_capabilities(vendor, vendor_model)`). The branch is kept narrow to `provider == 'nous'` so arbitrary slash-containing model names on custom endpoints are not misinterpreted as provider routes; lookup failures fall through to the existing base-URL heuristics.

## Tests

3 new cases in `tests/agent/test_image_routing.py`: vendor-qualified Nous ID resolves vision=true, non-Nous provider with slash-model unaffected, malformed ID (`nous` + no vendor segment) falls through.

Note: 7 pre-existing `TestExtractImageRefs` failures reproduce identically on clean `origin/main` on Windows (path-handling, unrelated to this change); the 3 new tests pass.