### PR TITLE
fix(tui): auto-scroll transcript to bottom during agent streaming

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -8,7 +8,7 @@ import {
   useTerminalTitle
 } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { DASHBOARD_TUI_MODE, STARTUP_RESUME_ID } from '../config/env.js'
 import { MAX_HISTORY, WHEEL_SCROLL_STEP } from '../config/limits.js'
@@ -433,6 +433,15 @@ export function useMainApp(gw: GatewayClient) {
     (msg: Msg) => setHistoryItems(prev => capHistory(appendTranscriptMessage(prev, msg))),
     []
   )
+
+  // Auto-scroll to bottom when new content streams in and the user is
+  // already at the bottom.  When the user scrolls up manually isSticky()
+  // returns false and the follow stops.  Scrolling back to the bottom
+  // restores the sticky flag via the renderer's positional follow so the
+  // effect resumes on the next content change.
+  useLayoutEffect(() => {
+    scrollRef.current?.isSticky() && scrollRef.current.scrollToBottom()
+  }, [historyItems.length])
 
   const sys = useCallback((text: string) => appendMessage({ role: 'system', text }), [appendMessage])
 


### PR DESCRIPTION
## Summary

Fixes #69873 — when Hermes runs in TUI mode, the transcript now auto-scrolls to the bottom as new content streams in, as long as the user hasn't manually scrolled up.

## Behaviour

| State | Result |
|-------|--------|
| User at bottom (sticky) | New content triggers scrollToBottom — live progress is visible |
| User scrolls up | isSticky() → false, follow stops |
| User scrolls back to bottom | Renderer's positional follow restores sticky, follow resumes on next content change |

## Implementation

Added a single `useLayoutEffect` in `useMainApp.ts` that watches `historyItems.length`:

```ts
useLayoutEffect(() => {
  scrollRef.current?.isSticky() && scrollRef.current.scrollToBottom()
}, [historyItems.length])
```

- Uses `useLayoutEffect` (not `useEffect`) to scroll before paint, avoiding flicker
- Reuses the existing `ScrollBoxHandle.isSticky()` / `scrollToBottom()` API — same path the resize handler already calls (line 640-641)
- Minimal diff: +10 / −1 lines

## Test Plan

- [x] Existing scroll tests pass (7/7)
- Manual: open TUI, start a long tool call, verify the transcript scrolls to follow new output; scroll up during output, verify it stops following; scroll back down, verify it resumes