### PR TITLE
fix(gemini): ensure native array tool schemas include items

### DIFF
--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -111,6 +111,21 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
         elif len(valid_required) != len(required_val):
             cleaned["required"] = valid_required
 
+    # Gemini's Schema validator requires an ``items`` field on every array
+    # node — a bare ``{"type": "array"}`` (valid standard JSON Schema, where
+    # element types are simply unconstrained) fails the ENTIRE
+    # GenerateContentRequest with HTTP 400
+    # ``...parameters.properties[<name>].items: missing field`` before any model
+    # output. MCP / plugin / dynamic tool schemas routinely omit ``items``, so
+    # populate an empty schema when it is absent. An empty schema preserves the
+    # unconstrained-element meaning of the omitted keyword; a declared ``items``
+    # is left untouched. This also repairs nodes left bare after this legacy
+    # ``FunctionDeclaration.parameters`` allow-list strips ``prefixItems``
+    # (which the newer structured-output JSON Schema path supports, but the
+    # legacy path does not pass through).
+    if cleaned.get("type") == "array" and "items" not in cleaned:
+        cleaned["items"] = {}
+
     return cleaned
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -178,6 +178,45 @@ def test_build_native_request_strips_json_schema_only_fields_from_tool_parameter
     }
 
 
+def test_build_native_request_array_property_without_items_is_repaired():
+    """Wire regression for #69031 (Bug 2): a valid JSON Schema array property
+    that omits ``items`` must gain an empty ``items`` on the final
+    functionDeclarations payload, or Gemini rejects the whole tool catalog
+    with HTTP 400 ``...parameters.properties[decisions].items: missing field``.
+    """
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[{"role": "user", "content": "Decide."}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "propose_action",
+                    "description": "Propose candidate decisions.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "decisions": {
+                                "type": "array",
+                                "description": "Candidate decisions",
+                            }
+                        },
+                        "required": ["decisions"],
+                    },
+                },
+            }
+        ],
+        tool_choice=None,
+    )
+
+    decisions = request["tools"][0]["functionDeclarations"][0]["parameters"][
+        "properties"
+    ]["decisions"]
+    assert decisions["type"] == "array"
+    assert decisions["items"] == {}
+
+
 def test_translate_native_response_surfaces_reasoning_and_tool_calls():
     from agent.gemini_native_adapter import translate_gemini_response
 

--- a/tests/agent/test_gemini_schema.py
+++ b/tests/agent/test_gemini_schema.py
@@ -195,6 +195,92 @@ class TestRequiredPropertyPruning:
         assert "required" not in cleaned["anyOf"][1]
 
 
+class TestArrayItemsInvariant:
+    """Gemini rejects array ``FunctionDeclaration`` schemas that omit ``items``.
+
+    Standard JSON Schema permits a bare ``{"type": "array"}`` (elements are
+    unconstrained), but Google's native validator fails the ENTIRE
+    GenerateContentRequest with HTTP 400
+    ``...parameters.properties[<name>].items: missing field`` before any model
+    output. MCP / plugin / dynamic tool schemas routinely emit this shape, so
+    every array node produced by the sanitizer must carry an ``items`` key.
+    """
+
+    def test_bare_array_property_gets_empty_items(self):
+        """Exact #69031 (Bug 2) shape: a required array property without items."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "decisions": {"type": "array", "description": "Candidate decisions"}
+            },
+            "required": ["decisions"],
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        decisions = cleaned["properties"]["decisions"]
+        assert decisions["type"] == "array"
+        assert decisions["items"] == {}
+
+    def test_bare_array_input_is_not_mutated(self):
+        """The sanitizer builds a cleaned copy; the input schema is untouched."""
+        schema = {"type": "array", "description": "Unconstrained list."}
+        sanitize_gemini_schema(schema)
+        assert "items" not in schema
+        assert schema == {"type": "array", "description": "Unconstrained list."}
+
+    def test_declared_items_schema_is_preserved(self):
+        """An existing ``items`` schema must survive untouched (no overwrite)."""
+        schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"id": {"type": "string"}},
+                "required": ["id"],
+            },
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["items"] == {
+            "type": "object",
+            "properties": {"id": {"type": "string"}},
+            "required": ["id"],
+        }
+
+    def test_recursive_nested_arrays_all_carry_items(self):
+        """Invariant must hold on every array node reachable through the walk."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "matrix": {"type": "array", "items": {"type": "array"}},
+                "any_branch": {
+                    "anyOf": [
+                        {"type": "array"},
+                        {"type": "string"},
+                    ]
+                },
+            },
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        # Outer matrix array keeps items; the inner bare-typed array also gets items.
+        matrix_items = cleaned["properties"]["matrix"]["items"]
+        assert matrix_items["type"] == "array"
+        assert matrix_items["items"] == {}
+        # The array branch inside anyOf is repaired too.
+        assert cleaned["properties"]["any_branch"]["anyOf"][0]["items"] == {}
+
+    def test_prefixitems_only_array_still_gets_items(self):
+        """A typed array whose only element spec is ``prefixItems`` must still
+        end up with an ``items`` key. The legacy ``FunctionDeclaration.parameters``
+        allow-list filters ``prefixItems`` out (the newer structured-output JSON
+        Schema path supports it, but the legacy path does not pass it through),
+        which leaves the node bare. Tuple semantics are intentionally NOT
+        preserved here.
+        """
+        schema = {"type": "array", "prefixItems": [{"type": "string"}]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert "prefixItems" not in cleaned
+        assert cleaned["type"] == "array"
+        assert cleaned["items"] == {}
+
+
 class TestSanitizeGeminiToolParameters:
     def test_empty_parameters_return_valid_object_schema(self):
         """Gemini requires ``parameters`` to be a valid object schema."""


### PR DESCRIPTION
## What does this PR do?

Fixes Bug 2 of #69031. Starting a session against the Gemini native API
(`/v1beta`) can fail immediately with:

```text
HTTP 400 INVALID_ARGUMENT
GenerateContentRequest.tools[0].function_declarations[N]
.parameters.properties[decisions].items: missing field
```

One tool parameter with `type: "array"` but no `items` key causes Gemini to
reject the entire `GenerateContentRequest` before any model output.

The final Gemini-native schema translator now enforces a last-mile invariant:
every cleaned array node has an `items` field. Missing element schemas become
`items: {}`, preserving the original unconstrained-element meaning without
guessing an element type.

### Root cause and placement

A bare array is valid JSON Schema, but strict provider validators may reject
it. This PR enforces the requirement specifically at the Gemini-native wire
boundary.

`sanitize_gemini_schema()` runs after all tool sources have been assembled and
after the legacy `FunctionDeclaration.parameters` allow-list has filtered the
schema. The shared sanitizer is not the final boundary for every source:
memory and context-engine tools can be appended later. The Gemini translator is
the one place that sees every declaration immediately before native request
construction.

Merged PR #64054 established the same placement pattern for a different
Gemini-only final-wire invariant (`required` pruning).

### Semantics

- Omitting `items` and using `{}` both mean unconstrained array elements in
  JSON Schema.
- Existing `items` schemas are sanitized recursively but never overwritten by
  the fallback.
- The input schema is not mutated.
- The transformation is deterministic.
- A `prefixItems`-only array can become bare because the current legacy
  `FunctionDeclaration.parameters` allow-list does not pass `prefixItems`
  through; the newer structured-output JSON Schema path is separate.

### Overlap analysis

- #22056 and #25846 add related repairs in upstream/shared schema paths. There
  is partial overlap for tools that pass through those paths, but a
  Gemini-native final-wire invariant is still needed for tools appended after
  shared sanitization and for the final structure left after Gemini-specific
  key filtering.
- #62271 is open and has a triage comment considering it a duplicate of
  #22056. Its `items: {"type":"string"}` fallback narrows unknown element
  semantics; this PR uses `items: {}`.
- #38972 handles the inverse Gemini invariant: array-only fields on non-array
  nodes.
- #55643 handles list-valued `type` schemas and does not repair a scalar
  `type: "array"` that lacks `items`.
- #69068 addresses only Bug 1, the inherited `Authorization` header.

## Related Issue

Refs #69031 — Bug 2 only

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `agent/gemini_schema.py`: add the final array/`items` post-condition.
- `tests/agent/test_gemini_schema.py`: cover the exact issue shape, input
  immutability, declared-items preservation, recursive arrays, `anyOf`, and the
  `prefixItems` last-mile case.
- `tests/agent/test_gemini_native_adapter.py`: assert the final
  `functionDeclarations` wire payload.

Three existing files are modified; the diff is entirely additions
(`+140/-0`).

## How to Test

1. Run the target tests:

   ```bash
   scripts/run_tests.sh \
     tests/agent/test_gemini_schema.py \
     tests/agent/test_gemini_native_adapter.py
   # 50 passed
   ```

2. Run the adjacent shared-schema tests:

   ```bash
   scripts/run_tests.sh \
     tests/tools/test_schema_sanitizer.py \
     tests/tools/test_mcp_tool.py
   # 263 passed
   ```

3. Build a Gemini native request containing:

   ```json
   {"type":"array","description":"Candidate decisions"}
   ```

   and verify the final declaration contains `items: {}`.

### Live `/v1beta` A/B

The same tiny prompt, native `x-goog-api-key` auth, and
`maxOutputTokens: 16` were sent with `gemini-flash-latest`, which the server
reported as `gemini-3.6-flash`:

| `decisions` property | Result |
|---|---|
| `{"type":"array","description":"...","items":{}}` | HTTP 200 |
| `{"type":"array","description":"..."}` | HTTP 400 `items: missing field` |

The positive payload came from the complete patched `build_gemini_request()`.
The negative payload bypassed the sanitizer. An offline capture confirmed the
payloads are identical after removing only `decisions.items`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and merged PRs for duplicates.
- [x] The PR contains only changes related to this fix.
- [ ] I've run the entire `pytest tests/ -q` suite and all tests pass.
- [x] I've added tests for the bug fix.
- [x] Tested on Ubuntu 24.04, Linux 6.14.0-29-generic, x86_64.

The full-suite checkbox is intentionally left unchecked. The focused 313 tests
pass; GitHub Actions will provide repository-wide results.

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior is internal and covered by comments
  and tests.
- [x] `cli-config.yaml.example`: N/A; no configuration changes.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow or architecture change.
- [x] Cross-platform impact considered; the change is a pure Python
  copy-based dictionary transformation.
- [x] Tool descriptions/schemas: N/A; the final provider wire schema is
  repaired without changing source tool definitions.

## Screenshots / Logs

Not applicable. The redacted live A/B results are included above.
