### PR TITLE
fix(cron): preserve explicit Telegram topic targets

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1166,19 +1166,23 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
             chat_id, thread_id = rest, None
 
         # Resolve human-friendly labels like "Alice (dm)" to real IDs.
-        try:
-            from gateway.channel_directory import resolve_channel_name
-            resolved = resolve_channel_name(platform_key, chat_id)
-            if resolved:
-                parsed_chat_id, parsed_thread_id, resolved_is_explicit = _parse_target_ref(platform_key, resolved)
-                if resolved_is_explicit:
-                    chat_id = parsed_chat_id
-                    if parsed_thread_id is not None:
-                        thread_id = parsed_thread_id
-                else:
-                    chat_id = resolved
-        except Exception:
-            pass
+        # Do NOT run raw explicit IDs (e.g. telegram:-100123:16) through
+        # the channel directory: session-derived topic labels can prefix-match
+        # the bare chat id and overwrite the explicitly requested thread.
+        if not is_explicit and chat_id:
+            try:
+                from gateway.channel_directory import resolve_channel_name
+                resolved = resolve_channel_name(platform_key, str(chat_id))
+                if resolved:
+                    parsed_chat_id, parsed_thread_id, resolved_is_explicit = _parse_target_ref(platform_key, resolved)
+                    if resolved_is_explicit:
+                        chat_id = parsed_chat_id
+                        if parsed_thread_id is not None:
+                            thread_id = parsed_thread_id
+                    else:
+                        chat_id = resolved
+            except Exception:
+                pass
 
         if (
             thread_id is None

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -167,6 +167,28 @@ class TestResolveDeliveryTarget:
             "thread_id": "17",
         }
 
+    def test_explicit_telegram_topic_thread_survives_directory_topic_prefix_match(self):
+        """Raw explicit chat_id:thread_id must not be rewritten by cached topic labels.
+
+        Session-derived Telegram directory entries may include labels such as
+        ``-1003724596514 / topic 38`` whose id resolves to ``-1003724596514:38``
+        when a bare chat id is used as a human-friendly prefix. An explicit
+        cron target ``telegram:-1003724596514:17`` must still go to thread 17.
+        """
+        job = {
+            "deliver": "telegram:-1003724596514:17",
+        }
+        with patch(
+            "gateway.channel_directory.resolve_channel_name",
+            return_value="-1003724596514:38",
+        ) as resolve_mock:
+            result = _resolve_delivery_target(job)
+        resolve_mock.assert_not_called()
+        assert result == {
+            "platform": "telegram",
+            "chat_id": "-1003724596514",
+            "thread_id": "17",
+        }
 
     def test_human_friendly_label_resolved_via_channel_directory(self):
         """deliver: 'whatsapp:Alice (dm)' resolves to the real JID."""


### PR DESCRIPTION
## Summary
- Preserve explicit `platform:chat_id:thread_id` cron targets instead of re-resolving their raw chat IDs through the channel directory.
- Keep human-friendly delivery labels working for non-explicit targets.
- Tighten the Telegram regression test to cover cached topic prefix matches that would otherwise rewrite the requested topic.

## Why
A cron job configured with an explicit Telegram forum topic such as `telegram:-1003724596514:17` should always deliver to thread `17`. If the channel directory contains a session-derived entry for the same chat, for example `-1003724596514:38`, resolving the already-explicit chat id through friendly-name lookup can overwrite the requested thread.

## Verification
- `python3 -m py_compile cron/scheduler.py tests/cron/test_scheduler.py`
- `python -m pytest tests/cron/test_scheduler.py::TestResolveDeliveryTarget::test_explicit_telegram_topic_thread_survives_directory_topic_prefix_match -q`
- `python -m pytest tests/cron/test_scheduler.py::TestResolveDeliveryTarget -q`
- `git diff --check`
- changed-line secret scan: no findings
