### PR TITLE
fix(gateway): bound callback telemetry queues (#32637)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -76,8 +76,76 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
+_GATEWAY_CALLBACK_QUEUE_MAXSIZE = 512
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
+
+
+class _BoundedCallbackQueue:
+    """Bound best-effort callback telemetry without blocking producers.
+
+    Ordinary progress and tool-log events are rejected when the consumer falls
+    behind. Control markers may evict the oldest stale event so content
+    ordering remains correct even when the queue is saturated.
+    """
+
+    def __init__(self, *, maxsize: int = _GATEWAY_CALLBACK_QUEUE_MAXSIZE):
+        self._queue: queue.Queue[Any] = queue.Queue(maxsize=maxsize)
+        self._offer_lock = threading.Lock()
+        self._dropped = 0
+        self._dropped_lock = threading.Lock()
+
+    def offer(self, item: Any) -> bool:
+        """Enqueue an ordinary event immediately, or reject it when full."""
+        with self._offer_lock:
+            try:
+                self._queue.put_nowait(item)
+            except queue.Full:
+                self._record_drop()
+                return False
+        return True
+
+    def offer_latest(self, item: Any) -> bool:
+        """Admit a control event, evicting one stale event when necessary."""
+        with self._offer_lock:
+            try:
+                self._queue.put_nowait(item)
+                return True
+            except queue.Full:
+                pass
+
+            try:
+                self._queue.get_nowait()
+            except queue.Empty:
+                pass
+            else:
+                self._record_drop()
+
+            try:
+                self._queue.put_nowait(item)
+            except queue.Full:
+                self._record_drop()
+                return False
+            return True
+
+    def _record_drop(self) -> None:
+        with self._dropped_lock:
+            self._dropped += 1
+
+    @property
+    def dropped(self) -> int:
+        with self._dropped_lock:
+            return self._dropped
+
+    def empty(self) -> bool:
+        return self._queue.empty()
+
+    def get_nowait(self) -> Any:
+        return self._queue.get_nowait()
+
+    def qsize(self) -> int:
+        return self._queue.qsize()
+
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
@@ -3398,7 +3466,7 @@ class TurnRunner:
             if event_type == "tool.started" and tool_name and tool_name != "_thinking":
                 ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 preview_str = f' "{preview}"' if preview else ""
-                ctx.log_queue.put(f"{ts}  {tool_name}:{preview_str}".rstrip())
+                ctx.log_queue.offer(f"{ts}  {tool_name}:{preview_str}".rstrip())
             if not ctx.progress_queue:
                 return
         if not ctx.progress_queue or not ctx._run_still_current():
@@ -3426,9 +3494,9 @@ class TurnRunner:
                         default=False,
                     )
                     if gate_on and not is_seen(_cfg, TOOL_PROGRESS_FLAG):
-                        ctx.long_tool_hint_fired[0] = True
-                        ctx.progress_queue.put(tool_progress_hint_gateway())
-                        mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
+                        if ctx.progress_queue.offer(tool_progress_hint_gateway()):
+                            ctx.long_tool_hint_fired[0] = True
+                            mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
             except Exception as _hint_err:
                 logger.debug("tool-progress onboarding hint failed: %s", _hint_err)
             return
@@ -3444,7 +3512,7 @@ class TurnRunner:
             thinking_text = preview if tool_name == "_thinking" else tool_name
             msg = f"💬 {thinking_text}" if thinking_text else None
             if msg:
-                ctx.progress_queue.put(msg)
+                ctx.progress_queue.offer(msg)
             return
 
         # If tool_progress is off, only _thinking passes through (above).
@@ -3486,7 +3554,6 @@ class TurnRunner:
         # "new" mode: only report when tool changes
         if ctx.progress_mode == "new" and tool_name == ctx.last_tool[0]:
             return
-        ctx.last_tool[0] = tool_name
 
         # Build progress message with primary argument preview
         from agent.display import get_tool_emoji
@@ -3542,10 +3609,10 @@ class TurnRunner:
         # Verbose mode: show detailed arguments, respects tool_preview_length
         if ctx.progress_mode == "verbose":
             if _code_block_full is not None:
-                ctx.last_was_terminal_block[0] = True
-                ctx.progress_queue.put(_code_block_full)
+                if ctx.progress_queue.offer(_code_block_full):
+                    ctx.last_tool[0] = tool_name
+                    ctx.last_was_terminal_block[0] = True
                 return
-            ctx.last_was_terminal_block[0] = False
             if args:
                 from agent.display import get_tool_preview_max_len
                 _pl = get_tool_preview_max_len()
@@ -3560,7 +3627,9 @@ class TurnRunner:
                 msg = f"{emoji} {tool_name}: \"{preview}\""
             else:
                 msg = f"{emoji} {tool_name}..."
-            ctx.progress_queue.put(msg)
+            if ctx.progress_queue.offer(msg):
+                ctx.last_tool[0] = tool_name
+                ctx.last_was_terminal_block[0] = False
             return
 
         # "all" / "new" modes: short preview, respects tool_preview_length
@@ -3570,7 +3639,7 @@ class TurnRunner:
         # fenced block (built above) instead of the truncated preview.
         if _code_block_short is not None:
             msg = _code_block_short
-            ctx.last_was_terminal_block[0] = True
+            next_was_terminal_block = True
         elif preview:
             from agent.display import (
                 get_tool_preview_max_len,
@@ -3595,24 +3664,27 @@ class TurnRunner:
                     msg = f"{emoji} {_verb}{tool_verb_connector(tool_name)}{preview}"
             else:
                 msg = f"{emoji} {tool_name}: \"{preview}\""
-            ctx.last_was_terminal_block[0] = False
+            next_was_terminal_block = False
         else:
             msg = f"{emoji} {tool_name}..."
-            ctx.last_was_terminal_block[0] = False
+            next_was_terminal_block = False
 
         # Dedup: collapse consecutive identical progress messages.
         # Common with execute_code where models iterate with the same
         # code (same boilerplate imports → identical previews).
         if msg == ctx.last_progress_msg[0]:
-            ctx.repeat_count[0] += 1
+            next_repeat_count = ctx.repeat_count[0] + 1
             # Update the last line in progress_lines with a counter
             # via a special "dedup" queue message.
-            ctx.progress_queue.put(("__dedup__", msg, ctx.repeat_count[0]))
+            if ctx.progress_queue.offer(("__dedup__", msg, next_repeat_count)):
+                ctx.repeat_count[0] = next_repeat_count
             return
-        ctx.last_progress_msg[0] = msg
-        ctx.repeat_count[0] = 0
 
-        ctx.progress_queue.put(msg)
+        if ctx.progress_queue.offer(msg):
+            ctx.last_tool[0] = tool_name
+            ctx.last_progress_msg[0] = msg
+            ctx.repeat_count[0] = 0
+            ctx.last_was_terminal_block[0] = next_was_terminal_block
 
     async def send_progress_messages(self):
         ctx = self._ctx
@@ -4184,7 +4256,7 @@ class TurnRunner:
                         config=_consumer_cfg,
                         metadata=ctx._status_thread_metadata,
                         on_new_message=(
-                            (lambda: ctx.progress_queue.put(("__reset__",)))
+                            (lambda: ctx.progress_queue.offer_latest(("__reset__",)))
                             if ctx.progress_queue is not None
                             else None
                         ),
@@ -23284,7 +23356,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # "log" mode: tool calls are written to ~/.hermes/logs/tool_calls.log
         # instead of the chat (#3459 / #3458). Gateway-only by design.
         log_mode_enabled = progress_mode == "log" and source.platform != Platform.WEBHOOK
-        log_queue: "queue.Queue | None" = queue.Queue() if log_mode_enabled else None
+        log_queue: "_BoundedCallbackQueue | None" = (
+            _BoundedCallbackQueue() if log_mode_enabled else None
+        )
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
@@ -23311,7 +23385,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
         # Queue for progress messages (thread-safe)
-        progress_queue = queue.Queue() if needs_progress_queue else None
+        progress_queue = _BoundedCallbackQueue() if needs_progress_queue else None
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
@@ -24556,6 +24630,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await task
                     except asyncio.CancelledError:
                         pass
+            if progress_queue is not None and progress_queue.dropped:
+                logger.warning(
+                    "Dropped %d gateway progress events after the callback queue saturated",
+                    progress_queue.dropped,
+                )
+            if log_queue is not None and log_queue.dropped:
+                logger.warning(
+                    "Dropped %d gateway tool-log events after the callback queue saturated",
+                    log_queue.dropped,
+                )
 
         # If streaming already delivered the response, mark it so the
         # caller's send() is skipped (avoiding duplicate messages).

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -29,6 +29,7 @@ from gateway.session import (
 )
 from gateway.session_transcript import TranscriptReadError
 from gateway.turn_context import TurnContext
+from gateway.run_turn_runner import _BoundedCallbackQueue
 from gateway.turn_lease import DEFAULT_LEASE_WAIT, TurnLeaseTimeoutError
 from hermes_constants import get_hermes_home_override
 from pathlib import Path
@@ -2706,7 +2707,7 @@ class GatewayTurnMixin:
             _display_surface_mode=_display_surface_mode,
             tool_progress_enabled=tool_progress_enabled, _live_status_mode=_live_status_mode,
             _live_status_adapter=_live_status_adapter, log_mode_enabled=log_mode_enabled,
-            log_queue=queue.Queue() if log_mode_enabled else None,
+            log_queue=_BoundedCallbackQueue() if log_mode_enabled else None,
             interim_assistant_messages_enabled=interim_assistant_messages_enabled,
             _thinking_enabled=_thinking_enabled, _native_slack_task_cards=_native_slack_task_cards,
             needs_progress_queue=tool_progress_enabled or _thinking_enabled or _native_slack_task_cards,
@@ -2758,7 +2759,7 @@ class GatewayTurnMixin:
             source=source, message=message, AIAgent=AIAgent, session_key=session_key,
             run_generation=run_generation, _cleanup_progress=_cleanup_progress,
             _run_still_current=self._run_still_current_fn(session_key, run_generation),
-            progress_queue=queue.Queue() if disp.needs_progress_queue else None,
+            progress_queue=_BoundedCallbackQueue() if disp.needs_progress_queue else None,
             _voice_ack_guild=_voice_ack_guild, _voice_ack_loop=asyncio.get_running_loop(),
             **{name: getattr(disp, name) for name in self._DISPLAY_TO_TURN_CTX}, **turn_params,
         )
@@ -3586,6 +3587,11 @@ class GatewayTurnMixin:
                 except Exception:
                     # A background task that died of a real error must not abort the cleanup path.
                     logger.debug("background turn task failed during cleanup", exc_info=True)
+
+        for label, callback_queue in (("progress", turn_ctx.progress_queue), ("tool-log", turn_ctx.log_queue)):
+            dropped = getattr(callback_queue, "dropped", 0)
+            if dropped:
+                logger.warning("Dropped %d gateway %s events after the callback queue saturated", dropped, label)
 
     async def _run_agent_edit_streamed_message(
         self, _sc, source, response, content, *, _sk, ok, fail_result, fail_exc,

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -45,6 +45,44 @@ class _ExecApprovalDeclined(RuntimeError):
     """
 
 
+class _BoundedCallbackQueue(queue.Queue):
+    """Best-effort telemetry; capacity never blocks a callback producer."""
+
+    def __init__(self, maxsize=512):
+        super().__init__(maxsize=maxsize)
+        self._dropped = 0
+
+    def offer(self, item, *, latest=False):
+        # Use Queue's mutex for one atomic eviction/admission, including ordinary
+        # Queue producers and consumers. Its storage and wakeups stay standard.
+        with self.not_full:
+            if self.maxsize > 0 and self._qsize() >= self.maxsize:
+                self._dropped += 1
+                if not latest:
+                    return False
+                self._get()
+                self.unfinished_tasks -= 1
+            self._put(item)
+            self.unfinished_tasks += 1
+            self.not_empty.notify()
+            return True
+
+    @property
+    def dropped(self):
+        with self.mutex:
+            return self._dropped
+
+
+def _offer_callback_event(callback_queue, item, *, latest=False):
+    if isinstance(callback_queue, _BoundedCallbackQueue):
+        return callback_queue.offer(item, latest=latest)
+    try:
+        callback_queue.put_nowait(item)
+        return True
+    except queue.Full:
+        return False
+
+
 class TurnRunner:
     """Per-turn collaborator carrying ``GatewayRunner._run_agent_inner``'s tool-progress callbacks."""
 
@@ -108,7 +146,7 @@ class TurnRunner:
         if ctx.log_queue is not None and event_type == "tool.started" and tool_name and tool_name != "_thinking":
             ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             preview_str = f' "{preview}"' if preview else ""
-            ctx.log_queue.put(f"{ts}  {tool_name}:{preview_str}".rstrip())
+            _offer_callback_event(ctx.log_queue, f"{ts}  {tool_name}:{preview_str}".rstrip())
         if not ctx.progress_queue or not ctx._run_still_current():
             return
         if event_type == "tool.completed" and not ctx.long_tool_hint_fired[0]:
@@ -119,7 +157,7 @@ class TurnRunner:
         if event_type == "_thinking" or tool_name == "_thinking":
             thinking_text = (preview if tool_name == "_thinking" else tool_name) if ctx._thinking_enabled else None
             if thinking_text:
-                ctx.progress_queue.put(f"💬 {thinking_text}")
+                _offer_callback_event(ctx.progress_queue, f"💬 {thinking_text}")
             return
         # Native task cards consume the ID-bearing tool_start/tool_complete callbacks instead;
         # name-correlated text events would duplicate cards and mispair concurrent same-tool calls.
@@ -144,10 +182,12 @@ class TurnRunner:
         # "new" mode: only report when tool changes
         if ctx.progress_mode == "new" and tool_name == ctx.last_tool[0]:
             return
-        ctx.last_tool[0] = tool_name
+        previous_terminal_block = ctx.last_was_terminal_block[0]
         msg = self._progress_build_message(tool_name, preview, args)
-        if msg is not None:
-            self._progress_emit(msg)
+        if self._progress_emit(msg, dedup=ctx.progress_mode != "verbose"):
+            ctx.last_tool[0] = tool_name
+        else:
+            ctx.last_was_terminal_block[0] = previous_terminal_block
 
     def _progress_subagent_notice(self, preview, kwargs: dict) -> None:
         """Only terminal failure statuses render (same notice rail as credit warnings)."""
@@ -192,9 +232,9 @@ class TurnRunner:
                 cfg = _load_gateway_config()
                 gate_on = is_truthy_value(cfg_get(cfg, "display", "tool_progress_command"), default=False)
                 if gate_on and not is_seen(cfg, TOOL_PROGRESS_FLAG):
-                    ctx.long_tool_hint_fired[0] = True
-                    ctx.progress_queue.put(tool_progress_hint_gateway())
-                    mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
+                    if _offer_callback_event(ctx.progress_queue, tool_progress_hint_gateway()):
+                        ctx.long_tool_hint_fired[0] = True
+                        mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
         except Exception as err:
             logger.debug("tool-progress onboarding hint failed: %s", err)
 
@@ -229,7 +269,7 @@ class TurnRunner:
         return f"{header}```\n{cmd_full}\n```", f"{header}```\n{cmd_short}\n```"
 
     def _progress_build_message(self, tool_name, preview, args) -> Optional[str]:
-        """Render the progress line. Verbose mode queues directly (no dedup) and returns None."""
+        """Render a progress line without advancing accepted-event state."""
         ctx = self._ctx
         from agent.display import get_tool_emoji
         emoji = get_tool_emoji(tool_name, default="⚙️")
@@ -253,8 +293,7 @@ class TurnRunner:
                 code = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
             elif code is None:
                 code = f"{emoji} {tool_name}: \"{preview}\"" if preview else f"{emoji} {tool_name}..."
-            ctx.progress_queue.put(code)
-            return None
+            return code
         if code is not None:
             return code
         if not preview:
@@ -269,24 +308,28 @@ class TurnRunner:
             return f"{emoji} {tool_name}: \"{preview}\""
         return f"{emoji} {verb}" if verb_drops_preview(tool_name) else f"{emoji} {verb}{tool_verb_connector(tool_name)}{preview}"
 
-    def _progress_emit(self, msg: str) -> None:
+    def _progress_emit(self, msg: str, *, dedup=True) -> bool:
         """Dedup consecutive identical lines (execute_code boilerplate), then route to the native
         stream bubble when the consumer accepts tool progress, else the progress queue."""
         ctx = self._ctx
+        if not dedup:
+            return _offer_callback_event(ctx.progress_queue, msg)
         sc = self._stream_consumer()
         native = sc is not None and getattr(sc, "accepts_tool_progress", False)
         if msg == ctx.last_progress_msg[0]:
-            ctx.repeat_count[0] += 1
+            repeats = ctx.repeat_count[0] + 1
             if native:
-                sc.on_tool_progress(f"{msg} (×{ctx.repeat_count[0] + 1})")
-            else:
-                ctx.progress_queue.put(("__dedup__", msg, ctx.repeat_count[0]))
-            return
-        ctx.last_progress_msg[0], ctx.repeat_count[0] = msg, 0
+                sc.on_tool_progress(f"{msg} (×{repeats + 1})")
+            elif not _offer_callback_event(ctx.progress_queue, ("__dedup__", msg, repeats)):
+                return False
+            ctx.repeat_count[0] = repeats
+            return True
         if native:
             sc.on_tool_progress(msg)
-        else:
-            ctx.progress_queue.put(msg)
+        elif not _offer_callback_event(ctx.progress_queue, msg):
+            return False
+        ctx.last_progress_msg[0], ctx.repeat_count[0] = msg, 0
+        return True
 
     # ── Slack-native task cards (progress-queue drain) ──────────────────────────────────────
 
@@ -727,7 +770,7 @@ class TurnRunner:
             return
         from agent.display import build_tool_preview
         name = str(tool_name or "tool")
-        self._ctx.progress_queue.put({
+        _offer_callback_event(self._ctx.progress_queue, {
             "type": "tool.started", "tool_call_id": str(call_id or ""), "tool_name": name,
             "preview": build_tool_preview(name, args or {}, max_len=64) or "",
         })
@@ -739,9 +782,9 @@ class TurnRunner:
         from agent.display import _detect_tool_failure
         name = str(tool_name or "tool")
         is_error, _ = _detect_tool_failure(name, result)
-        self._ctx.progress_queue.put({
+        _offer_callback_event(self._ctx.progress_queue, {
             "type": "tool.completed", "tool_call_id": str(call_id or ""), "tool_name": name, "is_error": bool(is_error),
-        })
+        }, latest=True)
 
     def combined_tool_start_callback(self, call_id, tool_name, args):
         """Compose the voice ack + native task-card start consumers."""
@@ -864,7 +907,7 @@ class TurnRunner:
                         adapter=adapter, chat_id=ctx.source.chat_id, config=consumer_cfg,
                         metadata=ctx._status_thread_metadata,
                         on_new_message=(
-                            (lambda: ctx.progress_queue.put(("__reset__",))) if ctx.progress_queue is not None else None
+                            (lambda: _offer_callback_event(ctx.progress_queue, ("__reset__",), latest=True)) if ctx.progress_queue is not None else None
                         ),
                         on_before_finalize=pause_typing_before_finalize,
                         initial_reply_to_id=ctx.event_message_id, run_still_current=ctx._run_still_current,

--- a/tests/gateway/test_callback_queue.py
+++ b/tests/gateway/test_callback_queue.py
@@ -1,0 +1,82 @@
+"""Regression coverage for bounded gateway callback backlogs."""
+
+import threading
+
+from gateway.run import TurnRunner, _BoundedCallbackQueue
+from gateway.turn_context import TurnContext
+
+
+class _StubGatewayRunner:
+    def _adapter_for_source(self, source):
+        return None
+
+
+def test_callback_queue_rejects_saturation_without_blocking():
+    callback_queue = _BoundedCallbackQueue(maxsize=2)
+
+    assert callback_queue.offer("first") is True
+    assert callback_queue.offer("second") is True
+
+    result = []
+    producer = threading.Thread(
+        target=lambda: result.append(callback_queue.offer("overflow")),
+        daemon=True,
+    )
+    producer.start()
+    producer.join(timeout=0.5)
+
+    assert producer.is_alive() is False
+    assert result == [False]
+    assert callback_queue.qsize() == 2
+    assert callback_queue.dropped == 1
+    assert callback_queue.get_nowait() == "first"
+    assert callback_queue.get_nowait() == "second"
+
+
+def test_callback_queue_keeps_accepting_after_consumer_drains_space():
+    callback_queue = _BoundedCallbackQueue(maxsize=1)
+
+    assert callback_queue.offer("first") is True
+    assert callback_queue.offer("rejected") is False
+    assert callback_queue.get_nowait() == "first"
+    assert callback_queue.offer("next") is True
+
+    assert callback_queue.get_nowait() == "next"
+    assert callback_queue.dropped == 1
+
+
+def test_callback_queue_prioritizes_control_event_over_stale_telemetry():
+    callback_queue = _BoundedCallbackQueue(maxsize=2)
+    callback_queue.offer("oldest")
+    callback_queue.offer("newer")
+
+    assert callback_queue.offer_latest(("__reset__",)) is True
+
+    assert callback_queue.get_nowait() == "newer"
+    assert callback_queue.get_nowait() == ("__reset__",)
+    assert callback_queue.dropped == 1
+
+
+def test_progress_dedup_state_tracks_only_accepted_events():
+    callback_queue = _BoundedCallbackQueue(maxsize=1)
+    callback_queue.offer("already queued")
+    ctx = TurnContext(
+        _run_still_current=lambda: True,
+        progress_mode="new",
+        tool_progress_enabled=True,
+        progress_queue=callback_queue,
+    )
+    runner = TurnRunner(_StubGatewayRunner(), ctx)
+
+    runner.progress_callback("tool.started", "web_search", "first", {})
+
+    assert ctx.last_tool == [None]
+    assert ctx.last_progress_msg == [None]
+    assert ctx.repeat_count == [0]
+
+    assert callback_queue.get_nowait() == "already queued"
+    runner.progress_callback("tool.started", "web_search", "first", {})
+
+    assert ctx.last_tool == ["web_search"]
+    assert ctx.last_progress_msg[0] is not None
+    assert callback_queue.get_nowait() == ctx.last_progress_msg[0]

--- a/tests/gateway/test_callback_queue.py
+++ b/tests/gateway/test_callback_queue.py
@@ -1,0 +1,110 @@
+"""Regression coverage for bounded gateway callback backlogs."""
+
+import threading
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+from gateway.run_turn_runner import TurnRunner, _BoundedCallbackQueue
+from gateway.turn_context import TurnContext
+
+
+class _StubGatewayRunner:
+    def _adapter_for_source(self, source):
+        return None
+
+
+def test_callback_queue_rejects_saturation_without_blocking():
+    callback_queue = _BoundedCallbackQueue(maxsize=2)
+
+    assert callback_queue.offer("first") is True
+    assert callback_queue.offer("second") is True
+
+    result = []
+    producer = threading.Thread(
+        target=lambda: result.append(callback_queue.offer("overflow")),
+        daemon=True,
+    )
+    producer.start()
+    producer.join(timeout=0.5)
+
+    assert producer.is_alive() is False
+    assert result == [False]
+    assert callback_queue.qsize() == 2
+    assert callback_queue.dropped == 1
+    assert callback_queue.get_nowait() == "first"
+    assert callback_queue.get_nowait() == "second"
+
+
+def test_callback_queue_keeps_accepting_after_consumer_drains_space():
+    callback_queue = _BoundedCallbackQueue(maxsize=1)
+
+    assert callback_queue.offer("first") is True
+    assert callback_queue.offer("rejected") is False
+    assert callback_queue.get_nowait() == "first"
+    assert callback_queue.offer("next") is True
+
+    assert callback_queue.get_nowait() == "next"
+    assert callback_queue.dropped == 1
+
+
+def test_callback_queue_prioritizes_control_event_over_stale_telemetry():
+    callback_queue = _BoundedCallbackQueue(maxsize=2)
+    callback_queue.offer("oldest")
+    callback_queue.offer("newer")
+
+    assert callback_queue.offer(("__reset__",), latest=True) is True
+
+    assert callback_queue.get_nowait() == "newer"
+    assert callback_queue.get_nowait() == ("__reset__",)
+    assert callback_queue.dropped == 1
+
+
+def test_progress_dedup_state_tracks_only_accepted_events():
+    callback_queue = _BoundedCallbackQueue(maxsize=1)
+    callback_queue.offer("already queued")
+    ctx = TurnContext(
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="test"),
+        _run_still_current=lambda: True,
+        progress_mode="new",
+        tool_progress_enabled=True,
+        progress_queue=callback_queue,
+    )
+    runner = TurnRunner(_StubGatewayRunner(), ctx)
+
+    runner.progress_callback("tool.started", "web_search", "first", {})
+
+    assert ctx.last_tool == [None]
+    assert ctx.last_progress_msg == [None]
+    assert ctx.repeat_count == [0]
+
+    assert callback_queue.get_nowait() == "already queued"
+    runner.progress_callback("tool.started", "web_search", "first", {})
+
+    assert ctx.last_tool == ["web_search"]
+    assert ctx.last_progress_msg[0] is not None
+    assert callback_queue.get_nowait() == ctx.last_progress_msg[0]
+
+
+def test_rejected_duplicate_does_not_advance_repeat_count():
+    callback_queue = _BoundedCallbackQueue(maxsize=1)
+    ctx = TurnContext(progress_queue=callback_queue, source=SessionSource(platform=Platform.TELEGRAM, chat_id="test"))
+    runner = TurnRunner(_StubGatewayRunner(), ctx)
+    assert runner._progress_emit("first") is True
+    assert runner._progress_emit("first") is False
+    assert ctx.repeat_count == [0]
+    assert callback_queue.get_nowait() == "first"
+    assert runner._progress_emit("first") is True
+    assert callback_queue.get_nowait() == ("__dedup__", "first", 1)
+
+
+def test_native_completion_survives_saturation_with_its_call_id():
+    callback_queue = _BoundedCallbackQueue(maxsize=1)
+    ctx = TurnContext(progress_queue=callback_queue, _run_still_current=lambda: True,
+                      source=SessionSource(platform=Platform.SLACK, chat_id="test"))
+    runner = TurnRunner(_StubGatewayRunner(), ctx)
+    runner.native_tool_start_callback("older", "web_search", {})
+    runner.native_tool_complete_callback("current", "web_search", {}, {"success": True})
+    event = callback_queue.get_nowait()
+    assert event["type"] == "tool.completed"
+    assert event["tool_call_id"] == "current"
+    assert callback_queue.dropped == 1

--- a/tests/gateway/test_run_progress_interrupt.py
+++ b/tests/gateway/test_run_progress_interrupt.py
@@ -129,6 +129,33 @@ class PartialTruncationAgent:
         }
 
 
+class SaturatingProgressAgent:
+    """Floods callback telemetry while the async sender is unable to drain."""
+
+    callback_elapsed = None
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+        self._interrupt_requested = False
+
+    @property
+    def is_interrupted(self) -> bool:
+        return self._interrupt_requested
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        started = time.monotonic()
+        for index in range(1024):
+            self.tool_progress_callback(
+                "tool.started",
+                "web_search",
+                f"saturation-{index}",
+                {},
+            )
+        type(self).callback_elapsed = time.monotonic() - started
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
@@ -249,3 +276,24 @@ async def test_progress_suppressed_when_agent_is_interrupted(monkeypatch, tmp_pa
             f"event '{leaked_query}' leaked into the UI after interrupt — "
             f"progress_callback / drain loop is not checking is_interrupted"
         )
+
+
+@pytest.mark.asyncio
+async def test_progress_saturation_rejects_events_without_blocking_agent(
+    monkeypatch, tmp_path, caplog
+):
+    caplog.set_level("WARNING", logger="gateway.run")
+    SaturatingProgressAgent.callback_elapsed = None
+
+    _, result = await _run_once(
+        monkeypatch,
+        tmp_path,
+        SaturatingProgressAgent,
+        "sess-saturated-progress",
+    )
+
+    assert result["final_response"] == "done"
+    assert SaturatingProgressAgent.callback_elapsed is not None
+    assert SaturatingProgressAgent.callback_elapsed < 0.5
+    assert "Dropped " in caplog.text
+    assert "gateway progress events" in caplog.text


### PR DESCRIPTION
Bound per-turn gateway progress and tool-log queues to 512 events. Ordinary telemetry is rejected immediately when consumers fall behind; reset markers and native task completions can replace stale telemetry. Callback producers do not wait for queue capacity.

Advance deduplication, tool-name, and terminal-rendering state only for accepted events, and report dropped telemetry during turn cleanup. Current native task-card producers are included. Final responses, stream deltas, subprocess queues, and executor ownership are unchanged.

This preserves the narrow callback-telemetry salvage of #32706 by Ernest Hysa, adapted to the extracted turn runner. His co-author credit remains. It excludes the source's unrelated queue, response-loss, executor, and audit-artifact changes.

Validation on `485aaf69b7f0930a5f6631752172d90a4a5575c6`:
- Before: the real gateway saturation regression fails because all events enter an unbounded backlog.
- After: six focused gateway files pass, 56 tests, covering turn saturation, progress routing, interruption, log mode, cleanup, and stream progress.
- Final queue group: 6 passed, including rejected-dedup state and native completion identity under saturation.
- Ruff and diff checks pass. Merge simulation against subsequent `83467c28f78987acdeb55636fb625946ec572a30` is clean; its file-tool changes do not alter this callback path.

Not checked: full suite, native platform runtime; CodeRabbit skipped for author-side maintenance without P0/P1 priority. Saturation intentionally loses best-effort telemetry, with counts reported in gateway logs.

Related #32637

Agent disclosure: original work by GPT-5.6-sol with xhigh reasoning in Codex Desktop. Maintenance by GPT-6 in Codex desktop (parent reasoning level unavailable). The account owner loosely reviews these actions and receives the usual GitHub notifications.
