### PR TITLE
fix: /model and session info reflect channel_overrides

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13952,15 +13952,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
-                return self._format_session_info()
-        return self._format_session_info()
+                return self._format_session_info(source=source)
+        return self._format_session_info(source=source)
 
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, *, source: Optional[SessionSource] = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
+
+        When ``source`` is provided, ``channel_overrides`` are applied so the
+        block reflects the effective model for this channel, not just the
+        global config.
         """
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
@@ -13998,6 +14002,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     custom_provs = data.get("custom_providers")
         except Exception:
             pass
+
+        # Apply channel_overrides so the session info reflects the effective
+        # model for this channel, not just the global config.
+        cfg_obj = getattr(self, "config", None)
+        if cfg_obj is not None and source is not None:
+            chat_id = str(source.chat_id) if source.chat_id else ""
+            thread_id = (
+                str(source.thread_id)
+                if getattr(source, "thread_id", None)
+                else None
+            )
+            parent_id = (
+                str(source.parent_chat_id)
+                if getattr(source, "parent_chat_id", None)
+                else None
+            )
+            ch_ov = _get_channel_override(
+                cfg_obj,
+                source.platform,
+                chat_id,
+                thread_id=thread_id,
+                parent_id=parent_id,
+            )
+            if ch_ov is not None:
+                if ch_ov.model:
+                    model = ch_ov.model
+                    configured_model = ch_ov.model
+                if ch_ov.provider:
+                    provider = ch_ov.provider
+                    configured_provider = ch_ov.provider
 
         # Resolve runtime credentials for probing
         try:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1444,7 +1444,7 @@ class GatewaySlashCommandsMixin:
           /model <name> --provider <provider> — switch provider + model
           /model --provider <provider>        — switch to provider, auto-detect model
         """
-        from gateway.run import _hermes_home, _load_gateway_config
+        from gateway.run import _hermes_home, _load_gateway_config, _get_channel_override
         import yaml
         from hermes_cli.model_switch import (
             switch_model as _switch_model, parse_model_flags_detailed,
@@ -1517,6 +1517,34 @@ class GatewaySlashCommandsMixin:
                     excluded_provs = _excl
         except Exception:
             pass
+
+        # Apply channel_overrides so /model reflects the effective model for
+        # this channel, not just the global config (#issue).
+        cfg_obj = getattr(self, "config", None)
+        if cfg_obj is not None and source is not None:
+            chat_id = str(source.chat_id) if source.chat_id else ""
+            thread_id = (
+                str(source.thread_id)
+                if getattr(source, "thread_id", None)
+                else None
+            )
+            parent_id = (
+                str(source.parent_chat_id)
+                if getattr(source, "parent_chat_id", None)
+                else None
+            )
+            ch_ov = _get_channel_override(
+                cfg_obj,
+                source.platform,
+                chat_id,
+                thread_id=thread_id,
+                parent_id=parent_id,
+            )
+            if ch_ov is not None:
+                if ch_ov.model:
+                    current_model = ch_ov.model
+                if ch_ov.provider:
+                    current_provider = ch_ov.provider
 
         # Check for session override. Normalize the source the same way a normal
         # message turn does

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -300,3 +300,95 @@ class TestResolveSessionAgentRuntimePriority:
              }):
             model, _runtime = runner._resolve_session_agent_runtime(source=source)
         assert model == "parent/model"
+
+
+class TestFormatSessionInfoChannelOverride:
+    """_format_session_info should reflect channel_overrides, not just global config."""
+
+    def test_shows_channel_override_model(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "chan_1": ChannelOverride(
+                            model="channel/model",
+                            provider="openrouter",
+                        ),
+                    },
+                ),
+            },
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chan_1",
+            user_id="u1",
+        )
+        with patch("gateway.run._resolve_gateway_model", return_value="global/model"), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={}), \
+             patch("gateway.run._load_gateway_config", return_value=None), \
+             patch("agent.model_metadata.get_model_context_length", return_value=128000):
+            info = runner._format_session_info(source=source)
+        assert "channel/model" in info
+        assert "global/model" not in info
+
+    def test_shows_global_model_without_override(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(enabled=True),
+            },
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="unknown_chan",
+            user_id="u1",
+        )
+        with patch("gateway.run._resolve_gateway_model", return_value="global/model"), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={}), \
+             patch("gateway.run._load_gateway_config", return_value=None), \
+             patch("agent.model_metadata.get_model_context_length", return_value=128000):
+            info = runner._format_session_info(source=source)
+        assert "global/model" in info
+
+    def test_no_source_shows_global_model(self):
+        """Backward compat: no source arg → global model."""
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig()
+        with patch("gateway.run._resolve_gateway_model", return_value="global/model"), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={}), \
+             patch("gateway.run._load_gateway_config", return_value=None), \
+             patch("agent.model_metadata.get_model_context_length", return_value=128000):
+            info = runner._format_session_info()
+        assert "global/model" in info
+
+    def test_thread_inherits_parent_override(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "parent_chan": ChannelOverride(model="parent/model"),
+                    },
+                ),
+            },
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="thread_1",
+            chat_type="thread",
+            parent_chat_id="parent_chan",
+            user_id="u1",
+        )
+        with patch("gateway.run._resolve_gateway_model", return_value="global/model"), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={}), \
+             patch("gateway.run._load_gateway_config", return_value=None), \
+             patch("agent.model_metadata.get_model_context_length", return_value=128000):
+            info = runner._format_session_info(source=source)
+        assert "parent/model" in info
+        assert "global/model" not in info


### PR DESCRIPTION
## Problem

When `channel_overrides` are configured for a Discord (or other platform) channel, the `/model` slash command displays the global default model instead of the effective model for that channel.

The same gap exists in `_format_session_info` (used by the auto-reset notice), which resolves the model from `_resolve_gateway_model()` without considering `channel_overrides`.

## Root cause

- `_handle_model_command` (`slash_commands.py`) reads `current_model`/`current_provider` from the global config, then checks session overrides, but never consults `channel_overrides`. The interactive picker and text list therefore pre-select the wrong model.
- `_format_session_info` (`run.py`) had the same gap.

## Fix

Resolve `_get_channel_override` from the event `source` in both paths, applying the override **before** session overrides so the priority order stays:

```
session /model > channel_overrides > global config
```

This mirrors the existing priority in `_resolve_session_agent_runtime` (the actual message routing path), which already handles `channel_overrides` correctly.

## Changes

- `gateway/slash_commands.py`: after reading global config, resolve `channel_override` from `source` and apply `model`/`provider` before the session override check.
- `gateway/run.py`: `_format_session_info` now accepts an optional `source` parameter; when provided, `channel_overrides` are resolved and applied. `_reset_notice_session_info` passes `source` through. Backward-compatible: no-arg call still works.
- `tests/gateway/test_channel_overrides.py`: 4 new tests in `TestFormatSessionInfoChannelOverride` covering override present, no override, no source arg (backward compat), and thread inheriting parent override.

## Testing

```
scripts/run_tests.sh tests/gateway/test_channel_overrides.py -v --tb=short
```

19 tests passed, 0 failed (including 4 new tests). No regressions in existing gateway tests.