### PR TITLE
feat(github-auth): GitHub App installation tokens for git/gh workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -424,7 +424,8 @@ IMAGE_TOOLS_DEBUG=false
 # Get at: https://github.com/settings/tokens (Fine-grained recommended)
 # GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
 
-# GitHub App credentials (optional — for bot identity on PRs)
+# GitHub App credentials (optional — bot identity on PRs; also used by the
+# github-auth skill to mint short-lived tokens for git/gh workflows)
 # GITHUB_APP_ID=
 # GITHUB_APP_PRIVATE_KEY_PATH=
 # GITHUB_APP_INSTALLATION_ID=

--- a/contributors/emails/juniper@churprimo.org
+++ b/contributors/emails/juniper@churprimo.org
@@ -1,0 +1,2 @@
+juniperbevensee
+# GitHub App token auth for github-auth skill

--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -1,22 +1,23 @@
 ---
 name: github-auth
-description: "GitHub auth setup: HTTPS tokens, SSH keys, gh CLI login."
-version: 1.1.0
+description: "GitHub auth: PAT, SSH, gh CLI, and GitHub App tokens."
+version: 1.2.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [GitHub, Authentication, Git, gh-cli, SSH, Setup]
+    tags: [GitHub, Authentication, Git, gh-cli, SSH, GitHub-App, Setup]
     related_skills: [github-pr-workflow, github-code-review, github-issues, github-repo-management]
 ---
 
 # GitHub Authentication Setup
 
-This skill sets up authentication so the agent can work with GitHub repositories, PRs, issues, and CI. It covers two paths:
+This skill sets up authentication so the agent can work with GitHub repositories, PRs, issues, and CI. It covers three paths:
 
 - **`git` (always available)** — uses HTTPS personal access tokens or SSH keys
 - **`gh` CLI (if installed)** — richer GitHub API access with a simpler auth flow
+- **GitHub App installation tokens (opt-in)** — short-lived, auto-rotating tokens with a bot identity; see Method 3
 
 ## Detection Flow
 
@@ -183,6 +184,92 @@ gh auth setup-git
 ```bash
 gh auth status
 ```
+
+---
+
+## Method 3: GitHub App Installation Tokens (Bot Identity)
+
+An opt-in alternative to personal access tokens: a GitHub App installed on an
+account or org mints short-lived (~1 hour) installation tokens on demand.
+Benefits over a PAT:
+
+- **No long-lived secret at rest** — only the App's private key is stored;
+  tokens auto-rotate every hour
+- **Org-scoped and revocable** — uninstall the App and every token stops working
+- **Bot identity** — commits and PRs are attributed to the App, not a person
+
+**Precedence:** this method is the *last* fallback. Explicit auth always wins —
+`gh auth login`, an exported `GITHUB_TOKEN`, a token key in the Hermes `.env`,
+or `~/.git-credentials` are all checked first by `scripts/gh-env.sh`. With no
+App credentials configured, behavior is unchanged.
+
+### Setup
+
+**Step 1: Create a GitHub App**
+
+Tell the user to go to: **https://github.com/settings/apps** (or the org's
+Settings → Developer settings → GitHub Apps) and create a new App:
+
+- Name it something like "hermes-agent-bot"
+- Disable webhooks (not needed)
+- Repository permissions: `Contents: Read and write`, `Pull requests: Read and
+  write`, `Issues: Read and write` (add `Workflows: Read and write` if the
+  agent edits Actions files)
+- After creating: note the **App ID**, then "Generate a private key" and save
+  the downloaded `.pem` file somewhere private (e.g. `~/.hermes/github-app.pem`)
+
+**Step 2: Install the App** on the user's account or org ("Install App" in the
+App's settings) and grant it the repos the agent should touch.
+
+**Step 3: Configure the Hermes .env** (`${HERMES_HOME:-~/.hermes}/.env`):
+
+```bash
+GITHUB_APP_ID=123456
+GITHUB_APP_PRIVATE_KEY_PATH=/home/user/.hermes/github-app.pem
+# Optional — auto-discovered when the App has exactly one installation:
+# GITHUB_APP_INSTALLATION_ID=987654
+```
+
+The helper reads these from the `.env` file directly (not from process env),
+so it works even in restricted subprocess environments.
+
+### Usage
+
+The helper script has two subcommands:
+
+```bash
+# Print a valid installation token (mints or reuses the cache)
+python3 skills/github/github-auth/scripts/gh-app-token.py mint
+
+# Git credential-helper protocol (used by git, below)
+python3 skills/github/github-auth/scripts/gh-app-token.py credential get
+```
+
+`scripts/gh-env.sh` picks this up automatically as its final fallback and
+exports `GITHUB_TOKEN`/`GH_TOKEN` for the session.
+
+**Git credential-helper wiring** (lets plain `git push`/`git fetch` mint
+tokens transparently):
+
+```bash
+# Scope the helper to github.com — git invokes credential helpers for every
+# https remote, and a GitHub token should never be offered anywhere else.
+git config --global 'credential.https://github.com.helper' \
+  '!python3 /absolute/path/to/skills/github/github-auth/scripts/gh-app-token.py credential'
+```
+
+Git invokes the helper with a trailing operation argument (`get`, `store`, or
+`erase`); the script emits credentials only on `get` and is a silent no-op for
+the others, so it composes cleanly with other configured helpers. As a second
+layer, the script itself refuses to answer for hosts other than `github.com` /
+`gist.github.com`, so even an unscoped wiring cannot leak the token to a
+different remote.
+
+### Token Cache
+
+Tokens are cached at `${HERMES_HOME:-~/.hermes}/cache/github-app-token.json`
+(owner-only permissions, atomic writes) and re-minted automatically when less
+than 10 minutes of validity remain. Delete the file to force a fresh mint.
 
 ---
 

--- a/skills/github/github-auth/scripts/gh-app-token.py
+++ b/skills/github/github-auth/scripts/gh-app-token.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Mint short-lived GitHub App installation tokens for git/gh workflows.
+
+Part of the github-auth skill. Reads GitHub App credentials from the Hermes
+.env file — never from process env, because tool subprocesses may run with
+GITHUB_APP_* stripped from their environment; the file read is the path that
+works everywhere, and it matches how gh-env.sh already reads .env. Builds an
+RS256 app JWT, exchanges it for an installation access token (~1 hour
+lifetime, auto-rotating, revocable by uninstalling the App), and caches the
+result so repeated git operations don't re-mint.
+
+Subcommands:
+    mint        Print a valid installation token (bare) to stdout.
+    credential  Git credential-helper protocol. Git appends an operation
+                argument (get/store/erase); output is emitted only for
+                "get" — store/erase are silent no-ops.
+
+Configuration keys (flat key=value lines in ${HERMES_HOME:-~/.hermes}/.env):
+    GITHUB_APP_ID                App ID (required)
+    GITHUB_APP_PRIVATE_KEY_PATH  Path to the App's PEM private key (required)
+    GITHUB_APP_INSTALLATION_ID   Installation ID (optional — auto-discovered
+                                 when the App has exactly one installation)
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import httpx
+import jwt  # PyJWT
+
+API_BASE = "https://api.github.com"
+HTTP_TIMEOUT = 10
+JWT_LOOKBACK_SECONDS = 60  # tolerate clock skew (matches tools/skills_hub.py)
+JWT_LIFETIME_SECONDS = 600  # GitHub caps app JWTs at 10 minutes
+REMINT_MARGIN_SECONDS = 600  # re-mint when < 10 minutes of validity remain
+
+
+class TokenError(Exception):
+    """A credential/config/API problem. Message is safe to print (no secrets)."""
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def default_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+
+
+def default_env_file() -> Path:
+    return default_home() / ".env"
+
+
+def default_cache_file() -> Path:
+    return default_home() / "cache" / "github-app-token.json"
+
+
+def parse_env_file(path: Path) -> dict:
+    """Flat key=value parse. No shell expansion, no `source` semantics."""
+    values: dict = {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return values
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        if key:
+            values[key] = value
+    return values
+
+
+@dataclass
+class AppCredentials:
+    app_id: str
+    private_key_path: Path
+    installation_id: Optional[str] = None
+
+
+def read_app_credentials(env_file: Path) -> Optional[AppCredentials]:
+    """Read GITHUB_APP_* from the .env file. None unless both required keys set."""
+    values = parse_env_file(env_file)
+    app_id = values.get("GITHUB_APP_ID", "")
+    key_path = values.get("GITHUB_APP_PRIVATE_KEY_PATH", "")
+    if not app_id or not key_path:
+        return None
+    return AppCredentials(
+        app_id=app_id,
+        private_key_path=Path(key_path).expanduser(),
+        installation_id=values.get("GITHUB_APP_INSTALLATION_ID") or None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# JWT + GitHub API
+# ---------------------------------------------------------------------------
+
+
+def build_app_jwt(app_id: str, private_key_pem: str, now: Optional[int] = None) -> str:
+    if now is None:
+        now = int(time.time())
+    payload = {
+        "iat": now - JWT_LOOKBACK_SECONDS,
+        "exp": now + JWT_LIFETIME_SECONDS,
+        "iss": app_id,
+    }
+    return jwt.encode(payload, private_key_pem, algorithm="RS256")
+
+
+def _api_headers(app_jwt: str) -> dict:
+    return {
+        "Authorization": f"Bearer {app_jwt}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+
+
+def discover_installation_id(app_jwt: str) -> str:
+    """Resolve the installation id when GITHUB_APP_INSTALLATION_ID is unset."""
+    resp = httpx.get(
+        f"{API_BASE}/app/installations",
+        headers=_api_headers(app_jwt),
+        timeout=HTTP_TIMEOUT,
+    )
+    if resp.status_code != 200:
+        raise TokenError(
+            f"installation discovery failed (HTTP {resp.status_code} from GitHub)"
+        )
+    installations = resp.json()
+    if not installations:
+        raise TokenError(
+            "GitHub App has no installations — install it on your account or org first"
+        )
+    if len(installations) > 1:
+        accounts = ", ".join(
+            sorted(
+                str((inst.get("account") or {}).get("login") or inst.get("id"))
+                for inst in installations
+            )
+        )
+        raise TokenError(
+            f"GitHub App has multiple installations ({accounts}) — "
+            "set GITHUB_APP_INSTALLATION_ID to pick one"
+        )
+    return str(installations[0]["id"])
+
+
+def mint_installation_token(app_jwt: str, installation_id: str) -> tuple:
+    """POST /app/installations/{id}/access_tokens → (token, expires_at)."""
+    resp = httpx.post(
+        f"{API_BASE}/app/installations/{installation_id}/access_tokens",
+        headers=_api_headers(app_jwt),
+        timeout=HTTP_TIMEOUT,
+    )
+    if resp.status_code != 201:
+        raise TokenError(f"token mint failed (HTTP {resp.status_code} from GitHub)")
+    data = resp.json()
+    token = data.get("token")
+    if not token:
+        raise TokenError("token mint response had no token field")
+    return token, data.get("expires_at", "")
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+
+def _parse_expires_at(iso: str) -> float:
+    return dt.datetime.fromisoformat(iso.replace("Z", "+00:00")).timestamp()
+
+
+def load_cached_token(cache_file: Path) -> Optional[str]:
+    """Return the cached token if it still has > REMINT_MARGIN_SECONDS left."""
+    try:
+        data = json.loads(cache_file.read_text(encoding="utf-8"))
+        token = data["token"]
+        expires_epoch = _parse_expires_at(data["expires_at"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return None  # missing or corrupt cache — treat as a miss
+    if not token or expires_epoch - time.time() < REMINT_MARGIN_SECONDS:
+        return None
+    return token
+
+
+def store_cached_token(cache_file: Path, token: str, expires_at: str) -> None:
+    """Write the cache atomically (tmp + rename) with owner-only permissions."""
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp = cache_file.with_name(f"{cache_file.name}.{os.getpid()}.tmp")
+    try:
+        tmp.unlink()  # clear any stale tmp (crashed prior run / planted link)
+    except OSError:
+        pass
+    # O_EXCL: never follow or reuse a pre-existing path — refuse instead.
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"token": token, "expires_at": expires_at}, fh)
+        os.chmod(tmp, 0o600)
+        tmp.replace(cache_file)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+def get_installation_token(
+    env_file: Path, cache_file: Path, force: bool = False
+) -> str:
+    """Cache-first token fetch; mints and caches a fresh one when needed."""
+    if not force:
+        cached = load_cached_token(cache_file)
+        if cached:
+            return cached
+
+    creds = read_app_credentials(env_file)
+    if creds is None:
+        raise TokenError(
+            "GitHub App credentials not configured — set GITHUB_APP_ID and "
+            f"GITHUB_APP_PRIVATE_KEY_PATH in {env_file}"
+        )
+    try:
+        private_key_pem = creds.private_key_path.read_text(encoding="utf-8")
+    except OSError:
+        raise TokenError(
+            f"GitHub App private key not readable at {creds.private_key_path}"
+        ) from None
+
+    app_jwt = build_app_jwt(creds.app_id, private_key_pem)
+    installation_id = creds.installation_id or discover_installation_id(app_jwt)
+    token, expires_at = mint_installation_token(app_jwt, installation_id)
+    store_cached_token(cache_file, token, expires_at)
+    return token
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+# Hosts this helper will answer for. Git invokes credential helpers for EVERY
+# https remote, so an unscoped helper that ignored the request's host would
+# hand the GitHub token to any URL a repo (or a malicious submodule/redirect)
+# points at. Both layers guard against that: SKILL.md wires the helper scoped
+# to https://github.com, and this allowlist enforces it even when a user wires
+# the helper globally.
+ALLOWED_HOSTS = frozenset({"github.com", "gist.github.com"})
+
+
+def _read_credential_request() -> dict:
+    """Parse git's credential description block (key=value lines) from stdin."""
+    request: dict = {}
+    try:
+        if sys.stdin is None or sys.stdin.isatty():
+            return request
+        for line in sys.stdin.read().splitlines():
+            key, sep, value = line.partition("=")
+            if sep:
+                request[key.strip()] = value.strip()
+    except OSError:
+        pass
+    return request
+
+
+def _cmd_mint(args: argparse.Namespace) -> int:
+    try:
+        token = get_installation_token(args.env_file, args.cache_file)
+    except TokenError as exc:
+        print(f"gh-app-token: {exc}", file=sys.stderr)
+        return 1
+    print(token)
+    return 0
+
+
+def _cmd_credential(args: argparse.Namespace) -> int:
+    request = _read_credential_request()
+    if args.operation != "get":
+        return 0  # store/erase: nothing to persist or forget — silent no-op
+    # Only answer for GitHub over https. For anything else, emit nothing and
+    # exit 0 so git falls through to other helpers / prompts — never send the
+    # token toward a host we don't recognize.
+    host = request.get("host", "")
+    protocol = request.get("protocol", "")
+    if host and host not in ALLOWED_HOSTS:
+        return 0
+    if protocol and protocol != "https":
+        return 0
+    try:
+        token = get_installation_token(args.env_file, args.cache_file)
+    except TokenError as exc:
+        # No stdout on failure so git falls through to the next helper.
+        print(f"gh-app-token: {exc}", file=sys.stderr)
+        return 1
+    sys.stdout.write(f"username=x-access-token\npassword={token}\n\n")
+    return 0
+
+
+def main(argv: Optional[list] = None) -> int:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--env-file", type=Path, default=default_env_file(),
+        help="path to the .env file holding GITHUB_APP_* keys",
+    )
+    common.add_argument(
+        "--cache-file", type=Path, default=default_cache_file(),
+        help="path to the token cache file",
+    )
+
+    parser = argparse.ArgumentParser(prog="gh-app-token", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    mint = sub.add_parser("mint", parents=[common], help="print an installation token")
+    mint.set_defaults(func=_cmd_mint)
+
+    cred = sub.add_parser(
+        "credential", parents=[common], help="git credential-helper protocol"
+    )
+    cred.add_argument(
+        "operation", nargs="?", default="get", choices=["get", "store", "erase"],
+        help="git credential operation (git always appends one)",
+    )
+    cred.set_defaults(func=_cmd_credential)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/github/github-auth/scripts/gh-env.sh
+++ b/skills/github/github-auth/scripts/gh-env.sh
@@ -33,6 +33,21 @@ elif [ -f "$HOME/.git-credentials" ] && grep -q "github.com" "$HOME/.git-credent
     if [ -n "$GITHUB_TOKEN" ]; then
         GH_AUTH_METHOD="curl"
     fi
+elif _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] \
+        && grep -q "^GITHUB_APP_ID=" "$_hermes_env" 2>/dev/null \
+        && grep -q "^GITHUB_APP_PRIVATE_KEY_PATH=" "$_hermes_env" 2>/dev/null; then
+    # Last fallback: mint a short-lived GitHub App installation token.
+    # Explicit auth (gh login, GITHUB_TOKEN, .env token, .git-credentials) always wins.
+    _gh_app_script="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/gh-app-token.py"
+    if [ -f "$_gh_app_script" ]; then
+        GITHUB_TOKEN=$(python3 "$_gh_app_script" mint 2>/dev/null | tr -d '\n\r')
+        if [ -n "$GITHUB_TOKEN" ]; then
+            GH_AUTH_METHOD="curl"
+            GH_TOKEN="$GITHUB_TOKEN"
+            export GH_TOKEN
+        fi
+    fi
+    unset _gh_app_script
 fi
 
 # Resolve username for curl method

--- a/tests/skills/test_github_auth_skill.py
+++ b/tests/skills/test_github_auth_skill.py
@@ -1,0 +1,435 @@
+"""Tests for the github-auth skill's gh-app-token.py helper.
+
+The helper mints short-lived (~1h) GitHub App installation tokens for git/gh
+workflows. It reads App credentials from the Hermes .env FILE (never from
+process env — tool subprocesses may have GITHUB_APP_* stripped), exchanges an
+RS256 app JWT for an installation token, caches it with owner-only
+permissions, and speaks the git credential-helper protocol.
+
+Hermetic: in-test RSA keypair (via cryptography), httpx mocked — no network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import stat
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "github"
+    / "github-auth"
+    / "scripts"
+    / "gh-app-token.py"
+)
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("gh_app_token_skill", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    return key, pem
+
+
+@pytest.fixture
+def app_home(tmp_path: Path, rsa_keypair) -> Path:
+    """A HERMES_HOME-shaped dir: .env with App creds + the PEM key file."""
+    _key, pem = rsa_keypair
+    home = tmp_path / "hermes"
+    home.mkdir()
+    pem_path = home / "github-app.pem"
+    pem_path.write_text(pem, encoding="utf-8")
+    (home / ".env").write_text(
+        "# hermes agent env\n"
+        "GITHUB_APP_ID=123456\n"
+        "GITHUB_APP_INSTALLATION_ID=987654\n"
+        f"GITHUB_APP_PRIVATE_KEY_PATH={pem_path}\n",
+        encoding="utf-8",
+    )
+    return home
+
+
+def _env_file(home: Path) -> Path:
+    return home / ".env"
+
+
+def _cache_file(home: Path) -> Path:
+    return home / "cache" / "github-app-token.json"
+
+
+def _write_cache(home: Path, token: str, expires_epoch: float) -> None:
+    import datetime as dt
+
+    cache = _cache_file(home)
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    iso = dt.datetime.fromtimestamp(expires_epoch, tz=dt.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    cache.write_text(json.dumps({"token": token, "expires_at": iso}), encoding="utf-8")
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+# ---------------------------------------------------------------------------
+# .env parsing + credential reading
+# ---------------------------------------------------------------------------
+
+
+def test_parse_env_file_skips_comments_blanks_and_strips_quotes(mod, tmp_path: Path):
+    env = tmp_path / ".env"
+    env.write_text(
+        "# comment\n\nA=1\nB='two'\nC=\"three\"\nnot a kv line\nD=a=b\n",
+        encoding="utf-8",
+    )
+    values = mod.parse_env_file(env)
+    assert values == {"A": "1", "B": "two", "C": "three", "D": "a=b"}
+
+
+def test_read_app_credentials_reads_required_keys(mod, app_home: Path):
+    creds = mod.read_app_credentials(_env_file(app_home))
+    assert creds is not None
+    assert creds.app_id == "123456"
+    assert creds.installation_id == "987654"
+    assert creds.private_key_path == app_home / "github-app.pem"
+
+
+def test_read_app_credentials_none_when_app_id_missing(mod, tmp_path: Path):
+    env = tmp_path / ".env"
+    env.write_text("GITHUB_APP_PRIVATE_KEY_PATH=/x/key.pem\n", encoding="utf-8")
+    assert mod.read_app_credentials(env) is None
+
+
+def test_read_app_credentials_none_when_key_path_missing(mod, tmp_path: Path):
+    env = tmp_path / ".env"
+    env.write_text("GITHUB_APP_ID=1\nGITHUB_APP_INSTALLATION_ID=2\n", encoding="utf-8")
+    assert mod.read_app_credentials(env) is None
+
+
+def test_read_app_credentials_installation_id_optional(mod, tmp_path: Path):
+    env = tmp_path / ".env"
+    env.write_text(
+        "GITHUB_APP_ID=1\nGITHUB_APP_PRIVATE_KEY_PATH=/x/key.pem\n", encoding="utf-8"
+    )
+    creds = mod.read_app_credentials(env)
+    assert creds is not None
+    assert creds.installation_id is None
+
+
+def test_read_app_credentials_ignores_process_env(mod, app_home: Path, monkeypatch):
+    # Tool subprocesses may have GITHUB_APP_* stripped or stale — the file wins.
+    monkeypatch.setenv("GITHUB_APP_ID", "999999")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "111111")
+    creds = mod.read_app_credentials(_env_file(app_home))
+    assert creds.app_id == "123456"
+    assert creds.installation_id == "987654"
+
+
+# ---------------------------------------------------------------------------
+# App JWT
+# ---------------------------------------------------------------------------
+
+
+def test_build_app_jwt_claims_and_alg(mod, rsa_keypair):
+    import jwt as pyjwt
+
+    key, pem = rsa_keypair
+    now = 1_700_000_000
+    token = mod.build_app_jwt("123456", pem, now=now)
+    assert pyjwt.get_unverified_header(token)["alg"] == "RS256"
+    decoded = pyjwt.decode(
+        token, key.public_key(), algorithms=["RS256"], options={"verify_exp": False}
+    )
+    assert decoded["iss"] == "123456"
+    assert decoded["iat"] == now - 60
+    assert decoded["exp"] == now + 600
+
+
+# ---------------------------------------------------------------------------
+# Minting + installation discovery (httpx mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_mint_posts_bearer_jwt_and_parses_201(mod, monkeypatch):
+    calls = {}
+
+    def fake_post(url, headers=None, timeout=None):
+        calls["url"] = url
+        calls["auth"] = headers.get("Authorization", "")
+        return _FakeResp(201, {"token": "ghs_minted", "expires_at": "2099-01-01T00:00:00Z"})
+
+    monkeypatch.setattr(mod.httpx, "post", fake_post)
+    token, expires = mod.mint_installation_token("fake.jwt.here", "987654")
+    assert token == "ghs_minted"
+    assert expires == "2099-01-01T00:00:00Z"
+    assert calls["url"].endswith("/app/installations/987654/access_tokens")
+    assert calls["auth"] == "Bearer fake.jwt.here"
+
+
+def test_mint_raises_on_non_201(mod, monkeypatch):
+    monkeypatch.setattr(
+        mod.httpx, "post", lambda *a, **k: _FakeResp(401, {"message": "bad"})
+    )
+    with pytest.raises(mod.TokenError, match="401"):
+        mod.mint_installation_token("fake.jwt.here", "987654")
+
+
+def test_discover_single_installation(mod, monkeypatch):
+    monkeypatch.setattr(
+        mod.httpx, "get", lambda *a, **k: _FakeResp(200, [{"id": 555}])
+    )
+    assert mod.discover_installation_id("fake.jwt.here") == "555"
+
+
+def test_discover_multiple_installations_errors_with_hint(mod, monkeypatch):
+    payload = [
+        {"id": 1, "account": {"login": "org-a"}},
+        {"id": 2, "account": {"login": "org-b"}},
+    ]
+    monkeypatch.setattr(mod.httpx, "get", lambda *a, **k: _FakeResp(200, payload))
+    with pytest.raises(mod.TokenError, match="GITHUB_APP_INSTALLATION_ID"):
+        mod.discover_installation_id("fake.jwt.here")
+
+
+def test_discover_no_installations_errors(mod, monkeypatch):
+    monkeypatch.setattr(mod.httpx, "get", lambda *a, **k: _FakeResp(200, []))
+    with pytest.raises(mod.TokenError, match="no installations"):
+        mod.discover_installation_id("fake.jwt.here")
+
+
+# ---------------------------------------------------------------------------
+# Cache behavior
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_when_fresh(mod, app_home: Path, monkeypatch):
+    _write_cache(app_home, "ghs_cached", time.time() + 3600)
+
+    def boom(*a, **k):
+        raise AssertionError("must not mint on a fresh cache hit")
+
+    monkeypatch.setattr(mod.httpx, "post", boom)
+    token = mod.get_installation_token(_env_file(app_home), _cache_file(app_home))
+    assert token == "ghs_cached"
+
+
+def test_remint_when_within_expiry_margin(mod, app_home: Path, monkeypatch):
+    _write_cache(app_home, "ghs_stale", time.time() + 120)  # < 10 min left
+    monkeypatch.setattr(
+        mod.httpx,
+        "post",
+        lambda *a, **k: _FakeResp(201, {"token": "ghs_fresh", "expires_at": "2099-01-01T00:00:00Z"}),
+    )
+    token = mod.get_installation_token(_env_file(app_home), _cache_file(app_home))
+    assert token == "ghs_fresh"
+    # Fresh token replaces the stale cache entry
+    cached = json.loads(_cache_file(app_home).read_text(encoding="utf-8"))
+    assert cached["token"] == "ghs_fresh"
+
+
+def test_remint_when_cache_corrupt(mod, app_home: Path, monkeypatch):
+    cache = _cache_file(app_home)
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(
+        mod.httpx,
+        "post",
+        lambda *a, **k: _FakeResp(201, {"token": "ghs_recovered", "expires_at": "2099-01-01T00:00:00Z"}),
+    )
+    token = mod.get_installation_token(_env_file(app_home), _cache_file(app_home))
+    assert token == "ghs_recovered"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes")
+def test_cache_written_owner_only(mod, app_home: Path, monkeypatch):
+    monkeypatch.setattr(
+        mod.httpx,
+        "post",
+        lambda *a, **k: _FakeResp(201, {"token": "ghs_x", "expires_at": "2099-01-01T00:00:00Z"}),
+    )
+    mod.get_installation_token(_env_file(app_home), _cache_file(app_home), force=True)
+    mode = stat.S_IMODE(_cache_file(app_home).stat().st_mode)
+    assert mode == 0o600
+
+
+def test_cache_write_is_atomic_no_tmp_leftovers(mod, app_home: Path, monkeypatch):
+    monkeypatch.setattr(
+        mod.httpx,
+        "post",
+        lambda *a, **k: _FakeResp(201, {"token": "ghs_x", "expires_at": "2099-01-01T00:00:00Z"}),
+    )
+    mod.get_installation_token(_env_file(app_home), _cache_file(app_home), force=True)
+    leftovers = [p.name for p in _cache_file(app_home).parent.iterdir() if p.name != _cache_file(app_home).name]
+    assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# CLI: mint
+# ---------------------------------------------------------------------------
+
+
+def _cli(mod, home: Path, *argv: str) -> list:
+    return [
+        *argv,
+        "--env-file",
+        str(_env_file(home)),
+        "--cache-file",
+        str(_cache_file(home)),
+    ]
+
+
+def test_mint_cli_prints_bare_token(mod, app_home: Path, monkeypatch, capsys):
+    _write_cache(app_home, "ghs_cli", time.time() + 3600)
+    rc = mod.main(_cli(mod, app_home, "mint"))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out == "ghs_cli\n"
+
+
+def test_mint_cli_missing_creds_exit_1_one_stderr_line(mod, tmp_path: Path, capsys):
+    home = tmp_path / "empty"
+    home.mkdir()
+    (home / ".env").write_text("SOME_OTHER_KEY=1\n", encoding="utf-8")
+    rc = mod.main(_cli(mod, home, "mint"))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert captured.out == ""
+    assert len(captured.err.strip().splitlines()) == 1
+    assert "GITHUB_APP_ID" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# CLI: credential (git credential-helper protocol)
+# ---------------------------------------------------------------------------
+
+
+def _feed_stdin(monkeypatch):
+    monkeypatch.setattr(
+        sys, "stdin", io.StringIO("protocol=https\nhost=github.com\n\n")
+    )
+
+
+def test_credential_get_stdout_format(mod, app_home: Path, monkeypatch, capsys):
+    _write_cache(app_home, "ghs_helper", time.time() + 3600)
+    _feed_stdin(monkeypatch)
+    rc = mod.main(_cli(mod, app_home, "credential", "get"))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "username=x-access-token\n" in out
+    assert "password=ghs_helper\n" in out
+    assert out.endswith("\n\n")
+
+
+def test_credential_defaults_to_get_when_no_operation(mod, app_home: Path, monkeypatch, capsys):
+    _write_cache(app_home, "ghs_default", time.time() + 3600)
+    _feed_stdin(monkeypatch)
+    rc = mod.main(_cli(mod, app_home, "credential"))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "password=ghs_default\n" in out
+
+
+@pytest.mark.parametrize("operation", ["store", "erase"])
+def test_credential_store_erase_silent_noop(mod, app_home: Path, monkeypatch, capsys, operation):
+    def boom(*a, **k):
+        raise AssertionError("store/erase must never mint")
+
+    monkeypatch.setattr(mod.httpx, "post", boom)
+    _feed_stdin(monkeypatch)
+    rc = mod.main(_cli(mod, app_home, "credential", operation))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_credential_missing_creds_exit_1_no_stdout(mod, tmp_path: Path, monkeypatch, capsys):
+    # No stdout on failure so git falls through to other configured helpers.
+    home = tmp_path / "empty"
+    home.mkdir()
+    (home / ".env").write_text("", encoding="utf-8")
+    _feed_stdin(monkeypatch)
+    rc = mod.main(_cli(mod, home, "credential", "get"))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert captured.out == ""
+    assert captured.err != ""
+
+
+def _feed_stdin_for(monkeypatch, block: str):
+    monkeypatch.setattr(sys, "stdin", io.StringIO(block))
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        "protocol=https\nhost=evil.example.com\n\n",
+        "protocol=https\nhost=github.com.evil.example\n\n",
+        "protocol=http\nhost=github.com\n\n",  # plaintext http: never
+    ],
+)
+def test_credential_refuses_foreign_host_or_plain_http(
+    mod, app_home: Path, monkeypatch, capsys, block
+):
+    """Git invokes helpers for EVERY remote; the token must only ever be
+    offered to GitHub over https. Foreign host -> silent exit 0 so git falls
+    through, and no mint attempt is made."""
+
+    def boom(*a, **k):
+        raise AssertionError("must not mint for a foreign host")
+
+    monkeypatch.setattr(mod.httpx, "post", boom)
+    _write_cache(app_home, "ghs_leakable", time.time() + 3600)
+    _feed_stdin_for(monkeypatch, block)
+    rc = mod.main(_cli(mod, app_home, "credential", "get"))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+
+
+def test_credential_allows_gist_host(mod, app_home: Path, monkeypatch, capsys):
+    _write_cache(app_home, "ghs_gist", time.time() + 3600)
+    _feed_stdin_for(monkeypatch, "protocol=https\nhost=gist.github.com\n\n")
+    rc = mod.main(_cli(mod, app_home, "credential", "get"))
+    assert rc == 0
+    assert "password=ghs_gist\n" in capsys.readouterr().out
+
+
+def test_credential_no_stdin_block_still_answers(mod, app_home: Path, monkeypatch, capsys):
+    """Manual invocation without a description block (not-git) still works —
+    git itself always supplies host=, so absence means a human/test caller."""
+    _write_cache(app_home, "ghs_manual", time.time() + 3600)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    rc = mod.main(_cli(mod, app_home, "credential", "get"))
+    assert rc == 0
+    assert "password=ghs_manual\n" in capsys.readouterr().out


### PR DESCRIPTION
## What does this PR do?

Adds a documented, tested GitHub App installation-token path to the `github-auth` skill, alongside the existing PAT / SSH / `gh auth` methods.

Hermes already reserves `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY_PATH` / `GITHUB_APP_INSTALLATION_ID` in `.env.example` and mints App JWTs for the Skills Hub (`tools/skills_hub.py`). This extends that same credential family to git/`gh`/REST workflows: short-lived (~1h), auto-rotating, app-scoped tokens instead of a static PAT — bot identity on commits/PRs, revocable by uninstalling the App, no long-lived secret at rest.

**Scope, per the issue's review notes:** skill + helper script only. No core-runtime changes, no changes to the subprocess env blocklist, no new env var names, no new dependencies (PyJWT and httpx are already pinned).

**Precedence:** explicit auth (gh login, `$GITHUB_TOKEN`, `.env` token, `.git-credentials`) always wins; the App path activates only when nothing else is configured and the App vars are present. Zero behavior change for installs without App creds.

**Security posture** (this touches auth, so stating it explicitly):
- Credentials are read from the `.env` file, never process env; the PEM never leaves its file; no secret is ever printed to stderr or embedded in error messages.
- Token cache: `${HERMES_HOME:-~/.hermes}/cache/github-app-token.json`, 0600, atomic replace via `O_EXCL` tmp + rename, re-mint <10 min before expiry.
- The `credential` subcommand parses git's request block and **refuses to answer for any host other than `github.com`/`gist.github.com` over https** — git invokes credential helpers for every https remote, so without this guard an unscoped wiring would offer the token to arbitrary remotes. SKILL.md additionally documents the `credential.https://github.com.helper`-scoped wiring.
- Git's trailing operation argument (`get`/`store`/`erase`) is handled per the credential-helper protocol; `store`/`erase` are silent no-ops.

## Related Issue

Fixes #4193

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `skills/github/github-auth/scripts/gh-app-token.py` — new helper: `.env` parse, RS256 App JWT (mirrors `tools/skills_hub.py`), installation auto-discovery (clear error when multiple installations and none pinned), token mint, cache, `mint` + `credential` subcommands with host allowlist.
- `skills/github/github-auth/scripts/gh-env.sh` — App detection as the last fallback in the existing chain; exports `GH_TOKEN` only when a token is actually minted.
- `skills/github/github-auth/SKILL.md` — new "GitHub App Installation Tokens" method section, setup guide, scoped credential-helper wiring; description ≤60 chars; version 1.1.0 → 1.2.0.
- `tests/skills/test_github_auth_skill.py` — 29 hermetic tests (in-test RSA keypair, mocked httpx, no network): JWT claims, mint, discovery, cache atomicity/expiry/corruption/0600 (skipped on Windows), credential protocol incl. trailing-arg semantics, foreign-host/plain-http refusal, lookalike-host refusal, precedence, missing-creds exit codes.
- `.env.example` — comment-only amendment to the existing `GITHUB_APP` block (no new keys).
- `contributors/emails/juniper@churprimo.org` — contributor mapping per the attribution check.

## How to Test

1. Create a GitHub App (permissions: Contents R/W, Pull requests R/W as needed), install it on your account/org, download the PEM.
2. In `${HERMES_HOME:-~/.hermes}/.env`, set `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY_PATH` (installation id optional — auto-discovered).
3. `python3 skills/github/github-auth/scripts/gh-app-token.py mint` → prints a `ghs_…` token; `GH_TOKEN=$(…) gh api /rate_limit` works.
4. `source skills/github/github-auth/scripts/gh-env.sh` with no other auth configured → exports the minted token; with `gh auth login` or `GITHUB_TOKEN` present → App path never engages.
5. `pytest tests/skills/test_github_auth_skill.py -q` → 29 passed; full `tests/skills/` → 332 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (`tests/skills/`: 332 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — SKILL.md
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `check-windows-footguns.py` clean; mode assertions skipped on Windows