### PR TITLE
fix(email): bound standalone SMTP connections (#69979)

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -1222,12 +1222,22 @@ async def _standalone_send(
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
-        server = smtplib.SMTP(smtp_host, smtp_port)
+        server = smtplib.SMTP(smtp_host, smtp_port, timeout=SMTP_CONNECT_TIMEOUT)
         server.starttls(context=_ssl.create_default_context())
         server.login(address, password)
         server.send_message(msg)
         server.quit()
         return {"success": True, "platform": "email", "chat_id": chat_id}
+    except TimeoutError:
+        timeout_error = (
+            f"Email send timed out after {SMTP_CONNECT_TIMEOUT}s: "
+            f"{smtp_host}:{smtp_port}"
+        )
+        try:
+            from tools.send_message_tool import _error as _e
+            return _e(timeout_error)
+        except Exception:
+            return {"error": timeout_error}
     except Exception as e:
         try:
             from tools.send_message_tool import _error as _e

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -771,17 +771,21 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
         msg = MIMEText(message, "plain", "utf-8")
         for key, value in (("From", address), ("To", chat_id), ("Subject", "Hermes Agent"), ("Date", formatdate(localtime=True))):
             msg[key] = value
-        server = _open_smtp(smtp_host, smtp_port, smtp_security, _tls_context(smtp_tls_verify, smtp_host), smtplib.SMTP, smtplib.SMTP_SSL)
+        server = _open_smtp(smtp_host, smtp_port, smtp_security, _tls_context(smtp_tls_verify, smtp_host), smtplib.SMTP, smtplib.SMTP_SSL, timeout=SMTP_CONNECT_TIMEOUT)
         server.login(address, password)
         server.send_message(msg)
         server.quit()
         return {"success": True, "platform": "email", "chat_id": chat_id}
     except Exception as e:
+        error = (
+            f"Email send timed out ({SMTP_CONNECT_TIMEOUT}s socket timeout): {smtp_host}:{smtp_port}"
+            if isinstance(e, TimeoutError) else f"Email send failed: {e}"
+        )
         try:
             from tools.send_message_tool import _error as _e
-            return _e(f"Email send failed: {e}")
+            return _e(error)
         except Exception:
-            return {"error": f"Email send failed: {e}"}
+            return {"error": error}
 
 
 def _is_connected(config) -> bool:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -595,7 +595,10 @@ class TestSendEmailStandalone(unittest.TestCase):
         """_send_email should use verified STARTTLS when sending."""
         import asyncio
         import ssl
-        from plugins.platforms.email.adapter import _standalone_send as _email_send
+        from plugins.platforms.email.adapter import (
+            SMTP_CONNECT_TIMEOUT,
+            _standalone_send as _email_send,
+        )
         from types import SimpleNamespace
         async def _send_email(extra, chat_id, message):
             return await _email_send(SimpleNamespace(token=None, api_key=None, extra=extra or {}), chat_id, message)
@@ -610,6 +613,11 @@ class TestSendEmailStandalone(unittest.TestCase):
 
             self.assertTrue(result["success"])
             self.assertEqual(result["platform"], "email")
+            mock_smtp.assert_called_once_with(
+                "smtp.test.com",
+                587,
+                timeout=SMTP_CONNECT_TIMEOUT,
+            )
             _, kwargs = mock_server.starttls.call_args
             self.assertIsInstance(kwargs["context"], ssl.SSLContext)
             send_call = mock_server.send_message.call_args[0][0]
@@ -617,6 +625,47 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertIn("Date", send_call)
             self.assertEqual(send_call["To"], "user@test.com")
             self.assertEqual(send_call["From"], "hermes@test.com")
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_SMTP_PORT": "587",
+    })
+    def test_send_email_tool_timeout(self):
+        """SMTP timeout should return a specific endpoint-aware error."""
+        import asyncio
+        from plugins.platforms.email.adapter import (
+            SMTP_CONNECT_TIMEOUT,
+            _standalone_send as _email_send,
+        )
+        from types import SimpleNamespace
+
+        with patch("smtplib.SMTP", side_effect=TimeoutError("timed out")):
+            result = asyncio.run(
+                _email_send(
+                    SimpleNamespace(
+                        token=None,
+                        api_key=None,
+                        extra={
+                            "address": "hermes@test.com",
+                            "smtp_host": "smtp.test.com",
+                        },
+                    ),
+                    "user@test.com",
+                    "Hello",
+                )
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "error": (
+                    f"Email send timed out after {SMTP_CONNECT_TIMEOUT}s: "
+                    "smtp.test.com:587"
+                )
+            },
+        )
 
 
 class TestSmtpConnectionCleanup(unittest.TestCase):

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -810,7 +810,10 @@ class TestSendEmailStandalone(unittest.TestCase):
         """_send_email should use verified STARTTLS when sending."""
         import asyncio
         import ssl
-        from plugins.platforms.email.adapter import _standalone_send as _email_send
+        from plugins.platforms.email.adapter import (
+            SMTP_CONNECT_TIMEOUT,
+            _standalone_send as _email_send,
+        )
         from types import SimpleNamespace
         async def _send_email(extra, chat_id, message):
             return await _email_send(SimpleNamespace(token=None, api_key=None, extra=extra or {}), chat_id, message)
@@ -825,6 +828,11 @@ class TestSendEmailStandalone(unittest.TestCase):
 
             self.assertTrue(result["success"])
             self.assertEqual(result["platform"], "email")
+            mock_smtp.assert_called_once_with(
+                "smtp.test.com",
+                587,
+                timeout=SMTP_CONNECT_TIMEOUT,
+            )
             _, kwargs = mock_server.starttls.call_args
             self.assertIsInstance(kwargs["context"], ssl.SSLContext)
             send_call = mock_server.send_message.call_args[0][0]
@@ -832,6 +840,63 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertIn("Date", send_call)
             self.assertEqual(send_call["To"], "user@test.com")
             self.assertEqual(send_call["From"], "hermes@test.com")
+
+    @patch.dict(os.environ, {"EMAIL_PASSWORD": "secret", "EMAIL_SMTP_SECURITY": ""})
+    def test_other_smtp_modes_bound_the_constructor(self):
+        import asyncio
+        from types import SimpleNamespace
+        from plugins.platforms.email.adapter import SMTP_CONNECT_TIMEOUT, _standalone_send
+
+        for security, constructor in (("tls", "SMTP_SSL"), ("none", "SMTP")):
+            with self.subTest(security=security), patch(f"smtplib.{constructor}") as smtp:
+                result = asyncio.run(_standalone_send(
+                    SimpleNamespace(extra={"address": "hermes@test.com", "smtp_host": "smtp.test.com",
+                                           "smtp_security": security}),
+                    "user@test.com", "Hello",
+                ))
+                self.assertTrue(result["success"])
+                self.assertEqual(smtp.call_args.kwargs["timeout"], SMTP_CONNECT_TIMEOUT)
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_SMTP_PORT": "587",
+    })
+    def test_send_email_tool_timeout(self):
+        """SMTP timeout should return a specific endpoint-aware error."""
+        import asyncio
+        from plugins.platforms.email.adapter import (
+            SMTP_CONNECT_TIMEOUT,
+            _standalone_send as _email_send,
+        )
+        from types import SimpleNamespace
+
+        with patch("smtplib.SMTP", side_effect=TimeoutError("timed out")):
+            result = asyncio.run(
+                _email_send(
+                    SimpleNamespace(
+                        token=None,
+                        api_key=None,
+                        extra={
+                            "address": "hermes@test.com",
+                            "smtp_host": "smtp.test.com",
+                        },
+                    ),
+                    "user@test.com",
+                    "Hello",
+                )
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "error": (
+                    f"Email send timed out ({SMTP_CONNECT_TIMEOUT}s socket timeout): "
+                    "smtp.test.com:587"
+                )
+            },
+        )
 
 
 class TestSmtpConnectionCleanup(unittest.TestCase):


### PR DESCRIPTION
Standalone email delivery calls the shared SMTP opener without a timeout, while live-adapter delivery already supplies `SMTP_CONNECT_TIMEOUT`. Pass that existing timeout through the current opener so STARTTLS, implicit TLS, and plaintext constructors are bounded.

Report timeouts with the configured SMTP endpoint and socket timeout. This is a per-operation socket timeout, not a whole-send deadline. Current TLS selection, verification, authentication, delivery, and non-timeout error formatting are preserved.

This preserves Ernest Hysa's focused fix from #32718, adapted to the current email plugin and SMTP helper. His co-author credit remains in the commit. The broader historical #47269 work is not restored over upstream's current TLS implementation.

Validation on current main `485aaf69b7f0930a5f6631752172d90a4a5575c6`:
- Before: both original standalone regressions fail (missing constructor timeout and generic timeout error).
- After: `scripts/run_tests.sh tests/gateway/test_email.py tests/tools/test_send_message_tool.py -q`: 87 passed.
- Added implicit-TLS/plaintext constructor coverage; final standalone group: 3 passed.
- Ruff and diff checks passed.

Not checked: full suite, live SMTP delivery, native Windows; CodeRabbit skipped for author-side maintenance without P0/P1 priority.

Agent disclosure: original work by GPT-5.6-sol with xhigh reasoning in Codex. Maintenance by GPT-6 in Codex desktop (parent reasoning level unavailable). The account owner loosely reviews these actions and receives the usual GitHub notifications.
