### PR TITLE
docs(api-server): clarify /v1/chat/completions persists a session

### DIFF
--- a/contributors/emails/git@accounts.watergard.com
+++ b/contributors/emails/git@accounts.watergard.com
@@ -1,0 +1,1 @@
+Watergard

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -57,7 +57,9 @@ Or connect Open WebUI, LobeChat, or any other frontend — see the [Open WebUI i
 
 ### POST /v1/chat/completions
 
-Standard OpenAI Chat Completions format. Stateless — the full conversation is included in each request via the `messages` array.
+Standard OpenAI Chat Completions format. Stateless **on the wire** — the full conversation is included in each request via the `messages` array, and the endpoint carries no conversation state between calls.
+
+Note that the server still **persists a session and its messages** for each request. When no `X-Hermes-Session-Id` header is supplied, the session id is derived deterministically as `api-<16 hex>` from the system prompt and the first user message; identical opening exchanges therefore reuse the same session (and the same sandbox directory), which is deliberate. One-shot callers should expect one persisted session per distinct opening exchange and are responsible for their own cleanup via `DELETE /api/sessions/{id}`.
 
 **Request:**
 ```json


### PR DESCRIPTION
## What does this PR do?

The API server docs describe `/v1/chat/completions` as "Stateless", but every call persists a session row and its messages. With no `X-Hermes-Session-Id` supplied, the id is derived by hashing the system prompt plus the first user message (`api-<16 hex>`), so a caller using the endpoint for one-shot work accumulates one persisted session per distinct opening exchange — in the same table as human conversations, with no marker distinguishing them and no documented cleanup expectation.

This corrects the doc to say stateless *on the wire*, discloses the persistence and the `api-<hash>` derivation (deliberate — it maps a frontend's consecutive turns to one Hermes session and sandbox directory), and notes the caller owns cleanup via `DELETE /api/sessions/{id}`. Documentation-only; no behavior change.

## Related Issue

<!-- Optional. The doc correction stands alone; file a separate issue only if you want to raise the deeper "unmarked machine-generated rows" gap. -->

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/features/api-server.md` — qualify the "Stateless" claim under `POST /v1/chat/completions`; document that the server persists a session, the `api-<hash>` id derivation, and cleanup via `DELETE /api/sessions/{id}`.

## How to Test

Documentation only — no code paths are touched. Render the docs site; the `/v1/chat/completions` section now reads "stateless on the wire" and describes the persistence. To confirm the underlying behaviour: POST one completion with no session id, then `GET /api/sessions` shows a new `api-<hash>` row.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (N/A — documentation only, no code paths touched)
- [x] I've added tests for my changes (N/A — documentation only)
- [x] I've tested on my platform: Windows 11 (rendered docs verified)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A