### PR TITLE
fix(factory): gate worktree admission machine-wide

### DIFF
--- a/docs/ai-factory-worktree-admission.md
+++ b/docs/ai-factory-worktree-admission.md
@@ -103,11 +103,12 @@ hooks:
 At tool time the plugin manager calls the hook with the standard shell-hook stdin
 payload (`hook_event_name`, `tool_name`, `tool_input`, `session_id`, `cwd`, …).
 The hook is **read-only**: it resolves every effective mutation target — explicit
-terminal `workdir`, file-tool `path`/`file_path`, path-shaped terminal command
-tokens, then the session `cwd` fallback — to its git top-level before calling
-`factory_lane.evaluate_admission_guard(...)`. This prevents a session launched
-outside a worktree from bypassing admission by targeting it through tool
-arguments. Only when the guard denies, the hook prints
+terminal `workdir`, file-tool `path`/`file_path`, Codex `apply_patch`
+`changes[*].path`, and path arguments in terminal commands (absolute or relative
+to the session cwd), then the session `cwd` fallback — to its git top-level
+before calling `factory_lane.evaluate_admission_guard(...)`. This prevents a
+session launched outside a worktree from bypassing admission by targeting it
+through tool arguments. Only when the guard denies, the hook prints
 `{"decision": "block", "reason": "..."}`. `agent/shell_hooks.py`
 translates that into the canonical `{"action": "block", "message": …}` that
 `hermes_cli.plugins.get_pre_tool_call_block_message()` (the exact call site in

--- a/docs/ai-factory-worktree-admission.md
+++ b/docs/ai-factory-worktree-admission.md
@@ -16,15 +16,29 @@ python scripts/factory_lane.py \
   --profile default \
   --session <session-id> \
   --gateway-session-key <platform:chat:thread> \
+  --owner-pid <long-lived-agent-pid> \
   --worktree /Users/jeanyoder/Documents/GitHub/_worktrees/hermes-her-95-worktree-admission-gate
 ```
 
 Hard owner admission:
 - serializes the final decision under `.worktree-admission.lock` to close preflight→claim TOCTOU races;
 - refuses a second live owner for the same canonical worktree, even if the second owner uses another issue key;
-- refreshes heartbeat for the same owner/session;
-- stores `profile` and `gateway_session_key` when supplied, but no tokens or chat secrets;
+- refreshes heartbeat for the same owner/session; a same-session re-claim onto a
+  *different* worktree that is already owned by another lane is refused (never
+  rewrites the owner, never creates two owners for one worktree);
+- stores `profile` and `gateway_session_key` when supplied, but rejects a
+  secret-like `gateway_session_key` (anything matching token/password/api_key/…)
+  before writing owner.json — no tokens or chat secrets are ever persisted;
+- records the transported **parent** process identity (`--owner-pid`, optional
+  `--owner-start-time`) instead of the ephemeral `factory_lane.py` subprocess
+  pid, so liveness/reclaim stays correct when the gate is driven as a subprocess;
+  a dead `--owner-pid` (or a start-time that does not match it) is refused;
 - refuses dirty ownerless git worktrees before a build, without resetting or deleting anything.
+
+`--owner-pid` defaults to the running `factory_lane.py` process only when
+omitted (standalone CLI use). When the gate is invoked from a launcher/gateway
+subprocess, always transport the long-lived agent pid so a claim never persists a
+pid that dies the instant the subprocess exits.
 
 ### Reviewer read-only admission
 
@@ -67,15 +81,116 @@ python scripts/factory_lane.py --registry <registry> admit SCA-740 \
 
 A key outside the allowed prefixes is refused before any owner file is written. This is the canary path for generic `continue` prompts arriving in a business gateway.
 
+## Runtime wiring — real pre-mutation gate (`pre_tool_call` hook)
+
+The `admit` / `claim` CLI takes *ownership*; the runtime gate that actually runs
+**before every build-capable tool** is `scripts/factory_admission_hook.py`, wired
+through the generic shell-hook bridge Hermes already loads at startup
+(`agent.shell_hooks.register_from_config(load_config(), …)`, called from
+`cli.py`, `hermes_cli/main.py`, and `gateway/run.py`). No core file changes: the
+gate is a declarative, opt-in `hooks:` entry in `cli-config.yaml` (profile-aware).
+
+```yaml
+# ~/.hermes/cli-config.yaml (or a profile's cli-config.yaml)
+hooks:
+  pre_tool_call:
+    - matcher: "terminal|patch|write_file|str_replace_editor|apply_patch"
+      command: >-
+        python3 /ABS/scripts/factory_admission_hook.py
+        --registry /ABS/registry --agent default
+```
+
+At tool time the plugin manager calls the hook with the standard shell-hook stdin
+payload (`hook_event_name`, `tool_name`, `session_id`, `cwd`, …). The hook is
+**read-only**: it resolves the worktree from `cwd` (git top-level), calls
+`factory_lane.evaluate_admission_guard(...)`, and — only when the guard denies —
+prints `{"decision": "block", "reason": "..."}`. `agent/shell_hooks.py`
+translates that into the canonical `{"action": "block", "message": …}` that
+`hermes_cli.plugins.get_pre_tool_call_block_message()` (the exact call site in
+`model_tools.handle_function_call`) uses to veto the tool before it executes.
+
+Guard semantics:
+- worktree owned by a **different live session** → block (one winner per worktree);
+- same owning session → allowed (the hook never rewrites owner.json, never
+  persists the hook subprocess pid);
+- **business profile out of domain** → block automatically — the
+  `--profile` / `--domain-prefixes` live in the hook command line (the profile's
+  `cli-config.yaml`), so the denial no longer depends on a caller remembering to
+  pass flags;
+- ownerless worktree or absent/corrupt registry → advisory fail-open (the gate
+  only constrains genuinely admitted lanes);
+- an unexpected error in the advisory hook fails open (a gate bug must not freeze
+  every tool), while a *detected* conflict fails closed.
+
+For a business profile such as `hermes-immo`, the same block is produced with the
+profile's own hook line:
+
+```yaml
+hooks:
+  pre_tool_call:
+    - matcher: "terminal|patch|write_file|str_replace_editor|apply_patch"
+      command: >-
+        python3 /ABS/scripts/factory_admission_hook.py
+        --registry /ABS/registry --agent hermes-immo
+        --profile hermes-immo --domain-prefixes JYI,HER
+```
+
+The hook is opt-in and consent-gated exactly like any other shell hook
+(allowlist + `--accept-hooks` / `HERMES_ACCEPT_HOOKS` / `hooks_auto_accept`), and
+it is skipped entirely under `--safe-mode`.
+
+## AppSec hardening (exact-head review fixes)
+
+The two exact-head reviews' blockers are closed and covered by
+`tests/test_factory_lane_appsec.py` and `tests/test_factory_lane_integration.py`:
+
+- **Ancestor symlink swap (`registry/locks`, `registry/lanes`).** Every
+  claim/admit write descends the path with `openat(O_NOFOLLOW|O_DIRECTORY)` from a
+  registry-root fd, re-validated per write, so a swapped ancestor fails the
+  `openat` (`ELOOP`/`ENOTDIR`) and the write can never land outside the registry.
+  On platforms without `renameat(dir_fd)` (macOS), the atomic replace re-checks
+  `(st_dev, st_ino)` of the open fd against the textual path before renaming, and
+  the temp file lives in the real directory so a late swap fails the rename.
+- **Same-session rebind** onto an already-owned worktree is refused (guarded
+  before any owner rewrite).
+- **Secret-like `gateway_session_key`** is validated and rejected before write.
+- **`process_start_time=None`** is classified `alive`, never `reused`, so a live
+  owner without a recorded start baseline never becomes reclaimable.
+- **Process identity** is transported from the long-lived parent (`--owner-pid`),
+  never the ephemeral gate subprocess pid.
+
 ## Canary for Hermes Immo (no live restart in this task)
 
 1. Use a temporary registry and two temporary git worktrees.
-2. Claim one worktree as `default` on a product lane.
+2. Claim one worktree as `default` on a product lane (transport a live
+   `--owner-pid` so the owner is not immediately reclaimable).
 3. Run `hook-session-start --agent hermes-immo --session continue` against the same worktree and verify the STOP advisory.
 4. Run `admit --mode owner --hard --profile hermes-immo --domain-prefixes JYI,HER` for `SCA-740` and verify it refuses before owner creation.
 5. Run `admit --mode reviewer` and verify it exits 0 without changing the owner JSON.
-6. Only after review/merge should a real gateway integration call this hard gate before launching build-capable agents. Do not restart `hermes-immo` from this canary.
+6. Wire `factory_admission_hook.py` into a *temporary* `cli-config.yaml` and
+   confirm `hermes hooks test pre_tool_call` (or a scripted
+   `get_pre_tool_call_block_message`) blocks a `terminal`/`patch` tool in the
+   foreign-owned worktree and allows the owning session — this is what
+   `tests/test_factory_lane_integration.py` automates.
+7. Only after review/merge should a real gateway config enable this hook before
+   launching build-capable agents. Do not restart `hermes-immo` from this canary.
 
 ## Rollback
 
-This change is additive in the repo. To roll back before installation, remove `scripts/factory_lane.py`, this doc, and `tests/test_factory_lane_admission.py` from the branch. If a deployed copy has already been installed into `~/.hermes/scripts/factory_lane.py`, restore the timestamped backup of that file and remove only the new hook invocations. The registry remains reconstructible evidence; do not delete `registry/` as part of rollback unless Jean explicitly asks for a separate cleanup gate.
+This change is additive in the repo. The tracked files are
+`scripts/factory_lane.py`, `scripts/factory_admission_hook.py`, this doc, and the
+tests `tests/test_factory_lane_admission.py`,
+`tests/test_factory_lane_appsec.py`, `tests/test_factory_lane_integration.py`.
+
+The runtime wiring is **config-only and opt-in**: the gate is disabled until a
+`hooks: pre_tool_call:` entry is added to `cli-config.yaml`. To roll the wiring
+back, delete that `hooks` entry (and, optionally, revoke the hook from the
+shell-hook allowlist with `hermes hooks revoke <command>`) — no core file is
+touched, so nothing else changes.
+
+To roll the code back before installation, remove the files above from the
+branch. If a deployed copy has already been installed into
+`~/.hermes/scripts/factory_lane.py`, restore the timestamped backup of that file
+and remove the `hooks` entry. The registry remains reconstructible evidence; do
+not delete `registry/` as part of rollback unless Jean explicitly asks for a
+separate cleanup gate.

--- a/docs/ai-factory-worktree-admission.md
+++ b/docs/ai-factory-worktree-admission.md
@@ -101,10 +101,14 @@ hooks:
 ```
 
 At tool time the plugin manager calls the hook with the standard shell-hook stdin
-payload (`hook_event_name`, `tool_name`, `session_id`, `cwd`, …). The hook is
-**read-only**: it resolves the worktree from `cwd` (git top-level), calls
-`factory_lane.evaluate_admission_guard(...)`, and — only when the guard denies —
-prints `{"decision": "block", "reason": "..."}`. `agent/shell_hooks.py`
+payload (`hook_event_name`, `tool_name`, `tool_input`, `session_id`, `cwd`, …).
+The hook is **read-only**: it resolves every effective mutation target — explicit
+terminal `workdir`, file-tool `path`/`file_path`, path-shaped terminal command
+tokens, then the session `cwd` fallback — to its git top-level before calling
+`factory_lane.evaluate_admission_guard(...)`. This prevents a session launched
+outside a worktree from bypassing admission by targeting it through tool
+arguments. Only when the guard denies, the hook prints
+`{"decision": "block", "reason": "..."}`. `agent/shell_hooks.py`
 translates that into the canonical `{"action": "block", "message": …}` that
 `hermes_cli.plugins.get_pre_tool_call_block_message()` (the exact call site in
 `model_tools.handle_function_call`) uses to veto the tool before it executes.

--- a/docs/ai-factory-worktree-admission.md
+++ b/docs/ai-factory-worktree-admission.md
@@ -105,10 +105,12 @@ payload (`hook_event_name`, `tool_name`, `tool_input`, `session_id`, `cwd`, …)
 The hook is **read-only**: it resolves every effective mutation target — explicit
 terminal `workdir`, file-tool `path`/`file_path`, Codex `apply_patch`
 `changes[*].path`, and path arguments in terminal commands (absolute or relative
-to the session cwd), then the session `cwd` fallback — to its git top-level
-before calling `factory_lane.evaluate_admission_guard(...)`. This prevents a
-session launched outside a worktree from bypassing admission by targeting it
-through tool arguments. Only when the guard denies, the hook prints
+to the session cwd). Shell punctuation is tokenized even when adjacent to a path
+(`repo;`, `repo&&`), closing no-whitespace command-chain bypasses. The session
+`cwd` is evaluated last as a fallback before each candidate is resolved to its
+git top-level and passed to `factory_lane.evaluate_admission_guard(...)`. This
+prevents a session launched outside a worktree from bypassing admission by
+targeting it through tool arguments. Only when the guard denies, the hook prints
 `{"decision": "block", "reason": "..."}`. `agent/shell_hooks.py`
 translates that into the canonical `{"action": "block", "message": …}` that
 `hermes_cli.plugins.get_pre_tool_call_block_message()` (the exact call site in

--- a/docs/ai-factory-worktree-admission.md
+++ b/docs/ai-factory-worktree-admission.md
@@ -1,0 +1,81 @@
+# AI Factory worktree admission gate
+
+HER-95 adds a machine-wide worktree admission gate to the existing `factory_lane.py` registry layout. It does not introduce a second registry: owners still live under `registry/locks/<KEY>/owner.json`, lane journals under `registry/lanes/<KEY>.jsonl`, and all worktree conflict decisions canonicalize `realpath(worktree)`.
+
+## Commands
+
+### Owner claim / pre-build hard gate
+
+```bash
+python scripts/factory_lane.py \
+  --registry /Users/jeanyoder/Documents/Jean-AI-Memory/Agent-Shared/AI-Factory/registry \
+  admit HER-95 \
+  --mode owner \
+  --hard \
+  --agent default \
+  --profile default \
+  --session <session-id> \
+  --gateway-session-key <platform:chat:thread> \
+  --worktree /Users/jeanyoder/Documents/GitHub/_worktrees/hermes-her-95-worktree-admission-gate
+```
+
+Hard owner admission:
+- serializes the final decision under `.worktree-admission.lock` to close preflight→claim TOCTOU races;
+- refuses a second live owner for the same canonical worktree, even if the second owner uses another issue key;
+- refreshes heartbeat for the same owner/session;
+- stores `profile` and `gateway_session_key` when supplied, but no tokens or chat secrets;
+- refuses dirty ownerless git worktrees before a build, without resetting or deleting anything.
+
+### Reviewer read-only admission
+
+```bash
+python scripts/factory_lane.py --registry <registry> admit HER-95 \
+  --mode reviewer --agent opus-reviewer --session <session-id> \
+  --worktree <worktree> --json
+```
+
+Reviewer mode is read-only: it may report the current owner, but it never creates or mutates `owner.json`.
+
+### Advisory SessionStart
+
+```bash
+python scripts/factory_lane.py --registry <registry> hook-session-start \
+  --repo <worktree> --agent hermes-immo --session <session-id>
+```
+
+If the same worktree is owned by another live session, the hook prints a bounded `STOP: worktree already owned ...` advisory. If the registry is absent or corrupt, the hook fails open with exit 0 and no output.
+
+### Stale recovery
+
+```bash
+python scripts/factory_lane.py --registry <registry> claim HER-96 \
+  --agent default --session <session-id> --worktree <worktree> \
+  --reclaim-worktree --ttl-hours 2
+```
+
+Recovery only succeeds when the previous owner process is stale (`not_found`, `zombie`, or PID `reused`), heartbeat TTL is expired, and the worktree has been inactive for 24h. Otherwise the claim fails closed.
+
+### Business-profile domain guard
+
+For a métier profile such as `hermes-immo`, pass a bounded domain prefix set before hard owner admission:
+
+```bash
+python scripts/factory_lane.py --registry <registry> admit SCA-740 \
+  --mode owner --hard --agent hermes-immo --profile hermes-immo \
+  --domain-prefixes JYI,HER --session <session-id> --worktree <worktree>
+```
+
+A key outside the allowed prefixes is refused before any owner file is written. This is the canary path for generic `continue` prompts arriving in a business gateway.
+
+## Canary for Hermes Immo (no live restart in this task)
+
+1. Use a temporary registry and two temporary git worktrees.
+2. Claim one worktree as `default` on a product lane.
+3. Run `hook-session-start --agent hermes-immo --session continue` against the same worktree and verify the STOP advisory.
+4. Run `admit --mode owner --hard --profile hermes-immo --domain-prefixes JYI,HER` for `SCA-740` and verify it refuses before owner creation.
+5. Run `admit --mode reviewer` and verify it exits 0 without changing the owner JSON.
+6. Only after review/merge should a real gateway integration call this hard gate before launching build-capable agents. Do not restart `hermes-immo` from this canary.
+
+## Rollback
+
+This change is additive in the repo. To roll back before installation, remove `scripts/factory_lane.py`, this doc, and `tests/test_factory_lane_admission.py` from the branch. If a deployed copy has already been installed into `~/.hermes/scripts/factory_lane.py`, restore the timestamped backup of that file and remove only the new hook invocations. The registry remains reconstructible evidence; do not delete `registry/` as part of rollback unless Jean explicitly asks for a separate cleanup gate.

--- a/scripts/factory_admission_hook.py
+++ b/scripts/factory_admission_hook.py
@@ -62,6 +62,7 @@ _PATH_AFFECTING_SHELL_COMMANDS = frozenset({
 })
 _HARD_READONLY_SHELL_COMMANDS = frozenset({"echo", "false", "printf", "pwd", "true", ":"})
 _SHELL_CONTROL_TOKENS = frozenset({"&&", "||", ";", "|", "&", "(", ")", "<", ">", ">>"})
+_MAX_REPARSED_SHELL_DEPTH = 4
 
 
 def _emit_block(reason):
@@ -210,7 +211,71 @@ def _unquote_shell_token(token):
     return token
 
 
-def _reparsed_shell_target_is_dynamic(command_name, operands):
+def _shell_segments(command):
+    """Return shell command segments, or ``None`` when syntax is ambiguous."""
+    masked_command = _mask_active_command_substitutions(command)
+    if masked_command is None:
+        return None
+    try:
+        lexer = shlex.shlex(masked_command, posix=False, punctuation_chars=";&|()<>")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return None
+
+    segments = []
+    current = []
+    for token in [*tokens, ";"]:
+        if token in _SHELL_CONTROL_TOKENS:
+            if current:
+                segments.append(current)
+            current = []
+        else:
+            current.append(token)
+    return segments
+
+
+def _reparsed_shell_programs(command, depth=0):
+    """Return literal programs evaluated by ``sh -c``/``eval`` recursively.
+
+    ``None`` means that a nested reparse is ambiguous or exceeds the fixed
+    budget, so callers fail closed rather than silently omit a target.
+    """
+    if depth >= _MAX_REPARSED_SHELL_DEPTH:
+        return None
+    segments = _shell_segments(command)
+    if segments is None:
+        return None
+    programs = []
+    for segment in segments:
+        command_name = os.path.basename(segment[0].strip("'\""))
+        operands = segment[1:]
+        if command_name in {"sh", "bash", "dash", "ksh", "zsh"}:
+            script = None
+            for index, operand in enumerate(operands):
+                if operand == "-c":
+                    if index + 1 >= len(operands):
+                        return None
+                    script = _unquote_shell_token(operands[index + 1])
+                    break
+            if script is None:
+                continue
+            programs.append(script)
+        elif command_name == "eval":
+            if not operands:
+                return None
+            programs.append(" ".join(_unquote_shell_token(operand) for operand in operands))
+        else:
+            continue
+        nested = _reparsed_shell_programs(programs[-1], depth + 1)
+        if nested is None:
+            return None
+        programs.extend(nested)
+    return programs
+
+
+def _reparsed_shell_target_is_dynamic(command_name, operands, depth):
     """Inspect code evaluated by ``sh -c``/``eval`` with the same path policy.
 
     The outer shell can safely single-quote a script, but that quote disappears
@@ -221,17 +286,19 @@ def _reparsed_shell_target_is_dynamic(command_name, operands):
         for index, operand in enumerate(operands):
             if operand == "-c" and index + 1 < len(operands):
                 return _terminal_has_unresolved_dynamic_target(
-                    _unquote_shell_token(operands[index + 1])
+                    _unquote_shell_token(operands[index + 1]), depth + 1,
                 )
-        return False
+        return "-c" in operands
     if command_name == "eval":
+        if not operands:
+            return True
         return _terminal_has_unresolved_dynamic_target(
-            " ".join(_unquote_shell_token(operand) for operand in operands)
+            " ".join(_unquote_shell_token(operand) for operand in operands), depth + 1,
         )
     return False
 
 
-def _terminal_has_unresolved_dynamic_target(command):
+def _terminal_has_unresolved_dynamic_target(command, depth=0):
     """True when terminal inspection cannot resolve a potentially mutable path.
 
     Simple variable and command/backtick substitutions are blocked only when
@@ -241,6 +308,8 @@ def _terminal_has_unresolved_dynamic_target(command):
     preventing wrappers such as ``env`` or ``sudo`` from hiding the real
     command. Literal single-quoted dollars remain safe data.
     """
+    if depth >= _MAX_REPARSED_SHELL_DEPTH:
+        return True
     marker = "__HERMES_DYNAMIC_SUBSTITUTION__"
     masked_command = _mask_active_command_substitutions(command)
     if masked_command is None:
@@ -251,7 +320,6 @@ def _terminal_has_unresolved_dynamic_target(command):
         lexer.commenters = ""
         tokens = list(lexer)
     except ValueError:
-        # An unparsable shell command cannot be proven not to expand a path.
         return _has_active_shell_expansion(command)
 
     segment = []
@@ -271,7 +339,7 @@ def _terminal_has_unresolved_dynamic_target(command):
                     return True
                 command_name = os.path.basename(segment[0].strip("'\""))
                 operands = segment[1:]
-                if _reparsed_shell_target_is_dynamic(command_name, operands):
+                if _reparsed_shell_target_is_dynamic(command_name, operands, depth):
                     return True
                 dynamic_operand = any(
                     marker in value or _has_active_shell_expansion(value)
@@ -354,27 +422,29 @@ def _target_directories(payload):
     # execution or expansion; malformed commands simply contribute no targets.
     command = tool_input.get("command")
     if payload.get("tool_name") == "terminal" and isinstance(command, str):
-        try:
-            lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()<>")
-            lexer.whitespace_split = True
-            lexer.commenters = ""
-            tokens = list(lexer)
-        except ValueError:
-            tokens = []
-        shell_operators = {"&&", "||", ";", "|", "&", "(", ")", "<", ">", ">>"}
-        for index, token in enumerate(tokens):
-            candidate = token.split("=", 1)[-1] if "=" in token else token
-            # Skip the command name and shell syntax, but evaluate every other
-            # non-option token relative to cwd.  This catches ``git -C repo``,
-            # ``cd repo`` and ``touch repo/file`` without executing the shell.
-            path_shaped = os.path.isabs(candidate) or candidate.startswith(("./", "../"))
-            relative_argument = (
-                index > 0
-                and token not in shell_operators
-                and not token.startswith("-")
-            )
-            if path_shaped or relative_argument:
-                raw_targets.append(candidate)
+        nested_programs = _reparsed_shell_programs(command)
+        if nested_programs is None:
+            return
+        commands_to_scan = [command, *nested_programs]
+        for shell_command in commands_to_scan:
+            try:
+                lexer = shlex.shlex(shell_command, posix=True, punctuation_chars=";&|()<>")
+                lexer.whitespace_split = True
+                lexer.commenters = ""
+                tokens = list(lexer)
+            except ValueError:
+                continue
+            shell_operators = {"&&", "||", ";", "|", "&", "(", ")", "<", ">", ">>"}
+            for index, token in enumerate(tokens):
+                candidate = token.split("=", 1)[-1] if "=" in token else token
+                path_shaped = os.path.isabs(candidate) or candidate.startswith(("./", "../"))
+                relative_argument = (
+                    index > 0
+                    and token not in shell_operators
+                    and not token.startswith("-")
+                )
+                if path_shaped or relative_argument:
+                    raw_targets.append(candidate)
 
     raw_targets.append(cwd)
     seen = set()
@@ -411,14 +481,24 @@ def main(argv=None):
 
     command = (payload.get("tool_input") or {}).get("command")
     if payload.get("tool_name") == "terminal" and isinstance(command, str):
-        if _terminal_has_unresolved_dynamic_target(command):
+        if (
+            _terminal_has_unresolved_dynamic_target(command)
+            or _reparsed_shell_programs(command) is None
+        ):
             _emit_block("unresolved shell expansion can affect a worktree target")
             return 0
 
-    # 2) Infra absente/anormale => fail-open advisory.
+    # 2) Root absent => fail-open advisory. Existing but malformed or
+    # unreadable registry state is ambiguous, so it blocks fail-closed.
     try:
-        root = factory_lane._safe_registry_root(args.registry)
+        root = factory_lane._readonly_registry_root(args.registry)
+    except factory_lane.RegistryError as exc:
+        _emit_block(str(exc))
+        return 0
     except Exception:
+        _emit_block("registry root cannot be inspected safely")
+        return 0
+    if root is None:
         return 0
 
     try:

--- a/scripts/factory_admission_hook.py
+++ b/scripts/factory_admission_hook.py
@@ -41,6 +41,7 @@ un conflit d'occupation avéré ou une violation de domaine métier.
 import argparse
 import json
 import os
+import shlex
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -57,6 +58,67 @@ _MUTATING_TOOLS = frozenset({
 
 def _emit_block(reason):
     print(json.dumps({"decision": "block", "reason": reason}))
+
+
+def _path_anchor(path, base):
+    """Return an existing directory from which git can resolve a target path.
+
+    File mutation tools commonly target a not-yet-created file.  Walk upward to
+    the first existing ancestor instead of falling back to the gateway cwd.
+    """
+    if not isinstance(path, str) or not path.strip():
+        return None
+    candidate = path if os.path.isabs(path) else os.path.join(base, path)
+    candidate = os.path.realpath(candidate)
+    while not os.path.exists(candidate):
+        parent = os.path.dirname(candidate)
+        if parent == candidate:
+            return None
+        candidate = parent
+    if os.path.isfile(candidate):
+        candidate = os.path.dirname(candidate)
+    return candidate
+
+
+def _target_directories(payload):
+    """Yield effective tool targets before the process cwd, without duplicates."""
+    cwd = payload.get("cwd") or os.getcwd()
+    tool_input = payload.get("tool_input")
+    tool_input = tool_input if isinstance(tool_input, dict) else {}
+
+    raw_targets = []
+    workdir = tool_input.get("workdir")
+    if isinstance(workdir, str) and workdir.strip():
+        raw_targets.append(workdir)
+
+    # File mutation tools use one of these names across Hermes adapters.
+    for key in ("path", "file_path", "target_path"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.strip():
+            raw_targets.append(value)
+
+    # A terminal command can address a foreign worktree without setting
+    # ``workdir`` (``git -C /abs/path``, ``cd /abs/path``, ``touch /abs/file``).
+    # Inspect path-shaped shell tokens as a defence in depth.  This is not shell
+    # execution or expansion; malformed commands simply contribute no targets.
+    command = tool_input.get("command")
+    if payload.get("tool_name") == "terminal" and isinstance(command, str):
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            tokens = []
+        for token in tokens:
+            candidate = token.split("=", 1)[-1] if "=" in token else token
+            if os.path.isabs(candidate) or candidate.startswith(("./", "../")):
+                raw_targets.append(candidate)
+
+    raw_targets.append(cwd)
+    seen = set()
+    for raw in raw_targets:
+        anchor = _path_anchor(raw, cwd)
+        if anchor is not None and anchor not in seen:
+            seen.add(anchor)
+            yield anchor
 
 
 def main(argv=None):
@@ -82,7 +144,6 @@ def main(argv=None):
         return 0
 
     session = payload.get("session_id") or ""
-    cwd = payload.get("cwd") or os.getcwd()
 
     # 2) Infra absente/anormale => fail-open advisory.
     try:
@@ -91,20 +152,25 @@ def main(argv=None):
         return 0
 
     try:
-        worktree_real = factory_lane._git_toplevel_or_none(cwd)
-        if worktree_real is None:
-            worktree_real = os.path.realpath(cwd)
-        allowed, reason = factory_lane.evaluate_admission_guard(
-            root, worktree_real, args.agent, session,
-            profile=args.profile, domain_prefixes=args.domain_prefixes,
-        )
+        # Evaluate every effective target.  The gateway process cwd is only a
+        # fallback: terminal(workdir=...) and absolute file paths must not bypass
+        # admission when the session itself started elsewhere.
+        for target_dir in _target_directories(payload):
+            worktree_real = factory_lane._git_toplevel_or_none(target_dir)
+            if worktree_real is None:
+                worktree_real = os.path.realpath(target_dir)
+            allowed, reason = factory_lane.evaluate_admission_guard(
+                root, worktree_real, args.agent, session,
+                profile=args.profile, domain_prefixes=args.domain_prefixes,
+            )
+            if not allowed:
+                _emit_block(reason or "worktree admission denied")
+                return 0
     except Exception:
         # Une anomalie inattendue du gate advisory ne doit pas geler tous les
         # tools de la session — fail-open, le conflit avéré reste fail-closed.
         return 0
 
-    if not allowed:
-        _emit_block(reason or "worktree admission denied")
     return 0
 
 

--- a/scripts/factory_admission_hook.py
+++ b/scripts/factory_admission_hook.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""factory_admission_hook.py — pont Hermes `pre_tool_call` -> gate d'admission.
+
+Ce script est le point d'intégration runtime de la porte d'admission worktree
+(HER-95). Il se branche via le mécanisme de shell-hooks générique déjà chargé
+par `cli.py`, `hermes_cli/main.py` et `gateway/run.py`
+(`agent.shell_hooks.register_from_config`) — aucun changement de core n'est
+requis. Déclaration opt-in dans `cli-config.yaml` (profile-aware) :
+
+    hooks:
+      pre_tool_call:
+        - matcher: "terminal|patch|write_file|str_replace_editor|apply_patch"
+          command: >-
+            python3 /ABS/scripts/factory_admission_hook.py
+            --registry /ABS/registry --agent default
+
+    # Profil métier (ex. hermes-immo) : le refus de domaine est AUTOMATIQUE car
+    # --profile/--domain-prefixes vivent dans la config du profil, pas dans un
+    # flag que l'appelant doit se souvenir de passer.
+    hooks:
+      pre_tool_call:
+        - matcher: "terminal|patch|write_file|str_replace_editor|apply_patch"
+          command: >-
+            python3 /ABS/scripts/factory_admission_hook.py
+            --registry /ABS/registry --agent hermes-immo
+            --profile hermes-immo --domain-prefixes JYI,HER
+
+Protocole (voir `agent/shell_hooks.py`) : la charge utile arrive en JSON sur
+stdin ; pour bloquer un tool AVANT son exécution, on émet sur stdout
+`{"decision": "block", "reason": "..."}` (traduit par `_parse_response` en
+`{"action": "block", "message": "..."}`, la forme que
+`get_pre_tool_call_block_message` remonte au dispatcher de tools).
+
+Posture : LECTURE SEULE. Le hook n'écrit jamais d'owner et ne persiste jamais le
+PID éphémère de ce subprocess (cf. blocker identité process) — il ne fait
+qu'interroger `evaluate_admission_guard`. Fail-open advisory si l'infra est
+absente/anormale (pas de registry, pas un dépôt git) ; fail-closed (block) sur
+un conflit d'occupation avéré ou une violation de domaine métier.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import factory_lane  # noqa: E402  (résolu via le sys.path ci-dessus)
+
+# Événements build-capable pour lesquels le gate a un sens. Le matcher du hook
+# filtre déjà côté Hermes ; cette liste est une défense en profondeur si le hook
+# est câblé sans matcher.
+_MUTATING_TOOLS = frozenset({
+    "terminal", "patch", "write_file", "str_replace_editor", "apply_patch",
+    "edit_file", "create_file", "delete_file", "move_file",
+})
+
+
+def _emit_block(reason):
+    print(json.dumps({"decision": "block", "reason": reason}))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="factory_admission_hook")
+    parser.add_argument("--registry", required=True)
+    parser.add_argument("--agent", required=True)
+    parser.add_argument("--profile")
+    parser.add_argument("--domain-prefixes")
+    # Optionnel : restreint le gate à un sous-ensemble de tools même sans matcher.
+    parser.add_argument("--only-mutating", action="store_true")
+    args = parser.parse_args(argv)
+
+    # 1) Charge utile stdin — illisible => fail-open (ne jamais casser un tool).
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    if payload.get("hook_event_name") != "pre_tool_call":
+        return 0
+    if args.only_mutating and payload.get("tool_name") not in _MUTATING_TOOLS:
+        return 0
+
+    session = payload.get("session_id") or ""
+    cwd = payload.get("cwd") or os.getcwd()
+
+    # 2) Infra absente/anormale => fail-open advisory.
+    try:
+        root = factory_lane._safe_registry_root(args.registry)
+    except Exception:
+        return 0
+
+    try:
+        worktree_real = factory_lane._git_toplevel_or_none(cwd)
+        if worktree_real is None:
+            worktree_real = os.path.realpath(cwd)
+        allowed, reason = factory_lane.evaluate_admission_guard(
+            root, worktree_real, args.agent, session,
+            profile=args.profile, domain_prefixes=args.domain_prefixes,
+        )
+    except Exception:
+        # Une anomalie inattendue du gate advisory ne doit pas geler tous les
+        # tools de la session — fail-open, le conflit avéré reste fail-closed.
+        return 0
+
+    if not allowed:
+        _emit_block(reason or "worktree admission denied")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/factory_admission_hook.py
+++ b/scripts/factory_admission_hook.py
@@ -116,7 +116,10 @@ def _target_directories(payload):
     command = tool_input.get("command")
     if payload.get("tool_name") == "terminal" and isinstance(command, str):
         try:
-            tokens = shlex.split(command)
+            lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()<>")
+            lexer.whitespace_split = True
+            lexer.commenters = ""
+            tokens = list(lexer)
         except ValueError:
             tokens = []
         shell_operators = {"&&", "||", ";", "|", "&", "(", ")", "<", ">", ">>"}

--- a/scripts/factory_admission_hook.py
+++ b/scripts/factory_admission_hook.py
@@ -97,6 +97,18 @@ def _target_directories(payload):
         if isinstance(value, str) and value.strip():
             raw_targets.append(value)
 
+    # Codex-style apply_patch transports one or more paths under ``changes``.
+    # Treat every declared path as a first-class mutation target.
+    changes = tool_input.get("changes")
+    if isinstance(changes, list):
+        for change in changes:
+            if not isinstance(change, dict):
+                continue
+            for key in ("path", "file_path", "target_path"):
+                value = change.get(key)
+                if isinstance(value, str) and value.strip():
+                    raw_targets.append(value)
+
     # A terminal command can address a foreign worktree without setting
     # ``workdir`` (``git -C /abs/path``, ``cd /abs/path``, ``touch /abs/file``).
     # Inspect path-shaped shell tokens as a defence in depth.  This is not shell
@@ -107,9 +119,19 @@ def _target_directories(payload):
             tokens = shlex.split(command)
         except ValueError:
             tokens = []
-        for token in tokens:
+        shell_operators = {"&&", "||", ";", "|", "&", "(", ")", "<", ">", ">>"}
+        for index, token in enumerate(tokens):
             candidate = token.split("=", 1)[-1] if "=" in token else token
-            if os.path.isabs(candidate) or candidate.startswith(("./", "../")):
+            # Skip the command name and shell syntax, but evaluate every other
+            # non-option token relative to cwd.  This catches ``git -C repo``,
+            # ``cd repo`` and ``touch repo/file`` without executing the shell.
+            path_shaped = os.path.isabs(candidate) or candidate.startswith(("./", "../"))
+            relative_argument = (
+                index > 0
+                and token not in shell_operators
+                and not token.startswith("-")
+            )
+            if path_shaped or relative_argument:
                 raw_targets.append(candidate)
 
     raw_targets.append(cwd)

--- a/scripts/factory_admission_hook.py
+++ b/scripts/factory_admission_hook.py
@@ -55,9 +55,248 @@ _MUTATING_TOOLS = frozenset({
     "edit_file", "create_file", "delete_file", "move_file",
 })
 
+_PATH_AFFECTING_SHELL_COMMANDS = frozenset({
+    "apply_patch", "cat", "chmod", "chown", "cp", "dd", "install", "ln",
+    "mkdir", "mktemp", "mv", "perl", "python", "python3", "rm", "ruby",
+    "sed", "sh", "tee", "touch", "truncate", "zsh",
+})
+_HARD_READONLY_SHELL_COMMANDS = frozenset({"echo", "false", "printf", "pwd", "true", ":"})
+_SHELL_CONTROL_TOKENS = frozenset({"&&", "||", ";", "|", "&", "(", ")", "<", ">", ">>"})
+
 
 def _emit_block(reason):
     print(json.dumps({"decision": "block", "reason": reason}))
+
+
+def _has_active_shell_expansion(text):
+    """Detect shell expansions that survive into execution, never quoted data.
+
+    ``shlex`` deliberately removes quote context, so it cannot tell ``'$HOME'``
+    (literal) from ``"$HOME"`` (expanded). This small scanner keeps that
+    distinction and treats escaped ``$``/backticks as literal. It is a guard,
+    not a shell interpreter: uncertainty remains a reason to refuse a mutable
+    target rather than attempt expansion in the hook.
+    """
+    quote = None
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "\\":
+            index += 2
+            continue
+        if quote == "'":
+            if char == "'":
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if char == "`":
+            return True
+        if char != "$" or index + 1 >= len(text):
+            index += 1
+            continue
+        next_char = text[index + 1]
+        if next_char == "(":
+            return True
+        if next_char == "{" or next_char == "_" or next_char.isalnum() or next_char in "?*@$#!-":
+            return True
+        index += 1
+    return False
+
+
+def _scan_dollar_paren_end(command, start):
+    """Return the offset after a balanced active ``$(...)`` substitution."""
+    depth = 1
+    quote = None
+    index = start + 2
+    while index < len(command):
+        char = command[index]
+        if quote:
+            if char == "\\" and quote == '"' and index + 1 < len(command):
+                index += 2
+                continue
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if char == "\\" and index + 1 < len(command):
+            index += 2
+            continue
+        if command.startswith("$(", index):
+            depth += 1
+            index += 2
+            continue
+        if char == ")":
+            depth -= 1
+            index += 1
+            if depth == 0:
+                return index
+            continue
+        index += 1
+    return None
+
+
+def _scan_backtick_end(command, start):
+    """Return the offset after an active backtick substitution."""
+    index = start + 1
+    while index < len(command):
+        if command[index] == "\\" and index + 1 < len(command):
+            index += 2
+            continue
+        if command[index] == "`":
+            return index + 1
+        index += 1
+    return None
+
+
+def _mask_active_command_substitutions(command):
+    """Replace active substitution bodies before tokenizing shell syntax.
+
+    ``shlex`` otherwise splits ``$(date)`` on its parentheses, losing the fact
+    that the resulting word is dynamic.  Single-quoted syntax stays untouched;
+    unmatched substitutions remain unparseable and must be rejected by callers.
+    """
+    marker = "__HERMES_DYNAMIC_SUBSTITUTION__"
+    result = []
+    quote = None
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if char == "\\" and index + 1 < len(command):
+            result.append(command[index:index + 2])
+            index += 2
+            continue
+        if quote == "'":
+            result.append(char)
+            if char == "'":
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            result.append(char)
+            quote = char
+            index += 1
+            continue
+        if command.startswith("$(", index):
+            end = _scan_dollar_paren_end(command, index)
+            if end is None:
+                return None
+            result.append(marker)
+            index = end
+            continue
+        if char == "`":
+            end = _scan_backtick_end(command, index)
+            if end is None:
+                return None
+            result.append(marker)
+            index = end
+            continue
+        result.append(char)
+        index += 1
+    return "".join(result)
+
+
+def _unquote_shell_token(token):
+    """Return the one shell-quoted word a re-parsing wrapper will execute."""
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {"'", '"'}:
+        return token[1:-1]
+    return token
+
+
+def _reparsed_shell_target_is_dynamic(command_name, operands):
+    """Inspect code evaluated by ``sh -c``/``eval`` with the same path policy.
+
+    The outer shell can safely single-quote a script, but that quote disappears
+    before a re-parsing wrapper evaluates it. Treat only dynamic nested path
+    effects as unsafe, preserving harmless ``printf $(date)`` scripts.
+    """
+    if command_name in {"sh", "bash", "dash", "ksh", "zsh"}:
+        for index, operand in enumerate(operands):
+            if operand == "-c" and index + 1 < len(operands):
+                return _terminal_has_unresolved_dynamic_target(
+                    _unquote_shell_token(operands[index + 1])
+                )
+        return False
+    if command_name == "eval":
+        return _terminal_has_unresolved_dynamic_target(
+            " ".join(_unquote_shell_token(operand) for operand in operands)
+        )
+    return False
+
+
+def _terminal_has_unresolved_dynamic_target(command):
+    """True when terminal inspection cannot resolve a potentially mutable path.
+
+    Simple variable and command/backtick substitutions are blocked only when
+    they can select a cwd (``cd``/``pushd``), a git ``-C`` target, a redirection
+    target, or an operand of a command that may write. Commands outside a tiny
+    hard read-only allowlist are conservatively treated as write-capable,
+    preventing wrappers such as ``env`` or ``sudo`` from hiding the real
+    command. Literal single-quoted dollars remain safe data.
+    """
+    marker = "__HERMES_DYNAMIC_SUBSTITUTION__"
+    masked_command = _mask_active_command_substitutions(command)
+    if masked_command is None:
+        return _has_active_shell_expansion(command)
+    try:
+        lexer = shlex.shlex(masked_command, posix=False, punctuation_chars=";&|()<>")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        # An unparsable shell command cannot be proven not to expand a path.
+        return _has_active_shell_expansion(command)
+
+    segment = []
+    redirection_target = False
+    for token in [*tokens, ";"]:
+        if redirection_target:
+            if token in _SHELL_CONTROL_TOKENS:
+                return True
+            if marker in token or _has_active_shell_expansion(token):
+                return True
+            redirection_target = False
+        if token in _SHELL_CONTROL_TOKENS:
+            if segment:
+                if marker in segment[0] or _has_active_shell_expansion(segment[0]):
+                    # A dynamic command word can resolve to a write-capable
+                    # command or wrapper, so it is never a safe readonly call.
+                    return True
+                command_name = os.path.basename(segment[0].strip("'\""))
+                operands = segment[1:]
+                if _reparsed_shell_target_is_dynamic(command_name, operands):
+                    return True
+                dynamic_operand = any(
+                    marker in value or _has_active_shell_expansion(value)
+                    for value in operands
+                )
+                if dynamic_operand:
+                    if command_name in {"cd", "pushd"}:
+                        return True
+                    if command_name == "git":
+                        for index, value in enumerate(operands):
+                            if value == "-C" and index + 1 < len(operands):
+                                if _has_active_shell_expansion(operands[index + 1]):
+                                    return True
+                            if value.startswith("-C") and _has_active_shell_expansion(value[2:]):
+                                return True
+                    if (
+                        command_name in _PATH_AFFECTING_SHELL_COMMANDS
+                        or command_name not in _HARD_READONLY_SHELL_COMMANDS
+                    ):
+                        return True
+            segment = []
+            redirection_target = token in {"<", ">", ">>"}
+        else:
+            segment.append(token)
+    return False
 
 
 def _path_anchor(path, base):
@@ -170,6 +409,12 @@ def main(argv=None):
 
     session = payload.get("session_id") or ""
 
+    command = (payload.get("tool_input") or {}).get("command")
+    if payload.get("tool_name") == "terminal" and isinstance(command, str):
+        if _terminal_has_unresolved_dynamic_target(command):
+            _emit_block("unresolved shell expansion can affect a worktree target")
+            return 0
+
     # 2) Infra absente/anormale => fail-open advisory.
     try:
         root = factory_lane._safe_registry_root(args.registry)
@@ -191,9 +436,16 @@ def main(argv=None):
             if not allowed:
                 _emit_block(reason or "worktree admission denied")
                 return 0
+    except factory_lane.RegistryError as exc:
+        # An owner scan that cannot prove the registry's integrity is not an
+        # ownerless scan. Refuse before the mutable tool can observe a hidden
+        # competing worktree claim.
+        _emit_block(str(exc))
+        return 0
     except Exception:
-        # Une anomalie inattendue du gate advisory ne doit pas geler tous les
-        # tools de la session — fail-open, le conflit avéré reste fail-closed.
+        # The advisory path remains fail-open only for unexpected errors outside
+        # the secure registry scan. Registry scan/read errors are handled just
+        # above and fail closed.
         return 0
 
     return 0

--- a/scripts/factory_lane.py
+++ b/scripts/factory_lane.py
@@ -1,0 +1,1831 @@
+"""factory_lane.py — registry core cross-agent (HER-54).
+
+Journal per-lane JSONL append-only en `registry/lanes/<KEY>.jsonl`, verrous
+par répertoire atomique en `registry/locks/<KEY>/owner.json`, protégés par
+`fcntl.flock` sur un fichier de verrou dédié. Python stdlib uniquement.
+"""
+
+import argparse
+import calendar
+import contextlib
+import errno
+import fcntl
+import json
+import math
+import os
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# Constantes de contrat
+# --------------------------------------------------------------------------
+
+KNOWN_PREFIXES = frozenset({"HER", "SCA", "IMP", "TL", "JYI"})
+_TICKET_KEY_RE = re.compile(
+    r"^(" + "|".join(sorted(KNOWN_PREFIXES)) + r")-[1-9][0-9]*\Z"
+)
+_ADHOC_KEY_RE = re.compile(r"^adhoc-[a-z0-9]+(?:-[a-z0-9]+)*\Z")
+
+ALLOWED_MANUAL_EVENTS = frozenset({
+    "build_started", "checkpoint", "pr_opened", "ci_green", "review_done",
+    "ready_to_merge", "go_jean", "merged", "deployed", "smoke_ok",
+    "memory_written", "lane_abandoned",
+})
+
+STATUS_LADDER = {
+    "lane_claimed": "claimed",
+    "build_started": "in_progress",
+    "pr_opened": "pr_open",
+    "lane_closed": "closed",
+}
+
+ALLOWED_HANDOFF_STATUS = frozenset({
+    "ready_to_merge", "blocked", "in_progress", "needs_review", "done",
+})
+
+MAX_EVIDENCE_LEN = 200
+MAX_NEXT_STEP_LEN = 1000
+WORKTREE_ACTIVE_SECONDS = 24 * 3600
+DEFAULT_TTL_HOURS = 72.0
+
+_SECRET_PATTERN = re.compile(
+    r"(token|password|passwd|secret|api[_-]?key|credential)", re.IGNORECASE
+)
+
+# --------------------------------------------------------------------------
+# Constantes context pack (HER-55 Scope A)
+# --------------------------------------------------------------------------
+
+CONTEXT_PACK_MAX_LINES = 300
+UNMAPPED_BRIEF_MAX_LINES = 20
+LINEAR_CACHE_STALE_HOURS = 24.0
+UNMAPPED_REPO_MARKER = "UNMAPPED-REPO"
+# Motifs de répertoire bloqués en défense en profondeur, même si allow-listés
+# par erreur dans context-map.json. `_SECRET_PATTERN` couvre déjà
+# secret/token/credential/password (insensible à la casse).
+_VAULT_BLOCKED_DIR_PREFIXES = ("transcripts/", "Legal/", "Clients/")
+
+
+class RegistryError(Exception):
+    """Erreur de validation ou d'état attendue — provoque un exit non nul."""
+
+
+# --------------------------------------------------------------------------
+# Validation clé / chemins
+# --------------------------------------------------------------------------
+
+def validate_key(key):
+    if not isinstance(key, str) or not key:
+        raise RegistryError("key must be a non-empty string")
+    if _TICKET_KEY_RE.match(key) or _ADHOC_KEY_RE.match(key):
+        return
+    raise RegistryError(f"invalid lane key: {key!r}")
+
+
+_NOFOLLOW_FLAG = getattr(os, "O_NOFOLLOW", 0)
+
+# Alias système connus (macOS monte `/var`, `/tmp`, `/etc` comme symlinks vers
+# `/private/...`). Ce ne sont pas des symlinks créés par un attaquant dans un
+# chemin utilisateur : ils sont fixes, racine du système, et la résolution
+# réelle est vérifiée avant de les tolérer.
+_KNOWN_SYSTEM_ALIAS_ROOTS = frozenset({"/var", "/tmp", "/etc"})
+
+
+def _is_known_system_alias(ancestor):
+    """True seulement pour un alias macOS top-level résolvant vers /private/<nom>."""
+    ancestor_str = str(ancestor)
+    if ancestor_str not in _KNOWN_SYSTEM_ALIAS_ROOTS:
+        return False
+    try:
+        resolved = os.path.realpath(ancestor_str)
+    except OSError:
+        return False
+    return resolved == f"/private{ancestor_str}"
+
+
+def _reject_symlink_ancestors(path):
+    for ancestor in Path(path).parents:
+        if ancestor.exists() and ancestor.is_symlink():
+            if _is_known_system_alias(ancestor):
+                continue
+            raise RegistryError(f"path ancestor must not be a symlink: {ancestor}")
+
+
+def _open_secure(path, flags, mode=0o600):
+    """os.open with O_NOFOLLOW when available; refuses to traverse a symlink."""
+    try:
+        return os.open(str(path), flags | _NOFOLLOW_FLAG, mode)
+    except OSError as exc:
+        if _NOFOLLOW_FLAG and exc.errno in (errno.ELOOP, errno.EMLINK):
+            raise RegistryError(f"refusing to follow symlink: {path}") from exc
+        raise
+
+
+def _reject_symlink(path, label):
+    if Path(path).is_symlink():
+        raise RegistryError(f"{label} must not be a symlink: {path}")
+
+
+def _safe_registry_root(path_str):
+    root = Path(path_str)
+    _reject_symlink_ancestors(root)
+    if root.is_symlink():
+        raise RegistryError(f"registry path must not be a symlink: {root}")
+    if root.exists():
+        if not root.is_dir():
+            raise RegistryError(f"registry path is not a directory: {root}")
+    else:
+        root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _safe_subdir(root, name):
+    p = root / name
+    if p.is_symlink():
+        raise RegistryError(f"{name} directory must not be a symlink: {p}")
+    if p.exists():
+        if not p.is_dir():
+            raise RegistryError(f"{name} path is not a directory: {p}")
+    else:
+        p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _validate_metadata_field(value, label):
+    if len(value) > MAX_EVIDENCE_LEN:
+        raise RegistryError(f"{label} too long")
+    if "\n" in value or "\r" in value:
+        raise RegistryError(f"{label} must not contain newlines")
+    if _SECRET_PATTERN.search(value):
+        raise RegistryError(f"{label} looks like a secret and was rejected")
+
+
+def _validate_evidence(evidence):
+    _validate_metadata_field(evidence, "evidence")
+
+
+# --------------------------------------------------------------------------
+# I/O bas niveau : verrou, owner.json, journal JSONL
+# --------------------------------------------------------------------------
+
+@contextlib.contextmanager
+def _locked(lock_path):
+    fd = _open_secure(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield fd
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def _read_json(path):
+    fd = _open_secure(path, os.O_RDONLY)
+    with os.fdopen(fd, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _fsync_dir(dir_path):
+    """fsync du répertoire (no-follow) pour rendre un os.replace durable."""
+    fd = _open_secure(dir_path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _write_owner(owner_file, owner):
+    lock_dir = owner_file.parent
+    fd, tmp_path = tempfile.mkstemp(dir=str(lock_dir), prefix=".owner-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(owner, f, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, str(owner_file))
+        _fsync_dir(lock_dir)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.remove(tmp_path)
+        raise
+
+
+def _parse_jsonl_lines(text, source):
+    """Parse fail-closed : toute ligne corrompue lève, aucune ligne n'est ignorée."""
+    events = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise RegistryError(
+                f"corrupt journal {source} at line {lineno}: {exc}"
+            ) from exc
+    return events
+
+
+def _read_all_events(lane_file):
+    """Lit le journal via ouverture secure no-follow + flock partagé (cohérent
+    avec le flock exclusif utilisé pendant l'append)."""
+    fd = _open_secure(lane_file, os.O_RDONLY)
+    with os.fdopen(fd, "r", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+        try:
+            text = f.read()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+    return _parse_jsonl_lines(text, lane_file)
+
+
+def _same_event(a, b):
+    keys = (set(a.keys()) | set(b.keys())) - {"ts"}
+    return all(a.get(k) == b.get(k) for k in keys)
+
+
+def _append_event(lane_file, key, event_name, extra=None):
+    payload = {"ts": time.time(), "key": key, "event": event_name}
+    if extra:
+        payload.update(extra)
+
+    fd = _open_secure(lane_file, os.O_CREAT | os.O_RDWR, 0o600)
+    with os.fdopen(fd, "r+", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            os.fchmod(f.fileno(), 0o600)
+            events = _parse_jsonl_lines(f.read(), lane_file)
+            last = events[-1] if events else None
+            if last is not None and _same_event(last, payload):
+                return
+            f.seek(0, os.SEEK_END)
+            f.write(json.dumps(payload, sort_keys=True) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def _compute_status(events):
+    status = "unclaimed"
+    for e in events:
+        name = e.get("event")
+        if name in STATUS_LADDER:
+            status = STATUS_LADDER[name]
+    return status
+
+
+# --------------------------------------------------------------------------
+# Identité de processus / activité worktree (pour la réclamation de lock)
+# --------------------------------------------------------------------------
+
+def _get_process_start_time(pid):
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    return out or None
+
+
+def _get_process_state_char(pid):
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "state=", "-p", str(pid)],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    return out[:1] if out else None
+
+
+def determine_process_state(owner):
+    """Retourne 'alive' | 'zombie' | 'reused' | 'not_found'."""
+    pid = owner.get("pid")
+    if not isinstance(pid, int):
+        return "not_found"
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return "not_found"
+    except PermissionError:
+        pass
+    except OSError:
+        return "not_found"
+
+    if _get_process_state_char(pid) == "Z":
+        return "zombie"
+
+    current_start = _get_process_start_time(pid)
+    recorded_start = owner.get("process_start_time")
+    if current_start is not None and recorded_start != current_start:
+        return "reused"
+    return "alive"
+
+
+_WORKTREE_SCAN_MAX_ENTRIES = 5000
+_WORKTREE_SCAN_MAX_DEPTH = 8
+
+
+def _get_worktree_last_active(path):
+    """Dernière activité du worktree, avec refus conservateur d'un scan partiel.
+
+    Ne lit aucun contenu et ne suit aucun symlink. Si la profondeur ou le
+    nombre maximal d'entrées empêche un scan complet, retourne l'instant
+    courant : le worktree est alors considéré actif et le reclaim est refusé.
+    """
+    if not path:
+        return None
+    root = Path(path)
+    try:
+        last = os.stat(root, follow_symlinks=False).st_mtime
+    except OSError:
+        return None
+
+    remaining = [_WORKTREE_SCAN_MAX_ENTRIES]
+    scan_complete = [True]
+
+    def _scan(dir_path, depth):
+        nonlocal last
+        if depth > _WORKTREE_SCAN_MAX_DEPTH:
+            scan_complete[0] = False
+            return
+        try:
+            with os.scandir(dir_path) as it:
+                for entry in it:
+                    if remaining[0] <= 0:
+                        scan_complete[0] = False
+                        return
+                    remaining[0] -= 1
+                    try:
+                        st = entry.stat(follow_symlinks=False)
+                    except OSError:
+                        scan_complete[0] = False
+                        continue
+                    if st.st_mtime > last:
+                        last = st.st_mtime
+                    if entry.is_dir(follow_symlinks=False):
+                        _scan(entry.path, depth + 1)
+        except OSError:
+            scan_complete[0] = False
+
+    _scan(root, 0)
+    return time.time() if not scan_complete[0] else last
+
+
+def evaluate_reclaim(now, owner, process_state, worktree_last_active):
+    """Fonction pure : décide si un lock détenu par `owner` est réclamable.
+
+    Réclamable seulement si le processus n'est PAS vivant, le TTL basé sur
+    heartbeat est expiré, ET le worktree n'a pas été touché récemment.
+    """
+    ttl_seconds = owner["ttl_hours"] * 3600
+    heartbeat_age = now - owner["heartbeat_at"]
+    ttl_expired = heartbeat_age > ttl_seconds
+    worktree_active = (
+        worktree_last_active is not None
+        and (now - worktree_last_active) < WORKTREE_ACTIVE_SECONDS
+    )
+    process_stale = process_state in ("zombie", "reused", "not_found")
+    reclaimable = process_stale and ttl_expired and not worktree_active
+    return {
+        "reclaimable": reclaimable,
+        "process_stale": process_stale,
+        "ttl_expired": ttl_expired,
+        "worktree_active": worktree_active,
+    }
+
+
+def _canonical_worktree(worktree):
+    return os.path.realpath(str(worktree))
+
+
+def _build_owner(agent, session, worktree, ttl_hours, now, profile=None, gateway_session_key=None):
+    pid = os.getpid()
+    owner = {
+        "host": socket.gethostname(),
+        "agent": agent,
+        "session_id": session,
+        "pid": pid,
+        "process_start_time": _get_process_start_time(pid),
+        "started_at": now,
+        "heartbeat_at": now,
+        "ttl_hours": ttl_hours,
+        "worktree": _canonical_worktree(worktree),
+    }
+    if profile:
+        owner["profile"] = profile
+    if gateway_session_key:
+        owner["gateway_session_key"] = gateway_session_key
+    return owner
+
+
+def _is_same_session(owner, agent, session):
+    return owner.get("agent") == agent and owner.get("session_id") == session
+
+
+def _iter_owner_files(locks_root):
+    if not locks_root.exists() or locks_root.is_symlink():
+        return []
+    try:
+        entries = sorted(locks_root.iterdir())
+    except OSError:
+        return []
+    owner_files = []
+    for lock_dir in entries:
+        if lock_dir.is_symlink() or not lock_dir.is_dir():
+            continue
+        owner_file = lock_dir / "owner.json"
+        if owner_file.exists() and not owner_file.is_symlink():
+            owner_files.append((lock_dir.name, owner_file))
+    return owner_files
+
+
+def _find_worktree_claim(locks_root, worktree_real):
+    for key, owner_file in _iter_owner_files(locks_root):
+        owner = _read_json(owner_file)
+        claimed = owner.get("worktree")
+        if claimed and _canonical_worktree(claimed) == worktree_real:
+            return key, owner, owner_file
+    return None
+
+
+def _can_reclaim_owner(now, owner):
+    process_state = determine_process_state(owner)
+    worktree_last_active = _get_worktree_last_active(owner.get("worktree"))
+    verdict = evaluate_reclaim(
+        now=now,
+        owner=owner,
+        process_state=process_state,
+        worktree_last_active=worktree_last_active,
+    )
+    return verdict["reclaimable"]
+
+
+def _unlink_owner(owner_file):
+    with contextlib.suppress(FileNotFoundError):
+        owner_file.unlink()
+    _fsync_dir(owner_file.parent)
+
+
+def _git_dirty(repo):
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain=v1"],
+            cwd=str(repo), capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    return bool(result.stdout.strip())
+
+
+# --------------------------------------------------------------------------
+# Commandes
+# --------------------------------------------------------------------------
+
+def cmd_preflight(root, key, as_json):
+    validate_key(key)
+    lanes_dir = _safe_subdir(root, "lanes")
+    locks_root = _safe_subdir(root, "locks")
+    lane_file = lanes_dir / f"{key}.jsonl"
+
+    if lane_file.exists():
+        events = _read_all_events(lane_file)
+        status = _compute_status(events)
+    else:
+        status = "unclaimed"
+
+    owner_file = locks_root / key / "owner.json"
+    payload = {"key": key, "status": status, "active": owner_file.exists()}
+    if as_json:
+        print(json.dumps(payload))
+    else:
+        print(f"{key}: {status}")
+    return 0
+
+
+def _validate_ttl_hours(ttl_hours):
+    if not isinstance(ttl_hours, (int, float)) or isinstance(ttl_hours, bool):
+        raise RegistryError(f"invalid ttl-hours: {ttl_hours!r}")
+    if not math.isfinite(ttl_hours) or ttl_hours <= 0:
+        raise RegistryError(f"invalid ttl-hours: {ttl_hours!r}")
+
+
+def _claim_under_gate(root, key, agent, session, worktree, reclaim, ttl_hours,
+                      profile=None, gateway_session_key=None):
+    validate_key(key)
+    _validate_ttl_hours(ttl_hours)
+    lanes_dir = _safe_subdir(root, "lanes")
+    locks_root = _safe_subdir(root, "locks")
+    worktree_real = _canonical_worktree(worktree)
+
+    lock_dir = locks_root / key
+    if lock_dir.is_symlink():
+        raise RegistryError(f"lock directory must not be a symlink: {lock_dir}")
+    lock_dir.mkdir(parents=True, exist_ok=True)
+
+    owner_file = lock_dir / "owner.json"
+    lane_file = lanes_dir / f"{key}.jsonl"
+    lock_file = lock_dir / ".lock"
+    gate_file = root / ".worktree-admission.lock"
+
+    with _locked(gate_file), _locked(lock_file):
+        now = time.time()
+        if owner_file.exists():
+            owner = _read_json(owner_file)
+            if _is_same_session(owner, agent, session):
+                owner["heartbeat_at"] = now
+                owner["worktree"] = worktree_real
+                _write_owner(owner_file, owner)
+                return 0
+
+            if not reclaim:
+                raise RegistryError(
+                    f"lane {key} already claimed by "
+                    f"{owner.get('agent')}/{owner.get('session_id')}"
+                )
+
+            if not _can_reclaim_owner(now, owner):
+                raise RegistryError(
+                    f"lane {key} owner still active, refusing --reclaim"
+                )
+
+            previous_agent = owner.get("agent")
+            previous_session = owner.get("session_id")
+            new_owner = _build_owner(
+                agent, session, worktree_real, ttl_hours, now,
+                profile=profile, gateway_session_key=gateway_session_key,
+            )
+            _write_owner(owner_file, new_owner)
+            _append_event(lane_file, key, "lock_reclaimed", extra={
+                "previous_agent": previous_agent,
+                "previous_session": previous_session,
+            })
+            return 0
+
+        conflict = _find_worktree_claim(locks_root, worktree_real)
+        if conflict is not None:
+            conflict_key, conflict_owner, conflict_owner_file = conflict
+            if conflict_key != key:
+                if not reclaim:
+                    raise RegistryError(
+                        f"worktree already claimed by {conflict_key} "
+                        f"{conflict_owner.get('agent')}/{conflict_owner.get('session_id')}"
+                    )
+                if not _can_reclaim_owner(now, conflict_owner):
+                    raise RegistryError(
+                        f"worktree already claimed by active owner {conflict_key}"
+                    )
+                _unlink_owner(conflict_owner_file)
+
+        new_owner = _build_owner(
+            agent, session, worktree_real, ttl_hours, now,
+            profile=profile, gateway_session_key=gateway_session_key,
+        )
+        _write_owner(owner_file, new_owner)
+        _append_event(lane_file, key, "lane_claimed")
+        return 0
+
+
+def cmd_claim(root, key, agent, session, worktree, reclaim, ttl_hours,
+              profile=None, gateway_session_key=None):
+    return _claim_under_gate(
+        root, key, agent, session, worktree, reclaim, ttl_hours,
+        profile=profile, gateway_session_key=gateway_session_key,
+    )
+
+
+def _lane_prefix(key):
+    return key.split("-", 1)[0]
+
+
+def _validate_profile_domain(key, profile, domain_prefixes):
+    if not profile or not domain_prefixes:
+        return
+    allowed = {part.strip() for part in domain_prefixes.split(",") if part.strip()}
+    if allowed and _lane_prefix(key) not in allowed:
+        raise RegistryError(f"profile {profile} cannot own lane {key}")
+
+
+def cmd_admit(root, key, mode, hard, agent, session, worktree, ttl_hours,
+              as_json=False, profile=None, gateway_session_key=None,
+              domain_prefixes=None):
+    validate_key(key)
+    _validate_ttl_hours(ttl_hours)
+    locks_root = _safe_subdir(root, "locks")
+    _safe_subdir(root, "lanes")
+    worktree_real = _canonical_worktree(worktree)
+    gate_file = root / ".worktree-admission.lock"
+
+    with _locked(gate_file):
+        conflict = _find_worktree_claim(locks_root, worktree_real)
+        if mode == "reviewer":
+            payload = {
+                "key": key,
+                "worktree": worktree_real,
+                "decision": "reviewer_allowed",
+            }
+            if conflict:
+                payload["owner_key"] = conflict[0]
+                payload["owner_agent"] = conflict[1].get("agent")
+                payload["owner_session"] = conflict[1].get("session_id")
+            if as_json:
+                print(json.dumps(payload, sort_keys=True))
+            return 0
+
+        _validate_profile_domain(key, profile, domain_prefixes)
+        if hard and conflict is None and _git_dirty(worktree_real):
+            raise RegistryError(f"dirty ownerless worktree: {worktree_real}")
+
+    return _claim_under_gate(
+        root, key, agent, session, worktree_real, False, ttl_hours,
+        profile=profile, gateway_session_key=gateway_session_key,
+    )
+
+
+def cmd_event(root, key, event_name, evidence, pr, commit=None, ci=None, deploy=None):
+    validate_key(key)
+    lanes_dir = _safe_subdir(root, "lanes")
+    locks_root = _safe_subdir(root, "locks")
+
+    if event_name not in ALLOWED_MANUAL_EVENTS:
+        raise RegistryError(f"unknown event: {event_name!r}")
+    if evidence is not None:
+        _validate_evidence(evidence)
+    if commit is not None:
+        _validate_metadata_field(commit, "commit")
+    if ci is not None:
+        _validate_metadata_field(ci, "ci")
+    if deploy is not None:
+        _validate_metadata_field(deploy, "deploy")
+    if pr is not None:
+        _validate_metadata_field(pr, "pr")
+    if event_name == "pr_opened" and not pr:
+        raise RegistryError("pr_opened requires --pr")
+
+    lock_dir = locks_root / key
+    owner_file = lock_dir / "owner.json"
+    lane_file = lanes_dir / f"{key}.jsonl"
+
+    if not owner_file.exists():
+        raise RegistryError(f"no active claim for lane {key}")
+
+    lock_file = lock_dir / ".lock"
+    with _locked(lock_file):
+        if not owner_file.exists():
+            raise RegistryError(f"no active claim for lane {key}")
+        owner = _read_json(owner_file)
+        owner["heartbeat_at"] = time.time()
+        _write_owner(owner_file, owner)
+
+        extra = {}
+        if evidence is not None:
+            extra["evidence"] = evidence
+        if pr is not None:
+            extra["pr"] = pr
+        if commit is not None:
+            extra["commit"] = commit
+        if ci is not None:
+            extra["ci"] = ci
+        if deploy is not None:
+            extra["deploy"] = deploy
+        _append_event(lane_file, key, event_name, extra=extra)
+    return 0
+
+
+def cmd_handoff(root, key, status, next_step, evidence):
+    validate_key(key)
+    if status not in ALLOWED_HANDOFF_STATUS:
+        raise RegistryError(f"unknown handoff status: {status!r}")
+    if "\n" in next_step or "\r" in next_step:
+        raise RegistryError("next-step must not contain newlines")
+    if len(next_step) > MAX_NEXT_STEP_LEN:
+        raise RegistryError("next-step too long")
+    if _SECRET_PATTERN.search(next_step):
+        raise RegistryError("next-step looks like a secret and was rejected")
+    if evidence is not None:
+        _validate_evidence(evidence)
+
+    lanes_dir = _safe_subdir(root, "lanes")
+    locks_root = _safe_subdir(root, "locks")
+    handoffs_dir = _safe_subdir(root, "handoffs")
+
+    lock_dir = locks_root / key
+    owner_file = lock_dir / "owner.json"
+    lane_file = lanes_dir / f"{key}.jsonl"
+
+    if not owner_file.exists():
+        raise RegistryError(f"no active claim for lane {key}")
+
+    lock_file = lock_dir / ".lock"
+    with _locked(lock_file):
+        if not owner_file.exists():
+            raise RegistryError(f"no active claim for lane {key}")
+
+        now = time.time()
+        ts_ms = int(now * 1000)
+        date_suffix = time.strftime("%Y-%m-%d", time.gmtime(now))
+        handoff_path = handoffs_dir / f"{key}-{date_suffix}.md"
+        if handoff_path.is_symlink():
+            raise RegistryError(f"handoff target must not be a symlink: {handoff_path}")
+        lines = [
+            f"# Handoff {key}",
+            f"Status: {status}",
+            f"Next step: {next_step}",
+        ]
+        if evidence is not None:
+            lines.append(f"Evidence: {evidence}")
+        lines.append(f"Timestamp: {ts_ms}")
+        content = "\n".join(lines) + "\n"
+
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(handoffs_dir), prefix=f".{key}-", suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, str(handoff_path))
+            _fsync_dir(handoffs_dir)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.remove(tmp_path)
+            raise
+
+        _append_event(lane_file, key, "handoff", extra={
+            "status": status, "handoff_file": handoff_path.name,
+        })
+    return 0
+
+
+def cmd_render(root):
+    lanes_dir = _safe_subdir(root, "lanes")
+    locks_root = _safe_subdir(root, "locks")
+
+    entries = []
+    for lane_file in sorted(lanes_dir.glob("*.jsonl")):
+        key = lane_file.stem
+        events = _read_all_events(lane_file)
+        owner_file = locks_root / key / "owner.json"
+        if not owner_file.exists():
+            continue
+        entries.append((key, _compute_status(events)))
+
+    lines = ["# LANES", ""]
+    if not entries:
+        lines.append("_No active lanes._")
+    else:
+        lines.append("| Key | Status |")
+        lines.append("|-----|--------|")
+        for key, status in entries:
+            lines.append(f"| {key} | {status} |")
+    content = "\n".join(lines) + "\n"
+
+    lanes_md = root / "LANES.md"
+    _reject_symlink(lanes_md, "LANES.md")
+    fd, tmp_path = tempfile.mkstemp(dir=str(root), prefix=".LANES-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_path, 0o644)
+        os.replace(tmp_path, str(lanes_md))
+        _fsync_dir(root)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.remove(tmp_path)
+        raise
+    return 0
+
+
+def cmd_close(root, key):
+    validate_key(key)
+    lanes_dir = _safe_subdir(root, "lanes")
+    locks_root = _safe_subdir(root, "locks")
+
+    lock_dir = locks_root / key
+    owner_file = lock_dir / "owner.json"
+    lane_file = lanes_dir / f"{key}.jsonl"
+
+    if not owner_file.exists():
+        raise RegistryError(f"no active claim for lane {key}")
+
+    lock_file = lock_dir / ".lock"
+    with _locked(lock_file):
+        if not owner_file.exists():
+            raise RegistryError(f"no active claim for lane {key}")
+        _append_event(lane_file, key, "lane_closed")
+        owner_file.unlink()
+        _fsync_dir(lock_dir)
+    return 0
+
+
+# --------------------------------------------------------------------------
+# Context pack (HER-55 Scope A) — Hermes -> Claude Code
+# --------------------------------------------------------------------------
+
+def _lane_status(root, key):
+    """Statut de lane courant, sans effet de bord (aucune création de dossier)."""
+    lane_file = root / "lanes" / f"{key}.jsonl"
+    if not lane_file.exists():
+        return "unclaimed"
+    try:
+        events = _read_all_events(lane_file)
+    except RegistryError:
+        return "unclaimed"
+    return _compute_status(events)
+
+
+def _load_context_map(path):
+    """Charge `context-map.json`. Toute anomalie (absent, symlink, corrompu)
+    dégrade silencieusement vers "aucun repo mappé", jamais une exception :
+    un repo mal mappé doit se comporter comme un repo inconnu, pas planter."""
+    path = Path(path)
+    try:
+        if path.is_symlink() or not path.exists():
+            return {}
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    repos = data.get("repos")
+    if not isinstance(repos, dict):
+        return {}
+    return repos
+
+
+def _is_blocked_vault_path(relpath):
+    """Défense en profondeur : blocage même si `allow_files` liste le chemin."""
+    if not isinstance(relpath, str) or not relpath:
+        return True
+    posix = relpath.replace(os.sep, "/").lstrip("/")
+    basename = posix.rsplit("/", 1)[-1]
+    if basename == ".env" or basename.startswith(".env"):
+        return True
+    if _SECRET_PATTERN.search(posix):
+        return True
+    return any(
+        posix == prefix.rstrip("/") or posix.startswith(prefix)
+        for prefix in _VAULT_BLOCKED_DIR_PREFIXES
+    )
+
+
+def _read_vault_file_safely(vault_root, relpath):
+    """Lit un fichier du vault sans jamais suivre un symlink ni sortir de
+    `vault_root`. Retourne None (jamais une exception) sur toute anomalie."""
+    if not isinstance(relpath, str) or not relpath or relpath.startswith("/"):
+        return None
+    target = vault_root / relpath
+    try:
+        _reject_symlink_ancestors(target)
+        if target.is_symlink():
+            return None
+        resolved = target.resolve(strict=True)
+        resolved.relative_to(vault_root)
+    except (OSError, ValueError, RegistryError):
+        return None
+    try:
+        fd = _open_secure(resolved, os.O_RDONLY)
+    except (OSError, RegistryError):
+        return None
+    try:
+        with os.fdopen(fd, "r", encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except OSError:
+        return None
+
+
+def _filter_markdown_sections(content, allow_sections):
+    """Ne garde que les sections `## Titre` explicitement autorisées.
+
+    Liste vide -> aucune restriction (fichier entier)."""
+    if not allow_sections:
+        return content
+    allowed = set(allow_sections)
+    kept = []
+    keep = False
+    for line in content.splitlines():
+        if line.startswith("## "):
+            keep = line in allowed
+        if keep:
+            kept.append(line)
+    return "\n".join(kept)
+
+
+def _linear_cache_banner(root, key):
+    """Bannière missing/stale sans jamais planter ; None si cache frais."""
+    cache_path = root / "linear-cache" / f"{key}.json"
+    try:
+        if cache_path.is_symlink() or not cache_path.exists():
+            return f"> Linear cache MISSING for {key}."
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return f"> Linear cache MISSING or unreadable for {key}."
+
+    cached_at = data.get("cached_at")
+    if not isinstance(cached_at, (int, float)) or isinstance(cached_at, bool):
+        return f"> Linear cache STALE for {key} (no cached_at)."
+
+    age_hours = (time.time() - cached_at) / 3600
+    if age_hours > LINEAR_CACHE_STALE_HOURS:
+        return f"> Linear cache STALE for {key} ({age_hours:.1f}h old)."
+
+    title = data.get("title")
+    if isinstance(title, str) and title:
+        return f"Linear: {key} — {title}"
+    return f"Linear cache: fresh for {key}."
+
+
+def _render_unmapped_brief(key, repo_real, status):
+    lines = [
+        f"# Context Claude Code — {key}",
+        UNMAPPED_REPO_MARKER,
+        f"Repo: {repo_real}",
+        f"Lane status: {status}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _render_mapped_pack(key, repo_real, status, root, vault_root, entry):
+    allow_files = entry.get("allow_files") or []
+    allow_sections = entry.get("allow_sections") or []
+
+    lines = [
+        f"# Context Claude Code — {key}",
+        f"Repo: {repo_real}",
+        f"Lane status: {status}",
+    ]
+    banner = _linear_cache_banner(root, key)
+    if banner:
+        lines.append(banner)
+    lines.append("")
+
+    for relpath in allow_files:
+        if _is_blocked_vault_path(relpath):
+            continue
+        raw = _read_vault_file_safely(vault_root, relpath)
+        if raw is None:
+            continue
+        filtered = _filter_markdown_sections(raw, allow_sections)
+        if not filtered.strip():
+            continue
+        lines.append(f"## Fichier: {relpath}")
+        lines.extend(filtered.splitlines())
+        lines.append("")
+
+    content = "\n".join(lines).rstrip("\n") + "\n"
+    body_lines = content.splitlines()
+    if len(body_lines) > CONTEXT_PACK_MAX_LINES:
+        body_lines = body_lines[: CONTEXT_PACK_MAX_LINES - 1] + ["_(pack tronqué à 300 lignes)_"]
+        content = "\n".join(body_lines) + "\n"
+    return content
+
+
+def _write_context_output(out_path, content):
+    out_path = Path(out_path)
+    _reject_symlink_ancestors(out_path)
+    if out_path.is_symlink():
+        raise RegistryError(f"context output must not be a symlink: {out_path}")
+    parent = out_path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    if parent.is_symlink():
+        raise RegistryError(f"context output directory must not be a symlink: {parent}")
+
+    fd, tmp_path = tempfile.mkstemp(dir=str(parent), prefix=".context-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, str(out_path))
+        _fsync_dir(parent)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.remove(tmp_path)
+        raise
+
+
+def _path_is_within(path, root):
+    try:
+        Path(path).relative_to(Path(root))
+        return True
+    except ValueError:
+        return False
+
+
+def cmd_context(root, key, repo, vault, context_map_arg, out_arg):
+    validate_key(key)
+    repo_real = os.path.realpath(repo)
+    registry_output_root = root / "contexts"
+    repo_output_root = Path(repo_real) / ".factory"
+    out_path = Path(out_arg) if out_arg else registry_output_root / f"{key}.md"
+    output_parent_real = Path(os.path.realpath(str(out_path.parent)))
+    allowed_output_roots = (
+        Path(os.path.realpath(str(registry_output_root))),
+        Path(os.path.realpath(str(repo_output_root))),
+    )
+    if not any(
+        _path_is_within(output_parent_real, allowed_root)
+        for allowed_root in allowed_output_roots
+    ):
+        raise RegistryError(
+            "context output must stay inside registry contexts or repo .factory"
+        )
+
+    context_map_path = Path(context_map_arg) if context_map_arg else root / "context-map.json"
+    repos_map = _load_context_map(context_map_path)
+    entry = repos_map.get(repo_real)
+    status = _lane_status(root, key)
+
+    if entry is None:
+        # Repo inconnu : aucun accès au vault, pas même `os.path.realpath`.
+        content = _render_unmapped_brief(key, repo_real, status)
+        _write_context_output(out_path, content)
+        return 0
+
+    vault_root = Path(os.path.realpath(vault))
+    content = _render_mapped_pack(key, repo_real, status, root, vault_root, entry)
+    _write_context_output(out_path, content)
+    return 0
+
+
+# --------------------------------------------------------------------------
+# Capture handoff (HER-55 Scope B) — Claude Code -> Hermes
+# --------------------------------------------------------------------------
+
+MAX_GIT_STATUS_ENTRIES = 5000
+MAX_SUMMARY_TEXT_LEN = 1000
+MAX_SUMMARY_BYTES = 64 * 1024
+MAX_SUMMARY_NODES = 256
+MAX_SUMMARY_DEPTH = 8
+MAX_SUMMARY_CONTAINER_ITEMS = 128
+MAX_HANDOFF_BYTES = 1024 * 1024
+SUMMARY_ALLOWED_KEYS = frozenset({
+    "tests", "decisions", "blockers", "next_step", "pr", "ci",
+})
+
+
+def _run_git(repo_real, *args, timeout=10):
+    try:
+        return subprocess.run(
+            ["git", *args], cwd=str(repo_real), capture_output=True, text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RegistryError(f"git {' '.join(args)} failed: {exc}") from exc
+
+
+def _git_toplevel(repo_path):
+    result = _run_git(repo_path, "rev-parse", "--show-toplevel")
+    if result.returncode != 0:
+        raise RegistryError(f"--repo is not a git worktree: {repo_path}")
+    return os.path.realpath(result.stdout.strip())
+
+
+def _git_current_branch(repo_real):
+    result = _run_git(repo_real, "rev-parse", "--abbrev-ref", "HEAD")
+    if result.returncode != 0:
+        raise RegistryError("failed to determine current branch")
+    return result.stdout.strip()
+
+
+def _git_head_commit(repo_real):
+    result = _run_git(repo_real, "rev-parse", "HEAD")
+    if result.returncode != 0:
+        raise RegistryError("failed to determine HEAD commit")
+    return result.stdout.strip()
+
+
+def _git_ref_exists(repo_real, ref):
+    result = _run_git(repo_real, "rev-parse", "--verify", "--quiet", ref)
+    return result.returncode == 0
+
+
+def _git_base_commit(repo_real, branch):
+    """merge-base avec `main` si elle existe et diffère de `branch`, sinon
+    commit racine (premier commit de l'historique)."""
+    if branch and branch != "main" and _git_ref_exists(repo_real, "main"):
+        result = _run_git(repo_real, "merge-base", branch, "main")
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    result = _run_git(repo_real, "rev-list", "--max-parents=0", "HEAD")
+    if result.returncode == 0:
+        lines = [line for line in result.stdout.splitlines() if line.strip()]
+        if lines:
+            return lines[0]
+    raise RegistryError("unable to determine base commit")
+
+
+def _git_status_entries(repo_real):
+    """Chemins + codes de statut seulement — jamais de contenu ni de diff.
+
+    Le format NUL de porcelain v1 préserve les espaces, guillemets et la
+    sous-chaîne littérale ` -> `. Pour rename/copy, Git place la destination
+    dans le premier record et la source dans le record NUL suivant."""
+    result = _run_git(repo_real, "status", "--porcelain=v1", "-z")
+    if result.returncode != 0:
+        raise RegistryError("failed to read git status")
+    records = result.stdout.split("\0")
+    entries = []
+    index = 0
+    while index < len(records):
+        record = records[index]
+        index += 1
+        if not record:
+            continue
+        if len(entries) >= MAX_GIT_STATUS_ENTRIES:
+            raise RegistryError("too many git status entries to capture safely")
+        if len(record) < 3:
+            raise RegistryError("malformed git status record")
+        code = record[:2]
+        path = record[3:] if record[2:3] == " " else record[2:]
+        if "R" in code or "C" in code:
+            if index >= len(records) or not records[index]:
+                raise RegistryError("malformed git rename/copy status record")
+            index += 1  # source path; destination is the first path in -z mode
+        entries.append({"path": path, "status": code})
+    return entries
+
+
+def _validate_summary_text(value, label):
+    if len(value) > MAX_SUMMARY_TEXT_LEN:
+        raise RegistryError(f"summary field {label} too long")
+    if "\n" in value or "\r" in value:
+        raise RegistryError(f"summary field {label} must not contain newlines")
+    if _SECRET_PATTERN.search(value):
+        raise RegistryError(f"summary field {label} looks like a secret and was rejected")
+
+
+def _validate_summary_value(label, value, depth=0, budget=None):
+    if budget is None:
+        budget = [0]
+    budget[0] += 1
+    if budget[0] > MAX_SUMMARY_NODES:
+        raise RegistryError("summary has too many nodes")
+    if depth > MAX_SUMMARY_DEPTH:
+        raise RegistryError("summary is nested too deeply")
+    if isinstance(value, str):
+        _validate_summary_text(value, label)
+        return value
+    if value is None or isinstance(value, bool) or isinstance(value, (int, float)):
+        return value
+    if isinstance(value, list):
+        if len(value) > MAX_SUMMARY_CONTAINER_ITEMS:
+            raise RegistryError(f"summary field {label} has too many items")
+        return [
+            _validate_summary_value(f"{label}[]", item, depth + 1, budget)
+            for item in value
+        ]
+    if isinstance(value, dict):
+        if len(value) > MAX_SUMMARY_CONTAINER_ITEMS:
+            raise RegistryError(f"summary field {label} has too many entries")
+        result = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise RegistryError(f"summary field {label} has a non-string key")
+            _validate_summary_text(key, f"{label}.key")
+            result[key] = _validate_summary_value(
+                f"{label}.{key}", item, depth + 1, budget
+            )
+        return result
+    raise RegistryError(f"summary field {label} has an unsupported type")
+
+
+def _load_summary(summary_path):
+    path = Path(summary_path)
+    if path.is_symlink():
+        raise RegistryError(f"summary path must not be a symlink: {path}")
+    if not path.exists() or not path.is_file():
+        raise RegistryError(f"summary path is not a regular file: {path}")
+
+    fd = _open_secure(path, os.O_RDONLY)
+    with os.fdopen(fd, "r", encoding="utf-8") as f:
+        if os.fstat(f.fileno()).st_size > MAX_SUMMARY_BYTES:
+            raise RegistryError("summary JSON is too large")
+        raw = f.read(MAX_SUMMARY_BYTES + 1)
+    if len(raw.encode("utf-8")) > MAX_SUMMARY_BYTES:
+        raise RegistryError("summary JSON is too large")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RegistryError(f"summary is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RegistryError("summary must be a JSON object")
+
+    unknown = set(data.keys()) - SUMMARY_ALLOWED_KEYS
+    if unknown:
+        raise RegistryError(f"summary has unsupported keys: {sorted(unknown)}")
+    budget = [0]
+    return {
+        k: _validate_summary_value(k, v, depth=0, budget=budget)
+        for k, v in data.items()
+    }
+
+
+def _serialize_handoff(payload):
+    content = json.dumps(payload, sort_keys=True) + "\n"
+    if len(content.encode("utf-8")) > MAX_HANDOFF_BYTES:
+        raise RegistryError("handoff JSON is too large")
+    return content
+
+
+def cmd_capture_handoff(root, key, repo, summary_path):
+    validate_key(key)
+    lanes_dir = _safe_subdir(root, "lanes")
+    locks_root = _safe_subdir(root, "locks")
+    handoffs_dir = _safe_subdir(root, "handoffs")
+
+    lock_dir = locks_root / key
+    owner_file = lock_dir / "owner.json"
+    lane_file = lanes_dir / f"{key}.jsonl"
+
+    if not owner_file.exists():
+        raise RegistryError(f"no active claim for lane {key}")
+
+    summary_fields = {}
+    if summary_path is not None:
+        summary_fields = _load_summary(summary_path)
+
+    lock_file = lock_dir / ".lock"
+    with _locked(lock_file):
+        if not owner_file.exists():
+            raise RegistryError(f"no active claim for lane {key}")
+        owner = _read_json(owner_file)
+
+        repo_real = _git_toplevel(repo)
+        claimed_worktree = owner.get("worktree")
+        if claimed_worktree and os.path.realpath(claimed_worktree) != repo_real:
+            raise RegistryError(
+                f"--repo {repo_real} does not match claimed worktree {claimed_worktree}"
+            )
+
+        branch = _git_current_branch(repo_real)
+        head_sha = _git_head_commit(repo_real)
+        base_commit = _git_base_commit(repo_real, branch)
+        git_status = _git_status_entries(repo_real)
+        files_changed = sorted({entry["path"] for entry in git_status if entry["path"]})
+
+        now = time.time()
+        date_suffix = time.strftime("%Y-%m-%d", time.gmtime(now))
+        handoff_path = handoffs_dir / f"{key}-{date_suffix}.handoff.json"
+        if handoff_path.is_symlink():
+            raise RegistryError(f"handoff target must not be a symlink: {handoff_path}")
+
+        payload = {
+            "issue": key,
+            "agent": owner.get("agent"),
+            "session_id": owner.get("session_id"),
+            "repo": repo_real,
+            "worktree": repo_real,
+            "branch": branch,
+            "base_commit": base_commit,
+            "head_commit": head_sha,
+            "git_status": git_status,
+            "files_changed": files_changed,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)),
+        }
+        payload.update(summary_fields)
+
+        content = _serialize_handoff(payload)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(handoffs_dir), prefix=f".{key}-", suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, str(handoff_path))
+            _fsync_dir(handoffs_dir)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.remove(tmp_path)
+            raise
+
+        _append_event(lane_file, key, "handoff_captured", extra={
+            "handoff_file": handoff_path.name,
+        })
+    return 0
+
+
+# --------------------------------------------------------------------------
+# Réconciliation Claude -> Hermes + hooks Claude Code (HER-55 Scope B suite)
+# --------------------------------------------------------------------------
+
+RECONCILE_STALE_HOURS = 24.0
+
+
+def _git_toplevel_or_none(repo_path, timeout=5):
+    """Comme `_git_toplevel` mais ne lève jamais : `None` sur tout échec
+    (binaire git absent, timeout, pas un dépôt Git). Usage exclusif hooks
+    fail-open — `reconcile` reste fail-closed via `_git_toplevel`."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(repo_path), capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    if not out:
+        return None
+    try:
+        return os.path.realpath(out)
+    except OSError:
+        return None
+
+
+def _find_claim_for_worktree(root, repo_real):
+    """Cherche un `owner.json` actif dont le worktree realpath correspond à
+    `repo_real`. Retourne `(key, owner)` ou `None`. Tolère toute entrée
+    corrompue/symlinkée en la sautant plutôt qu'en levant."""
+    locks_root = root / "locks"
+    if not locks_root.exists() or locks_root.is_symlink():
+        return None
+    try:
+        entries = sorted(locks_root.iterdir())
+    except OSError:
+        return None
+    for lock_dir in entries:
+        try:
+            if not lock_dir.is_dir() or lock_dir.is_symlink():
+                continue
+            owner_file = lock_dir / "owner.json"
+            if not owner_file.exists() or owner_file.is_symlink():
+                continue
+            owner = _read_json(owner_file)
+            worktree = owner.get("worktree")
+            if not worktree:
+                continue
+            if os.path.realpath(worktree) == repo_real:
+                return lock_dir.name, owner
+        except Exception:
+            continue
+    return None
+
+
+def _load_handoff(handoff_path, handoffs_dir):
+    path = Path(handoff_path)
+    _reject_symlink_ancestors(path)
+    if path.is_symlink():
+        raise RegistryError(f"handoff path must not be a symlink: {path}")
+    try:
+        resolved = path.resolve(strict=True)
+        resolved.relative_to(Path(handoffs_dir).resolve(strict=True))
+    except (OSError, ValueError) as exc:
+        raise RegistryError("handoff path must stay inside registry/handoffs") from exc
+    if not resolved.is_file():
+        raise RegistryError(f"handoff path is not a regular file: {resolved}")
+
+    fd = _open_secure(resolved, os.O_RDONLY)
+    with os.fdopen(fd, "r", encoding="utf-8") as f:
+        if os.fstat(f.fileno()).st_size > MAX_HANDOFF_BYTES:
+            raise RegistryError("handoff JSON is too large")
+        raw = f.read(MAX_HANDOFF_BYTES + 1)
+    if len(raw.encode("utf-8")) > MAX_HANDOFF_BYTES:
+        raise RegistryError("handoff JSON is too large")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RegistryError(f"handoff is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RegistryError("handoff must be a JSON object")
+    return data
+
+
+def _parse_handoff_timestamp(value):
+    """epoch seconds (int/float) ou ISO8601 UTC `%Y-%m-%dT%H:%M:%SZ`.
+    Toute autre forme -> `None` (traité comme périmé, jamais comme frais)."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return calendar.timegm(time.strptime(value, "%Y-%m-%dT%H:%M:%SZ"))
+        except ValueError:
+            return None
+    return None
+
+
+def _test_entry_has_artifact(entry, repo_real):
+    """Une déclaration de test ne compte comme preuve que si elle est verte et
+    pointe vers un artefact régulier sous `<repo>/.factory/test-artifacts/`.
+    Les fichiers système, chemins externes et symlinks ne valent jamais preuve."""
+    if not isinstance(entry, dict):
+        return False
+    if entry.get("result") != "pass":
+        return False
+    artifact_path = entry.get("artifact_path")
+    if not isinstance(artifact_path, str) or not artifact_path:
+        return False
+    try:
+        p = Path(artifact_path)
+        _reject_symlink_ancestors(p)
+        if p.is_symlink() or not p.is_file():
+            return False
+        resolved = p.resolve(strict=True)
+        allowed_root = (Path(repo_real) / ".factory" / "test-artifacts").resolve(strict=False)
+        resolved.relative_to(allowed_root)
+        return True
+    except (OSError, ValueError, RegistryError):
+        return False
+
+
+def _evaluate_handoff(repo_real, owner, handoff):
+    """Fonction pure (hors accès Git en lecture seule) : verdict fermé +
+    raisons. Priorité conflicting > stale > partial > verified."""
+    reasons = []
+
+    if handoff.get("agent") != owner.get("agent"):
+        reasons.append("agent_mismatch")
+    if handoff.get("session_id") != owner.get("session_id"):
+        reasons.append("session_mismatch")
+
+    claimed_worktree = owner.get("worktree")
+    handoff_worktree = handoff.get("worktree")
+    worktree_ok = (
+        isinstance(handoff_worktree, str)
+        and bool(claimed_worktree)
+        and os.path.realpath(handoff_worktree) == os.path.realpath(claimed_worktree)
+    )
+    if not worktree_ok:
+        reasons.append("worktree_mismatch")
+
+    try:
+        actual_branch = _git_current_branch(repo_real)
+    except RegistryError:
+        actual_branch = None
+    if actual_branch is None or handoff.get("branch") != actual_branch:
+        reasons.append("branch_mismatch")
+
+    try:
+        actual_head = _git_head_commit(repo_real)
+    except RegistryError:
+        actual_head = None
+    if actual_head is None or handoff.get("head_commit") != actual_head:
+        reasons.append("head_commit_mismatch")
+
+    conflicting = bool(reasons)
+
+    ts = _parse_handoff_timestamp(handoff.get("timestamp"))
+    stale = ts is None or (time.time() - ts) > (RECONCILE_STALE_HOURS * 3600)
+    if stale:
+        reasons.append("stale_timestamp")
+
+    tests = handoff.get("tests")
+    unproven_tests = isinstance(tests, list) and len(tests) > 0 and any(
+        not _test_entry_has_artifact(entry, repo_real) for entry in tests
+    )
+    if unproven_tests:
+        reasons.append("unproven_test_claim")
+
+    if conflicting:
+        verdict = "conflicting"
+    elif stale:
+        verdict = "stale"
+    elif unproven_tests:
+        verdict = "partial"
+    else:
+        verdict = "verified"
+
+    return verdict, reasons
+
+
+def cmd_reconcile(root, key, repo, handoff_path):
+    validate_key(key)
+    lanes_dir = _safe_subdir(root, "lanes")
+    locks_root = _safe_subdir(root, "locks")
+    handoffs_dir = _safe_subdir(root, "handoffs")
+
+    lock_dir = locks_root / key
+    owner_file = lock_dir / "owner.json"
+    lane_file = lanes_dir / f"{key}.jsonl"
+
+    if not owner_file.exists():
+        raise RegistryError(f"no active claim for lane {key}")
+
+    handoff = _load_handoff(handoff_path, handoffs_dir)
+
+    if handoff.get("issue") != key:
+        raise RegistryError(
+            f"handoff issue {handoff.get('issue')!r} does not match lane {key!r}"
+        )
+
+    repo_real = _git_toplevel(repo)
+
+    handoff_repo = handoff.get("repo")
+    if not isinstance(handoff_repo, str) or os.path.realpath(handoff_repo) != repo_real:
+        raise RegistryError("handoff repo does not match --repo")
+
+    handoff_canonical = handoff.get("canonical_repo")
+    if handoff_canonical is not None:
+        if not isinstance(handoff_canonical, str) or os.path.realpath(handoff_canonical) != repo_real:
+            raise RegistryError("handoff canonical_repo does not match --repo")
+
+    lock_file = lock_dir / ".lock"
+    with _locked(lock_file):
+        if not owner_file.exists():
+            raise RegistryError(f"no active claim for lane {key}")
+        owner = _read_json(owner_file)
+
+        verdict, reasons = _evaluate_handoff(repo_real, owner, handoff)
+
+        _append_event(lane_file, key, "reconciled", extra={
+            "verdict": verdict,
+            "reasons": reasons,
+            "handoff_head_commit": handoff.get("head_commit"),
+        })
+
+    payload = {
+        "key": key,
+        "issue": key,
+        "repo": repo_real,
+        "verdict": verdict,
+        "reasons": reasons,
+    }
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+def cmd_hook_session_start(root, repo, agent=None, session=None):
+    """`SessionStart` : silencieux hors repo suivi/sans claim, brief court
+    sinon. Fail-open strict : toute exception -> code 0 sans sortie."""
+    try:
+        repo_real = _git_toplevel_or_none(repo)
+        if repo_real is None:
+            return 0
+
+        match = _find_claim_for_worktree(root, repo_real)
+        if match is None:
+            return 0
+        key, owner = match
+
+        status = _lane_status(root, key)
+        if agent and session and not _is_same_session(owner, agent, session):
+            print(
+                "STOP: worktree already owned by "
+                f"{key} {owner.get('agent', '?')}/{owner.get('session_id', '?')} "
+                f"for {repo_real}"
+            )
+            return 0
+
+        lines = [
+            f"# Hermes — {key}",
+            f"Repo: {repo_real}",
+            f"Lane status: {status}",
+            f"Agent: {owner.get('agent', '?')}",
+        ]
+        print("\n".join(lines[:UNMAPPED_BRIEF_MAX_LINES]))
+        return 0
+    except Exception:
+        return 0
+
+
+def cmd_hook_stop(root, repo, key, summary_path=None):
+    """`Stop` : capture les faits Git objectifs (jamais transcript/contenu),
+    silencieux hors repo suivi/sans claim. Fail-open strict."""
+    try:
+        validate_key(key)
+
+        repo_real = _git_toplevel_or_none(repo)
+        if repo_real is None:
+            return 0
+
+        locks_root = root / "locks"
+        lock_dir = locks_root / key
+        owner_file = lock_dir / "owner.json"
+        if not owner_file.exists() or owner_file.is_symlink():
+            return 0
+
+        owner = _read_json(owner_file)
+        claimed_worktree = owner.get("worktree")
+        if not claimed_worktree or os.path.realpath(claimed_worktree) != repo_real:
+            return 0
+
+        branch = _git_current_branch(repo_real)
+        head_sha = _git_head_commit(repo_real)
+        git_status = _git_status_entries(repo_real)
+        files_changed = sorted({e["path"] for e in git_status if e["path"]})
+
+        payload = {
+            "issue": key,
+            "agent": owner.get("agent"),
+            "session_id": owner.get("session_id"),
+            "repo": repo_real,
+            "worktree": repo_real,
+            "branch": branch,
+            "head_commit": head_sha,
+            "git_status": git_status,
+            "files_changed": files_changed,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time())),
+        }
+
+        if summary_path is not None:
+            try:
+                payload.update(_load_summary(summary_path))
+            except RegistryError:
+                pass
+
+        handoffs_dir = root / "handoffs"
+        if handoffs_dir.is_symlink():
+            return 0
+        handoffs_dir.mkdir(parents=True, exist_ok=True)
+
+        capture_path = handoffs_dir / f"{key}-stop-{time.time_ns()}.json"
+        if capture_path.is_symlink():
+            return 0
+
+        content = _serialize_handoff(payload)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(handoffs_dir), prefix=f".{key}-stop-", suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, str(capture_path))
+            _fsync_dir(handoffs_dir)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.remove(tmp_path)
+            return 0
+
+        return 0
+    except Exception:
+        return 0
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+def _build_parser():
+    parser = argparse.ArgumentParser(prog="factory_lane")
+    parser.add_argument("--registry", required=True)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_preflight = sub.add_parser("preflight")
+    p_preflight.add_argument("key")
+    p_preflight.add_argument("--json", action="store_true")
+
+    p_claim = sub.add_parser("claim")
+    p_claim.add_argument("key")
+    p_claim.add_argument("--agent", required=True)
+    p_claim.add_argument("--session", required=True)
+    p_claim.add_argument("--worktree", required=True)
+    p_claim.add_argument("--reclaim", action="store_true")
+    p_claim.add_argument("--reclaim-worktree", action="store_true")
+    p_claim.add_argument("--ttl-hours", type=float, default=DEFAULT_TTL_HOURS)
+    p_claim.add_argument("--profile")
+    p_claim.add_argument("--gateway-session-key")
+
+    p_admit = sub.add_parser("admit")
+    p_admit.add_argument("key")
+    p_admit.add_argument("--mode", choices=("owner", "reviewer"), required=True)
+    p_admit.add_argument("--hard", action="store_true")
+    p_admit.add_argument("--agent", required=True)
+    p_admit.add_argument("--session", required=True)
+    p_admit.add_argument("--worktree", required=True)
+    p_admit.add_argument("--ttl-hours", type=float, default=DEFAULT_TTL_HOURS)
+    p_admit.add_argument("--json", action="store_true")
+    p_admit.add_argument("--profile")
+    p_admit.add_argument("--gateway-session-key")
+    p_admit.add_argument("--domain-prefixes")
+
+    p_event = sub.add_parser("event")
+    p_event.add_argument("key")
+    p_event.add_argument("event_name")
+    p_event.add_argument("--evidence")
+    p_event.add_argument("--pr")
+    p_event.add_argument("--commit")
+    p_event.add_argument("--ci")
+    p_event.add_argument("--deploy")
+
+    sub.add_parser("render")
+
+    p_handoff = sub.add_parser("handoff")
+    p_handoff.add_argument("key")
+    p_handoff.add_argument("--status", required=True)
+    p_handoff.add_argument("--next-step", required=True)
+    p_handoff.add_argument("--evidence")
+
+    p_close = sub.add_parser("close")
+    p_close.add_argument("key")
+
+    p_context = sub.add_parser("context")
+    p_context.add_argument("key")
+    p_context.add_argument("--repo", required=True)
+    p_context.add_argument("--vault", required=True)
+    p_context.add_argument("--context-map")
+    p_context.add_argument("--out")
+
+    p_capture_handoff = sub.add_parser("capture-handoff")
+    p_capture_handoff.add_argument("key")
+    p_capture_handoff.add_argument("--repo", required=True)
+    p_capture_handoff.add_argument("--summary")
+
+    p_reconcile = sub.add_parser("reconcile")
+    p_reconcile.add_argument("key")
+    p_reconcile.add_argument("--repo", required=True)
+    p_reconcile.add_argument("--handoff", required=True)
+
+    p_hook_session_start = sub.add_parser("hook-session-start")
+    p_hook_session_start.add_argument("--repo", required=True)
+    p_hook_session_start.add_argument("--agent")
+    p_hook_session_start.add_argument("--session")
+
+    p_hook_stop = sub.add_parser("hook-stop")
+    p_hook_stop.add_argument("--repo", required=True)
+    p_hook_stop.add_argument("--key", required=True)
+    p_hook_stop.add_argument("--summary")
+
+    return parser
+
+
+def main(argv=None):
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        root = _safe_registry_root(args.registry)
+        if args.command == "preflight":
+            return cmd_preflight(root, args.key, args.json)
+        if args.command == "claim":
+            return cmd_claim(
+                root, args.key, args.agent, args.session, args.worktree,
+                args.reclaim or args.reclaim_worktree, args.ttl_hours,
+                profile=args.profile, gateway_session_key=args.gateway_session_key,
+            )
+        if args.command == "admit":
+            return cmd_admit(
+                root, args.key, args.mode, args.hard, args.agent, args.session,
+                args.worktree, args.ttl_hours, as_json=args.json,
+                profile=args.profile,
+                gateway_session_key=args.gateway_session_key,
+                domain_prefixes=args.domain_prefixes,
+            )
+        if args.command == "event":
+            return cmd_event(
+                root, args.key, args.event_name, args.evidence, args.pr,
+                commit=args.commit, ci=args.ci, deploy=args.deploy,
+            )
+        if args.command == "render":
+            return cmd_render(root)
+        if args.command == "handoff":
+            return cmd_handoff(root, args.key, args.status, args.next_step, args.evidence)
+        if args.command == "close":
+            return cmd_close(root, args.key)
+        if args.command == "context":
+            return cmd_context(
+                root, args.key, args.repo, args.vault,
+                args.context_map, args.out,
+            )
+        if args.command == "capture-handoff":
+            return cmd_capture_handoff(root, args.key, args.repo, args.summary)
+        if args.command == "reconcile":
+            return cmd_reconcile(root, args.key, args.repo, args.handoff)
+        if args.command == "hook-session-start":
+            return cmd_hook_session_start(root, args.repo, args.agent, args.session)
+        if args.command == "hook-stop":
+            return cmd_hook_stop(root, args.repo, args.key, args.summary)
+        print(f"unknown command: {args.command}", file=sys.stderr)
+        return 1
+    except RegistryError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # fail-closed sur toute erreur inattendue
+        print(f"unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/factory_lane.py
+++ b/scripts/factory_lane.py
@@ -8,6 +8,7 @@ par répertoire atomique en `registry/locks/<KEY>/owner.json`, protégés par
 import argparse
 import calendar
 import contextlib
+import ctypes
 import errno
 import fcntl
 import json
@@ -89,6 +90,7 @@ def validate_key(key):
 
 
 _NOFOLLOW_FLAG = getattr(os, "O_NOFOLLOW", 0)
+_NONBLOCK_FLAG = getattr(os, "O_NONBLOCK", 0)
 
 # Alias système connus (macOS monte `/var`, `/tmp`, `/etc` comme symlinks vers
 # `/private/...`). Ce ne sont pas des symlinks créés par un attaquant dans un
@@ -145,6 +147,33 @@ def _safe_registry_root(path_str):
     return root
 
 
+def _readonly_registry_root(path_str):
+    """Inspect a registry root without creating it.
+
+    The runtime admission hook is read-only: an absent root is healthy and
+    advisory, while an existing but malformed or unreadable root is ambiguous
+    registry state and must be surfaced to the hook as a fail-closed error.
+    """
+    root = Path(path_str)
+    _reject_symlink_ancestors(root)
+    if root.is_symlink():
+        raise RegistryError(f"registry path must not be a symlink: {root}")
+    if not root.exists():
+        return None
+    if not root.is_dir():
+        raise RegistryError(f"registry path is not a directory: {root}")
+    try:
+        fd = _open_secure(root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    except OSError as exc:
+        raise RegistryError(f"registry root is unreadable: {root}: {exc}") from exc
+    try:
+        if not stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise RegistryError(f"registry path is not a directory: {root}")
+    finally:
+        os.close(fd)
+    return root
+
+
 def _safe_subdir(root, name):
     p = root / name
     if p.is_symlink():
@@ -188,7 +217,12 @@ def _locked(lock_path):
 
 
 def _read_json(path):
-    fd = _open_secure(path, os.O_RDONLY)
+    fd = _open_secure(path, os.O_RDONLY | _NONBLOCK_FLAG)
+    try:
+        _require_regular_fd(fd, str(path))
+    except BaseException:
+        os.close(fd)
+        raise
     with os.fdopen(fd, "r", encoding="utf-8") as f:
         return json.load(f)
 
@@ -220,7 +254,12 @@ def _parse_jsonl_lines(text, source):
 def _read_all_events(lane_file):
     """Lit le journal via ouverture secure no-follow + flock partagé (cohérent
     avec le flock exclusif utilisé pendant l'append)."""
-    fd = _open_secure(lane_file, os.O_RDONLY)
+    fd = _open_secure(lane_file, os.O_RDONLY | _NONBLOCK_FLAG)
+    try:
+        _require_regular_fd(fd, f"journal {lane_file}")
+    except BaseException:
+        os.close(fd)
+        raise
     with os.fdopen(fd, "r", encoding="utf-8") as f:
         fcntl.flock(f.fileno(), fcntl.LOCK_SH)
         try:
@@ -245,8 +284,16 @@ def _same_event(a, b):
 # --------------------------------------------------------------------------
 
 _ODIRECTORY_FLAG = getattr(os, "O_DIRECTORY", 0)
-_REPLACE_SUPPORTS_DIR_FD = os.replace in os.supports_dir_fd
+_RENAME_SUPPORTS_DIR_FD = os.rename in os.supports_dir_fd
 _SYMLINK_ERRNOS = (errno.ELOOP, errno.ENOTDIR, errno.EMLINK)
+
+try:
+    _native_libc = ctypes.CDLL(None, use_errno=True)
+    _NATIVE_RENAMEAT = _native_libc.renameat
+    _NATIVE_RENAMEAT.argtypes = (ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p)
+    _NATIVE_RENAMEAT.restype = ctypes.c_int
+except (AttributeError, OSError):
+    _NATIVE_RENAMEAT = None
 
 
 def _openat_subdir(parent_fd, name, create):
@@ -287,34 +334,37 @@ def _open_dir_chain(root_path, parts, create=False):
 
 
 def _read_json_at(parent_fd, name):
-    fd = os.open(name, os.O_RDONLY | _NOFOLLOW_FLAG, dir_fd=parent_fd)
+    fd = os.open(name, os.O_RDONLY | _NOFOLLOW_FLAG | _NONBLOCK_FLAG, dir_fd=parent_fd)
+    try:
+        _require_regular_fd(fd, f"registry file {name}")
+    except BaseException:
+        os.close(fd)
+        raise
     with os.fdopen(fd, "r", encoding="utf-8") as f:
         return json.load(f)
+
+
+def _require_regular_fd(fd, label):
+    if not stat.S_ISREG(os.fstat(fd).st_mode):
+        raise RegistryError(f"{label} is not a regular file")
 
 
 def _atomic_replace_at(parent_fd, parent_path, tmp_name, final_name):
     """Rename atomique tmp -> final à l'intérieur de `parent_fd`.
 
-    Sur les plateformes exposant renameat(dir_fd) (Linux), l'opération est
-    entièrement relative au fd. Sinon (macOS), on re-valide que le chemin textuel
-    désigne toujours l'inode ouvert (anti-swap) avant un rename textuel ; comme
-    le tmp vit dans le vrai répertoire (créé via dir_fd), un swap tardif ferait
-    de toute façon échouer le rename (source introuvable) — fail-closed."""
-    if _REPLACE_SUPPORTS_DIR_FD:
-        os.replace(tmp_name, final_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+    The replace is always relative to the directory fd.  This deliberately
+    avoids a post-validation text-path rename on macOS: a swapped ancestor may
+    change a path string, but cannot redirect an already-open directory fd.
+    """
+    del parent_path  # kept in the signature for existing callers and diagnostics.
+    if _RENAME_SUPPORTS_DIR_FD:
+        os.rename(tmp_name, final_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
         return
-    st_fd = os.fstat(parent_fd)
-    try:
-        st_path = os.stat(parent_path, follow_symlinks=False)
-    except OSError as exc:
-        raise RegistryError(
-            f"registry path vanished during write: {parent_path}"
-        ) from exc
-    if (st_fd.st_dev, st_fd.st_ino) != (st_path.st_dev, st_path.st_ino):
-        raise RegistryError(f"registry ancestor swapped during write: {parent_path}")
-    os.replace(
-        os.path.join(parent_path, tmp_name), os.path.join(parent_path, final_name),
-    )
+    if _NATIVE_RENAMEAT is None:
+        raise RegistryError("no safe dirfd rename primitive is available")
+    if _NATIVE_RENAMEAT(parent_fd, os.fsencode(tmp_name), parent_fd, os.fsencode(final_name)) != 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err), final_name)
 
 
 def _write_json_at(parent_fd, parent_path, name, obj, mode=0o600):
@@ -362,8 +412,13 @@ def _append_event_at(parent_fd, name, source_label, key, event_name, extra=None)
     if extra:
         payload.update(extra)
     fd = os.open(
-        name, os.O_CREAT | os.O_RDWR | _NOFOLLOW_FLAG, 0o600, dir_fd=parent_fd,
+        name, os.O_CREAT | os.O_RDWR | _NOFOLLOW_FLAG | _NONBLOCK_FLAG, 0o600, dir_fd=parent_fd,
     )
+    try:
+        _require_regular_fd(fd, f"journal {source_label}")
+    except BaseException:
+        os.close(fd)
+        raise
     with os.fdopen(fd, "r+", encoding="utf-8") as f:
         fcntl.flock(f.fileno(), fcntl.LOCK_EX)
         try:
@@ -1292,6 +1347,33 @@ def _write_context_output(out_path, content):
         raise
 
 
+def _write_registry_context_output(root, registry_output_root, out_path, content):
+    """Write a context pack under ``registry/contexts`` through dirfds only.
+
+    Context packs are registry mutations.  Resolve their logical relative path
+    without following links, then use the same ``openat``/``renameat`` chain as
+    owners and handoffs so a post-validation ancestor swap cannot redirect the
+    write outside the registry on macOS.
+    """
+    root_abs = Path(os.path.abspath(str(registry_output_root)))
+    output_abs = Path(os.path.abspath(str(out_path)))
+    try:
+        relative_output = output_abs.relative_to(root_abs)
+    except ValueError as exc:
+        raise RegistryError("context output must stay inside registry contexts") from exc
+    if not relative_output.parts or relative_output.name in {"", ".", ".."}:
+        raise RegistryError("context output must name a file")
+    if any(part in {"", ".", ".."} for part in relative_output.parts):
+        raise RegistryError("context output path is invalid")
+
+    parent_parts = ("contexts", *relative_output.parts[:-1])
+    parent_fd = _open_dir_chain(str(root), parent_parts, create=True)
+    try:
+        _write_text_at(parent_fd, "", relative_output.name, content)
+    finally:
+        os.close(parent_fd)
+
+
 def _path_is_within(path, root):
     try:
         Path(path).relative_to(Path(root))
@@ -1327,12 +1409,18 @@ def cmd_context(root, key, repo, vault, context_map_arg, out_arg):
     if entry is None:
         # Repo inconnu : aucun accès au vault, pas même `os.path.realpath`.
         content = _render_unmapped_brief(key, repo_real, status)
-        _write_context_output(out_path, content)
+        if _path_is_within(Path(os.path.abspath(str(out_path))), registry_output_root):
+            _write_registry_context_output(root, registry_output_root, out_path, content)
+        else:
+            _write_context_output(out_path, content)
         return 0
 
     vault_root = Path(os.path.realpath(vault))
     content = _render_mapped_pack(key, repo_real, status, root, vault_root, entry)
-    _write_context_output(out_path, content)
+    if _path_is_within(Path(os.path.abspath(str(out_path))), registry_output_root):
+        _write_registry_context_output(root, registry_output_root, out_path, content)
+    else:
+        _write_context_output(out_path, content)
     return 0
 
 
@@ -1651,15 +1739,16 @@ def _find_claim_for_worktree(root, repo_real):
                 raise RegistryError(f"registry lock scan failed for {key!r}: {exc}") from exc
             try:
                 try:
-                    owner_fd = os.open("owner.json", os.O_RDONLY | _NOFOLLOW_FLAG, dir_fd=key_fd)
+                    owner_fd = os.open(
+                        "owner.json", os.O_RDONLY | _NOFOLLOW_FLAG | _NONBLOCK_FLAG, dir_fd=key_fd,
+                    )
                 except FileNotFoundError:
                     continue
                 except OSError as exc:
                     raise RegistryError(f"registry lock scan failed for {key!r}: {exc}") from exc
                 try:
+                    _require_regular_fd(owner_fd, f"owner record for {key!r}")
                     with os.fdopen(owner_fd, "r", encoding="utf-8") as f:
-                        if not stat.S_ISREG(os.fstat(f.fileno()).st_mode):
-                            raise RegistryError(f"owner record is not a regular file for {key!r}")
                         owner = json.load(f)
                 except (OSError, ValueError, json.JSONDecodeError, RegistryError) as exc:
                     raise RegistryError(f"registry lock scan failed for {key!r}: {exc}") from exc

--- a/scripts/factory_lane.py
+++ b/scripts/factory_lane.py
@@ -15,6 +15,7 @@ import math
 import os
 import re
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
@@ -201,23 +202,6 @@ def _fsync_dir(dir_path):
         os.close(fd)
 
 
-def _write_owner(owner_file, owner):
-    lock_dir = owner_file.parent
-    fd, tmp_path = tempfile.mkstemp(dir=str(lock_dir), prefix=".owner-", suffix=".tmp")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(owner, f, sort_keys=True)
-            f.flush()
-            os.fsync(f.fileno())
-        os.chmod(tmp_path, 0o600)
-        os.replace(tmp_path, str(owner_file))
-        _fsync_dir(lock_dir)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.remove(tmp_path)
-        raise
-
-
 def _parse_jsonl_lines(text, source):
     """Parse fail-closed : toute ligne corrompue lève, aucune ligne n'est ignorée."""
     events = []
@@ -249,28 +233,6 @@ def _read_all_events(lane_file):
 def _same_event(a, b):
     keys = (set(a.keys()) | set(b.keys())) - {"ts"}
     return all(a.get(k) == b.get(k) for k in keys)
-
-
-def _append_event(lane_file, key, event_name, extra=None):
-    payload = {"ts": time.time(), "key": key, "event": event_name}
-    if extra:
-        payload.update(extra)
-
-    fd = _open_secure(lane_file, os.O_CREAT | os.O_RDWR, 0o600)
-    with os.fdopen(fd, "r+", encoding="utf-8") as f:
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-        try:
-            os.fchmod(f.fileno(), 0o600)
-            events = _parse_jsonl_lines(f.read(), lane_file)
-            last = events[-1] if events else None
-            if last is not None and _same_event(last, payload):
-                return
-            f.seek(0, os.SEEK_END)
-            f.write(json.dumps(payload, sort_keys=True) + "\n")
-            f.flush()
-            os.fsync(f.fileno())
-        finally:
-            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
 
 # --------------------------------------------------------------------------
@@ -365,6 +327,26 @@ def _write_json_at(parent_fd, parent_path, name, obj, mode=0o600):
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(obj, f, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        _atomic_replace_at(parent_fd, parent_path, tmp_name, name)
+        os.fsync(parent_fd)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name, dir_fd=parent_fd)
+        raise
+
+
+def _write_text_at(parent_fd, parent_path, name, content, mode=0o600):
+    """Write text atomically inside an already verified directory fd."""
+    tmp_name = f".{name}.{os.getpid()}.{time.time_ns()}.tmp"
+    fd = os.open(
+        tmp_name, os.O_CREAT | os.O_EXCL | os.O_WRONLY | _NOFOLLOW_FLAG, mode,
+        dir_fd=parent_fd,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
             f.flush()
             os.fsync(f.fileno())
         _atomic_replace_at(parent_fd, parent_path, tmp_name, name)
@@ -716,12 +698,6 @@ def _can_reclaim_owner(now, owner):
     return verdict["reclaimable"]
 
 
-def _unlink_owner(owner_file):
-    with contextlib.suppress(FileNotFoundError):
-        owner_file.unlink()
-    _fsync_dir(owner_file.parent)
-
-
 def _git_dirty(repo):
     try:
         result = subprocess.run(
@@ -991,8 +967,8 @@ def cmd_guard(root, repo, agent, session, profile=None, domain_prefixes=None,
 
 def cmd_event(root, key, event_name, evidence, pr, commit=None, ci=None, deploy=None):
     validate_key(key)
-    lanes_dir = _safe_subdir(root, "lanes")
-    locks_root = _safe_subdir(root, "locks")
+    _safe_subdir(root, "lanes")
+    _safe_subdir(root, "locks")
 
     if event_name not in ALLOWED_MANUAL_EVENTS:
         raise RegistryError(f"unknown event: {event_name!r}")
@@ -1009,20 +985,13 @@ def cmd_event(root, key, event_name, evidence, pr, commit=None, ci=None, deploy=
     if event_name == "pr_opened" and not pr:
         raise RegistryError("pr_opened requires --pr")
 
-    lock_dir = locks_root / key
-    owner_file = lock_dir / "owner.json"
-    lane_file = lanes_dir / f"{key}.jsonl"
-
-    if not owner_file.exists():
-        raise RegistryError(f"no active claim for lane {key}")
-
-    lock_file = lock_dir / ".lock"
-    with _locked(lock_file):
-        if not owner_file.exists():
+    root_path = str(root)
+    with _dirfd_flock(root_path, ("locks", key), ".lock"):
+        owner = _read_owner_via_chain(root_path, key)
+        if owner is None:
             raise RegistryError(f"no active claim for lane {key}")
-        owner = _read_json(owner_file)
         owner["heartbeat_at"] = time.time()
-        _write_owner(owner_file, owner)
+        _write_owner_via_chain(root_path, key, owner)
 
         extra = {}
         if evidence is not None:
@@ -1035,7 +1004,7 @@ def cmd_event(root, key, event_name, evidence, pr, commit=None, ci=None, deploy=
             extra["ci"] = ci
         if deploy is not None:
             extra["deploy"] = deploy
-        _append_event(lane_file, key, event_name, extra=extra)
+        _append_event_via_chain(root_path, key, event_name, extra=extra)
     return 0
 
 
@@ -1052,28 +1021,19 @@ def cmd_handoff(root, key, status, next_step, evidence):
     if evidence is not None:
         _validate_evidence(evidence)
 
-    lanes_dir = _safe_subdir(root, "lanes")
-    locks_root = _safe_subdir(root, "locks")
-    handoffs_dir = _safe_subdir(root, "handoffs")
+    _safe_subdir(root, "lanes")
+    _safe_subdir(root, "locks")
+    _safe_subdir(root, "handoffs")
 
-    lock_dir = locks_root / key
-    owner_file = lock_dir / "owner.json"
-    lane_file = lanes_dir / f"{key}.jsonl"
-
-    if not owner_file.exists():
-        raise RegistryError(f"no active claim for lane {key}")
-
-    lock_file = lock_dir / ".lock"
-    with _locked(lock_file):
-        if not owner_file.exists():
+    root_path = str(root)
+    with _dirfd_flock(root_path, ("locks", key), ".lock"):
+        if _read_owner_via_chain(root_path, key) is None:
             raise RegistryError(f"no active claim for lane {key}")
 
         now = time.time()
         ts_ms = int(now * 1000)
         date_suffix = time.strftime("%Y-%m-%d", time.gmtime(now))
-        handoff_path = handoffs_dir / f"{key}-{date_suffix}.md"
-        if handoff_path.is_symlink():
-            raise RegistryError(f"handoff target must not be a symlink: {handoff_path}")
+        handoff_name = f"{key}-{date_suffix}.md"
         lines = [
             f"# Handoff {key}",
             f"Status: {status}",
@@ -1084,24 +1044,16 @@ def cmd_handoff(root, key, status, next_step, evidence):
         lines.append(f"Timestamp: {ts_ms}")
         content = "\n".join(lines) + "\n"
 
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(handoffs_dir), prefix=f".{key}-", suffix=".tmp",
-        )
+        handoffs_fd = _open_dir_chain(root_path, ("handoffs",), create=True)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(content)
-                f.flush()
-                os.fsync(f.fileno())
-            os.chmod(tmp_path, 0o600)
-            os.replace(tmp_path, str(handoff_path))
-            _fsync_dir(handoffs_dir)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                os.remove(tmp_path)
-            raise
+            _write_text_at(
+                handoffs_fd, os.path.join(root_path, "handoffs"), handoff_name, content,
+            )
+        finally:
+            os.close(handoffs_fd)
 
-        _append_event(lane_file, key, "handoff", extra={
-            "status": status, "handoff_file": handoff_path.name,
+        _append_event_via_chain(root_path, key, "handoff", extra={
+            "status": status, "handoff_file": handoff_name,
         })
     return 0
 
@@ -1129,43 +1081,26 @@ def cmd_render(root):
             lines.append(f"| {key} | {status} |")
     content = "\n".join(lines) + "\n"
 
-    lanes_md = root / "LANES.md"
-    _reject_symlink(lanes_md, "LANES.md")
-    fd, tmp_path = tempfile.mkstemp(dir=str(root), prefix=".LANES-", suffix=".tmp")
+    root_path = str(root)
+    root_fd = _open_dir_chain(root_path, (), create=False)
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(content)
-            f.flush()
-            os.fsync(f.fileno())
-        os.chmod(tmp_path, 0o644)
-        os.replace(tmp_path, str(lanes_md))
-        _fsync_dir(root)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.remove(tmp_path)
-        raise
+        _write_text_at(root_fd, root_path, "LANES.md", content, mode=0o644)
+    finally:
+        os.close(root_fd)
     return 0
 
 
 def cmd_close(root, key):
     validate_key(key)
-    lanes_dir = _safe_subdir(root, "lanes")
-    locks_root = _safe_subdir(root, "locks")
+    _safe_subdir(root, "lanes")
+    _safe_subdir(root, "locks")
 
-    lock_dir = locks_root / key
-    owner_file = lock_dir / "owner.json"
-    lane_file = lanes_dir / f"{key}.jsonl"
-
-    if not owner_file.exists():
-        raise RegistryError(f"no active claim for lane {key}")
-
-    lock_file = lock_dir / ".lock"
-    with _locked(lock_file):
-        if not owner_file.exists():
+    root_path = str(root)
+    with _dirfd_flock(root_path, ("locks", key), ".lock"):
+        if _read_owner_via_chain(root_path, key) is None:
             raise RegistryError(f"no active claim for lane {key}")
-        _append_event(lane_file, key, "lane_closed")
-        owner_file.unlink()
-        _fsync_dir(lock_dir)
+        _append_event_via_chain(root_path, key, "lane_closed")
+        _unlink_owner_via_chain(root_path, key)
     return 0
 
 
@@ -1583,26 +1518,19 @@ def _serialize_handoff(payload):
 
 def cmd_capture_handoff(root, key, repo, summary_path):
     validate_key(key)
-    lanes_dir = _safe_subdir(root, "lanes")
-    locks_root = _safe_subdir(root, "locks")
-    handoffs_dir = _safe_subdir(root, "handoffs")
-
-    lock_dir = locks_root / key
-    owner_file = lock_dir / "owner.json"
-    lane_file = lanes_dir / f"{key}.jsonl"
-
-    if not owner_file.exists():
-        raise RegistryError(f"no active claim for lane {key}")
+    _safe_subdir(root, "lanes")
+    _safe_subdir(root, "locks")
+    _safe_subdir(root, "handoffs")
 
     summary_fields = {}
     if summary_path is not None:
         summary_fields = _load_summary(summary_path)
 
-    lock_file = lock_dir / ".lock"
-    with _locked(lock_file):
-        if not owner_file.exists():
+    root_path = str(root)
+    with _dirfd_flock(root_path, ("locks", key), ".lock"):
+        owner = _read_owner_via_chain(root_path, key)
+        if owner is None:
             raise RegistryError(f"no active claim for lane {key}")
-        owner = _read_json(owner_file)
 
         repo_real = _git_toplevel(repo)
         claimed_worktree = owner.get("worktree")
@@ -1619,9 +1547,7 @@ def cmd_capture_handoff(root, key, repo, summary_path):
 
         now = time.time()
         date_suffix = time.strftime("%Y-%m-%d", time.gmtime(now))
-        handoff_path = handoffs_dir / f"{key}-{date_suffix}.handoff.json"
-        if handoff_path.is_symlink():
-            raise RegistryError(f"handoff target must not be a symlink: {handoff_path}")
+        handoff_name = f"{key}-{date_suffix}.handoff.json"
 
         payload = {
             "issue": key,
@@ -1639,24 +1565,16 @@ def cmd_capture_handoff(root, key, repo, summary_path):
         payload.update(summary_fields)
 
         content = _serialize_handoff(payload)
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(handoffs_dir), prefix=f".{key}-", suffix=".tmp",
-        )
+        handoffs_fd = _open_dir_chain(root_path, ("handoffs",), create=True)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(content)
-                f.flush()
-                os.fsync(f.fileno())
-            os.chmod(tmp_path, 0o600)
-            os.replace(tmp_path, str(handoff_path))
-            _fsync_dir(handoffs_dir)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                os.remove(tmp_path)
-            raise
+            _write_text_at(
+                handoffs_fd, os.path.join(root_path, "handoffs"), handoff_name, content,
+            )
+        finally:
+            os.close(handoffs_fd)
 
-        _append_event(lane_file, key, "handoff_captured", extra={
-            "handoff_file": handoff_path.name,
+        _append_event_via_chain(root_path, key, "handoff_captured", extra={
+            "handoff_file": handoff_name,
         })
     return 0
 
@@ -1692,31 +1610,71 @@ def _git_toplevel_or_none(repo_path, timeout=5):
 
 def _find_claim_for_worktree(root, repo_real):
     """Cherche un `owner.json` actif dont le worktree realpath correspond à
-    `repo_real`. Retourne `(key, owner)` ou `None`. Tolère toute entrée
-    corrompue/symlinkée en la sautant plutôt qu'en levant."""
-    locks_root = root / "locks"
-    if not locks_root.exists() or locks_root.is_symlink():
-        return None
+    `repo_real`. Retourne `(key, owner)` ou `None`.
+
+    Le gate runtime ne peut pas transformer un scan incomplet en ``ownerless``:
+    un locks/owner remplacé par symlink, un fichier non régulier ou un échec de
+    lecture est indiscernable d'un owner caché. Le scan descend donc depuis le
+    fd du registry avec ``openat(..., O_NOFOLLOW)`` et propage ``RegistryError``
+    au hook, qui refuse alors la mutation avant l'outil.
+    """
     try:
-        entries = sorted(locks_root.iterdir())
-    except OSError:
+        locks_fd = _open_dir_chain(str(root), ("locks",), create=False)
+    except FileNotFoundError:
         return None
-    for lock_dir in entries:
+    except (OSError, RegistryError) as exc:
+        raise RegistryError(f"registry lock scan failed: {exc}") from exc
+    try:
+        def assert_locks_path_stable():
+            """Reject a textual locks/ path swapped after its no-follow open."""
+            try:
+                path_stat = os.stat(root / "locks", follow_symlinks=False)
+            except OSError as exc:
+                raise RegistryError(f"registry locks changed during owner scan: {exc}") from exc
+            fd_stat = os.fstat(locks_fd)
+            if (
+                not stat.S_ISDIR(path_stat.st_mode)
+                or (fd_stat.st_dev, fd_stat.st_ino) != (path_stat.st_dev, path_stat.st_ino)
+            ):
+                raise RegistryError("registry locks changed during owner scan")
+
         try:
-            if not lock_dir.is_dir() or lock_dir.is_symlink():
-                continue
-            owner_file = lock_dir / "owner.json"
-            if not owner_file.exists() or owner_file.is_symlink():
-                continue
-            owner = _read_json(owner_file)
-            worktree = owner.get("worktree")
-            if not worktree:
-                continue
-            if os.path.realpath(worktree) == repo_real:
-                return lock_dir.name, owner
-        except Exception:
-            continue
-    return None
+            names = sorted(os.listdir(locks_fd))
+        except OSError as exc:
+            raise RegistryError(f"registry lock scan failed: {exc}") from exc
+        assert_locks_path_stable()
+        for key in names:
+            try:
+                validate_key(key)
+                key_fd = _openat_subdir(locks_fd, key, create=False)
+            except (OSError, RegistryError) as exc:
+                raise RegistryError(f"registry lock scan failed for {key!r}: {exc}") from exc
+            try:
+                try:
+                    owner_fd = os.open("owner.json", os.O_RDONLY | _NOFOLLOW_FLAG, dir_fd=key_fd)
+                except FileNotFoundError:
+                    continue
+                except OSError as exc:
+                    raise RegistryError(f"registry lock scan failed for {key!r}: {exc}") from exc
+                try:
+                    with os.fdopen(owner_fd, "r", encoding="utf-8") as f:
+                        if not stat.S_ISREG(os.fstat(f.fileno()).st_mode):
+                            raise RegistryError(f"owner record is not a regular file for {key!r}")
+                        owner = json.load(f)
+                except (OSError, ValueError, json.JSONDecodeError, RegistryError) as exc:
+                    raise RegistryError(f"registry lock scan failed for {key!r}: {exc}") from exc
+                if not isinstance(owner, dict):
+                    raise RegistryError(f"registry lock scan failed for {key!r}: owner record is not an object")
+                worktree = owner.get("worktree")
+                if isinstance(worktree, str) and os.path.realpath(worktree) == repo_real:
+                    assert_locks_path_stable()
+                    return key, owner
+            finally:
+                os.close(key_fd)
+        assert_locks_path_stable()
+        return None
+    finally:
+        os.close(locks_fd)
 
 
 def _load_handoff(handoff_path, handoffs_dir):
@@ -1849,16 +1807,9 @@ def _evaluate_handoff(repo_real, owner, handoff):
 
 def cmd_reconcile(root, key, repo, handoff_path):
     validate_key(key)
-    lanes_dir = _safe_subdir(root, "lanes")
-    locks_root = _safe_subdir(root, "locks")
+    _safe_subdir(root, "lanes")
+    _safe_subdir(root, "locks")
     handoffs_dir = _safe_subdir(root, "handoffs")
-
-    lock_dir = locks_root / key
-    owner_file = lock_dir / "owner.json"
-    lane_file = lanes_dir / f"{key}.jsonl"
-
-    if not owner_file.exists():
-        raise RegistryError(f"no active claim for lane {key}")
 
     handoff = _load_handoff(handoff_path, handoffs_dir)
 
@@ -1878,15 +1829,15 @@ def cmd_reconcile(root, key, repo, handoff_path):
         if not isinstance(handoff_canonical, str) or os.path.realpath(handoff_canonical) != repo_real:
             raise RegistryError("handoff canonical_repo does not match --repo")
 
-    lock_file = lock_dir / ".lock"
-    with _locked(lock_file):
-        if not owner_file.exists():
+    root_path = str(root)
+    with _dirfd_flock(root_path, ("locks", key), ".lock"):
+        owner = _read_owner_via_chain(root_path, key)
+        if owner is None:
             raise RegistryError(f"no active claim for lane {key}")
-        owner = _read_json(owner_file)
 
         verdict, reasons = _evaluate_handoff(repo_real, owner, handoff)
 
-        _append_event(lane_file, key, "reconciled", extra={
+        _append_event_via_chain(root_path, key, "reconciled", extra={
             "verdict": verdict,
             "reasons": reasons,
             "handoff_head_commit": handoff.get("head_commit"),
@@ -1947,13 +1898,10 @@ def cmd_hook_stop(root, repo, key, summary_path=None):
         if repo_real is None:
             return 0
 
-        locks_root = root / "locks"
-        lock_dir = locks_root / key
-        owner_file = lock_dir / "owner.json"
-        if not owner_file.exists() or owner_file.is_symlink():
+        root_path = str(root)
+        owner = _read_owner_via_chain(root_path, key)
+        if owner is None:
             return 0
-
-        owner = _read_json(owner_file)
         claimed_worktree = owner.get("worktree")
         if not claimed_worktree or os.path.realpath(claimed_worktree) != repo_real:
             return 0
@@ -1982,31 +1930,15 @@ def cmd_hook_stop(root, repo, key, summary_path=None):
             except RegistryError:
                 pass
 
-        handoffs_dir = root / "handoffs"
-        if handoffs_dir.is_symlink():
-            return 0
-        handoffs_dir.mkdir(parents=True, exist_ok=True)
-
-        capture_path = handoffs_dir / f"{key}-stop-{time.time_ns()}.json"
-        if capture_path.is_symlink():
-            return 0
-
         content = _serialize_handoff(payload)
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(handoffs_dir), prefix=f".{key}-stop-", suffix=".tmp",
-        )
+        capture_name = f"{key}-stop-{time.time_ns()}.json"
+        handoffs_fd = _open_dir_chain(root_path, ("handoffs",), create=True)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(content)
-                f.flush()
-                os.fsync(f.fileno())
-            os.chmod(tmp_path, 0o600)
-            os.replace(tmp_path, str(capture_path))
-            _fsync_dir(handoffs_dir)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                os.remove(tmp_path)
-            return 0
+            _write_text_at(
+                handoffs_fd, os.path.join(root_path, "handoffs"), capture_name, content,
+            )
+        finally:
+            os.close(handoffs_fd)
 
         return 0
     except Exception:

--- a/scripts/factory_lane.py
+++ b/scripts/factory_lane.py
@@ -273,6 +273,199 @@ def _append_event(lane_file, key, event_name, extra=None):
             fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
 
+# --------------------------------------------------------------------------
+# I/O durci dirfd/openat — écriture claim/admit fail-closed contre un swap
+# d'ancêtre symlink (registry/locks, registry/lanes) survenant APRÈS la
+# validation Path. `O_NOFOLLOW` sur la feuille seule ne suffit pas : chaque
+# composant du chemin est ré-ouvert via openat `O_NOFOLLOW|O_DIRECTORY` depuis
+# un fd du registry root, donc un ancêtre swappé fait échouer l'openat
+# (fail-closed) et aucune écriture ne peut sortir du registry.
+# --------------------------------------------------------------------------
+
+_ODIRECTORY_FLAG = getattr(os, "O_DIRECTORY", 0)
+_REPLACE_SUPPORTS_DIR_FD = os.replace in os.supports_dir_fd
+_SYMLINK_ERRNOS = (errno.ELOOP, errno.ENOTDIR, errno.EMLINK)
+
+
+def _openat_subdir(parent_fd, name, create):
+    """openat d'un sous-répertoire via `O_NOFOLLOW|O_DIRECTORY`. Lève
+    RegistryError si `name` est un symlink (swap d'ancêtre). Propage
+    FileNotFoundError si `name` est simplement absent et `create` est faux."""
+    if create:
+        with contextlib.suppress(FileExistsError):
+            os.mkdir(name, 0o700, dir_fd=parent_fd)
+    try:
+        return os.open(
+            name, os.O_RDONLY | _NOFOLLOW_FLAG | _ODIRECTORY_FLAG, dir_fd=parent_fd,
+        )
+    except OSError as exc:
+        if exc.errno in _SYMLINK_ERRNOS:
+            raise RegistryError(
+                f"refusing symlinked registry directory: {name!r}"
+            ) from exc
+        raise
+
+
+def _open_dir_chain(root_path, parts, create=False):
+    """Descend depuis le registry root via openat `O_NOFOLLOW` à chaque composant.
+
+    Retourne un fd du dernier répertoire (à fermer par l'appelant) ; ferme tous
+    les fds intermédiaires. Ré-ouvrir cette chaîne à chaque écriture re-valide
+    tous les ancêtres et referme la fenêtre TOCTOU du swap symlink."""
+    fd = _open_secure(root_path, os.O_RDONLY | _ODIRECTORY_FLAG)
+    try:
+        for part in parts:
+            nxt = _openat_subdir(fd, part, create)
+            os.close(fd)
+            fd = nxt
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _read_json_at(parent_fd, name):
+    fd = os.open(name, os.O_RDONLY | _NOFOLLOW_FLAG, dir_fd=parent_fd)
+    with os.fdopen(fd, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _atomic_replace_at(parent_fd, parent_path, tmp_name, final_name):
+    """Rename atomique tmp -> final à l'intérieur de `parent_fd`.
+
+    Sur les plateformes exposant renameat(dir_fd) (Linux), l'opération est
+    entièrement relative au fd. Sinon (macOS), on re-valide que le chemin textuel
+    désigne toujours l'inode ouvert (anti-swap) avant un rename textuel ; comme
+    le tmp vit dans le vrai répertoire (créé via dir_fd), un swap tardif ferait
+    de toute façon échouer le rename (source introuvable) — fail-closed."""
+    if _REPLACE_SUPPORTS_DIR_FD:
+        os.replace(tmp_name, final_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        return
+    st_fd = os.fstat(parent_fd)
+    try:
+        st_path = os.stat(parent_path, follow_symlinks=False)
+    except OSError as exc:
+        raise RegistryError(
+            f"registry path vanished during write: {parent_path}"
+        ) from exc
+    if (st_fd.st_dev, st_fd.st_ino) != (st_path.st_dev, st_path.st_ino):
+        raise RegistryError(f"registry ancestor swapped during write: {parent_path}")
+    os.replace(
+        os.path.join(parent_path, tmp_name), os.path.join(parent_path, final_name),
+    )
+
+
+def _write_json_at(parent_fd, parent_path, name, obj, mode=0o600):
+    """Écrit `obj` (JSON) sous `name` dans `parent_fd`, atomiquement."""
+    tmp_name = f".{name}.{os.getpid()}.{time.time_ns()}.tmp"
+    fd = os.open(
+        tmp_name, os.O_CREAT | os.O_EXCL | os.O_WRONLY | _NOFOLLOW_FLAG, mode,
+        dir_fd=parent_fd,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(obj, f, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        _atomic_replace_at(parent_fd, parent_path, tmp_name, name)
+        os.fsync(parent_fd)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name, dir_fd=parent_fd)
+        raise
+
+
+def _append_event_at(parent_fd, name, source_label, key, event_name, extra=None):
+    payload = {"ts": time.time(), "key": key, "event": event_name}
+    if extra:
+        payload.update(extra)
+    fd = os.open(
+        name, os.O_CREAT | os.O_RDWR | _NOFOLLOW_FLAG, 0o600, dir_fd=parent_fd,
+    )
+    with os.fdopen(fd, "r+", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            os.fchmod(f.fileno(), 0o600)
+            events = _parse_jsonl_lines(f.read(), source_label)
+            last = events[-1] if events else None
+            if last is not None and _same_event(last, payload):
+                return
+            f.seek(0, os.SEEK_END)
+            f.write(json.dumps(payload, sort_keys=True) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+@contextlib.contextmanager
+def _dirfd_flock(root_path, parts, name):
+    """flock exclusif sur `name` sous la chaîne dirfd `parts` (créée sûrement)."""
+    parent_fd = _open_dir_chain(root_path, parts, create=True)
+    try:
+        fd = os.open(
+            name, os.O_CREAT | os.O_RDWR | _NOFOLLOW_FLAG, 0o600, dir_fd=parent_fd,
+        )
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+    finally:
+        os.close(parent_fd)
+
+
+def _read_owner_via_chain(root_path, key):
+    """owner.json de la lane `key` via chaîne dirfd, ou None si absent."""
+    try:
+        key_fd = _open_dir_chain(root_path, ("locks", key), create=False)
+    except FileNotFoundError:
+        return None
+    try:
+        return _read_json_at(key_fd, "owner.json")
+    except FileNotFoundError:
+        return None
+    finally:
+        os.close(key_fd)
+
+
+def _write_owner_via_chain(root_path, key, owner):
+    key_fd = _open_dir_chain(root_path, ("locks", key), create=True)
+    try:
+        parent_path = os.path.join(root_path, "locks", key)
+        _write_json_at(key_fd, parent_path, "owner.json", owner)
+    finally:
+        os.close(key_fd)
+
+
+def _unlink_owner_via_chain(root_path, key):
+    try:
+        key_fd = _open_dir_chain(root_path, ("locks", key), create=False)
+    except FileNotFoundError:
+        return
+    try:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink("owner.json", dir_fd=key_fd)
+        os.fsync(key_fd)
+    finally:
+        os.close(key_fd)
+
+
+def _append_event_via_chain(root_path, key, event_name, extra=None):
+    lanes_fd = _open_dir_chain(root_path, ("lanes",), create=True)
+    try:
+        _append_event_at(
+            lanes_fd, f"{key}.jsonl",
+            os.path.join(root_path, "lanes", f"{key}.jsonl"),
+            key, event_name, extra=extra,
+        )
+    finally:
+        os.close(lanes_fd)
+
+
 def _compute_status(events):
     status = "unclaimed"
     for e in events:
@@ -333,6 +526,11 @@ def determine_process_state(owner):
 
     current_start = _get_process_start_time(pid)
     recorded_start = owner.get("process_start_time")
+    # Sans empreinte de départ enregistrée, la réutilisation de PID est
+    # indémontrable : un process vivant reste 'alive' (jamais 'reused'), sinon
+    # un owner vivant sans baseline deviendrait faussement réclamable.
+    if recorded_start is None:
+        return "alive"
     if current_start is not None and recorded_start != current_start:
         return "reused"
     return "alive"
@@ -415,14 +613,55 @@ def _canonical_worktree(worktree):
     return os.path.realpath(str(worktree))
 
 
-def _build_owner(agent, session, worktree, ttl_hours, now, profile=None, gateway_session_key=None):
-    pid = os.getpid()
+def _resolve_owner_identity(owner_pid, owner_start_time):
+    """Valide une identité de process parent transportée par l'appelant.
+
+    Le hard gate/gateway lance `factory_lane.py` en subprocess éphémère : si on
+    persistait `os.getpid()`, l'owner porterait un PID mort dès la fin de la
+    commande et deviendrait immédiatement réclamable. L'appelant transporte donc
+    l'identité de l'agent parent de longue durée via `--owner-pid`
+    (+ `--owner-start-time` optionnel, anti-usurpation).
+
+    Retourne `(pid, start_time)` validés, ou `(None, None)` si aucune identité
+    n'est transportée (mode CLI autonome — l'appelant EST le process propriétaire).
+    Lève `RegistryError` pour un PID absent/mort ou une empreinte incohérente :
+    on ne crée jamais un owner déjà mort.
+    """
+    if owner_pid is None:
+        return None, None
+    if not isinstance(owner_pid, int) or isinstance(owner_pid, bool) or owner_pid <= 0:
+        raise RegistryError(f"invalid owner-pid: {owner_pid!r}")
+    try:
+        os.kill(owner_pid, 0)
+    except ProcessLookupError as exc:
+        raise RegistryError(f"owner-pid {owner_pid} is not a live process") from exc
+    except PermissionError:
+        pass  # vivant mais appartenant à un autre utilisateur
+    except OSError as exc:
+        raise RegistryError(f"owner-pid {owner_pid} is not usable: {exc}") from exc
+
+    actual_start = _get_process_start_time(owner_pid)
+    if owner_start_time is not None:
+        if actual_start is None or owner_start_time != actual_start:
+            raise RegistryError("owner-start-time does not match owner-pid start time")
+        return owner_pid, owner_start_time
+    return owner_pid, actual_start
+
+
+def _build_owner(agent, session, worktree, ttl_hours, now, profile=None,
+                 gateway_session_key=None, owner_pid=None, owner_start_time=None):
+    if owner_pid is not None:
+        pid = owner_pid
+        start_time = owner_start_time
+    else:
+        pid = os.getpid()
+        start_time = _get_process_start_time(pid)
     owner = {
         "host": socket.gethostname(),
         "agent": agent,
         "session_id": session,
         "pid": pid,
-        "process_start_time": _get_process_start_time(pid),
+        "process_start_time": start_time,
         "started_at": now,
         "heartbeat_at": now,
         "ttl_hours": ttl_hours,
@@ -529,10 +768,19 @@ def _validate_ttl_hours(ttl_hours):
 
 
 def _claim_under_gate(root, key, agent, session, worktree, reclaim, ttl_hours,
-                      profile=None, gateway_session_key=None):
+                      profile=None, gateway_session_key=None,
+                      owner_pid=None, owner_start_time=None):
     validate_key(key)
     _validate_ttl_hours(ttl_hours)
-    lanes_dir = _safe_subdir(root, "lanes")
+    # Un `gateway_session_key` ressemblant à un secret (token/password/api_key…)
+    # ne doit jamais être persisté en clair dans owner.json — rejet fail-closed.
+    if gateway_session_key is not None:
+        _validate_metadata_field(gateway_session_key, "gateway_session_key")
+    resolved_pid, resolved_start = _resolve_owner_identity(owner_pid, owner_start_time)
+
+    # Validation Path-level (crée + refuse un symlink d'emblée) ; les écritures
+    # elles-mêmes passent ensuite par les chaînes dirfd fail-closed ci-dessous.
+    _safe_subdir(root, "lanes")
     locks_root = _safe_subdir(root, "locks")
     worktree_real = _canonical_worktree(worktree)
 
@@ -541,19 +789,31 @@ def _claim_under_gate(root, key, agent, session, worktree, reclaim, ttl_hours,
         raise RegistryError(f"lock directory must not be a symlink: {lock_dir}")
     lock_dir.mkdir(parents=True, exist_ok=True)
 
-    owner_file = lock_dir / "owner.json"
-    lane_file = lanes_dir / f"{key}.jsonl"
-    lock_file = lock_dir / ".lock"
-    gate_file = root / ".worktree-admission.lock"
-
-    with _locked(gate_file), _locked(lock_file):
+    root_path = str(root)
+    # Verrou machine-wide (préflight->claim TOCTOU) + verrou par-lane, tous deux
+    # ouverts via chaîne dirfd O_NOFOLLOW ; toute écriture (owner.json, journal)
+    # ré-ouvre sa chaîne et échoue fermé si un ancêtre a été swappé en symlink.
+    with _dirfd_flock(root_path, (), ".worktree-admission.lock"), \
+            _dirfd_flock(root_path, ("locks", key), ".lock"):
         now = time.time()
-        if owner_file.exists():
-            owner = _read_json(owner_file)
+        owner = _read_owner_via_chain(root_path, key)
+        if owner is not None:
             if _is_same_session(owner, agent, session):
+                current_wt = owner.get("worktree")
+                if not (current_wt and _canonical_worktree(current_wt) == worktree_real):
+                    # Rebind vers un worktree différent : ne jamais réécrire
+                    # l'owner vers un worktree déjà détenu par une autre lane
+                    # (sinon deux owners pour le même worktree).
+                    rebind_conflict = _find_worktree_claim(locks_root, worktree_real)
+                    if rebind_conflict is not None and rebind_conflict[0] != key:
+                        rc_owner = rebind_conflict[1]
+                        raise RegistryError(
+                            f"worktree already claimed by {rebind_conflict[0]} "
+                            f"{rc_owner.get('agent')}/{rc_owner.get('session_id')}"
+                        )
+                    owner["worktree"] = worktree_real
                 owner["heartbeat_at"] = now
-                owner["worktree"] = worktree_real
-                _write_owner(owner_file, owner)
+                _write_owner_via_chain(root_path, key, owner)
                 return 0
 
             if not reclaim:
@@ -572,9 +832,10 @@ def _claim_under_gate(root, key, agent, session, worktree, reclaim, ttl_hours,
             new_owner = _build_owner(
                 agent, session, worktree_real, ttl_hours, now,
                 profile=profile, gateway_session_key=gateway_session_key,
+                owner_pid=resolved_pid, owner_start_time=resolved_start,
             )
-            _write_owner(owner_file, new_owner)
-            _append_event(lane_file, key, "lock_reclaimed", extra={
+            _write_owner_via_chain(root_path, key, new_owner)
+            _append_event_via_chain(root_path, key, "lock_reclaimed", extra={
                 "previous_agent": previous_agent,
                 "previous_session": previous_session,
             })
@@ -582,7 +843,7 @@ def _claim_under_gate(root, key, agent, session, worktree, reclaim, ttl_hours,
 
         conflict = _find_worktree_claim(locks_root, worktree_real)
         if conflict is not None:
-            conflict_key, conflict_owner, conflict_owner_file = conflict
+            conflict_key, conflict_owner, _conflict_owner_file = conflict
             if conflict_key != key:
                 if not reclaim:
                     raise RegistryError(
@@ -593,22 +854,25 @@ def _claim_under_gate(root, key, agent, session, worktree, reclaim, ttl_hours,
                     raise RegistryError(
                         f"worktree already claimed by active owner {conflict_key}"
                     )
-                _unlink_owner(conflict_owner_file)
+                _unlink_owner_via_chain(root_path, conflict_key)
 
         new_owner = _build_owner(
             agent, session, worktree_real, ttl_hours, now,
             profile=profile, gateway_session_key=gateway_session_key,
+            owner_pid=resolved_pid, owner_start_time=resolved_start,
         )
-        _write_owner(owner_file, new_owner)
-        _append_event(lane_file, key, "lane_claimed")
+        _write_owner_via_chain(root_path, key, new_owner)
+        _append_event_via_chain(root_path, key, "lane_claimed")
         return 0
 
 
 def cmd_claim(root, key, agent, session, worktree, reclaim, ttl_hours,
-              profile=None, gateway_session_key=None):
+              profile=None, gateway_session_key=None,
+              owner_pid=None, owner_start_time=None):
     return _claim_under_gate(
         root, key, agent, session, worktree, reclaim, ttl_hours,
         profile=profile, gateway_session_key=gateway_session_key,
+        owner_pid=owner_pid, owner_start_time=owner_start_time,
     )
 
 
@@ -626,7 +890,7 @@ def _validate_profile_domain(key, profile, domain_prefixes):
 
 def cmd_admit(root, key, mode, hard, agent, session, worktree, ttl_hours,
               as_json=False, profile=None, gateway_session_key=None,
-              domain_prefixes=None):
+              domain_prefixes=None, owner_pid=None, owner_start_time=None):
     validate_key(key)
     _validate_ttl_hours(ttl_hours)
     locks_root = _safe_subdir(root, "locks")
@@ -657,7 +921,72 @@ def cmd_admit(root, key, mode, hard, agent, session, worktree, ttl_hours,
     return _claim_under_gate(
         root, key, agent, session, worktree_real, False, ttl_hours,
         profile=profile, gateway_session_key=gateway_session_key,
+        owner_pid=owner_pid, owner_start_time=owner_start_time,
     )
+
+
+# --------------------------------------------------------------------------
+# Hard gate pré-mutation (lecture seule) — appelé par le hook `pre_tool_call`
+# --------------------------------------------------------------------------
+
+def evaluate_admission_guard(root, worktree_real, agent, session,
+                             profile=None, domain_prefixes=None):
+    """Décision de gate pré-mutation, en LECTURE SEULE (aucun owner écrit, aucun
+    PID éphémère persisté).
+
+    Retourne `(allowed: bool, reason: str | None)`.
+
+    - Worktree non revendiqué -> `(True, None)` : advisory fail-open (le gate
+      n'agit que sur des lanes réellement admises).
+    - Profil métier borné (`profile` + `domain_prefixes`) et lane possédant le
+      worktree hors domaine -> `(False, ...)` : refus automatique, indépendant de
+      la session et de la liveness.
+    - Autre session détenant le worktree avec un process VIVANT -> `(False, ...)`
+      : anti double-occupation (un seul gagnant par worktree).
+    - Sinon -> `(True, None)`.
+    """
+    match = _find_claim_for_worktree(root, worktree_real)
+    if match is None:
+        return True, None
+    key, owner = match
+
+    if profile and domain_prefixes:
+        allowed = {p.strip() for p in domain_prefixes.split(",") if p.strip()}
+        if allowed and _lane_prefix(key) not in allowed:
+            return False, (
+                f"profile {profile} cannot mutate lane {key} "
+                f"(out of domain {sorted(allowed)})"
+            )
+
+    if not _is_same_session(owner, agent, session):
+        if determine_process_state(owner) == "alive":
+            return False, (
+                f"worktree owned by {key} "
+                f"{owner.get('agent', '?')}/{owner.get('session_id', '?')}"
+            )
+
+    return True, None
+
+
+def cmd_guard(root, repo, agent, session, profile=None, domain_prefixes=None,
+              as_json=False):
+    """Hard gate CLI (debug/canary). Le vrai flux runtime importe
+    `evaluate_admission_guard` depuis `factory_admission_hook.py`."""
+    worktree_real = _git_toplevel_or_none(repo) or os.path.realpath(repo)
+    allowed, reason = evaluate_admission_guard(
+        root, worktree_real, agent, session,
+        profile=profile, domain_prefixes=domain_prefixes,
+    )
+    if as_json:
+        print(json.dumps(
+            {"allowed": allowed, "reason": reason, "worktree": worktree_real},
+            sort_keys=True,
+        ))
+    if not allowed:
+        if not as_json:
+            print(f"BLOCKED: {reason}", file=sys.stderr)
+        return 1
+    return 0
 
 
 def cmd_event(root, key, event_name, evidence, pr, commit=None, ci=None, deploy=None):
@@ -1707,6 +2036,8 @@ def _build_parser():
     p_claim.add_argument("--ttl-hours", type=float, default=DEFAULT_TTL_HOURS)
     p_claim.add_argument("--profile")
     p_claim.add_argument("--gateway-session-key")
+    p_claim.add_argument("--owner-pid", type=int)
+    p_claim.add_argument("--owner-start-time")
 
     p_admit = sub.add_parser("admit")
     p_admit.add_argument("key")
@@ -1720,6 +2051,16 @@ def _build_parser():
     p_admit.add_argument("--profile")
     p_admit.add_argument("--gateway-session-key")
     p_admit.add_argument("--domain-prefixes")
+    p_admit.add_argument("--owner-pid", type=int)
+    p_admit.add_argument("--owner-start-time")
+
+    p_guard = sub.add_parser("guard")
+    p_guard.add_argument("--repo", required=True)
+    p_guard.add_argument("--agent", required=True)
+    p_guard.add_argument("--session", required=True)
+    p_guard.add_argument("--profile")
+    p_guard.add_argument("--domain-prefixes")
+    p_guard.add_argument("--json", action="store_true")
 
     p_event = sub.add_parser("event")
     p_event.add_argument("key")
@@ -1784,6 +2125,7 @@ def main(argv=None):
                 root, args.key, args.agent, args.session, args.worktree,
                 args.reclaim or args.reclaim_worktree, args.ttl_hours,
                 profile=args.profile, gateway_session_key=args.gateway_session_key,
+                owner_pid=args.owner_pid, owner_start_time=args.owner_start_time,
             )
         if args.command == "admit":
             return cmd_admit(
@@ -1792,6 +2134,13 @@ def main(argv=None):
                 profile=args.profile,
                 gateway_session_key=args.gateway_session_key,
                 domain_prefixes=args.domain_prefixes,
+                owner_pid=args.owner_pid, owner_start_time=args.owner_start_time,
+            )
+        if args.command == "guard":
+            return cmd_guard(
+                root, args.repo, args.agent, args.session,
+                profile=args.profile, domain_prefixes=args.domain_prefixes,
+                as_json=args.json,
             )
         if args.command == "event":
             return cmd_event(

--- a/scripts/factory_lane.py
+++ b/scripts/factory_lane.py
@@ -255,8 +255,19 @@ def _read_all_events(lane_file):
     """Lit le journal via ouverture secure no-follow + flock partagé (cohérent
     avec le flock exclusif utilisé pendant l'append)."""
     fd = _open_secure(lane_file, os.O_RDONLY | _NONBLOCK_FLAG)
+    return _read_all_events_fd(fd, lane_file)
+
+
+def _read_all_events_at(parent_fd, name, source):
+    """Read one regular JSONL journal relative to an anchored directory fd."""
+    fd = os.open(name, os.O_RDONLY | _NOFOLLOW_FLAG | _NONBLOCK_FLAG, dir_fd=parent_fd)
+    return _read_all_events_fd(fd, source)
+
+
+def _read_all_events_fd(fd, source):
+    """Parse a JSONL journal already opened with no-follow semantics."""
     try:
-        _require_regular_fd(fd, f"journal {lane_file}")
+        _require_regular_fd(fd, f"journal {source}")
     except BaseException:
         os.close(fd)
         raise
@@ -266,7 +277,7 @@ def _read_all_events(lane_file):
             text = f.read()
         finally:
             fcntl.flock(f.fileno(), fcntl.LOCK_UN)
-    return _parse_jsonl_lines(text, lane_file)
+    return _parse_jsonl_lines(text, source)
 
 
 def _same_event(a, b):
@@ -296,6 +307,63 @@ except (AttributeError, OSError):
     _NATIVE_RENAMEAT = None
 
 
+class _RegistryRootAnchor:
+    """Trusted registry-root descriptor held for one logical operation."""
+
+    def __init__(self, path, fd):
+        self.path = os.fspath(path)
+        self.fd = fd
+
+
+def _assert_dirfd_matches_path(fd, path, label):
+    """Reject a directory path replaced after its descriptor was opened."""
+    try:
+        path_stat = os.stat(path, follow_symlinks=False)
+    except OSError as exc:
+        raise RegistryError(f"{label} changed during operation: {exc}") from exc
+    fd_stat = os.fstat(fd)
+    if (
+        not stat.S_ISDIR(path_stat.st_mode)
+        or (fd_stat.st_dev, fd_stat.st_ino) != (path_stat.st_dev, path_stat.st_ino)
+    ):
+        raise RegistryError(f"{label} changed during operation")
+
+
+@contextlib.contextmanager
+def _anchored_registry_root(root):
+    """Keep one no-follow registry-root fd and reject a later path replacement."""
+    if isinstance(root, _RegistryRootAnchor):
+        _assert_dirfd_matches_path(root.fd, root.path, "registry root")
+        root_path = root.path
+        fd = os.dup(root.fd)
+    else:
+        root_path = os.fspath(root)
+        fd = _open_secure(root_path, os.O_RDONLY | _ODIRECTORY_FLAG)
+    try:
+        if not stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise RegistryError(f"registry path is not a directory: {root_path}")
+        anchor = _RegistryRootAnchor(root_path, fd)
+        _assert_dirfd_matches_path(anchor.fd, anchor.path, "registry root")
+        yield anchor
+    finally:
+        os.close(fd)
+
+
+def _ensure_registry_subdirs(root, *names):
+    """Create required registry directories from an anchored root descriptor."""
+    for name in names:
+        fd = _open_dir_chain(root, (name,), create=True)
+        os.close(fd)
+
+
+@contextlib.contextmanager
+def _registry_operation(root, *required_subdirs):
+    """Anchor a registry root before all subsequent I/O and mutations."""
+    with _anchored_registry_root(root) as anchor:
+        _ensure_registry_subdirs(anchor, *required_subdirs)
+        yield anchor
+
+
 def _openat_subdir(parent_fd, name, create):
     """openat d'un sous-répertoire via `O_NOFOLLOW|O_DIRECTORY`. Lève
     RegistryError si `name` est un symlink (swap d'ancêtre). Propage
@@ -321,7 +389,13 @@ def _open_dir_chain(root_path, parts, create=False):
     Retourne un fd du dernier répertoire (à fermer par l'appelant) ; ferme tous
     les fds intermédiaires. Ré-ouvrir cette chaîne à chaque écriture re-valide
     tous les ancêtres et referme la fenêtre TOCTOU du swap symlink."""
-    fd = _open_secure(root_path, os.O_RDONLY | _ODIRECTORY_FLAG)
+    if isinstance(root_path, _RegistryRootAnchor):
+        _assert_dirfd_matches_path(root_path.fd, root_path.path, "registry root")
+        fd = os.dup(root_path.fd)
+    elif isinstance(root_path, int):
+        fd = os.dup(root_path)
+    else:
+        fd = _open_secure(root_path, os.O_RDONLY | _ODIRECTORY_FLAG)
     try:
         for part in parts:
             nxt = _openat_subdir(fd, part, create)
@@ -469,10 +543,14 @@ def _read_owner_via_chain(root_path, key):
         os.close(key_fd)
 
 
+def _root_text_path(root_path):
+    return root_path.path if isinstance(root_path, _RegistryRootAnchor) else os.fspath(root_path)
+
+
 def _write_owner_via_chain(root_path, key, owner):
     key_fd = _open_dir_chain(root_path, ("locks", key), create=True)
     try:
-        parent_path = os.path.join(root_path, "locks", key)
+        parent_path = os.path.join(_root_text_path(root_path), "locks", key)
         _write_json_at(key_fd, parent_path, "owner.json", owner)
     finally:
         os.close(key_fd)
@@ -496,7 +574,7 @@ def _append_event_via_chain(root_path, key, event_name, extra=None):
     try:
         _append_event_at(
             lanes_fd, f"{key}.jsonl",
-            os.path.join(root_path, "lanes", f"{key}.jsonl"),
+            os.path.join(_root_text_path(root_path), "lanes", f"{key}.jsonl"),
             key, event_name, extra=extra,
         )
     finally:
@@ -809,92 +887,78 @@ def _claim_under_gate(root, key, agent, session, worktree, reclaim, ttl_hours,
         _validate_metadata_field(gateway_session_key, "gateway_session_key")
     resolved_pid, resolved_start = _resolve_owner_identity(owner_pid, owner_start_time)
 
-    # Validation Path-level (crée + refuse un symlink d'emblée) ; les écritures
-    # elles-mêmes passent ensuite par les chaînes dirfd fail-closed ci-dessous.
-    _safe_subdir(root, "lanes")
-    locks_root = _safe_subdir(root, "locks")
-    worktree_real = _canonical_worktree(worktree)
+    with _registry_operation(root, "lanes", "locks") as root_anchor:
+        worktree_real = _canonical_worktree(worktree)
 
-    lock_dir = locks_root / key
-    if lock_dir.is_symlink():
-        raise RegistryError(f"lock directory must not be a symlink: {lock_dir}")
-    lock_dir.mkdir(parents=True, exist_ok=True)
-
-    root_path = str(root)
-    # Verrou machine-wide (préflight->claim TOCTOU) + verrou par-lane, tous deux
-    # ouverts via chaîne dirfd O_NOFOLLOW ; toute écriture (owner.json, journal)
-    # ré-ouvre sa chaîne et échoue fermé si un ancêtre a été swappé en symlink.
-    with _dirfd_flock(root_path, (), ".worktree-admission.lock"), \
-            _dirfd_flock(root_path, ("locks", key), ".lock"):
-        now = time.time()
-        owner = _read_owner_via_chain(root_path, key)
-        if owner is not None:
-            if _is_same_session(owner, agent, session):
-                current_wt = owner.get("worktree")
-                if not (current_wt and _canonical_worktree(current_wt) == worktree_real):
-                    # Rebind vers un worktree différent : ne jamais réécrire
-                    # l'owner vers un worktree déjà détenu par une autre lane
-                    # (sinon deux owners pour le même worktree).
-                    rebind_conflict = _find_worktree_claim(locks_root, worktree_real)
-                    if rebind_conflict is not None and rebind_conflict[0] != key:
-                        rc_owner = rebind_conflict[1]
+        # Verrou machine-wide (préflight->claim TOCTOU) + verrou par-lane, tous deux
+        # ouverts via chaîne dirfd O_NOFOLLOW ; toute écriture (owner.json, journal)
+        # ré-ouvre sa chaîne et échoue fermé si un ancêtre a été swappé en symlink.
+        with _dirfd_flock(root_anchor, (), ".worktree-admission.lock"), \
+                _dirfd_flock(root_anchor, ("locks", key), ".lock"):
+            now = time.time()
+            owner = _read_owner_via_chain(root_anchor, key)
+            if owner is not None:
+                if _is_same_session(owner, agent, session):
+                    current_wt = owner.get("worktree")
+                    if not current_wt or _canonical_worktree(current_wt) != worktree_real:
                         raise RegistryError(
-                            f"worktree already claimed by {rebind_conflict[0]} "
-                            f"{rc_owner.get('agent')}/{rc_owner.get('session_id')}"
+                            "worktree already claimed by this same session from a different worktree"
                         )
-                    owner["worktree"] = worktree_real
-                owner["heartbeat_at"] = now
-                _write_owner_via_chain(root_path, key, owner)
+                    if resolved_pid is not None:
+                        owner["pid"] = resolved_pid
+                        owner["process_start_time"] = resolved_start
+                    owner["heartbeat_at"] = now
+                    _write_owner_via_chain(root_anchor, key, owner)
+                    return 0
+
+                if not reclaim:
+                    raise RegistryError(
+                        f"lane {key} already claimed by "
+                        f"{owner.get('agent')}/{owner.get('session_id')}"
+                    )
+
+                if not _can_reclaim_owner(now, owner):
+                    raise RegistryError(
+                        f"lane {key} owner still active, refusing --reclaim"
+                    )
+
+                previous_agent = owner.get("agent")
+                previous_session = owner.get("session_id")
+                new_owner = _build_owner(
+                    agent, session, worktree_real, ttl_hours, now,
+                    profile=profile, gateway_session_key=gateway_session_key,
+                    owner_pid=resolved_pid, owner_start_time=resolved_start,
+                )
+                _write_owner_via_chain(root_anchor, key, new_owner)
+                _append_event_via_chain(root_anchor, key, "lock_reclaimed", extra={
+                    "previous_agent": previous_agent,
+                    "previous_session": previous_session,
+                })
                 return 0
 
-            if not reclaim:
-                raise RegistryError(
-                    f"lane {key} already claimed by "
-                    f"{owner.get('agent')}/{owner.get('session_id')}"
-                )
+            conflict = _find_claim_for_worktree(root_anchor, worktree_real)
+            if conflict is not None:
+                conflict_key, conflict_owner = conflict
+                if conflict_key != key:
+                    if not reclaim:
+                        raise RegistryError(
+                            f"worktree already claimed by {conflict_key} "
+                            f"{conflict_owner.get('agent')}/{conflict_owner.get('session_id')}"
+                        )
+                    if not _can_reclaim_owner(now, conflict_owner):
+                        raise RegistryError(
+                            f"worktree already claimed by active owner {conflict_key}"
+                        )
+                    _unlink_owner_via_chain(root_anchor, conflict_key)
 
-            if not _can_reclaim_owner(now, owner):
-                raise RegistryError(
-                    f"lane {key} owner still active, refusing --reclaim"
-                )
-
-            previous_agent = owner.get("agent")
-            previous_session = owner.get("session_id")
             new_owner = _build_owner(
                 agent, session, worktree_real, ttl_hours, now,
                 profile=profile, gateway_session_key=gateway_session_key,
                 owner_pid=resolved_pid, owner_start_time=resolved_start,
             )
-            _write_owner_via_chain(root_path, key, new_owner)
-            _append_event_via_chain(root_path, key, "lock_reclaimed", extra={
-                "previous_agent": previous_agent,
-                "previous_session": previous_session,
-            })
+            _write_owner_via_chain(root_anchor, key, new_owner)
+            _append_event_via_chain(root_anchor, key, "lane_claimed")
             return 0
-
-        conflict = _find_worktree_claim(locks_root, worktree_real)
-        if conflict is not None:
-            conflict_key, conflict_owner, _conflict_owner_file = conflict
-            if conflict_key != key:
-                if not reclaim:
-                    raise RegistryError(
-                        f"worktree already claimed by {conflict_key} "
-                        f"{conflict_owner.get('agent')}/{conflict_owner.get('session_id')}"
-                    )
-                if not _can_reclaim_owner(now, conflict_owner):
-                    raise RegistryError(
-                        f"worktree already claimed by active owner {conflict_key}"
-                    )
-                _unlink_owner_via_chain(root_path, conflict_key)
-
-        new_owner = _build_owner(
-            agent, session, worktree_real, ttl_hours, now,
-            profile=profile, gateway_session_key=gateway_session_key,
-            owner_pid=resolved_pid, owner_start_time=resolved_start,
-        )
-        _write_owner_via_chain(root_path, key, new_owner)
-        _append_event_via_chain(root_path, key, "lane_claimed")
-        return 0
 
 
 def cmd_claim(root, key, agent, session, worktree, reclaim, ttl_hours,
@@ -924,36 +988,33 @@ def cmd_admit(root, key, mode, hard, agent, session, worktree, ttl_hours,
               domain_prefixes=None, owner_pid=None, owner_start_time=None):
     validate_key(key)
     _validate_ttl_hours(ttl_hours)
-    locks_root = _safe_subdir(root, "locks")
-    _safe_subdir(root, "lanes")
     worktree_real = _canonical_worktree(worktree)
-    gate_file = root / ".worktree-admission.lock"
+    with _registry_operation(root, "locks", "lanes") as root_anchor:
+        with _dirfd_flock(root_anchor, (), ".worktree-admission.lock"):
+            conflict = _find_claim_for_worktree(root_anchor, worktree_real)
+            if mode == "reviewer":
+                payload = {
+                    "key": key,
+                    "worktree": worktree_real,
+                    "decision": "reviewer_allowed",
+                }
+                if conflict:
+                    payload["owner_key"] = conflict[0]
+                    payload["owner_agent"] = conflict[1].get("agent")
+                    payload["owner_session"] = conflict[1].get("session_id")
+                if as_json:
+                    print(json.dumps(payload, sort_keys=True))
+                return 0
 
-    with _locked(gate_file):
-        conflict = _find_worktree_claim(locks_root, worktree_real)
-        if mode == "reviewer":
-            payload = {
-                "key": key,
-                "worktree": worktree_real,
-                "decision": "reviewer_allowed",
-            }
-            if conflict:
-                payload["owner_key"] = conflict[0]
-                payload["owner_agent"] = conflict[1].get("agent")
-                payload["owner_session"] = conflict[1].get("session_id")
-            if as_json:
-                print(json.dumps(payload, sort_keys=True))
-            return 0
+            _validate_profile_domain(key, profile, domain_prefixes)
+            if hard and conflict is None and _git_dirty(worktree_real):
+                raise RegistryError(f"dirty ownerless worktree: {worktree_real}")
 
-        _validate_profile_domain(key, profile, domain_prefixes)
-        if hard and conflict is None and _git_dirty(worktree_real):
-            raise RegistryError(f"dirty ownerless worktree: {worktree_real}")
-
-    return _claim_under_gate(
-        root, key, agent, session, worktree_real, False, ttl_hours,
-        profile=profile, gateway_session_key=gateway_session_key,
-        owner_pid=owner_pid, owner_start_time=owner_start_time,
-    )
+        return _claim_under_gate(
+            root_anchor, key, agent, session, worktree_real, False, ttl_hours,
+            profile=profile, gateway_session_key=gateway_session_key,
+            owner_pid=owner_pid, owner_start_time=owner_start_time,
+        )
 
 
 # --------------------------------------------------------------------------
@@ -976,7 +1037,8 @@ def evaluate_admission_guard(root, worktree_real, agent, session,
       : anti double-occupation (un seul gagnant par worktree).
     - Sinon -> `(True, None)`.
     """
-    match = _find_claim_for_worktree(root, worktree_real)
+    with _anchored_registry_root(root) as root_anchor:
+        match = _find_claim_for_worktree(root_anchor, worktree_real)
     if match is None:
         return True, None
     key, owner = match
@@ -1022,9 +1084,6 @@ def cmd_guard(root, repo, agent, session, profile=None, domain_prefixes=None,
 
 def cmd_event(root, key, event_name, evidence, pr, commit=None, ci=None, deploy=None):
     validate_key(key)
-    _safe_subdir(root, "lanes")
-    _safe_subdir(root, "locks")
-
     if event_name not in ALLOWED_MANUAL_EVENTS:
         raise RegistryError(f"unknown event: {event_name!r}")
     if evidence is not None:
@@ -1040,26 +1099,26 @@ def cmd_event(root, key, event_name, evidence, pr, commit=None, ci=None, deploy=
     if event_name == "pr_opened" and not pr:
         raise RegistryError("pr_opened requires --pr")
 
-    root_path = str(root)
-    with _dirfd_flock(root_path, ("locks", key), ".lock"):
-        owner = _read_owner_via_chain(root_path, key)
-        if owner is None:
-            raise RegistryError(f"no active claim for lane {key}")
-        owner["heartbeat_at"] = time.time()
-        _write_owner_via_chain(root_path, key, owner)
+    with _registry_operation(root, "lanes", "locks") as root_anchor:
+        with _dirfd_flock(root_anchor, ("locks", key), ".lock"):
+            owner = _read_owner_via_chain(root_anchor, key)
+            if owner is None:
+                raise RegistryError(f"no active claim for lane {key}")
+            owner["heartbeat_at"] = time.time()
+            _write_owner_via_chain(root_anchor, key, owner)
 
-        extra = {}
-        if evidence is not None:
-            extra["evidence"] = evidence
-        if pr is not None:
-            extra["pr"] = pr
-        if commit is not None:
-            extra["commit"] = commit
-        if ci is not None:
-            extra["ci"] = ci
-        if deploy is not None:
-            extra["deploy"] = deploy
-        _append_event_via_chain(root_path, key, event_name, extra=extra)
+            extra = {}
+            if evidence is not None:
+                extra["evidence"] = evidence
+            if pr is not None:
+                extra["pr"] = pr
+            if commit is not None:
+                extra["commit"] = commit
+            if ci is not None:
+                extra["ci"] = ci
+            if deploy is not None:
+                extra["deploy"] = deploy
+            _append_event_via_chain(root_anchor, key, event_name, extra=extra)
     return 0
 
 
@@ -1076,86 +1135,88 @@ def cmd_handoff(root, key, status, next_step, evidence):
     if evidence is not None:
         _validate_evidence(evidence)
 
-    _safe_subdir(root, "lanes")
-    _safe_subdir(root, "locks")
-    _safe_subdir(root, "handoffs")
+    with _registry_operation(root, "lanes", "locks", "handoffs") as root_anchor:
+        with _dirfd_flock(root_anchor, ("locks", key), ".lock"):
+            if _read_owner_via_chain(root_anchor, key) is None:
+                raise RegistryError(f"no active claim for lane {key}")
 
-    root_path = str(root)
-    with _dirfd_flock(root_path, ("locks", key), ".lock"):
-        if _read_owner_via_chain(root_path, key) is None:
-            raise RegistryError(f"no active claim for lane {key}")
+            now = time.time()
+            ts_ms = int(now * 1000)
+            date_suffix = time.strftime("%Y-%m-%d", time.gmtime(now))
+            handoff_name = f"{key}-{date_suffix}.md"
+            lines = [
+                f"# Handoff {key}",
+                f"Status: {status}",
+                f"Next step: {next_step}",
+            ]
+            if evidence is not None:
+                lines.append(f"Evidence: {evidence}")
+            lines.append(f"Timestamp: {ts_ms}")
+            content = "\n".join(lines) + "\n"
 
-        now = time.time()
-        ts_ms = int(now * 1000)
-        date_suffix = time.strftime("%Y-%m-%d", time.gmtime(now))
-        handoff_name = f"{key}-{date_suffix}.md"
-        lines = [
-            f"# Handoff {key}",
-            f"Status: {status}",
-            f"Next step: {next_step}",
-        ]
-        if evidence is not None:
-            lines.append(f"Evidence: {evidence}")
-        lines.append(f"Timestamp: {ts_ms}")
-        content = "\n".join(lines) + "\n"
+            handoffs_fd = _open_dir_chain(root_anchor, ("handoffs",), create=True)
+            try:
+                _write_text_at(
+                    handoffs_fd, os.path.join(_root_text_path(root_anchor), "handoffs"), handoff_name, content,
+                )
+            finally:
+                os.close(handoffs_fd)
 
-        handoffs_fd = _open_dir_chain(root_path, ("handoffs",), create=True)
-        try:
-            _write_text_at(
-                handoffs_fd, os.path.join(root_path, "handoffs"), handoff_name, content,
-            )
-        finally:
-            os.close(handoffs_fd)
-
-        _append_event_via_chain(root_path, key, "handoff", extra={
-            "status": status, "handoff_file": handoff_name,
-        })
+            _append_event_via_chain(root_anchor, key, "handoff", extra={
+                "status": status, "handoff_file": handoff_name,
+            })
     return 0
 
 
 def cmd_render(root):
-    lanes_dir = _safe_subdir(root, "lanes")
-    locks_root = _safe_subdir(root, "locks")
+    with _registry_operation(root, "lanes", "locks") as root_anchor:
+        lanes_fd = _open_dir_chain(root_anchor, ("lanes",), create=False)
+        try:
+            try:
+                lane_names = sorted(name for name in os.listdir(lanes_fd) if name.endswith(".jsonl"))
+            except OSError as exc:
+                raise RegistryError(f"registry lane scan failed: {exc}") from exc
 
-    entries = []
-    for lane_file in sorted(lanes_dir.glob("*.jsonl")):
-        key = lane_file.stem
-        events = _read_all_events(lane_file)
-        owner_file = locks_root / key / "owner.json"
-        if not owner_file.exists():
-            continue
-        entries.append((key, _compute_status(events)))
+            entries = []
+            for lane_name in lane_names:
+                key = Path(lane_name).stem
+                events = _read_all_events_at(
+                    lanes_fd,
+                    lane_name,
+                    os.path.join(_root_text_path(root_anchor), "lanes", lane_name),
+                )
+                if _read_owner_via_chain(root_anchor, key) is None:
+                    continue
+                entries.append((key, _compute_status(events)))
+        finally:
+            os.close(lanes_fd)
 
-    lines = ["# LANES", ""]
-    if not entries:
-        lines.append("_No active lanes._")
-    else:
-        lines.append("| Key | Status |")
-        lines.append("|-----|--------|")
-        for key, status in entries:
-            lines.append(f"| {key} | {status} |")
-    content = "\n".join(lines) + "\n"
+        lines = ["# LANES", ""]
+        if not entries:
+            lines.append("_No active lanes._")
+        else:
+            lines.append("| Key | Status |")
+            lines.append("|-----|--------|")
+            for key, status in entries:
+                lines.append(f"| {key} | {status} |")
+        content = "\n".join(lines) + "\n"
 
-    root_path = str(root)
-    root_fd = _open_dir_chain(root_path, (), create=False)
-    try:
-        _write_text_at(root_fd, root_path, "LANES.md", content, mode=0o644)
-    finally:
-        os.close(root_fd)
+        root_fd = _open_dir_chain(root_anchor, (), create=False)
+        try:
+            _write_text_at(root_fd, _root_text_path(root_anchor), "LANES.md", content, mode=0o644)
+        finally:
+            os.close(root_fd)
     return 0
 
 
 def cmd_close(root, key):
     validate_key(key)
-    _safe_subdir(root, "lanes")
-    _safe_subdir(root, "locks")
-
-    root_path = str(root)
-    with _dirfd_flock(root_path, ("locks", key), ".lock"):
-        if _read_owner_via_chain(root_path, key) is None:
-            raise RegistryError(f"no active claim for lane {key}")
-        _append_event_via_chain(root_path, key, "lane_closed")
-        _unlink_owner_via_chain(root_path, key)
+    with _registry_operation(root, "lanes", "locks") as root_anchor:
+        with _dirfd_flock(root_anchor, ("locks", key), ".lock"):
+            if _read_owner_via_chain(root_anchor, key) is None:
+                raise RegistryError(f"no active claim for lane {key}")
+            _append_event_via_chain(root_anchor, key, "lane_closed")
+            _unlink_owner_via_chain(root_anchor, key)
     return 0
 
 
@@ -1332,19 +1393,30 @@ def _write_context_output(out_path, content):
     if parent.is_symlink():
         raise RegistryError(f"context output directory must not be a symlink: {parent}")
 
-    fd, tmp_path = tempfile.mkstemp(dir=str(parent), prefix=".context-", suffix=".tmp")
+    parent_fd = _open_secure(parent, os.O_RDONLY | _ODIRECTORY_FLAG)
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(content)
-            f.flush()
-            os.fsync(f.fileno())
-        os.chmod(tmp_path, 0o600)
-        os.replace(tmp_path, str(out_path))
-        _fsync_dir(parent)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.remove(tmp_path)
-        raise
+        _assert_dirfd_matches_path(parent_fd, parent, "context output directory")
+        fd, tmp_path = tempfile.mkstemp(dir=str(parent), prefix=".context-", suffix=".tmp")
+        tmp_name = Path(tmp_path).name
+        try:
+            # The temporary file was created through a text path.  Before writing
+            # or renaming it, prove that path still names the descriptor we opened.
+            # This turns a post-mkstemp ancestor replacement into a clean refusal.
+            _assert_dirfd_matches_path(parent_fd, parent, "context output directory")
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+                os.fchmod(f.fileno(), 0o600)
+            _assert_dirfd_matches_path(parent_fd, parent, "context output directory")
+            _atomic_replace_at(parent_fd, str(parent), tmp_name, out_path.name)
+            os.fsync(parent_fd)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name, dir_fd=parent_fd)
+            raise
+    finally:
+        os.close(parent_fd)
 
 
 def _write_registry_context_output(root, registry_output_root, out_path, content):
@@ -1367,7 +1439,7 @@ def _write_registry_context_output(root, registry_output_root, out_path, content
         raise RegistryError("context output path is invalid")
 
     parent_parts = ("contexts", *relative_output.parts[:-1])
-    parent_fd = _open_dir_chain(str(root), parent_parts, create=True)
+    parent_fd = _open_dir_chain(root, parent_parts, create=True)
     try:
         _write_text_at(parent_fd, "", relative_output.name, content)
     finally:
@@ -1383,9 +1455,17 @@ def _path_is_within(path, root):
 
 
 def cmd_context(root, key, repo, vault, context_map_arg, out_arg):
+    with _anchored_registry_root(root) as root_anchor:
+        return _cmd_context_anchored(
+            root_anchor, key, repo, vault, context_map_arg, out_arg,
+        )
+
+
+def _cmd_context_anchored(root, key, repo, vault, context_map_arg, out_arg):
     validate_key(key)
     repo_real = os.path.realpath(repo)
-    registry_output_root = root / "contexts"
+    root_text = Path(_root_text_path(root))
+    registry_output_root = root_text / "contexts"
     repo_output_root = Path(repo_real) / ".factory"
     out_path = Path(out_arg) if out_arg else registry_output_root / f"{key}.md"
     output_parent_real = Path(os.path.realpath(str(out_path.parent)))
@@ -1401,10 +1481,10 @@ def cmd_context(root, key, repo, vault, context_map_arg, out_arg):
             "context output must stay inside registry contexts or repo .factory"
         )
 
-    context_map_path = Path(context_map_arg) if context_map_arg else root / "context-map.json"
+    context_map_path = Path(context_map_arg) if context_map_arg else root_text / "context-map.json"
     repos_map = _load_context_map(context_map_path)
     entry = repos_map.get(repo_real)
-    status = _lane_status(root, key)
+    status = _lane_status(root_text, key)
 
     if entry is None:
         # Repo inconnu : aucun accès au vault, pas même `os.path.realpath`.
@@ -1416,7 +1496,7 @@ def cmd_context(root, key, repo, vault, context_map_arg, out_arg):
         return 0
 
     vault_root = Path(os.path.realpath(vault))
-    content = _render_mapped_pack(key, repo_real, status, root, vault_root, entry)
+    content = _render_mapped_pack(key, repo_real, status, root_text, vault_root, entry)
     if _path_is_within(Path(os.path.abspath(str(out_path))), registry_output_root):
         _write_registry_context_output(root, registry_output_root, out_path, content)
     else:
@@ -1606,16 +1686,12 @@ def _serialize_handoff(payload):
 
 def cmd_capture_handoff(root, key, repo, summary_path):
     validate_key(key)
-    _safe_subdir(root, "lanes")
-    _safe_subdir(root, "locks")
-    _safe_subdir(root, "handoffs")
-
     summary_fields = {}
     if summary_path is not None:
         summary_fields = _load_summary(summary_path)
 
-    root_path = str(root)
-    with _dirfd_flock(root_path, ("locks", key), ".lock"):
+    with _registry_operation(root, "lanes", "locks", "handoffs") as root_path, \
+            _dirfd_flock(root_path, ("locks", key), ".lock"):
         owner = _read_owner_via_chain(root_path, key)
         if owner is None:
             raise RegistryError(f"no active claim for lane {key}")
@@ -1656,7 +1732,7 @@ def cmd_capture_handoff(root, key, repo, summary_path):
         handoffs_fd = _open_dir_chain(root_path, ("handoffs",), create=True)
         try:
             _write_text_at(
-                handoffs_fd, os.path.join(root_path, "handoffs"), handoff_name, content,
+                handoffs_fd, os.path.join(_root_text_path(root_path), "handoffs"), handoff_name, content,
             )
         finally:
             os.close(handoffs_fd)
@@ -1706,8 +1782,9 @@ def _find_claim_for_worktree(root, repo_real):
     fd du registry avec ``openat(..., O_NOFOLLOW)`` et propage ``RegistryError``
     au hook, qui refuse alors la mutation avant l'outil.
     """
+    root_path = Path(root.path) if isinstance(root, _RegistryRootAnchor) else Path(root)
     try:
-        locks_fd = _open_dir_chain(str(root), ("locks",), create=False)
+        locks_fd = _open_dir_chain(root, ("locks",), create=False)
     except FileNotFoundError:
         return None
     except (OSError, RegistryError) as exc:
@@ -1715,8 +1792,10 @@ def _find_claim_for_worktree(root, repo_real):
     try:
         def assert_locks_path_stable():
             """Reject a textual locks/ path swapped after its no-follow open."""
+            if isinstance(root, _RegistryRootAnchor):
+                _assert_dirfd_matches_path(root.fd, root.path, "registry root")
             try:
-                path_stat = os.stat(root / "locks", follow_symlinks=False)
+                path_stat = os.stat(root_path / "locks", follow_symlinks=False)
             except OSError as exc:
                 raise RegistryError(f"registry locks changed during owner scan: {exc}") from exc
             fd_stat = os.fstat(locks_fd)
@@ -1895,10 +1974,13 @@ def _evaluate_handoff(repo_real, owner, handoff):
 
 
 def cmd_reconcile(root, key, repo, handoff_path):
+    with _registry_operation(root, "lanes", "locks", "handoffs") as root_anchor:
+        return _cmd_reconcile_anchored(root_anchor, key, repo, handoff_path)
+
+
+def _cmd_reconcile_anchored(root, key, repo, handoff_path):
     validate_key(key)
-    _safe_subdir(root, "lanes")
-    _safe_subdir(root, "locks")
-    handoffs_dir = _safe_subdir(root, "handoffs")
+    handoffs_dir = Path(_root_text_path(root)) / "handoffs"
 
     handoff = _load_handoff(handoff_path, handoffs_dir)
 
@@ -1918,7 +2000,7 @@ def cmd_reconcile(root, key, repo, handoff_path):
         if not isinstance(handoff_canonical, str) or os.path.realpath(handoff_canonical) != repo_real:
             raise RegistryError("handoff canonical_repo does not match --repo")
 
-    root_path = str(root)
+    root_path = root
     with _dirfd_flock(root_path, ("locks", key), ".lock"):
         owner = _read_owner_via_chain(root_path, key)
         if owner is None:
@@ -1987,47 +2069,50 @@ def cmd_hook_stop(root, repo, key, summary_path=None):
         if repo_real is None:
             return 0
 
-        root_path = str(root)
-        owner = _read_owner_via_chain(root_path, key)
-        if owner is None:
-            return 0
-        claimed_worktree = owner.get("worktree")
-        if not claimed_worktree or os.path.realpath(claimed_worktree) != repo_real:
-            return 0
+        with _anchored_registry_root(root) as root_anchor:
+            owner = _read_owner_via_chain(root_anchor, key)
+            if owner is None:
+                return 0
+            claimed_worktree = owner.get("worktree")
+            if not claimed_worktree or os.path.realpath(claimed_worktree) != repo_real:
+                return 0
 
-        branch = _git_current_branch(repo_real)
-        head_sha = _git_head_commit(repo_real)
-        git_status = _git_status_entries(repo_real)
-        files_changed = sorted({e["path"] for e in git_status if e["path"]})
+            branch = _git_current_branch(repo_real)
+            head_sha = _git_head_commit(repo_real)
+            git_status = _git_status_entries(repo_real)
+            files_changed = sorted({e["path"] for e in git_status if e["path"]})
 
-        payload = {
-            "issue": key,
-            "agent": owner.get("agent"),
-            "session_id": owner.get("session_id"),
-            "repo": repo_real,
-            "worktree": repo_real,
-            "branch": branch,
-            "head_commit": head_sha,
-            "git_status": git_status,
-            "files_changed": files_changed,
-            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time())),
-        }
+            payload = {
+                "issue": key,
+                "agent": owner.get("agent"),
+                "session_id": owner.get("session_id"),
+                "repo": repo_real,
+                "worktree": repo_real,
+                "branch": branch,
+                "head_commit": head_sha,
+                "git_status": git_status,
+                "files_changed": files_changed,
+                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time())),
+            }
 
-        if summary_path is not None:
+            if summary_path is not None:
+                try:
+                    payload.update(_load_summary(summary_path))
+                except RegistryError:
+                    pass
+
+            content = _serialize_handoff(payload)
+            capture_name = f"{key}-stop-{time.time_ns()}.json"
+            handoffs_fd = _open_dir_chain(root_anchor, ("handoffs",), create=True)
             try:
-                payload.update(_load_summary(summary_path))
-            except RegistryError:
-                pass
-
-        content = _serialize_handoff(payload)
-        capture_name = f"{key}-stop-{time.time_ns()}.json"
-        handoffs_fd = _open_dir_chain(root_path, ("handoffs",), create=True)
-        try:
-            _write_text_at(
-                handoffs_fd, os.path.join(root_path, "handoffs"), capture_name, content,
-            )
-        finally:
-            os.close(handoffs_fd)
+                _write_text_at(
+                    handoffs_fd,
+                    os.path.join(_root_text_path(root_anchor), "handoffs"),
+                    capture_name,
+                    content,
+                )
+            finally:
+                os.close(handoffs_fd)
 
         return 0
     except Exception:

--- a/tests/test_factory_lane_admission.py
+++ b/tests/test_factory_lane_admission.py
@@ -1,0 +1,291 @@
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "factory_lane.py"
+
+
+def run_lane(registry, *args, check=False, cwd=None):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--registry", str(registry), *args],
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return result
+
+
+def load_factory_lane():
+    spec = importlib.util.spec_from_file_location("factory_lane_under_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_git_worktree(path: Path):
+    path.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True)
+    (path / "README.md").write_text("ok\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, check=True)
+
+
+def read_owner(registry: Path, key: str):
+    return json.loads((registry / "locks" / key / "owner.json").read_text())
+
+
+def test_different_issues_cannot_claim_same_realpath_via_trailing_slash_or_symlink(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    link = tmp_path / "repo-link"
+    link.symlink_to(worktree, target_is_directory=True)
+
+    first = run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "s1", "--worktree", f"{worktree}/")
+    assert first.returncode == 0, first.stderr
+
+    second = run_lane(registry, "claim", "HER-96", "--agent", "hermes-immo", "--session", "s2", "--worktree", str(link))
+    assert second.returncode != 0
+    assert "worktree already claimed" in second.stderr
+    assert not (registry / "locks" / "HER-96" / "owner.json").exists()
+
+
+def test_owner_reentrant_claim_refreshes_heartbeat_without_conflict(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+
+    assert run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "s1", "--worktree", str(worktree)).returncode == 0
+    before = read_owner(registry, "HER-95")["heartbeat_at"]
+    time.sleep(0.01)
+    again = run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "s1", "--worktree", str(worktree))
+    assert again.returncode == 0, again.stderr
+    after = read_owner(registry, "HER-95")["heartbeat_at"]
+    assert after > before
+
+
+def test_reviewer_admission_coexists_without_touching_owner(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    assert run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "owner", "--worktree", str(worktree)).returncode == 0
+    before = read_owner(registry, "HER-95")
+
+    result = run_lane(
+        registry,
+        "admit",
+        "HER-96",
+        "--mode",
+        "reviewer",
+        "--agent",
+        "opus-reviewer",
+        "--session",
+        "review",
+        "--worktree",
+        str(worktree),
+        "--json",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["decision"] == "reviewer_allowed"
+    assert read_owner(registry, "HER-95") == before
+    assert not (registry / "locks" / "HER-96" / "owner.json").exists()
+
+
+def test_hard_admission_refuses_second_live_owner_before_lane_mutation(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    assert run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "owner", "--worktree", str(worktree)).returncode == 0
+
+    result = run_lane(
+        registry,
+        "admit",
+        "HER-96",
+        "--mode",
+        "owner",
+        "--hard",
+        "--agent",
+        "hermes-immo",
+        "--session",
+        "intruder",
+        "--worktree",
+        str(worktree),
+    )
+
+    assert result.returncode != 0
+    assert "worktree already claimed" in result.stderr
+    assert not (registry / "lanes" / "HER-96.jsonl").exists()
+
+
+def test_stale_dead_owner_can_be_reclaimed_only_after_ttl_and_inactive_worktree(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    assert run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "old", "--worktree", str(worktree)).returncode == 0
+    owner_file = registry / "locks" / "HER-95" / "owner.json"
+    owner = json.loads(owner_file.read_text())
+    owner.update({"pid": 987654321, "heartbeat_at": time.time() - 7200, "ttl_hours": 0.001})
+    owner_file.write_text(json.dumps(owner), encoding="utf-8")
+    old = time.time() - (25 * 3600)
+    os.utime(worktree, (old, old))
+
+    result = run_lane(
+        registry,
+        "claim",
+        "HER-96",
+        "--agent",
+        "default",
+        "--session",
+        "new",
+        "--worktree",
+        str(worktree),
+        "--reclaim-worktree",
+        "--ttl-hours",
+        "0.001",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not owner_file.exists()
+    assert read_owner(registry, "HER-96")["session_id"] == "new"
+
+
+def test_fresh_or_active_ownerless_dirty_worktree_is_refused_before_build(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_worktree(worktree)
+    (worktree / "dirty.txt").write_text("untracked\n", encoding="utf-8")
+
+    result = run_lane(
+        registry,
+        "admit",
+        "HER-95",
+        "--mode",
+        "owner",
+        "--hard",
+        "--agent",
+        "default",
+        "--session",
+        "s1",
+        "--worktree",
+        str(worktree),
+    )
+
+    assert result.returncode != 0
+    assert "dirty ownerless worktree" in result.stderr
+    assert not (registry / "locks" / "HER-95" / "owner.json").exists()
+
+
+def test_toctou_parallel_hard_admission_has_exactly_one_winner(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    commands = [
+        [sys.executable, str(SCRIPT), "--registry", str(registry), "admit", key, "--mode", "owner", "--hard", "--agent", agent, "--session", agent, "--worktree", str(worktree)]
+        for key, agent in (("HER-95", "default"), ("HER-96", "hermes-immo"))
+    ]
+
+    procs = [subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True) for cmd in commands]
+    results = [p.communicate(timeout=20) + (p.returncode,) for p in procs]
+
+    assert sorted(r[2] for r in results) == [0, 1]
+    owners = list((registry / "locks").glob("*/owner.json"))
+    assert len(owners) == 1
+
+
+def test_advisory_hook_fails_open_when_registry_is_corrupt(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_worktree(worktree)
+    owner_dir = registry / "locks" / "HER-95"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "owner.json").write_text("{not-json", encoding="utf-8")
+
+    result = run_lane(registry, "hook-session-start", "--repo", str(worktree))
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_advisory_hook_prints_stop_for_different_live_owner(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_worktree(worktree)
+    assert run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "owner", "--worktree", str(worktree)).returncode == 0
+
+    result = run_lane(
+        registry,
+        "hook-session-start",
+        "--repo",
+        str(worktree),
+        "--agent",
+        "hermes-immo",
+        "--session",
+        "continue",
+    )
+
+    assert result.returncode == 0
+    assert "STOP: worktree already owned" in result.stdout
+    assert "HER-95" in result.stdout
+    assert "default/owner" in result.stdout
+
+
+def test_business_profile_cannot_hard_admit_product_lane_outside_allowed_prefixes(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+
+    result = run_lane(
+        registry,
+        "admit",
+        "SCA-740",
+        "--mode",
+        "owner",
+        "--hard",
+        "--agent",
+        "hermes-immo",
+        "--profile",
+        "hermes-immo",
+        "--domain-prefixes",
+        "JYI,HER",
+        "--session",
+        "continue",
+        "--worktree",
+        str(worktree),
+    )
+
+    assert result.returncode != 0
+    assert "profile hermes-immo cannot own lane SCA-740" in result.stderr
+    assert not (registry / "locks" / "SCA-740" / "owner.json").exists()
+
+
+def test_process_start_time_mismatch_marks_owner_as_reused(monkeypatch):
+    module = load_factory_lane()
+    monkeypatch.setattr(module.os, "kill", lambda pid, sig: None)
+    monkeypatch.setattr(module, "_get_process_state_char", lambda pid: "S")
+    monkeypatch.setattr(module, "_get_process_start_time", lambda pid: "new-start")
+
+    assert module.determine_process_state({"pid": 123, "process_start_time": "old-start"}) == "reused"
+
+
+def test_close_releases_owner_after_handoff_flow(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    assert run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "s1", "--worktree", str(worktree)).returncode == 0
+
+    result = run_lane(registry, "close", "HER-95")
+
+    assert result.returncode == 0, result.stderr
+    assert not (registry / "locks" / "HER-95" / "owner.json").exists()

--- a/tests/test_factory_lane_appsec.py
+++ b/tests/test_factory_lane_appsec.py
@@ -24,6 +24,8 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "factory_lane.py"
 
@@ -241,6 +243,103 @@ def test_ancestor_symlink_swap_during_claim_never_escapes_registry(tmp_path, mon
         # Failing closed is an acceptable outcome; escaping the registry is not.
         pass
 
-    assert not (evil / "HER-95" / "owner.json").exists(), (
-        "owner.json escaped the registry through a swapped ancestor symlink"
-    )
+    assert not (evil / "HER-95" / "owner.json").exists()
+
+
+def test_runtime_owner_scan_rejects_locks_swap_after_open(tmp_path, monkeypatch):
+    """A locks directory swapped after its no-follow open cannot become an
+    ownerless result: the runtime guard must detect the inode change and block."""
+    module = load_factory_lane()
+    registry = tmp_path / "registry"
+    locks = registry / "locks"
+    locks.mkdir(parents=True)
+    root = module._safe_registry_root(str(registry))
+    original_listdir = module.os.listdir
+    swapped = {"done": False}
+
+    def list_then_swap(fd):
+        names = original_listdir(fd)
+        if not swapped["done"]:
+            swapped["done"] = True
+            shutil.move(str(locks), str(registry / "locks-old"))
+            locks.mkdir()
+        return names
+
+    monkeypatch.setattr(module.os, "listdir", list_then_swap)
+
+    with pytest.raises(module.RegistryError, match="changed during owner scan"):
+        module._find_claim_for_worktree(root, str(tmp_path / "repo"))
+
+
+def make_git_repo(path: Path):
+    path.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=path, check=True)
+    (path / "README.md").write_text("ok\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, check=True)
+
+
+@pytest.mark.parametrize("operation", ["event", "handoff", "close", "capture", "reconcile"])
+def test_registry_mutations_reject_ancestor_symlink_swap_before_external_write(
+    tmp_path, monkeypatch, operation,
+):
+    """Every mutating registry command must re-open its directories by dirfd.
+
+    Swapping both ``locks`` and ``lanes`` after their initial Path preflight
+    used to redirect owner and journal writes outside the registry. The command
+    must now fail closed, leaving attacker-controlled records byte-for-byte
+    unchanged.
+    """
+    module = load_factory_lane()
+    key = "HER-95"
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_repo(worktree)
+    root = module._safe_registry_root(str(registry))
+    module.cmd_claim(root, key, "default", "s1", str(worktree), False, 72.0)
+
+    handoffs_dir = registry / "handoffs"
+    handoffs_dir.mkdir()
+    handoff_path = handoffs_dir / f"{key}-input.handoff.json"
+    handoff_path.write_text(json.dumps({"issue": key, "repo": str(worktree.resolve())}), encoding="utf-8")
+
+    evil = tmp_path / "evil"
+    evil_owner = evil / "locks" / key / "owner.json"
+    evil_owner.parent.mkdir(parents=True)
+    evil_owner.write_text('{"external": "owner"}\n', encoding="utf-8")
+    evil_lane = evil / "lanes" / f"{key}.jsonl"
+    evil_lane.parent.mkdir(parents=True)
+    evil_lane.write_text('{"external": "journal"}\n', encoding="utf-8")
+    external_before = {path: path.read_bytes() for path in (evil_owner, evil_lane)}
+
+    original_safe_subdir = module._safe_subdir
+    swapped = False
+
+    def swap_after_locks_preflight(root_arg, name):
+        nonlocal swapped
+        result = original_safe_subdir(root_arg, name)
+        if name == "locks" and not swapped:
+            swapped = True
+            shutil.move(str(registry / "locks"), str(registry / "locks-real"))
+            shutil.move(str(registry / "lanes"), str(registry / "lanes-real"))
+            os.symlink(str(evil / "locks"), str(registry / "locks"), target_is_directory=True)
+            os.symlink(str(evil / "lanes"), str(registry / "lanes"), target_is_directory=True)
+        return result
+
+    monkeypatch.setattr(module, "_safe_subdir", swap_after_locks_preflight)
+
+    with pytest.raises(module.RegistryError):
+        if operation == "event":
+            module.cmd_event(root, key, "ci_passed", None, None)
+        elif operation == "handoff":
+            module.cmd_handoff(root, key, "blocked", "repair the gate", None)
+        elif operation == "close":
+            module.cmd_close(root, key)
+        elif operation == "capture":
+            module.cmd_capture_handoff(root, key, str(worktree), None)
+        else:
+            module.cmd_reconcile(root, key, str(worktree), str(handoff_path))
+
+    assert {path: path.read_bytes() for path in external_before} == external_before

--- a/tests/test_factory_lane_appsec.py
+++ b/tests/test_factory_lane_appsec.py
@@ -271,6 +271,120 @@ def test_runtime_owner_scan_rejects_locks_swap_after_open(tmp_path, monkeypatch)
         module._find_claim_for_worktree(root, str(tmp_path / "repo"))
 
 
+def test_atomic_owner_replace_cannot_escape_after_text_path_swap(tmp_path, monkeypatch):
+    """A text-path replace after fstat/stat can be redirected by a post-check
+    swap.  Owner writes must instead rename relative to the open directory fd."""
+    module = load_factory_lane()
+    registry = tmp_path / "registry"
+    parent = registry / "locks" / "HER-95"
+    parent.mkdir(parents=True)
+    evil = tmp_path / "evil"
+    evil.mkdir()
+    external_owner = evil / "owner.json"
+    external_owner.write_text('{"external": true}\n', encoding="utf-8")
+    root = module._safe_registry_root(str(registry))
+    parent_fd = module._open_dir_chain(str(root), ("locks", "HER-95"), create=False)
+    original_replace = module.os.replace
+    original_rename = module.os.rename
+    swapped = False
+
+    def swap_parent():
+        nonlocal swapped
+        if swapped:
+            return
+        swapped = True
+        (registry / "locks-real").mkdir()
+        original_rename(str(parent), str(registry / "locks-real" / "HER-95"))
+        os.symlink(str(evil), str(parent), target_is_directory=True)
+
+    def swap_then_replace(source, target, *args, **kwargs):
+        swap_parent()
+        (evil / Path(source).name).write_text('{"attacker": true}\n', encoding="utf-8")
+        return original_replace(source, target, *args, **kwargs)
+
+    def swap_then_rename(source, target, *args, **kwargs):
+        swap_parent()
+        return original_rename(source, target, *args, **kwargs)
+
+    monkeypatch.setattr(module.os, "replace", swap_then_replace)
+    monkeypatch.setattr(module.os, "rename", swap_then_rename)
+    try:
+        module._write_json_at(parent_fd, str(parent), "owner.json", {"safe": True})
+    finally:
+        os.close(parent_fd)
+
+    assert external_owner.read_text(encoding="utf-8") == '{"external": true}\n'
+
+
+def test_context_output_cannot_escape_after_post_stat_parent_swap(tmp_path, monkeypatch):
+    """Registry context writes must use the same dirfd rename discipline as
+    owner records: a swapped ``contexts/`` path cannot redirect the output."""
+    module = load_factory_lane()
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_repo(worktree)
+    root = module._safe_registry_root(str(registry))
+    contexts = registry / "contexts"
+    contexts.mkdir()
+    evil = tmp_path / "evil"
+    evil.mkdir()
+    external_output = evil / "HER-95.md"
+    external_output.write_text("external\n", encoding="utf-8")
+    external_before = external_output.read_bytes()
+    original_replace = module.os.replace
+    original_rename = module.os.rename
+    swapped = False
+
+    def swap_contexts():
+        nonlocal swapped
+        if swapped:
+            return
+        swapped = True
+        original_rename(str(contexts), str(registry / "contexts-real"))
+        os.symlink(str(evil), str(contexts), target_is_directory=True)
+
+    def swap_then_replace(source, target, *args, **kwargs):
+        swap_contexts()
+        (evil / Path(source).name).write_text("attacker\n", encoding="utf-8")
+        return original_replace(source, target, *args, **kwargs)
+
+    def swap_then_rename(source, target, *args, **kwargs):
+        swap_contexts()
+        return original_rename(source, target, *args, **kwargs)
+
+    monkeypatch.setattr(module.os, "replace", swap_then_replace)
+    monkeypatch.setattr(module.os, "rename", swap_then_rename)
+    try:
+        module.cmd_context(root, "HER-95", str(worktree), str(tmp_path / "vault"), None, None)
+    except module.RegistryError:
+        pass
+
+    assert external_output.read_bytes() == external_before
+
+
+def test_fifo_journal_refuses_without_waiting(tmp_path):
+    """Existing journal FIFOs are malformed registry state, never a blocking
+    read or a timeout-derived allow path."""
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("FIFO unsupported")
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "s1",
+             "--worktree", str(worktree), check=True)
+    lane_file = registry / "lanes" / "HER-95.jsonl"
+    lane_file.unlink()
+    os.mkfifo(lane_file)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--registry", str(registry), "event", "HER-95", "ci_green"],
+        capture_output=True, text=True, timeout=1,
+    )
+
+    assert result.returncode != 0
+    assert "regular file" in result.stderr
+
+
 def make_git_repo(path: Path):
     path.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=path, check=True)

--- a/tests/test_factory_lane_appsec.py
+++ b/tests/test_factory_lane_appsec.py
@@ -1,0 +1,246 @@
+"""HER-95 — RED probes for the AppSec / concurrency blockers raised by the two
+exact-head reviews of PR #69955.
+
+Each test reproduces one blocker before the fix and pins the fail-closed
+behavior after it:
+
+1. ``process_start_time=None`` must never be classified ``reused`` (a live owner
+   with no recorded start baseline stays ``alive`` and non-reclaimable).
+2. Same-session rebind from an owned worktree W1 onto a worktree W2 that is
+   already owned by another lane must refuse — never rewrite the owner, never
+   create two owners for W2.
+3. A secret-like ``gateway_session_key`` (e.g. ``bot_token=sekret-123``) must be
+   rejected before any owner file is written; a benign routing key survives.
+4. An ancestor-symlink swap of ``registry/locks`` between validation and the
+   write must never let an owner.json escape the registry.
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "factory_lane.py"
+
+
+def run_lane(registry, *args, check=False, cwd=None):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--registry", str(registry), *args],
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return result
+
+
+def load_factory_lane():
+    spec = importlib.util.spec_from_file_location("factory_lane_appsec_uut", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_owner(registry: Path, key: str):
+    return json.loads((registry / "locks" / key / "owner.json").read_text())
+
+
+def owner_worktrees(registry: Path):
+    return [
+        json.loads(p.read_text()).get("worktree")
+        for p in (registry / "locks").glob("*/owner.json")
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Blocker 4 — process_start_time=None must never be "reused"
+# ---------------------------------------------------------------------------
+
+def test_missing_recorded_start_time_is_alive_not_reused(monkeypatch):
+    """A live PID whose owner has no recorded process_start_time cannot be
+    proven to be a reused PID, so it must be treated as ``alive`` — the current
+    code wrongly returns ``reused`` because ``None != "<real-start>"``."""
+    module = load_factory_lane()
+    monkeypatch.setattr(module.os, "kill", lambda pid, sig: None)
+    monkeypatch.setattr(module, "_get_process_state_char", lambda pid: "S")
+    monkeypatch.setattr(module, "_get_process_start_time", lambda pid: "real-start")
+
+    state = module.determine_process_state({"pid": 4321, "process_start_time": None})
+    assert state == "alive", state
+
+
+def test_live_owner_with_missing_start_time_is_not_reclaimable():
+    """End-to-end: a genuinely live owner PID with no recorded start time must
+    not be reclaimable, even with an expired heartbeat and an idle worktree."""
+    import tempfile
+
+    registry = Path(tempfile.mkdtemp()) / "registry"
+    worktree = Path(tempfile.mkdtemp()) / "repo"
+    worktree.mkdir(parents=True)
+
+    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        run_lane(registry, "claim", "HER-95", "--agent", "default",
+                 "--session", "old", "--worktree", str(worktree), check=True)
+        owner_file = registry / "locks" / "HER-95" / "owner.json"
+        owner = json.loads(owner_file.read_text())
+        owner.update({
+            "pid": holder.pid,
+            "process_start_time": None,
+            "heartbeat_at": time.time() - 7200,
+            "ttl_hours": 0.001,
+        })
+        owner_file.write_text(json.dumps(owner), encoding="utf-8")
+        idle = time.time() - (25 * 3600)
+        os.utime(worktree, (idle, idle))
+
+        result = run_lane(
+            registry, "claim", "HER-96", "--agent", "default", "--session", "new",
+            "--worktree", str(worktree), "--reclaim-worktree", "--ttl-hours", "0.001",
+        )
+        assert result.returncode != 0, "live owner without start baseline was reclaimed"
+        assert owner_file.exists()
+        assert not (registry / "locks" / "HER-96" / "owner.json").exists()
+    finally:
+        holder.terminate()
+        holder.wait(timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# Blocker 1 — same-session rebind onto an already-owned worktree
+# ---------------------------------------------------------------------------
+
+def test_same_session_rebind_onto_owned_worktree_is_refused(tmp_path):
+    registry = tmp_path / "registry"
+    w1 = tmp_path / "w1"
+    w1.mkdir()
+    w2 = tmp_path / "w2"
+    w2.mkdir()
+
+    # Another lane already owns W2.
+    run_lane(registry, "claim", "HER-96", "--agent", "other", "--session", "sX",
+             "--worktree", str(w2), check=True)
+    # Our session owns HER-95 on W1.
+    run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "s1",
+             "--worktree", str(w1), check=True)
+
+    # Same session tries to rebind HER-95 from W1 onto the already-owned W2.
+    result = run_lane(registry, "claim", "HER-95", "--agent", "default",
+                      "--session", "s1", "--worktree", str(w2))
+
+    assert result.returncode != 0, "rebind onto an owned worktree was allowed"
+    assert "already claimed" in result.stderr
+    # HER-95 must remain on W1 — no silent owner rewrite.
+    assert read_owner(registry, "HER-95")["worktree"] == os.path.realpath(str(w1))
+    # Exactly one owner for W2, and it is still HER-96.
+    w2_real = os.path.realpath(str(w2))
+    holders = [wt for wt in owner_worktrees(registry) if wt == w2_real]
+    assert len(holders) == 1
+    assert read_owner(registry, "HER-96")["worktree"] == w2_real
+
+
+def test_same_session_reentrant_same_worktree_still_heartbeats(tmp_path):
+    """The rebind guard must not break the legitimate reentrant path: the same
+    session re-claiming the SAME worktree only refreshes the heartbeat."""
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+
+    run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "s1",
+             "--worktree", str(worktree), check=True)
+    before = read_owner(registry, "HER-95")["heartbeat_at"]
+    time.sleep(0.02)
+    again = run_lane(registry, "claim", "HER-95", "--agent", "default",
+                     "--session", "s1", "--worktree", str(worktree))
+    assert again.returncode == 0, again.stderr
+    assert read_owner(registry, "HER-95")["heartbeat_at"] > before
+
+
+# ---------------------------------------------------------------------------
+# Blocker 3 — gateway_session_key must not persist secret-like values
+# ---------------------------------------------------------------------------
+
+def test_secret_like_gateway_session_key_is_rejected(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+
+    result = run_lane(
+        registry, "claim", "HER-95", "--agent", "default", "--session", "s1",
+        "--worktree", str(worktree), "--gateway-session-key", "bot_token=sekret-123",
+    )
+
+    assert result.returncode != 0, "secret-like gateway_session_key was accepted"
+    assert "secret" in result.stderr.lower()
+    owner_file = registry / "locks" / "HER-95" / "owner.json"
+    if owner_file.exists():
+        assert "sekret-123" not in owner_file.read_text()
+
+
+def test_benign_gateway_session_key_is_preserved(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+
+    result = run_lane(
+        registry, "claim", "HER-95", "--agent", "default", "--session", "s1",
+        "--worktree", str(worktree), "--gateway-session-key", "telegram:12345:67",
+    )
+    assert result.returncode == 0, result.stderr
+    assert read_owner(registry, "HER-95")["gateway_session_key"] == "telegram:12345:67"
+
+
+# ---------------------------------------------------------------------------
+# Blocker 2 — ancestor symlink swap must never escape the registry
+# ---------------------------------------------------------------------------
+
+def test_ancestor_symlink_swap_during_claim_never_escapes_registry(tmp_path, monkeypatch):
+    """Adversarial TOCTOU probe: swap ``registry/locks`` for a symlink pointing
+    OUTSIDE the registry after path validation but before the owner write. The
+    write must never land under the attacker-controlled target. ``O_NOFOLLOW``
+    on the leaf alone does not stop this — the fix must resolve every ancestor
+    via dirfd/openat and fail closed."""
+    module = load_factory_lane()
+
+    registry = tmp_path / "registry"
+    (registry / "locks").mkdir(parents=True)
+    (registry / "lanes").mkdir(parents=True)
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    evil = tmp_path / "evil"
+    (evil / "HER-95").mkdir(parents=True)
+
+    root = module._safe_registry_root(str(registry))
+
+    original_build_owner = module._build_owner
+    fired = {"done": False}
+
+    def swap_then_build(*args, **kwargs):
+        # Runs after _safe_subdir validation, immediately before the owner is
+        # written: rename the real locks/ aside and drop a symlink to `evil`.
+        if not fired["done"]:
+            fired["done"] = True
+            shutil.move(str(registry / "locks"), str(registry / "locks-real"))
+            os.symlink(str(evil), str(registry / "locks"), target_is_directory=True)
+        return original_build_owner(*args, **kwargs)
+
+    monkeypatch.setattr(module, "_build_owner", swap_then_build)
+
+    try:
+        module._claim_under_gate(
+            root, "HER-95", "default", "s1", str(worktree), False, 72.0,
+        )
+    except module.RegistryError:
+        # Failing closed is an acceptable outcome; escaping the registry is not.
+        pass
+
+    assert not (evil / "HER-95" / "owner.json").exists(), (
+        "owner.json escaped the registry through a swapped ancestor symlink"
+    )

--- a/tests/test_factory_lane_appsec.py
+++ b/tests/test_factory_lane_appsec.py
@@ -165,6 +165,45 @@ def test_same_session_reentrant_same_worktree_still_heartbeats(tmp_path):
     assert read_owner(registry, "HER-95")["heartbeat_at"] > before
 
 
+def test_same_session_claim_rejects_a_different_canonical_worktree(tmp_path):
+    """A session may heartbeat its claim but must never rebind it elsewhere."""
+    module = load_factory_lane()
+    registry = tmp_path / "registry"
+    first_worktree = tmp_path / "repo-one"
+    second_worktree = tmp_path / "repo-two"
+    first_worktree.mkdir()
+    second_worktree.mkdir()
+    root = module._safe_registry_root(str(registry))
+    module.cmd_claim(root, "HER-95", "hermes-code", "kanban:t_3bea83e5", str(first_worktree), False, 72.0)
+
+    with pytest.raises(module.RegistryError, match="different worktree"):
+        module.cmd_claim(root, "HER-95", "hermes-code", "kanban:t_3bea83e5", str(second_worktree), False, 72.0)
+
+    assert read_owner(registry, "HER-95")["worktree"] == str(first_worktree.resolve())
+
+
+def test_same_session_claim_rebinds_exact_worker_identity(tmp_path, monkeypatch):
+    """A restarted Kanban worker retains its session id but not its PID.
+
+    The reentrant claim must refresh the stored parent-process identity, not
+    merely heartbeat an already-dead PID.  Otherwise a subsequent owner check
+    cannot prove the current worker owns the lane.
+    """
+    module = load_factory_lane()
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    root = module._safe_registry_root(str(registry))
+    identities = iter(((111, "old-start"), (222, "current-start")))
+    monkeypatch.setattr(module, "_resolve_owner_identity", lambda *_: next(identities))
+
+    module.cmd_claim(root, "HER-95", "hermes-code", "kanban:t_3bea83e5", str(worktree), False, 72.0)
+    module.cmd_claim(root, "HER-95", "hermes-code", "kanban:t_3bea83e5", str(worktree), False, 72.0)
+
+    owner = read_owner(registry, "HER-95")
+    assert (owner["pid"], owner["process_start_time"]) == (222, "current-start")
+
+
 # ---------------------------------------------------------------------------
 # Blocker 3 — gateway_session_key must not persist secret-like values
 # ---------------------------------------------------------------------------
@@ -428,21 +467,20 @@ def test_registry_mutations_reject_ancestor_symlink_swap_before_external_write(
     evil_lane.write_text('{"external": "journal"}\n', encoding="utf-8")
     external_before = {path: path.read_bytes() for path in (evil_owner, evil_lane)}
 
-    original_safe_subdir = module._safe_subdir
+    original_open_chain = module._open_dir_chain
     swapped = False
 
-    def swap_after_locks_preflight(root_arg, name):
+    def swap_after_locks_open(root_arg, parts, create=False):
         nonlocal swapped
-        result = original_safe_subdir(root_arg, name)
-        if name == "locks" and not swapped:
+        if parts == ("locks",) and not swapped:
             swapped = True
             shutil.move(str(registry / "locks"), str(registry / "locks-real"))
             shutil.move(str(registry / "lanes"), str(registry / "lanes-real"))
             os.symlink(str(evil / "locks"), str(registry / "locks"), target_is_directory=True)
             os.symlink(str(evil / "lanes"), str(registry / "lanes"), target_is_directory=True)
-        return result
+        return original_open_chain(root_arg, parts, create)
 
-    monkeypatch.setattr(module, "_safe_subdir", swap_after_locks_preflight)
+    monkeypatch.setattr(module, "_open_dir_chain", swap_after_locks_open)
 
     with pytest.raises(module.RegistryError):
         if operation == "event":
@@ -457,3 +495,273 @@ def test_registry_mutations_reject_ancestor_symlink_swap_before_external_write(
             module.cmd_reconcile(root, key, str(worktree), str(handoff_path))
 
     assert {path: path.read_bytes() for path in external_before} == external_before
+
+
+def test_claim_rejects_registry_root_directory_swap_before_owner_write(tmp_path, monkeypatch):
+    """A root path reopened after validation can be replaced by a real directory.
+
+    ``O_NOFOLLOW`` only rejects a symlink root: it does not bind operations to
+    the original registry inode.  A replacement directory must not receive an
+    owner record after the original root was validated.
+    """
+    module = load_factory_lane()
+    registry = tmp_path / "registry"
+    (registry / "locks").mkdir(parents=True)
+    (registry / "lanes").mkdir()
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    root = module._safe_registry_root(str(registry))
+
+    attacker_root = tmp_path / "attacker-root"
+    attacker_owner = attacker_root / "locks" / "HER-95" / "owner.json"
+    attacker_owner.parent.mkdir(parents=True)
+    (attacker_root / "lanes").mkdir()
+    original_rename = module.os.rename
+    original_open_chain = module._open_dir_chain
+    swapped = False
+
+    def swap_root_after_validation(root_arg, parts, create=False):
+        nonlocal swapped
+        if parts == ("locks",) and not swapped:
+            swapped = True
+            original_rename(str(registry), str(tmp_path / "registry-real"))
+            original_rename(str(attacker_root), str(registry))
+        return original_open_chain(root_arg, parts, create)
+
+    monkeypatch.setattr(module, "_open_dir_chain", swap_root_after_validation)
+
+    with pytest.raises(module.RegistryError):
+        module.cmd_claim(root, "HER-95", "default", "s1", str(worktree), False, 72.0)
+
+    assert not (registry / "locks" / "HER-95" / "owner.json").exists()
+
+
+def test_event_rejects_registry_root_directory_swap_before_owner_write(tmp_path, monkeypatch):
+    """Root anchoring applies to an existing lane mutation, not only claim."""
+    module = load_factory_lane()
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    root = module._safe_registry_root(str(registry))
+    module.cmd_claim(root, "HER-95", "default", "s1", str(worktree), False, 72.0)
+
+    attacker_root = tmp_path / "attacker-root"
+    attacker_owner = attacker_root / "locks" / "HER-95" / "owner.json"
+    attacker_owner.parent.mkdir(parents=True)
+    attacker_owner.write_text(json.dumps(read_owner(registry, "HER-95")), encoding="utf-8")
+    attacker_lane = attacker_root / "lanes" / "HER-95.jsonl"
+    attacker_lane.parent.mkdir(parents=True)
+    attacker_lane.write_text('{"external": true}\n', encoding="utf-8")
+    attacker_before = {
+        Path("locks/HER-95/owner.json"): attacker_owner.read_bytes(),
+        Path("lanes/HER-95.jsonl"): attacker_lane.read_bytes(),
+    }
+    original_rename = module.os.rename
+    original_open_chain = module._open_dir_chain
+    swapped = False
+
+    def swap_root_after_validation(root_arg, parts, create=False):
+        nonlocal swapped
+        if parts == ("locks",) and not swapped:
+            swapped = True
+            original_rename(str(registry), str(tmp_path / "registry-real"))
+            original_rename(str(attacker_root), str(registry))
+        return original_open_chain(root_arg, parts, create)
+
+    monkeypatch.setattr(module, "_open_dir_chain", swap_root_after_validation)
+
+    with pytest.raises(module.RegistryError):
+        module.cmd_event(root, "HER-95", "ci_green", None, None)
+
+    assert {relative: (registry / relative).read_bytes() for relative in attacker_before} == attacker_before
+
+
+def test_admit_rejects_registry_root_swap_before_owner_write(tmp_path, monkeypatch):
+    """The owner-admission command has the same root-reopen hazard as claim."""
+    module = load_factory_lane()
+    registry = tmp_path / "registry"
+    (registry / "locks").mkdir(parents=True)
+    (registry / "lanes").mkdir()
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    root = module._safe_registry_root(str(registry))
+
+    attacker_root = tmp_path / "attacker-root"
+    attacker_owner = attacker_root / "locks" / "HER-95" / "owner.json"
+    attacker_owner.parent.mkdir(parents=True)
+    attacker_owner.write_text('{"external": true}\n', encoding="utf-8")
+    (attacker_root / "lanes").mkdir()
+    attacker_before = attacker_owner.read_bytes()
+    original_rename = module.os.rename
+    original_open_chain = module._open_dir_chain
+    swapped = False
+
+    def swap_root_before_locks_open(root_arg, parts, create=False):
+        nonlocal swapped
+        if parts == ("locks",) and not swapped:
+            swapped = True
+            original_rename(str(registry), str(tmp_path / "registry-real"))
+            original_rename(str(attacker_root), str(registry))
+        return original_open_chain(root_arg, parts, create)
+
+    monkeypatch.setattr(module, "_open_dir_chain", swap_root_before_locks_open)
+
+    with pytest.raises(module.RegistryError):
+        module.cmd_admit(root, "HER-95", "owner", True, "default", "s1", str(worktree), 72.0)
+
+    assert (registry / "locks" / "HER-95" / "owner.json").read_bytes() == attacker_before
+
+
+def test_guard_rejects_registry_root_swap_during_owner_scan(tmp_path, monkeypatch):
+    """A root replacement during the read-only guard is not an ownerless scan."""
+    module = load_factory_lane()
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    root = module._safe_registry_root(str(registry))
+    module.cmd_claim(root, "HER-95", "default", "owner", str(worktree), False, 72.0)
+
+    attacker_root = tmp_path / "attacker-root"
+    (attacker_root / "locks").mkdir(parents=True)
+    original_rename = module.os.rename
+    original_open_chain = module._open_dir_chain
+    swapped = False
+
+    def swap_root_before_owner_scan(root_arg, parts, create=False):
+        nonlocal swapped
+        if parts == ("locks",) and not swapped:
+            swapped = True
+            original_rename(str(registry), str(tmp_path / "registry-real"))
+            original_rename(str(attacker_root), str(registry))
+        return original_open_chain(root_arg, parts, create)
+
+    monkeypatch.setattr(module, "_open_dir_chain", swap_root_before_owner_scan)
+
+    with pytest.raises(module.RegistryError, match="registry root changed"):
+        module.evaluate_admission_guard(root, str(worktree), "intruder", "other")
+
+
+def test_repo_context_output_rejects_factory_swap_after_temp_write(tmp_path, monkeypatch):
+    """A post-mkstemp ``repo/.factory`` swap must not overwrite attacker output.
+
+    The failed write must also remove the temporary file from the original
+    directory rather than leaking it after the attacker replaces the text path.
+    """
+    module = load_factory_lane()
+    registry = tmp_path / "registry"
+    root = module._safe_registry_root(str(registry))
+    worktree = tmp_path / "repo"
+    make_git_repo(worktree)
+    factory = worktree / ".factory"
+    factory.mkdir()
+    output = factory / "HER-95.md"
+
+    evil = tmp_path / "evil"
+    evil.mkdir()
+    external_output = evil / "HER-95.md"
+    external_output.write_text("external\n", encoding="utf-8")
+    external_before = external_output.read_bytes()
+    original_rename = module.os.rename
+    original_mkstemp = module.tempfile.mkstemp
+    swapped = False
+
+    def create_temp_then_swap(*args, **kwargs):
+        nonlocal swapped
+        fd, tmp_path = original_mkstemp(*args, **kwargs)
+        if not swapped:
+            swapped = True
+            original_rename(str(factory), str(worktree / ".factory-real"))
+            os.symlink(str(evil), str(factory), target_is_directory=True)
+            (evil / Path(tmp_path).name).write_text("attacker\n", encoding="utf-8")
+        return fd, tmp_path
+
+    monkeypatch.setattr(module.tempfile, "mkstemp", create_temp_then_swap)
+
+    with pytest.raises(module.RegistryError):
+        module.cmd_context(root, "HER-95", str(worktree), str(tmp_path / "vault"), None, str(output))
+
+    assert external_output.read_bytes() == external_before
+    assert not list((worktree / ".factory-real").glob(".context-*.tmp"))
+
+
+def _tree_bytes(root: Path):
+    """Snapshot attacker-visible files so new outputs are detected too."""
+    return {
+        path.relative_to(root): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_render_rejects_registry_root_replacement_before_lanes_output(tmp_path, monkeypatch):
+    """Rendering must retain one trusted root from scan through ``LANES.md``.
+
+    Replacing the registry root with a normal directory after status calculation
+    used to redirect the final text-path reopen into the attacker's ``LANES.md``.
+    """
+    module = load_factory_lane()
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    root = module._safe_registry_root(str(registry))
+    module.cmd_claim(root, "HER-95", "default", "s1", str(worktree), False, 72.0)
+
+    attacker_root = tmp_path / "attacker-root"
+    (attacker_root / "lanes").mkdir(parents=True)
+    (attacker_root / "locks").mkdir()
+    attacker_lanes = attacker_root / "LANES.md"
+    attacker_lanes.write_text("attacker lanes\n", encoding="utf-8")
+    attacker_before = _tree_bytes(attacker_root)
+    original_rename = module.os.rename
+    original_compute_status = module._compute_status
+    swapped = False
+
+    def swap_root_after_scan(events):
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            original_rename(str(registry), str(tmp_path / "registry-real"))
+            original_rename(str(attacker_root), str(registry))
+        return original_compute_status(events)
+
+    monkeypatch.setattr(module, "_compute_status", swap_root_after_scan)
+
+    with pytest.raises(module.RegistryError, match="registry root changed"):
+        module.cmd_render(root)
+
+    assert _tree_bytes(registry) == attacker_before
+
+
+def test_hook_stop_keeps_handoff_capture_inside_original_registry_root(tmp_path, monkeypatch):
+    """The fail-open Stop hook must never write a capture into a swapped root."""
+    module = load_factory_lane()
+    key = "HER-95"
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_repo(worktree)
+    root = module._safe_registry_root(str(registry))
+    module.cmd_claim(root, key, "default", "s1", str(worktree), False, 72.0)
+
+    attacker_root = tmp_path / "attacker-root"
+    (attacker_root / "lanes").mkdir(parents=True)
+    (attacker_root / "locks").mkdir()
+    (attacker_root / "handoffs").mkdir()
+    marker = attacker_root / "handoffs" / "marker.json"
+    marker.write_text('{"attacker": true}\n', encoding="utf-8")
+    attacker_before = _tree_bytes(attacker_root)
+    original_rename = module.os.rename
+    original_current_branch = module._git_current_branch
+    swapped = False
+
+    def swap_root_after_owner_read(repo):
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            original_rename(str(registry), str(tmp_path / "registry-real"))
+            original_rename(str(attacker_root), str(registry))
+        return original_current_branch(repo)
+
+    monkeypatch.setattr(module, "_git_current_branch", swap_root_after_owner_read)
+
+    assert module.cmd_hook_stop(root, str(worktree), key) == 0
+    assert _tree_bytes(registry) == attacker_before

--- a/tests/test_factory_lane_integration.py
+++ b/tests/test_factory_lane_integration.py
@@ -1,0 +1,239 @@
+"""HER-95 — RED probes for the functional integration blockers.
+
+The two exact-head reviews of PR #69955 rejected the change because the gate was
+only a manual CLI: it was never wired into the real Hermes pre-mutation path, and
+the ``hermes-immo`` domain denial depended on a caller remembering to pass
+``--profile`` / ``--domain-prefixes``.
+
+These tests exercise the REAL control flow that ``run_agent._invoke_tool`` uses:
+``register_from_config()`` wires ``scripts/factory_admission_hook.py`` onto the
+plugin manager as a ``pre_tool_call`` hook, and
+``plugins.get_pre_tool_call_block_message()`` (the exact call site that vetoes a
+build-capable tool before it executes) must surface the block. The profile /
+domain flags live in the hook's configured command line — i.e. in the profile's
+``cli-config.yaml`` — so the denial is automatic, not caller-remembered.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "factory_lane.py"
+HOOK = REPO_ROOT / "scripts" / "factory_admission_hook.py"
+
+
+def run_lane(registry, *args, check=False):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--registry", str(registry), *args],
+        capture_output=True, text=True, timeout=30,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return result
+
+
+def make_git_worktree(path: Path):
+    path.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=path, check=True)
+    (path / "README.md").write_text("ok\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, check=True)
+
+
+def read_owner(registry: Path, key: str):
+    return json.loads((registry / "locks" / key / "owner.json").read_text())
+
+
+def hook_command(registry, agent, *, profile=None, domain_prefixes=None):
+    parts = [sys.executable, str(HOOK), "--registry", str(registry), "--agent", agent]
+    if profile:
+        parts += ["--profile", profile]
+    if domain_prefixes:
+        parts += ["--domain-prefixes", domain_prefixes]
+    return " ".join(parts)
+
+
+@pytest.fixture
+def wired(monkeypatch, tmp_path):
+    """Fresh plugin manager + shell-hook registry, isolated HERMES_HOME."""
+    from hermes_cli import plugins
+    from agent import shell_hooks
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("HERMES_ACCEPT_HOOKS", "1")
+    plugins._plugin_manager = plugins.PluginManager()
+    shell_hooks.reset_for_tests()
+    yield plugins, shell_hooks
+    shell_hooks.reset_for_tests()
+
+
+def register_gate(shell_hooks, command, matcher="terminal|patch|write_file|str_replace_editor"):
+    cfg = {"hooks": {"pre_tool_call": [{"matcher": matcher, "command": command}]}}
+    registered = shell_hooks.register_from_config(cfg, accept_hooks=True)
+    assert len(registered) == 1, "gate hook did not register"
+
+
+# ---------------------------------------------------------------------------
+# Functional blocker 1 — real pre-mutation wiring
+# ---------------------------------------------------------------------------
+
+def test_gate_blocks_build_capable_tool_in_foreign_owned_worktree(wired, tmp_path, monkeypatch):
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_worktree(worktree)
+
+    # A live owner (parent identity transported via --owner-pid) owns the tree.
+    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        run_lane(registry, "admit", "HER-95", "--mode", "owner", "--agent", "default",
+                 "--session", "owner", "--worktree", str(worktree),
+                 "--owner-pid", str(holder.pid), check=True)
+
+        register_gate(shell_hooks, hook_command(registry, "default"))
+
+        # Intruder session tries to run `terminal` inside that worktree.
+        monkeypatch.chdir(worktree)
+        msg = plugins.get_pre_tool_call_block_message(
+            tool_name="terminal", args={"command": "rm -rf /"}, session_id="intruder",
+        )
+        assert msg is not None, "gate did not block a mutation in a foreign-owned worktree"
+        assert "HER-95" in msg
+    finally:
+        holder.terminate()
+        holder.wait(timeout=10)
+
+
+def test_gate_allows_owning_session_mutation(wired, tmp_path, monkeypatch):
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_worktree(worktree)
+
+    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        run_lane(registry, "admit", "HER-95", "--mode", "owner", "--agent", "default",
+                 "--session", "owner", "--worktree", str(worktree),
+                 "--owner-pid", str(holder.pid), check=True)
+
+        register_gate(shell_hooks, hook_command(registry, "default"))
+
+        monkeypatch.chdir(worktree)
+        msg = plugins.get_pre_tool_call_block_message(
+            tool_name="terminal", args={"command": "ls"}, session_id="owner",
+        )
+        assert msg is None, f"gate wrongly blocked the owning session: {msg!r}"
+    finally:
+        holder.terminate()
+        holder.wait(timeout=10)
+
+
+def test_gate_ignores_readonly_tool_not_matched(wired, tmp_path, monkeypatch):
+    """A read-only reviewer tool (not in the mutation matcher) never fires the
+    gate, so a read-only reviewer coexists with the owner unimpeded."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_worktree(worktree)
+
+    run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "owner",
+             "--worktree", str(worktree), check=True)
+    register_gate(shell_hooks, hook_command(registry, "default"))
+
+    monkeypatch.chdir(worktree)
+    msg = plugins.get_pre_tool_call_block_message(
+        tool_name="read_file", args={"path": "README.md"}, session_id="reviewer",
+    )
+    assert msg is None
+
+
+def test_gate_fails_open_when_no_claim(wired, tmp_path, monkeypatch):
+    """Advisory posture: an ownerless / empty registry lets the tool proceed."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_worktree(worktree)
+
+    register_gate(shell_hooks, hook_command(registry, "default"))
+
+    monkeypatch.chdir(worktree)
+    msg = plugins.get_pre_tool_call_block_message(
+        tool_name="terminal", args={"command": "ls"}, session_id="anyone",
+    )
+    assert msg is None
+
+
+# ---------------------------------------------------------------------------
+# Functional blocker 2 — automatic business-profile domain denial
+# ---------------------------------------------------------------------------
+
+def test_gate_blocks_business_profile_out_of_domain_without_caller_flags(wired, tmp_path, monkeypatch):
+    """The caller passes NO profile/domain flags at tool time — they come from
+    the hook's configured command line (the hermes-immo profile config). Even
+    when the same session owns the lane (no ownership conflict), a product lane
+    outside the business domain is refused automatically."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_worktree(worktree)
+
+    # hermes-immo itself owns a product lane (claim does not enforce domain).
+    run_lane(registry, "claim", "SCA-740", "--agent", "hermes-immo", "--session", "s1",
+             "--worktree", str(worktree), check=True)
+
+    register_gate(
+        shell_hooks,
+        hook_command(registry, "hermes-immo", profile="hermes-immo", domain_prefixes="JYI,HER"),
+    )
+
+    monkeypatch.chdir(worktree)
+    msg = plugins.get_pre_tool_call_block_message(
+        tool_name="patch", args={"path": "x"}, session_id="s1",
+    )
+    assert msg is not None, "business profile mutated a lane outside its domain"
+    assert "SCA-740" in msg
+
+
+# ---------------------------------------------------------------------------
+# Functional blocker 4 — parent process identity transport (not the subprocess)
+# ---------------------------------------------------------------------------
+
+def test_admit_records_transported_parent_pid_not_subprocess(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+
+    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        run_lane(registry, "admit", "HER-95", "--mode", "owner", "--agent", "default",
+                 "--session", "s1", "--worktree", str(worktree),
+                 "--owner-pid", str(holder.pid), check=True)
+        owner = read_owner(registry, "HER-95")
+        assert owner["pid"] == holder.pid, "owner.json did not record the transported parent pid"
+        assert owner.get("process_start_time"), "parent start-time baseline was not recorded"
+    finally:
+        holder.terminate()
+        holder.wait(timeout=10)
+
+
+def test_admit_refuses_transported_identity_of_dead_process(tmp_path):
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait(timeout=10)
+
+    result = run_lane(
+        registry, "admit", "HER-95", "--mode", "owner", "--agent", "default",
+        "--session", "s1", "--worktree", str(worktree), "--owner-pid", str(dead.pid),
+    )
+    assert result.returncode != 0, "admit accepted a dead transported owner pid"
+    assert not (registry / "locks" / "HER-95" / "owner.json").exists()

--- a/tests/test_factory_lane_integration.py
+++ b/tests/test_factory_lane_integration.py
@@ -111,6 +111,96 @@ def test_gate_blocks_build_capable_tool_in_foreign_owned_worktree(wired, tmp_pat
         holder.wait(timeout=10)
 
 
+def test_gate_uses_terminal_workdir_when_session_cwd_is_elsewhere(wired, tmp_path, monkeypatch):
+    """The original SCA-740 collision used an explicit tool workdir while the
+    gateway session itself was outside the worktree.  The gate must evaluate
+    that effective target, not merely the gateway process cwd."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    outside = tmp_path / "home"
+    make_git_worktree(worktree)
+    outside.mkdir()
+
+    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        run_lane(registry, "admit", "HER-95", "--mode", "owner", "--agent", "default",
+                 "--session", "owner", "--worktree", str(worktree),
+                 "--owner-pid", str(holder.pid), check=True)
+        register_gate(shell_hooks, hook_command(registry, "default"))
+
+        monkeypatch.chdir(outside)
+        msg = plugins.get_pre_tool_call_block_message(
+            tool_name="terminal",
+            args={"command": "touch blocked.txt", "workdir": str(worktree)},
+            session_id="intruder",
+        )
+        assert msg is not None, "explicit terminal workdir bypassed worktree admission"
+        assert "HER-95" in msg
+    finally:
+        holder.terminate()
+        holder.wait(timeout=10)
+
+
+def test_gate_uses_write_file_path_when_session_cwd_is_elsewhere(wired, tmp_path, monkeypatch):
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    outside = tmp_path / "home"
+    make_git_worktree(worktree)
+    outside.mkdir()
+
+    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        run_lane(registry, "admit", "HER-95", "--mode", "owner", "--agent", "default",
+                 "--session", "owner", "--worktree", str(worktree),
+                 "--owner-pid", str(holder.pid), check=True)
+        register_gate(shell_hooks, hook_command(registry, "default"))
+
+        monkeypatch.chdir(outside)
+        msg = plugins.get_pre_tool_call_block_message(
+            tool_name="write_file",
+            args={"path": str(worktree / "blocked.txt"), "content": "no"},
+            session_id="intruder",
+        )
+        assert msg is not None, "absolute write_file path bypassed worktree admission"
+        assert "HER-95" in msg
+    finally:
+        holder.terminate()
+        holder.wait(timeout=10)
+
+
+def test_gate_detects_owned_worktree_referenced_in_terminal_command(wired, tmp_path, monkeypatch):
+    """An explicit workdir is not mandatory in the terminal contract.  Direct
+    absolute paths in the command (for example ``git -C`` or ``cd``) must also
+    be evaluated against live owners."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    outside = tmp_path / "home"
+    make_git_worktree(worktree)
+    outside.mkdir()
+
+    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        run_lane(registry, "admit", "HER-95", "--mode", "owner", "--agent", "default",
+                 "--session", "owner", "--worktree", str(worktree),
+                 "--owner-pid", str(holder.pid), check=True)
+        register_gate(shell_hooks, hook_command(registry, "default"))
+
+        monkeypatch.chdir(outside)
+        msg = plugins.get_pre_tool_call_block_message(
+            tool_name="terminal",
+            args={"command": f"git -C {worktree} status"},
+            session_id="intruder",
+        )
+        assert msg is not None, "absolute path in terminal command bypassed admission"
+        assert "HER-95" in msg
+    finally:
+        holder.terminate()
+        holder.wait(timeout=10)
+
+
 def test_gate_allows_owning_session_mutation(wired, tmp_path, monkeypatch):
     plugins, shell_hooks = wired
     registry = tmp_path / "registry"

--- a/tests/test_factory_lane_integration.py
+++ b/tests/test_factory_lane_integration.py
@@ -15,6 +15,8 @@ domain flags live in the hook's configured command line — i.e. in the profile'
 """
 
 import json
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -236,6 +238,161 @@ def test_gate_detects_relative_worktree_in_terminal_command(
     finally:
         holder.terminate()
         holder.wait(timeout=10)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'git -C "$WORKTREE" status',
+        'cd $(printf "%s" "$WORKTREE") && touch blocked.txt',
+        'pushd ${WORKTREE} && touch blocked.txt',
+        'git -C `printf "%s" "$WORKTREE"` status',
+        '$(printf touch) blocked.txt',
+        'touch $(printf "%s" "$WORKTREE")/blocked.txt',
+        'env DEST=$(printf "%s" "$WORKTREE") touch "$DEST/blocked.txt"',
+        'printf blocked > $(printf "%s" "$WORKTREE/blocked.txt")',
+        'touch "$WORKTREE/blocked.txt"',
+        'env DEST="$WORKTREE" touch "$DEST/blocked.txt"',
+        'sudo touch "$WORKTREE/blocked.txt"',
+    ],
+)
+def test_gate_blocks_unresolved_shell_expansion_in_terminal_target(
+    wired, tmp_path, monkeypatch, command,
+):
+    """An unresolved expansion can select an owned worktree after inspection."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    register_gate(shell_hooks, hook_command(registry, "default"))
+    monkeypatch.chdir(outside)
+
+    msg = plugins.get_pre_tool_call_block_message(
+        tool_name="terminal", args={"command": command}, session_id="intruder",
+    )
+
+    assert msg is not None, f"unresolved terminal target expansion bypassed admission: {command}"
+    assert "unresolved shell expansion" in msg
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "printf $(date)",
+        "printf `date`",
+        "printf '$(date)'",
+        "printf '`date`'",
+    ],
+)
+def test_gate_allows_substitution_when_it_cannot_select_a_path(
+    wired, tmp_path, monkeypatch, command,
+):
+    """Substitution is not itself a worktree target: reject it only when the
+    resulting value can select cwd, a git ``-C`` path, or a write-capable
+    operand.  Single-quoted syntax remains literal data."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    register_gate(shell_hooks, hook_command(registry, "default"))
+    monkeypatch.chdir(outside)
+
+    msg = plugins.get_pre_tool_call_block_message(
+        tool_name="terminal", args={"command": command}, session_id="intruder",
+    )
+
+    assert msg is None, f"safe non-path substitution was rejected: {command}: {msg}"
+
+
+def test_gate_allows_single_quoted_literal_dollar_in_terminal_command(wired, tmp_path, monkeypatch):
+    """A single-quoted dollar is data, not an unresolved shell target."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    register_gate(shell_hooks, hook_command(registry, "default"))
+    monkeypatch.chdir(outside)
+
+    msg = plugins.get_pre_tool_call_block_message(
+        tool_name="terminal",
+        args={"command": "printf '$WORKTREE' > literal.txt"},
+        session_id="intruder",
+    )
+
+    assert msg is None, msg
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sh -c 'touch \"$WORKTREE/x\"'",
+        "eval 'touch \"$WORKTREE/x\"'",
+        'touch$IFS"$WORKTREE/x"',
+    ],
+)
+def test_gate_blocks_reparsed_or_dynamic_command_words_with_path_expansion(
+    wired, tmp_path, monkeypatch, command,
+):
+    """Nested shell syntax and a dynamic command word can resolve a write target
+    only after the hook's first tokenization, so neither may bypass admission."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    register_gate(shell_hooks, hook_command(registry, "default"))
+    monkeypatch.chdir(outside)
+
+    msg = plugins.get_pre_tool_call_block_message(
+        tool_name="terminal", args={"command": command}, session_id="intruder",
+    )
+
+    assert msg is not None, f"dynamic shell bypass was admitted: {command}"
+    assert "unresolved shell expansion" in msg
+
+
+def test_gate_blocks_when_registry_locks_is_replaced_with_symlink(wired, tmp_path, monkeypatch):
+    """A symlinked locks root makes the owner scan untrustworthy, never ownerless."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    make_git_worktree(worktree)
+    outside.mkdir()
+    run_lane(registry, "claim", "HER-95", "--agent", "default", "--session", "owner",
+             "--worktree", str(worktree), check=True)
+    shutil.move(str(registry / "locks"), str(registry / "locks-real"))
+    os.symlink(str(registry / "locks-real"), str(registry / "locks"), target_is_directory=True)
+    register_gate(shell_hooks, hook_command(registry, "default"))
+    monkeypatch.chdir(outside)
+
+    msg = plugins.get_pre_tool_call_block_message(
+        tool_name="terminal", args={"command": "touch blocked.txt"}, session_id="intruder",
+    )
+
+    assert msg is not None, "symlinked registry locks made the admission hook fail open"
+    assert "registry lock scan" in msg
+
+
+def test_gate_blocks_when_registry_owner_cannot_be_read(wired, tmp_path, monkeypatch):
+    """A malformed/unreadable owner record is an admission error, not no claim."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    make_git_worktree(worktree)
+    outside.mkdir()
+    owner_dir = registry / "locks" / "HER-95"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "owner.json").write_text("{not-json", encoding="utf-8")
+    register_gate(shell_hooks, hook_command(registry, "default"))
+    monkeypatch.chdir(outside)
+
+    msg = plugins.get_pre_tool_call_block_message(
+        tool_name="terminal", args={"command": "touch blocked.txt"}, session_id="intruder",
+    )
+
+    assert msg is not None, "unreadable registry owner made the admission hook fail open"
+    assert "registry lock scan" in msg
 
 
 @pytest.mark.parametrize("relative", [True, False])

--- a/tests/test_factory_lane_integration.py
+++ b/tests/test_factory_lane_integration.py
@@ -201,6 +201,68 @@ def test_gate_detects_owned_worktree_referenced_in_terminal_command(wired, tmp_p
         holder.wait(timeout=10)
 
 
+@pytest.mark.parametrize(
+    "command",
+    ["git -C repo status", "cd repo && touch blocked.txt", "touch repo/blocked.txt"],
+)
+def test_gate_detects_relative_worktree_in_terminal_command(
+    wired, tmp_path, monkeypatch, command,
+):
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_worktree(worktree)
+
+    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        run_lane(registry, "admit", "HER-95", "--mode", "owner", "--agent", "default",
+                 "--session", "owner", "--worktree", str(worktree),
+                 "--owner-pid", str(holder.pid), check=True)
+        register_gate(shell_hooks, hook_command(registry, "default"))
+        monkeypatch.chdir(tmp_path)
+
+        msg = plugins.get_pre_tool_call_block_message(
+            tool_name="terminal", args={"command": command}, session_id="intruder",
+        )
+        assert msg is not None, f"relative terminal target bypassed admission: {command}"
+        assert "HER-95" in msg
+    finally:
+        holder.terminate()
+        holder.wait(timeout=10)
+
+
+@pytest.mark.parametrize("relative", [True, False])
+def test_gate_reads_apply_patch_change_paths(wired, tmp_path, monkeypatch, relative):
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    make_git_worktree(worktree)
+
+    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        run_lane(registry, "admit", "HER-95", "--mode", "owner", "--agent", "default",
+                 "--session", "owner", "--worktree", str(worktree),
+                 "--owner-pid", str(holder.pid), check=True)
+        register_gate(
+            shell_hooks,
+            hook_command(registry, "default"),
+            matcher="terminal|patch|write_file|str_replace_editor|apply_patch",
+        )
+        monkeypatch.chdir(tmp_path)
+        path = "repo/a.py" if relative else str(worktree / "a.py")
+
+        msg = plugins.get_pre_tool_call_block_message(
+            tool_name="apply_patch",
+            args={"changes": [{"kind": "add", "path": path}]},
+            session_id="intruder",
+        )
+        assert msg is not None, "apply_patch changes[*].path bypassed admission"
+        assert "HER-95" in msg
+    finally:
+        holder.terminate()
+        holder.wait(timeout=10)
+
+
 def test_gate_allows_owning_session_mutation(wired, tmp_path, monkeypatch):
     plugins, shell_hooks = wired
     registry = tmp_path / "registry"

--- a/tests/test_factory_lane_integration.py
+++ b/tests/test_factory_lane_integration.py
@@ -203,7 +203,14 @@ def test_gate_detects_owned_worktree_referenced_in_terminal_command(wired, tmp_p
 
 @pytest.mark.parametrize(
     "command",
-    ["git -C repo status", "cd repo && touch blocked.txt", "touch repo/blocked.txt"],
+    [
+        "git -C repo status",
+        "cd repo && touch blocked.txt",
+        "touch repo/blocked.txt",
+        "cd repo; touch blocked.txt",
+        "cd repo&& touch blocked.txt",
+        "cd ./repo; touch blocked.txt",
+    ],
 )
 def test_gate_detects_relative_worktree_in_terminal_command(
     wired, tmp_path, monkeypatch, command,

--- a/tests/test_factory_lane_integration.py
+++ b/tests/test_factory_lane_integration.py
@@ -304,6 +304,86 @@ def test_gate_allows_substitution_when_it_cannot_select_a_path(
     assert msg is None, f"safe non-path substitution was rejected: {command}: {msg}"
 
 
+def test_hook_allows_absent_registry_without_creating_it(wired, tmp_path, monkeypatch):
+    """The read-only pre-tool hook must not bootstrap registry state merely by
+    inspecting an otherwise healthy, absent registry path."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry-not-created"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    register_gate(shell_hooks, hook_command(registry, "default"))
+    monkeypatch.chdir(outside)
+
+    msg = plugins.get_pre_tool_call_block_message(
+        tool_name="terminal", args={"command": "touch safe.txt"}, session_id="intruder",
+    )
+
+    assert msg is None, msg
+    assert not registry.exists(), "read-only hook created an absent registry"
+
+
+@pytest.mark.parametrize("command_template", [
+    "sh -c 'touch {worktree}/blocked.txt'",
+    "eval 'touch {worktree}/blocked.txt'",
+])
+def test_gate_detects_literal_target_inside_reparsed_shell_program(
+    wired, tmp_path, monkeypatch, command_template,
+):
+    """A re-parsing wrapper must expose literal nested targets to the same
+    admission scan as direct terminal operands."""
+    plugins, shell_hooks = wired
+    registry = tmp_path / "registry"
+    worktree = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    make_git_worktree(worktree)
+    outside.mkdir()
+    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        run_lane(registry, "admit", "HER-95", "--mode", "owner", "--agent", "default",
+                 "--session", "owner", "--worktree", str(worktree),
+                 "--owner-pid", str(holder.pid), check=True)
+        register_gate(shell_hooks, hook_command(registry, "default"))
+        monkeypatch.chdir(outside)
+
+        msg = plugins.get_pre_tool_call_block_message(
+            tool_name="terminal",
+            args={"command": command_template.format(worktree=worktree)},
+            session_id="intruder",
+        )
+
+        assert msg is not None, "literal target in reparsed shell program bypassed admission"
+        assert "HER-95" in msg
+    finally:
+        holder.terminate()
+        holder.wait(timeout=10)
+
+
+def test_hook_blocks_fifo_owner_without_waiting(tmp_path):
+    """The real hook must reject a FIFO owner record promptly rather than hang
+    opening it and then silently allow a later tool timeout."""
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("FIFO unsupported")
+    registry = tmp_path / "registry"
+    owner_dir = registry / "locks" / "HER-95"
+    owner_dir.mkdir(parents=True)
+    os.mkfifo(owner_dir / "owner.json")
+    payload = {
+        "hook_event_name": "pre_tool_call",
+        "tool_name": "terminal",
+        "tool_input": {"command": "touch blocked.txt"},
+        "session_id": "intruder",
+    }
+
+    result = subprocess.run(
+        [sys.executable, str(HOOK), "--registry", str(registry), "--agent", "default"],
+        input=json.dumps(payload), capture_output=True, text=True, timeout=1,
+    )
+
+    decision = json.loads(result.stdout)
+    assert decision["decision"] == "block"
+    assert "registry lock scan" in decision["reason"]
+
+
 def test_gate_allows_single_quoted_literal_dollar_in_terminal_command(wired, tmp_path, monkeypatch):
     """A single-quoted dollar is data, not an unresolved shell target."""
     plugins, shell_hooks = wired


### PR DESCRIPTION
## Summary

Implements the HER-95 machine-wide worktree admission gate on top of the existing `factory_lane.py` registry layout:

- adds canonical `realpath(worktree)` ownership checks under the same registry (`registry/locks/<KEY>/owner.json`, `registry/lanes/<KEY>.jsonl`);
- serializes admission decisions with a machine-wide `.worktree-admission.lock` so preflight→claim races have exactly one winner;
- supports owner re-entry heartbeat refresh, stale recovery with PID start-time/TTL/worktree-inactivity checks, reviewer read-only admission, dirty ownerless worktree refusal, and business-profile prefix guard;
- extends SessionStart advisory mode to print a bounded STOP when another live owner holds the worktree while still failing open on registry/hook errors;
- documents installation, rollback, and Hermes Immo canary steps without touching live gateways.

## Validation

- RED observed before production script existed: `uv run --extra dev python -m pytest tests/test_factory_lane_admission.py -v` failed with missing `scripts/factory_lane.py`.
- `scripts/run_tests.sh tests/test_factory_lane_admission.py -v` → 12 passed.
- `python -m py_compile scripts/factory_lane.py tests/test_factory_lane_admission.py` → pass.
- `git diff --check` → pass.
- `uv run ruff check scripts/factory_lane.py tests/test_factory_lane_admission.py` → pass.
- Local canary with temporary registry/worktree verified STOP advisory, hermes-immo domain denial, reviewer read-only coexistence, and single owner JSON.

## Safety

No live gateway restart, no live registry mutation, no merge/deploy, no worktree reset/deletion. Push to upstream `NousResearch/hermes-agent` was denied for this token, so the branch was pushed to fork `Rmup67350/hermes-agent` and this PR targets upstream from the fork.
