### PR TITLE
fix(process): report Windows PTY EOF as unsupported

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -136,10 +136,8 @@ def test_kill_all_backward_compat_and_exclude_ids(registry):
 
 
 def _python_command(source: str) -> str:
-    """Build a shell-safe Python command for the platform under test."""
-    executable = sys.executable if sys.platform == "win32" else "python3"
-
-    return f"{shlex.quote(executable)} -c {shlex.quote(source)}"
+    """Build a command for the shell used by ``spawn_local``."""
+    return shlex.join([sys.executable, "-c", source])
 
 
 def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool:
@@ -633,7 +631,7 @@ class TestStdinHelpers:
         supported path.
         """
         session = registry.spawn_local(
-            'python3 -c "import sys; print(sys.stdin.read().strip())"',
+            _python_command("import sys; print(sys.stdin.read().strip())"),
             cwd=str(tmp_path),
             use_pty=True,
         )
@@ -661,18 +659,19 @@ class TestStdinHelpers:
         finally:
             registry.kill_process(session.id)
 
-    @pytest.mark.skipif(
-        sys.platform != "win32",
-        reason="requires the native Windows PTY backend",
-    )
+    @pytest.mark.windows_only
     def test_close_stdin_windows_real_pty_remains_writable(self, registry, tmp_path):
         """Unsupported EOF leaves a native Windows PTY child unchanged."""
         session = registry.spawn_local(
             _python_command(
                 "import sys\n"
                 "print('READY', flush=True)\n"
-                "for line in sys.stdin:\n"
-                "    print('READ:' + line.strip(), flush=True)"
+                "while True:\n"
+                "    byte = sys.stdin.buffer.read(1)\n"
+                "    if not byte:\n"
+                "        print('EOF_RECEIVED', flush=True)\n"
+                "        break\n"
+                "    print(f'BYTE={byte!r}', flush=True)"
             ),
             cwd=str(tmp_path),
             use_pty=True,
@@ -696,18 +695,18 @@ class TestStdinHelpers:
             assert registry.close_stdin(session.id) == expected
             assert registry.poll(session.id)["status"] == "running"
 
-            assert registry.submit_stdin(session.id, "after-close") == {
+            assert registry.write_stdin(session.id, "after-close\r") == {
                 "status": "ok",
                 "bytes_written": 12,
             }
             assert _wait_until(
-                lambda: "READ:after-close"
-                in registry.poll(session.id)["output_preview"]
+                lambda: "BYTE=b'e'" in registry.poll(session.id)["output_preview"]
             )
 
             poll = registry.poll(session.id)
             assert poll["status"] == "running"
-            assert "\x04" not in poll["output_preview"]
+            assert "BYTE=b'\\x04'" not in poll["output_preview"]
+            assert "EOF_RECEIVED" not in poll["output_preview"]
         finally:
             registry.kill_process(session.id)
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -132,6 +133,13 @@ def test_kill_all_backward_compat_and_exclude_ids(registry):
     calls.clear()
     assert registry.kill_all("session-a") == 2
     assert sorted(c[0] for c in calls) == ["proc_a", "proc_b"]
+
+
+def _python_command(source: str) -> str:
+    """Build a shell-safe Python command for the platform under test."""
+    executable = sys.executable if sys.platform == "win32" else "python3"
+
+    return f"{shlex.quote(executable)} -c {shlex.quote(source)}"
 
 
 def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool:
@@ -570,6 +578,52 @@ class TestStdinHelpers:
         proc.stdin.close.assert_called_once()
         assert result["status"] == "ok"
 
+    def test_close_stdin_posix_pty_mode(self, registry, monkeypatch):
+        pty = MagicMock()
+        s = _make_session()
+        s._pty = pty
+        registry._running[s.id] = s
+        monkeypatch.setattr("tools.process_registry._IS_WINDOWS", False)
+
+        result = registry.close_stdin(s.id)
+
+        pty.sendeof.assert_called_once()
+        assert result["status"] == "ok"
+
+    def test_close_stdin_windows_pty_reports_unsupported_without_writing(
+        self, registry, monkeypatch
+    ):
+        pty = MagicMock()
+        s = _make_session()
+        s._pty = pty
+        registry._running[s.id] = s
+        monkeypatch.setattr("tools.process_registry._IS_WINDOWS", True)
+
+        result = registry.close_stdin(s.id)
+
+        assert result == {
+            "status": "error",
+            "code": "EOF_UNSUPPORTED_FOR_PTY_BACKEND",
+            "error": (
+                "The native Windows PTY backend cannot close stdin without "
+                "terminating the child; no EOF was sent."
+            ),
+        }
+        pty.sendeof.assert_not_called()
+        pty.write.assert_not_called()
+
+        # Unsupported means no write-side state changed. The child remains
+        # usable and a later write still reaches pywinpty as text.
+        assert registry.write_stdin(s.id, "after-close\r") == {
+            "status": "ok",
+            "bytes_written": 12,
+        }
+        pty.write.assert_called_once_with("after-close\r")
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="native Windows PTYs cannot close stdin non-destructively",
+    )
     def test_close_stdin_allows_eof_driven_process_to_finish(self, registry, tmp_path):
         """PTY mode: writing data + sending EOF lets an EOF-driven child finish.
 
@@ -604,6 +658,56 @@ class TestStdinHelpers:
                 time.sleep(0.02)
 
             pytest.fail("process did not exit after stdin was closed")
+        finally:
+            registry.kill_process(session.id)
+
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="requires the native Windows PTY backend",
+    )
+    def test_close_stdin_windows_real_pty_remains_writable(self, registry, tmp_path):
+        """Unsupported EOF leaves a native Windows PTY child unchanged."""
+        session = registry.spawn_local(
+            _python_command(
+                "import sys\n"
+                "print('READY', flush=True)\n"
+                "for line in sys.stdin:\n"
+                "    print('READ:' + line.strip(), flush=True)"
+            ),
+            cwd=str(tmp_path),
+            use_pty=True,
+        )
+
+        try:
+            assert session._pty is not None
+            assert _wait_until(
+                lambda: "READY" in registry.poll(session.id)["output_preview"]
+            )
+
+            expected = {
+                "status": "error",
+                "code": "EOF_UNSUPPORTED_FOR_PTY_BACKEND",
+                "error": (
+                    "The native Windows PTY backend cannot close stdin without "
+                    "terminating the child; no EOF was sent."
+                ),
+            }
+            assert registry.close_stdin(session.id) == expected
+            assert registry.close_stdin(session.id) == expected
+            assert registry.poll(session.id)["status"] == "running"
+
+            assert registry.submit_stdin(session.id, "after-close") == {
+                "status": "ok",
+                "bytes_written": 12,
+            }
+            assert _wait_until(
+                lambda: "READ:after-close"
+                in registry.poll(session.id)["output_preview"]
+            )
+
+            poll = registry.poll(session.id)
+            assert poll["status"] == "running"
+            assert "\x04" not in poll["output_preview"]
         finally:
             registry.kill_process(session.id)
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -427,8 +427,12 @@ class TestStdinHelpers:
             _python_command(
                 "import sys\n"
                 "print('READY', flush=True)\n"
-                "for line in sys.stdin:\n"
-                "    print('READ:' + line.strip(), flush=True)"
+                "while True:\n"
+                "    byte = sys.stdin.buffer.read(1)\n"
+                "    if not byte:\n"
+                "        print('EOF_RECEIVED', flush=True)\n"
+                "        break\n"
+                "    print(f'BYTE={byte!r}', flush=True)"
             ),
             cwd=str(tmp_path),
             use_pty=True,
@@ -452,18 +456,18 @@ class TestStdinHelpers:
             assert registry.close_stdin(session.id) == expected
             assert registry.poll(session.id)["status"] == "running"
 
-            assert registry.submit_stdin(session.id, "after-close") == {
+            assert registry.write_stdin(session.id, "after-close\r") == {
                 "status": "ok",
                 "bytes_written": 12,
             }
             assert _wait_until(
-                lambda: "READ:after-close"
-                in registry.poll(session.id)["output_preview"]
+                lambda: "BYTE=b'e'" in registry.poll(session.id)["output_preview"]
             )
 
             poll = registry.poll(session.id)
             assert poll["status"] == "running"
-            assert "\x04" not in poll["output_preview"]
+            assert "BYTE=b'\\x04'" not in poll["output_preview"]
+            assert "EOF_RECEIVED" not in poll["output_preview"]
         finally:
             registry.kill_process(session.id)
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -53,6 +54,13 @@ def _spawn_python_sleep(seconds: float) -> subprocess.Popen:
     return subprocess.Popen(
         [sys.executable, "-c", f"import time; time.sleep({seconds})"],
     )
+
+
+def _python_command(source: str) -> str:
+    """Build a shell-safe Python command for the platform under test."""
+    executable = sys.executable if sys.platform == "win32" else "python3"
+
+    return f"{shlex.quote(executable)} -c {shlex.quote(source)}"
 
 
 def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool:
@@ -326,6 +334,52 @@ class TestStdinHelpers:
         proc.stdin.close.assert_called_once()
         assert result["status"] == "ok"
 
+    def test_close_stdin_posix_pty_mode(self, registry, monkeypatch):
+        pty = MagicMock()
+        s = _make_session()
+        s._pty = pty
+        registry._running[s.id] = s
+        monkeypatch.setattr("tools.process_registry._IS_WINDOWS", False)
+
+        result = registry.close_stdin(s.id)
+
+        pty.sendeof.assert_called_once()
+        assert result["status"] == "ok"
+
+    def test_close_stdin_windows_pty_reports_unsupported_without_writing(
+        self, registry, monkeypatch
+    ):
+        pty = MagicMock()
+        s = _make_session()
+        s._pty = pty
+        registry._running[s.id] = s
+        monkeypatch.setattr("tools.process_registry._IS_WINDOWS", True)
+
+        result = registry.close_stdin(s.id)
+
+        assert result == {
+            "status": "error",
+            "code": "EOF_UNSUPPORTED_FOR_PTY_BACKEND",
+            "error": (
+                "The native Windows PTY backend cannot close stdin without "
+                "terminating the child; no EOF was sent."
+            ),
+        }
+        pty.sendeof.assert_not_called()
+        pty.write.assert_not_called()
+
+        # Unsupported means no write-side state changed. The child remains
+        # usable and a later write still reaches pywinpty as text.
+        assert registry.write_stdin(s.id, "after-close\r") == {
+            "status": "ok",
+            "bytes_written": 12,
+        }
+        pty.write.assert_called_once_with("after-close\r")
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="native Windows PTYs cannot close stdin non-destructively",
+    )
     def test_close_stdin_allows_eof_driven_process_to_finish(self, registry, tmp_path):
         """PTY mode: writing data + sending EOF lets an EOF-driven child finish.
 
@@ -360,6 +414,56 @@ class TestStdinHelpers:
                 time.sleep(0.02)
 
             pytest.fail("process did not exit after stdin was closed")
+        finally:
+            registry.kill_process(session.id)
+
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="requires the native Windows PTY backend",
+    )
+    def test_close_stdin_windows_real_pty_remains_writable(self, registry, tmp_path):
+        """Unsupported EOF leaves a native Windows PTY child unchanged."""
+        session = registry.spawn_local(
+            _python_command(
+                "import sys\n"
+                "print('READY', flush=True)\n"
+                "for line in sys.stdin:\n"
+                "    print('READ:' + line.strip(), flush=True)"
+            ),
+            cwd=str(tmp_path),
+            use_pty=True,
+        )
+
+        try:
+            assert session._pty is not None
+            assert _wait_until(
+                lambda: "READY" in registry.poll(session.id)["output_preview"]
+            )
+
+            expected = {
+                "status": "error",
+                "code": "EOF_UNSUPPORTED_FOR_PTY_BACKEND",
+                "error": (
+                    "The native Windows PTY backend cannot close stdin without "
+                    "terminating the child; no EOF was sent."
+                ),
+            }
+            assert registry.close_stdin(session.id) == expected
+            assert registry.close_stdin(session.id) == expected
+            assert registry.poll(session.id)["status"] == "running"
+
+            assert registry.submit_stdin(session.id, "after-close") == {
+                "status": "ok",
+                "bytes_written": 12,
+            }
+            assert _wait_until(
+                lambda: "READ:after-close"
+                in registry.poll(session.id)["output_preview"]
+            )
+
+            poll = registry.poll(session.id)
+            assert poll["status"] == "running"
+            assert "\x04" not in poll["output_preview"]
         finally:
             registry.kill_process(session.id)
 
@@ -1368,4 +1472,3 @@ class TestReaderLoopOrphanedPipe:
                 os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
             except (ProcessLookupError, PermissionError):
                 pass
-

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2549,6 +2549,21 @@ class ProcessRegistry:
             return {"status": "already_exited", "error": "Process has already finished"}
 
         if hasattr(session, '_pty') and session._pty:
+            # pywinpty's ``sendeof()`` writes a literal Ctrl-D character. A
+            # native Windows child reads that as application data rather than
+            # observing an exhausted input stream, so reporting success here
+            # would claim an effect the backend cannot provide. Keep the PTY
+            # and its write side untouched; callers can still write or choose
+            # the explicitly destructive ``kill`` action.
+            if _IS_WINDOWS:
+                return {
+                    "status": "error",
+                    "code": "EOF_UNSUPPORTED_FOR_PTY_BACKEND",
+                    "error": (
+                        "The native Windows PTY backend cannot close stdin "
+                        "without terminating the child; no EOF was sent."
+                    ),
+                }
             try:
                 session._pty.sendeof()
                 return {"status": "ok", "message": "EOF sent"}
@@ -3376,7 +3391,8 @@ PROCESS_SCHEMA = {
         "poll: status + new output. log: full output, paged. wait: block "
         "until exit or timeout (partial output on timeout). write vs "
         "submit: submit appends Enter — use it to answer prompts; write "
-        "sends raw bytes, no newline. close: EOF stdin. kill: terminate."
+        "sends raw bytes, no newline. close: EOF stdin (unsupported on "
+        "native Windows PTYs). kill: terminate."
     ),
     "parameters": {
         "type": "object",

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1743,6 +1743,21 @@ class ProcessRegistry:
             return {"status": "already_exited", "error": "Process has already finished"}
 
         if hasattr(session, '_pty') and session._pty:
+            # pywinpty's ``sendeof()`` writes a literal Ctrl-D character. A
+            # native Windows child reads that as application data rather than
+            # observing an exhausted input stream, so reporting success here
+            # would claim an effect the backend cannot provide. Keep the PTY
+            # and its write side untouched; callers can still write or choose
+            # the explicitly destructive ``kill`` action.
+            if _IS_WINDOWS:
+                return {
+                    "status": "error",
+                    "code": "EOF_UNSUPPORTED_FOR_PTY_BACKEND",
+                    "error": (
+                        "The native Windows PTY backend cannot close stdin "
+                        "without terminating the child; no EOF was sent."
+                    ),
+                }
             try:
                 session._pty.sendeof()
                 return {"status": "ok", "message": "EOF sent"}
@@ -2307,7 +2322,8 @@ PROCESS_SCHEMA = {
         "Actions: 'list' (show all), 'poll' (check status + new output), "
         "'log' (full output with pagination), 'wait' (block until done or timeout), "
         "'kill' (terminate), 'write' (send raw stdin data without newline), "
-        "'submit' (send data + Enter, for answering prompts), 'close' (close stdin/send EOF)."
+        "'submit' (send data + Enter, for answering prompts), 'close' (close stdin/send EOF; "
+        "unsupported for native Windows PTYs)."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## What does this PR do?

Prevents `process(action="close")` from reporting a successful EOF on native Windows PTYs when `pywinpty` can only write a literal Ctrl-D byte. On current `main` (`8ad055414b`), the Windows path still returns `{"status": "ok", "message": "EOF sent"}` and calls `sendeof()` once even though the child receives `b"\x04"` as application data instead of EOF.

The Windows PTY path now fails closed with `EOF_UNSUPPORTED_FOR_PTY_BACKEND` before calling `sendeof()`. It does not write substitute input, mark the write side closed, or terminate the child, so later writes remain valid. POSIX PTY EOF and pipe-backed stdin closure retain their existing behavior.

This preserves the original purpose of `close_stdin()`—allowing EOF-driven children to finish where the backend supports real EOF—without replacing it with `PtyProcess.close()`, which may terminate the child.

## Related Issue

Fixes #69929

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/process_registry.py`: return a stable unsupported result before native Windows `pywinpty.sendeof()`, and document the backend limitation in the process tool schema.
- `tests/tools/test_process_registry.py`: cover supported POSIX PTY EOF, the Windows no-write contract, repeated unsupported closes, continued child liveness, absence of Ctrl-D/EOF delivery, and successful subsequent writes using a byte-oriented native-Windows child.
- Build test child commands from `sys.executable` with quoting that matches `spawn_local()`'s shell command contract on both Windows and POSIX.

## How to Test

1. On native Windows, spawn the Windows-only regression child under a PTY and wait for its child-produced `READY` marker.
2. Call `close_stdin()` twice. Both calls must return the same structured unsupported error, the child must remain running, and the child must emit neither `BYTE=b'\x04'` nor `EOF_RECEIVED`.
3. Write `after-close\r`. Child-produced `BYTE=...` output must prove the write side remains usable.
4. On POSIX, submit input to the EOF-driven PTY child, close stdin, and verify that the child exits successfully with the submitted text.

Validation after rebasing onto `8ad055414b`, head `9cf3de08af`:

- `scripts/run_tests.sh tests/tools/test_process_registry.py -q -k close_stdin` — 4 passed, 0 failed, 1 skipped
- `scripts/run_tests.sh tests/tools/test_process_registry.py -q` — 78 passed, 0 failed, 6 skipped
- complete affected process/terminal surface (27 files) via `scripts/run_tests.sh` — 319 passed, 0 failed, 6 skipped
- `ruff check --no-cache tools/process_registry.py tests/tools/test_process_registry.py` — passed
- byte compilation and `git diff --check upstream/main..HEAD` — passed
- Windows-footgun scan reports the same 21 pre-existing findings on unmodified `upstream/main`; this diff introduces no new finding
- [GitHub CI](https://github.com/NousResearch/hermes-agent/actions/runs/31932825876) — all required checks passed, including the native-Windows job and 12/12 Python slices
- [Docker build](https://github.com/NousResearch/hermes-agent/actions/runs/31932825586) — amd64 and arm64 builds passed

Local platform: macOS 26.5.1, Python 3.11.15. The byte-oriented regression previously passed independently on native Windows with Python 3.11.15 and pywinpty 2.0.15 (`5 passed, 1 skipped` on pre-rebase head `182921fae5`), and the final rebased head passed the repository's native-Windows GitHub Actions lane.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — behavior is covered by process-registry regression tests.
