### PR TITLE
fix: pin default launchd gateway profile

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3952,6 +3952,16 @@ def generate_launchd_plist() -> str:
     log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
     profile_arg = _profile_arg(hermes_home)
+    if not profile_arg:
+        # Pin the root service to the default profile explicitly. A bare
+        # ``hermes_cli.main gateway run`` follows the sticky active profile,
+        # so when a named profile is active the root and named launchd jobs can
+        # both start that profile with ``--replace`` and repeatedly terminate
+        # each other.
+        from hermes_constants import get_default_hermes_root
+
+        if Path(hermes_home).resolve() == get_default_hermes_root().resolve():
+            profile_arg = "--profile default"
     # Build a sane PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
     # nvm, cargo, etc.  We prepend venv/bin and node_modules/.bin (matching

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -505,6 +505,27 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
 
+    def test_launchd_default_service_pins_root_profile(self, tmp_path, monkeypatch):
+        """The root launchd job must not follow the sticky active profile."""
+        import hermes_constants
+
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_root)
+        monkeypatch.setattr(
+            hermes_constants,
+            "get_default_hermes_root",
+            lambda: hermes_root,
+        )
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert (
+            "<string>--profile</string>\n"
+            "        <string>default</string>\n"
+            "        <string>gateway</string>"
+        ) in plist
+
     def test_user_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
         monkeypatch.setenv(


### PR DESCRIPTION
## Summary
- pin the root macOS launchd gateway job to `--profile default`
- prevent a sticky named active profile from redirecting the default job
- add regression coverage for generated launchd arguments

## Root cause
The default launchd plist used a bare `gateway run --replace` command. When `active_profile` pointed to a named profile, both the root launchd job and that named profile job launched the same profile and repeatedly replaced each other, flooding home channels with shutdown warnings.

## Verification
- regression test observed failing before the fix and passing after
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -k launchd --tb=short`: 47 passed
- live default and named launchd gateways held distinct PIDs and profile-scoped state/lock files for 35 seconds

Full gateway service file currently has 186 passing tests and 4 unrelated pre-existing macOS/systemd preflight failures.