### PR TITLE
fix(desktop): register local Linux deep links

### DIFF
--- a/hermes_cli/linux_desktop_integration.py
+++ b/hermes_cli/linux_desktop_integration.py
@@ -1,0 +1,183 @@
+"""Linux desktop integration for locally built Hermes Desktop apps.
+
+``electron-builder --dir`` produces a runnable unpacked tree, but unlike its
+deb/rpm targets it does not install a ``.desktop`` file.  Electron therefore
+has no desktop application id to hand to ``xdg-mime`` when the unpacked binary
+calls ``app.setAsDefaultProtocolClient()``.  Register the local build explicitly
+so ``hermes://`` links have a stable handler too.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+_DESKTOP_FILE_NAME = "hermes.desktop"
+_PROTOCOL_MIME = "x-scheme-handler/hermes"
+
+
+def _desktop_exec_arg(path: Path) -> str:
+    """Quote one executable for the Desktop Entry ``Exec`` grammar."""
+    value = str(path)
+    if "\n" in value or "\r" in value:
+        raise ValueError("Desktop executable path contains a newline")
+    # Exec values are not shell commands. Inside a quoted argument the Desktop
+    # Entry spec requires these characters to be backslash-escaped; ``%%`` is
+    # the literal-percent field code.
+    value = value.replace("\\", "\\\\")
+    value = value.replace('"', '\\"').replace("`", "\\`").replace("$", "\\$")
+    value = value.replace("%", "%%")
+    return f'"{value}"'
+
+
+def _desktop_string(value: Path) -> str:
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+
+
+def _desktop_entry(executable: Path, icon: Optional[Path]) -> str:
+    lines = [
+        "[Desktop Entry]",
+        "Type=Application",
+        "Name=Hermes",
+        "Comment=Native desktop shell for Hermes Agent",
+        f"Exec={_desktop_exec_arg(executable)} %U",
+    ]
+    if icon is not None and icon.is_file():
+        lines.append(f"Icon={_desktop_string(icon)}")
+    lines.extend(
+        [
+            "Terminal=false",
+            "Categories=Development;",
+            "StartupWMClass=Hermes",
+            f"MimeType={_PROTOCOL_MIME};",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _applications_dir() -> Path:
+    data_home = os.environ.get("XDG_DATA_HOME")
+    if data_home:
+        candidate = Path(data_home).expanduser()
+        # The XDG Base Directory spec requires absolute paths and says relative
+        # values must be ignored.
+        if candidate.is_absolute():
+            return candidate / "applications"
+    return Path.home() / ".local" / "share" / "applications"
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def register_linux_deep_link_protocol(
+    executable: Path, *, icon: Optional[Path] = None
+) -> bool:
+    """Install and register a user-scoped handler for ``hermes://``.
+
+    This is deliberately best-effort: a missing desktop utility must not make a
+    successful Desktop build unusable.  The caller gets ``False`` and the user
+    gets one actionable warning instead of Electron silently discarding its
+    failed boolean registration result.
+    """
+    if sys.platform != "linux":
+        return True
+
+    executable = executable.expanduser().resolve()
+    icon = icon.expanduser().resolve() if icon is not None else None
+    applications_dir = _applications_dir()
+    desktop_file = applications_dir / _DESKTOP_FILE_NAME
+
+    try:
+        if not executable.is_file():
+            raise FileNotFoundError(f"Desktop executable not found: {executable}")
+        applications_dir.mkdir(parents=True, exist_ok=True)
+        content = _desktop_entry(executable, icon)
+        entry_changed = (
+            not desktop_file.is_file()
+            or desktop_file.read_text(encoding="utf-8") != content
+        )
+        if entry_changed:
+            temporary = desktop_file.with_suffix(".desktop.tmp")
+            temporary.write_text(content, encoding="utf-8")
+            temporary.chmod(0o644)
+            temporary.replace(desktop_file)
+
+        update_database = shutil.which("update-desktop-database")
+        if update_database and entry_changed:
+            try:
+                _run([update_database, str(applications_dir)])
+            except (OSError, subprocess.SubprocessError):
+                # xdg-mime can register a handler without the optional cache
+                # refresh utility; keep going and verify the authoritative MIME
+                # association below.
+                pass
+
+        xdg_mime = shutil.which("xdg-mime")
+        if not xdg_mime:
+            raise RuntimeError("xdg-mime is not installed")
+
+        verified = _run([xdg_mime, "query", "default", _PROTOCOL_MIME])
+        if (
+            verified.returncode == 0
+            and (verified.stdout or "").strip() == _DESKTOP_FILE_NAME
+        ):
+            return True
+
+        registered = _run([xdg_mime, "default", _DESKTOP_FILE_NAME, _PROTOCOL_MIME])
+        if registered.returncode != 0:
+            detail = (registered.stderr or registered.stdout).strip()
+            raise RuntimeError(
+                detail or f"xdg-mime exited with status {registered.returncode}"
+            )
+
+        verified = _run([xdg_mime, "query", "default", _PROTOCOL_MIME])
+        if (
+            verified.returncode != 0
+            or (verified.stdout or "").strip() != _DESKTOP_FILE_NAME
+        ):
+            raise RuntimeError("xdg-mime did not retain the Hermes protocol handler")
+        return True
+    except (OSError, RuntimeError, ValueError, subprocess.SubprocessError) as exc:
+        print(
+            "⚠ Could not register hermes:// links for this local Linux Desktop build: "
+            f"{exc}\n"
+            f"  Desktop entry: {desktop_file}\n"
+            f"  Retry: xdg-mime default {_DESKTOP_FILE_NAME} {_PROTOCOL_MIME}"
+        )
+        return False
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Register a local Hermes Desktop build on Linux"
+    )
+    parser.add_argument("executable", type=Path)
+    parser.add_argument("--icon", type=Path)
+    args = parser.parse_args(argv)
+    return (
+        0 if register_linux_deep_link_protocol(args.executable, icon=args.icon) else 1
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6123,6 +6123,14 @@ def cmd_gui(args: argparse.Namespace):
             # Build succeeded — write the stamp so next run can skip
             _write_desktop_build_stamp(PROJECT_ROOT, source_mode=source_mode)
 
+    if not source_mode and packaged_executable is not None:
+        from hermes_cli.linux_desktop_integration import register_linux_deep_link_protocol
+
+        register_linux_deep_link_protocol(
+            packaged_executable,
+            icon=desktop_dir / "assets" / "icon.png",
+        )
+
     # --build-only: produce the artifact but do NOT launch. The installer's
     # --update flow drives the rebuild headlessly and then launches the desktop
     # itself (detached, after the old exe has exited), so the launch must NOT

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2907,6 +2907,15 @@ install_desktop() {
                 return 1
             fi
         fi
+
+        # electron-builder --dir creates a runnable unpacked tree but, unlike
+        # deb/rpm packaging, installs no .desktop file. Register the local build
+        # explicitly so xdg-mime has an application id for hermes:// links.
+        # Best-effort: desktop integration failure must not discard a good build.
+        if [ -x "$INSTALL_DIR/venv/bin/python" ]; then
+            "$INSTALL_DIR/venv/bin/python" -m hermes_cli.linux_desktop_integration \
+                "$app" --icon "$desktop_dir/assets/icon.png" || true
+        fi
     fi
 
     # macOS: make the locally-built (ad-hoc) app relaunchable after an in-place

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -28,6 +28,15 @@ def _ns(**kw):
     return argparse.Namespace(**defaults)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_linux_desktop_registration(monkeypatch):
+    """GUI command tests must not mutate the host's desktop MIME database."""
+    monkeypatch.setattr(
+        "hermes_cli.linux_desktop_integration.register_linux_deep_link_protocol",
+        lambda *args, **kwargs: True,
+    )
+
+
 def _make_desktop_tree(tmp_path: Path) -> Path:
     root = tmp_path / "hermes-agent"
     desktop_dir = root / "apps" / "desktop"
@@ -217,6 +226,25 @@ def test_gui_linux_configures_sandbox_before_launch(tmp_path, monkeypatch):
     assert mock_run.call_args_list[0].args[0] == ["/usr/bin/sudo", "chown", "root:root", str(sandbox)]
     assert mock_run.call_args_list[1].args[0] == ["/usr/bin/sudo", "chmod", "4755", str(sandbox)]
     assert mock_run.call_args_list[2].args[0] == [str(packaged_exe)]
+
+
+def test_gui_linux_registers_deep_links_before_launch(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+    register = patch("hermes_cli.linux_desktop_integration.register_linux_deep_link_protocol")
+
+    with register as mock_register, \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main.subprocess.run", return_value=subprocess.CompletedProcess([], 0)), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    mock_register.assert_called_once_with(
+        packaged_exe,
+        icon=root / "apps" / "desktop" / "assets" / "icon.png",
+    )
 
 
 def test_gui_linux_rejects_symlink_sandbox(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_linux_desktop_integration.py
+++ b/tests/hermes_cli/test_linux_desktop_integration.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from hermes_cli import linux_desktop_integration as integration
+
+
+def _completed(command: list[str], *, stdout: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(command, returncode, stdout=stdout, stderr="")
+
+
+def test_registers_local_build_as_user_protocol_handler(tmp_path, monkeypatch):
+    executable = tmp_path / "checkout with spaces" / "linux-unpacked" / "Hermes"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("", encoding="utf-8")
+    icon = tmp_path / "icon.png"
+    icon.write_bytes(b"png")
+    data_home = tmp_path / "xdg-data"
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+    monkeypatch.setattr(integration.sys, "platform", "linux")
+    monkeypatch.setattr(
+        integration.shutil,
+        "which",
+        lambda name: f"/usr/bin/{name}",
+    )
+    calls: list[list[str]] = []
+
+    def run(command: list[str]):
+        calls.append(command)
+        if command[1:3] == ["query", "default"]:
+            query_count = sum(call[1:3] == ["query", "default"] for call in calls)
+            return _completed(
+                command, stdout="hermes.desktop\n" if query_count > 1 else ""
+            )
+        return _completed(command)
+
+    monkeypatch.setattr(integration, "_run", run)
+
+    assert integration.register_linux_deep_link_protocol(executable, icon=icon) is True
+
+    desktop_file = data_home / "applications" / "hermes.desktop"
+    content = desktop_file.read_text(encoding="utf-8")
+    assert f'Exec="{executable.resolve()}" %U' in content
+    assert f"Icon={icon.resolve()}" in content
+    assert "MimeType=x-scheme-handler/hermes;" in content
+    assert calls == [
+        ["/usr/bin/update-desktop-database", str(data_home / "applications")],
+        ["/usr/bin/xdg-mime", "query", "default", "x-scheme-handler/hermes"],
+        ["/usr/bin/xdg-mime", "default", "hermes.desktop", "x-scheme-handler/hermes"],
+        ["/usr/bin/xdg-mime", "query", "default", "x-scheme-handler/hermes"],
+    ]
+
+
+def test_exec_path_escapes_desktop_entry_field_codes(tmp_path, monkeypatch):
+    executable = tmp_path / 'cash$-quote"-percent%-tick`' / "Hermes"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("", encoding="utf-8")
+    monkeypatch.setattr(integration.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setattr(
+        integration.shutil,
+        "which",
+        lambda name: "/usr/bin/xdg-mime" if name == "xdg-mime" else None,
+    )
+    monkeypatch.setattr(
+        integration,
+        "_run",
+        lambda command: _completed(
+            command, stdout="hermes.desktop\n" if "query" in command else ""
+        ),
+    )
+
+    assert integration.register_linux_deep_link_protocol(executable) is True
+    content = (tmp_path / "data" / "applications" / "hermes.desktop").read_text(
+        encoding="utf-8"
+    )
+    exec_line = next(line for line in content.splitlines() if line.startswith("Exec="))
+    assert "\\$" in exec_line
+    assert '\\"' in exec_line
+    assert "%%" in exec_line
+    assert "\\`" in exec_line
+
+
+def test_failed_xdg_registration_keeps_entry_and_prints_actionable_warning(
+    tmp_path, monkeypatch, capsys
+):
+    executable = tmp_path / "Hermes"
+    executable.write_text("", encoding="utf-8")
+    data_home = tmp_path / "data"
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+    monkeypatch.setattr(integration.sys, "platform", "linux")
+    monkeypatch.setattr(
+        integration.shutil,
+        "which",
+        lambda name: "/usr/bin/xdg-mime" if name == "xdg-mime" else None,
+    )
+    monkeypatch.setattr(
+        integration,
+        "_run",
+        lambda command: _completed(command, returncode=1),
+    )
+
+    assert integration.register_linux_deep_link_protocol(executable) is False
+    assert (data_home / "applications" / "hermes.desktop").is_file()
+    output = capsys.readouterr().out
+    assert "Could not register hermes://" in output
+    assert "xdg-mime default hermes.desktop x-scheme-handler/hermes" in output
+
+
+def test_non_linux_is_a_noop(tmp_path, monkeypatch):
+    monkeypatch.setattr(integration.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        integration, "_applications_dir", lambda: tmp_path / "applications"
+    )
+
+    assert integration.register_linux_deep_link_protocol(tmp_path / "missing") is True
+    assert not (tmp_path / "applications").exists()


### PR DESCRIPTION
Fixes #69643.

## Root cause

The local Linux Desktop workflows use `electron-builder --dir`, which creates a runnable `linux-unpacked` tree but does not install the `.desktop` entry that deb/rpm packaging would provide. The unpacked Electron app therefore has no stable desktop application id for `app.setAsDefaultProtocolClient("hermes")`, and its boolean registration failure was effectively silent.

## What changed

- Add a user-scoped Linux integration helper that writes `hermes.desktop` under the XDG applications directory with the unpacked executable, `%U`, and `x-scheme-handler/hermes` metadata.
- Refresh the desktop database when available, register the handler with `xdg-mime`, and query the association back instead of assuming success.
- Invoke the same helper from both local build paths: `hermes desktop` (including `--build-only`) and `scripts/install.sh --include-desktop`.
- Keep registration best-effort so a missing/broken XDG utility cannot discard an otherwise good Desktop build; emit an actionable retry command on failure.
- Preserve idempotence, XDG path semantics, Desktop Entry escaping, and Python 3.9 compatibility.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_linux_desktop_integration.py tests/hermes_cli/test_gui_command.py -q` — 67 passed
- `python3 -m py_compile hermes_cli/linux_desktop_integration.py tests/hermes_cli/test_linux_desktop_integration.py` — Python 3.9.6
- `bash -n scripts/install.sh`
- `git diff --check`

The tests exercise real entry creation under a temporary XDG data home and the register/query contract with isolated command results. A live KDE/Wayland `xdg-mime` smoke test was not available on the current macOS development host.
