### PR TITLE
fix(desktop): self-heal Linux unpacked deep links

### DIFF
--- a/apps/desktop/electron/deep-link-registration.test.ts
+++ b/apps/desktop/electron/deep-link-registration.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test, vi } from 'vitest'
+
+import {
+  ensureLinuxUnpackedDeepLink,
+  isLinuxUnpackedExecutable,
+  registerDeepLinkProtocol
+} from './deep-link-registration'
+
+function withTempDir(run) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-deep-link-'))
+
+  try {
+    return run(directory)
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+function xdgRunner(calls) {
+  let current = ''
+
+  return {
+    get current() {
+      return current
+    },
+    run(command, args) {
+      calls.push([command, args])
+
+      if (command === 'xdg-mime' && args[0] === 'query') {
+        return current
+      }
+
+      if (command === 'xdg-mime' && args[0] === 'default') {
+        current = args[1]
+      }
+
+      return ''
+    }
+  }
+}
+
+test('ensureLinuxUnpackedDeepLink installs and verifies the local desktop handler', () =>
+  withTempDir(directory => {
+    const calls = []
+    const runner = xdgRunner(calls)
+    const executable = '/opt/Hermes Agent/apps/desktop/release/linux-unpacked/Hermes'
+
+    const result = ensureLinuxUnpackedDeepLink({
+      execPath: executable,
+      env: { XDG_DATA_HOME: directory },
+      homeDir: directory,
+      run: runner.run
+    })
+
+    assert.equal(result.ok, true)
+    assert.equal(result.changed, true)
+    assert.equal(runner.current, 'hermes.desktop')
+    assert.deepEqual(calls, [
+      ['update-desktop-database', [path.join(directory, 'applications')]],
+      ['xdg-mime', ['query', 'default', 'x-scheme-handler/hermes']],
+      ['xdg-mime', ['default', 'hermes.desktop', 'x-scheme-handler/hermes']],
+      ['xdg-mime', ['query', 'default', 'x-scheme-handler/hermes']]
+    ])
+
+    const entry = fs.readFileSync(path.join(directory, 'applications', 'hermes.desktop'), 'utf8')
+    assert.match(entry, /^Type=Application$/m)
+    assert.match(entry, /^Name=Hermes$/m)
+    assert.match(entry, /^Exec="\/opt\/Hermes Agent\/apps\/desktop\/release\/linux-unpacked\/Hermes" %U$/m)
+    assert.match(entry, /^Terminal=false$/m)
+    assert.match(entry, /^MimeType=x-scheme-handler\/hermes;$/m)
+  }))
+
+test('ensureLinuxUnpackedDeepLink is idempotent after registration succeeds', () =>
+  withTempDir(directory => {
+    const calls = []
+    const runner = xdgRunner(calls)
+
+    const options = {
+      execPath: '/home/user/hermes/apps/desktop/release/linux-unpacked/Hermes',
+      env: { XDG_DATA_HOME: directory },
+      homeDir: directory,
+      run: runner.run
+    }
+
+    assert.equal(ensureLinuxUnpackedDeepLink(options).ok, true)
+    calls.length = 0
+
+    const second = ensureLinuxUnpackedDeepLink(options)
+    assert.equal(second.ok, true)
+    assert.equal(second.changed, false)
+    assert.deepEqual(calls, [['xdg-mime', ['query', 'default', 'x-scheme-handler/hermes']]])
+  }))
+
+test('registerDeepLinkProtocol uses the explicit Linux handler for unpacked builds', () =>
+  withTempDir(directory => {
+    const runner = xdgRunner([])
+    const setAsDefaultProtocolClient = vi.fn(() => false)
+    const logs = []
+
+    const registered = registerDeepLinkProtocol({
+      protocol: 'hermes',
+      platform: 'linux',
+      execPath: '/home/user/hermes/apps/desktop/release/linux-unpacked/Hermes',
+      defaultApp: false,
+      argv: [],
+      setAsDefaultProtocolClient,
+      log: message => logs.push(message),
+      linux: {
+        env: { XDG_DATA_HOME: directory },
+        homeDir: directory,
+        run: runner.run
+      }
+    })
+
+    assert.equal(registered, true)
+    assert.equal(setAsDefaultProtocolClient.mock.calls.length, 0)
+    assert.deepEqual(logs, [])
+  }))
+
+test('registerDeepLinkProtocol logs a false Electron registration result', () => {
+  const logs = []
+
+  const registered = registerDeepLinkProtocol({
+    protocol: 'hermes',
+    platform: 'linux',
+    execPath: '/opt/Hermes/Hermes',
+    defaultApp: false,
+    argv: [],
+    setAsDefaultProtocolClient: () => false,
+    log: message => logs.push(message)
+  })
+
+  assert.equal(registered, false)
+  assert.deepEqual(logs, ['[deeplink] protocol registration failed: setAsDefaultProtocolClient returned false'])
+})
+
+test('registerDeepLinkProtocol logs an actionable local Linux registration failure', () =>
+  withTempDir(directory => {
+    const logs = []
+
+    const registered = registerDeepLinkProtocol({
+      protocol: 'hermes',
+      platform: 'linux',
+      execPath: '/home/user/hermes/apps/desktop/release/linux-unpacked/Hermes',
+      defaultApp: false,
+      argv: [],
+      setAsDefaultProtocolClient: vi.fn(() => false),
+      log: message => logs.push(message),
+      linux: {
+        env: { XDG_DATA_HOME: directory },
+        homeDir: directory,
+        run: command => {
+          throw new Error(`${command} is unavailable`)
+        }
+      }
+    })
+
+    assert.equal(registered, false)
+    assert.equal(logs.length, 1)
+    assert.match(logs[0], /could not register x-scheme-handler\/hermes with hermes\.desktop/)
+    assert.match(logs[0], /xdg-mime is unavailable/)
+  }))
+
+test('isLinuxUnpackedExecutable only matches the local electron-builder layout', () => {
+  assert.equal(isLinuxUnpackedExecutable('/repo/apps/desktop/release/linux-unpacked/Hermes'), true)
+  assert.equal(isLinuxUnpackedExecutable('/opt/Hermes/Hermes'), false)
+  assert.equal(isLinuxUnpackedExecutable('/repo/apps/desktop/release/linux-unpacked-old/Hermes'), false)
+})

--- a/apps/desktop/electron/deep-link-registration.ts
+++ b/apps/desktop/electron/deep-link-registration.ts
@@ -1,0 +1,163 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const DESKTOP_FILE_ID = 'hermes.desktop'
+const HERMES_SCHEME_MIME = 'x-scheme-handler/hermes'
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isLinuxUnpackedExecutable(execPath) {
+  const parts = String(execPath || '')
+    .replaceAll('\\', '/')
+    .split('/')
+    .filter(Boolean)
+
+  return parts.length >= 2 && parts.at(-2) === 'linux-unpacked'
+}
+
+function quoteDesktopExec(execPath) {
+  const value = String(execPath || '')
+
+  if (!path.posix.isAbsolute(value) || /[\0\r\n]/.test(value)) {
+    throw new Error('the Linux Desktop executable path must be an absolute single-line path')
+  }
+
+  const escaped = value.replace(/%/g, '%%').replace(/([\\`"$])/g, '\\$1')
+
+  return `"${escaped}"`
+}
+
+function linuxDesktopEntry(execPath) {
+  return [
+    '[Desktop Entry]',
+    'Type=Application',
+    'Name=Hermes',
+    `Exec=${quoteDesktopExec(execPath)} %U`,
+    'Terminal=false',
+    `MimeType=${HERMES_SCHEME_MIME};`,
+    'Categories=Development;',
+    ''
+  ].join('\n')
+}
+
+function writeDesktopEntry(filePath, content) {
+  try {
+    const stat = fs.lstatSync(filePath)
+
+    if (stat.isFile() && !stat.isSymbolicLink() && fs.readFileSync(filePath, 'utf8') === content) {
+      return false
+    }
+  } catch (error: any) {
+    if (error?.code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  const directory = path.dirname(filePath)
+  const temporary = path.join(directory, `.${DESKTOP_FILE_ID}.${process.pid}.${Date.now()}.tmp`)
+  fs.mkdirSync(directory, { recursive: true })
+
+  try {
+    fs.writeFileSync(temporary, content, { encoding: 'utf8', flag: 'wx', mode: 0o644 })
+    fs.renameSync(temporary, filePath)
+  } finally {
+    fs.rmSync(temporary, { force: true })
+  }
+
+  return true
+}
+
+function runCommand(command, args) {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 5_000
+  })
+}
+
+function ensureLinuxUnpackedDeepLink({ execPath, env = process.env, homeDir = os.homedir(), run = runCommand }) {
+  const dataHome = String(env.XDG_DATA_HOME || '').trim() || path.join(homeDir, '.local', 'share')
+  const applicationsDirectory = path.join(dataHome, 'applications')
+  const desktopFile = path.join(applicationsDirectory, DESKTOP_FILE_ID)
+  let changed = false
+
+  try {
+    changed = writeDesktopEntry(desktopFile, linuxDesktopEntry(execPath))
+
+    if (changed) {
+      try {
+        run('update-desktop-database', [applicationsDirectory])
+      } catch {
+        // Optional cache refresh. xdg-mime below is the authoritative registration.
+      }
+    }
+
+    let registered = String(run('xdg-mime', ['query', 'default', HERMES_SCHEME_MIME]) || '').trim()
+
+    if (registered !== DESKTOP_FILE_ID) {
+      run('xdg-mime', ['default', DESKTOP_FILE_ID, HERMES_SCHEME_MIME])
+      registered = String(run('xdg-mime', ['query', 'default', HERMES_SCHEME_MIME]) || '').trim()
+    }
+
+    if (registered !== DESKTOP_FILE_ID) {
+      throw new Error(`xdg-mime reported ${registered || 'no default handler'} after registration`)
+    }
+
+    return { ok: true, changed, desktopFile }
+  } catch (error) {
+    return {
+      ok: false,
+      changed,
+      desktopFile,
+      error: `could not register ${HERMES_SCHEME_MIME} with ${DESKTOP_FILE_ID}: ${errorMessage(error)}`
+    }
+  }
+}
+
+function registerDeepLinkProtocol({
+  protocol,
+  platform,
+  execPath,
+  defaultApp,
+  argv,
+  setAsDefaultProtocolClient,
+  log,
+  linux = {}
+}) {
+  try {
+    if (platform === 'linux' && isLinuxUnpackedExecutable(execPath)) {
+      const result = ensureLinuxUnpackedDeepLink({ execPath, ...linux })
+
+      if (!result.ok) {
+        log(`[deeplink] protocol registration failed: ${result.error}`)
+      }
+
+      return result.ok
+    }
+
+    const registered =
+      defaultApp && argv.length >= 2
+        ? setAsDefaultProtocolClient(protocol, execPath, [path.resolve(argv[1])])
+        : setAsDefaultProtocolClient(protocol)
+
+    if (!registered) {
+      log('[deeplink] protocol registration failed: setAsDefaultProtocolClient returned false')
+    }
+
+    return registered
+  } catch (error) {
+    log(`[deeplink] protocol registration failed: ${errorMessage(error)}`)
+
+    return false
+  }
+}
+
+export {
+  ensureLinuxUnpackedDeepLink,
+  isLinuxUnpackedExecutable,
+  registerDeepLinkProtocol
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -66,6 +66,7 @@ import {
   tokenPreview
 } from './connection-config'
 import { adoptServedDashboardToken } from './dashboard-token'
+import { registerDeepLinkProtocol as registerDeepLinkProtocolImpl } from './deep-link-registration'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import {
   buildPosixCleanupScript,
@@ -10593,17 +10594,15 @@ ipcMain.handle('hermes:deep-link-ready', () => {
 })
 
 function registerDeepLinkProtocol() {
-  try {
-    if (process.defaultApp && process.argv.length >= 2) {
-      // Dev: register with the electron exec path + entry script so the OS can
-      // relaunch us with the URL.
-      app.setAsDefaultProtocolClient(HERMES_PROTOCOL, process.execPath, [path.resolve(process.argv[1])])
-    } else {
-      app.setAsDefaultProtocolClient(HERMES_PROTOCOL)
-    }
-  } catch (err) {
-    rememberLog(`[deeplink] protocol registration failed: ${err.message}`)
-  }
+  registerDeepLinkProtocolImpl({
+    protocol: HERMES_PROTOCOL,
+    platform: process.platform,
+    execPath: process.execPath,
+    defaultApp: Boolean(process.defaultApp),
+    argv: process.argv,
+    setAsDefaultProtocolClient: app.setAsDefaultProtocolClient.bind(app),
+    log: rememberLog
+  })
 }
 
 // Single-instance lock: deep links on a running app (Win/Linux) arrive as a


### PR DESCRIPTION
## Summary

- install a user-level `hermes.desktop` handler for local `release/linux-unpacked` builds without disturbing packaged deb/rpm/AppImage registrations
- register and verify `x-scheme-handler/hermes` through bounded, quiet `xdg-mime` calls; subsequent launches only query the already-valid registration
- check Electron's boolean protocol-registration result on other installation paths and log one actionable failure instead of silently accepting `false`

## Concurrent work

#69923 appeared as a draft after this branch was implemented. That PR performs installer-time registration in Python. This PR is the runtime-side alternative: it also repairs already-built or upgraded unpacked apps on first launch, suppresses the repeated `xdg-mime` stderr, and covers the ignored Electron boolean result. Maintainers can choose the preferred ownership boundary without losing either analysis.

## Testing

- `npm exec -- vitest run --project electron electron/deep-link-registration.test.ts` (6 passed)
- `npm run typecheck --workspace apps/desktop`
- `npm exec -- tsc -p tsconfig.electron.json --noEmit`
- `npm exec -- eslint electron/deep-link-registration.ts electron/deep-link-registration.test.ts electron/main.ts`
- `npm exec -- prettier --check electron/deep-link-registration.ts electron/deep-link-registration.test.ts`
- `npm run test:desktop:platforms --workspace apps/desktop` (653 passed; the Windows host also reported 25 unrelated POSIX/path/permission failures and 2 existing platform-script import failures)

Fixes #69643
