### PR TITLE
fix(windows): preserve writes across sharing violations

### DIFF
--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -321,6 +321,55 @@ def test_atomic_replace_other_oserror_propagates(
     assert tmp.exists()
 
 
+def test_atomic_replace_retries_windows_sharing_violation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "gateway_state.json"
+    target.write_text("old\n", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new\n")
+    real_replace = os.replace
+    attempts = 0
+
+    def transient_sharing_violation(src: str, dst: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise PermissionError(errno.EACCES, os.strerror(errno.EACCES), dst)
+        real_replace(src, dst)
+
+    monkeypatch.setattr("utils._IS_WINDOWS", True)
+    monkeypatch.setattr("utils.os.replace", transient_sharing_violation)
+    monkeypatch.setattr("utils.time.sleep", lambda _seconds: None)
+
+    assert Path(atomic_replace(tmp, target)) == target
+    assert attempts == 3
+    assert target.read_text(encoding="utf-8") == "new\n"
+    assert not tmp.exists()
+
+
+def test_atomic_replace_falls_back_after_windows_sharing_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "gateway_state.json"
+    target.write_text("old\n", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new\n")
+    attempts = 0
+
+    def persistent_sharing_violation(src: str, dst: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise PermissionError(errno.EACCES, os.strerror(errno.EACCES), dst)
+
+    monkeypatch.setattr("utils._IS_WINDOWS", True)
+    monkeypatch.setattr("utils.os.replace", persistent_sharing_violation)
+    monkeypatch.setattr("utils.time.sleep", lambda _seconds: None)
+
+    assert Path(atomic_replace(tmp, target)) == target
+    assert attempts == 4
+    assert target.read_text(encoding="utf-8") == "new\n"
+    assert not tmp.exists()
+
+
 def test_atomic_replace_real_cross_device(tmp_path: Path) -> None:
     shm = Path("/dev/shm")
     if os.name != "posix" or not os.access(shm, os.W_OK):

--- a/utils.py
+++ b/utils.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import stat
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, Union
 from urllib.parse import urlparse
@@ -17,6 +18,9 @@ logger = logging.getLogger(__name__)
 
 
 TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
+_IS_WINDOWS = os.name == "nt"
+_WINDOWS_REPLACE_RETRIES = 3
+_WINDOWS_REPLACE_RETRY_DELAY_SECONDS = 0.02
 
 
 def is_truthy_value(value: Any, default: bool = False) -> bool:
@@ -101,9 +105,11 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     This helper resolves the symlink first so ``os.replace`` writes to
     the real file in-place while the symlink survives.  For non-symlink
     and non-existent paths the behavior is identical to a plain
-    ``os.replace`` call unless the rename fails with ``EXDEV`` or ``EBUSY``;
-    those cases fall back to copy/fsync/unlink for cross-device, bind-mount,
-    and busy-file deployments.
+    ``os.replace`` call unless the rename fails with ``EXDEV`` or ``EBUSY``.
+    Windows sharing violations are retried briefly before joining those cases
+    on the copy/fsync/unlink fallback path. This lets concurrent readers finish
+    without dropping state writes while preserving atomic replacement whenever
+    possible.
 
     Returns the resolved real path used for the replace, so callers that
     need to re-apply permissions can target it instead of the symlink.
@@ -114,7 +120,21 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     try:
         os.replace(tmp_str, real_path)
     except OSError as exc:
-        if exc.errno not in (errno.EXDEV, errno.EBUSY):
+        is_windows_sharing_violation = _IS_WINDOWS and exc.errno == errno.EACCES
+        if is_windows_sharing_violation:
+            for _ in range(_WINDOWS_REPLACE_RETRIES):
+                time.sleep(_WINDOWS_REPLACE_RETRY_DELAY_SECONDS)
+                try:
+                    os.replace(tmp_str, real_path)
+                    return real_path
+                except OSError as retry_exc:
+                    exc = retry_exc
+                    if not (_IS_WINDOWS and exc.errno == errno.EACCES):
+                        break
+
+        if exc.errno not in (errno.EXDEV, errno.EBUSY) and not (
+            _IS_WINDOWS and exc.errno == errno.EACCES
+        ):
             raise
         logger.debug(
             "atomic_replace: %s -> %s failed with %s; falling back to copy",


### PR DESCRIPTION
## Summary
- retry Windows atomic replacement when a concurrent reader causes EACCES
- preserve atomicity for transient conflicts and use the existing durable copy fallback only after bounded retries
- leave POSIX permission failures unchanged

Fixes #57775

## Testing
- pytest tests/test_atomic_replace_symlinks.py -q (18 passed, 1 skipped)
- pytest tests/hermes_cli/test_atomic_json_write.py -q (16 passed)
- ruff check utils.py tests/test_atomic_replace_symlinks.py