### PR TITLE
fix(deepseek): replace deprecated model names before 2026-07-24 cut-off

### DIFF
--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -1,20 +1,27 @@
 """DeepSeek provider profile.
 
-DeepSeek's V4 family (and the legacy ``deepseek-reasoner``) defaults to
-thinking-mode ON when ``extra_body.thinking`` is unset.  The API then returns
+DeepSeek's V4 family defaults to thinking-mode ON when
+``extra_body.thinking`` is unset.  The API then returns
 ``reasoning_content`` and starts enforcing the contract that subsequent turns
 echo it back; combined with how Hermes replays history this lands on the
 notorious HTTP 400 ``reasoning_content must be passed back`` error after the
 first tool call (#15700, #17212, #17825).
 
 This profile overrides :meth:`build_api_kwargs_extras` to mirror the Kimi /
-Moonshot wire shape that DeepSeek's OpenAI-compat endpoint expects:
+Moonshot wire shape that DeepSeek's OpenAI-compat endpoint expects::
 
     {"reasoning_effort": "<low|medium|high|max>",
      "extra_body": {"thinking": {"type": "enabled" | "disabled"}}}
 
-Non-thinking models (only ``deepseek-chat`` today, which is V3) are left as
-no-ops so we don't perturb the V3 wire format.
+Non-thinking models (``deepseek-v3-*`` variants) are left as no-ops so
+we don't perturb the V3 wire format.
+
+.. important::
+
+    The legacy aliases ``deepseek-chat`` and ``deepseek-reasoner`` were
+    deprecated on 2026-07-24.  This profile no longer references them.
+    Use the permanent ``deepseek-v4-flash`` (non-thinking via
+    ``reasoning_config: {enabled: false}``) or ``deepseek-v4-pro`` directly.
 """
 
 from __future__ import annotations
@@ -90,11 +97,10 @@ deepseek = DeepSeekProfile(
     description="DeepSeek — native DeepSeek API",
     signup_url="https://platform.deepseek.com/",
     fallback_models=(
-        "deepseek-chat",
-        "deepseek-reasoner",
+        "deepseek-v4-flash",
     ),
     base_url="https://api.deepseek.com/v1",
-    default_aux_model="deepseek-chat",
+    default_aux_model="deepseek-v4-flash",
 )
 
 register_provider(deepseek)

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -195,12 +195,12 @@ class TestDeepSeekAuxModel:
     system.
     """
 
-    def test_profile_advertises_deepseek_chat(self, deepseek_profile):
-        assert deepseek_profile.default_aux_model == "deepseek-chat"
+    def test_profile_advertises_deepseek_v4_flash(self, deepseek_profile):
+        assert deepseek_profile.default_aux_model == "deepseek-v4-flash"
 
-    def test_consumer_api_returns_deepseek_chat(self):
+    def test_consumer_api_returns_deepseek_v4_flash(self):
         from agent.auxiliary_client import _get_aux_model_for_provider
-        assert _get_aux_model_for_provider("deepseek") == "deepseek-chat"
+        assert _get_aux_model_for_provider("deepseek") == "deepseek-v4-flash"
 
     def test_consumer_api_returns_non_empty(self):
         from agent.auxiliary_client import _get_aux_model_for_provider


### PR DESCRIPTION
DeepSeek is deprecating `deepseek-chat` and `deepseek-reasoner` on **2026-07-24 23:59 Beijing time**. After that date, API calls using those names will fail.

**Changes:**

1. **`plugins/model-providers/deepseek/__init__.py`**
   - `default_aux_model="deepseek-chat"` → `"deepseek-v4-flash"`
   - `fallback_models`: removed deprecated `"deepseek-chat"` and `"deepseek-reasoner"`, kept `"deepseek-v4-flash"`
   - Updated module docstring with deprecation notice and migration guidance

2. **`tests/plugins/model_providers/test_deepseek_profile.py`**
   - `test_profile_advertises_deepseek_chat` → `test_profile_advertises_deepseek_v4_flash`
   - `test_consumer_api_returns_deepseek_chat` → `test_consumer_api_returns_deepseek_v4_flash`
   - Updated assertions to expect `"deepseek-v4-flash"`

**Not changed (intentionally):**
- `_model_supports_thinking()` still recognizes `deepseek-reasoner` — existing configs that reference it will still get correct thinking behavior until their users update
- `aliases=("deepseek-chat",)` kept as-is — this is the provider profile alias resolution, not a model name sent to the API
- Test `test_non_thinking_models_emit_nothing` still includes `"deepseek-chat"` — the function correctly treats it as non-V4 (no thinking injected)

**Verification:** All 29 existing tests pass.