### PR TITLE
fix(terminal): avoid Windows pipe close deadlock

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -57,6 +57,57 @@ class TestBoundedOutputCollector:
         assert "[OUTPUT TRUNCATED" in rendered
 
 
+def test_windows_wait_does_not_close_pipe_during_blocking_read(monkeypatch):
+    """A detached GUI may retain stdout after the shell wrapper exits."""
+    import os
+    import threading
+    from types import SimpleNamespace
+
+    import tools.environments.base as base_module
+
+    read_fd, write_fd = os.pipe()
+    closed = threading.Event()
+    close_threads = []
+
+    class BlockingStream:
+        def fileno(self):
+            return read_fd
+
+        def close(self):
+            close_threads.append(threading.current_thread())
+            if threading.current_thread() is threading.main_thread():
+                raise AssertionError(
+                    "waiter must not close a Windows pipe with ReadFile pending"
+                )
+            os.close(read_fd)
+            closed.set()
+
+    class ExitedProcess:
+        stdout = BlockingStream()
+        returncode = 0
+        pid = 1234
+
+        @staticmethod
+        def poll():
+            return 0
+
+    monkeypatch.setattr(
+        base_module,
+        "os",
+        SimpleNamespace(name="nt", read=os.read),
+    )
+
+    try:
+        result = _TestableEnv()._wait_for_process(ExitedProcess(), timeout=1)
+    finally:
+        os.close(write_fd)
+
+    assert result["returncode"] == 0
+    assert closed.wait(2), "reader thread should close its own stream after EOF"
+    assert len(close_threads) == 1
+    assert close_threads[0] is not threading.main_thread()
+
+
 class TestWrapCommand:
     def test_basic_shape(self):
         env = _TestableEnv()

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -51,6 +51,57 @@ class TestBoundedOutputCollector:
         assert "[OUTPUT TRUNCATED" in rendered
 
 
+def test_windows_wait_does_not_close_pipe_during_blocking_read(monkeypatch):
+    """A detached GUI may retain stdout after the shell wrapper exits."""
+    import os
+    import threading
+    from types import SimpleNamespace
+
+    import tools.environments.base as base_module
+
+    read_fd, write_fd = os.pipe()
+    closed = threading.Event()
+    close_threads = []
+
+    class BlockingStream:
+        def fileno(self):
+            return read_fd
+
+        def close(self):
+            close_threads.append(threading.current_thread())
+            if threading.current_thread() is threading.main_thread():
+                raise AssertionError(
+                    "waiter must not close a Windows pipe with ReadFile pending"
+                )
+            os.close(read_fd)
+            closed.set()
+
+    class ExitedProcess:
+        stdout = BlockingStream()
+        returncode = 0
+        pid = 1234
+
+        @staticmethod
+        def poll():
+            return 0
+
+    monkeypatch.setattr(
+        base_module,
+        "os",
+        SimpleNamespace(name="nt", read=os.read),
+    )
+
+    try:
+        result = _TestableEnv()._wait_for_process(ExitedProcess(), timeout=1)
+    finally:
+        os.close(write_fd)
+
+    assert result["returncode"] == 0
+    assert closed.wait(2), "reader thread should close its own stream after EOF"
+    assert len(close_threads) == 1
+    assert close_threads[0] is not threading.main_thread()
+
+
 class TestWrapCommand:
     def test_basic_shape(self):
         env = _TestableEnv()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -804,6 +804,14 @@ class BaseEnvironment(ABC):
                             output.append(tail)
                     except Exception:
                         pass
+                    # Close from the reader thread after ReadFile reaches EOF.
+                    # Closing this stream from the waiter thread while a
+                    # descendant GUI still owns the pipe's write end can block
+                    # Windows indefinitely.
+                    try:
+                        stream.close()
+                    except Exception:
+                        pass
                 return
             idle_after_exit = 0
             try:
@@ -959,10 +967,17 @@ class BaseEnvironment(ABC):
         # it means the non-blocking loop itself stopped cooperating.
         drain_thread.join(timeout=2)
 
-        try:
-            proc.stdout.close()
-        except Exception:
-            pass
+        # A Windows GUI launched through `cmd.exe /c start` may inherit the
+        # stdout write handle after the shell wrapper exits. Its reader thread
+        # then remains blocked in ReadFile until the GUI closes. Do not close
+        # the read stream concurrently from this waiter thread: Windows can
+        # block that close behind the outstanding read and wedge the whole tool
+        # turn. The daemon reader owns cleanup once EOF eventually arrives.
+        if not drain_thread.is_alive():
+            try:
+                proc.stdout.close()
+            except Exception:
+                pass
 
         if _DEBUG_INTERRUPT:
             logger.info(

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1176,6 +1176,14 @@ class BaseEnvironment(ABC):
                             output.append(tail)
                     except Exception:
                         pass
+                    # Close from the reader thread after ReadFile reaches EOF.
+                    # Closing this stream from the waiter thread while a
+                    # descendant GUI still owns the pipe's write end can block
+                    # Windows indefinitely.
+                    try:
+                        stream.close()
+                    except Exception:
+                        pass
                 return
             idle_after_exit = 0
             try:
@@ -1333,10 +1341,17 @@ class BaseEnvironment(ABC):
         # it means the non-blocking loop itself stopped cooperating.
         drain_thread.join(timeout=2)
 
-        try:
-            proc.stdout.close()
-        except Exception:
-            pass
+        # A Windows GUI launched through `cmd.exe /c start` may inherit the
+        # stdout write handle after the shell wrapper exits. Its reader thread
+        # then remains blocked in ReadFile until the GUI closes. Do not close
+        # the read stream concurrently from this waiter thread: Windows can
+        # block that close behind the outstanding read and wedge the whole tool
+        # turn. The daemon reader owns cleanup once EOF eventually arrives.
+        if not drain_thread.is_alive():
+            try:
+                proc.stdout.close()
+            except Exception:
+                pass
 
         if _DEBUG_INTERRUPT:
             logger.info(


### PR DESCRIPTION
## Summary
- avoid closing a Windows stdout pipe from the waiter while its reader is blocked in ReadFile
- let the daemon reader own stream cleanup after a detached GUI finally releases the inherited write handle
- add a regression test for an exited shell whose descendant keeps stdout open

## Verification
- python -m pytest -q tests/tools/test_base_environment.py tests/tools/test_local_background_child_hang.py
- python -m ruff check tools/environments/base.py tests/tools/test_base_environment.py
- git diff --check

Fixes #69916