### PR TITLE
fix(kanban): inherit board default_workdir kind on CLI/tool create

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -333,9 +333,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
     p_create.add_argument("--parent", action="append", default=[],
                           help="Parent task id (repeatable)")
-    p_create.add_argument("--workspace", default="scratch",
-                          help="scratch | worktree | worktree:<path> | dir:<path> "
-                               "(default: scratch)")
+    p_create.add_argument("--workspace", default=None,
+                          help="scratch | worktree | worktree:<path> | dir:<path>. "
+                               "Default: inherit board default_workdir kind "
+                               "(git→worktree, plain dir→dir), else scratch.")
     p_create.add_argument("--branch", default=None,
                           help="Branch name for worktree tasks, e.g. wt/t6-wire")
     p_create.add_argument("--project", default=None,
@@ -1474,7 +1475,13 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
 
 def _cmd_create(args: argparse.Namespace) -> int:
     try:
-        ws_kind, ws_path = _parse_workspace_flag(args.workspace)
+        if getattr(args, "workspace", None) in (None, ""):
+            # Board-level default: kind only from default_workdir (#69787).
+            # Explicit --workspace scratch keeps disposable scratch (no path).
+            board_for_ws = getattr(args, "board", None) or kb.get_current_board()
+            ws_kind, ws_path = kb.recommended_workspace_kind_for_board(board_for_ws)
+        else:
+            ws_kind, ws_path = _parse_workspace_flag(args.workspace)
         branch_name = _parse_branch_flag(getattr(args, "branch", None))
     except argparse.ArgumentTypeError as exc:
         print(f"kanban: {exc}", file=sys.stderr)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6220,6 +6220,33 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
 # Workspace resolution
 # ---------------------------------------------------------------------------
 
+def recommended_workspace_kind_for_board(board: Optional[str] = None) -> tuple[str, Optional[str]]:
+    """Recommend ``(workspace_kind, workspace_path)`` from board ``default_workdir``.
+
+    Mirrors the dashboard helper ``_default_workspace_kind`` so CLI / tool
+    creates inherit the same non-scratch default the create dialog suggests
+    (#69787). Scratch is never given a real path (see #28818 / #30917).
+
+    Returns ``("scratch", None)`` when the board has no default_workdir or
+    the path does not exist as a directory.
+    """
+    board_slug = board if board else get_current_board()
+    meta = read_board_metadata(board_slug)
+    workdir = str(meta.get("default_workdir") or "").strip()
+    if not workdir:
+        return ("scratch", None)
+    try:
+        path = Path(workdir).expanduser()
+        if not path.exists() or not path.is_dir():
+            # Keep scratch rather than a dead dir:/worktree root.
+            return ("scratch", None)
+        path = path.resolve()
+        kind = "worktree" if _git_toplevel(path) else "dir"
+        return (kind, str(path))
+    except (OSError, ValueError):
+        return ("scratch", None)
+
+
 def _git_toplevel(path: Path) -> Optional[Path]:
     """Return the git toplevel containing ``path``, or ``None`` if not in a repo."""
     try:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -981,6 +981,132 @@ def _make_create_ns(**overrides):
     return ns
 
 
+def test_cli_create_warns_when_no_gateway(kanban_home, monkeypatch, capsys):
+    """ready+assigned task + no gateway -> warning on stderr."""
+    from hermes_cli import kanban as kb_cli
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"dispatch_in_gateway": True}},
+    )
+    ns = _make_create_ns(title="warn-me", assignee="worker")
+    assert kb_cli._cmd_create(ns) == 0
+    captured = capsys.readouterr()
+    # Stderr has the warning prefix + guidance.
+    assert "hermes gateway start" in captured.err
+
+
+def test_cli_create_silent_when_gateway_up(kanban_home, monkeypatch, capsys):
+    """gateway running + dispatch enabled -> no warning."""
+    from hermes_cli import kanban as kb_cli
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4242)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"dispatch_in_gateway": True}},
+    )
+    ns = _make_create_ns(title="silent", assignee="worker")
+    assert kb_cli._cmd_create(ns) == 0
+    captured = capsys.readouterr()
+    assert "hermes gateway start" not in captured.err
+
+
+def test_cli_create_no_warn_on_triage(kanban_home, monkeypatch, capsys):
+    """Triage tasks can't be dispatched -> no warning."""
+    from hermes_cli import kanban as kb_cli
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"dispatch_in_gateway": True}},
+    )
+    ns = _make_create_ns(title="triage-task", assignee=None, triage=True)
+    assert kb_cli._cmd_create(ns) == 0
+    err = capsys.readouterr().err
+    assert "hermes gateway start" not in err
+
+
+def test_cli_create_no_warn_unassigned(kanban_home, monkeypatch, capsys):
+    """Unassigned tasks can't be dispatched -> no warning."""
+    from hermes_cli import kanban as kb_cli
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"dispatch_in_gateway": True}},
+    )
+    ns = _make_create_ns(title="nobody", assignee=None)
+    assert kb_cli._cmd_create(ns) == 0
+    err = capsys.readouterr().err
+    assert "hermes gateway start" not in err
+
+
+
+def test_cli_create_inherits_board_default_workdir_kind(kanban_home, tmp_path, monkeypatch):
+    """No --workspace + board default_workdir in a git repo → worktree (#69787)."""
+    import subprocess
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db as kb
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    kb.create_board("cli-inherit", default_workdir=str(repo))
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 1)
+    ns = _make_create_ns(title="from-board", assignee="worker", workspace=None, board="cli-inherit")
+    for k, v in {
+        "branch": None, "project": None, "max_retries": None,
+        "model_override": None, "provider_override": None,
+        "goal_mode": False, "goal_max_turns": None, "initial_status": "running",
+    }.items():
+        setattr(ns, k, v)
+    with kb.scoped_current_board("cli-inherit"):
+        assert kb_cli._cmd_create(ns) == 0
+    with kb.connect(board="cli-inherit") as conn:
+        tasks = list(kb.list_tasks(conn))
+    assert len(tasks) >= 1
+    t = tasks[0]
+    assert t.workspace_kind == "worktree"
+    assert t.workspace_path == str(repo.resolve())
+
+
+def test_cli_create_explicit_scratch_skips_board_default(kanban_home, tmp_path, monkeypatch):
+    """Explicit --workspace scratch must not inherit board path (#30917)."""
+    import subprocess
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db as kb
+    repo = tmp_path / "proj2"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    kb.create_board("cli-scratch", default_workdir=str(repo))
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 1)
+    ns = _make_create_ns(title="force-scratch", assignee="worker", workspace="scratch", board="cli-scratch")
+    for k, v in {
+        "branch": None, "project": None, "max_retries": None,
+        "model_override": None, "provider_override": None,
+        "goal_mode": False, "goal_max_turns": None, "initial_status": "running",
+    }.items():
+        setattr(ns, k, v)
+    with kb.scoped_current_board("cli-scratch"):
+        assert kb_cli._cmd_create(ns) == 0
+    with kb.connect(board="cli-scratch") as conn:
+        tasks = list(kb.list_tasks(conn))
+    t = [x for x in tasks if x.title == "force-scratch"][0]
+    assert t.workspace_kind == "scratch"
+    assert t.workspace_path is None
+
+
+
+def test_cli_daemon_without_force_prints_deprecation_exits_2(kanban_home, capsys):
+    """`hermes kanban daemon` (no --force) is a deprecation stub."""
+    from hermes_cli import kanban as kb_cli
+    ns = argparse.Namespace(
+        force=False, interval=60.0, max=None, failure_limit=3,
+        pidfile=None, verbose=False,
+    )
+    rc = kb_cli._cmd_daemon(ns)
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "DEPRECATED" in err
+    assert "hermes gateway start" in err
+
+
 def test_cli_daemon_help_marks_deprecated():
     """The argparse help string on `daemon` mentions deprecation so users
     scanning `--help` see the migration before running the stub."""

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1225,6 +1225,35 @@ def _make_task(**overrides) -> "kb.Task":
 
 
 
+def test_recommended_workspace_kind_git_repo(kanban_home, tmp_path):
+    """Board default_workdir inside a git toplevel → worktree kind (#69787)."""
+    import subprocess
+    repo = tmp_path / "coding-board-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    kb.create_board("coding", default_workdir=str(repo))
+    kind, path = kb.recommended_workspace_kind_for_board("coding")
+    assert kind == "worktree"
+    assert path == str(repo.resolve())
+
+
+def test_recommended_workspace_kind_plain_dir(kanban_home, tmp_path):
+    plain = tmp_path / "notes"
+    plain.mkdir()
+    kb.create_board("notes-board", default_workdir=str(plain))
+    kind, path = kb.recommended_workspace_kind_for_board("notes-board")
+    assert kind == "dir"
+    assert path == str(plain.resolve())
+
+
+def test_recommended_workspace_kind_no_default(kanban_home):
+    kb.create_board("empty-default")
+    kind, path = kb.recommended_workspace_kind_for_board("empty-default")
+    assert kind == "scratch"
+    assert path is None
+
+
+
 # ---------------------------------------------------------------------------
 # dispatch_once — max_in_progress
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,65 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_inherits_board_default_workdir_kind(worker_env, tmp_path):
+    """Tool create with no workspace + no parent-task project inherits the
+    board's git ``default_workdir`` as a ``worktree`` (#69787).
+
+    Exercises the ``kanban_create`` chat/orchestrator branch that resolves the
+    board default when the caller omits ``workspace_kind``/``workspace_path``.
+    """
+    import subprocess
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    kb.create_board("tool-inherit", default_workdir=str(repo))
+    # No parent-task project to inherit from -> board default applies.
+    monkeypatch_task = os.environ.pop("HERMES_KANBAN_TASK", None)
+    try:
+        out = kt._handle_create({
+            "title": "from-board",
+            "assignee": "peer",
+            "board": "tool-inherit",
+        })
+    finally:
+        if monkeypatch_task is not None:
+            os.environ["HERMES_KANBAN_TASK"] = monkeypatch_task
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["workspace_kind"] == "worktree"
+    assert d["workspace_path"] == str(repo.resolve())
+
+
+def test_create_explicit_scratch_skips_board_default(worker_env, tmp_path):
+    """Explicit ``workspace_kind='scratch'`` must not inherit the board path."""
+    import subprocess
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    repo = tmp_path / "proj2"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    kb.create_board("tool-scratch", default_workdir=str(repo))
+    monkeypatch_task = os.environ.pop("HERMES_KANBAN_TASK", None)
+    try:
+        out = kt._handle_create({
+            "title": "force-scratch",
+            "assignee": "peer",
+            "board": "tool-scratch",
+            "workspace_kind": "scratch",
+        })
+    finally:
+        if monkeypatch_task is not None:
+            os.environ["HERMES_KANBAN_TASK"] = monkeypatch_task
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["workspace_kind"] == "scratch"
+    assert d["workspace_path"] is None
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1203,11 +1203,23 @@ def _handle_create(args: dict, **kw) -> str:
             # literal workspace kind/path; directory sharing must be explicit.
             if _inherit_project and project_id is None:
                 _self_tid = os.environ.get("HERMES_KANBAN_TASK")
+                _inherited_project = False
                 if _self_tid:
                     _self_task = kb.get_task(conn, _self_tid)
                     if _self_task is not None and _self_task.project_id:
                         project_id = _self_task.project_id
                         project_source_task_id = _self_task.id
+                        _inherited_project = True
+                if not _inherited_project:
+                    # Chat / CLI-tool create with no parent-task project to
+                    # inherit: mirror the dashboard board default_workdir kind
+                    # (#69787). This is explicit board configuration, not the
+                    # parent's literal checkout, so directory sharing stays
+                    # opt-in per #67567.
+                    _bslug = board if board else kb.get_current_board()
+                    workspace_kind, workspace_path = (
+                        kb.recommended_workspace_kind_for_board(_bslug)
+                    )
             new_tid = kb.create_task(
                 conn,
                 title=str(title).strip(),


### PR DESCRIPTION
## Summary

CLI and `kanban_create` now default workspace **kind** from the board’s `default_workdir` the same way the dashboard create dialog already does (git repo → `worktree`, plain dir → `dir`, none → `scratch`).

## Motivation

Docs promise every new task inherits the board project directory. After #30917, only dashboard path honored that for useful kinds; CLI/tool/chat creates always landed on disposable `scratch`, so coding boards dead-ended without git (#69787).

## Root cause

- `hermes kanban create --workspace` defaulted to `"scratch"`.
- `kanban_create` set `workspace_kind = "scratch"` when unset (parent-task inherit only helped workers with `HERMES_KANBAN_TASK`).

## Fix

1. `recommended_workspace_kind_for_board()` in `kanban_db` (mirrors dashboard `_default_workspace_kind`; missing/non-dir path → scratch, never a real path on scratch).
2. CLI: `--workspace` default `None` → board recommendation; explicit `scratch` unchanged.
3. Tool: if no explicit workspace and no parent-task inherit, use board recommendation.

Preserves #28818/#30917: scratch never inherits a real path.

## Verification

```bash
python3 -m pytest \
  tests/hermes_cli/test_kanban_db.py::test_recommended_workspace_kind_git_repo \
  tests/hermes_cli/test_kanban_db.py::test_recommended_workspace_kind_plain_dir \
  tests/hermes_cli/test_kanban_db.py::test_recommended_workspace_kind_no_default \
  tests/hermes_cli/test_kanban_db.py::test_create_task_scratch_without_workspace_ignores_board_default_workdir \
  tests/hermes_cli/test_kanban_core_functionality.py::test_cli_create_inherits_board_default_workdir_kind \
  tests/hermes_cli/test_kanban_core_functionality.py::test_cli_create_explicit_scratch_skips_board_default \
  -q
# 6 passed
```

Closes #69787