### PR TITLE
fix(desktop): preserve SSH profile state during reconnect

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6902,7 +6902,11 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     const lifecycle = platform.os === 'Windows' ? connectWindowsRemote : remoteLifecycle.connect
     result = await lifecycle({
       ssh,
-      profile: connectionScopeKey(profile) || '',
+      // Always pin the root profile explicitly. Leaving it blank lets the
+      // remote's sticky active_profile decide which state store `default`
+      // means, which is exactly how an SSH Desktop session can silently point
+      // at a profile with no Telegram/cron history.
+      profile: connectionScopeKey(profile) || 'default',
       remoteHermesPath: sshConfig.remoteHermesPath || '',
       ownershipId: sshOwnershipKey(profile),
       reuseToken: reuseToken || '',

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -440,6 +440,32 @@ test('connect() reuses a healthy dashboard when fingerprint + probe pass', async
   assert.ok(!ssh.calls.some(c => /setsid/.test(c)), 'reuse path must not spawn a new dashboard')
 })
 
+test('connect() replaces an unpinned default backend with an explicit default profile', async () => {
+  const reuseToken = 'stored-token'
+  const lock = ownedLock({ profile: '', tokenFingerprint: fingerprintToken(reuseToken) })
+
+  const ssh = fakeSsh([
+    [/uname/, 'Linux\nx86_64'],
+    [/\[ -x/, 'OK'],
+    [/cat .*lock\.json/, JSON.stringify(lock)],
+    [/kill -0 333/, 'ALIVE'],
+    [/print\("OWNED"/, 'OWNED\n'],
+    [/grep -q ssh-session-token-file/, 'YES\n'],
+    [/python3 -c/, ''],
+    [/setsid/, '901\n'],
+    [/kill -0 901/, 'ALIVE'],
+    [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=42001\n']
+  ])
+
+  const result = await connect(
+    connectDeps(ssh, { profile: 'default', reuseToken, adoptServedToken: async () => 'fresh' })
+  )
+
+  assert.equal(result.reused, false)
+  assert.ok(ssh.calls.some(command => /kill 333\b/.test(command)))
+  assert.ok(ssh.calls.some(command => /--profile.*default/.test(command)))
+})
+
 test('connect() respawns when the lockfile hermesPath differs from the resolved path', async () => {
   const reuseToken = 'stored-token'
   const lock = ownedLock({ hermesPath: '/old/stale/hermes', tokenFingerprint: fingerprintToken(reuseToken) })

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -713,6 +713,7 @@ async function connect(deps) {
       pidAlive &&
       owned &&
       lock.port > 0 &&
+      lock.profile === profile &&
       Boolean(reuseToken) &&
       lock.tokenFingerprint === fingerprintToken(reuseToken) &&
       lock.hermesPath === hermesPath &&

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -199,6 +199,27 @@ describe('revalidateRemoteConnection', () => {
     expect(test.log).toHaveBeenLastCalledWith(expect.stringContaining('dropping stale connection'))
   })
 
+  it('rebuilds an SSH backend on its first failed health probe', async () => {
+    const probe = vi.fn().mockRejectedValue(new Error('local forward refused'))
+    const connection = { baseUrl: 'http://127.0.0.1:43210', mode: 'remote', remoteKind: 'ssh' }
+    const connectionPromise = Promise.resolve(connection)
+    const resetConnection = vi.fn()
+
+    await expect(
+      revalidateRemoteConnection({
+        connectionPromise,
+        currentConnectionPromise: () => connectionPromise,
+        log: vi.fn(),
+        probe,
+        resetConnection,
+        tracker: new RemoteLivenessTracker()
+      })
+    ).resolves.toEqual({ ok: true, rebuilt: true })
+
+    expect(resetConnection).toHaveBeenCalledOnce()
+    expect(probe).toHaveBeenCalledOnce()
+  })
+
   it('ignores a late failed probe after the cached connection is replaced', async () => {
     let rejectProbe: (error: Error) => void = () => undefined
 

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -13,6 +13,7 @@ export interface RemoteLivenessFailure {
 interface RemoteConnectionDescriptor {
   baseUrl?: null | string
   mode?: null | string
+  remoteKind?: null | string
 }
 
 export interface RevalidateRemoteConnectionOptions<TConnection extends RemoteConnectionDescriptor> {
@@ -162,6 +163,19 @@ export async function revalidateRemoteConnection<TConnection extends RemoteConne
   } catch {
     if (currentConnectionPromise() !== connectionPromise) {
       return { ok: true, rebuilt: false }
+    }
+
+    // An SSH backend is reached through a Desktop-owned local forward. Once
+    // that forward fails an HTTP health check it cannot recover in place: the
+    // renderer will keep dialing the same dead localhost port. Rebuild it on
+    // the first failure, while URL/cloud remotes retain the gentler 3-probe
+    // policy for transient Internet hiccups.
+    if (connection.remoteKind === 'ssh') {
+      tracker.clear()
+      log('SSH Hermes backend failed liveness probe; dropping stale SSH connection.')
+      resetConnection()
+
+      return { ok: true, rebuilt: true }
     }
 
     const failure = tracker.recordFailure(baseUrl)

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -23,7 +23,7 @@ import {
   setPrimaryGateway,
   touchSecondaryGateways
 } from '@/store/gateway'
-import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
+import { $gatewaySwitching, retainSessionListsForGatewayReconnect } from '@/store/gateway-switch'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, normalizeProfileKey, touchActiveGatewayBackend } from '@/store/profile'
 import {
@@ -260,7 +260,10 @@ export function useGatewayBoot({
     }
 
     // Soft gateway-mode apply: main tore down the primary without reloading.
-    // Wipe session lists so skeletons retrigger, then re-dial in place.
+    // Keep the active profile's last confirmed data visible while the remote
+    // backend is rebuilt; refreshSessions replaces it once the new backend
+    // answers. A hard profile switch still reloads the renderer and starts
+    // with that profile's own state.
     const softSwitch = async () => {
       if (cancelled) {
         return
@@ -272,7 +275,7 @@ export function useGatewayBoot({
       escalated = false
       reauthNotified = false
       callbacksRef.current.beforeConnectionSwitch()
-      wipeSessionListsForGatewaySwitch()
+      retainSessionListsForGatewayReconnect()
 
       try {
         gateway.close()

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -236,6 +236,32 @@ describe('refreshSessions batches slices into one request', () => {
     )
   })
 
+  it('ignores a response from the profile that was active before a switch', async () => {
+    let resolveResponse: (value: SidebarSessionsResponse) => void = () => undefined
+    listSidebarSessions.mockReturnValueOnce(
+      new Promise<SidebarSessionsResponse>(resolve => {
+        resolveResponse = resolve
+      })
+    )
+
+    const { result, rerender } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'default' } }
+    )
+
+    const pending = result.current.refreshSessions()
+    rerender({ profileScope: 'coder' })
+
+    await act(async () => {
+      resolveResponse(sidebar({ sessions: [row('default-chat')], total: 1, profile_totals: { default: 1 } }))
+      await pending
+    })
+
+    expect($sessions.get()).toEqual([])
+    expect($cronSessions.get()).toEqual([])
+    expect($messagingSessions.get()).toEqual([])
+  })
+
   it('scopes the cron-jobs fetch to the active profile (all → unified view)', async () => {
     const { getCronJobs } = await import('@/hermes')
     listSidebarSessions.mockResolvedValue(sidebar({ sessions: [], total: 0, profile_totals: {} }))

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -75,6 +75,8 @@ interface UseSessionListActionsArgs {
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
   const refreshSessionsRequestRef = useRef(0)
+  const profileScopeRef = useRef(profileScope)
+  profileScopeRef.current = profileScope
 
   // Messaging-platform sessions as their own slice, fetched separately from
   // local recents so each platform renders a self-managed section and never
@@ -129,10 +131,17 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // fetch to the sidebar's profile scope — a concrete profile sees only its
   // own jobs; ALL_PROFILES keeps the unified view.
   const refreshCronJobs = useCallback(async () => {
-    try {
-      const jobs = await getCronJobs(profileScope === ALL_PROFILES ? 'all' : profileScope)
+    const requestedScope = profileScope
 
-      setCronJobs(jobs)
+    try {
+      const jobs = await getCronJobs(requestedScope === ALL_PROFILES ? 'all' : requestedScope)
+
+      // A profile switch can happen while the prior profile's request is in
+      // flight. Never let that older result replace the newly selected
+      // profile's cron list.
+      if (profileScopeRef.current === requestedScope) {
+        setCronJobs(jobs)
+      }
     } catch {
       // Non-fatal: the cron section just keeps its last-known jobs.
     }
@@ -141,6 +150,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   const refreshSessions = useCallback(async () => {
     const requestId = refreshSessionsRequestRef.current + 1
     refreshSessionsRequestRef.current = requestId
+    const requestedScope = profileScope
     // The loading flag exists to drive the initial skeletons (they only render
     // while the list is empty). Turn-complete / reconnect refreshes over a
     // populated list used to flip it true→false anyway, churning every
@@ -164,7 +174,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       // with few recent sessions isn't windowed out of the cross-profile
       // recency page — the empty-history-on-profile-switch bug. Cron + messaging
       // stay cross-profile.
-      const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+      const sessionProfile = requestedScope === ALL_PROFILES ? 'all' : requestedScope
 
       // Batched: one request opens each profile DB once and returns all three
       // source-scoped slices, instead of three separate listAllProfileSessions
@@ -178,7 +188,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         messagingExclude: MESSAGING_EXCLUDED_SOURCES
       })
 
-      if (refreshSessionsRequestRef.current === requestId) {
+      if (refreshSessionsRequestRef.current === requestId && profileScopeRef.current === requestedScope) {
         const recents = result.recents
 
         // Drop rows the user just deleted/archived: a refresh can race an

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -17,7 +17,11 @@ import {
 } from '@/store/session'
 import { $stalledSessionIds } from '@/store/session-states'
 
-import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from './gateway-switch'
+import {
+  $gatewaySwitching,
+  retainSessionListsForGatewayReconnect,
+  wipeSessionListsForGatewaySwitch
+} from './gateway-switch'
 
 vi.mock('@/lib/query-client', () => ({
   invalidateProfileScopedQueries: vi.fn()
@@ -57,5 +61,15 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     expect($sessionsLoading.get()).toBe(true)
     expect($sessionsLimit.get()).toBe(SIDEBAR_SESSIONS_PAGE_SIZE)
     expect($freshDraftReady.get()).toBe(true)
+  })
+
+  it('keeps the active profile data visible during a transient reconnect', () => {
+    retainSessionListsForGatewayReconnect()
+
+    expect($sessions.get()).toHaveLength(1)
+    expect($sessionsTotal.get()).toBe(1)
+    expect($cronSessions.get()).toHaveLength(1)
+    expect($messagingSessions.get()).toHaveLength(1)
+    expect($sessionsLoading.get()).toBe(false)
   })
 })

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -26,6 +26,17 @@ import { clearAllSessionStates } from '@/store/session-states'
 export const $gatewaySwitching = atom(false)
 
 /**
+ * Prepare the renderer for a transient reconnect without discarding data from
+ * the active profile. A remote SSH forward can disappear while the profile's
+ * sessions still exist on disk; clearing first makes the sidebar incorrectly
+ * show "No sessions yet" until every follow-up request succeeds.
+ */
+export function retainSessionListsForGatewayReconnect(): void {
+  resetSidebarBatchCapability()
+  invalidateProfileScopedQueries()
+}
+
+/**
  * Clear gateway-bound session UI so sidebar skeletons retrigger.
  *
  * Sessions live in nanostores (not React Query) — refreshSessions merges into


### PR DESCRIPTION
## Summary
- pin SSH Desktop backends to the selected profile, including `default`
- rebuild dead SSH forwards immediately and retain sidebar data while reconnecting
- prevent stale profile refreshes from overwriting the newly selected profile

## Validation
- `npm --workspace apps/desktop test -- --run electron/remote-liveness.test.ts electron/remote-lifecycle.test.ts src/store/gateway-switch.test.ts src/app/session/hooks/use-session-list-actions.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run pack`