### PR TITLE
fix(kanban): make worker termination and retries fail closed

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -753,6 +753,25 @@ def run_conversation(
     # Commentary deduplication spans all provider continuations and tool calls
     # within one user turn, but must not suppress the same phrase next turn.
     agent._delivered_interim_texts = set()
+    agent._kanban_terminal_tool = None
+    agent._kanban_ownership_lost_reason = None
+    _kanban_worker = bool(os.environ.get("HERMES_KANBAN_TASK"))
+    if not _kanban_worker:
+        os.environ.pop("HERMES_ITERATIONS_REMAINING", None)
+        os.environ.pop("HERMES_MAX_ITERATIONS", None)
+
+    def _sync_kanban_iteration_env() -> None:
+        if not _kanban_worker:
+            return
+        os.environ["HERMES_ITERATIONS_REMAINING"] = str(
+            max(0, int(agent.iteration_budget.remaining))
+        )
+        budget_max = getattr(
+            agent.iteration_budget,
+            "max_total",
+            agent.max_iterations,
+        )
+        os.environ["HERMES_MAX_ITERATIONS"] = str(int(budget_max))
 
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
@@ -812,6 +831,19 @@ def run_conversation(
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+        _sync_kanban_iteration_env()
+        from tools.kanban_tools import current_worker_ownership_error
+
+        ownership_error = current_worker_ownership_error()
+        if ownership_error:
+            agent._kanban_ownership_lost_reason = ownership_error
+            _turn_exit_reason = "kanban_ownership_lost"
+            final_response = (
+                "This Kanban worker stopped because it no longer owns the "
+                f"active task run: {ownership_error}."
+            )
+            break
+
         _redirect_text = agent._drain_pending_redirect()
         if _redirect_text:
             _apply_active_turn_redirect(agent, messages, _redirect_text)
@@ -843,10 +875,12 @@ def run_conversation(
         if agent._budget_grace_call:
             agent._budget_grace_call = False
         elif not agent.iteration_budget.consume():
+            _sync_kanban_iteration_env()
             _turn_exit_reason = "budget_exhausted"
             if not agent.quiet_mode:
                 agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")
             break
+        _sync_kanban_iteration_env()
 
         # Fire step_callback for gateway hooks (agent:step event)
         if agent.step_callback is not None:
@@ -5315,6 +5349,28 @@ def run_conversation(
                         pass
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+
+                terminal_tool = getattr(agent, "_kanban_terminal_tool", None)
+                if terminal_tool:
+                    _turn_exit_reason = f"kanban_terminal({terminal_tool})"
+                    final_response = (
+                        "Kanban task closed successfully via "
+                        f"`{terminal_tool}`."
+                    )
+                    break
+
+                ownership_error = getattr(
+                    agent,
+                    "_kanban_ownership_lost_reason",
+                    None,
+                )
+                if ownership_error:
+                    _turn_exit_reason = "kanban_ownership_lost"
+                    final_response = (
+                        "This Kanban worker stopped because it no longer owns "
+                        f"the active task run: {ownership_error}."
+                    )
+                    break
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -38,7 +38,7 @@ from agent.conversation_compression import (
 )
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
-from agent.iteration_budget import IterationBudget
+from agent.iteration_budget import IterationBudget, effective_iteration_state
 from agent.turn_context import (
     _compression_warrants_another_preflight_pass,
     build_turn_context,
@@ -763,15 +763,13 @@ def run_conversation(
     def _sync_kanban_iteration_env() -> None:
         if not _kanban_worker:
             return
-        os.environ["HERMES_ITERATIONS_REMAINING"] = str(
-            max(0, int(agent.iteration_budget.remaining))
-        )
-        budget_max = getattr(
+        _, effective_remaining, effective_max = effective_iteration_state(
             agent.iteration_budget,
-            "max_total",
             agent.max_iterations,
+            api_call_count,
         )
-        os.environ["HERMES_MAX_ITERATIONS"] = str(int(budget_max))
+        os.environ["HERMES_ITERATIONS_REMAINING"] = str(effective_remaining)
+        os.environ["HERMES_MAX_ITERATIONS"] = str(effective_max)
 
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0

--- a/agent/iteration_budget.py
+++ b/agent/iteration_budget.py
@@ -59,4 +59,21 @@ class IterationBudget:
             return max(0, self.max_total - self._used)
 
 
-__all__ = ["IterationBudget"]
+def effective_iteration_state(
+    budget: IterationBudget,
+    max_iterations: int,
+    api_call_count: int,
+) -> tuple[int, int, int]:
+    """Return effective ``(used, remaining, maximum)`` iteration limits."""
+    maximum = max(0, min(int(budget.max_total), int(max_iterations)))
+    remaining = max(
+        0,
+        min(
+            int(budget.remaining),
+            int(max_iterations) - int(api_call_count),
+        ),
+    )
+    return maximum - remaining, remaining, maximum
+
+
+__all__ = ["IterationBudget", "effective_iteration_state"]

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -13,6 +13,7 @@ loop continues instead of exiting.
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any, Iterable, Optional
 
@@ -35,34 +36,30 @@ def kanban_stop_nudge_enabled() -> bool:
     return bool(task)
 
 
-def _tool_call_name(tc: Any) -> str:
-    if isinstance(tc, dict):
-        fn = tc.get("function")
-        if isinstance(fn, dict):
-            return str(fn.get("name") or "")
-        return str(tc.get("name") or "")
-    fn = getattr(tc, "function", None)
-    if fn is not None:
-        return str(getattr(fn, "name", "") or "")
-    return str(getattr(tc, "name", "") or "")
+def kanban_terminal_succeeded(tool_name: str, result: Any) -> bool:
+    """Return whether a terminal Kanban tool confirmed its state change."""
+    if tool_name not in _TERMINAL_KANBAN_TOOLS:
+        return False
+    if isinstance(result, str):
+        try:
+            result = json.loads(result)
+        except (TypeError, ValueError):
+            return False
+    return isinstance(result, dict) and result.get("ok") is True
 
 
 def session_called_kanban_terminal(messages: Iterable[dict] | None) -> bool:
-    """True if this conversation already invoked a terminal kanban tool."""
+    """True if this conversation successfully closed its Kanban task."""
     if not messages:
         return False
     for msg in messages:
         if not isinstance(msg, dict):
             continue
-        role = msg.get("role")
-        if role == "assistant":
-            for tc in msg.get("tool_calls") or []:
-                if _tool_call_name(tc) in _TERMINAL_KANBAN_TOOLS:
-                    return True
-        elif role == "tool":
-            name = str(msg.get("name") or "")
-            if name in _TERMINAL_KANBAN_TOOLS:
-                return True
+        if msg.get("role") != "tool":
+            continue
+        name = str(msg.get("name") or "")
+        if kanban_terminal_succeeded(name, msg.get("content")):
+            return True
     return False
 
 
@@ -103,6 +100,7 @@ def build_kanban_stop_nudge(
 
 __all__ = [
     "build_kanban_stop_nudge",
+    "kanban_terminal_succeeded",
     "kanban_stop_nudge_enabled",
     "session_called_kanban_terminal",
 ]

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -38,9 +38,13 @@ from tools.threat_patterns import scan_for_threats
 
 logger = logging.getLogger(__name__)
 
-# Tools that must never run concurrently (interactive / user-facing).
+# Tools that must never run concurrently (interactive or terminal barriers).
 # When any of these appear in a batch, we fall back to sequential execution.
-_NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
+_NEVER_PARALLEL_TOOLS = frozenset({
+    "clarify",
+    "kanban_block",
+    "kanban_complete",
+})
 
 # Read-only tools with no shared mutable session state.
 _PARALLEL_SAFE_TOOLS = frozenset({

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -209,6 +209,50 @@ def _cancelled_tool_result(reason: str = "user interrupt") -> str:
     )
 
 
+def _kanban_worker_ownership_error() -> Optional[str]:
+    """Return the current worker ownership error, if this is a Kanban worker."""
+    from tools.kanban_tools import current_worker_ownership_error
+
+    return current_worker_ownership_error()
+
+
+def _skip_tool_calls(
+    agent,
+    messages: list,
+    tool_calls,
+    *,
+    reason: str,
+) -> None:
+    """Append one non-effect result for each tool call that was not started."""
+    for tool_call in tool_calls:
+        name = tool_call.function.name
+        messages.append(
+            make_tool_result_message(
+                name,
+                f"[Tool execution skipped — {name} was not started. {reason}]",
+                tool_call.id,
+                effect_disposition="none",
+            )
+        )
+        _flush_session_db_after_tool_progress(
+            agent,
+            messages,
+            stage=f"skipped tool result {name}",
+        )
+
+
+def _terminal_barrier_succeeded(agent, function_name: str, result: Any) -> bool:
+    """Mark a successful terminal tool for this worker's own task."""
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return False
+    from agent.kanban_stop import kanban_terminal_succeeded
+
+    if not kanban_terminal_succeeded(function_name, result):
+        return False
+    agent._kanban_terminal_tool = function_name
+    return True
+
+
 def _emit_cancelled_terminal_post_tool_call(
     agent,
     *,
@@ -362,6 +406,17 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     # Resolve the context-scaled tool-output budget once per turn (cheap, but
     # avoids rebuilding it per result inside the loop below).
     _tool_budget = _budget_for_agent(agent)
+
+    ownership_error = _kanban_worker_ownership_error()
+    if ownership_error:
+        agent._kanban_ownership_lost_reason = ownership_error
+        _skip_tool_calls(
+            agent,
+            messages,
+            tool_calls,
+            reason=f"Kanban worker ownership was lost: {ownership_error}",
+        )
+        return
 
     # ── Pre-flight: interrupt check ──────────────────────────────────
     if agent._interrupt_requested:
@@ -625,6 +680,23 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # submit site below (GHSA-qg5c-hvr5-hjgr, #13617).
         start = time.time()
         try:
+            ownership_error = _kanban_worker_ownership_error()
+            if ownership_error:
+                agent._kanban_ownership_lost_reason = ownership_error
+                result = (
+                    f"[Tool execution skipped — {function_name} was not started. "
+                    f"Kanban worker ownership was lost: {ownership_error}]"
+                )
+                results[index] = (
+                    function_name,
+                    function_args,
+                    result,
+                    0.0,
+                    True,
+                    True,
+                    middleware_trace,
+                )
+                return
             try:
                 result = agent._invoke_tool(
                     function_name,
@@ -659,6 +731,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
             duration = time.time() - start
             is_error, _ = _detect_tool_failure(function_name, result)
+            _terminal_barrier_succeeded(agent, function_name, result)
             if is_error:
                 logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
             else:
@@ -1059,6 +1132,18 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
+        ownership_error = _kanban_worker_ownership_error()
+        if ownership_error:
+            agent._kanban_ownership_lost_reason = ownership_error
+            remaining_calls = assistant_message.tool_calls[i - 1:]
+            _skip_tool_calls(
+                agent,
+                messages,
+                remaining_calls,
+                reason=f"Kanban worker ownership was lost: {ownership_error}",
+            )
+            break
+
         # SAFETY: check interrupt BEFORE starting each tool.
         # If the user sent "stop" during a previous tool's execution,
         # do NOT start any more tools -- skip them all immediately.
@@ -1595,6 +1680,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Log tool errors to the persistent error log so [error] tags
         # in the UI always have a corresponding detailed entry on disk.
         _is_error_result, _ = _detect_tool_failure(function_name, function_result)
+        _terminal_succeeded = (
+            not _execution_blocked
+            and _terminal_barrier_succeeded(
+                agent,
+                function_name,
+                function_result,
+            )
+        )
         # The agent-runtime tools above (todo, session_search, memory,
         # context-engine, memory-manager, clarify, delegate_task) are
         # dispatched inline — they never reach handle_function_call, so the
@@ -1719,6 +1812,19 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # entire batch.  The model sees it on the next API iteration.
         agent._apply_pending_steer_to_tool_results(messages, 1)
 
+        if _terminal_succeeded and i < len(assistant_message.tool_calls):
+            remaining_calls = assistant_message.tool_calls[i:]
+            _skip_tool_calls(
+                agent,
+                messages,
+                remaining_calls,
+                reason=(
+                    f"{function_name} closed the Kanban task; later calls in "
+                    "this response were not started"
+                ),
+            )
+            break
+
         if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
             if agent.verbose_logging:
                 print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s")
@@ -1793,7 +1899,7 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
         _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
 
-    for kind, calls in segments:
+    for segment_index, (kind, calls) in enumerate(segments):
         segment_message = SimpleNamespace(tool_calls=list(calls))
         if kind == "parallel":
             execute_tool_calls_concurrent(
@@ -1805,6 +1911,28 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
                 agent, segment_message, messages, effective_task_id, api_call_count,
                 finalize=False,
             )
+        terminal_tool = getattr(agent, "_kanban_terminal_tool", None)
+        ownership_error = getattr(agent, "_kanban_ownership_lost_reason", None)
+        if terminal_tool or ownership_error:
+            later_calls = [
+                tool_call
+                for _kind, segment_calls in segments[segment_index + 1:]
+                for tool_call in segment_calls
+            ]
+            if later_calls:
+                reason = (
+                    f"{terminal_tool} closed the Kanban task; later calls in "
+                    "this response were not started"
+                    if terminal_tool
+                    else f"Kanban worker ownership was lost: {ownership_error}"
+                )
+                _skip_tool_calls(
+                    agent,
+                    messages,
+                    later_calls,
+                    reason=reason,
+                )
+            break
 
     # ── Whole-turn finalize (budget + /steer) ─────────────────────────
     total_tools = len(assistant_message.tool_calls)

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -148,9 +148,12 @@ def finalize_turn(
         # came from the summary call or an explicitly pending continuation;
         # both exhausted the task budget and must advance the failure circuit.
         #
-        # We route through ``_record_task_failure(outcome="timed_out")``
+        # We route through
+        # ``_record_task_failure(outcome="iteration_exhausted")``
         # rather than ``kanban_block`` so this counts toward the dispatcher's
-        # consecutive-failure circuit breaker (#29747 gap 2).
+        # consecutive-failure circuit breaker (#29747 gap 2). Iteration
+        # exhaustion is not a wall-clock timeout: keeping the outcomes
+        # distinct lets operators and notifiers report the real trigger.
         _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
         if _kanban_task:
             try:
@@ -166,7 +169,7 @@ def finalize_turn(
                             "task could not complete within the allowed "
                             "iterations"
                         ),
-                        outcome="timed_out",
+                        outcome="iteration_exhausted",
                         release_claim=True,
                         end_run=True,
                         event_payload_extra={

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.iteration_budget import effective_iteration_state
 from agent.message_content import flatten_message_text
 
 
@@ -91,10 +92,14 @@ def finalize_turn(
     """
     from agent.conversation_loop import logger
 
-    budget_exhausted = (
-        api_call_count >= agent.max_iterations
-        or agent.iteration_budget.remaining <= 0
+    effective_budget_used, effective_budget_remaining, effective_budget_max = (
+        effective_iteration_state(
+            agent.iteration_budget,
+            agent.max_iterations,
+            api_call_count,
+        )
     )
+    budget_exhausted = effective_budget_remaining <= 0
     budget_fallback_eligible = (
         budget_exhausted
         and not interrupted
@@ -121,21 +126,29 @@ def finalize_turn(
         # response-loss blocker)
         if _pending_verification_response_previewed:
             agent._response_was_previewed = True
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        _turn_exit_reason = (
+            f"max_iterations_reached("
+            f"{effective_budget_used}/{effective_budget_max})"
+        )
         iteration_limit_fallback = True
         preserved_verification_fallback = True
     elif final_response is None and budget_fallback_eligible:
         # Budget exhausted — ask the model for a summary via one extra
         # API call with tools stripped.  _handle_max_iterations injects a
         # user message and makes a single toolless request.
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        _turn_exit_reason = (
+            f"max_iterations_reached("
+            f"{effective_budget_used}/{effective_budget_max})"
+        )
         agent._emit_status(
-            f"⚠️ Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
+            f"⚠️ Iteration budget exhausted "
+            f"({effective_budget_used}/{effective_budget_max}) "
             "— asking model to summarise"
         )
         if not agent.quiet_mode:
             agent._safe_print(
-                f"\n⚠️  Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
+                f"\n⚠️  Iteration budget exhausted "
+                f"({effective_budget_used}/{effective_budget_max}) "
                 "— requesting summary..."
             )
         final_response = agent._handle_max_iterations(messages, api_call_count)
@@ -165,7 +178,7 @@ def finalize_turn(
                         _kanban_task,
                         error=(
                             f"Iteration budget exhausted "
-                            f"({api_call_count}/{agent.max_iterations}) — "
+                            f"({effective_budget_used}/{effective_budget_max}) — "
                             "task could not complete within the allowed "
                             "iterations"
                         ),
@@ -173,13 +186,15 @@ def finalize_turn(
                         release_claim=True,
                         end_run=True,
                         event_payload_extra={
-                            "budget_used": api_call_count,
-                            "budget_max": agent.max_iterations,
+                            "budget_used": effective_budget_used,
+                            "budget_max": effective_budget_max,
                         },
                     )
                     logger.info(
                         "recorded budget-exhausted failure for task %s (%d/%d)",
-                        _kanban_task, api_call_count, agent.max_iterations,
+                        _kanban_task,
+                        effective_budget_used,
+                        effective_budget_max,
                     )
                 finally:
                     try:
@@ -198,8 +213,9 @@ def finalize_turn(
     completed = (
         final_response is not None
         and not failed
+        and not iteration_limit_fallback
         and (
-            api_call_count < agent.max_iterations
+            effective_budget_remaining > 0
             or normal_text_response
         )
     )
@@ -347,8 +363,8 @@ def finalize_turn(
         if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
     )
     _resp_len = len(final_response) if final_response else 0
-    _budget_used = agent.iteration_budget.used if agent.iteration_budget else 0
-    _budget_max = agent.iteration_budget.max_total if agent.iteration_budget else 0
+    _budget_used = effective_budget_used
+    _budget_max = effective_budget_max
 
     _diag_msg = (
         "Turn ended: reason=%s model=%s api_calls=%d/%d budget=%d/%d "

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -25,6 +25,55 @@ from agent.i18n import t
 logger = logging.getLogger("gateway.run")
 
 
+def _kanban_retry_disposition(task: Any) -> str:
+    """Describe whether an abnormal task outcome can be retried."""
+    status = str(getattr(task, "status", "") or "")
+    if status == "ready":
+        return "dispatcher will retry"
+    if status == "running":
+        return "worker is currently running; no retry is scheduled"
+    if status == "blocked":
+        return "task is blocked; no automatic retry"
+    if status in {"done", "archived", "failed", "cancelled"}:
+        return "task is already terminal; no retry"
+    if status:
+        return "task is not ready; no automatic retry"
+    return "retry state is unavailable"
+
+
+def _iteration_budget_detail(payload: Optional[dict]) -> str:
+    """Format an iteration budget only when both real values are present."""
+    if not payload:
+        return ""
+    used = payload.get("budget_used")
+    maximum = payload.get("budget_max")
+    if used is None or maximum is None:
+        return ""
+    try:
+        return f" ({int(used)}/{int(maximum)} iterations)"
+    except (TypeError, ValueError):
+        return ""
+
+
+def _gave_up_trigger(payload: Optional[dict]) -> str:
+    """Return a human label for the failure that tripped the retry limit."""
+    payload = payload or {}
+    if payload.get("protocol_violations"):
+        return "worker protocol violation"
+    raw = str(payload.get("trigger_outcome") or "").strip()
+    labels = {
+        "spawn_failed": "worker launch failure",
+        "crashed": "worker crash",
+        "timed_out": "runtime timeout",
+        "iteration_exhausted": "iteration budget exhaustion",
+        "protocol_violation": "worker protocol violation",
+        "stale": "worker staleness",
+    }
+    if not raw:
+        return ""
+    return labels.get(raw, raw.replace("_", " ")[:80])
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -117,8 +166,9 @@ class GatewayKanbanWatchersMixin:
 
         For each subscription row, fetches ``task_events`` newer than the
         stored cursor with kind in the terminal set (``completed``,
-        ``blocked``, ``gave_up``, ``crashed``, ``timed_out``). Sends one
-        message per new event to ``(platform, chat_id, thread_id)``,
+        ``blocked``, ``gave_up``, ``crashed``, ``timed_out``,
+        ``iteration_exhausted``). Sends one message per new event to
+        ``(platform, chat_id, thread_id)``,
         then advances the cursor. When a task reaches a terminal state
         (``completed`` / ``archived``), the subscription is removed.
 
@@ -164,7 +214,17 @@ class GatewayKanbanWatchersMixin:
 
         # "status" covers dashboard drag-drop and `_set_status_direct()`
         # writes — surface those transitions to subscribers too.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked")
+        TERMINAL_KINDS = (
+            "completed",
+            "blocked",
+            "gave_up",
+            "crashed",
+            "timed_out",
+            "iteration_exhausted",
+            "status",
+            "archived",
+            "unblocked",
+        )
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -374,22 +434,36 @@ class GatewayKanbanWatchersMixin:
                             err = ""
                             if ev.payload and ev.payload.get("error"):
                                 err = f"\n{str(ev.payload['error'])[:200]}"
+                            trigger = _gave_up_trigger(ev.payload)
+                            trigger_text = f" after {trigger}" if trigger else ""
+                            budget = _iteration_budget_detail(ev.payload)
                             msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
+                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up: "
+                                f"retry limit reached{trigger_text}{budget}{err}"
                             )
                         elif kind == "crashed":
                             msg = (
                                 f"✖ {board_tag}{tag}Kanban {sub['task_id']} worker crashed "
-                                f"(pid gone); dispatcher will retry"
+                                f"(pid gone); {_kanban_retry_disposition(task)}"
                             )
                         elif kind == "timed_out":
-                            limit = 0
-                            if ev.payload and ev.payload.get("limit_seconds"):
-                                limit = int(ev.payload["limit_seconds"])
+                            limit_text = ""
+                            try:
+                                limit = int((ev.payload or {}).get("limit_seconds"))
+                                if limit > 0:
+                                    limit_text = f" (max_runtime={limit}s)"
+                            except (TypeError, ValueError):
+                                pass
                             msg = (
-                                f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
-                                f"(max_runtime={limit}s); will retry"
+                                f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out"
+                                f"{limit_text}; {_kanban_retry_disposition(task)}"
+                            )
+                        elif kind == "iteration_exhausted":
+                            budget = _iteration_budget_detail(ev.payload)
+                            msg = (
+                                f"⏱ {board_tag}{tag}Kanban {sub['task_id']} "
+                                f"exhausted its iteration budget{budget}; "
+                                f"{_kanban_retry_disposition(task)}"
                             )
                         elif kind == "status":
                             new_status = ""
@@ -483,13 +557,21 @@ class GatewayKanbanWatchersMixin:
                         )
                         # Unsubscribe only when the task has reached a truly
                         # final status (done / archived). For blocked /
-                        # gave_up / crashed / timed_out the subscription is
+                        # gave_up / crashed / timed_out / iteration_exhausted
+                        # the subscription is
                         # kept alive so the user gets notified again if the
                         # dispatcher respawns the task and it cycles into the
                         # same state. See the longer comment on TERMINAL_KINDS
                         # above for the failure mode this prevents.
                         task_terminal = task and task.status in {"done", "archived"}
-                        _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
+                        _WAKE_KINDS = (
+                            "completed",
+                            "gave_up",
+                            "crashed",
+                            "timed_out",
+                            "iteration_exhausted",
+                            "blocked",
+                        )
                         _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
                         if _wake_kinds:
                             try:
@@ -502,7 +584,20 @@ class GatewayKanbanWatchersMixin:
                                     if "gave_up" in _wake_kinds: _parts.append(t("gateway.kanban.wake.gave_up"))
                                     if "crashed" in _wake_kinds: _parts.append(t("gateway.kanban.wake.crashed"))
                                     if "timed_out" in _wake_kinds: _parts.append(t("gateway.kanban.wake.timed_out"))
+                                    if "iteration_exhausted" in _wake_kinds:
+                                        _parts.append(
+                                            t("gateway.kanban.wake.iteration_exhausted")
+                                        )
                                     if "blocked" in _wake_kinds: _parts.append(t("gateway.kanban.wake.blocked"))
+                                    _retry_events = {
+                                        "crashed", "timed_out", "iteration_exhausted",
+                                    }
+                                    if _wake_kinds & _retry_events:
+                                        _task_status = str(getattr(task, "status", "") or "")
+                                        if _task_status == "blocked":
+                                            _parts.append(t("gateway.kanban.wake.retry_blocked"))
+                                        elif _task_status == "ready":
+                                            _parts.append(t("gateway.kanban.wake.retry_scheduled"))
                                     _status = t("gateway.kanban.wake.status_joiner").join(_parts) or t("gateway.kanban.wake.status_default")
                                     _synth = t(
                                         "gateway.kanban.wake.message",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2850,7 +2850,8 @@ DEFAULT_CONFIG = {
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,
         # Auto-block after this many consecutive non-success attempts for the
-        # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
+        # same task/profile (spawn_failed, timed_out, iteration_exhausted, or
+        # crashed). Reassignment
         # resets the streak for the new profile.
         "failure_limit": 2,
         # Worker stdout/stderr logs rotate at spawn time. Defaults preserve

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -25,6 +25,12 @@ from typing import Any, Dict, List
 
 def hooks_command(args) -> None:
     """Entry point for ``hermes hooks`` — dispatches to the requested action."""
+    if getattr(args, "accept_hooks", False):
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+
+        register_from_config(load_config(), accept_hooks=True)
+
     sub = getattr(args, "hooks_action", None)
 
     if not sub:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -695,7 +695,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_disp.add_argument("--failure-limit", type=int,
                         default=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
                         help=f"Auto-block a task after this many consecutive non-success attempts "
-                             f"(spawn_failed, timed_out, or crashed; default: {kb.DEFAULT_SPAWN_FAILURE_LIMIT})")
+                             "(spawn_failed, timed_out, iteration_exhausted, "
+                             f"or crashed; default: {kb.DEFAULT_SPAWN_FAILURE_LIMIT})")
     p_disp.add_argument("--json", action="store_true")
 
     # --- daemon (deprecated) ---
@@ -730,7 +731,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                          help="Only show events from tasks in this tenant")
     p_watch.add_argument("--kinds", default=None,
                          help="Comma-separated event kinds to include "
-                              "(e.g. 'completed,blocked,gave_up,crashed,timed_out')")
+                              "(e.g. 'completed,blocked,gave_up,crashed,"
+                              "timed_out,iteration_exhausted')")
     p_watch.add_argument("--interval", type=float, default=0.5,
                          help="Poll interval in seconds (default: 0.5)")
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -862,6 +862,7 @@ class Task:
     # Unified non-success counter. Incremented on any of:
     #   * spawn failure (dispatcher couldn't launch the worker)
     #   * timed_out outcome (worker exceeded max_runtime_seconds)
+    #   * iteration_exhausted outcome (worker used its model-turn budget)
     #   * crashed outcome (worker PID vanished)
     # Reset to 0 only on a successful completion. See
     # ``_record_task_failure`` for the circuit-breaker trip rule.
@@ -1232,7 +1233,8 @@ CREATE TABLE IF NOT EXISTS task_runs (
     profile             TEXT,
     step_key            TEXT,
     status              TEXT NOT NULL,
-    -- status: running | done | blocked | crashed | timed_out | failed | released
+    -- status: running | done | blocked | crashed | timed_out |
+    --         iteration_exhausted | failed | released
     claim_lock          TEXT,
     claim_expires       INTEGER,
     worker_pid          INTEGER,
@@ -1241,8 +1243,9 @@ CREATE TABLE IF NOT EXISTS task_runs (
     started_at          INTEGER NOT NULL,
     ended_at            INTEGER,
     outcome             TEXT,
-    -- outcome: completed | blocked | crashed | timed_out | spawn_failed |
-    --          gave_up | reclaimed | (null while still running)
+    -- outcome: completed | blocked | crashed | timed_out |
+    --          iteration_exhausted | spawn_failed | gave_up | reclaimed |
+    --          (null while still running)
     summary             TEXT,
     metadata            TEXT,
     error               TEXT
@@ -2801,6 +2804,15 @@ def create_task(
     provider_override = (provider_override or "").strip() or None
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
+    if max_retries is not None:
+        if isinstance(max_retries, bool):
+            raise ValueError("max_retries must be an integer >= 1")
+        try:
+            max_retries = int(max_retries)
+        except (TypeError, ValueError):
+            raise ValueError("max_retries must be an integer >= 1")
+        if max_retries < 1:
+            raise ValueError("max_retries must be >= 1")
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
@@ -3050,6 +3062,7 @@ def create_task(
                         "tenant": tenant,
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
+                        "max_retries": max_retries,
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
@@ -3665,7 +3678,8 @@ def _end_run(
     """Close the currently-active run for ``task_id`` and clear the pointer.
 
     ``outcome`` is the semantic result (completed / blocked / crashed /
-    timed_out / spawn_failed / gave_up / reclaimed). ``status`` is the
+    timed_out / iteration_exhausted / spawn_failed / gave_up / reclaimed).
+    ``status`` is the
     run-row status (usually just ``outcome``, but callers can pass it
     explicitly). Returns the closed run_id or ``None`` if no active run
     existed (e.g. a CLI user calling ``hermes kanban complete`` on a
@@ -3784,7 +3798,8 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       emits a ``"blocked"`` event row in ``task_events``.
 
     * **Circuit-breaker** — ``_record_task_failure`` tripped after
-      repeated crashes / spawn failures / timeouts.  This emits
+      repeated crashes / spawn failures / timeouts / iteration exhaustion.
+      This emits
       ``"gave_up"``, *not* ``"blocked"``, and is meant to recover
       automatically once the underlying conditions change (e.g. parents
       finish, transient infra error clears).
@@ -7195,7 +7210,7 @@ def detect_stale_running(
         # auto-block, even though no worker actually failed. The 'stale'
         # event already lives in task_events for auditability; that's the
         # right surface for "this happened" without conflating with the
-        # spawn_failed / timed_out / crashed counters.
+        # spawn_failed / timed_out / iteration_exhausted / crashed counters.
 
     return reclaimed
 
@@ -7564,7 +7579,8 @@ def _record_task_failure(
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
 ) -> bool:
-    """Record a non-success outcome (spawn_failed / crashed / timed_out)
+    """Record a non-success outcome (spawn_failed / crashed / timed_out /
+    iteration_exhausted)
     and maybe trip the circuit breaker.
 
     Unified replacement for the old spawn-only ``_record_spawn_failure``.
@@ -7577,7 +7593,7 @@ def _record_task_failure(
 
     Modes:
 
-    * ``release_claim=True, end_run=True`` — spawn-failure path.
+    * ``release_claim=True, end_run=True`` — caller-owned failure path.
       Caller has a running task with an open run; this transitions
       it back to ``ready`` (or ``blocked`` when the breaker trips),
       releases the claim, and closes the run with ``outcome=<outcome>``.
@@ -7655,17 +7671,20 @@ def _record_task_failure(
                 )
             run_id = None
             if end_run:
-                # Only the spawn path has an open run to close.
+                # This mode owns an open run that must be closed.
+                run_metadata = {
+                    "failures": failures,
+                    "trigger_outcome": outcome,
+                    "effective_limit": effective_limit,
+                    "limit_source": limit_source,
+                }
+                if event_payload_extra:
+                    run_metadata.update(event_payload_extra)
                 run_id = _end_run(
                     conn, task_id,
                     outcome="gave_up", status="gave_up",
                     error=error[:500],
-                    metadata={
-                        "failures": failures,
-                        "trigger_outcome": outcome,
-                        "effective_limit": effective_limit,
-                        "limit_source": limit_source,
-                    },
+                    metadata=run_metadata,
                 )
             payload = {
                 "failures": failures,
@@ -7700,16 +7719,24 @@ def _record_task_failure(
                     (failures, error[:500], task_id),
                 )
             if end_run:
-                # Spawn path: close the open run with outcome.
+                # Close the caller-owned open run with its actual outcome.
+                run_metadata = {"failures": failures}
+                event_payload = {
+                    "error": error[:500],
+                    "failures": failures,
+                }
+                if event_payload_extra:
+                    run_metadata.update(event_payload_extra)
+                    event_payload.update(event_payload_extra)
                 run_id = _end_run(
                     conn, task_id,
                     outcome=outcome, status=outcome,
                     error=error[:500],
-                    metadata={"failures": failures},
+                    metadata=run_metadata,
                 )
                 _append_event(
                     conn, task_id, outcome,
-                    {"error": error[:500], "failures": failures},
+                    event_payload,
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4293,7 +4293,8 @@ def reclaim_task(
     reclaimable state (not running, or doesn't exist).
     """
     row = conn.execute(
-        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+        "SELECT status, current_run_id, claim_lock, worker_pid "
+        "FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if not row:
@@ -4305,13 +4306,28 @@ def reclaim_task(
     termination = _terminate_reclaimed_worker(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
     )
+    if _worker_survived_termination(termination):
+        _defer_reclaim_for_live_worker(
+            conn,
+            task_id,
+            prev_lock,
+            int(time.time()),
+            termination,
+            reason="manual_reclaim_worker_alive",
+        )
+        return False
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
             "claim_expires = NULL, worker_pid = NULL "
             "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
-            "AND claim_lock IS ?",
-            (task_id, prev_lock),
+            "AND current_run_id IS ? AND claim_lock IS ? AND worker_pid IS ?",
+            (
+                task_id,
+                row["current_run_id"],
+                prev_lock,
+                row["worker_pid"],
+            ),
         )
         if cur.rowcount != 1:
             return False
@@ -5299,6 +5315,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    signal_fn=None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -5331,6 +5348,43 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    ownership_suffix = ""
+    ownership_params: tuple[Any, ...] = ()
+    if expected_run_id is None:
+        worker = conn.execute(
+            "SELECT status, current_run_id, claim_lock, worker_pid "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if worker is not None and worker["status"] == "running":
+            termination = _terminate_reclaimed_worker(
+                worker["worker_pid"],
+                worker["claim_lock"],
+                signal_fn=signal_fn,
+            )
+            if _worker_survived_termination(termination):
+                _defer_reclaim_for_live_worker(
+                    conn,
+                    task_id,
+                    worker["claim_lock"],
+                    int(time.time()),
+                    termination,
+                    reason="external_block_worker_alive",
+                )
+                return False
+            ownership_suffix = (
+                " AND current_run_id IS ?"
+                " AND claim_lock IS ?"
+                " AND worker_pid IS ?"
+            )
+            ownership_params = (
+                worker["current_run_id"],
+                worker["claim_lock"],
+                worker["worker_pid"],
+            )
+    else:
+        ownership_suffix = " AND current_run_id = ?"
+        ownership_params = (int(expected_run_id),)
     routed_to = "blocked"
     recurrences = 0
     with write_txn(conn):
@@ -5363,9 +5417,8 @@ def block_task(
                        block_kind    = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, task_id) if expected_run_id is None
-                else (kind, task_id, int(expected_run_id)),
+                """ + ownership_suffix,
+                (kind, task_id, *ownership_params),
             )
             if cur.rowcount != 1:
                 return False
@@ -5417,9 +5470,8 @@ def block_task(
                        block_recurrences = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, recurrences, task_id) if expected_run_id is None
-                else (kind, recurrences, task_id, int(expected_run_id)),
+                """ + ownership_suffix,
+                (kind, recurrences, task_id, *ownership_params),
             )
             if cur.rowcount != 1:
                 return False
@@ -5444,37 +5496,20 @@ def block_task(
             )
             routed_to = "triage"
         else:
-            if expected_run_id is None:
-                cur = conn.execute(
-                    """
-                    UPDATE tasks
-                       SET status        = 'blocked',
-                           claim_lock    = NULL,
-                           claim_expires = NULL,
-                           worker_pid    = NULL,
-                           block_kind    = ?,
-                           block_recurrences = ?
-                     WHERE id = ?
-                       AND status IN ('running', 'ready')
-                    """,
-                    (kind, recurrences, task_id),
-                )
-            else:
-                cur = conn.execute(
-                    """
-                    UPDATE tasks
-                       SET status        = 'blocked',
-                           claim_lock    = NULL,
-                           claim_expires = NULL,
-                           worker_pid    = NULL,
-                           block_kind    = ?,
-                           block_recurrences = ?
-                     WHERE id = ?
-                       AND status IN ('running', 'ready')
-                       AND current_run_id = ?
-                    """,
-                    (kind, recurrences, task_id, int(expected_run_id)),
-                )
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status        = 'blocked',
+                       claim_lock    = NULL,
+                       claim_expires = NULL,
+                       worker_pid    = NULL,
+                       block_kind    = ?,
+                       block_recurrences = ?
+                 WHERE id = ?
+                   AND status IN ('running', 'ready')
+                """ + ownership_suffix,
+                (kind, recurrences, task_id, *ownership_params),
+            )
             if cur.rowcount != 1:
                 return False
             run_id = _end_run(
@@ -6666,13 +6701,65 @@ def _pid_alive(pid: Optional[int]) -> bool:
     return True
 
 
+def _process_group_alive(process_group_id: int) -> bool:
+    """Return whether a POSIX process group has a non-zombie member."""
+    if process_group_id <= 0 or not hasattr(os, "killpg"):
+        return False
+    try:
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return True
+
+    try:
+        proc = subprocess.run(
+            ["ps", "-axo", "pgid=,stat="],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return True
+        for line in (proc.stdout or "").splitlines():
+            fields = line.strip().split(None, 1)
+            if len(fields) != 2:
+                continue
+            try:
+                pgid = int(fields[0])
+            except ValueError:
+                continue
+            if pgid == process_group_id and "Z" not in fields[1]:
+                return True
+        return False
+    except (OSError, subprocess.SubprocessError, TimeoutError):
+        return True
+
+
+def _worker_uses_own_process_group(pid: int) -> bool:
+    """Return whether ``pid`` is the dispatcher-created process-group leader."""
+    if os.name == "nt" or not hasattr(os, "getpgid"):
+        return False
+    try:
+        return os.getpgid(pid) == pid
+    except ProcessLookupError:
+        # The leader may have exited while descendants remain. Workers are
+        # spawned with start_new_session=True, so their group id stays the
+        # recorded leader pid until the final descendant exits.
+        return _process_group_alive(pid)
+    except OSError:
+        return False
+
+
 def _terminate_reclaimed_worker(
     pid: Optional[int],
     claim_lock: Optional[str],
     *,
     signal_fn=None,
 ) -> dict[str, Any]:
-    """Best-effort host-local worker termination for reclaim paths."""
+    """Terminate a host-local worker and every descendant in its process group."""
     import signal
 
     info: dict[str, Any] = {
@@ -6681,6 +6768,9 @@ def _terminate_reclaimed_worker(
         "termination_attempted": False,
         "terminated": False,
         "sigkill": False,
+        "process_group": False,
+        "process_group_id": None,
+        "self_process": False,
     }
     if not pid or pid <= 0 or not claim_lock:
         return info
@@ -6690,9 +6780,29 @@ def _terminate_reclaimed_worker(
         return info
     info["host_local"] = True
 
-    kill = signal_fn if signal_fn is not None else (
-        os.kill if hasattr(os, "kill") else None
+    if int(pid) == os.getpid() and signal_fn is None:
+        # A worker closing its own task must return normally so it can persist
+        # the paired tool result and exit at the terminal barrier.
+        info["self_process"] = True
+        return info
+
+    use_process_group = signal_fn is None and _worker_uses_own_process_group(
+        int(pid)
     )
+    if use_process_group:
+        info["process_group"] = True
+        info["process_group_id"] = int(pid)
+        kill = os.killpg
+
+        def target_alive() -> bool:
+            return _process_group_alive(int(pid))
+    else:
+        kill = signal_fn if signal_fn is not None else (
+            os.kill if hasattr(os, "kill") else None
+        )
+
+        def target_alive() -> bool:
+            return _pid_alive(pid)
     if kill is None:
         return info
 
@@ -6709,22 +6819,30 @@ def _terminate_reclaimed_worker(
         return info
 
     for _ in range(10):
-        if not _pid_alive(pid):
+        if not target_alive():
             info["terminated"] = True
             return info
         time.sleep(0.5)
 
-    if _pid_alive(pid):
+    if target_alive():
         try:
             # signal.SIGKILL doesn't exist on Windows; fall back to SIGTERM
             # (which maps to TerminateProcess via the stdlib shim).
             _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
             kill(int(pid), _sigkill)
             info["sigkill"] = True
-        except (ProcessLookupError, OSError):
+        except ProcessLookupError:
+            info["terminated"] = not target_alive()
+            return info
+        except OSError:
             return info
 
-    info["terminated"] = not _pid_alive(pid)
+    for _ in range(10):
+        if not target_alive():
+            info["terminated"] = True
+            return info
+        time.sleep(0.5)
+    info["terminated"] = not target_alive()
     return info
 
 
@@ -6853,13 +6971,13 @@ def enforce_max_runtime(
     (same reasoning as ``detect_crashed_workers``). ``signal_fn`` is a
     test hook; defaults to ``os.kill`` on POSIX.
     """
-    import signal
     timed_out: list[str] = []
     now = int(time.time())
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
 
     rows = conn.execute(
         "SELECT t.id, t.worker_pid, "
+        "       t.current_run_id, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at, "
         "       t.max_runtime_seconds, t.claim_lock "
         "FROM tasks t "
@@ -6881,31 +6999,21 @@ def enforce_max_runtime(
 
         pid = int(row["worker_pid"])
         tid = row["id"]
-        # SIGTERM then SIGKILL. Keep it simple: 5 s grace. Workers that
-        # want a cleaner shutdown can install their own SIGTERM handler
-        # before the grace expires.
-        killed = False
-        kill = signal_fn if signal_fn is not None else (
-            os.kill if hasattr(os, "kill") else None
+        termination = _terminate_reclaimed_worker(
+            pid,
+            row["claim_lock"],
+            signal_fn=signal_fn,
         )
-        if kill is not None:
-            try:
-                kill(pid, signal.SIGTERM)
-            except (ProcessLookupError, OSError):
-                pass
-            # Short polling wait — no time.sleep on the write txn.
-            for _ in range(10):
-                if not _pid_alive(pid):
-                    break
-                time.sleep(0.5)
-            if _pid_alive(pid):
-                try:
-                    # signal.SIGKILL doesn't exist on Windows.
-                    _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-                    kill(pid, _sigkill)
-                    killed = True
-                except (ProcessLookupError, OSError):
-                    pass
+        if _worker_survived_termination(termination):
+            _defer_reclaim_for_live_worker(
+                conn,
+                tid,
+                row["claim_lock"],
+                now,
+                termination,
+                reason="max_runtime_worker_alive",
+            )
+            continue
 
         with write_txn(conn):
             cur = conn.execute(
@@ -6913,16 +7021,22 @@ def enforce_max_runtime(
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
+                "  AND current_run_id IS ? "
                 "  AND worker_pid = ? AND claim_lock IS ?",
-                (tid, pid, row["claim_lock"]),
+                (
+                    tid,
+                    row["current_run_id"],
+                    pid,
+                    row["claim_lock"],
+                ),
             )
             if cur.rowcount == 1:
                 payload = {
                     "pid": pid,
                     "elapsed_seconds": int(elapsed),
                     "limit_seconds": int(row["max_runtime_seconds"]),
-                    "sigkill": killed,
                 }
+                payload.update(termination)
                 run_id = _end_run(
                     conn, tid,
                     outcome="timed_out", status="timed_out",
@@ -6945,7 +7059,7 @@ def enforce_max_runtime(
                 outcome="timed_out",
                 release_claim=False,
                 end_run=False,
-                event_payload_extra={"pid": pid, "sigkill": killed},
+                event_payload_extra={"pid": pid, **termination},
             )
     return timed_out
 
@@ -7620,25 +7734,101 @@ def _record_spawn_failure(
     )
 
 
-def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
-    """Record the spawned child's pid + emit a ``spawned`` event.
+def _set_worker_pid(
+    conn: sqlite3.Connection,
+    task_id: str,
+    pid: int,
+    *,
+    expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
+) -> bool:
+    """CAS-register a spawned child pid and emit a ``spawned`` event.
 
     The event's payload carries the pid so a human reading ``hermes kanban
     tail`` can correlate log lines with OS-level traces without opening
-    the drawer.
+    the drawer. Returns False if an external transition revoked the claim
+    between ``Popen`` and PID registration.
     """
     with write_txn(conn):
+        task = conn.execute(
+            "SELECT status, current_run_id, claim_lock, worker_pid "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if task is None or task["status"] != "running":
+            return False
+        run_id = (
+            int(expected_run_id)
+            if expected_run_id is not None
+            else task["current_run_id"]
+        )
+        claim_lock = (
+            expected_claim_lock
+            if expected_claim_lock is not None
+            else task["claim_lock"]
+        )
+        if (
+            run_id is None
+            or task["current_run_id"] != run_id
+            or task["claim_lock"] != claim_lock
+            or task["worker_pid"] is not None
+        ):
+            return False
+        run = conn.execute(
+            "SELECT status, claim_lock, worker_pid, ended_at "
+            "FROM task_runs WHERE id = ? AND task_id = ?",
+            (run_id, task_id),
+        ).fetchone()
+        if (
+            run is None
+            or run["status"] != "running"
+            or run["claim_lock"] != claim_lock
+            or run["worker_pid"] is not None
+            or run["ended_at"] is not None
+        ):
+            return False
         conn.execute(
             "UPDATE tasks SET worker_pid = ? WHERE id = ?",
             (int(pid), task_id),
         )
-        run_id = _current_run_id(conn, task_id)
-        if run_id is not None:
-            conn.execute(
-                "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
-                (int(pid), run_id),
-            )
+        conn.execute(
+            "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
+            (int(pid), run_id),
+        )
         _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
+    return True
+
+
+def _register_spawned_worker(
+    conn: sqlite3.Connection,
+    task: Task,
+    pid: int,
+) -> bool:
+    """Register a spawn or terminate it if the task claim was revoked."""
+    if _set_worker_pid(
+        conn,
+        task.id,
+        pid,
+        expected_run_id=task.current_run_id,
+        expected_claim_lock=task.claim_lock,
+    ):
+        return True
+
+    termination = _terminate_reclaimed_worker(pid, task.claim_lock)
+    with write_txn(conn):
+        _append_event(
+            conn,
+            task.id,
+            "spawn_registration_rejected",
+            {
+                "pid": int(pid),
+                "expected_run_id": task.current_run_id,
+                "expected_claim_lock": task.claim_lock,
+                **termination,
+            },
+            run_id=task.current_run_id,
+        )
+    return False
 
 
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
@@ -8218,8 +8408,12 @@ def _dispatch_once_locked(
                     pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+            if pid and not _register_spawned_worker(
+                conn,
+                claimed,
+                int(pid),
+            ):
+                continue
             # NOTE: we intentionally do NOT reset consecutive_failures
             # here. A successful spawn proves the worker can start but
             # doesn't prove the run will succeed. Under unified
@@ -8313,8 +8507,12 @@ def _dispatch_once_locked(
                     pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+            if pid and not _register_spawned_worker(
+                conn,
+                claimed,
+                int(pid),
+            ):
+                continue
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
         except Exception as exc:

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -573,7 +573,15 @@ def _rule_repeated_failures(task, events, runs, now, cfg) -> list[Diagnostic]:
     most_recent_outcome = None
     for r in reversed(ordered_runs):
         oc = _task_field(r, "outcome")
-        if oc in {"spawn_failed", "timed_out", "crashed"}:
+        if oc == "gave_up":
+            metadata = _task_field(r, "metadata", {}) or {}
+            oc = _task_field(metadata, "trigger_outcome")
+        if oc in {
+            "spawn_failed",
+            "timed_out",
+            "iteration_exhausted",
+            "crashed",
+        }:
             most_recent_outcome = oc
             break
 
@@ -591,7 +599,11 @@ def _rule_repeated_failures(task, events, runs, now, cfg) -> list[Diagnostic]:
             label=f"Fix profile auth: hermes -p {assignee} auth",
             payload={"command": f"hermes -p {assignee} auth"},
         ))
-    elif most_recent_outcome in {"timed_out", "crashed"}:
+    elif most_recent_outcome in {
+        "timed_out",
+        "iteration_exhausted",
+        "crashed",
+    }:
         # Worker got off the ground but died. Logs are the right place
         # to diagnose; reclaim/reassign are the recovery levers.
         task_id = _task_field(task, "id")
@@ -612,6 +624,7 @@ def _rule_repeated_failures(task, events, runs, now, cfg) -> list[Diagnostic]:
     outcome_label = {
         "spawn_failed": "spawn",
         "timed_out": "timeout",
+        "iteration_exhausted": "iteration exhaustion",
         "crashed": "crash",
     }.get(most_recent_outcome or "", "failure")
     if err_snippet:

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -177,8 +177,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -166,8 +166,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "completed"
       gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
+      crashed:             "crashed (worker exited)"
+      timed_out:           "timed out"
+      iteration_exhausted: "exhausted its iteration budget"
+      retry_scheduled:     "dispatcher retry is enabled"
+      retry_blocked:       "task is blocked; no automatic retry"
       blocked:             "blocked; needs attention"
       status_default:      "status changed"
       status_joiner:       ", "

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -162,8 +162,11 @@ gateway:
     wake:
       completed:           "已完成"
       gave_up:             "已放弃（重试次数耗尽）"
-      crashed:             "崩溃（worker 异常退出），dispatcher 将重试"
-      timed_out:           "超时，dispatcher 将重试"
+      crashed:             "崩溃（worker 异常退出）"
+      timed_out:           "超时"
+      iteration_exhausted: "迭代预算已耗尽"
+      retry_scheduled:     "dispatcher 将重试"
+      retry_blocked:       "任务已阻塞，不会自动重试"
       blocked:             "被阻塞，需要处理"
       status_default:      "状态变化"
       status_joiner:       "，"

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from agent.kanban_stop import (
@@ -74,7 +76,12 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
                 }
             ],
         },
-        {"role": "tool", "name": "kanban_complete", "tool_call_id": "1", "content": "done"},
+        {
+            "role": "tool",
+            "name": "kanban_complete",
+            "tool_call_id": "1",
+            "content": json.dumps({"ok": True}),
+        },
     ]
     assert session_called_kanban_terminal(messages) is True
     assert build_kanban_stop_nudge(messages=messages) is None
@@ -83,9 +90,28 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
 def test_no_nudge_after_kanban_block(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
     messages = [
-        {"role": "tool", "name": "kanban_block", "tool_call_id": "1", "content": "blocked"},
+        {
+            "role": "tool",
+            "name": "kanban_block",
+            "tool_call_id": "1",
+            "content": json.dumps({"ok": True}),
+        },
     ]
     assert build_kanban_stop_nudge(messages=messages) is None
+
+
+def test_failed_terminal_call_does_not_suppress_nudge(clear_kanban_env):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    messages = [
+        {
+            "role": "tool",
+            "name": "kanban_block",
+            "tool_call_id": "1",
+            "content": json.dumps({"ok": False, "error": "claim changed"}),
+        },
+    ]
+    assert session_called_kanban_terminal(messages) is False
+    assert build_kanban_stop_nudge(messages=messages) is not None
 
 
 def test_nudge_budget_exhausted(clear_kanban_env):

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -267,7 +267,7 @@ def test_pending_response_does_not_mask_later_terminal_exit(
     assert agent._handle_max_iterations_called is False
 
 
-def test_pending_response_records_kanban_timeout(monkeypatch):
+def test_pending_response_records_kanban_iteration_exhaustion(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
     record = MagicMock(name="record_task_failure")
@@ -291,11 +291,112 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
             "Iteration budget exhausted (60/60) — task could not complete "
             "within the allowed iterations"
         ),
-        outcome="timed_out",
+        outcome="iteration_exhausted",
         release_claim=True,
         end_run=True,
         event_payload_extra={"budget_used": 60, "budget_max": 60},
     )
+
+
+def test_iteration_exhaustion_blocks_one_attempt_task_and_preserves_budget(
+    monkeypatch, tmp_path
+):
+    """A one-attempt task cannot silently enter run #2 after budget exhaustion."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+
+    kb._INITIALIZED_PATHS.clear()
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="strict worker",
+            assignee="worker",
+            max_retries=1,
+        )
+        assert kb.claim_task(conn, task_id) is not None
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    result = _finalize(
+        _LimitAgent(),
+        final_response=None,
+        exit_reason="unknown",
+    )
+
+    assert result["completed"] is False
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 1
+        assert kb.claim_task(conn, task_id) is None
+        assert kb.recompute_ready(conn) == 0
+
+        runs = kb.list_runs(conn, task_id)
+        assert len(runs) == 1
+        assert runs[0].outcome == "gave_up"
+        assert runs[0].metadata["trigger_outcome"] == "iteration_exhausted"
+        assert runs[0].metadata["budget_used"] == 60
+        assert runs[0].metadata["budget_max"] == 60
+
+        gave_up = [e for e in kb.list_events(conn, task_id) if e.kind == "gave_up"]
+        assert len(gave_up) == 1
+        assert gave_up[0].payload["trigger_outcome"] == "iteration_exhausted"
+        assert gave_up[0].payload["budget_used"] == 60
+        assert gave_up[0].payload["budget_max"] == 60
+
+
+def test_iteration_exhaustion_has_distinct_run_and_event_outcome(
+    monkeypatch, tmp_path
+):
+    """A retryable exhaustion remains distinct from wall-clock timeout."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+
+    kb._INITIALIZED_PATHS.clear()
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="retryable worker",
+            assignee="worker",
+            max_retries=2,
+        )
+        assert kb.claim_task(conn, task_id) is not None
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    _finalize(
+        _LimitAgent(),
+        final_response=None,
+        exit_reason="unknown",
+    )
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 1
+
+        runs = kb.list_runs(conn, task_id)
+        assert len(runs) == 1
+        assert runs[0].outcome == "iteration_exhausted"
+        assert runs[0].metadata == {
+            "failures": 1,
+            "budget_used": 60,
+            "budget_max": 60,
+        }
+
+        exhaustion = [
+            e
+            for e in kb.list_events(conn, task_id)
+            if e.kind == "iteration_exhausted"
+        ]
+        assert len(exhaustion) == 1
+        assert exhaustion[0].payload["budget_used"] == 60
+        assert exhaustion[0].payload["budget_max"] == 60
+        assert not any(e.kind == "timed_out" for e in kb.list_events(conn, task_id))
 
 
 def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch):

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -14,11 +14,16 @@ class _LimitAgent:
         *,
         max_iterations=60,
         budget_remaining=0,
+        budget_max=None,
         completion_explainer=False,
     ):
         self.max_iterations = max_iterations
+        if budget_max is None:
+            budget_max = max_iterations
         self.iteration_budget = SimpleNamespace(
-            remaining=budget_remaining, used=max_iterations, max_total=max_iterations
+            remaining=budget_remaining,
+            used=max(0, budget_max - budget_remaining),
+            max_total=budget_max,
         )
         self.quiet_mode = True
         self.model = "test-model"
@@ -295,6 +300,42 @@ def test_pending_response_records_kanban_iteration_exhaustion(monkeypatch):
         release_claim=True,
         end_run=True,
         event_payload_extra={"budget_used": 60, "budget_max": 60},
+    )
+
+
+def test_iteration_exhaustion_uses_effective_budget_metadata(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    record = MagicMock(name="record_task_failure")
+    conn = SimpleNamespace(close=lambda: None)
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    agent = _LimitAgent(
+        max_iterations=60,
+        budget_remaining=0,
+        budget_max=15,
+    )
+
+    result = _finalize(
+        agent,
+        final_response=None,
+        exit_reason="budget_exhausted",
+        api_call_count=15,
+    )
+
+    assert result["completed"] is False
+    assert result["turn_exit_reason"] == "max_iterations_reached(15/15)"
+    record.assert_called_once_with(
+        conn,
+        "task-123",
+        error=(
+            "Iteration budget exhausted (15/15) — task could not complete "
+            "within the allowed iterations"
+        ),
+        outcome="iteration_exhausted",
+        release_claim=True,
+        end_run=True,
+        event_payload_extra={"budget_used": 15, "budget_max": 15},
     )
 
 

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,8 +1,10 @@
 import asyncio
 from pathlib import Path
 
+import pytest
 
 from gateway.config import Platform
+from gateway.kanban_watchers import _kanban_retry_disposition
 from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
 
@@ -13,6 +15,37 @@ class RecordingAdapter:
 
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+
+class WakingAdapter(RecordingAdapter):
+    def __init__(self):
+        super().__init__()
+        self.wakes = []
+
+    async def handle_message(self, event):
+        self.wakes.append(event)
+
+
+@pytest.mark.parametrize(
+    ("status", "expected", "forbidden"),
+    [
+        ("ready", "dispatcher will retry", "no automatic retry"),
+        ("running", "worker is currently running", "dispatcher will retry"),
+        ("blocked", "no automatic retry", "dispatcher will retry"),
+        ("triage", "no automatic retry", "dispatcher will retry"),
+        ("todo", "no automatic retry", "dispatcher will retry"),
+        ("failed", "no retry", "dispatcher will retry"),
+        ("cancelled", "no retry", "dispatcher will retry"),
+        ("done", "no retry", "dispatcher will retry"),
+        ("archived", "no retry", "dispatcher will retry"),
+    ],
+)
+def test_retry_disposition_only_schedules_ready_tasks(
+    status, expected, forbidden
+):
+    disposition = _kanban_retry_disposition(type("Task", (), {"status": status})())
+    assert expected in disposition
+    assert forbidden not in disposition
 
 
 class DisconnectedAdapters(dict):
@@ -233,6 +266,135 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
     assert "crashed" in adapter.sent[1]["text"].lower()
+
+
+def test_iteration_exhaustion_notifies_and_wakes_with_budget(tmp_path, monkeypatch):
+    """Iteration exhaustion has its own event and wake wording."""
+    db_path = tmp_path / "iteration-exhausted.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="bounded worker",
+            assignee="worker",
+            session_id="origin-session",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+        )
+        kb._append_event(
+            conn,
+            tid,
+            kind="iteration_exhausted",
+            payload={"budget_used": 90, "budget_max": 90},
+        )
+        conn.commit()
+
+    adapter = WakingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    sent = adapter.sent[0]["text"]
+    assert "exhausted its iteration budget (90/90 iterations)" in sent
+    assert "dispatcher will retry" in sent
+    assert len(adapter.wakes) == 1
+    wake = adapter.wakes[0].text
+    assert "exhausted its iteration budget" in wake
+    assert "dispatcher retry is enabled" in wake
+
+
+def test_timeout_without_limit_never_invents_zero_runtime(tmp_path, monkeypatch):
+    db_path = tmp_path / "timeout-no-limit.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="wall timeout", assignee="worker")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+        )
+        kb._append_event(conn, tid, kind="timed_out", payload={})
+        conn.commit()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    sent = adapter.sent[0]["text"]
+    assert "timed out; dispatcher will retry" in sent
+    assert "max_runtime=0" not in sent
+
+
+def test_abnormal_event_does_not_claim_retry_for_blocked_task(tmp_path, monkeypatch):
+    db_path = tmp_path / "blocked-no-retry.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="blocked worker", assignee="worker")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+        )
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (tid,))
+        kb._append_event(conn, tid, kind="crashed", payload={"pid": 123})
+        conn.commit()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    sent = adapter.sent[0]["text"]
+    assert "task is blocked; no automatic retry" in sent
+    assert "dispatcher will retry" not in sent
+
+
+def test_gave_up_names_iteration_trigger_instead_of_spawn_failure(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "gave-up-trigger.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="strict worker", assignee="worker")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+        )
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (tid,))
+        kb._append_event(
+            conn,
+            tid,
+            kind="gave_up",
+            payload={
+                "trigger_outcome": "iteration_exhausted",
+                "budget_used": 90,
+                "budget_max": 90,
+            },
+        )
+        conn.commit()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    sent = adapter.sent[0]["text"]
+    assert "retry limit reached after iteration budget exhaustion" in sent
+    assert "(90/90 iterations)" in sent
+    assert "spawn failure" not in sent
 
 
 def test_notifier_owning_profile_adapter_no_default_fallback(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -48,6 +48,29 @@ class TestHooksList:
             out = _run(SimpleNamespace(hooks_action="list"))
         assert "No shell hooks configured" in out
 
+    def test_accept_hooks_registers_before_list(self, tmp_path):
+        script = _hook_script(
+            tmp_path, "#!/usr/bin/env bash\nprintf '{}\\n'\n",
+        )
+        cfg = {
+            "hooks": {
+                "pre_tool_call": [
+                    {"matcher": "terminal", "command": str(script), "timeout": 30},
+                ],
+            },
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = _run(SimpleNamespace(
+                hooks_action="list",
+                accept_hooks=True,
+            ))
+
+        assert "✓ allowed" in out
+        assert shell_hooks.allowlist_entry_for(
+            "pre_tool_call", str(script),
+        ) is not None
+
     def test_shows_configured_and_consent_status(self, tmp_path):
         script = _hook_script(
             tmp_path, "#!/usr/bin/env bash\nprintf '{}\\n'\n",

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -972,7 +972,14 @@ def test_worker_termination_kills_parent_and_grandchild(tmp_path):
         parent.wait(timeout=5)
 
         assert termination["process_group"] is True
-        assert termination["terminated"] is True
+        assert termination["termination_attempted"] is True
+        settle_deadline = time.time() + 5
+        while (
+            kb._process_group_alive(parent.pid)
+            and time.time() < settle_deadline
+        ):
+            time.sleep(0.05)
+        assert kb._process_group_alive(parent.pid) is False
         assert kb._pid_alive(parent.pid) is False
         assert kb._pid_alive(child_pid) is False
     finally:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -14,6 +14,7 @@ import argparse
 import json
 import os
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -939,6 +940,124 @@ def test_run_slash_every_verb_returns_sensible_output(kanban_home, tmp_path):
 # ---------------------------------------------------------------------------
 # Max-runtime enforcement (item 1 from the Multica audit)
 # ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics")
+def test_worker_termination_kills_parent_and_grandchild(tmp_path):
+    import signal
+
+    child_pid_file = tmp_path / "child.pid"
+    parent_code = (
+        "import pathlib, subprocess, sys, time\n"
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(120)'])\n"
+        "pathlib.Path(sys.argv[1]).write_text(str(child.pid))\n"
+        "time.sleep(120)\n"
+    )
+    parent = subprocess.Popen(
+        [sys.executable, "-c", parent_code, str(child_pid_file)],
+        start_new_session=True,
+    )
+    try:
+        deadline = time.time() + 5
+        while not child_pid_file.exists() and time.time() < deadline:
+            time.sleep(0.05)
+        assert child_pid_file.exists()
+        child_pid = int(child_pid_file.read_text())
+        host = kb._claimer_id().split(":", 1)[0]
+
+        termination = kb._terminate_reclaimed_worker(
+            parent.pid,
+            f"{host}:test-worker",
+        )
+        parent.wait(timeout=5)
+
+        assert termination["process_group"] is True
+        assert termination["terminated"] is True
+        assert kb._pid_alive(parent.pid) is False
+        assert kb._pid_alive(child_pid) is False
+    finally:
+        if kb._process_group_alive(parent.pid):
+            os.killpg(parent.pid, signal.SIGKILL)
+        try:
+            parent.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            parent.kill()
+            parent.wait(timeout=5)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics")
+def test_external_block_during_spawn_rejects_pid_and_kills_group(
+    kanban_home,
+    tmp_path,
+    all_assignees_spawnable,
+):
+    import signal
+
+    child_pid_file = tmp_path / "spawn-child.pid"
+    parent_code = (
+        "import pathlib, subprocess, sys, time\n"
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(120)'])\n"
+        "pathlib.Path(sys.argv[1]).write_text(str(child.pid))\n"
+        "time.sleep(120)\n"
+    )
+    process = None
+    child_pid = None
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="block during spawn",
+            assignee="worker",
+        )
+
+        def spawn_then_block(task, _workspace):
+            nonlocal process, child_pid
+            process = subprocess.Popen(
+                [sys.executable, "-c", parent_code, str(child_pid_file)],
+                start_new_session=True,
+            )
+            deadline = time.time() + 5
+            while not child_pid_file.exists() and time.time() < deadline:
+                time.sleep(0.05)
+            assert child_pid_file.exists()
+            child_pid = int(child_pid_file.read_text())
+            assert kb.block_task(
+                conn,
+                task.id,
+                reason="operator stopped startup",
+            )
+            return process.pid
+
+        result = kb.dispatch_once(conn, spawn_fn=spawn_then_block)
+        assert process is not None
+        process.wait(timeout=5)
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert task.worker_pid is None
+        assert result.spawned == []
+        assert kb._pid_alive(child_pid) is False
+        events = kb.list_events(conn, task_id)
+        assert not any(event.kind == "spawned" for event in events)
+        rejected = next(
+            event
+            for event in events
+            if event.kind == "spawn_registration_rejected"
+        )
+        assert rejected.payload["termination_attempted"] is True
+        assert rejected.payload["process_group"] is True
+    finally:
+        conn.close()
+        if process is not None and kb._process_group_alive(process.pid):
+            os.killpg(process.pid, signal.SIGKILL)
+        if process is not None:
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+
 
 def test_max_runtime_terminates_overrun_worker(kanban_home):
     """A running task whose elapsed time exceeds max_runtime_seconds gets
@@ -4175,6 +4294,123 @@ def test_reclaim_task_resets_running_to_ready(kanban_home, monkeypatch):
         assert reclaim_evs[0].get("termination_attempted") is True
         assert reclaim_evs[0].get("terminated") is True
         assert killed == [signal.SIGTERM]
+    finally:
+        conn.close()
+
+
+def test_reclaim_keeps_claim_when_process_group_survives(
+    kanban_home,
+    monkeypatch,
+):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="stuck", assignee="worker")
+        task = kb.claim_task(conn, task_id)
+        kb._set_worker_pid(conn, task_id, 12345)
+        termination = {
+            "prev_pid": 12345,
+            "host_local": True,
+            "termination_attempted": True,
+            "terminated": False,
+            "sigkill": True,
+            "process_group": True,
+            "process_group_id": 12345,
+            "self_process": False,
+        }
+        monkeypatch.setattr(
+            kb,
+            "_terminate_reclaimed_worker",
+            lambda *_args, **_kwargs: termination,
+        )
+
+        assert kb.reclaim_task(conn, task_id, reason="operator stop") is False
+        current = kb.get_task(conn, task_id)
+        assert current.status == "running"
+        assert current.claim_lock == task.claim_lock
+        assert current.worker_pid == 12345
+        assert any(
+            event.kind == "reclaim_deferred"
+            for event in kb.list_events(conn, task_id)
+        )
+    finally:
+        conn.close()
+
+
+def test_external_block_keeps_claim_when_process_group_survives(
+    kanban_home,
+    monkeypatch,
+):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="active", assignee="worker")
+        task = kb.claim_task(conn, task_id)
+        kb._set_worker_pid(conn, task_id, 12345)
+        monkeypatch.setattr(
+            kb,
+            "_terminate_reclaimed_worker",
+            lambda *_args, **_kwargs: {
+                "prev_pid": 12345,
+                "host_local": True,
+                "termination_attempted": True,
+                "terminated": False,
+                "sigkill": True,
+                "process_group": True,
+                "process_group_id": 12345,
+                "self_process": False,
+            },
+        )
+
+        assert kb.block_task(conn, task_id, reason="operator stop") is False
+        current = kb.get_task(conn, task_id)
+        assert current.status == "running"
+        assert current.claim_lock == task.claim_lock
+        assert current.worker_pid == 12345
+    finally:
+        conn.close()
+
+
+def test_external_block_cannot_block_replacement_run(
+    kanban_home,
+    monkeypatch,
+):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="active", assignee="worker")
+        kb.claim_task(conn, task_id)
+        kb._set_worker_pid(conn, task_id, 11111)
+
+        def replace_run(*_args, **_kwargs):
+            now = int(time.time())
+            with kb.write_txn(conn):
+                run = conn.execute(
+                    "INSERT INTO task_runs "
+                    "(task_id, status, claim_lock, worker_pid, started_at) "
+                    "VALUES (?, 'running', 'host:new', 22222, ?)",
+                    (task_id, now),
+                )
+                conn.execute(
+                    "UPDATE tasks SET current_run_id=?, claim_lock='host:new', "
+                    "worker_pid=22222 WHERE id=?",
+                    (run.lastrowid, task_id),
+                )
+            return {
+                "prev_pid": 11111,
+                "host_local": True,
+                "termination_attempted": True,
+                "terminated": True,
+                "sigkill": False,
+                "process_group": True,
+                "process_group_id": 11111,
+                "self_process": False,
+            }
+
+        monkeypatch.setattr(kb, "_terminate_reclaimed_worker", replace_run)
+
+        assert kb.block_task(conn, task_id, reason="operator stop") is False
+        current = kb.get_task(conn, task_id)
+        assert current.status == "running"
+        assert current.claim_lock == "host:new"
+        assert current.worker_pid == 22222
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -54,11 +54,12 @@ def _event(kind, ts=None, **payload):
     }
 
 
-def _run(outcome="completed", run_id=1, error=None):
+def _run(outcome="completed", run_id=1, error=None, metadata=None):
     return {
         "id": run_id,
         "outcome": outcome,
         "error": error,
+        "metadata": metadata,
     }
 
 
@@ -168,6 +169,56 @@ def test_repeated_failures_fires_on_timeout_loop():
     assert d.data["most_recent_outcome"] == "timed_out"
     suggested = [a.label for a in d.actions if a.suggested]
     assert any("log" in s.lower() for s in suggested)
+
+
+def test_repeated_failures_classifies_iteration_exhaustion():
+    """Iteration exhaustion is reported separately from wall-clock timeout."""
+    task = _task(
+        status="blocked",
+        consecutive_failures=3,
+        last_failure_error="Iteration budget exhausted (90/90)",
+    )
+    runs = [
+        _run(outcome="iteration_exhausted", run_id=1),
+        _run(outcome="iteration_exhausted", run_id=2),
+        _run(outcome="iteration_exhausted", run_id=3),
+    ]
+
+    diags = kd.compute_task_diagnostics(task, [], runs)
+
+    repeated = [d for d in diags if d.kind == "repeated_failures"]
+    assert len(repeated) == 1
+    assert repeated[0].data["most_recent_outcome"] == "iteration_exhausted"
+    assert "iteration exhaustion" in repeated[0].title.lower()
+    suggested = [a.label for a in repeated[0].actions if a.suggested]
+    assert any("log" in label.lower() for label in suggested)
+
+
+def test_repeated_failures_uses_gave_up_trigger_outcome():
+    """A threshold-tripping run keeps its actual cause in run metadata."""
+    task = _task(
+        status="blocked",
+        consecutive_failures=1,
+        last_failure_error="Iteration budget exhausted (90/90)",
+    )
+    runs = [
+        _run(
+            outcome="gave_up",
+            metadata={"trigger_outcome": "iteration_exhausted"},
+        ),
+    ]
+
+    diags = kd.compute_task_diagnostics(
+        task,
+        [],
+        runs,
+        config={"failure_threshold": 1, "failure_limit": 1},
+    )
+
+    repeated = [d for d in diags if d.kind == "repeated_failures"]
+    assert len(repeated) == 1
+    assert repeated[0].data["most_recent_outcome"] == "iteration_exhausted"
+    assert "iteration exhaustion" in repeated[0].title.lower()
 
 
 def test_repeated_failures_escalates_to_critical():

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -79,16 +79,25 @@ async def test_notifier_unsubs_after_completed_event(kanban_home):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('kind', ["gave_up", "crashed", "timed_out"])
-async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
+@pytest.mark.parametrize(
+    ("kind", "message_fragment"),
+    [
+        ("gave_up", "gave up"),
+        ("crashed", "crashed"),
+        ("timed_out", "timed out"),
+        ("iteration_exhausted", "iteration budget"),
+    ],
+)
+async def test_notifier_unsubs_after_abnormal_events(
+    kind, message_fragment, kanban_home
+):
     """
-    Event kinds gave_up / crashed / timed_out send a notification but DO
-    NOT delete the subscription. The dispatcher may respawn the task and
-    fire the same event kind again (e.g. a worker that crashes, gets
-    reclaimed, and crashes a second time); the user must hear about the
-    second event too. Subscriptions are removed only when the task hits
-    a truly final status (done / archived) — see the comment on
-    TERMINAL_KINDS in gateway/run.py and PR #21398.
+    Abnormal event kinds send a notification but DO NOT delete the
+    subscription. The dispatcher may respawn the task and fire the same
+    event kind again (e.g. a worker that crashes, gets reclaimed, and
+    crashes a second time); the user must hear about the second event too.
+    Subscriptions are removed only when the task hits a truly final status
+    (done / archived) — see TERMINAL_KINDS in the gateway watcher.
     """
     import hermes_cli.kanban_db as kb
     from gateway.run import GatewayRunner
@@ -128,7 +137,7 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
 
     # The user is notified about the abnormal event...
     fake_adapter.send.assert_called_once()
-    assert kind.replace('_', ' ') in fake_adapter.send.call_args[0][1]
+    assert message_fragment in fake_adapter.send.call_args[0][1]
 
     # ...but the subscription survives so a respawn-then-same-event cycle
     # reaches the user too. The cursor (last_event_id) advanced inside

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -10,6 +10,7 @@ import inspect
 import io
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -5688,6 +5689,202 @@ class TestRunConversation:
         assert "truncated due to output length limit" in result["error"]
         mock_handle_function_call.assert_not_called()
 
+    def test_successful_kanban_block_ends_without_second_model_call(
+        self,
+        agent,
+        monkeypatch,
+    ):
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("kanban_block")
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+
+        terminal_call = _mock_tool_call(
+            name="kanban_block",
+            arguments='{"reason":"finished"}',
+            call_id="close-1",
+        )
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[terminal_call],
+        )
+        tool_env = {}
+
+        def close_task(*_args, **_kwargs):
+            tool_env["remaining"] = os.environ.get(
+                "HERMES_ITERATIONS_REMAINING"
+            )
+            tool_env["maximum"] = os.environ.get("HERMES_MAX_ITERATIONS")
+            return json.dumps({"ok": True, "status": "blocked"})
+
+        with (
+            patch(
+                "tools.kanban_tools.current_worker_ownership_error",
+                return_value=None,
+            ),
+            patch(
+                "run_agent.handle_function_call",
+                side_effect=close_task,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("close this task")
+
+        assert agent.client.chat.completions.create.call_count == 1
+        assert result["completed"] is True
+        assert result["final_response"] == (
+            "Kanban task closed successfully via `kanban_block`."
+        )
+        assert tool_env == {
+            "remaining": str(agent.iteration_budget.max_total - 1),
+            "maximum": str(agent.iteration_budget.max_total),
+        }
+
+    def test_non_worker_turn_clears_stale_iteration_remaining_env(
+        self,
+        agent,
+        monkeypatch,
+    ):
+        self._setup_agent(agent)
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.setenv("HERMES_ITERATIONS_REMAINING", "77")
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "88")
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="done",
+            finish_reason="stop",
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.run_conversation("normal turn")
+
+        assert "HERMES_ITERATIONS_REMAINING" not in os.environ
+        assert "HERMES_MAX_ITERATIONS" not in os.environ
+
+    def test_expired_kanban_lease_stops_before_model_or_tool(
+        self,
+        agent,
+        monkeypatch,
+        tmp_path,
+    ):
+        from hermes_cli import kanban_db as kb
+
+        self._setup_agent(agent)
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        kb._INITIALIZED_PATHS.clear()
+        conn = kb.connect()
+        try:
+            task_id = kb.create_task(
+                conn,
+                title="expired worker",
+                assignee="worker",
+            )
+            task = kb.claim_task(conn, task_id, ttl_seconds=60)
+            assert task is not None
+            assert kb._set_worker_pid(conn, task_id, os.getpid())
+            expired_at = int(time.time())
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+                    (expired_at, task_id),
+                )
+                conn.execute(
+                    "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
+                    (expired_at, task.current_run_id),
+                )
+        finally:
+            conn.close()
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+        monkeypatch.setenv(
+            "HERMES_KANBAN_RUN_ID",
+            str(task.current_run_id),
+        )
+        monkeypatch.setenv(
+            "HERMES_KANBAN_CLAIM_LOCK",
+            task.claim_lock,
+        )
+
+        with (
+            patch(
+                "tools.kanban_tools.heartbeat_current_worker_from_env",
+                return_value=False,
+            ),
+            patch("run_agent.handle_function_call") as tool_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("continue stale work")
+
+        assert agent.client.chat.completions.create.call_count == 0
+        tool_call.assert_not_called()
+        assert result["api_calls"] == 0
+        assert "claim expired" in result["final_response"]
+
+    def test_failed_kanban_block_continues_to_next_model_call(
+        self,
+        agent,
+        monkeypatch,
+    ):
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("kanban_block")
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+
+        terminal_call = _mock_tool_call(
+            name="kanban_block",
+            arguments='{"reason":"finished"}',
+            call_id="close-1",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[terminal_call],
+            ),
+            _mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[
+                    _mock_tool_call(
+                        name="kanban_block",
+                        arguments='{"reason":"retry"}',
+                        call_id="close-2",
+                    )
+                ],
+            ),
+        ]
+
+        with (
+            patch(
+                "tools.kanban_tools.current_worker_ownership_error",
+                return_value=None,
+            ),
+            patch(
+                "run_agent.handle_function_call",
+                side_effect=[
+                    json.dumps({"ok": False, "error": "claim changed"}),
+                    json.dumps({"ok": True, "status": "blocked"}),
+                ],
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("close this task")
+
+        assert agent.client.chat.completions.create.call_count == 2
+        assert result["final_response"] == (
+            "Kanban task closed successfully via `kanban_block`."
+        )
+
     def test_kanban_block_called_on_iteration_exhaustion(self, agent, monkeypatch):
         """Regression: kanban worker must signal the dispatcher when its
         iteration budget is exhausted, otherwise the task silently re-runs
@@ -5723,6 +5920,10 @@ class TestRunConversation:
         mock_connect = MagicMock(return_value=MagicMock())
 
         with (
+            patch(
+                "tools.kanban_tools.current_worker_ownership_error",
+                return_value=None,
+            ),
             patch("run_agent.handle_function_call", return_value="ok"),
             patch("hermes_cli.kanban_db._record_task_failure",
                   mock_record_failure),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5766,6 +5766,72 @@ class TestRunConversation:
         assert "HERMES_ITERATIONS_REMAINING" not in os.environ
         assert "HERMES_MAX_ITERATIONS" not in os.environ
 
+    def test_refunded_execute_code_exports_api_limited_cleanup_reserve(
+        self,
+        agent,
+        monkeypatch,
+    ):
+        self._setup_agent(agent)
+        agent.max_iterations = 3
+        agent.valid_tool_names.update({"execute_code", "kanban_block"})
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+
+        execute_call = _mock_tool_call(
+            name="execute_code",
+            arguments='{"code":"return 1"}',
+            call_id="execute-1",
+        )
+        block_call = _mock_tool_call(
+            name="kanban_block",
+            arguments='{"reason":"cleanup reserve"}',
+            call_id="block-1",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[execute_call],
+            ),
+            _mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[block_call],
+            ),
+        ]
+        tool_env = []
+
+        def handle_tool(name, *_args, **_kwargs):
+            tool_env.append(
+                (
+                    name,
+                    os.environ.get("HERMES_ITERATIONS_REMAINING"),
+                    os.environ.get("HERMES_MAX_ITERATIONS"),
+                )
+            )
+            if name == "kanban_block":
+                return json.dumps({"ok": True, "status": "blocked"})
+            return json.dumps({"ok": True})
+
+        with (
+            patch(
+                "tools.kanban_tools.current_worker_ownership_error",
+                return_value=None,
+            ),
+            patch("run_agent.handle_function_call", side_effect=handle_tool),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("run then reserve cleanup")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert agent.iteration_budget.used == 1
+        assert tool_env == [
+            ("execute_code", "2", "3"),
+            ("kanban_block", "1", "3"),
+        ]
+
     def test_expired_kanban_lease_stops_before_model_or_tool(
         self,
         agent,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5892,7 +5892,7 @@ class TestRunConversation:
         (issue #23216 / #29747 gap 2).
 
         As of #29747, the exhaustion path routes through
-        ``kanban_db._record_task_failure(outcome="timed_out")`` so the
+        ``kanban_db._record_task_failure(outcome="iteration_exhausted")`` so the
         ``consecutive_failures`` counter increments and the dispatcher's
         ``failure_limit`` breaker eventually trips. The legacy
         ``kanban_block`` call was replaced because blocked-outcome runs
@@ -5938,7 +5938,7 @@ class TestRunConversation:
         assert result["completed"] is False
 
         # _record_task_failure should have been called exactly once for
-        # the exhaustion event, with outcome="timed_out".
+        # the exhaustion event, with its own outcome (not a wall timeout).
         assert mock_record_failure.call_count == 1, (
             f"Expected exactly 1 _record_task_failure call, "
             f"got {mock_record_failure.call_count}. "
@@ -5947,7 +5947,7 @@ class TestRunConversation:
         call = mock_record_failure.call_args_list[0]
         # Positional: (conn, task_id, ...)
         assert call.args[1] == "t_test_task_123"
-        assert call.kwargs.get("outcome") == "timed_out"
+        assert call.kwargs.get("outcome") == "iteration_exhausted"
         assert call.kwargs.get("release_claim") is True
         assert call.kwargs.get("end_run") is True
         assert "Iteration budget exhausted" in call.kwargs.get("error", "")

--- a/tests/run_agent/test_tool_batch_segmentation.py
+++ b/tests/run_agent/test_tool_batch_segmentation.py
@@ -116,6 +116,18 @@ class TestPlanToolBatchSegments:
         assert _kinds(segments) == ["parallel", "sequential"]
         assert [tc.id for tc in segments[1][1]] == ["c1"]
 
+    def test_kanban_terminal_is_an_explicit_barrier(self):
+        calls = [
+            _tc("web_search", call_id="r1"),
+            _tc("web_search", call_id="r2"),
+            _tc("kanban_complete", call_id="done"),
+            _tc("web_search", call_id="r3"),
+            _tc("web_search", call_id="r4"),
+        ]
+        segments = _plan_tool_batch_segments(calls)
+        assert _kinds(segments) == ["parallel", "sequential", "parallel"]
+        assert [tc.id for tc in segments[1][1]] == ["done"]
+
     def test_malformed_args_call_is_a_barrier_not_a_batch_poison(self):
         calls = [
             _tc("web_search", call_id="r1"),
@@ -218,7 +230,11 @@ def agent():
     with (
         patch(
             "run_agent.get_tool_definitions",
-            return_value=_make_tool_defs("web_search", "terminal"),
+            return_value=_make_tool_defs(
+                "web_search",
+                "terminal",
+                "kanban_block",
+            ),
         ),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
@@ -235,6 +251,75 @@ def agent():
 
 
 class TestSegmentedDispatchIntegration:
+    def test_successful_kanban_terminal_skips_later_segments(
+        self,
+        agent,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+        calls = [
+            _tc("web_search", '{"query":"a"}', call_id="s1"),
+            _tc("web_search", '{"query":"b"}', call_id="s2"),
+            _tc("kanban_block", '{"reason":"done"}', call_id="b1"),
+            _tc("web_search", '{"query":"c"}', call_id="s3"),
+            _tc("web_search", '{"query":"d"}', call_id="s4"),
+        ]
+        msg = SimpleNamespace(content="", tool_calls=calls)
+        messages = []
+        executed = []
+
+        def fake_handle(name, args, task_id, **kwargs):
+            executed.append(kwargs["tool_call_id"])
+            return json.dumps({"ok": True})
+
+        with (
+            patch(
+                "agent.tool_executor._kanban_worker_ownership_error",
+                return_value=None,
+            ),
+            patch("run_agent.handle_function_call", side_effect=fake_handle),
+        ):
+            agent._execute_tool_calls(msg, messages, "task-1")
+
+        assert [m["tool_call_id"] for m in messages] == [
+            "s1",
+            "s2",
+            "b1",
+            "s3",
+            "s4",
+        ]
+        assert set(executed[:2]) == {"s1", "s2"}
+        assert executed[2:] == ["b1"]
+        assert agent._kanban_terminal_tool == "kanban_block"
+        assert all("not started" in m["content"] for m in messages[-2:])
+
+    def test_ownership_is_rechecked_before_each_sequential_tool(self, agent):
+        calls = [
+            _tc("terminal", '{"command":"first"}', call_id="t1"),
+            _tc("terminal", '{"command":"second"}', call_id="t2"),
+        ]
+        msg = SimpleNamespace(content="", tool_calls=calls)
+        messages = []
+        executed = []
+
+        def fake_handle(name, args, task_id, **kwargs):
+            executed.append(kwargs["tool_call_id"])
+            return json.dumps({"ok": True})
+
+        with (
+            patch(
+                "agent.tool_executor._kanban_worker_ownership_error",
+                side_effect=[None, "task claim changed"],
+            ),
+            patch("run_agent.handle_function_call", side_effect=fake_handle),
+        ):
+            agent._execute_tool_calls(msg, messages, "task-1")
+
+        assert executed == ["t1"]
+        assert [m["tool_call_id"] for m in messages] == ["t1", "t2"]
+        assert "ownership was lost" in messages[-1]["content"]
+        assert agent._kanban_ownership_lost_reason == "task claim changed"
+
     def test_mixed_batch_runs_safe_prefix_concurrently_and_barrier_after(self, agent):
         """Two web_search calls must overlap in time; terminal must start only
         after both finish; results land in the model's emission order."""

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -150,34 +150,23 @@ class TestAtomicSnapshotWrite:
         assert f"export -p > {snap} " not in wrapped
         assert f"export -p > '{snap}'" not in wrapped
 
-    def test_temp_path_uses_bashpid_not_dollardollar(self):
-        """The temp name MUST use ``$BASHPID`` (the real subshell PID), not
-        ``$$``.  In ``&``-launched concurrent subshells ``$$`` stays the parent
-        shell's PID, so two writers would pick the same temp name, clobber each
-        other mid-write, and mv would publish a torn file — the corruption is
-        only narrowed, not closed.  This is the bug shared by every prior PR in
-        the #38249 cluster."""
+    def test_temp_path_is_allocated_atomically_with_mktemp(self):
+        """The temp name must remain unique when Bash lacks ``BASHPID``."""
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("echo hi", "/tmp")
-        assert "$BASHPID" in wrapped
-        # The bare $$ temp form must be gone.
-        assert ".tmp.$$" not in wrapped
+        assert "__hermes_snap_tmp=$(mktemp " in wrapped
+        assert ".tmp.XXXXXX" in wrapped
+        assert "$BASHPID" not in wrapped
 
-    def test_temp_path_static_part_is_quoted_bashpid_outside(self):
-        """The static path portion must be shlex-quoted (Windows/Git-Bash
-        ``C:/Users/...`` or spaces) while ``$BASHPID`` stays OUTSIDE the quotes
-        so it still expands."""
+    def test_temp_template_static_path_is_quoted(self):
+        """A snapshot path with spaces stays one ``mktemp`` argument."""
         env = _TestableEnv()
         env._snapshot_ready = True
         env._snapshot_path = "/tmp/has space/hermes-snap-x.sh"
         wrapped = env._wrap_command("echo hi", "/tmp")
-        # The static path (with its space) is shlex-quoted as a single word, with
-        # $BASHPID appended OUTSIDE the quotes so it still expands at runtime.
-        assert "'/tmp/has space/hermes-snap-x.sh.tmp.'$BASHPID" in wrapped
-        # The space must never appear bare/unquoted in the temp token (that would
-        # word-split into two args and break the redirect/mv).
-        assert " space/hermes-snap-x.sh.tmp.$BASHPID" not in wrapped
+        assert "mktemp '/tmp/has space/hermes-snap-x.sh.tmp.XXXXXX'" in wrapped
+        assert "mktemp /tmp/has space/" not in wrapped
 
     def test_wrap_command_mv_chained_on_export_success(self):
         """A failed/partial ``export -p`` must NOT mv a torn temp over a good
@@ -189,10 +178,9 @@ class TestAtomicSnapshotWrite:
         assert "export -p > " in wrapped and "&& mv -f " in wrapped
         assert "rm -f " in wrapped  # temp cleanup on failure
 
-    def test_init_session_bootstrap_also_atomic_and_bashpid(self):
+    def test_init_session_bootstrap_also_uses_mktemp(self):
         """The init_session bootstrap (first snapshot write) is the same shared
-        file a concurrent command could source — it must be atomic and use
-        ``$BASHPID`` too."""
+        file a concurrent command could source, so it needs a unique temp too."""
         env = _TestableEnv()
         captured = {}
 
@@ -207,8 +195,8 @@ class TestAtomicSnapshotWrite:
             pass
         boot = captured.get("cmd", "")
         assert ".tmp." in boot and "mv -f " in boot, boot
-        assert "$BASHPID" in boot
-        assert ".tmp.$$" not in boot
+        assert "__hermes_snap_tmp=$(mktemp " in boot
+        assert ".tmp.XXXXXX" in boot
 
     def test_snapshot_writes_use_private_umask_after_user_command(self):
         env = _TestableEnv()
@@ -245,8 +233,8 @@ class TestAtomicSnapshotConcurrencyBehavioral:
     the emitted script's guarantee holds under real concurrency: N concurrent
     writers + readers, and the snapshot is ALWAYS a complete, parseable env
     dump — never truncated mid-line with a ``declare -x`` / ``export`` fragment
-    that would corrupt PATH.  Crucially it uses ``$BASHPID`` (per-subshell
-    unique), which is what closes the race; ``$$`` would still tear here.
+    that would corrupt PATH. The temp path is allocated atomically so this also
+    holds on macOS Bash 3.2, where ``BASHPID`` is empty.
     """
 
     def _run(self, script):
@@ -261,13 +249,14 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         import shlex
         snap = str(tmp_path / "hermes-snap-x.sh")
         _q = shlex.quote
-        _snap_tmp = _q(snap + ".tmp.") + "$BASHPID"
+        _snap_template = _q(snap + ".tmp.XXXXXX")
         # One writer iteration = the exact atomic sequence _wrap_command emits.
         writer = (
             "for i in $(seq 1 80); do "
             "export BIG_$i=$(head -c 600 /dev/zero | tr '\\0' x); "
-            f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_q(snap)}; }} "
-            f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true; "
+            f"tmp=$(mktemp {_snap_template}) || continue; "
+            f"{{ export -p > \"$tmp\" && mv -f \"$tmp\" {_q(snap)}; }} "
+            "2>/dev/null || rm -f \"$tmp\" 2>/dev/null || true; "
             "done"
         )
         # Reader: repeatedly source the snapshot and check PATH never absorbs

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1538,6 +1538,68 @@ def test_kanban_guidance_prompt_size_bounded(monkeypatch, tmp_path):
 # tasks on behalf of the child.
 
 
+def test_worker_ownership_fence_detects_external_transition(
+    worker_env,
+    monkeypatch,
+):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        kb._set_worker_pid(conn, worker_env, os.getpid())
+        task = kb.get_task(conn, worker_env)
+        monkeypatch.setenv(
+            "HERMES_KANBAN_RUN_ID",
+            str(task.current_run_id),
+        )
+        monkeypatch.setenv(
+            "HERMES_KANBAN_CLAIM_LOCK",
+            task.claim_lock,
+        )
+
+        assert kt.current_worker_ownership_error() is None
+        assert kb.block_task(conn, worker_env, reason="operator stop") is True
+        assert "no longer running" in kt.current_worker_ownership_error()
+    finally:
+        conn.close()
+
+
+def test_worker_ownership_fence_waits_for_dispatcher_pid_handoff(
+    worker_env,
+    monkeypatch,
+):
+    import threading
+    import time
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(task.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", task.claim_lock)
+
+    def register_pid():
+        time.sleep(0.1)
+        worker_conn = kb.connect()
+        try:
+            kb._set_worker_pid(worker_conn, worker_env, os.getpid())
+        finally:
+            worker_conn.close()
+
+    registrar = threading.Thread(target=register_pid)
+    registrar.start()
+    try:
+        assert kt.current_worker_ownership_error() is None
+    finally:
+        registrar.join(timeout=2)
+    assert not registrar.is_alive()
+
+
 def test_worker_complete_rejects_foreign_task_id(worker_env):
     """A worker cannot complete a task that isn't its own (#19534)."""
     from hermes_cli import kanban_db as kb

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1008,6 +1008,69 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_max_retries_round_trips_and_blocks_first_failure(worker_env):
+    """The model-facing create tool can request a no-retry worker policy."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "one attempt",
+        "assignee": "peer",
+        "max_retries": 1,
+    })
+    created = json.loads(out)
+    assert created["ok"] is True
+    assert created["max_retries"] == 1
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, created["task_id"])
+        assert task.max_retries == 1
+
+        created_events = [
+            event
+            for event in kb.list_events(conn, created["task_id"])
+            if event.kind == "created"
+        ]
+        assert created_events[-1].payload["max_retries"] == 1
+
+        assert kb.claim_task(conn, created["task_id"]) is not None
+        blocked = kb._record_task_failure(
+            conn,
+            created["task_id"],
+            error="first abnormal exit",
+            outcome="crashed",
+            release_claim=True,
+            end_run=True,
+        )
+        assert blocked is True
+        assert kb.get_task(conn, created["task_id"]).status == "blocked"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [0, -1, True, 1.2, "1", "not-an-integer"],
+)
+def test_create_rejects_invalid_max_retries(worker_env, value):
+    from tools import kanban_tools as kt
+
+    result = json.loads(kt._handle_create({
+        "title": "invalid retry policy",
+        "assignee": "peer",
+        "max_retries": value,
+    }))
+    assert result.get("ok") is not True
+    assert "max_retries" in result.get("error", "")
+
+
+def test_create_schema_exposes_positive_max_retries():
+    """Schema validators reject zero before the call reaches the handler."""
+    from tools.kanban_tools import KANBAN_CREATE_SCHEMA
+
+    retry_property = KANBAN_CREATE_SCHEMA["parameters"]["properties"]["max_retries"]
+    assert retry_property["type"] == "integer"
+    assert retry_property["minimum"] == 1
+
+
 def test_create_inherits_worker_dir_workspace(monkeypatch, worker_env):
     """A worker scoped to a dir: task that spawns a child without a
     workspace arg inherits the dir, not scratch (so follow-up code-gen

--- a/tests/tools/test_local_env_iteration_budget.py
+++ b/tests/tools/test_local_env_iteration_budget.py
@@ -1,0 +1,50 @@
+from tools.environments.local import LocalEnvironment
+
+
+def _read_budget(env: LocalEnvironment) -> str:
+    result = env.execute(
+        "printf '%s/%s' "
+        '"$HERMES_ITERATIONS_REMAINING" "$HERMES_MAX_ITERATIONS"'
+    )
+    assert result["returncode"] == 0
+    return result["output"].strip()
+
+
+def test_kanban_budget_refreshes_after_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_budget")
+    monkeypatch.setenv("HERMES_ITERATIONS_REMAINING", "89")
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", "90")
+    env = LocalEnvironment(
+        cwd=str(tmp_path),
+        timeout=10,
+        env={
+            "HERMES_ITERATIONS_REMAINING": "89",
+            "HERMES_MAX_ITERATIONS": "90",
+        },
+    )
+    try:
+        assert _read_budget(env) == "89/90"
+
+        monkeypatch.setenv("HERMES_ITERATIONS_REMAINING", "14")
+        assert _read_budget(env) == "14/90"
+
+        inline = env.execute(
+            "HERMES_ITERATIONS_REMAINING=90 "
+            "/bin/bash -c 'printf \"inline=%s/%s\" "
+            "\"$HERMES_ITERATIONS_REMAINING\" \"$HERMES_MAX_ITERATIONS\"'"
+        )
+        assert "inline=90/90" not in inline["output"]
+        assert "inline=14/90" in inline["output"]
+
+        override = env.execute(
+            "export HERMES_ITERATIONS_REMAINING=90; "
+            "printf '%s/%s' "
+            '"$HERMES_ITERATIONS_REMAINING" "$HERMES_MAX_ITERATIONS"'
+        )
+        assert "90/90" not in override["output"]
+        assert "14/90" in override["output"]
+
+        monkeypatch.setenv("HERMES_ITERATIONS_REMAINING", "13")
+        assert _read_budget(env) == "13/90"
+    finally:
+        env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -27,6 +27,66 @@ from tools.interrupt import is_interrupted
 
 logger = logging.getLogger(__name__)
 
+_TRUSTED_ITERATION_ENV_VARS = (
+    "HERMES_ITERATIONS_REMAINING",
+    "HERMES_MAX_ITERATIONS",
+)
+_TRUSTED_ITERATION_SNAPSHOT_PATTERN = (
+    r"^declare -[^ ]*x[^ ]* "
+    r"(HERMES_ITERATIONS_REMAINING|HERMES_MAX_ITERATIONS)="
+)
+
+
+def _trusted_iteration_env() -> dict[str, str]:
+    """Return the current worker budget carried by the parent process."""
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return {}
+    values = {
+        name: os.environ.get(name, "")
+        for name in _TRUSTED_ITERATION_ENV_VARS
+    }
+    if not all(value.isdigit() for value in values.values()):
+        return {}
+    remaining = int(values["HERMES_ITERATIONS_REMAINING"])
+    maximum = int(values["HERMES_MAX_ITERATIONS"])
+    if maximum <= 0 or remaining > maximum:
+        return {}
+    return values
+
+
+def _inject_trusted_iteration_env(env: dict[str, str]) -> None:
+    """Replace caller or snapshot budget values with current trusted values."""
+    trusted = _trusted_iteration_env()
+    for name in _TRUSTED_ITERATION_ENV_VARS:
+        if name in trusted:
+            env[name] = trusted[name]
+        else:
+            env.pop(name, None)
+
+
+def _trusted_iteration_shell_lines() -> list[str]:
+    """Build shell statements that refresh and protect worker budget values."""
+    trusted = _trusted_iteration_env()
+    lines = []
+    for name in _TRUSTED_ITERATION_ENV_VARS:
+        if name in trusted:
+            lines.append(f"declare -rx {name}={shlex.quote(trusted[name])}")
+        else:
+            lines.append(f"unset {name} 2>/dev/null || true")
+    return lines
+
+
+def _snapshot_export_command(target: str) -> str:
+    """Dump exported shell state without persisting dynamic worker budgets."""
+    pattern = shlex.quote(_TRUSTED_ITERATION_SNAPSHOT_PATTERN)
+    filtered = f"{target}.filtered"
+    return (
+        f"export -p > {target} && "
+        f"grep -Ev {pattern} {target} > {filtered} && "
+        f"mv -f {filtered} {target}"
+    )
+
+
 # Opt-in debug tracing for the interrupt/activity/poll machinery.  Set
 # HERMES_DEBUG_INTERRUPT=1 to log loop entry/exit, periodic heartbeats, and
 # every is_interrupted() state change from _wait_for_process.  Off by default
@@ -486,19 +546,17 @@ class BaseEnvironment(ABC):
         # source() either sees the old complete snapshot or the new complete
         # one — never a partial/truncated file.
         #
-        # The temp name MUST be unique per concurrent writer.  ``$$`` is the
-        # bash PID, but in ``&``-launched subshells (how concurrent terminal
-        # calls run) ``$$`` stays the *parent* shell's PID — so two concurrent
-        # writers would pick the SAME temp name, clobber each other's temp
-        # mid-write, and mv would then publish a torn file (the corruption is
-        # only narrowed, not closed).  ``$BASHPID`` is the actual subshell PID
-        # and is genuinely unique per writer, which closes the race.  The
-        # static path is shell-quoted (Windows/Git-Bash drive letters, spaces)
-        # with ``$BASHPID`` left outside the quotes so it still expands.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # Allocate the temp file atomically. macOS still ships Bash 3.2, where
+        # BASHPID is empty, so PID-derived names collide under concurrent
+        # writers and can publish a torn snapshot.
+        _snap_template = self._quote_shell_path(
+            self._snapshot_path + ".tmp.XXXXXX"
+        )
+        _snap_tmp = '"$__hermes_snap_tmp"'
         bootstrap = (
             f"umask 077\n"
-            f"export -p > {_snap_tmp}\n"
+            f"__hermes_snap_tmp=$(mktemp {_snap_template}) || exit 1\n"
+            f"{_snapshot_export_command(_snap_tmp)}\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
             # helpers — mainly bash-completion internals (``_git``, ``_make``…)
             # — by NAME, not by line.  A naive ``declare -f | grep -vE '^_[^_]'``
@@ -520,7 +578,8 @@ class BaseEnvironment(ABC):
             f"echo 'set +u' >> {_snap_tmp}\n"
             # Publish atomically only if assembly succeeded; otherwise drop the
             # partial temp rather than leave it to be sourced or orphaned.
-            f"mv -f {_snap_tmp} {_quoted_snap} || rm -f {_snap_tmp}\n"
+            f"mv -f {_snap_tmp} {_quoted_snap} || "
+            f"rm -f {_snap_tmp} {_snap_tmp}.filtered\n"
             f"builtin cd -- {_quoted_cwd} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
         )
@@ -606,11 +665,12 @@ class BaseEnvironment(ABC):
         # Use atomic file replacement for env snapshot updates (issue #38249).
         # Assemble into a per-writer-unique temp file, then mv to atomically
         # replace the snapshot so concurrent source() calls never read a
-        # truncated/half-written file.  ``$BASHPID`` (not ``$$``) is the actual
-        # subshell PID — unique per concurrent ``&``-launched writer — so two
-        # writers never share a temp name and clobber each other before the mv.
-        # Static path shell-quoted (Windows/spaces); ``$BASHPID`` left to expand.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # truncated/half-written file. ``mktemp`` works on Bash 3.2 (where
+        # BASHPID is absent) and creates the path atomically.
+        _snap_template = self._quote_shell_path(
+            self._snapshot_path + ".tmp.XXXXXX"
+        )
+        _snap_tmp = '"$__hermes_snap_tmp"'
 
         parts = []
 
@@ -624,6 +684,7 @@ class BaseEnvironment(ABC):
             parts.append(
                 f"source {_quoted_snap} >/dev/null 2>&1 || true"
             )
+        parts.extend(_trusted_iteration_shell_lines())
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.
@@ -644,8 +705,15 @@ class BaseEnvironment(ABC):
         # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
         if self._snapshot_ready:
             parts.append(
-                f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_quoted_snap}; }} "
-                f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
+                f"__hermes_snap_tmp=$(mktemp {_snap_template} 2>/dev/null) "
+                f"|| __hermes_snap_tmp="
+            )
+            parts.append(
+                f"[ -z \"$__hermes_snap_tmp\" ] || "
+                f"{{ {_snapshot_export_command(_snap_tmp)} && "
+                f"mv -f {_snap_tmp} {_quoted_snap}; }} "
+                f"2>/dev/null || "
+                f"rm -f {_snap_tmp} {_snap_tmp}.filtered 2>/dev/null || true"
             )
 
         # Emit the CWD stdout marker; all backends (including local, since

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -13,7 +13,11 @@ import tempfile
 import time
 from pathlib import Path
 
-from tools.environments.base import BaseEnvironment, _pipe_stdin
+from tools.environments.base import (
+    BaseEnvironment,
+    _inject_trusted_iteration_env,
+    _pipe_stdin,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -484,6 +488,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # Same cross-session leak guard as _make_run_env, for the background/PTY
     # spawn path (process_registry.spawn_local builds env via this function).
     _inject_session_context_env(sanitized)
+    _inject_trusted_iteration_env(sanitized)
 
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         sanitized.pop(_marker, None)
@@ -1168,6 +1173,7 @@ def _make_run_env(env: dict) -> dict:
     # cross-session leak guard — strips _UNSET vars when a concurrent host is
     # engaged so a sibling session's os.environ mirror can't leak in).
     _inject_session_context_env(run_env)
+    _inject_trusted_iteration_env(run_env)
 
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         run_env.pop(_marker, None)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
@@ -177,6 +178,113 @@ def _connect(board: Optional[str] = None):
     """
     from hermes_cli import kanban_db as kb
     return kb, kb.connect(board=board)
+
+
+def current_worker_ownership_error() -> Optional[str]:
+    """Return why this dispatcher worker no longer owns its active run.
+
+    Non-worker processes have no ownership fence. A worker fails closed when
+    its identity is incomplete, the board cannot be read, or any task/run
+    ownership field no longer matches the dispatcher-provided identity.
+    """
+    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if not task_id:
+        return None
+
+    run_id_raw = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    claim_lock = (os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or "").strip()
+    if not run_id_raw or not claim_lock:
+        return "dispatcher worker identity is incomplete"
+    try:
+        run_id = int(run_id_raw)
+    except ValueError:
+        return "dispatcher worker run id is invalid"
+
+    row = None
+    try:
+        _kb, conn = _connect()
+        try:
+            startup_deadline = time.monotonic() + 5.0
+            while True:
+                row = conn.execute(
+                    """
+                    SELECT t.status AS task_status,
+                           t.current_run_id,
+                           t.claim_lock AS task_claim_lock,
+                           t.claim_expires AS task_claim_expires,
+                           t.worker_pid AS task_worker_pid,
+                           r.status AS run_status,
+                           r.claim_lock AS run_claim_lock,
+                           r.claim_expires AS run_claim_expires,
+                           r.worker_pid AS run_worker_pid,
+                           r.ended_at AS run_ended_at
+                      FROM tasks t
+                 LEFT JOIN task_runs r
+                        ON r.id = ? AND r.task_id = t.id
+                     WHERE t.id = ?
+                    """,
+                    (run_id, task_id),
+                ).fetchone()
+                now = int(time.time())
+                waiting_for_pid = (
+                    row is not None
+                    and row["task_status"] == "running"
+                    and row["current_run_id"] == run_id
+                    and row["task_claim_lock"] == claim_lock
+                    and row["task_claim_expires"] is not None
+                    and int(row["task_claim_expires"]) > now
+                    and row["run_status"] == "running"
+                    and row["run_claim_lock"] == claim_lock
+                    and row["run_claim_expires"] is not None
+                    and int(row["run_claim_expires"]) > now
+                    and row["run_ended_at"] is None
+                    and row["task_worker_pid"] is None
+                    and row["run_worker_pid"] is None
+                )
+                if not waiting_for_pid or time.monotonic() >= startup_deadline:
+                    break
+                # Popen returns before the dispatcher records the PID in the
+                # task and run rows. Give that single startup handoff a bounded
+                # window; all later ownership failures remain immediate.
+                time.sleep(0.05)
+        finally:
+            conn.close()
+    except Exception as exc:
+        logger.warning(
+            "kanban ownership fence could not read task %s: %s",
+            task_id,
+            exc,
+        )
+        return "could not verify dispatcher worker ownership"
+
+    if row is None:
+        return "task no longer exists"
+    expected_pid = os.getpid()
+    now = int(time.time())
+    checks = (
+        (row["task_status"] == "running", "task is no longer running"),
+        (row["current_run_id"] == run_id, "task points to a different run"),
+        (row["task_claim_lock"] == claim_lock, "task claim changed"),
+        (
+            row["task_claim_expires"] is not None
+            and int(row["task_claim_expires"]) > now,
+            "task claim expired",
+        ),
+        (row["task_worker_pid"] == expected_pid, "task worker pid changed"),
+        (row["run_status"] == "running", "task run is no longer running"),
+        (row["run_claim_lock"] == claim_lock, "task run claim changed"),
+        (
+            row["run_claim_expires"] is not None
+            and int(row["run_claim_expires"]) > now,
+            "task run claim expired",
+        ),
+        (row["run_worker_pid"] == expected_pid, "task run worker pid changed"),
+        (row["run_ended_at"] is None, "task run already ended"),
+    )
+    for owned, reason in checks:
+        if not owned:
+            return reason
+    return None
 
 
 _GOAL_MODE_BLOCK_ALLOWED_KINDS = frozenset({"dependency", "needs_input"})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1213,6 +1213,12 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(bool_error)
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
+    max_retries = args.get("max_retries")
+    if max_retries is not None:
+        if isinstance(max_retries, bool) or not isinstance(max_retries, int):
+            return tool_error("max_retries must be an integer >= 1")
+        if max_retries < 1:
+            return tool_error("max_retries must be >= 1")
     initial_status = args.get("initial_status") or "running"
     skills = args.get("skills")
     if isinstance(skills, str):
@@ -1271,6 +1277,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                max_retries=max_retries,
                 model_override=model_override,
                 provider_override=provider_override,
                 goal_mode=goal_mode,
@@ -1286,6 +1293,7 @@ def _handle_create(args: dict, **kw) -> str:
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
+                max_retries=new_task.max_retries if new_task else None,
                 subscribed=subscribed,
             )
         finally:
@@ -1939,6 +1947,16 @@ KANBAN_CREATE_SCHEMA = {
                     "Per-task runtime cap. When exceeded, the "
                     "dispatcher SIGTERMs the worker and re-queues the "
                     "task with outcome='timed_out'."
+                ),
+            },
+            "max_retries": {
+                "type": "integer",
+                "minimum": 1,
+                "description": (
+                    "Per-task failure limit. The task blocks on the Nth "
+                    "abnormal worker outcome. Set 1 to block on the first "
+                    "failure with no automatic retry. Omit to use the "
+                    "dispatcher-level failure limit."
                 ),
             },
             "initial_status": {


### PR DESCRIPTION
## What does this PR do?

This fixes a Kanban worker incident in which a worker successfully called a terminal task tool, continued through its remaining model iterations, and left its task lease active. The same run was then reported as a timeout with `max_runtime=0s`, even though the actual trigger was iteration-budget exhaustion.

The root causes were split across the worker lifecycle: terminal task transitions were handled like ordinary tool calls, ownership was not fenced at every API/tool boundary, process cleanup targeted a PID instead of the whole worker process group, and the per-task retry policy was not persisted and reported end to end. A refunded `execute_code` call could also make the cleanup-reserve counter disagree with the hard API-call limit, while a persisted local-shell snapshot could restore an older budget into later tool calls.

The fix makes worker shutdown fail closed while preserving message-role alternation and existing non-worker behavior.

## Related Issue

No public issue. This was reproduced from an operator incident in a scheduled Kanban workflow.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Treat successful `kanban_complete` and `kanban_block` calls as terminal barriers: skip later calls in the batch with paired tool results and do not make another model call. A failed terminal transition still lets the worker continue.
- Revalidate task/run ownership before each worker API iteration and tool call using the task status, current run, claim token and expiry, and registered PID.
- Close the dispatcher PID-registration race and terminate the full POSIX worker process group on reclaim, external block, runtime expiry, and stale ownership.
- Distinguish `iteration_exhausted` from wall-clock `timed_out`, preserve effective budget metadata, and avoid misleading `max_runtime=0s` notifications.
- Cap the cleanup reserve with both counters: `max(0, min(iteration_budget.remaining, max_iterations - api_call_count))`. This prevents a refunded `execute_code` call from bypassing the hard API limit.
- Refresh Kanban iteration variables from the parent process for every local terminal invocation, exclude them from persisted shell snapshots, and make direct shell assignment/export unable to replace the current values.
- Allocate snapshot writer temp files with `mktemp`, which keeps concurrent snapshot updates atomic on macOS Bash 3.2 where `BASHPID` is empty.
- Add strict per-task `max_retries >= 1` persistence and readback. `max_retries=1` blocks on the first abnormal outcome without an automatic retry.
- Add behavior tests for terminal barriers, ownership loss, process descendants, retry limits, effective iteration accounting, shell snapshot refresh, direct override attempts, concurrent snapshot writers, diagnostics, and notifier text.

## How to Test

Run the directly related lifecycle and environment suite with file retries disabled:

`HERMES_PYTHON=/path/to/python scripts/run_tests.sh --file-retries 0 -j6 tests/agent/test_kanban_stop.py tests/agent/test_turn_finalizer_iteration_limit_exit.py tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_notify.py tests/run_agent/test_run_agent.py tests/run_agent/test_tool_batch_segmentation.py tests/tools/test_kanban_tools.py tests/tools/test_base_environment.py tests/tools/test_local_env_blocklist.py tests/tools/test_local_env_session_leak.py tests/tools/test_local_shell_init.py tests/tools/test_terminal_env_bridge.py tests/tools/test_local_env_iteration_budget.py`

Stable focused regressions:

- `tests/tools/test_local_env_iteration_budget.py::test_kanban_budget_refreshes_after_snapshot`
- `tests/tools/test_base_environment.py::TestAtomicSnapshotWrite::test_temp_path_is_allocated_atomically_with_mktemp`

Observed results on macOS:

- Combined related suite: 1005 passed across 15 files, 0 failed, file retries disabled.
- Core iteration-accounting files: 464 passed, 0 failed, file retries disabled.
- Environment files: 118 passed, 0 failed, file retries disabled.
- Snapshot concurrency file: 33 passed in three consecutive runs, 0 failed, file retries disabled.
- `git diff --check`: clean.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the full test suite; the focused 1005-test suite above passes
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update is N/A; CLI help, schema descriptions, config comments, diagnostics, and localized notifier text are updated in place
- [x] `cli-config.yaml.example` update is N/A; no new global config key is added
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A
- [ ] Cross-platform process semantics need maintainer review; process-group termination is POSIX-gated
- [x] Tool descriptions and schemas are updated for `max_retries`

## Additional hook-consent regression

The rollout canary also exposed that an explicit top-level `--accept-hooks` flag was ignored by `hermes hooks list` and `hermes hooks doctor` because management commands intentionally skip full agent startup. The CLI now registers configured hooks only when this explicit flag is present; ordinary hook inspection remains non-mutating and mtime-drift protection is unchanged.

Focused hook and parser validation: 117 tests passed across 4 files, 0 failed.