### PR TITLE
feat(desktop): add scoped credential command search

### DIFF
--- a/apps/desktop/src/app/settings/keys-settings.test.tsx
+++ b/apps/desktop/src/app/settings/keys-settings.test.tsx
@@ -1,0 +1,252 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, useNavigate } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EnvVarInfo } from '@/types/hermes'
+
+const getEnvVars = vi.fn()
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+vi.mock('@/hermes', () => ({
+  deleteEnvVar: vi.fn(),
+  getEnvVars: () => getEnvVars(),
+  revealEnvVar: vi.fn(),
+  setEnvVar: vi.fn()
+}))
+
+function envVar(category: string, patch: Partial<EnvVarInfo> = {}): EnvVarInfo {
+  return {
+    advanced: false,
+    category,
+    description: '',
+    is_password: true,
+    is_set: false,
+    redacted_value: null,
+    tools: [],
+    url: '',
+    ...patch
+  }
+}
+
+beforeEach(() => {
+  getEnvVars.mockResolvedValue({})
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn()
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+async function renderKeysSettings(view: 'settings' | 'tools', route = '/settings') {
+  const { KeysSettings } = await import('./keys-settings')
+
+  await act(async () => {
+    render(
+      <MemoryRouter initialEntries={[route]}>
+        <KeysSettings view={view} />
+      </MemoryRouter>
+    )
+  })
+}
+
+function DeepLinkButton({ target }: { target: string }) {
+  const navigate = useNavigate()
+
+  return (
+    <button onClick={() => navigate(`/settings?tab=keys&key=${target}`)} type="button">
+      Open key
+    </button>
+  )
+}
+
+describe('KeysSettings scoped command search', () => {
+  it('curates tool results by label, description, env key, URL, and tool name', async () => {
+    getEnvVars.mockResolvedValue({
+      BRAVE_SEARCH_API_KEY: envVar('tool', {
+        description: 'Search the web with Brave.',
+        url: 'https://brave.com/search/api/'
+      }),
+      FIRECRAWL_API_KEY: envVar('tool', {
+        description: 'Crawl and extract websites.',
+        tools: ['browser_navigate']
+      }),
+      GATEWAY_PROXY: envVar('setting', { description: 'Gateway reverse proxy.' })
+    })
+
+    await renderKeysSettings('tools')
+
+    const search = await screen.findByRole('combobox', { name: 'Search tools…' })
+    expect(screen.getByText('BRAVE SEARCH')).toBeTruthy()
+    expect(screen.getByText('FIRECRAWL')).toBeTruthy()
+    expect(screen.queryByText('GATEWAY PROXY')).toBeNull()
+    expect(screen.queryByRole('option')).toBeNull()
+    expect(search.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.change(search, { target: { value: 'crawl and extract' } })
+    const firecrawlResult = await screen.findByRole('option', { name: /FIRECRAWL/ })
+    expect(firecrawlResult.getAttribute('data-selected')).toBe('true')
+    expect(screen.queryByRole('option', { name: /BRAVE SEARCH/ })).toBeNull()
+
+    fireEvent.change(search, { target: { value: 'brave_search_api' } })
+    expect(await screen.findByRole('option', { name: /BRAVE SEARCH/ })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: /FIRECRAWL/ })).toBeNull()
+
+    fireEvent.change(search, { target: { value: 'brave.com' } })
+    expect(await screen.findByRole('option', { name: /BRAVE SEARCH/ })).toBeTruthy()
+
+    fireEvent.change(search, { target: { value: 'browser_navigate' } })
+    expect(await screen.findByRole('option', { name: /FIRECRAWL/ })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: /BRAVE SEARCH/ })).toBeNull()
+
+    fireEvent.change(search, { target: { value: 'does-not-exist' } })
+    expect(await screen.findByText('No entries match your search.')).toBeTruthy()
+  })
+
+  it('scopes settings results and excludes channel-managed credentials', async () => {
+    getEnvVars.mockResolvedValue({
+      API_SERVER_TOKEN: envVar('setting', { description: 'Protect the local API server.' }),
+      GATEWAY_PROXY: envVar('messaging', { description: 'Gateway reverse proxy address.' }),
+      TELEGRAM_BOT_TOKEN: envVar('messaging', {
+        channel_managed: true,
+        description: 'Telegram bot token.'
+      }),
+      BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' })
+    })
+
+    await renderKeysSettings('settings')
+
+    const search = await screen.findByRole('combobox', { name: 'Search settings…' })
+    expect(screen.getByText('API SERVER')).toBeTruthy()
+    expect(screen.getByText('GATEWAY PROXY')).toBeTruthy()
+    expect(screen.queryByText('TELEGRAM BOT')).toBeNull()
+    expect(screen.queryByText('BRAVE SEARCH')).toBeNull()
+
+    fireEvent.change(search, { target: { value: 'reverse proxy' } })
+    expect(await screen.findByRole('option', { name: /GATEWAY PROXY/ })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: /API SERVER/ })).toBeNull()
+  })
+
+  it('selects a command result, then expands and highlights its credential card', async () => {
+    getEnvVars.mockResolvedValue({
+      BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' }),
+      FIRECRAWL_API_KEY: envVar('tool', {
+        description: 'Crawl and extract websites.',
+        tools: ['browser_navigate']
+      })
+    })
+
+    await renderKeysSettings('tools', '/settings?tab=keys&kview=tools')
+
+    const search = await screen.findByRole('combobox', { name: 'Search tools…' })
+    fireEvent.change(search, { target: { value: 'browser_navigate' } })
+    await screen.findByRole('option', { name: /FIRECRAWL/ })
+    fireEvent.keyDown(search, { key: 'Enter' })
+
+    await waitFor(() => expect((search as HTMLInputElement).value).toBe(''))
+    await waitFor(() => {
+      const target = globalThis.document.getElementById('credential-key-FIRECRAWL_API_KEY')
+      expect(target?.classList).toContain('setting-field-highlight')
+    })
+    expect(screen.getByText('Crawl and extract websites.')).toBeTruthy()
+  })
+
+  it('re-arms pointer quiet on open, so a pre-moved parked cursor cannot steal the Enter commit', async () => {
+    getEnvVars.mockResolvedValue({
+      BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' }),
+      FIRECRAWL_API_KEY: envVar('tool', { description: 'Crawl and extract websites.' })
+    })
+
+    await renderKeysSettings('tools', '/settings?tab=keys&kview=tools')
+
+    const search = await screen.findByRole('combobox', { name: 'Search tools…' })
+
+    // The pointer moved before the list ever appeared, releasing the
+    // mount-scoped pointer-quiet guard...
+    fireEvent.mouseMove(globalThis.document.body)
+
+    // ...but the hidden → visible transition re-arms it, so a cursor parked
+    // over the list cannot hover-steal the selection Enter is about to commit.
+    fireEvent.change(search, { target: { value: 'crawl' } })
+    const list = await screen.findByRole('listbox')
+    expect(list.classList).toContain('pointer-events-none')
+
+    fireEvent.keyDown(search, { key: 'Enter' })
+    await waitFor(() => {
+      const target = globalThis.document.getElementById('credential-key-FIRECRAWL_API_KEY')
+      expect(target?.classList).toContain('setting-field-highlight')
+    })
+  })
+
+  it('dismisses outside and reopens on focus while Escape clears the query', async () => {
+    getEnvVars.mockResolvedValue({
+      BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' })
+    })
+
+    await renderKeysSettings('tools')
+
+    const search = await screen.findByRole('combobox', { name: 'Search tools…' })
+    fireEvent.change(search, { target: { value: 'brave' } })
+    expect(await screen.findByRole('option', { name: /BRAVE SEARCH/ })).toBeTruthy()
+    expect(search.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.pointerDown(globalThis.document.body)
+    await waitFor(() => expect(search.getAttribute('aria-expanded')).toBe('false'))
+    expect((search as HTMLInputElement).value).toBe('brave')
+
+    fireEvent.focus(search)
+    await waitFor(() => expect(search.getAttribute('aria-expanded')).toBe('true'))
+    fireEvent.keyDown(search, { key: 'Escape' })
+    expect((search as HTMLInputElement).value).toBe('')
+    expect(search.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('clears the scoped query when a deep link opens a key in the active view', async () => {
+    getEnvVars.mockResolvedValue({
+      BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' }),
+      FIRECRAWL_API_KEY: envVar('tool', { description: 'Crawl and extract websites.' })
+    })
+    const { KeysSettings } = await import('./keys-settings')
+
+    render(
+      <MemoryRouter initialEntries={['/settings?tab=keys']}>
+        <KeysSettings view="tools" />
+        <DeepLinkButton target="BRAVE_SEARCH_API_KEY" />
+      </MemoryRouter>
+    )
+
+    const search = await screen.findByRole('combobox', { name: 'Search tools…' })
+    fireEvent.change(search, { target: { value: 'firecrawl' } })
+    expect(await screen.findByRole('option', { name: /FIRECRAWL/ })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open key' }))
+
+    await waitFor(() => expect((search as HTMLInputElement).value).toBe(''))
+    expect(await screen.findByText('Search the web with Brave.')).toBeTruthy()
+  })
+
+  it('does not clear a query for a deep link owned by the other sub-view', async () => {
+    getEnvVars.mockResolvedValue({
+      BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' }),
+      GATEWAY_PROXY: envVar('setting', { description: 'Gateway reverse proxy address.' })
+    })
+
+    await renderKeysSettings('settings', '/settings?tab=keys&kview=settings&key=BRAVE_SEARCH_API_KEY')
+
+    const search = await screen.findByRole('combobox', { name: 'Search settings…' })
+    fireEvent.change(search, { target: { value: 'reverse proxy' } })
+
+    expect((search as HTMLInputElement).value).toBe('reverse proxy')
+    expect(await screen.findByRole('option', { name: /GATEWAY PROXY/ })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/settings/keys-settings.tsx
+++ b/apps/desktop/src/app/settings/keys-settings.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 
+import { ScopedCommandSearch, type ScopedCommandSearchItem } from '@/components/ui/scoped-command-search'
 import { useI18n } from '@/i18n'
-import type { EnvVarInfo } from '@/types/hermes'
 
 import { CredentialKeyCard, credentialPlaceholder, credentialRowLabel } from './credential-key-ui'
 import { useEnvCredentials } from './env-credentials'
@@ -28,73 +29,127 @@ const VIEW_CATEGORIES: Record<KeysView, readonly string[]> = {
   tools: ['tool']
 }
 
+const credentialElementId = (key: string) => `credential-key-${key}`
+
 export function KeysSettings({ view }: KeysSettingsProps) {
   const { t } = useI18n()
   const { rowProps, vars } = useEnvCredentials()
+  const [, setSearchParams] = useSearchParams()
   const [openKey, setOpenKey] = useState<null | string>(null)
+  const [query, setQuery] = useState('')
 
   useEffect(() => {
     setOpenKey(null)
+    setQuery('')
   }, [view])
 
-  // Deep link from Capabilities env-var rows (?tab=keys&key=<ENV_KEY>): scroll
-  // the credential card into view, flash it, and expand it. Same mechanism the
-  // command palette uses for config fields / archived sessions.
-  useDeepLinkHighlight({
-    elementId: key => `credential-key-${key}`,
-    onResolve: key => setOpenKey(key),
-    param: 'key',
-    ready: key => Boolean(vars && key in vars)
-  })
-
-  const groups = useMemo(() => {
+  const entries = useMemo(() => {
     if (!vars) {
       return []
     }
 
-    return KEYS_VIEWS.flatMap(v => {
-      const cats = VIEW_CATEGORIES[v]
+    const cats = VIEW_CATEGORIES[view]
 
-      const entries = Object.entries(vars)
-        .filter(([, info]) => !info.channel_managed && cats.includes(asText(info.category)))
-        .sort(([a], [b]) => a.localeCompare(b))
+    return Object.entries(vars)
+      .filter(([, info]) => !info.channel_managed && cats.includes(asText(info.category)))
+      .sort(([a], [b]) => a.localeCompare(b))
+  }, [vars, view])
 
-      return entries.length === 0 ? [] : [{ category: v, entries }]
-    })
-  }, [vars])
+  const searchItems = useMemo<ScopedCommandSearchItem[]>(
+    () =>
+      entries.map(([key, info]) => ({
+        description: info.description?.trim() || key,
+        id: key,
+        keywords: [
+          key,
+          asText(info.description),
+          asText(info.url),
+          ...(Array.isArray(info.tools) ? info.tools.map(asText) : [])
+        ].filter(Boolean),
+        label: credentialRowLabel(key, info)
+      })),
+    [entries]
+  )
+
+  const renderableKeys = useMemo(() => new Set(entries.map(([key]) => key)), [entries])
+
+  const resolveDeepLink = useCallback((key: string) => {
+    setQuery('')
+    setOpenKey(key)
+  }, [])
+
+  const deepLinkReady = useCallback((key: string) => renderableKeys.has(key), [renderableKeys])
+
+  const selectSearchResult = useCallback(
+    (item: ScopedCommandSearchItem) => {
+      setQuery('')
+      setSearchParams(
+        previous => {
+          const next = new URLSearchParams(previous)
+          next.set('key', item.id)
+
+          return next
+        },
+        { replace: true }
+      )
+    },
+    [setSearchParams]
+  )
+
+  // Deep link from Capabilities env-var rows (?tab=keys&key=<ENV_KEY>): scroll
+  // the credential card into view, flash it, and expand it. Only consume keys
+  // rendered by this sub-view so a stale Tools/Settings pairing cannot keep
+  // clearing the user's search while the target remains impossible to mount.
+  useDeepLinkHighlight({
+    elementId: credentialElementId,
+    onResolve: resolveDeepLink,
+    param: 'key',
+    ready: deepLinkReady
+  })
 
   if (!vars) {
-    return <SettingsSkeleton sections={[{ rows: 5 }]} />
+    return <SettingsSkeleton search sections={[{ rows: 5 }]} />
   }
 
-  const visible = groups.filter(g => g.category === view)
+  const searchLabel = view === 'tools' ? t.settings.keys.searchTools : t.settings.keys.searchSettings
 
   return (
     <SettingsContent>
-      {visible.map(group => (
-        <div className="grid gap-2" key={group.category}>
-          {group.entries.map(([key, info]: [string, EnvVarInfo]) => {
-            const label = credentialRowLabel(key, info)
+      {entries.length > 0 ? (
+        <>
+          <div className="pb-3">
+            <ScopedCommandSearch
+              emptyMessage={t.settings.keys.noMatch}
+              items={searchItems}
+              onSelect={selectSearchResult}
+              onValueChange={setQuery}
+              placeholder={searchLabel}
+              value={query}
+            />
+          </div>
 
-            return (
-              <div className="scroll-mt-6 rounded-[6px]" id={`credential-key-${key}`} key={key}>
-                <CredentialKeyCard
-                  expanded={openKey === key}
-                  info={info}
-                  label={label}
-                  onExpand={() => setOpenKey(key)}
-                  onToggle={() => setOpenKey(prev => (prev === key ? null : key))}
-                  placeholder={credentialPlaceholder(key, info, label)}
-                  rowProps={rowProps}
-                  varKey={key}
-                />
-              </div>
-            )
-          })}
-        </div>
-      ))}
+          <div className="grid gap-2">
+            {entries.map(([key, info]) => {
+              const label = credentialRowLabel(key, info)
 
-      {visible.length === 0 && (
+              return (
+                <div className="scroll-mt-6 rounded-[6px]" id={`credential-key-${key}`} key={key}>
+                  <CredentialKeyCard
+                    expanded={openKey === key}
+                    info={info}
+                    label={label}
+                    onExpand={() => setOpenKey(key)}
+                    onToggle={() => setOpenKey(prev => (prev === key ? null : key))}
+                    placeholder={credentialPlaceholder(key, info, label)}
+                    rowProps={rowProps}
+                    varKey={key}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        </>
+      ) : (
         <div className="rounded-lg border border-dashed border-(--ui-stroke-tertiary) px-4 py-8 text-center text-[length:var(--conversation-caption-font-size)] text-muted-foreground">
           {t.settings.keys.empty}
         </div>

--- a/apps/desktop/src/components/ui/command.tsx
+++ b/apps/desktop/src/components/ui/command.tsx
@@ -40,17 +40,20 @@ function CommandInput({ className, right, ...props }: CommandInputProps) {
   )
 }
 
-function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+function CommandList({ className, hidden, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
   // cmdk selects on pointer-enter, so a list that opens under a parked cursor —
   // or re-flows under one as the query narrows — hands the selection to
   // whatever row slid beneath the mouse, and Enter commits THAT. Inert until
-  // the pointer actually moves (see usePointerQuiet).
-  const pointerQuiet = usePointerQuiet()
+  // the pointer actually moves (see usePointerQuiet). A list kept mounted
+  // while hidden re-arms the guard when it becomes visible again, since the
+  // mount-scoped quiet was likely released long before it appeared.
+  const pointerQuiet = usePointerQuiet(hidden)
 
   return (
     <CommandPrimitive.List
       className={cn('max-h-100 overflow-y-auto overflow-x-hidden', pointerQuiet && 'pointer-events-none', className)}
       data-slot="command-list"
+      hidden={hidden}
       {...props}
     />
   )

--- a/apps/desktop/src/components/ui/keyboard-first.test.ts
+++ b/apps/desktop/src/components/ui/keyboard-first.test.ts
@@ -45,6 +45,33 @@ describe('usePointerQuiet', () => {
     expect(renderHook(() => usePointerQuiet()).result.current).toBe(true)
   })
 
+  it('re-arms when the re-arm key changes, even after the pointer moved', () => {
+    const { result, rerender } = renderHook(({ hidden }) => usePointerQuiet(hidden), {
+      initialProps: { hidden: true }
+    })
+
+    move()
+    expect(result.current).toBe(false)
+
+    // A list kept mounted while hidden becomes visible: the guard arms again
+    // for the fresh appearance despite the earlier movement.
+    rerender({ hidden: false })
+    expect(result.current).toBe(true)
+
+    move()
+    expect(result.current).toBe(false)
+  })
+
+  it('does not re-arm on re-render while the re-arm key is unchanged', () => {
+    const { result, rerender } = renderHook(({ hidden }) => usePointerQuiet(hidden), {
+      initialProps: { hidden: true }
+    })
+
+    move()
+    rerender({ hidden: true })
+    expect(result.current).toBe(false)
+  })
+
   it('drops its listeners on unmount', () => {
     const remove = vi.spyOn(window, 'removeEventListener')
 

--- a/apps/desktop/src/components/ui/keyboard-first.ts
+++ b/apps/desktop/src/components/ui/keyboard-first.ts
@@ -28,9 +28,19 @@ const RELEASE_EVENT = 'hermes:release-typing-focus'
  *
  * Mount-scoped: overlays mount when they open, so "quiet until moved" needs no
  * knowledge of whether a hotkey or a click opened it.
+ *
+ * Lists that stay MOUNTED while hidden (a scoped search keeps its listbox for
+ * the aria-controls contract) outlive that mount-scoped guard — the first
+ * pointer movement releases it long before the list ever appears. Pass a
+ * `rearm` value that changes when the list becomes visible and the guard arms
+ * again for the fresh appearance.
  */
-export function usePointerQuiet(): boolean {
+export function usePointerQuiet(rearm?: unknown): boolean {
   const [quiet, setQuiet] = useState(true)
+
+  useEffect(() => {
+    setQuiet(true)
+  }, [rearm])
 
   useEffect(() => {
     const wake = () => setQuiet(false)

--- a/apps/desktop/src/components/ui/scoped-command-search.tsx
+++ b/apps/desktop/src/components/ui/scoped-command-search.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
+import { ChevronRight } from '@/lib/icons'
+
+export interface ScopedCommandSearchItem {
+  description?: string
+  id: string
+  keywords?: string[]
+  label: string
+}
+
+/**
+ * Embeddable cmdk search whose caller owns the catalog and destination.
+ * Passing only the current pane's items keeps results scoped without teaching
+ * this component about settings, credentials, or routes.
+ */
+export function ScopedCommandSearch({
+  emptyMessage,
+  items,
+  onSelect,
+  onValueChange,
+  placeholder,
+  value
+}: ScopedCommandSearchProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const [dismissed, setDismissed] = useState(false)
+  const open = Boolean(value.trim()) && !dismissed
+
+  useLayoutEffect(() => {
+    inputRef.current?.setAttribute('aria-expanded', String(open))
+  }, [open])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const dismissOutside = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setDismissed(true)
+      }
+    }
+
+    globalThis.document.addEventListener('pointerdown', dismissOutside)
+
+    return () => globalThis.document.removeEventListener('pointerdown', dismissOutside)
+  }, [open])
+
+  const updateValue = (next: string) => {
+    setDismissed(false)
+    onValueChange(next)
+  }
+
+  return (
+    <Command
+      className="relative h-auto overflow-visible rounded-none bg-transparent"
+      label={placeholder}
+      loop
+      ref={rootRef}
+    >
+      <CommandInput
+        aria-expanded={open}
+        aria-label={placeholder}
+        className="text-xs"
+        onBlur={() => {
+          globalThis.requestAnimationFrame(() => {
+            if (!rootRef.current?.contains(globalThis.document.activeElement)) {
+              setDismissed(true)
+            }
+          })
+        }}
+        onFocus={() => setDismissed(false)}
+        onKeyDown={event => {
+          if (event.key === 'Escape' && open) {
+            event.preventDefault()
+            event.stopPropagation()
+            updateValue('')
+          }
+        }}
+        onValueChange={updateValue}
+        placeholder={placeholder}
+        ref={inputRef}
+        value={value}
+      />
+
+      <CommandList
+        className="dt-portal-scrollbar absolute inset-x-0 top-full z-30 mt-1 max-h-64 rounded-[6px] border border-border bg-popover p-1 shadow-nous"
+        hidden={!open}
+      >
+        <CommandEmpty>{emptyMessage}</CommandEmpty>
+        <CommandGroup className="p-0">
+          {open &&
+            items.map(item => (
+              <CommandItem
+                className="group grid grid-cols-[minmax(0,1fr)_auto] gap-3 px-3 py-2.5"
+                key={item.id}
+                keywords={item.keywords}
+                onSelect={() => onSelect(item)}
+                value={`${item.label}\u0001${item.id}`}
+              >
+                <span className="min-w-0">
+                  <span className="block truncate font-medium">{item.label}</span>
+                  <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                    {item.description || item.id}
+                  </span>
+                </span>
+                <ChevronRight className="size-4 self-center text-muted-foreground opacity-0 transition-opacity group-data-[selected=true]:opacity-100" />
+              </CommandItem>
+            ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}
+
+interface ScopedCommandSearchProps {
+  emptyMessage: string
+  items: ScopedCommandSearchItem[]
+  onSelect: (item: ScopedCommandSearchItem) => void
+  onValueChange: (value: string) => void
+  placeholder: string
+  value: string
+}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -733,7 +733,10 @@ export const en: Translations = {
     keys: {
       loading: 'Loading API keys and credentials...',
       failedLoad: 'API keys failed to load',
-      empty: 'Nothing configured in this category yet.'
+      empty: 'Nothing configured in this category yet.',
+      searchTools: 'Search tools…',
+      searchSettings: 'Search settings…',
+      noMatch: 'No entries match your search.'
     },
     mcp: {
       loading: 'Loading MCP servers...',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -802,7 +802,10 @@ export const ja = defineLocale({
     keys: {
       loading: 'API キーと認証情報を読み込み中...',
       failedLoad: 'API キーの読み込みに失敗しました',
-      empty: 'このカテゴリーにはまだ設定がありません。'
+      empty: 'このカテゴリーにはまだ設定がありません。',
+      searchTools: 'ツールを検索...',
+      searchSettings: '設定を検索...',
+      noMatch: '検索に一致する項目はありません。'
     },
     mcp: {
       loading: 'MCP サーバーを読み込み中...',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -623,6 +623,9 @@ export interface Translations {
       loading: string
       failedLoad: string
       empty: string
+      searchTools: string
+      searchSettings: string
+      noMatch: string
     }
     mcp: {
       loading: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -776,7 +776,10 @@ export const zhHant = defineLocale({
     keys: {
       loading: '正在載入 API 金鑰和憑證...',
       failedLoad: 'API 金鑰載入失敗',
-      empty: '此類別尚未有任何設定。'
+      empty: '此類別尚未有任何設定。',
+      searchTools: '搜尋工具...',
+      searchSettings: '搜尋設定...',
+      noMatch: '沒有符合搜尋條件的項目。'
     },
     mcp: {
       loading: '正在載入 MCP 伺服器...',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -937,7 +937,10 @@ export const zh: Translations = {
     keys: {
       loading: '正在加载 API 密钥和凭据...',
       failedLoad: 'API 密钥加载失败',
-      empty: '此类别暂时没有配置项。'
+      empty: '此类别暂时没有配置项。',
+      searchTools: '搜索工具...',
+      searchSettings: '搜索设置...',
+      noMatch: '没有与搜索匹配的条目。'
     },
     mcp: {
       loading: '正在加载 MCP 服务器...',


### PR DESCRIPTION
## What does this PR do?

Adds command-style search to the two large credential lists in Desktop Settings:

- Tools & Keys → Tools
- Tools & Keys → Settings

The search is built around a small reusable `ScopedCommandSearch` component using `cmdk`. Each pane passes in its own entries and decides what should happen when a result is selected. The component itself does not know about credentials, settings routes, or backend categories.

That keeps the current search properly scoped while leaving a useful building block for other Settings panes. A future pane can use the same component by supplying searchable metadata and a selection handler. This PR only wires it into Tools and Settings.

The result list is data-driven. It is built from the credential catalog returned by the backend for the active pane, so a newly added tool or setting does not need a matching frontend allowlist entry. Search includes the display label, environment key, description, documentation URL, and associated tool names.

Credential cards stay mounted while searching. Selecting a result updates the existing `key` deep link, then reuses the normal expansion, scrolling, and highlight behavior. This avoids nesting interactive credential cards inside `cmdk` items.

The search supports arrow-key navigation and Enter selection. Escape clears it, clicking outside or leaving the control dismisses the result list, and focusing the input again restores results for the current query.

## Related Issue

N/A. This is a self-contained Desktop usability improvement.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added `apps/desktop/src/components/ui/scoped-command-search.tsx` as an embeddable, caller-scoped `cmdk` search component.
- Updated `apps/desktop/src/app/settings/keys-settings.tsx` to provide only the active pane's credential entries.
- Kept `channel_managed` credentials out of these lists, matching the existing behavior.
- Added lightweight command results instead of wrapping interactive `CredentialKeyCard` components in `CommandItem`.
- Reused the existing credential deep-link flow for selection, expansion, scrolling, and highlighting.
- Added proper open and dismissal behavior for focus, blur, outside clicks, Tab, and Escape.
- Kept `aria-controls` connected to a mounted listbox and synchronized `aria-expanded` with the visible result state.
- Updated English, Japanese, Simplified Chinese, and Traditional Chinese strings.
- Expanded `keys-settings.test.tsx` to cover metadata matching, pane boundaries, backend-added entries, exclusions, keyboard selection, dismissal, deep links, expansion, and highlighting.

## How to Test

1. Open Desktop Settings and select **Tools & Keys → Tools**.
2. Search by display name, environment key, description, documentation URL, or associated tool name.
3. Use the arrow keys to move through results and press Enter.
4. Confirm the selected credential card expands, scrolls into view, and receives the normal temporary highlight.
5. Enter another query, click outside the result list, then focus the input again. Confirm the list dismisses and reopens without losing the query.
6. Press Escape and confirm the query and result list clear.
7. Switch to **Tools & Keys → Settings** and confirm results are limited to that pane.
8. Confirm channel-managed credentials do not appear.

Automated checks run:

```shell
cd apps/desktop
npx vitest run --project ui src/app/settings/keys-settings.test.tsx
npx vitest run --project ui src/app/settings --exclude 'src/app/settings/billing/**'
npx tsc -p . --noEmit
npx eslint src/components/ui/scoped-command-search.tsx src/app/settings/keys-settings.tsx src/app/settings/keys-settings.test.tsx
npx prettier --check src/components/ui/scoped-command-search.tsx src/app/settings/keys-settings.tsx src/app/settings/keys-settings.test.tsx src/i18n/en.ts src/i18n/ja.ts src/i18n/zh.ts src/i18n/zh-hant.ts src/i18n/types.ts
npm run pack
```

Results:

- Focused search tests: 6 passed
- Settings tests excluding the unrelated Billing suite: 133 passed
- TypeScript, ESLint, Prettier, and `git diff --check`: passed
- Production Windows package build: passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass. N/A because this is a Desktop-only TypeScript change. The relevant checks are listed above.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation or N/A. The component API is documented in code and there is no user-facing configuration change.
- [x] I've updated `cli-config.yaml.example` if I added or changed config keys or N/A. No config keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A. No contributor workflow changed.
- [x] I've considered cross-platform impact or N/A. This runs in the platform-independent renderer.
- [x] I've updated tool descriptions or schemas if I changed tool behavior or N/A. Tool behavior and schemas are unchanged.

## Screenshots / Logs

<img width="1220" height="800" alt="Hermes_ixsQzhkFZu" src="https://github.com/user-attachments/assets/dce8e89c-fd75-4e84-9e16-264af11c1bfd" />




The production Windows package was built and tested locally from commit `2e83aa923`.

