### PR TITLE
feat(feishu): support card stop controls

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4776,7 +4776,9 @@ class BasePlatformAdapter(ABC):
             # condition fix — issue #18912).  Previously the send happened
             # after cancel_session_processing, which could silently drop the
             # "/new" confirmation when an agent was actively running.
-            if _text:
+            if _text and not bool(
+                event.metadata.get("suppress_command_response", False)
+            ):
                 logger.info(
                     "[%s] Sending command '/%s' response (%d chars) to %s",
                     self.name,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2681,6 +2681,14 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        hermes_command = (
+            str(action_value.get("hermes_command", "") or "")
+            .strip()
+            .lower()
+            .lstrip("/")
+            if isinstance(action_value, dict)
+            else ""
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
@@ -2690,6 +2698,14 @@ class FeishuAdapter(BasePlatformAdapter):
                 action_value=action_value,
                 loop=loop,
             )
+        if hermes_command == "stop":
+            operator = getattr(event, "operator", None)
+            open_id = str(getattr(operator, "open_id", "") or "")
+            chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+            sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
+            if not self._allow_group_message(sender_id, chat_id, is_bot=False):
+                logger.warning("[Feishu] Unauthorized card command click by %s", open_id or "<unknown>")
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
         self._submit_on_loop(loop, self._handle_card_action_event(data))
         if P2CardActionTriggerResponse is None:
@@ -3025,15 +3041,30 @@ class FeishuAdapter(BasePlatformAdapter):
         action = getattr(event, "action", None)
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
+        hermes_command = (
+            str(action_value.get("hermes_command", "") or "")
+            .strip()
+            .lower()
+            .lstrip("/")
+            if isinstance(action_value, dict)
+            else ""
+        )
 
-        synthetic_text = f"/card {action_tag}"
-        if action_value:
+        synthetic_text = "/stop" if hermes_command == "stop" else f"/card {action_tag}"
+        if action_value and hermes_command != "stop":
             try:
                 synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
             except Exception:
                 pass
 
         sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
+        if hermes_command == "stop" and not self._allow_group_message(
+            sender_id,
+            chat_id,
+            is_bot=False,
+        ):
+            logger.warning("[Feishu] Unauthorized card command click by %s", open_id)
+            return
         sender_profile = await self._resolve_sender_profile(sender_id)
         chat_info = await self.get_chat_info(chat_id)
         source = self.build_source(
@@ -3054,6 +3085,8 @@ class FeishuAdapter(BasePlatformAdapter):
             channel_prompt=self._resolve_channel_prompt(chat_id),
             timestamp=datetime.now(),
         )
+        if hermes_command == "stop":
+            synthetic_event.metadata["suppress_command_response"] = True
         logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)
         await self._handle_message_with_guards(synthetic_event)
 

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -101,6 +101,20 @@ class TestCommandBypassActiveSession:
         )
 
     @pytest.mark.asyncio
+    async def test_stop_can_suppress_response_for_interactive_controls(self):
+        """Card controls may stop a run without adding a second chat message."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+        event = _make_event("/stop")
+        event.metadata["suppress_command_response"] = True
+
+        await adapter.handle_message(event)
+
+        assert sk not in adapter._pending_messages
+        assert adapter.sent_responses == []
+
+    @pytest.mark.asyncio
     async def test_new_bypasses_guard(self):
         """/new must be dispatched directly, not queued."""
         adapter = _make_adapter()

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -437,6 +437,50 @@ class TestNonApprovalCardAction:
         event = mock_handle.call_args[0][0]
         assert "/card button" in event.text
 
+    @pytest.mark.asyncio
+    async def test_stop_card_action_routes_as_silent_stop_command(self):
+        adapter = _make_adapter()
+        adapter._allowed_group_users = {"ou_user1"}
+        data = _make_card_action_data(
+            action_value={"hermes_command": "stop"},
+            token="tok_stop",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        mock_handle.assert_awaited_once()
+        event = mock_handle.call_args.args[0]
+        assert event.text == "/stop"
+        assert event.message_type.value == "command"
+        assert event.metadata["suppress_command_response"] is True
+
+    @pytest.mark.asyncio
+    async def test_stop_card_action_rechecks_operator_authorization(self):
+        adapter = _make_adapter()
+        adapter._allowed_group_users = {"ou_allowed"}
+        data = _make_card_action_data(
+            action_value={"hermes_command": "stop"},
+            open_id="ou_intruder",
+            token="tok_stop_unauthorized",
+        )
+
+        with (
+            patch.object(adapter, "_resolve_sender_profile", new_callable=AsyncMock) as mock_profile,
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        mock_profile.assert_not_awaited()
+        mock_handle.assert_not_awaited()
+
 
 # ===========================================================================
 # _on_card_action_trigger — inline card response for approval actions
@@ -548,6 +592,36 @@ class TestCardActionCallbackResponse:
 
         assert response is not None
         assert response.card is None
+
+    def test_stop_card_action_is_scheduled_without_replacing_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        data = _make_card_action_data({"hermes_command": "/STOP"})
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+
+    def test_stop_card_action_rejects_unauthorized_operator(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_allowed"}
+        data = _make_card_action_data(
+            {"hermes_command": "stop"},
+            open_id="ou_intruder",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
 
     def test_falls_back_to_open_id_when_name_not_cached(self, _patch_callback_card_types):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

- route authorized Feishu card actions with `hermes_command: stop` through the existing `/stop` path
- keep the active card in place and suppress the extra command acknowledgement
- leave all other card actions unchanged

## Tests

- 661 gateway and Feishu tests passed
- Ruff checks passed
