### PR TITLE
fix(sessions): prune stale active-session leases past a TTL, not just dead PIDs

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -209,11 +209,42 @@ def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
     return abs(current_start - expected_start) < 0.001
 
 
+# Found live 2026-07-23: a lease's owning process (the dashboard/gateway)
+# is long-running by design, so `_pid_alive` is true for the entire
+# process lifetime regardless of whether the specific frontend
+# connection that acquired the lease is still around. `updated_at` is
+# only bumped by `transfer_active_session` — an occasional rename, not
+# a heartbeat — so it can't distinguish "still in use" from "abandoned
+# hours ago" either. Net effect: a frontend that dies without a clean
+# detach() (crash, kill -9, hard browser refresh) leaves its lease
+# immortal until the whole host process restarts, eventually exhausting
+# max_concurrent_sessions with leases nothing is using. This TTL is a
+# conservative backstop, not a heartbeat-quality liveness check: any
+# genuinely active TUI/webUI session sees real interaction well inside
+# an hour, so pruning past that bar trades a theoretical false-positive
+# on an unusually long unattended session for reliably self-healing the
+# far more common stuck-lease case instead of requiring a manual
+# active_sessions.json edit every time it recurs.
+_STALE_LEASE_SECONDS = 3600
+
+
+def _lease_is_stale(entry: dict[str, Any], now: Optional[float] = None) -> bool:
+    now = time.time() if now is None else now
+    last_seen = _optional_float(entry.get("updated_at"))
+    if last_seen is None:
+        last_seen = _optional_float(entry.get("started_at"))
+    if last_seen is None:
+        return False
+    return (now - last_seen) > _STALE_LEASE_SECONDS
+
+
 def _prune_dead(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    now = time.time()
     return [
         entry
         for entry in entries
         if _pid_alive(entry.get("pid"), entry.get("process_start_time"))
+        and not _lease_is_stale(entry, now)
     ]
 
 

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -113,6 +113,84 @@ def test_active_session_registry_prunes_dead_pids(tmp_path, monkeypatch):
     lease.release()
 
 
+def test_active_session_registry_prunes_stale_lease_from_live_pid(tmp_path, monkeypatch):
+    """Regression guard, found live 2026-07-23: the owning process (the
+    dashboard/gateway) is long-running by design, so a lease whose
+    frontend died without a clean detach() stayed immortal forever —
+    `_pid_alive` is true for the process's whole lifetime, and
+    `updated_at` is only bumped by `transfer_active_session` (an
+    occasional rename, not a heartbeat), so nothing ever distinguished
+    "abandoned hours ago" from "still in use". A real lease from the
+    still-alive current test process, last touched 2 hours ago, must
+    now be pruned by the TTL fallback even though its pid is alive."""
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    runtime = home / "runtime"
+    runtime.mkdir(parents=True)
+    stale_time = time.time() - 7200  # 2 hours ago, past the 1-hour TTL
+    active_sessions._write_entries(
+        runtime / "active_sessions.json",
+        [
+            {
+                "lease_id": "stale-but-pid-alive",
+                "session_id": "orphaned-session",
+                "surface": "tui",
+                "pid": os.getpid(),
+                "process_start_time": active_sessions._process_start_time(os.getpid()),
+                "started_at": stale_time,
+                "updated_at": stale_time,
+            }
+        ],
+    )
+
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="fresh-session",
+        surface="tui",
+        config={"max_concurrent_sessions": 1},
+    )
+
+    assert message is None
+    assert lease is not None
+    assert [
+        entry["session_id"] for entry in active_sessions.active_session_registry_snapshot()
+    ] == ["fresh-session"]
+    lease.release()
+
+
+def test_active_session_recent_lease_from_live_pid_is_not_pruned(tmp_path, monkeypatch):
+    """A lease updated moments ago must NOT be pruned just because its
+    process has been running a while — the TTL is measured from
+    last-touched, not from process start."""
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    runtime = home / "runtime"
+    runtime.mkdir(parents=True)
+    active_sessions._write_entries(
+        runtime / "active_sessions.json",
+        [
+            {
+                "lease_id": "recent",
+                "session_id": "recent-session",
+                "surface": "tui",
+                "pid": os.getpid(),
+                "process_start_time": active_sessions._process_start_time(os.getpid()),
+                "started_at": time.time(),
+                "updated_at": time.time(),
+            }
+        ],
+    )
+
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="new-session",
+        surface="tui",
+        config={"max_concurrent_sessions": 1},
+    )
+
+    assert lease is None
+    assert message is not None
+    assert "recent-session" not in message  # message only reports the count
+
+
 def test_transfer_active_session_reanchors_existing_lease(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     monkeypatch.setenv("HERMES_HOME", str(home))


### PR DESCRIPTION
_prune_dead() only checked whether a lease's owning process (dashboard/gateway) was still alive — since that process is long-running by design, a lease from a frontend connection that died without a clean detach() (crash, kill -9, hard browser refresh) stayed "immortal" until the whole host process restarted, eventually exhausting max_concurrent_sessions with leases nothing was using. Adds a conservative 1-hour TTL fallback (_lease_is_stale) so genuinely stuck leases self-heal instead of requiring a manual active_sessions.json edit. Includes two new tests: a stale lease from a still-alive PID gets pruned, and a fresh lease is not pruned just because its owning process has run a long time.





