### PR TITLE
fix(memory): repair 5 non-MCP gateway leaks — per-session dict accumulation + task GC

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -244,6 +244,8 @@ class QQAdapter(BasePlatformAdapter):
 
         # Upload cache: content_hash -> {file_info, file_uuid, expires_at}
         self._upload_cache: Dict[str, Dict[str, Any]] = {}
+        # Strong-ref set for tracked background tasks (see _create_task).
+        self._background_tasks: set = set()
 
         # Inline-keyboard interaction routing. The callback (if set) is invoked
         # for every INTERACTION_CREATE event after the adapter has already
@@ -799,18 +801,24 @@ class QQAdapter(BasePlatformAdapter):
             self._session_id = None
             self._last_seq = None
 
-    @staticmethod
-    def _create_task(coro):
-        """Schedule a coroutine, silently skipping if no event loop is running.
+    def _create_task(self, coro):
+        """Schedule a coroutine, tracking it so the event loop's weak task
+        reference cannot GC it mid-await (which would silently drop the
+        message and swallow exceptions). Silently skip if no event loop is
+        running (tests call _dispatch_payload synchronously outside
+        asyncio.run()). #leak-fix
 
-        This avoids ``RuntimeError: no running event loop`` when tests call
-        ``_dispatch_payload`` synchronously outside of ``asyncio.run()``.
+        Was @staticmethod returning an untracked task; now an instance method
+        holding a strong ref until completion via a done-callback.
         """
         try:
             loop = asyncio.get_running_loop()
-            return loop.create_task(coro)
         except RuntimeError:
             return None
+        task = loop.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
 
     def _dispatch_payload(self, payload: Dict[str, Any]) -> None:
         """Route inbound WebSocket payloads (dispatch synchronously, spawn async handlers)."""
@@ -854,7 +862,7 @@ class QQAdapter(BasePlatformAdapter):
                     "GUILD_MESSAGE_CREATE",
                     "GUILD_AT_MESSAGE_CREATE",
             }:
-                asyncio.create_task(self._on_message(t, d))
+                self._create_task(self._on_message(t, d))
             elif t == "INTERACTION_CREATE":
                 self._create_task(self._on_interaction(d))
             else:

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1226,12 +1226,29 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        # Strong-ref set for fire-and-forget background tasks so the event
+        # loop's weak reference doesn't GC them mid-await (silent message
+        # loss / swallowed exceptions). Discarded via done-callback. #leak-fix
+        self._background_tasks: set = set()
 
         if self._account_id and not self._token:
             persisted = load_weixin_account(hermes_home, self._account_id)
             if persisted:
                 self._token = str(persisted.get("token") or "").strip()
                 self._base_url = str(persisted.get("base_url") or self._base_url).strip().rstrip("/")
+
+    def _track_task(self, coro) -> "asyncio.Task":
+        """Create a tracked background task.
+
+        Holds a strong reference until completion so the event loop's weak
+        task reference cannot GC the coroutine mid-await (which would
+        silently drop the message and swallow exceptions). Mirrors the
+        yuanbao adapter's _track_task pattern. #leak-fix
+        """
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
 
     def _coerce_float_extra(self, key: str, default: float) -> float:
         """Read a float from ``config.extra``, guarding against bad/non-finite values.
@@ -1385,7 +1402,7 @@ class WeixinAdapter(BasePlatformAdapter):
                     _save_sync_buf(self._hermes_home, self._account_id, sync_buf)
 
                 for message in response.get("msgs") or []:
-                    asyncio.create_task(self._process_message_safe(message))
+                    self._track_task(self._process_message_safe(message))
             except asyncio.CancelledError:
                 break
             except Exception as exc:
@@ -1436,7 +1453,7 @@ class WeixinAdapter(BasePlatformAdapter):
         context_token = str(message.get("context_token") or "").strip()
         if context_token:
             self._token_store.set(self._account_id, sender_id, context_token)
-        asyncio.create_task(self._maybe_fetch_typing_ticket(sender_id, context_token or None))
+        self._track_task(self._maybe_fetch_typing_ticket(sender_id, context_token or None))
 
         media_paths: List[str] = []
         media_types: List[str] = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2074,6 +2074,11 @@ _CONVERSATION_SCOPED_STATE: tuple = (
     # and run_sync) must not leak into a future conversation's first user
     # message — session keys are source-derived and REUSED.
     "_pending_turn_sidecar_notes",
+    # Native image paths staged for a session that never consumed them
+    # (turn aborted, platform delivery dropped) otherwise accumulate for
+    # the gateway lifetime with no eviction. Conversation-scoped like the
+    # siblings above. #leak-fix
+    "_pending_native_image_paths_by_session",
 )
 
 # Sentinel for "caller did not pass metadata" vs "caller passed None".
@@ -8638,6 +8643,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         self._clear_conversation_scope(
                             key, reason="expiry_finalized"
                         )
+                        # _session_run_generation is deliberately NOT in
+                        # _CONVERSATION_SCOPED_STATE (clearing it at /new or
+                        # /resume would reset the monotonic counter and break
+                        # stale-run detection, #28686). But at expiry
+                        # finalization the session is permanently dead — it
+                        # will never be resumed — so the entry is pure leak
+                        # with no correctness value. Pop it here only. #leak-fix
+                        _srg = getattr(self, "_session_run_generation", None)
+                        if isinstance(_srg, dict):
+                            _srg.pop(key, None)
                         # Persist the finalized flag to sessions.json AND
                         # state.db (single write-path, #9006) — also drops
                         # the persisted /model override, since finalization

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4000,6 +4000,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
         self._release_platform_lock()
 
+        # Abandoned inline-keyboard prompts (user never clicked, message
+        # expired, or delayed delivery was dropped) otherwise accumulate for
+        # the adapter lifetime with no TTL/max_size. Clear on disconnect so
+        # the dicts are bounded to one connection lifecycle. #leak-fix
+        self._approval_state.clear()
+        self._slash_confirm_state.clear()
+        self._clarify_state.clear()
+
         self._app = None
         self._bot = None
         logger.info("[%s] Disconnected from Telegram", self.name)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5584,6 +5584,15 @@ class AIAgent:
             )
 
         self._anthropic_image_fallback_cache[cache_key] = note
+        # Bound per-agent image-description cache so a long-lived session
+        # doesn't accumulate one entry per distinct image (esp. base64 data:
+        # URLs, each with a unique hash) forever. Plain dict is insertion-
+        # ordered on 3.7+, so next(iter(...)) yields the oldest key. #leak-fix
+        _IMG_FALLBACK_CACHE_MAX = 128
+        if len(self._anthropic_image_fallback_cache) > _IMG_FALLBACK_CACHE_MAX:
+            self._anthropic_image_fallback_cache.pop(
+                next(iter(self._anthropic_image_fallback_cache))
+            )
         return note
 
     def _model_supports_vision(self) -> bool:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4145,33 +4145,6 @@ def _snapshot_child_pids() -> set:
     return set()
 
 
-def _direct_child_pids(pid: int) -> set:
-    """Return the direct child PIDs of an arbitrary ``pid``.
-
-    Unlike ``_snapshot_child_pids`` (which snapshots the gateway's own
-    children via /proc/{self}/task/.../children), this reads any pid's
-    children. Used by ``_kill_orphaned_mcp_children`` Phase 3 to discover
-    the real MCP server R spawned by a watchdog W: R is a grandchild of the
-    gateway, runs in its own pgroup (start_new_session=True), and is never
-    tracked in ``_stdio_pids``/``_stdio_pgids`` — so the sweep's
-    ``killpg(W_pgid)`` cannot reach it. We discover R directly and SIGKILL
-    its pgroup so a wedged R that ignores SIGTERM is reaped even if W's
-    ``_forward_shutdown`` handler is interrupted mid-reap. See
-    tools/mcp_stdio_watchdog.py.
-    """
-    try:
-        children_path = f"/proc/{pid}/task/{pid}/children"
-        with open(children_path, encoding="utf-8") as f:
-            return {int(p) for p in f.read().split() if p.strip()}
-    except (FileNotFoundError, OSError, ValueError):
-        pass
-    try:
-        import psutil
-        return {c.pid for c in psutil.Process(pid).children()}
-    except Exception:
-        return set()
-
-
 # Non-MCP gateway children that can race into the _snapshot_child_pids() delta
 # during stdio MCP server spawn. LSP servers and slash_worker now use
 # start_new_session=True too; this remains defense-in-depth for any future
@@ -6361,38 +6334,16 @@ def _kill_orphaned_mcp_children(
         logger.debug("Sent SIGTERM to orphaned MCP process %d (%s)", pid, server_name)
 
     # Phase 2: Wait for graceful exit
-    # Must exceed mcp_stdio_watchdog._TERM_GRACE_S (3.0s) so a cooperative
-    # watchdog W has time to forward SIGTERM→SIGKILL to the real server R in
-    # R's own pgroup before we SIGKILL W itself; otherwise a wedged R that
-    # ignores SIGTERM (e.g. node/mcp-remote) leaks permanently. See
-    # tools/mcp_stdio_watchdog.py:_terminate_process_group.
-    time.sleep(4.0)
+    time.sleep(2)
 
     # Phase 3: SIGKILL any survivors
     _sigkill = getattr(_signal, "SIGKILL", _signal.SIGTERM)
-    _killpg = getattr(os, "killpg", None)
     # ``os.kill(pid, 0)`` is NOT a no-op on Windows. Use the cross-platform
     # existence check before escalating to SIGKILL.
     from gateway.status import _pid_exists
     for pid, server_name in pids.items():
         if not _pid_exists(pid):
             continue  # Good — exited after SIGTERM
-        # W (watchdog) may still be mid-handler reaping R. Discover R = W's
-        # direct child directly and SIGKILL its pgroup so a wedged R that
-        # ignores SIGTERM is reaped even if W's _forward_shutdown handler was
-        # interrupted (R runs in its own pgroup via start_new_session, so
-        # killpg(W_pgid) in _send_signal cannot reach it). See
-        # tools/mcp_stdio_watchdog.py:_terminate_process_group.
-        for _r_pid in _direct_child_pids(pid):
-            try:
-                _r_pgid = os.getpgid(_r_pid)
-            except (ProcessLookupError, PermissionError, OSError):
-                continue
-            if _killpg is not None and (_my_pgid is None or _r_pgid != _my_pgid):
-                try:
-                    _killpg(_r_pgid, _sigkill)
-                except (ProcessLookupError, PermissionError, OSError):
-                    pass
         _send_signal(pid, _sigkill, server_name)
         logger.warning(
             "Force-killed MCP process %d (%s) after SIGTERM timeout",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4145,6 +4145,33 @@ def _snapshot_child_pids() -> set:
     return set()
 
 
+def _direct_child_pids(pid: int) -> set:
+    """Return the direct child PIDs of an arbitrary ``pid``.
+
+    Unlike ``_snapshot_child_pids`` (which snapshots the gateway's own
+    children via /proc/{self}/task/.../children), this reads any pid's
+    children. Used by ``_kill_orphaned_mcp_children`` Phase 3 to discover
+    the real MCP server R spawned by a watchdog W: R is a grandchild of the
+    gateway, runs in its own pgroup (start_new_session=True), and is never
+    tracked in ``_stdio_pids``/``_stdio_pgids`` — so the sweep's
+    ``killpg(W_pgid)`` cannot reach it. We discover R directly and SIGKILL
+    its pgroup so a wedged R that ignores SIGTERM is reaped even if W's
+    ``_forward_shutdown`` handler is interrupted mid-reap. See
+    tools/mcp_stdio_watchdog.py.
+    """
+    try:
+        children_path = f"/proc/{pid}/task/{pid}/children"
+        with open(children_path, encoding="utf-8") as f:
+            return {int(p) for p in f.read().split() if p.strip()}
+    except (FileNotFoundError, OSError, ValueError):
+        pass
+    try:
+        import psutil
+        return {c.pid for c in psutil.Process(pid).children()}
+    except Exception:
+        return set()
+
+
 # Non-MCP gateway children that can race into the _snapshot_child_pids() delta
 # during stdio MCP server spawn. LSP servers and slash_worker now use
 # start_new_session=True too; this remains defense-in-depth for any future
@@ -6334,16 +6361,38 @@ def _kill_orphaned_mcp_children(
         logger.debug("Sent SIGTERM to orphaned MCP process %d (%s)", pid, server_name)
 
     # Phase 2: Wait for graceful exit
-    time.sleep(2)
+    # Must exceed mcp_stdio_watchdog._TERM_GRACE_S (3.0s) so a cooperative
+    # watchdog W has time to forward SIGTERM→SIGKILL to the real server R in
+    # R's own pgroup before we SIGKILL W itself; otherwise a wedged R that
+    # ignores SIGTERM (e.g. node/mcp-remote) leaks permanently. See
+    # tools/mcp_stdio_watchdog.py:_terminate_process_group.
+    time.sleep(4.0)
 
     # Phase 3: SIGKILL any survivors
     _sigkill = getattr(_signal, "SIGKILL", _signal.SIGTERM)
+    _killpg = getattr(os, "killpg", None)
     # ``os.kill(pid, 0)`` is NOT a no-op on Windows. Use the cross-platform
     # existence check before escalating to SIGKILL.
     from gateway.status import _pid_exists
     for pid, server_name in pids.items():
         if not _pid_exists(pid):
             continue  # Good — exited after SIGTERM
+        # W (watchdog) may still be mid-handler reaping R. Discover R = W's
+        # direct child directly and SIGKILL its pgroup so a wedged R that
+        # ignores SIGTERM is reaped even if W's _forward_shutdown handler was
+        # interrupted (R runs in its own pgroup via start_new_session, so
+        # killpg(W_pgid) in _send_signal cannot reach it). See
+        # tools/mcp_stdio_watchdog.py:_terminate_process_group.
+        for _r_pid in _direct_child_pids(pid):
+            try:
+                _r_pgid = os.getpgid(_r_pid)
+            except (ProcessLookupError, PermissionError, OSError):
+                continue
+            if _killpg is not None and (_my_pgid is None or _r_pgid != _my_pgid):
+                try:
+                    _killpg(_r_pgid, _sigkill)
+                except (ProcessLookupError, PermissionError, OSError):
+                    pass
         _send_signal(pid, _sigkill, server_name)
         logger.warning(
             "Force-killed MCP process %d (%s) after SIGTERM timeout",


### PR DESCRIPTION
## Summary

Root cause of gateway RSS 700M->1.4G + 2G swap over 36h (then codex OOM-killed on a 3.8G VPS). 5 non-MCP leak points located via adversarial code audit.

**Note**: The original audit found 7 leaks, but 2 of them (A/B, stdio-MCP watchdog process leak in `tools/mcp_tool.py`) overlap with #66590 which addresses the same root cause via a different process-group design (removes `start_new_session` so the real server stays in the SDK-owned pgroup). A/B have been reverted to avoid conflicting with #66590. This PR now contains only the 5 non-MCP fixes.

## Fixes

**C (P1) — `plugins/platforms/telegram/adapter.py`:** Clear `_approval_state`/`_slash_confirm_state`/`_clarify_state` on disconnect (no TTL/max_size before — abandoned inline-keyboard prompts accumulated for adapter lifetime).

**D (P1/P2) — `gateway/run.py` finalization:** Pop `_session_run_generation`, `_queued_events`, `_pending_native_image_paths_by_session` (siblings pruned, these were omitted). Adapted to upstream's `_CONVERSATION_SCOPED_STATE` registry:
- `_pending_native_image_paths_by_session` added to the registry (cleared at all conversation boundaries).
- `_queued_events` was already in the registry (no change needed).
- `_session_run_generation` is deliberately excluded from the registry (clearing at `/new`/`/resume` would reset the monotonic counter and break stale-run detection #28686); instead popped only at expiry finalization where the session is permanently dead.

**E (P1) — `run_agent.py`:** Bound `_anthropic_image_fallback_cache` to 128 entries (insertion-order eviction).

**G (P2) — `gateway/platforms/weixin.py` + `gateway/platforms/qqbot/adapter.py`:** Track fire-and-forget asyncio tasks (strong-ref set + done-callback) to prevent GC mid-await (silent message loss / swallowed exceptions).

## Verification

All 5 files pass `python3 -m py_compile`.

Fixes hermes-gateway 36h RSS 707M->1.4G + swap 2G leak (caused codex OOM-killed on a 3.8G VPS). 7 points located via adversarial code audit; 2 (MCP watchdog) deferred to #66590, 5 retained here. Details in commits.