### PR TITLE
fix(acp): discard stale route when provider is unknown

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2146,7 +2146,7 @@ class HermesACPAgent(acp.Agent):
                 current_provider or "openrouter",
             )
             state.model = resolved_model
-            provider_changed = bool(current_provider and requested_provider != current_provider)
+            provider_changed = requested_provider != current_provider
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
             state.agent = self.session_manager._make_agent(

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1117,6 +1117,74 @@ class TestSessionConfiguration:
         assert state.agent.base_url == "https://anthropic.example/v1"
         assert runtime_calls[-1] == "anthropic"
 
+    @pytest.mark.asyncio
+    async def test_set_session_model_discards_stale_route_without_provider_attribution(
+        self, tmp_path, monkeypatch
+    ):
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            provider = requested or "openrouter"
+            return {
+                "provider": provider,
+                "api_mode": (
+                    "codex_responses"
+                    if provider == "openai-codex"
+                    else "gemini_native"
+                ),
+                "base_url": (
+                    "https://chatgpt.com/backend-api/codex"
+                    if provider == "openai-codex"
+                    else "https://generativelanguage.googleapis.com/v1beta"
+                ),
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"provider": "openrouter", "default": "openrouter/gpt-5"}
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.parse_model_input",
+            lambda raw, current: ("openai-codex", "gpt-5.6-sol"),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            lambda model, current: None,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+            state.agent.provider = None
+            state.agent.base_url = "https://generativelanguage.googleapis.com/v1beta"
+            state.agent.api_mode = "gemini_native"
+
+            result = await acp_agent.set_session_model(
+                model_id="openai-codex:gpt-5.6-sol",
+                session_id=state.session_id,
+            )
+
+        assert isinstance(result, SetSessionModelResponse)
+        assert state.agent.provider == "openai-codex"
+        assert state.agent.base_url == "https://chatgpt.com/backend-api/codex"
+        assert state.agent.api_mode == "codex_responses"
+
 
 # ---------------------------------------------------------------------------
 # prompt


### PR DESCRIPTION
## Summary
- treat a missing legacy provider attribution as a provider change during ACP model switching
- resolve the new providers base URL and API mode instead of carrying stale route fields forward
- retain the current route only for same-provider model changes

Fixes #63222

## Testing
- pytest tests/acp/test_server.py -q (87 passed)
- pytest tests/acp/test_session.py -q (45 passed)
- ruff check acp_adapter/server.py tests/acp/test_server.py