### PR TITLE
docs: move OPENCODE_GO_BASE_URL to the OpenCode Go section

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,7 @@
 # OpenCode Go provides access to open models (GLM-5, Kimi K2.5, MiniMax M2.5)
 # $10/month subscription. Get your key at: https://opencode.ai/auth
 # OPENCODE_GO_API_KEY=
+# OPENCODE_GO_BASE_URL=https://opencode.ai/zen/go/v1  # Override default base URL
 
 # =============================================================================
 # LLM PROVIDER (Hugging Face Inference Providers)
@@ -113,7 +114,6 @@
 # Required permission: "Make calls to Inference Providers"
 # HF_TOKEN=
 # HF_BASE_URL=https://router.huggingface.co/v1  # Override default base URL
-# OPENCODE_GO_BASE_URL=https://opencode.ai/zen/go/v1  # Override default base URL
 
 # DeepInfra — 100+ top open models, pay-per-use.
 # Get your key at: https://deepinfra.com/dash/api_keys


### PR DESCRIPTION
## Changes

* Moved `OPENCODE_GO_BASE_URL` from the **Hugging Face Inference Providers** section to the **OpenCode Go** section in `.env.example`.
* Placed `OPENCODE_GO_BASE_URL` directly after `OPENCODE_GO_API_KEY` to keep the provider's configuration grouped together.

## Why

`OPENCODE_GO_BASE_URL` was listed under the Hugging Face section even though it belongs to the OpenCode Go provider. This separated the provider's base URL from its API key, unlike the organization used for the other providers in the file.

Grouping `OPENCODE_GO_API_KEY` and `OPENCODE_GO_BASE_URL` together makes the configuration consistent with the rest of the file and easier to navigate.

