### PR TITLE
fix(cli): forward system prompt overlay in oneshot (-z) mode (supersedes #34863)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -329,6 +329,17 @@ def _run_agent(
 
     cfg = load_config()
 
+    # Mirror interactive CLI prompt resolution: the ephemeral env overlay wins,
+    # then agent.system_prompt from config. Empty values mean no overlay.
+    agent_cfg = cfg.get("agent") or {}
+    if not isinstance(agent_cfg, dict):
+        agent_cfg = {}
+    ephemeral_system_prompt = (
+        os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
+        or agent_cfg.get("system_prompt", "")
+        or None
+    )
+
     # Resolve effective model: explicit arg → env var → config.
     model_cfg = cfg.get("model") or {}
     if isinstance(model_cfg, str):
@@ -419,6 +430,7 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            ephemeral_system_prompt=ephemeral_system_prompt,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction

--- a/tests/hermes_cli/test_oneshot_system_prompt.py
+++ b/tests/hermes_cli/test_oneshot_system_prompt.py
@@ -1,0 +1,83 @@
+"""Regression tests for system-prompt forwarding in ``hermes -z``."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakeAgent:
+    captured_kwargs = {}
+
+    def __init__(self, **kwargs):
+        type(self).captured_kwargs = kwargs
+        self.suppress_status_output = False
+        self.stream_delta_callback = object()
+        self.tool_gen_callback = object()
+
+    def run_conversation(self, prompt):
+        return {"final_response": f"response to {prompt}"}
+
+    def shutdown_memory_provider(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def _patch_oneshot_dependencies(monkeypatch, cfg):
+    import hermes_cli.config as config_mod
+    import hermes_cli.models as models_mod
+    import hermes_cli.oneshot as oneshot_mod
+    import hermes_cli.runtime_provider as runtime_provider_mod
+    import hermes_cli.tools_config as tools_config_mod
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: cfg)
+    monkeypatch.setattr(models_mod, "detect_provider_for_model", lambda model, provider: None)
+    monkeypatch.setattr(
+        runtime_provider_mod,
+        "resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "test-key",
+            "base_url": "https://example.invalid/v1",
+            "provider": "test-provider",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(tools_config_mod, "_get_platform_tools", lambda cfg, platform: set())
+    monkeypatch.setattr(oneshot_mod, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(oneshot_mod, "get_fallback_chain", lambda cfg: [])
+    monkeypatch.setitem(sys.modules, "run_agent", SimpleNamespace(AIAgent=_FakeAgent))
+
+    return oneshot_mod
+
+
+@pytest.mark.parametrize(
+    ("env_prompt", "config_prompt", "expected_overlay"),
+    [
+        ("Env prompt", "Config prompt", "Env prompt"),
+        (None, "Config prompt", "Config prompt"),
+        ("", "Config prompt", "Config prompt"),
+        (None, "", None),
+        ("", "", None),
+    ],
+)
+def test_oneshot_forwards_effective_system_prompt(
+    monkeypatch, env_prompt, config_prompt, expected_overlay
+):
+    cfg = {
+        "model": {"default": "test-model", "provider": "test-provider"},
+        "agent": {"system_prompt": config_prompt},
+    }
+    if env_prompt is None:
+        monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", env_prompt)
+    oneshot_mod = _patch_oneshot_dependencies(monkeypatch, cfg)
+
+    response, result = oneshot_mod._run_agent("hello")
+
+    assert response == "response to hello"
+    assert result == {"final_response": "response to hello"}
+    assert _FakeAgent.captured_kwargs["ephemeral_system_prompt"] == expected_overlay


### PR DESCRIPTION
## Summary

`hermes -z` builds its `AIAgent` directly in `hermes_cli/oneshot.py:_run_agent()` (L313) and never forwards the system-prompt overlay, so `HERMES_EPHEMERAL_SYSTEM_PROMPT` and the configured `agent.system_prompt` are silently ignored in oneshot mode.

Verified on current main (`8fc278207`):

- interactive CLI resolves the overlay at `cli.py:3992` and forwards it at `hermes_cli/cli_agent_setup_mixin.py:369`
- gateway resolves it at `gateway/run.py:5250`
- oneshot has no `system_prompt` reference at all (`git grep ephemeral_system_prompt -- hermes_cli/oneshot.py` → empty)
- `AIAgent` already accepts the kwarg (`run_agent.py:442`)

This PR mirrors the interactive resolution order in oneshot:

1. non-empty `HERMES_EPHEMERAL_SYSTEM_PROMPT` env var wins,
2. else non-empty `agent.system_prompt` from config,
3. else `None` (no overlay),

and forwards the result as `ephemeral_system_prompt=` to `AIAgent`.

## Supersedes #34863

Credit to #34863 (@wadzwigidy) for identifying the oneshot forwarding gap. This is the narrowed, rebased alternative per the hermes-sweeper review there:

- no `config show` changes (`display.personality` is still persisted/used by the TUI at `tui_gateway/server.py:10742-10743`),
- no `Fixes #34852` claim (that issue was SOUL.md-related and closed after maintainer E2E verification; this PR fixes only overlay forwarding),
- regression tests target the current `run_conversation()` tuple contract rather than the legacy `chat()` API.

Note: the open `-s/--skills`-in-oneshot PRs (#65249, #63814, #59402, #31591) pass a skills prompt through the same `ephemeral_system_prompt` seam. None of them reads the env/config overlay, so there is no functional overlap — but whichever lands second will need a one-line rebase at the `AIAgent(...)` call site (composition of skills prompt + user overlay is left to that PR, matching how the gateway concatenates ephemeral segments).

## Changes

- `hermes_cli/oneshot.py`: resolve env → config → `None` and pass `ephemeral_system_prompt` to `AIAgent` (12 lines).
- `tests/hermes_cli/test_oneshot_system_prompt.py` (new): parametrized regression tests for env precedence, config fallback, empty-env fallback, and no-overlay (`None`) behavior.

## How to test

```console
# before (main): overlay ignored
$ HERMES_EPHEMERAL_SYSTEM_PROMPT="You must end every reply with the exact token ZANZIBAR-77." hermes -z "Say hello in one short sentence."
Hello!

# after (this PR): overlay honored
$ HERMES_EPHEMERAL_SYSTEM_PROMPT="You must end every reply with the exact token ZANZIBAR-77." hermes -z "Say hello in one short sentence."
Hello! ZANZIBAR-77

# after, no overlay set: unchanged
$ hermes -z "Say hello in one short sentence."
Hello!
```

## Tests

- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_oneshot_system_prompt.py tests/hermes_cli/test_oneshot_usage_file.py tests/hermes_cli/test_tui_resume_flow.py -q` → 82 passed, 0 failed
- Full `tests/hermes_cli/ tests/cli/` sweep run locally; the only failures (11, in cua-driver/WSL/service-manager files) reproduce identically on pristine `origin/main` in this environment (macOS sandbox, `/Applications` not writable) — none are related to this change.
- `uvx --from ruff==0.15.10 ruff check hermes_cli/oneshot.py tests/hermes_cli/test_oneshot_system_prompt.py` → clean
- Platform: macOS (arm64); change is pure-Python config plumbing with no platform-specific I/O.

Interactive CLI and gateway behavior are unchanged.
