### PR TITLE
fix(profiles): clone plugins/ when cloning a profile

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1106,6 +1106,12 @@ def create_profile(
                     dst.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(src, dst)
 
+            # Clone plugins from the source profile
+            source_plugins = source_dir / "plugins"
+            if source_plugins.is_dir():
+                shutil.copytree(source_plugins, profile_dir / "plugins",
+                                symlinks=True, dirs_exist_ok=True)
+
     # Seed an empty .env so the profile has its own credentials file from
     # day one. Without it, profile-scoped env writes (dashboard Channels /
     # Keys pages, `hermes -p <name> auth add`) had no file until first

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -254,6 +254,22 @@ class TestCreateProfile:
             / "SKILL.md"
         ).read_text() == "---\nname: installed-skill\n---\n"
 
+    def test_clone_config_copies_source_plugins(self, profile_env):
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        plugin_dir = default_home / "plugins" / "example-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text("name: example-plugin\n")
+
+        profile_dir = create_profile("coder", clone_config=True, no_alias=True)
+
+        assert (
+            profile_dir
+            / "plugins"
+            / "example-plugin"
+            / "plugin.yaml"
+        ).read_text() == "name: example-plugin\n"
+
     def test_clone_all_copies_entire_tree(self, profile_env):
         tmp_path = profile_env
         default_home = tmp_path / ".hermes"


### PR DESCRIPTION
### What does this PR do?
When creating a profile with --clone or --clone-from, the source profile's plugins/ directory is now copied to the new profile, alongside config, skills, and memory files. Without this, plugins installed in the source profile are missing in the cloned profile, causing plugin hooks and tools to not work on non-default profiles.

The copy follows the same pattern as the existing skills clone:

symlinks=True — symlinks in the source stay as symlinks
dirs_exist_ok=True — doesn't overwrite if the target already exists

### Related Issue
Fixes #50937, #65593

### Type of Change
 🐛 Bug fix

### Changes Made
hermes_cli/profiles.py: Added 6 lines in create_profile() after the memory clone section to copy the source profile's plugins/ directory.
### How to Test
hermes profile create p1
install a plugin in p1
hermes profile create p2 --clone-from p1 ls ~/.hermes/profiles/p2/plugins/
→ p1's plugins should be visible in p2

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix