### PR TITLE
fix(lsp): reap idle gateway clients

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -485,6 +485,12 @@ class LSPService:
         return list(client.diagnostics_for(file_path))
 
     async def _get_or_spawn(self, file_path: str) -> Optional[LSPClient]:
+        # A gateway can touch hundreds of short-lived worktrees without ever
+        # exiting.  Reap clients before resolving the next one so the
+        # process-wide singleton stays bounded instead of retaining every
+        # language server until gateway shutdown.
+        await self._reap_idle_clients()
+
         srv = find_server_for_file(file_path)
         if srv is None:
             return None
@@ -508,6 +514,10 @@ class LSPService:
         with self._state_lock:
             client = self._clients.get(key)
             if client is not None and client.is_running:
+                # Refresh before handing the client to the caller.  This
+                # prevents another concurrent request's reaper pass from
+                # shutting down a client that is about to be used.
+                self._last_used[key] = time.time()
                 eventlog.log_active(srv.server_id, per_server_root)
                 return client
             spawning = self._spawning.get(key)
@@ -565,6 +575,46 @@ class LSPService:
         finally:
             with self._state_lock:
                 self._spawning.pop(key, None)
+
+    async def _reap_idle_clients(self, *, now: Optional[float] = None) -> int:
+        """Shut down clients that have been idle longer than the configured limit.
+
+        The service is process-wide and gateways are intentionally long-lived,
+        so relying on :meth:`shutdown` alone retains one language server per
+        visited workspace indefinitely.  Removing entries under the state lock
+        prevents new callers from receiving a client while it is being stopped;
+        the relatively slow protocol shutdowns then run concurrently outside
+        the lock.
+        """
+        if self._idle_timeout <= 0:
+            return 0
+
+        current = time.time() if now is None else now
+        stale: List[Tuple[Tuple[str, str], LSPClient]] = []
+        with self._state_lock:
+            for key, client in list(self._clients.items()):
+                last_used = self._last_used.get(key)
+                if last_used is None or current - last_used <= self._idle_timeout:
+                    continue
+                if key in self._spawning:
+                    continue
+                stale.append((key, client))
+                self._clients.pop(key, None)
+                self._last_used.pop(key, None)
+
+        if not stale:
+            return 0
+
+        await asyncio.gather(
+            *(client.shutdown() for _, client in stale),
+            return_exceptions=True,
+        )
+        logger.info(
+            "LSP idle reaper stopped %d client(s) after %.0fs idle timeout",
+            len(stale),
+            self._idle_timeout,
+        )
+        return len(stale)
 
     async def _shutdown_async(self) -> None:
         with self._state_lock:

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -8,6 +8,7 @@ on.
 from __future__ import annotations
 
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -172,5 +173,49 @@ def test_service_status_includes_clients(mock_pyright):
         info = svc.get_status()
         assert info["enabled"] is True
         assert any(c["server_id"] == "pyright" for c in info["clients"])
+    finally:
+        svc.shutdown()
+
+
+class _FakeIdleClient:
+    def __init__(self) -> None:
+        self.state = "running"
+        self.is_running = True
+        self.shutdown_calls = 0
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+        self.state = "stopped"
+        self.is_running = False
+
+
+def test_service_reaps_only_clients_past_idle_timeout():
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=2.0,
+        install_strategy="manual",
+        idle_timeout=10.0,
+    )
+    stale_key = ("pyright", "/tmp/stale-workspace")
+    fresh_key = ("pyright", "/tmp/fresh-workspace")
+    stale = _FakeIdleClient()
+    fresh = _FakeIdleClient()
+    now = time.time()
+    svc._clients = {stale_key: stale, fresh_key: fresh}  # type: ignore[assignment]
+    svc._last_used = {stale_key: now - 20.0, fresh_key: now}
+
+    try:
+        result = svc._loop.run(
+            svc._get_or_spawn("/tmp/no-server.hermes-idle-reaper-test"),
+            timeout=2.0,
+        )
+
+        assert result is None
+        assert stale.shutdown_calls == 1
+        assert fresh.shutdown_calls == 0
+        assert stale_key not in svc._clients
+        assert stale_key not in svc._last_used
+        assert svc._clients[fresh_key] is fresh
     finally:
         svc.shutdown()


### PR DESCRIPTION
## Summary
- The process-wide LSP service already tracked idle timeouts (`DEFAULT_IDLE_TIMEOUT = 600`) but never reaped clients.
- Long-lived gateways therefore retained one language server tree per visited worktree until process exit.
- On one host this accumulated to ~175 LSP process groups and multi-GB RSS under the gateway cgroup.

## Fix
- Reap idle clients on the next `_get_or_spawn()` call.
- Refresh `_last_used` before returning an existing client so concurrent use cannot race the reaper.
- Skip clients that are mid-spawn.
- Add a regression test covering the spawn-path reaper behavior.

## Test plan
- [x] `pytest tests/agent/lsp/test_service.py::test_service_reaps_only_clients_past_idle_timeout`
- [x] `pytest tests/agent/lsp` (160 passed in isolated TMPDIR)
- [x] `ruff check` on touched files
- [x] Live gateway restarted after patch deploy; new PID loads the updated manager module