### PR TITLE
fix(gemini): ensure native array tool schemas include items

### DIFF
--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -47,6 +47,7 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
     if not isinstance(schema, dict):
         return {}
 
+    prefix_items = schema.get("prefixItems")
     cleaned: Dict[str, Any] = {}
     for key, value in schema.items():
         if key not in _GEMINI_SCHEMA_ALLOWED_KEYS:
@@ -127,6 +128,45 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
             cleaned.pop("required", None)
         elif len(valid_required) != len(required_val):
             cleaned["required"] = valid_required
+
+    # Gemini's Schema validator requires an ``items`` field on every array
+    # node — a bare ``{"type": "array"}`` (valid standard JSON Schema, where
+    # element types are simply unconstrained) fails the ENTIRE
+    # GenerateContentRequest with HTTP 400
+    # ``...parameters.properties[<name>].items: missing field`` before any model
+    # output. MCP / plugin / dynamic tool schemas routinely omit ``items``, so
+    # populate a schema when it is absent. For a bounded homogeneous
+    # ``prefixItems`` tuple, collapse the repeated positional schema into
+    # ``items`` without inventing length bounds. Otherwise use an empty schema,
+    # which preserves the unconstrained-element meaning of a genuinely bare
+    # array. A declared ``items`` is left untouched. The legacy
+    # ``FunctionDeclaration.parameters`` allow-list does not pass
+    # ``prefixItems`` through; the newer JSON Schema path is separate.
+    if cleaned.get("type") == "array" and "items" not in cleaned:
+        cleaned_prefix = []
+        if (
+            isinstance(prefix_items, list)
+            and prefix_items
+            and all(isinstance(item, dict) for item in prefix_items)
+        ):
+            cleaned_prefix = [
+                sanitize_gemini_schema(item) for item in prefix_items
+            ]
+
+        max_items = cleaned.get("maxItems")
+        bounded_to_prefix = (
+            isinstance(max_items, int)
+            and not isinstance(max_items, bool)
+            and 0 <= max_items <= len(cleaned_prefix)
+        )
+        if (
+            cleaned_prefix
+            and bounded_to_prefix
+            and all(item == cleaned_prefix[0] for item in cleaned_prefix[1:])
+        ):
+            cleaned["items"] = cleaned_prefix[0]
+        else:
+            cleaned["items"] = {}
 
     return cleaned
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -133,6 +133,62 @@ def test_consecutive_user_messages_merge_for_gemini_alternation():
 
 
 
+def test_build_native_request_array_properties_are_repaired():
+    """Wire regression for bare arrays and homogeneous tuple schemas.
+
+    A bare array must gain ``items: {}`` or Gemini rejects the whole tool
+    catalog. A bounded homogeneous ``prefixItems`` tuple must retain its item
+    schema when translated to the legacy ``FunctionDeclaration.parameters``.
+    """
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[{"role": "user", "content": "Decide."}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "propose_action",
+                    "description": "Propose candidate decisions.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "decisions": {
+                                "type": "array",
+                                "description": "Candidate decisions",
+                            },
+                            "bbox": {
+                                "type": "array",
+                                "prefixItems": [{"type": "integer"}] * 4,
+                                "minItems": 4,
+                                "maxItems": 4,
+                            },
+                        },
+                        "required": ["decisions", "bbox"],
+                    },
+                },
+            }
+        ],
+        tool_choice=None,
+    )
+
+    decisions = request["tools"][0]["functionDeclarations"][0]["parameters"][
+        "properties"
+    ]["decisions"]
+    assert decisions["type"] == "array"
+    assert decisions["items"] == {}
+
+    bbox = request["tools"][0]["functionDeclarations"][0]["parameters"][
+        "properties"
+    ]["bbox"]
+    assert bbox == {
+        "type": "array",
+        "items": {"type": "integer"},
+        "minItems": 4,
+        "maxItems": 4,
+    }
+
+
 def test_translate_native_response_surfaces_reasoning_and_tool_calls():
     from agent.gemini_native_adapter import translate_gemini_response
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -133,6 +133,62 @@ def test_consecutive_user_messages_merge_for_gemini_alternation():
 
 
 
+def test_build_native_request_array_properties_are_repaired():
+    """Wire regression for bare arrays and homogeneous tuple schemas.
+
+    A bare array must gain ``items: {}`` or Gemini rejects the whole tool
+    catalog. A bounded homogeneous ``prefixItems`` tuple must retain its item
+    schema when translated to the legacy ``FunctionDeclaration.parameters``.
+    """
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[{"role": "user", "content": "Decide."}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "propose_action",
+                    "description": "Propose candidate decisions.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "decisions": {
+                                "type": "array",
+                                "description": "Candidate decisions",
+                            },
+                            "bbox": {
+                                "type": "array",
+                                "prefixItems": [{"type": "integer"}] * 4,
+                                "minItems": 4,
+                                "maxItems": 4,
+                            },
+                        },
+                        "required": ["decisions", "bbox"],
+                    },
+                },
+            }
+        ],
+        tool_choice=None,
+    )
+
+    decisions = request["tools"][0]["functionDeclarations"][0]["parameters"][
+        "properties"
+    ]["decisions"]
+    assert decisions["type"] == "array"
+    assert decisions["items"] == {}
+
+    bbox = request["tools"][0]["functionDeclarations"][0]["parameters"][
+        "properties"
+    ]["bbox"]
+    assert bbox == {
+        "type": "array",
+        "items": {"type": "integer"},
+        "minItems": 4,
+        "maxItems": 4,
+    }
+
+
 def test_translate_native_response_surfaces_reasoning_and_tool_calls():
     from agent.gemini_native_adapter import translate_gemini_response
 
@@ -301,7 +357,6 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
 # ---------------------------------------------------------------------------
 # X-Goog-Api-Client header tests
 # ---------------------------------------------------------------------------
-
 
 
 

--- a/tests/agent/test_gemini_schema.py
+++ b/tests/agent/test_gemini_schema.py
@@ -137,6 +137,104 @@ class TestRequiredPropertyPruning:
         assert "required" not in cleaned["anyOf"][1]
 
 
+class TestArrayItemsInvariant:
+    """Gemini rejects array ``FunctionDeclaration`` schemas that omit ``items``.
+
+    Standard JSON Schema permits a bare ``{"type": "array"}`` (elements are
+    unconstrained), but Google's native validator fails the ENTIRE
+    GenerateContentRequest with HTTP 400
+    ``...parameters.properties[<name>].items: missing field`` before any model
+    output. MCP / plugin / dynamic tool schemas routinely emit this shape, so
+    every array node produced by the sanitizer must carry an ``items`` key.
+    """
+
+    def test_bare_array_property_gets_empty_items(self):
+        """Exact #69031 (Bug 2) shape: a required array property without items."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "decisions": {"type": "array", "description": "Candidate decisions"}
+            },
+            "required": ["decisions"],
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        decisions = cleaned["properties"]["decisions"]
+        assert decisions["type"] == "array"
+        assert decisions["items"] == {}
+
+    def test_bare_array_input_is_not_mutated(self):
+        """The sanitizer builds a cleaned copy; the input schema is untouched."""
+        schema = {"type": "array", "description": "Unconstrained list."}
+        sanitize_gemini_schema(schema)
+        assert "items" not in schema
+        assert schema == {"type": "array", "description": "Unconstrained list."}
+
+    def test_declared_items_schema_is_preserved(self):
+        """An existing ``items`` schema must survive untouched (no overwrite)."""
+        schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"id": {"type": "string"}},
+                "required": ["id"],
+            },
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["items"] == {
+            "type": "object",
+            "properties": {"id": {"type": "string"}},
+            "required": ["id"],
+        }
+
+    def test_recursive_nested_arrays_all_carry_items(self):
+        """Invariant must hold on every array node reachable through the walk."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "matrix": {"type": "array", "items": {"type": "array"}},
+                "any_branch": {
+                    "anyOf": [
+                        {"type": "array"},
+                        {"type": "string"},
+                    ]
+                },
+            },
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        # Outer matrix array keeps items; the inner bare-typed array also gets items.
+        matrix_items = cleaned["properties"]["matrix"]["items"]
+        assert matrix_items["type"] == "array"
+        assert matrix_items["items"] == {}
+        # The array branch inside anyOf is repaired too.
+        assert cleaned["properties"]["any_branch"]["anyOf"][0]["items"] == {}
+
+    def test_bounded_homogeneous_prefixitems_preserve_item_schema(self):
+        """A fixed homogeneous tuple can be represented losslessly as items."""
+        schema = {
+            "type": "array",
+            "prefixItems": [{"type": "integer"}] * 4,
+            "minItems": 4,
+            "maxItems": 4,
+        }
+
+        cleaned = sanitize_gemini_schema(schema)
+
+        assert cleaned == {
+            "type": "array",
+            "items": {"type": "integer"},
+            "minItems": 4,
+            "maxItems": 4,
+        }
+
+    def test_unbounded_prefixitems_fall_back_to_empty_items(self):
+        """Do not narrow unconstrained tail elements to the prefix schema."""
+        schema = {"type": "array", "prefixItems": [{"type": "string"}]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert "prefixItems" not in cleaned
+        assert cleaned["type"] == "array"
+        assert cleaned["items"] == {}
+
+
 class TestSanitizeGeminiToolParameters:
     def test_empty_parameters_return_valid_object_schema(self):
         """Gemini requires ``parameters`` to be a valid object schema."""


### PR DESCRIPTION
## What does this PR do?

Fixes Bug 2 of #69031. Starting a session against the Gemini native API
(`/v1beta`) can fail immediately with:

```text
HTTP 400 INVALID_ARGUMENT
GenerateContentRequest.tools[0].function_declarations[N]
.parameters.properties[decisions].items: missing field
```

One tool parameter with `type: "array"` but no `items` key causes Gemini to
reject the entire `GenerateContentRequest` before any model output.

The final Gemini-native schema translator now enforces a last-mile invariant:
every cleaned array node has an `items` field. Genuinely bare arrays receive
`items: {}`, preserving their unconstrained-element meaning without guessing a
type.

## Root cause and placement

A bare array is valid JSON Schema, but Gemini's legacy
`FunctionDeclaration.parameters` validator requires `items`.

`sanitize_gemini_schema()` is the final native Gemini wire boundary. It runs
after all tool sources have been assembled and after the legacy Schema
allow-list has filtered unsupported keywords. The shared sanitizer is not the
final boundary for every source: memory and context-engine tools can be
appended later. The Gemini translator sees every declaration immediately
before native request construction.

Merged PR #64054 established the same placement pattern for another
Gemini-only final-wire invariant (`required` pruning).

## Tuple / `prefixItems` semantics

A follow-up report on #71804 identified Pydantic/Zod tuples as a common source
of arrays without `items`. For example, a Pydantic
`tuple[int, int, int, int]` emits four identical `prefixItems` plus
`minItems: 4` and `maxItems: 4`.

The legacy `FunctionDeclaration.parameters` Schema rejects `prefixItems`. The
sanitizer therefore preserves the common representable case before the
allow-list removes that keyword:

- A bounded homogeneous tuple is collapsed losslessly into a sanitized
  `items` schema while retaining its original `minItems` / `maxItems`.
- Missing length bounds are never synthesized: `prefixItems` count alone does
  not imply exact array length.
- An existing `items` schema is never overwritten.
- A genuinely bare array, or a tuple form that cannot be represented
  losslessly by the legacy Schema field, retains the permissive `items: {}`
  fallback. Original bounds still survive when present.

This PR deliberately does not switch declarations to `parametersJsonSchema`;
that is a broader compatibility change covering heterogeneous positional tuple
semantics and should be evaluated separately.

## Changes made

- `agent/gemini_schema.py`: enforce the final array/`items` post-condition and
  preserve bounded homogeneous `prefixItems` tuples.
- `tests/agent/test_gemini_schema.py`: cover the exact issue shape, input
  immutability, declared-items preservation, recursive arrays, `anyOf`,
  homogeneous tuple preservation, and the unbounded-prefix fallback.
- `tests/agent/test_gemini_native_adapter.py`: assert both bare-array repair
  and tuple preservation on the final `functionDeclarations` wire payload.

## How to test

```bash
HERMES_PYTHON=/path/to/python-with-pytest scripts/run_tests.sh \
  tests/agent/test_gemini_schema.py \
  tests/agent/test_gemini_native_adapter.py \
  tests/tools/test_schema_sanitizer.py
# 57 passed, 0 failed

uvx --from ruff==0.15.10 ruff check \
  agent/gemini_schema.py \
  tests/agent/test_gemini_schema.py \
  tests/agent/test_gemini_native_adapter.py
# All checks passed!
```

The tuple regression was observed RED before the implementation:
`items == {}` instead of the expected `items == {"type": "integer"}`.

## Live `/v1beta` verification

Native `x-goog-api-key` auth, `gemini-flash-latest` (server-reported
`gemini-3.6-flash`), tiny prompt, and `maxOutputTokens: 16`:

| Payload | Result |
|---|---|
| Bare array with patched `items: {}` | **HTTP 200** |
| Bare array without `items` | **HTTP 400** `items: missing field` |
| Patched bounded tuple: `items: {"type":"integer"}`, `minItems: 4`, `maxItems: 4` | **HTTP 200** |
| Raw tuple using `prefixItems` in legacy `parameters` | **HTTP 400** `Unknown name "prefixItems"` |

This confirms both that the permissive bare-array fallback is accepted and
that the new homogeneous-tuple collapse preserves the element type while
using fields accepted by the legacy wire schema.

## Overlap analysis

- #71804 and #71816 concern the shared/OpenAI-compatible sanitizer path. This
  PR covers the distinct native Gemini `/v1beta` boundary; automated triage has
  repeatedly recommended keeping #69928 separate.
- #22056 and #25846 add related repairs upstream, but they do not cover tools
  appended after shared sanitization or the final shape left after
  Gemini-specific filtering.
- #62271 uses `items: {"type":"string"}`, which narrows genuinely
  unconstrained arrays; this PR uses `items: {}` only when no lossless item
  schema is available.
- #38972 handles the inverse invariant: array-only fields on non-array nodes.
- #69068 addresses only Bug 1, the inherited `Authorization` header.

## Risk and compatibility

- Native Gemini only; no configuration, tool execution, prompt, or other
  provider changes.
- Deterministic, copy-based transformation; source schemas are not mutated.
- The common fixed homogeneous tuple form is preserved without expanding the
  wire protocol used by all declarations.

## Type of change

- [x] Bug fix
- [x] Tests
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Platform tested

- OS: Ubuntu 24.04, Linux x86_64
- Python: 3.13.9 (local tests and live A/B)
- Base commit: `c0106e50e` (`upstream/main` at rebase)

Refs #69031 (Bug 2 only)
