### PR TITLE
fix(agent): clamp GLM-5.2 ultra reasoning effort

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -22,8 +22,13 @@ def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> di
     """Return the model's wire-compatible reasoning config."""
     if not isinstance(reasoning_config, dict):
         return reasoning_config
+    normalized_model = (model or "").lower()
+    ultra_uses_max = any(
+        token in normalized_model
+        for token in ("gpt-5.6", "glm-5.2", "glm-5-2", "glm-5p2")
+    )
     if (
-        "gpt-5.6" in (model or "").lower()
+        ultra_uses_max
         and str(reasoning_config.get("effort") or "").strip().lower() == "ultra"
     ):
         normalized = dict(reasoning_config)

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -38,6 +38,26 @@ class TestChatCompletionsBasic:
         )
         assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "max"}
 
+    @pytest.mark.parametrize(
+        "model",
+        ["nvidia/z-ai/glm-5.2", "z-ai/glm-5-2", "fireworks/glm-5p2"],
+    )
+    def test_glm52_ultra_uses_max_wire_effort(self, transport, model):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("nous")
+        kw = transport.build_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            reasoning_config={"enabled": True, "effort": "ultra"},
+            supports_reasoning=True,
+            provider_profile=profile,
+            provider_name="nous",
+            base_url=profile.base_url,
+        )
+        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "max"}
+
     def test_convert_tools_identity(self, transport):
         tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]
         assert transport.convert_tools(tools) is tools


### PR DESCRIPTION
## Summary

- normalize `ultra` to GLM-5.2's supported `max` reasoning effort before provider-specific request shaping
- cover canonical and relay GLM-5.2 model aliases, including the reported `nvidia/z-ai/glm-5.2` route
- preserve the existing reasoning configuration for unrelated model families

## Testing

- `scripts/run_tests.sh tests/agent/transports/test_chat_completions.py -q` (94 passed)
- `.venv/Scripts/ruff.exe check agent/transports/chat_completions.py tests/agent/transports/test_chat_completions.py`

Fixes #69855
