### PR TITLE
fix(model-switch): guard explicit provider alias resolution

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -740,10 +740,19 @@ def resolve_alias(
 
     # Reverse lookup: match by model ID so full names (e.g. "kimi-k2.5",
     # "glm-4.7") route through direct aliases instead of falling through
-    # to the catalog/OpenRouter.
-    for alias_name, da in DIRECT_ALIASES.items():
-        if da.model.lower() == key:
-            return (da.provider, da.model, alias_name)
+    # to the catalog/OpenRouter. When multiple direct aliases share the
+    # same model ID, prefer the alias that matches the requested provider.
+    reverse_matches = [
+        (alias_name, da)
+        for alias_name, da in DIRECT_ALIASES.items()
+        if da.model.lower() == key
+    ]
+    if reverse_matches:
+        for alias_name, da in reverse_matches:
+            if da.provider == current_provider:
+                return (da.provider, da.model, alias_name)
+        alias_name, da = reverse_matches[0]
+        return (da.provider, da.model, alias_name)
 
     identity = MODEL_ALIASES.get(key)
     if identity is None:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -740,16 +740,18 @@ def resolve_alias(
 
     # Reverse lookup: match by model ID so full names (e.g. "kimi-k2.5",
     # "glm-4.7") route through direct aliases instead of falling through
-    # to the catalog/OpenRouter. When multiple direct aliases share the
-    # same model ID, prefer the alias that matches the requested provider.
+    # to the catalog/OpenRouter.  When several aliases share the same model
+    # ID, prefer the alias whose provider matches the requested provider;
+    # otherwise preserve the historical first-match fallback.
     reverse_matches = [
         (alias_name, da)
         for alias_name, da in DIRECT_ALIASES.items()
         if da.model.lower() == key
     ]
     if reverse_matches:
+        current_provider_norm = str(current_provider or "").strip().lower()
         for alias_name, da in reverse_matches:
-            if da.provider == current_provider:
+            if str(da.provider or "").strip().lower() == current_provider_norm:
                 return (da.provider, da.model, alias_name)
         alias_name, da = reverse_matches[0]
         return (da.provider, da.model, alias_name)
@@ -1155,10 +1157,16 @@ def switch_model(
                     ),
                 )
 
-        # Resolve alias on the TARGET provider
+        # Resolve alias on the TARGET provider.  Direct-alias reverse lookup is
+        # global, so two aliases that point at the same model on different
+        # endpoints can return whichever entry was configured first.  In an
+        # explicit-provider flow the provider choice is authoritative: only
+        # accept aliases that resolve back to the requested target provider.
         alias_result = resolve_alias(new_model, target_provider)
         if alias_result is not None:
-            _, new_model, resolved_alias = alias_result
+            alias_provider, alias_model, alias_name = alias_result
+            if str(alias_provider or "").strip().lower() == str(target_provider or "").strip().lower():
+                new_model, resolved_alias = alias_model, alias_name
 
     # =================================================================
     # PATH B: No explicit provider — resolve from model input
@@ -1435,8 +1443,13 @@ def switch_model(
         _ensure_direct_aliases()
         _da = DIRECT_ALIASES.get(resolved_alias)
         if _da is not None and _da.base_url:
+            _alias_base_url = _da.base_url
+            _same_base_url = str(base_url or "").strip().rstrip("/").lower() == str(
+                _alias_base_url or ""
+            ).strip().rstrip("/").lower()
             base_url = _da.base_url
-            api_mode = ""  # clear so determine_api_mode re-detects from URL
+            if not _same_base_url:
+                api_mode = ""  # clear so determine_api_mode re-detects from URL
             if not api_key:
                 api_key = "no-key-required"
 

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -149,6 +149,24 @@ class TestDirectAliases:
         assert result is not None
         assert result[1] == "GLM-4.7"
 
+    def test_reverse_lookup_prefers_current_provider_when_model_is_shared(self, monkeypatch):
+        """Reverse lookup should prefer the alias matching the requested provider."""
+        from hermes_cli.model_switch import DirectAlias, resolve_alias
+        import hermes_cli.model_switch as ms
+
+        test_aliases = {
+            "my-a": DirectAlias("claude-opus-4-6", "custom:provider-a", "https://api-a.example.com"),
+            "my-b": DirectAlias("claude-opus-4-6", "custom:provider-b", "https://api-b.example.com"),
+        }
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+
+        result = resolve_alias("claude-opus-4-6", "custom:provider-b")
+        assert result is not None
+        provider, model, alias = result
+        assert provider == "custom:provider-b"
+        assert model == "claude-opus-4-6"
+        assert alias == "my-b"
+
 
 # ---------------------------------------------------------------------------
 # /model command persistence
@@ -487,6 +505,55 @@ class TestSwitchModelDirectAliasOverride:
         assert result.success
         assert result.api_key == "no-key-required"
         assert result.base_url == "http://localhost:11434/v1"
+
+    def test_explicit_provider_prefers_matching_alias_base_url(self, monkeypatch):
+        """Explicit provider switches should not inherit another alias provider's base_url."""
+        from types import SimpleNamespace
+        from hermes_cli.model_switch import DirectAlias
+        import hermes_cli.model_switch as ms
+
+        test_aliases = {
+            "my-a": DirectAlias("claude-opus-4-6", "custom:provider-a", "https://api-a.example.com"),
+            "my-b": DirectAlias("claude-opus-4-6", "custom:provider-b", "https://api-b.example.com"),
+        }
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+
+        monkeypatch.setattr(
+            ms,
+            "resolve_provider_full",
+            lambda explicit_provider, *_args: SimpleNamespace(
+                id="custom:provider-b",
+                name="Provider B",
+                base_url="https://api-b.example.com",
+            ),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested: {
+                "api_key": "sk-bbb",
+                "base_url": "https://api-b.example.com",
+                "api_mode": "openai_compat",
+                "provider": requested,
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.validate_requested_model",
+            lambda *a, **kw: {"accepted": True, "persist": True, "recognized": True, "message": None},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.opencode_model_api_mode",
+            lambda *a, **kw: "openai_compat",
+        )
+
+        result = ms.switch_model(
+            "claude-opus-4-6",
+            "openrouter",
+            "old-model",
+            explicit_provider="custom:provider-b",
+        )
+        assert result.success
+        assert result.target_provider == "custom:provider-b"
+        assert result.base_url == "https://api-b.example.com"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -529,7 +529,7 @@ class TestSwitchModelDirectAliasOverride:
         )
         monkeypatch.setattr(
             "hermes_cli.runtime_provider.resolve_runtime_provider",
-            lambda requested: {
+            lambda requested, **_kwargs: {
                 "api_key": "sk-bbb",
                 "base_url": "https://api-b.example.com",
                 "api_mode": "openai_compat",
@@ -554,6 +554,62 @@ class TestSwitchModelDirectAliasOverride:
         assert result.success
         assert result.target_provider == "custom:provider-b"
         assert result.base_url == "https://api-b.example.com"
+        assert result.api_mode == "openai_compat"
+        assert result.resolved_via_alias == "my-b"
+
+    def test_explicit_provider_discards_alias_for_other_provider(self, monkeypatch):
+        """Explicit provider switches should not accept a different provider's alias."""
+        from types import SimpleNamespace
+        from hermes_cli.model_switch import DirectAlias
+        import hermes_cli.model_switch as ms
+
+        test_aliases = {
+            "my-a": DirectAlias("shared-model", "custom:provider-a", "https://api-a.example.com"),
+        }
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        monkeypatch.setattr(
+            ms,
+            "resolve_provider_full",
+            lambda explicit_provider, *_args: SimpleNamespace(
+                id="custom:provider-b",
+                name="Provider B",
+                base_url="https://api-b.example.com",
+            ),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested, **_kwargs: {
+                "api_key": "sk-bbb",
+                "base_url": "https://api-b.example.com",
+                "api_mode": "openai_compat",
+                "provider": requested,
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.validate_requested_model",
+            lambda *a, **kw: {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            },
+        )
+        monkeypatch.setattr(ms, "get_model_capabilities", lambda *a, **kw: None)
+        monkeypatch.setattr(ms, "get_model_info", lambda *a, **kw: None)
+
+        result = ms.switch_model(
+            "shared-model",
+            "custom:provider-a",
+            "old-model",
+            current_base_url="https://api-a.example.com",
+            explicit_provider="custom:provider-b",
+        )
+
+        assert result.success
+        assert result.target_provider == "custom:provider-b"
+        assert result.base_url == "https://api-b.example.com"
+        assert result.api_mode == "openai_compat"
+        assert result.resolved_via_alias == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- salvages #14851 by cherry-picking @LeonSGP43's original commit on top of current upstream/main while preserving author credit
- prefers direct-alias reverse matches whose provider matches the requested provider
- keeps explicit `--provider` authoritative so a shared model id cannot apply another provider alias's endpoint
- preserves the already-resolved `api_mode` when a matching direct alias has the same `base_url`
- adapts runtime-provider mocks to accept `target_model`/future kwargs used by the current model-switch path

## Commit / authorship notes
- `7a0b843edc30c125b1bf7522459f704813335c21` — cherry-pick of original author commit `13c06e4a3dcba2b07bbcdf8b4d11b7bff665a80e` from #14851, author preserved as @LeonSGP43
- `7cb1c69a61633933503dbbf8b852726881120c3b` — follow-up for current main: explicit-provider alias guard, same-base-url `api_mode` preservation, and current runtime mock signature

## Increment over #14851
- #14851 fixed reverse lookup preference when aliases share a model id
- this branch additionally prevents explicit provider switches from accepting a reverse alias for a different provider, and avoids clearing a resolved `api_mode` when the selected alias points at the same endpoint

## Testing
- RED: after cherry-picking #14851's author commit, `scripts/run_tests.sh tests/hermes_cli/test_ollama_cloud_auth.py -k 'reverse_lookup_prefers_current_provider_when_model_is_shared or explicit_provider_prefers_matching_alias_base_url' -q` failed because the runtime mock did not accept `target_model` and same-base-url alias override reset `api_mode`
- RED: with the follow-up regression test added, `scripts/run_tests.sh tests/hermes_cli/test_ollama_cloud_auth.py -k 'explicit_provider_prefers_matching_alias_base_url or explicit_provider_discards_alias_for_other_provider' -q` failed because explicit provider accepted another provider's reverse alias and overwrote `base_url`
- GREEN: `scripts/run_tests.sh tests/hermes_cli/test_ollama_cloud_auth.py -k 'reverse_lookup_prefers_current_provider_when_model_is_shared or explicit_provider_prefers_matching_alias_base_url or explicit_provider_discards_alias_for_other_provider' -q` (3 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_ollama_cloud_auth.py -k 'reverse_lookup_prefers_current_provider_when_model_is_shared or explicit_provider_prefers_matching_alias_base_url' -q` (2 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_ollama_cloud_auth.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_runtime_provider_resolution.py -q` (234 passed)
- `ruff check hermes_cli/model_switch.py tests/hermes_cli/test_ollama_cloud_auth.py`
- `git diff --check`
- changed-file secret-pattern scan

Fixes #14614
