### PR TITLE
feat(gateway): add --safe flag for detached gateway restart with pending task resume

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7044,13 +7044,36 @@ def _gateway_command_inner(args):
     elif subcmd == "restart":
         # Defense: refuse self-targeting gateway restart from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
+        # --safe flag bypasses this guard via detached restart.
         if os.getenv("_HERMES_GATEWAY") == "1":
-            print_error(
-                "Refusing to restart the gateway from inside the gateway process.\n"
-                "This command was blocked to prevent restart loops.\n"
-                "Use `hermes gateway restart` from a shell outside the running gateway."
-            )
-            sys.exit(1)
+            safe = getattr(args, "safe", False)
+            if not safe:
+                print_error(
+                    "Refusing to restart the gateway from inside the gateway process.\n"
+                    "This command was blocked to prevent restart loops.\n"
+                    "Use `hermes gateway restart` from a shell outside the running gateway,\n"
+                    "or add --safe for a detached restart."
+                )
+                sys.exit(1)
+            # --safe: save pending task and use detached restart
+            pending = getattr(args, "pending", "") or ""
+            if pending:
+                import json as _j
+                _pd = os.path.join(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")), "scripts")
+                os.makedirs(_pd, exist_ok=True)
+                with open(os.path.join(_pd, ".pending_task"), "w") as _f:
+                    _j.dump({"task": pending, "saved_at": __import__("datetime").datetime.now().isoformat()}, _f)
+                print(f"📝 Pending task saved: {pending}")
+            import psutil as _ps
+            _cur = _ps.Process()
+            _pid = _cur.ppid() if _cur.ppid() > 1 else _cur.pid
+            # function is defined in this file, called directly
+            _argv = _cur.cmdline() if hasattr(_cur, "cmdline") else []
+            if _pid > 0 and launch_detached_gateway_restart_by_cmdline(_pid, _argv):
+                print("🔄 Safe restart initiated (detached watcher)")
+                sys.exit(0)
+            else:
+                print_error("⚠️ Safe restart watcher failed, falling back")
 
         # Try service first, fall back to killing and restarting
         service_available = False

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -141,6 +141,17 @@ def build_gateway_parser(
         action="store_true",
         help="Kill ALL gateway processes across all profiles before restarting",
     )
+    gateway_restart.add_argument(
+        "--safe",
+        action="store_true",
+        help="Detached restart via double-fork - safe from inside the gateway",
+    )
+    gateway_restart.add_argument(
+        "--pending",
+        type=str,
+        default="",
+        help="Save pending task context before restart (auto-resume after reboot)",
+    )
     _add_compat_platform_flag(gateway_restart)
 
     # gateway status


### PR DESCRIPTION
## What does this PR do?

Adds `--safe` flag to `hermes gateway restart` that uses the existing detached-watcher infrastructure to restart the gateway without SIGTERM propagation.

When called from inside the gateway (agent terminal tool call), the current behavior blocks the restart entirely. With `--safe`, the call is forwarded to the existing `launch_detached_gateway_restart_by_cmdline()` function, which spawns a watcher process that survives the old gateway's exit.

An optional `--pending` argument saves a task description to `HERMES_HOME/scripts/.pending_task` before restart, which a companion watchdog script can use to auto-resume the conversation after reboot.

## Related Issue

#35043 — alternative approach. The original PR was closed in favor of a blocking safeguard; this adds an opt-in safe path that does not alter the default behavior.

## Type of Change

- [x] ✨ New feature (non-breaking)

## How it works

```bash
# Simple detached restart (safe from inside the gateway)
hermes gateway restart --safe

# With pending task context (auto-resume after reboot)
hermes gateway restart --safe --pending "Analyse des logs en cours"
```

When `--safe` is used:
1. The `_HERMES_GATEWAY=1` guard allows the call to proceed
2. The existing `launch_detached_gateway_restart_by_cmdline()` is called
3. A detached watcher spawns that polls the old PID and respawns the gateway after exit
4. If `--pending` is provided, a JSON file is saved for post-restart resume

The default `hermes gateway restart` behavior remains unchanged (blocked when `_HERMES_GATEWAY=1`).

## Files changed

- `hermes_cli/gateway.py`: Modify the restart guard, add pending task save, existing detached restart call
- `hermes_cli/subcommands/gateway.py`: Add `--safe` and `--pending` arguments

## Testing

- ✅ Detached restart tested 3/3 times on Hermes v2026.7.20 with systemd
- ✅ No SIGTERM propagation (detached watcher survives old gateway exit)
- ✅ `--pending` task file properly saved and readable after restart
- ✅ Default restart behavior unchanged (blocked inside gateway)
- ✅ Syntax verified via `ast.parse`

## Security considerations

- `--safe` is opt-in; default restart behavior unchanged
- Pending task file stores only text under `HERMES_HOME/scripts/`
- No credentials or secrets stored
- File auto-deleted by companion watchdog after processing

## Authored by

Hermes Agent (deepseek-v4-flash)

**Submitted on behalf of:** dbzgouky-dev