### PR TITLE
fix(agent): correct Qwen3.7 Max context length

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -361,6 +361,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     "llama": 131072,
     # Qwen — specific model families before the catch-all.
     # Official docs: https://help.aliyun.com/zh/model-studio/developer-reference/
+    # qwen3.7-max: https://www.qwencloud.com/models/qwen3.7-max
+    "qwen3.7-max": 1048576,       # 1M context (DashScope/Alibaba)
     "qwen3.6-plus": 1048576,      # 1M context (DashScope/Alibaba & OpenRouter)
     "qwen3.7-plus": 1048576,      # 1M context (DashScope/Alibaba)
     "qwen3-coder-plus": 1000000,  # 1M context

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -514,6 +514,41 @@ class TestGetModelContextLength:
 
 
 
+    @patch("agent.model_metadata.fetch_model_metadata", return_value={})
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={})
+    def test_qwen3_7_max_specific_fallback_wins_after_metadata_miss(
+        self, mock_endpoint_fetch, mock_fetch
+    ):
+        """A Token Plan metadata miss must prefer the specific family fallback."""
+        base_url = (
+            "https://token-plan.ap-southeast-1.maas.aliyuncs.com/"
+            "compatible-mode/v1"
+        )
+
+        with (
+            patch(
+                "agent.model_metadata._resolve_endpoint_context_length",
+                return_value=None,
+            ),
+            patch(
+                "agent.model_metadata._query_ollama_api_show",
+                return_value=None,
+            ),
+            patch(
+                "agent.model_metadata.is_local_endpoint",
+                return_value=False,
+            ),
+        ):
+            specific = get_model_context_length(
+                "qwen3.7-max", base_url=base_url, api_key="test-key"
+            )
+            generic = get_model_context_length(
+                "qwen-unknown", base_url=base_url, api_key="test-key"
+            )
+
+        assert specific == 1048576
+        assert generic == 131072
+        assert specific > generic
 
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_api_missing_context_length_key(self, mock_fetch):
@@ -1076,4 +1111,3 @@ class TestMoAContextLength:
         assert compressor.context_length == configured_context
         assert compressor.threshold_tokens == configured_context // 2
         endpoint_probe.assert_not_called()
-


### PR DESCRIPTION
## What does this PR do?

Hermes falls back to the generic Qwen 131,072-token limit when provider/endpoint metadata omits a context length for `qwen3.7-max`. That causes conversation compression far before the documented 1M context window.

This PR adds the narrow model-family fallback needed for `qwen3.7-max`. It preserves the earlier `qwen3-max` generation at 262,144 tokens.

The scope intentionally does not add `qwen3.8-max-preview`: open PR #69667 already covers that newer family together with Token Plan provider support.

Official source: [Qwen3.7 Max model page](https://www.qwencloud.com/models/qwen3.7-max)

## Related Issue

Fixes #69881

Related: #69667

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: add the specific 1,048,576-token `qwen3.7-max` fallback before the generic Qwen fallback.
- `tests/agent/test_model_metadata.py`: exercise the real resolution chain by forcing OpenRouter, endpoint, and provider metadata misses, then assert that the specific Qwen3.7 Max fallback wins while an unknown Qwen model still uses the generic 131,072-token fallback.

## How to Test

1. Resolve `qwen3.7-max` after provider/endpoint metadata misses.
2. Run `scripts/run_tests.sh tests/agent/test_model_metadata.py -q`.
3. Confirm `qwen3.7-max` resolves to `1048576`, an unknown Qwen model resolves to `131072`, and the specific fallback is larger than the generic fallback.

## Checklist

### Code

- [x] Read the Contributing Guide.
- [x] Commit message follows Conventional Commits.
- [x] Searched open PRs and accounted for related #69667.
- [x] PR contains only this context-length fix and its regression test.
- [ ] Ran the complete repository test suite. Not run; the complete affected metadata test file passed.
- [x] Added a behavior-focused regression test for the reported resolution path.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing workflow changed.
- [x] `cli-config.yaml.example`: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered; the change is platform-independent static metadata and tests.
- [x] Tool descriptions/schemas: N/A; no tool behavior changed.

## Screenshots / Logs

Validated against current `main` `98105f31f` with head `268c08d7a`:

```text
scripts/run_tests.sh tests/agent/test_model_metadata.py -q
51 passed

scripts/run_tests.sh tests/agent/test_model_metadata.py::TestGetModelContextLength::test_qwen3_7_max_specific_fallback_wins_after_metadata_miss -q
1 passed

python -m compileall -q agent/model_metadata.py tests/agent/test_model_metadata.py
git diff --check upstream/main...HEAD
```
