### PR TITLE
fix(agent): fail fast on custom-provider /models auth errors (401/403 short-circuit + streamed probe)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1053,8 +1053,22 @@ def fetch_endpoint_model_metadata(
 
     for candidate in candidates:
         url = candidate.rstrip("/") + "/models"
+        response = None
         try:
-            response = requests.get(url, headers=headers, timeout=(5, 10), verify=_resolve_requests_verify())
+            response = requests.get(
+                url,
+                headers=headers,
+                timeout=(5, 10),
+                verify=_resolve_requests_verify(),
+                stream=True,
+            )
+            if response.status_code in (401, 403):
+                logger.debug(
+                    "Model metadata probe received HTTP %s from %s; stopping candidate probing",
+                    response.status_code,
+                    url,
+                )
+                break
             response.raise_for_status()
             payload = response.json()
             cache: Dict[str, Dict[str, Any]] = {}
@@ -1104,6 +1118,9 @@ def fetch_endpoint_model_metadata(
             return cache
         except Exception as exc:
             last_error = exc
+        finally:
+            if response is not None:
+                response.close()
 
     if last_error:
         logger.debug("Failed to fetch model metadata from %s/models: %s", normalized, last_error)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -699,6 +699,79 @@ class TestCodexOAuthContextLength:
 
 
 # =========================================================================
+# Custom endpoint model metadata
+# =========================================================================
+
+class TestFetchEndpointModelMetadata:
+    def setup_method(self):
+        import agent.model_metadata as mm
+        mm._endpoint_model_metadata_cache.clear()
+        mm._endpoint_model_metadata_cache_time.clear()
+
+    @pytest.mark.parametrize("status_code", [401, 403])
+    def test_auth_failure_stops_after_first_candidate(self, status_code):
+        import agent.model_metadata as mm
+
+        response = MagicMock()
+        response.status_code = status_code
+        response.raise_for_status.side_effect = RuntimeError(str(status_code))
+
+        with patch("agent.model_metadata.requests.get", return_value=response) as mock_get:
+            result = mm.fetch_endpoint_model_metadata("https://custom.example/v1")
+
+        assert result == {}
+        mock_get.assert_called_once()
+        assert mock_get.call_args.kwargs["stream"] is True
+        response.raise_for_status.assert_not_called()
+        response.json.assert_not_called()
+        response.close.assert_called_once()
+
+    def test_auth_failure_empty_result_is_cached(self):
+        import agent.model_metadata as mm
+
+        response = MagicMock()
+        response.status_code = 401
+        response.raise_for_status.side_effect = RuntimeError("401")
+
+        with patch("agent.model_metadata.requests.get", return_value=response) as mock_get:
+            first = mm.fetch_endpoint_model_metadata("https://custom.example/v1")
+            second = mm.fetch_endpoint_model_metadata("https://custom.example/v1")
+
+        assert first == second == {}
+        mock_get.assert_called_once()
+        response.close.assert_called_once()
+
+    def test_not_found_still_tries_alternate_candidate(self):
+        import agent.model_metadata as mm
+
+        not_found = MagicMock()
+        not_found.status_code = 404
+        not_found.raise_for_status.side_effect = RuntimeError("404")
+        success = MagicMock()
+        success.status_code = 200
+        success.json.return_value = {
+            "data": [{"id": "test/model", "context_length": 32768}]
+        }
+
+        with patch(
+            "agent.model_metadata.requests.get",
+            side_effect=[not_found, success],
+        ) as mock_get:
+            result = mm.fetch_endpoint_model_metadata("https://custom.example/v1")
+
+        assert result["test/model"]["context_length"] == 32768
+        assert mock_get.call_count == 2
+        assert [call.args[0] for call in mock_get.call_args_list] == [
+            "https://custom.example/v1/models",
+            "https://custom.example/models",
+        ]
+        assert all(call.kwargs["stream"] is True for call in mock_get.call_args_list)
+        not_found.json.assert_not_called()
+        not_found.close.assert_called_once()
+        success.close.assert_called_once()
+
+
+# =========================================================================
 # Nous Portal context-window resolution (provider="nous")
 # =========================================================================
 


### PR DESCRIPTION
## What does this PR do?

When Hermes probes a custom provider's `/models` endpoint at startup with no API key available yet, an authenticated endpoint returns HTTP 401 — and the reported endpoint (Alibaba Cloud Token Plan) takes ~10 s just to return that status. Today the probe then goes on to try the alternate candidate URL (`/v1` toggled), which hits the same auth wall for another ~10 s: **20-30 s of cold-start latency per fully-functional provider** (#69905).

Two changes in `fetch_endpoint_model_metadata()`:

1. **Short-circuit the candidate waterfall on 401/403.** An auth wall proves the endpoint family exists and simply requires credentials the probe doesn't have — probing the alternate spelling can only hit the same wall. On 401/403 the loop breaks immediately (with a debug log of status + URL) and falls through to the existing negative-cache path. This is the main time saver: the second probe is eliminated no matter how slow the auth wall is.
2. **Stream the probe.** `stream=True` checks the HTTP status before downloading the body, so 4xx never waits on a slow error body; `.json()` runs only on 200. Responses are closed on every exit path (success, `raise_for_status`, JSON errors, auth break) via `try/finally`.

`404` semantics are unchanged (still falls through to the alternate candidate), 5xx keeps its existing retry-next-candidate behavior, and the LM Studio / llama.cpp local branches are untouched.

**Relationship to #69971:** opened while this fix was in verification — it covers the streaming/close half (which this PR also includes) but keeps probing the alternate candidate after a 401 (its test asserts `call_count == 2`). Since the reported endpoint is slow to return the 401 *status line* itself, streaming alone still pays the double probe (~20 s). Happy to converge either way — the delta to port is the 401/403 break plus the negative-cache/waterfall regression tests.

## Related Issue

Fixes #69905

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` — 401/403 check before `raise_for_status()` with loop break; `stream=True` probe; `try/finally` response close covering all exit paths (`response = None` guard for connection-refused).
- `tests/agent/test_model_metadata.py` — new `TestFetchEndpointModelMetadata` class: 401/403 single-call assertions (fail on `main`, which probes twice), negative-cache reuse (second call in the TTL window makes no request), 404-still-tries-alternate with both responses closed, no `.json()` on 4xx.

## How to Test

1. `python -m pytest tests/agent/test_model_metadata.py -q` → 132 passed.
2. Red/green: revert `agent/model_metadata.py` only → the 401/403 tests fail with `Expected 'get' to have been called once. Called 2 times.`; restore → green.
3. Manual: configure a custom provider whose `/models` requires auth (e.g. an OpenAI-compatible gateway) with no key in the probe context → startup no longer stalls ~20 s per provider; with a key, metadata resolution is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — #69971 overlaps on the streaming half; the relationship and remaining delta are described above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected test suite (`tests/agent/test_model_metadata.py` — 132 passed); full `pytest tests/ -q` on this machine stops at 12 pre-existing collection errors from missing optional `acp` deps, unrelated to this change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
- [x] I've updated relevant documentation — N/A (no user-facing behavior change beyond faster startup)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure `requests` usage, no platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
