### PR TITLE
fix(vision): preserve CLI named custom provider identity

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -86,6 +86,15 @@ class CLIAgentSetupMixin:
         api_key = runtime.get("api_key")
         base_url = runtime.get("base_url")
         resolved_provider = runtime.get("provider", "openrouter")
+        requested_provider = str(runtime.get("requested_provider") or "").strip().lower()
+        # Named custom runtimes use the canonical "custom" transport, but the
+        # namespaced identity is still needed for per-provider model metadata.
+        # Keep it on the live agent just as an in-session /model switch does.
+        effective_provider = (
+            requested_provider
+            if resolved_provider == "custom" and requested_provider.startswith("custom:")
+            else resolved_provider
+        )
         resolved_api_mode = runtime.get("api_mode", self.api_mode)
         resolved_acp_command = runtime.get("command")
         resolved_acp_args = list(runtime.get("args") or [])
@@ -121,12 +130,12 @@ class CLIAgentSetupMixin:
 
         credentials_changed = api_key != self.api_key or base_url != self.base_url
         routing_changed = (
-            resolved_provider != self.provider
+            effective_provider != self.provider
             or resolved_api_mode != self.api_mode
             or resolved_acp_command != self.acp_command
             or resolved_acp_args != self.acp_args
         )
-        self.provider = resolved_provider
+        self.provider = effective_provider
         self.api_mode = resolved_api_mode
         self.acp_command = resolved_acp_command
         self.acp_args = resolved_acp_args

--- a/tests/hermes_cli/test_cli_custom_provider_vision.py
+++ b/tests/hermes_cli/test_cli_custom_provider_vision.py
@@ -1,0 +1,165 @@
+"""CLI regression coverage for named custom-provider native vision."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+MODEL = "qwen3.8-max-preview"
+PROVIDER = "custom:qwen-token-plan"
+
+
+class _RuntimeCLI(CLIAgentSetupMixin):
+    def __init__(self, *, model: str, provider: str):
+        self.model = model
+        self.requested_provider = provider
+        self.provider = provider
+        self.api_key = None
+        self.base_url = None
+        self.api_mode = "chat_completions"
+        self.acp_command = None
+        self.acp_args = []
+        self.agent = None
+        self._fallback_model = []
+        self._explicit_api_key = None
+        self._explicit_base_url = None
+
+    def _normalize_model_for_provider(self, _provider: str) -> bool:
+        return False
+
+
+def _write_profile_config(hermes_home) -> None:
+    (hermes_home / "config.yaml").write_text(
+        """
+model:
+  default: ollama-cloud/glm-5.2
+  provider: ollama-cloud
+providers:
+  qwen-token-plan:
+    base_url: https://qwen-token-plan.example/v1
+    api_key: test-key
+    models:
+      qwen3.8-max-preview:
+        supports_vision: true
+agent:
+  image_input_mode: auto
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _resolve_cli_route():
+    from hermes_cli._parser import build_top_level_parser
+    from hermes_constants import get_hermes_home
+
+    _write_profile_config(get_hermes_home())
+    parser, _subparsers, _chat = build_top_level_parser()
+    args, _unknown = parser.parse_known_args(
+        ["-m", MODEL, "--provider", PROVIDER, "chat"]
+    )
+    cli = _RuntimeCLI(model=args.model, provider=args.provider)
+    assert cli._ensure_runtime_credentials() is True
+    return cli, cli._resolve_turn_agent_config("inspect the image")
+
+
+def test_cli_named_custom_provider_routes_declared_model_natively():
+    from agent.image_routing import decide_image_input_mode
+    from hermes_cli.config import load_config
+
+    cli, route = _resolve_cli_route()
+
+    assert cli.provider == PROVIDER
+    assert route["runtime"]["provider"] == PROVIDER
+    assert decide_image_input_mode(cli.provider, cli.model, load_config()) == "native"
+
+    sentinel_agent = SimpleNamespace()
+    cli.agent = sentinel_agent
+    assert cli._ensure_runtime_credentials() is True
+    assert cli.agent is sentinel_agent
+
+
+@pytest.mark.parametrize(
+    ("resolved_provider", "requested_provider", "expected_provider"),
+    [
+        ("custom", "custom:qwen-token-plan", "custom:qwen-token-plan"),
+        ("custom", "custom", "custom"),
+        ("custom", "", "custom"),
+        ("openrouter", "custom:qwen-token-plan", "openrouter"),
+    ],
+)
+def test_runtime_identity_only_preserves_namespaced_custom_provider(
+    monkeypatch,
+    resolved_provider,
+    requested_provider,
+    expected_provider,
+):
+    runtime = {
+        "provider": resolved_provider,
+        "requested_provider": requested_provider,
+        "api_key": "test-key",
+        "base_url": "https://provider.example/v1",
+        "api_mode": "chat_completions",
+    }
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: runtime,
+    )
+    cli = _RuntimeCLI(model=MODEL, provider="custom")
+    cli.api_key = runtime["api_key"]
+    cli.base_url = runtime["base_url"]
+
+    assert cli._ensure_runtime_credentials() is True
+    assert cli.provider == expected_provider
+
+
+def test_namespaced_identity_change_rebuilds_existing_agent(monkeypatch):
+    runtime = {
+        "provider": "custom",
+        "requested_provider": PROVIDER,
+        "api_key": "test-key",
+        "base_url": "https://qwen-token-plan.example/v1",
+        "api_mode": "chat_completions",
+    }
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: runtime,
+    )
+    cli = _RuntimeCLI(model=MODEL, provider="custom")
+    cli.api_key = runtime["api_key"]
+    cli.base_url = runtime["base_url"]
+    cli.agent = SimpleNamespace()
+
+    assert cli._ensure_runtime_credentials() is True
+    assert cli.provider == PROVIDER
+    assert cli.agent is None
+
+
+def test_cli_named_custom_provider_reaches_agent_and_tool_vision_gates():
+    from agent.auxiliary_client import reset_runtime_main, set_runtime_main
+    from run_agent import AIAgent
+    from tools.vision_tools import _should_use_native_vision_fast_path
+
+    cli, route = _resolve_cli_route()
+    runtime = route["runtime"]
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = runtime["provider"]
+    agent.model = route["model"]
+    assert agent._model_supports_vision() is True
+
+    token = set_runtime_main(
+        runtime["provider"],
+        route["model"],
+        base_url=runtime["base_url"],
+        api_key=runtime["api_key"],
+        api_mode=runtime["api_mode"],
+    )
+    try:
+        assert _should_use_native_vision_fast_path() is True
+    finally:
+        reset_runtime_main(token)


### PR DESCRIPTION
## What does this PR do?

Fixes native image routing when a named custom provider is selected at CLI startup with `-m` and `--provider custom:<name>` while the profile has a different configured default provider.

Runtime resolution keeps two provider values:

- `provider: custom` for the canonical custom transport
- `requested_provider: custom:qwen-token-plan` for the routable configuration identity

`CLIAgentSetupMixin._ensure_runtime_credentials` previously assigned the first value to `self.provider`. Image routing then looked for per-model capability metadata under bare `providers.custom`, missed `providers.qwen-token-plan.models.<model>.supports_vision`, and selected the text or auxiliary vision path.

This change keeps the namespaced requested identity on the live CLI when the resolved transport is `custom`. Credentials, base URL, API mode, and transport resolution stay unchanged. The same identity now reaches interactive and one-shot image routing, `AIAgent._model_supports_vision`, and the `vision_analyze` native fast path.

This is the initial CLI resolution path left after #69814. That change handles a routing call that already receives `custom:<name>`. The real startup resolver returns bare `custom` plus the separate requested identity.

## Related Issue

Fixes #69894

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/cli_agent_setup_mixin.py`: retain `requested_provider` when it is a namespaced custom provider and the resolved transport is `custom`. Use the retained identity for route-change detection and live agent state.
- `tests/hermes_cli/test_cli_custom_provider_vision.py`: parse the reporter's command-line model and provider flags with a different configured default, run the real provider resolver, and verify native routing through the CLI, AIAgent, and vision tool gates.
- Add guard coverage for bare custom, missing requested identity, non-custom transports, repeated credential refresh, and agent rebuild when the provider identity changes.

## How to Test

1. Reproduce on `main` with the profile config from #69894:

```shell
hermes -p sven chat -m qwen3.8-max-preview --provider custom:qwen-token-plan
```

Before this change:

```text
cli.provider = custom
image input mode = text
AIAgent._model_supports_vision() = False
```

With this change:

```text
cli.provider = custom:qwen-token-plan
image input mode = native
AIAgent._model_supports_vision() = True
vision tool native fast path = True
```

2. Run the exact CLI and vision regression:

```shell
scripts/run_tests.sh tests/hermes_cli/test_cli_custom_provider_vision.py -q
```

Result: 7 passed.

3. Run related image routing coverage:

```shell
scripts/run_tests.sh tests/agent/test_image_routing.py -q -k "not ExtractImageRefs"
```

Result: 85 passed.

4. Run provider and CLI resolution coverage:

```shell
scripts/run_tests.sh \
  tests/hermes_cli/test_codex_models.py \
  tests/hermes_cli/test_runtime_provider_resolution.py \
  tests/hermes_cli/test_main_model_custom_provider_normalization.py -q
```

Result: 176 passed.

5. Related argument propagation, custom-provider vision, AIAgent vision preprocessing, and native vision fast-path files also pass. Ruff and `git diff --check` are clean.

6. Fail-without proof: with only the new test file applied to `main`, the exact CLI test fails because `cli.provider` is `custom`, and the AIAgent gate returns false. Restoring the production change makes all 7 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run the full test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation or N/A
- [x] I've updated `cli-config.yaml.example` if I added or changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact or N/A. Provider identity handling is platform-independent.
- [x] I've updated tool descriptions or schemas if I changed tool behavior or N/A

## Screenshots / Logs

```text
# main
runtime.provider = custom
runtime.requested_provider = custom:qwen-token-plan
override with live provider = None
actual CLI routing decision = text

# this branch
runtime transport = custom
live CLI provider = custom:qwen-token-plan
override with live provider = True
actual CLI routing decision = native
AIAgent vision gate = True
vision tool native fast path = True
```
