### PR TITLE
feat(desktop): add global settings command search

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -157,8 +157,9 @@ Notes:
   padding; `PAGE_INSET_NEG_X` to bleed a child to the edge. Don't hardcode
   `px-6`/`px-8` on pages.
 - **Master/detail overlays:** `OverlaySplitLayout` + `OverlaySidebar` /
-  `OverlayMain`. Cron, profiles, etc. ride this — don't rebuild a titlebar
-  shell.
+  `OverlayMain`. Cron, profiles, etc. ride this. `OverlayNav` accepts an optional
+  header for controls such as Settings search and gives it a dedicated row in
+  narrow layouts. Don't rebuild a titlebar shell.
 - **Rows:** `ListRow` (settings `primitives.tsx`) for label/description/action
   rows. Flat, flush-left; no per-row indentation that fights flush headers.
 - **No dividers between rows** unless the list genuinely needs them; prefer

--- a/apps/desktop/src/app/overlays/overlay-split-layout.tsx
+++ b/apps/desktop/src/app/overlays/overlay-split-layout.tsx
@@ -145,73 +145,81 @@ export interface OverlayNavGroup extends OverlayNavLink {
 // dropdown in PageSearchShell), so every OverlaySplitLayout pane degrades the
 // same way instead of stacking its whole sidebar. Drop it in as the first
 // child of an OverlaySplitLayout, before OverlayMain.
-export function OverlayNav({ footer, groups }: { footer?: ReactNode; groups: OverlayNavGroup[] }) {
+export function OverlayNav({ footer, groups, header }: OverlayNavProps) {
   return (
     <>
-      <OverlaySidebar className={RAIL_HIDDEN}>
-        {groups.map(group => (
-          <Fragment key={group.id}>
-            {group.gapBefore && <div aria-hidden className="h-2" />}
-            <OverlayNavItem active={group.active} icon={group.icon} label={group.label} onClick={group.onSelect} />
-            {group.children && group.active && (
-              <div className="ml-3.5 flex flex-col gap-0.5 pl-1.5">
-                {group.children.map(child => (
-                  <OverlayNavItem
-                    active={child.active}
-                    icon={child.icon}
-                    key={child.id}
-                    label={child.label}
-                    nested
-                    onClick={child.onSelect}
-                  />
-                ))}
-              </div>
-            )}
-          </Fragment>
-        ))}
-        {footer && <div className="mt-auto flex items-center gap-1 pt-2">{footer}</div>}
+      <OverlaySidebar className={cn(RAIL_HIDDEN, header && 'overflow-visible')}>
+        {header && <div className="mb-2 min-w-0">{header}</div>}
+        <div
+          className={cn(header ? '-mx-2.5 flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-2.5' : 'contents')}
+        >
+          {groups.map(group => (
+            <Fragment key={group.id}>
+              {group.gapBefore && <div aria-hidden className="h-2" />}
+              <OverlayNavItem active={group.active} icon={group.icon} label={group.label} onClick={group.onSelect} />
+              {group.children && group.active && (
+                <div className="ml-3.5 flex flex-col gap-0.5 pl-1.5">
+                  {group.children.map(child => (
+                    <OverlayNavItem
+                      active={child.active}
+                      icon={child.icon}
+                      key={child.id}
+                      label={child.label}
+                      nested
+                      onClick={child.onSelect}
+                    />
+                  ))}
+                </div>
+              )}
+            </Fragment>
+          ))}
+          {footer && <div className="mt-auto flex items-center gap-1 pt-2">{footer}</div>}
+        </div>
       </OverlaySidebar>
 
-      {/* Narrow: ride the OverlayView titlebar strip so the dropdown shares the
-          close button's row instead of taking its own. The bar is
-          pointer-events-none (children opt back in) so the floating X underneath
-          stays clickable; pr clears it, no-drag beats the strip's drag region,
-          and the height matches the strip so the trigger lines up with the X. */}
-      <div
-        className={cn(
-          'pointer-events-none relative z-20 h-[calc(var(--titlebar-height)+0.1875rem)] items-center justify-between gap-2 pl-3 pr-12',
-          BAR_HIDDEN
-        )}
-      >
-        <div className="pointer-events-auto min-w-0 [-webkit-app-region:no-drag]">
-          <TabDropdown
-            align="start"
-            items={groups.flatMap(group => [
-              {
-                active: group.active && !group.children?.some(child => child.active),
-                icon: group.icon,
-                id: group.id,
-                label: group.label,
-                onSelect: group.onSelect,
-                separatorBefore: group.gapBefore
-              },
-              ...(group.children ?? []).map(child => ({
-                active: child.active,
-                icon: child.icon,
-                id: child.id,
-                indent: true,
-                label: child.label,
-                onSelect: child.onSelect
-              }))
-            ])}
-          />
-        </div>
-        {footer && (
-          <div className="pointer-events-auto flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
-            {footer}
+      {/* Narrow: the dropdown keeps the titlebar row, while an optional header
+          gets a full-width row beneath it instead of crowding the close button. */}
+      <div className={cn('pointer-events-none relative z-20 flex-col', BAR_HIDDEN)}>
+        <div className="flex h-[calc(var(--titlebar-height)+0.1875rem)] items-center justify-between gap-2 pl-3 pr-12">
+          <div className="pointer-events-auto min-w-0 [-webkit-app-region:no-drag]">
+            <TabDropdown
+              align="start"
+              items={groups.flatMap(group => [
+                {
+                  active: group.active && !group.children?.some(child => child.active),
+                  icon: group.icon,
+                  id: group.id,
+                  label: group.label,
+                  onSelect: group.onSelect,
+                  separatorBefore: group.gapBefore
+                },
+                ...(group.children ?? []).map(child => ({
+                  active: child.active,
+                  icon: child.icon,
+                  id: child.id,
+                  indent: true,
+                  label: child.label,
+                  onSelect: child.onSelect
+                }))
+              ])}
+            />
           </div>
+          {footer && (
+            <div className="pointer-events-auto flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
+              {footer}
+            </div>
+          )}
+        </div>
+        {header && (
+          <div className="pointer-events-auto min-w-0 px-3 pb-2 pr-12 [-webkit-app-region:no-drag]">{header}</div>
         )}
       </div>
     </>
   )
+}
+
+interface OverlayNavProps {
+  footer?: ReactNode
+  groups: OverlayNavGroup[]
+  header?: ReactNode
 }

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -26,6 +26,8 @@ import { $marketplaceInstalls, isUserTheme, removeUserTheme } from '@/themes/use
 import { MODE_OPTIONS } from './constants'
 import { PetSettings } from './pet-settings'
 import { ListRow, SectionHeading, SettingsContent } from './primitives'
+import { APPEARANCE_SETTING_IDS } from './settings-search'
+import { useDeepLinkHighlight } from './use-deep-link-highlight'
 
 function ThemePreview({ name, mode }: { name: string; mode: 'light' | 'dark' }) {
   // Preview in the *current* mode: the dark palette in Dark, and the light
@@ -69,6 +71,8 @@ function ThemePreview({ name, mode }: { name: string; mode: 'light' | 'dark' }) 
 // +/- step landing between presets highlights nothing, and the row
 // description keeps showing the exact current percent.
 const UI_SCALE_PRESETS = ['90', '100', '110', '125', '150', '175'] as const
+const APPEARANCE_SEARCH_TARGETS = new Set<string>(Object.values(APPEARANCE_SETTING_IDS))
+const appearanceSettingElementId = (id: string) => `setting-field-${id}`
 
 type UiScalePreset = (typeof UI_SCALE_PRESETS)[number]
 
@@ -257,6 +261,12 @@ export function AppearanceSettings() {
 
   const [query, setQuery] = useState('')
 
+  useDeepLinkHighlight({
+    elementId: appearanceSettingElementId,
+    param: 'setting',
+    ready: id => APPEARANCE_SEARCH_TARGETS.has(id)
+  })
+
   // One box does double duty: filter installed themes live (below), and run a
   // name search against the VS Code Marketplace (the Cmd-K "Install theme…"
   // backend) for anything not already installed.
@@ -309,6 +319,7 @@ export function AppearanceSettings() {
           <ListRow
             action={<LanguageSwitcher />}
             description={isSavingLocale ? t.language.saving : t.language.description}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.language)}
             title={t.language.label}
           />
 
@@ -396,6 +407,7 @@ export function AppearanceSettings() {
               </>
             }
             description={a.themeDesc}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.theme)}
             title={
               <div className="flex items-center justify-between gap-3">
                 <span>{a.themeTitle}</span>
@@ -424,6 +436,7 @@ export function AppearanceSettings() {
               />
             }
             description={a.uiScaleDesc(zoomPercent)}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.uiScale)}
             title={a.uiScaleTitle}
           />
 
@@ -450,6 +463,7 @@ export function AppearanceSettings() {
               </div>
             }
             description={a.translucencyDesc}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.translucency)}
             title={a.translucencyTitle}
           />
 
@@ -468,6 +482,7 @@ export function AppearanceSettings() {
               />
             }
             description={a.backdropDesc}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.backdrop)}
             title={a.backdropTitle}
           />
 
@@ -483,6 +498,7 @@ export function AppearanceSettings() {
               />
             }
             description={a.toolViewDesc}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.toolView)}
             title={a.toolViewTitle}
           />
 
@@ -512,6 +528,7 @@ export function AppearanceSettings() {
               </div>
             }
             description={a.embedsDesc}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.embeds)}
             title={a.embedsTitle}
           />
         </div>

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -17,31 +17,18 @@ import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 import { PanelEmpty } from '../overlays/panel'
 
 import { ConfigField } from './config-field'
-import { enumOptionsFor, getNested, isExternalMemoryProvider, sectionFieldEntries, setNested } from './helpers'
+import {
+  enumOptionsFor,
+  getNested,
+  isExternalMemoryProvider,
+  sectionFieldEntries,
+  setNested,
+  voiceFieldVisible
+} from './helpers'
 import { MemoryConnect } from './memory/connect'
 import { ProviderConfigPanel } from './memory/provider-config-panel'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
 import { EmptyState, SettingsContent, SettingsSkeleton, ToggleRow } from './primitives'
-
-// On the Voice page, only surface the sub-fields of the *selected* TTS/STT
-// provider — otherwise every provider's options render at once (the "totally
-// crazy" wall of ~30 fields). Top-level keys (tts.provider, stt.enabled,
-// voice.*) always show; STT provider fields hide entirely when STT is off.
-export function voiceFieldVisible(key: string, config: HermesConfigRecord): boolean {
-  const match = /^(tts|stt)\.([^.]+)\./.exec(key)
-
-  if (!match) {
-    return true
-  }
-
-  const [, domain, provider] = match
-
-  if (domain === 'stt' && !getNested(config, 'stt.enabled')) {
-    return false
-  }
-
-  return provider === String(getNested(config, `${domain}.provider`) ?? '')
-}
 
 export function ConfigSettings({
   activeSectionId,
@@ -201,6 +188,12 @@ export function ConfigSettings({
     }
 
     element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+
+    if (!element.hasAttribute('tabindex')) {
+      element.tabIndex = -1
+    }
+
+    element.focus({ preventScroll: true })
     element.classList.add('setting-field-highlight')
 
     const timeout = window.setTimeout(() => element.classList.remove('setting-field-highlight'), 1600)

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -97,6 +97,24 @@ export function getNested(obj: HermesConfigRecord, path: string): unknown {
   return cur
 }
 
+// Voice renders only fields for the selected TTS/STT provider. Search and the
+// page share this rule so every indexed field can actually mount when opened.
+export function voiceFieldVisible(key: string, config: HermesConfigRecord): boolean {
+  const match = /^(tts|stt)\.([^.]+)\./.exec(key)
+
+  if (!match) {
+    return true
+  }
+
+  const [, domain, provider] = match
+
+  if (domain === 'stt' && !getNested(config, 'stt.enabled')) {
+    return false
+  }
+
+  return provider === String(getNested(config, `${domain}.provider`) ?? '')
+}
+
 export function inferFieldSchema(value: unknown): ConfigFieldSchema {
   if (typeof value === 'boolean') {
     return { type: 'boolean' }

--- a/apps/desktop/src/app/settings/index.test.tsx
+++ b/apps/desktop/src/app/settings/index.test.tsx
@@ -1,0 +1,190 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { useEffect } from 'react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as HermesApi from '@/hermes'
+import type { EnvVarInfo } from '@/types/hermes'
+
+const getEnvVars = vi.fn()
+const getHermesConfigRecord = vi.fn()
+const getHermesConfigSchema = vi.fn()
+const configUnmounted = vi.fn()
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+vi.mock('@/hermes', async importOriginal => {
+  const actual = await importOriginal<typeof HermesApi>()
+
+  return {
+    ...actual,
+    getEnvVars: () => getEnvVars(),
+    getHermesConfigRecord: () => getHermesConfigRecord(),
+    getHermesConfigSchema: () => getHermesConfigSchema()
+  }
+})
+
+vi.mock('./config-settings', () => ({
+  ConfigSettings: ({ activeSectionId }: { activeSectionId: string }) => {
+    useEffect(() => () => configUnmounted(), [])
+
+    return <div>Config page: {activeSectionId}</div>
+  }
+}))
+
+function envVar(category: string, patch: Partial<EnvVarInfo> = {}): EnvVarInfo {
+  return {
+    advanced: false,
+    category,
+    description: '',
+    is_password: true,
+    is_set: false,
+    redacted_value: null,
+    tools: [],
+    url: '',
+    ...patch
+  }
+}
+
+function LocationProbe() {
+  const location = useLocation()
+
+  return <output data-testid="location">{`${location.pathname}${location.search}`}</output>
+}
+
+function searchResultsFor(search: HTMLElement) {
+  const listId = search.getAttribute('aria-controls')
+  const list = listId ? globalThis.document.getElementById(listId) : null
+
+  if (!list) {
+    throw new Error('Search input is not connected to its result list')
+  }
+
+  return within(list)
+}
+
+async function renderSettings() {
+  const { SettingsView } = await import('./index')
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  await act(async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/settings?tab=config:model']}>
+          <SettingsView onClose={vi.fn()} />
+          <LocationProbe />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+  })
+}
+
+beforeEach(() => {
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn()
+  })
+  getHermesConfigRecord.mockResolvedValue({ approvals: { timeout: 120 } })
+  getHermesConfigSchema.mockResolvedValue({
+    fields: {
+      'approvals.timeout': {
+        description: 'Seconds to wait for approval.',
+        type: 'number'
+      }
+    }
+  })
+  getEnvVars.mockResolvedValue({
+    FUTURE_CRAWLER_API_KEY: envVar('tool', {
+      description: 'Fetch structured pages from a new crawler.',
+      tools: ['future_crawl']
+    })
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('SettingsView global search', () => {
+  it('finds config fields and dynamic credentials, then opens their exact targets', async () => {
+    await renderSettings()
+
+    const [search] = await screen.findAllByRole('combobox', { name: 'Search all settings…' })
+
+    fireEvent.change(search, { target: { value: 'approval timeout' } })
+    expect(await searchResultsFor(search).findByRole('option', { name: /Approval Timeout.*Safety/ })).toBeTruthy()
+    fireEvent.keyDown(search, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toContain('tab=config%3Asafety')
+      expect(screen.getByTestId('location').textContent).toContain('field=approvals.timeout')
+    })
+    expect((search as HTMLInputElement).value).toBe('')
+    expect(screen.getByText('Config page: safety')).toBeTruthy()
+
+    fireEvent.change(search, { target: { value: 'structured crawler' } })
+    const credentialResult = await searchResultsFor(search).findByRole('option', { name: /FUTURE CRAWLER.*Tools/ })
+    fireEvent.click(credentialResult)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toContain('tab=keys')
+      expect(screen.getByTestId('location').textContent).toContain('kview=tools')
+      expect(screen.getByTestId('location').textContent).toContain('key=FUTURE_CRAWLER_API_KEY')
+    })
+    expect((search as HTMLInputElement).value).toBe('')
+  })
+
+  it('does not announce an empty result while the catalog is loading', async () => {
+    getEnvVars.mockReturnValue(new Promise(() => {}))
+
+    await renderSettings()
+
+    const [search] = await screen.findAllByRole('combobox', { name: 'Search all settings…' })
+    fireEvent.change(search, { target: { value: 'future crawler' } })
+
+    expect((await screen.findAllByText('Searching settings…')).length).toBeGreaterThan(0)
+    expect(screen.queryByText('No settings match your search.')).toBeNull()
+  })
+
+  it('keeps the active settings page mounted while the user searches', async () => {
+    await renderSettings()
+
+    const [search] = await screen.findAllByRole('combobox', { name: 'Search all settings…' })
+    fireEvent.change(search, { target: { value: 'theme' } })
+
+    expect(await searchResultsFor(search).findByRole('option', { name: /Theme.*Appearance/ })).toBeTruthy()
+    expect(configUnmounted).not.toHaveBeenCalled()
+
+    fireEvent.change(search, { target: { value: '' } })
+    expect(screen.getByText('Config page: model')).toBeTruthy()
+    expect(configUnmounted).not.toHaveBeenCalled()
+  })
+
+  it('keeps page destinations searchable for bespoke settings surfaces', async () => {
+    await renderSettings()
+
+    const [search] = await screen.findAllByRole('combobox', { name: 'Search all settings…' })
+    fireEvent.change(search, { target: { value: 'theme' } })
+
+    const appearanceResult = await searchResultsFor(search).findByRole('option', { name: /Theme.*Appearance/ })
+    fireEvent.click(appearanceResult)
+
+    await waitFor(() => {
+      const target = globalThis.document.getElementById('setting-field-appearance.theme')
+      expect(target?.classList).toContain('setting-field-highlight')
+      expect(globalThis.document.activeElement).toBe(target)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toContain('tab=config%3Aappearance')
+      expect(screen.getByTestId('location').textContent).not.toContain('setting=')
+    })
+  })
+})

--- a/apps/desktop/src/app/settings/index.tsx
+++ b/apps/desktop/src/app/settings/index.tsx
@@ -1,7 +1,10 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
+import { Button } from '@/components/ui/button'
 import { codiconIcon } from '@/components/ui/codicon'
+import { Loader } from '@/components/ui/loader'
+import { ScopedCommandSearch } from '@/components/ui/scoped-command-search'
 import { Tip } from '@/components/ui/tooltip'
 import { getHermesConfigDefaults, getHermesConfigRecord, saveHermesConfig } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -10,6 +13,7 @@ import {
   Archive,
   BarChart3,
   Bell,
+  ChevronRight,
   Download,
   Globe,
   Info,
@@ -43,6 +47,7 @@ import { PluginsSettings } from './plugins-settings'
 import { PROVIDER_VIEWS, ProvidersSettings, type ProviderView } from './providers-settings'
 import { SessionsSettings } from './sessions-settings'
 import type { SettingsPageProps, SettingsView as SettingsViewId } from './types'
+import { useSettingsSearch } from './use-settings-search'
 
 const SETTINGS_VIEWS: readonly SettingsViewId[] = [
   ...SECTIONS.map(s => `config:${s.id}` as SettingsViewId),
@@ -61,6 +66,7 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
   const { t } = useI18n()
   const navigate = useNavigate()
   const { hash, pathname, search } = useLocation()
+  const [settingsQuery, setSettingsQuery] = useState('')
 
   // MCP moved out of Settings into Capabilities (/skills?tab=mcp). Keep old
   // `/settings?tab=mcp` deep links working — `useRouteEnumParam` would silently
@@ -82,10 +88,17 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
   const [providerView, setProviderView] = useRouteEnumParam<ProviderView>('pview', PROVIDER_VIEWS, 'accounts')
   const [keysView] = useRouteEnumParam<KeysView>('kview', KEYS_VIEWS, 'tools')
 
+  const selectActiveView = (view: SettingsViewId) => {
+    setSettingsQuery('')
+    setActiveView(view)
+  }
+
   // Jump to a section + its sub-view in one navigate. Two sequential setters
   // would each read the same stale `search` and the second would clobber the
   // first's `tab` — so the sub-view never opened on narrow screens.
   const openSubView = (tab: SettingsViewId, param: string, value: string, fallback: string) => {
+    setSettingsQuery('')
+
     const params = new URLSearchParams(search)
     params.set('tab', tab)
 
@@ -143,7 +156,7 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
         icon: s.icon,
         id: view,
         label: t.settings.sections[s.id] ?? s.label,
-        onSelect: () => setActiveView(view)
+        onSelect: () => selectActiveView(view)
       }
     }),
     {
@@ -151,14 +164,14 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
       icon: Bell,
       id: 'notifications',
       label: t.settings.nav.notifications,
-      onSelect: () => setActiveView('notifications')
+      onSelect: () => selectActiveView('notifications')
     },
     {
       active: activeView === 'billing',
       icon: BarChart3,
       id: 'billing',
       label: t.settings.nav.billing,
-      onSelect: () => setActiveView('billing')
+      onSelect: () => selectActiveView('billing')
     },
     {
       active: activeView === 'providers',
@@ -189,21 +202,21 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
       icon: Zap,
       id: 'providers',
       label: t.settings.nav.providers,
-      onSelect: () => setActiveView('providers')
+      onSelect: () => selectActiveView('providers')
     },
     {
       active: activeView === 'gateway',
       icon: Globe,
       id: 'gateway',
       label: t.settings.nav.gateway,
-      onSelect: () => setActiveView('gateway')
+      onSelect: () => selectActiveView('gateway')
     },
     {
       active: activeView === 'keybinds',
       icon: Keyboard,
       id: 'keybinds',
       label: t.settings.nav.keybinds,
-      onSelect: () => setActiveView('keybinds')
+      onSelect: () => selectActiveView('keybinds')
     },
     {
       active: activeView === 'keys',
@@ -226,21 +239,21 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
       icon: KeyRound,
       id: 'keys',
       label: t.settings.nav.apiKeys,
-      onSelect: () => setActiveView('keys')
+      onSelect: () => selectActiveView('keys')
     },
     {
       active: activeView === 'plugins',
       icon: Package,
       id: 'plugins',
       label: t.settings.nav.plugins,
-      onSelect: () => setActiveView('plugins')
+      onSelect: () => selectActiveView('plugins')
     },
     {
       active: activeView === 'sessions',
       icon: Archive,
       id: 'sessions',
       label: t.settings.nav.archivedChats,
-      onSelect: () => setActiveView('sessions')
+      onSelect: () => selectActiveView('sessions')
     },
     {
       active: activeView === 'about',
@@ -248,9 +261,76 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
       icon: Info,
       id: 'about',
       label: t.settings.nav.about,
-      onSelect: () => setActiveView('about')
+      onSelect: () => selectActiveView('about')
     }
   ]
+
+  const settingsSearch = useSettingsSearch({
+    groups: navGroups,
+    onSelect: () => setSettingsQuery(''),
+    query: settingsQuery
+  })
+
+  const searchHeader = (
+    <ScopedCommandSearch
+      busy={settingsSearch.loading}
+      emptyMessage={settingsSearch.loading ? null : t.settings.search.noResults}
+      itemClassName="grid-cols-[auto_minmax(0,1fr)_auto]"
+      items={settingsSearch.entries}
+      listClassName="min-h-0 max-h-none flex-1"
+      listHeader={
+        <>
+          {settingsSearch.error && (
+            <div
+              className="flex items-center justify-between gap-3 px-3 py-2 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)"
+              role="alert"
+            >
+              <span>{t.settings.search.catalogError}</span>
+              <Button onClick={settingsSearch.retry} size="inline" variant="textStrong">
+                {t.common.retry}
+              </Button>
+            </div>
+          )}
+          {settingsSearch.loading && (
+            <div className="flex items-center gap-2 px-3 py-2 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+              <Loader className="size-3.5" />
+              <span>{t.settings.search.loading}</span>
+            </div>
+          )}
+        </>
+      }
+      onSelect={settingsSearch.selectEntry}
+      onValueChange={setSettingsQuery}
+      placeholder={t.settings.search.placeholder}
+      popoverClassName="left-0 flex max-h-[calc(100vh-9rem)] w-[min(32rem,calc(100vw-4rem))] flex-col max-[47.5rem]:inset-x-0 max-[47.5rem]:w-auto"
+      renderItem={entry => {
+        const Icon = entry.icon
+
+        return (
+          <>
+            <Icon className="size-4 self-center text-muted-foreground" />
+            <span className="min-w-0">
+              <span className="flex min-w-0 items-baseline gap-2">
+                <span className="truncate font-medium">{entry.label}</span>
+                <span className="shrink-0 text-xs text-muted-foreground">{entry.context}</span>
+              </span>
+              {entry.description && (
+                <span className="mt-0.5 block truncate text-xs text-muted-foreground">{entry.description}</span>
+              )}
+            </span>
+            <ChevronRight className="size-4 self-center text-muted-foreground opacity-0 transition-opacity group-data-[selected=true]:opacity-100" />
+          </>
+        )
+      }}
+      resultSummary={
+        settingsSearch.loading
+          ? t.settings.search.loading
+          : t.settings.search.resultCount(settingsSearch.entries.length)
+      }
+      shouldFilter={false}
+      value={settingsQuery}
+    />
+  )
 
   const navFooter = (
     <>
@@ -283,47 +363,48 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
     </>
   )
 
+  const activeSettingsContent =
+    activeView === 'config:appearance' ? (
+      <AppearanceSettings />
+    ) : activeView === 'about' ? (
+      <AboutSettings />
+    ) : activeView === 'gateway' ? (
+      <GatewaySettings />
+    ) : activeView === 'keybinds' ? (
+      <KeybindSettings />
+    ) : activeView.startsWith('config:') ? (
+      <ConfigSettings
+        activeSectionId={activeView.slice('config:'.length)}
+        importInputRef={importInputRef}
+        onConfigSaved={onConfigSaved}
+        onMainModelChanged={onMainModelChanged}
+      />
+    ) : activeView === 'providers' ? (
+      <ProvidersSettings
+        onClose={onClose}
+        onConfigSaved={onConfigSaved}
+        onMainModelChanged={onMainModelChanged}
+        onViewChange={setProviderView}
+        view={providerView}
+      />
+    ) : activeView === 'keys' ? (
+      <KeysSettings view={keysView} />
+    ) : activeView === 'notifications' ? (
+      <NotificationsSettings />
+    ) : activeView === 'billing' ? (
+      <BillingSettings />
+    ) : activeView === 'plugins' ? (
+      <PluginsSettings />
+    ) : (
+      <SessionsSettings />
+    )
+
   return (
     <OverlayView closeLabel={t.settings.closeSettings} onClose={onClose}>
       <OverlaySplitLayout>
-        <OverlayNav footer={navFooter} groups={navGroups} />
+        <OverlayNav footer={navFooter} groups={navGroups} header={searchHeader} />
 
-        <OverlayMain className="px-0 pb-0">
-          {activeView === 'config:appearance' ? (
-            <AppearanceSettings />
-          ) : activeView === 'about' ? (
-            <AboutSettings />
-          ) : activeView === 'gateway' ? (
-            <GatewaySettings />
-          ) : activeView === 'keybinds' ? (
-            <KeybindSettings />
-          ) : activeView.startsWith('config:') ? (
-            <ConfigSettings
-              activeSectionId={activeView.slice('config:'.length)}
-              importInputRef={importInputRef}
-              onConfigSaved={onConfigSaved}
-              onMainModelChanged={onMainModelChanged}
-            />
-          ) : activeView === 'providers' ? (
-            <ProvidersSettings
-              onClose={onClose}
-              onConfigSaved={onConfigSaved}
-              onMainModelChanged={onMainModelChanged}
-              onViewChange={setProviderView}
-              view={providerView}
-            />
-          ) : activeView === 'keys' ? (
-            <KeysSettings view={keysView} />
-          ) : activeView === 'notifications' ? (
-            <NotificationsSettings />
-          ) : activeView === 'billing' ? (
-            <BillingSettings />
-          ) : activeView === 'plugins' ? (
-            <PluginsSettings />
-          ) : (
-            <SessionsSettings />
-          )}
-        </OverlayMain>
+        <OverlayMain className="px-0 pb-0 pt-[calc(var(--titlebar-height)+1rem)]">{activeSettingsContent}</OverlayMain>
       </OverlaySplitLayout>
     </OverlayView>
   )

--- a/apps/desktop/src/app/settings/keys-settings.test.tsx
+++ b/apps/desktop/src/app/settings/keys-settings.test.tsx
@@ -1,0 +1,225 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, useNavigate } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EnvVarInfo } from '@/types/hermes'
+
+const getEnvVars = vi.fn()
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+vi.mock('@/hermes', () => ({
+  deleteEnvVar: vi.fn(),
+  getEnvVars: () => getEnvVars(),
+  revealEnvVar: vi.fn(),
+  setEnvVar: vi.fn()
+}))
+
+function envVar(category: string, patch: Partial<EnvVarInfo> = {}): EnvVarInfo {
+  return {
+    advanced: false,
+    category,
+    description: '',
+    is_password: true,
+    is_set: false,
+    redacted_value: null,
+    tools: [],
+    url: '',
+    ...patch
+  }
+}
+
+beforeEach(() => {
+  getEnvVars.mockResolvedValue({})
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn()
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+async function renderKeysSettings(view: 'settings' | 'tools', route = '/settings') {
+  const { KeysSettings } = await import('./keys-settings')
+
+  await act(async () => {
+    render(
+      <MemoryRouter initialEntries={[route]}>
+        <KeysSettings view={view} />
+      </MemoryRouter>
+    )
+  })
+}
+
+function DeepLinkButton({ target }: { target: string }) {
+  const navigate = useNavigate()
+
+  return (
+    <button onClick={() => navigate(`/settings?tab=keys&key=${target}`)} type="button">
+      Open key
+    </button>
+  )
+}
+
+describe('KeysSettings scoped command search', () => {
+  it('curates tool results by label, description, env key, URL, and tool name', async () => {
+    getEnvVars.mockResolvedValue({
+      BRAVE_SEARCH_API_KEY: envVar('tool', {
+        description: 'Search the web with Brave.',
+        url: 'https://brave.com/search/api/'
+      }),
+      FIRECRAWL_API_KEY: envVar('tool', {
+        description: 'Crawl and extract websites.',
+        tools: ['browser_navigate']
+      }),
+      GATEWAY_PROXY: envVar('setting', { description: 'Gateway reverse proxy.' })
+    })
+
+    await renderKeysSettings('tools')
+
+    const search = await screen.findByRole('combobox', { name: 'Search tools…' })
+    expect(screen.getByText('BRAVE SEARCH')).toBeTruthy()
+    expect(screen.getByText('FIRECRAWL')).toBeTruthy()
+    expect(screen.queryByText('GATEWAY PROXY')).toBeNull()
+    expect(screen.queryByRole('option')).toBeNull()
+    expect(search.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.change(search, { target: { value: 'crawl and extract' } })
+    const firecrawlResult = await screen.findByRole('option', { name: /FIRECRAWL/ })
+    expect(firecrawlResult.getAttribute('data-selected')).toBe('true')
+    expect(screen.queryByRole('option', { name: /BRAVE SEARCH/ })).toBeNull()
+
+    fireEvent.change(search, { target: { value: 'brave_search_api' } })
+    expect(await screen.findByRole('option', { name: /BRAVE SEARCH/ })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: /FIRECRAWL/ })).toBeNull()
+
+    fireEvent.change(search, { target: { value: 'brave.com' } })
+    expect(await screen.findByRole('option', { name: /BRAVE SEARCH/ })).toBeTruthy()
+
+    fireEvent.change(search, { target: { value: 'browser_navigate' } })
+    expect(await screen.findByRole('option', { name: /FIRECRAWL/ })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: /BRAVE SEARCH/ })).toBeNull()
+
+    fireEvent.change(search, { target: { value: 'does-not-exist' } })
+    expect(await screen.findByText('No entries match your search.')).toBeTruthy()
+  })
+
+  it('scopes settings results and excludes channel-managed credentials', async () => {
+    getEnvVars.mockResolvedValue({
+      API_SERVER_TOKEN: envVar('setting', { description: 'Protect the local API server.' }),
+      GATEWAY_PROXY: envVar('messaging', { description: 'Gateway reverse proxy address.' }),
+      TELEGRAM_BOT_TOKEN: envVar('messaging', {
+        channel_managed: true,
+        description: 'Telegram bot token.'
+      }),
+      BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' })
+    })
+
+    await renderKeysSettings('settings')
+
+    const search = await screen.findByRole('combobox', { name: 'Search settings…' })
+    expect(screen.getByText('API SERVER')).toBeTruthy()
+    expect(screen.getByText('GATEWAY PROXY')).toBeTruthy()
+    expect(screen.queryByText('TELEGRAM BOT')).toBeNull()
+    expect(screen.queryByText('BRAVE SEARCH')).toBeNull()
+
+    fireEvent.change(search, { target: { value: 'reverse proxy' } })
+    expect(await screen.findByRole('option', { name: /GATEWAY PROXY/ })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: /API SERVER/ })).toBeNull()
+  })
+
+  it('selects a command result, then expands and highlights its credential card', async () => {
+    getEnvVars.mockResolvedValue({
+      BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' }),
+      FIRECRAWL_API_KEY: envVar('tool', {
+        description: 'Crawl and extract websites.',
+        tools: ['browser_navigate']
+      })
+    })
+
+    await renderKeysSettings('tools', '/settings?tab=keys&kview=tools')
+
+    const search = await screen.findByRole('combobox', { name: 'Search tools…' })
+    fireEvent.change(search, { target: { value: 'browser_navigate' } })
+    await screen.findByRole('option', { name: /FIRECRAWL/ })
+    fireEvent.keyDown(search, { key: 'Enter' })
+
+    await waitFor(() => expect((search as HTMLInputElement).value).toBe(''))
+    await waitFor(() => {
+      const target = globalThis.document.getElementById('credential-key-FIRECRAWL_API_KEY')
+      expect(target?.classList).toContain('setting-field-highlight')
+    })
+    expect(screen.getByText('Crawl and extract websites.')).toBeTruthy()
+  })
+
+  it('dismisses outside and reopens on focus while Escape clears the query', async () => {
+    getEnvVars.mockResolvedValue({
+      BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' })
+    })
+
+    await renderKeysSettings('tools')
+
+    const search = await screen.findByRole('combobox', { name: 'Search tools…' })
+    fireEvent.change(search, { target: { value: 'brave' } })
+    expect(await screen.findByRole('option', { name: /BRAVE SEARCH/ })).toBeTruthy()
+    expect(search.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.pointerDown(globalThis.document.body)
+    await waitFor(() => expect(search.getAttribute('aria-expanded')).toBe('false'))
+    expect((search as HTMLInputElement).value).toBe('brave')
+
+    fireEvent.focus(search)
+    await waitFor(() => expect(search.getAttribute('aria-expanded')).toBe('true'))
+    fireEvent.keyDown(search, { key: 'Escape' })
+    expect((search as HTMLInputElement).value).toBe('')
+    expect(search.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('clears the scoped query when a deep link opens a key in the active view', async () => {
+    getEnvVars.mockResolvedValue({
+      BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' }),
+      FIRECRAWL_API_KEY: envVar('tool', { description: 'Crawl and extract websites.' })
+    })
+    const { KeysSettings } = await import('./keys-settings')
+
+    render(
+      <MemoryRouter initialEntries={['/settings?tab=keys']}>
+        <KeysSettings view="tools" />
+        <DeepLinkButton target="BRAVE_SEARCH_API_KEY" />
+      </MemoryRouter>
+    )
+
+    const search = await screen.findByRole('combobox', { name: 'Search tools…' })
+    fireEvent.change(search, { target: { value: 'firecrawl' } })
+    expect(await screen.findByRole('option', { name: /FIRECRAWL/ })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open key' }))
+
+    await waitFor(() => expect((search as HTMLInputElement).value).toBe(''))
+    expect(await screen.findByText('Search the web with Brave.')).toBeTruthy()
+  })
+
+  it('does not clear a query for a deep link owned by the other sub-view', async () => {
+    getEnvVars.mockResolvedValue({
+      BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search the web with Brave.' }),
+      GATEWAY_PROXY: envVar('setting', { description: 'Gateway reverse proxy address.' })
+    })
+
+    await renderKeysSettings('settings', '/settings?tab=keys&kview=settings&key=BRAVE_SEARCH_API_KEY')
+
+    const search = await screen.findByRole('combobox', { name: 'Search settings…' })
+    fireEvent.change(search, { target: { value: 'reverse proxy' } })
+
+    expect((search as HTMLInputElement).value).toBe('reverse proxy')
+    expect(await screen.findByRole('option', { name: /GATEWAY PROXY/ })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/settings/keys-settings.tsx
+++ b/apps/desktop/src/app/settings/keys-settings.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 
+import { ScopedCommandSearch, type ScopedCommandSearchItem } from '@/components/ui/scoped-command-search'
 import { useI18n } from '@/i18n'
-import type { EnvVarInfo } from '@/types/hermes'
 
 import { CredentialKeyCard, credentialPlaceholder, credentialRowLabel } from './credential-key-ui'
 import { useEnvCredentials } from './env-credentials'
@@ -28,73 +29,127 @@ const VIEW_CATEGORIES: Record<KeysView, readonly string[]> = {
   tools: ['tool']
 }
 
+const credentialElementId = (key: string) => `credential-key-${key}`
+
 export function KeysSettings({ view }: KeysSettingsProps) {
   const { t } = useI18n()
   const { rowProps, vars } = useEnvCredentials()
+  const [, setSearchParams] = useSearchParams()
   const [openKey, setOpenKey] = useState<null | string>(null)
+  const [query, setQuery] = useState('')
 
   useEffect(() => {
     setOpenKey(null)
+    setQuery('')
   }, [view])
 
-  // Deep link from Capabilities env-var rows (?tab=keys&key=<ENV_KEY>): scroll
-  // the credential card into view, flash it, and expand it. Same mechanism the
-  // command palette uses for config fields / archived sessions.
-  useDeepLinkHighlight({
-    elementId: key => `credential-key-${key}`,
-    onResolve: key => setOpenKey(key),
-    param: 'key',
-    ready: key => Boolean(vars && key in vars)
-  })
-
-  const groups = useMemo(() => {
+  const entries = useMemo(() => {
     if (!vars) {
       return []
     }
 
-    return KEYS_VIEWS.flatMap(v => {
-      const cats = VIEW_CATEGORIES[v]
+    const cats = VIEW_CATEGORIES[view]
 
-      const entries = Object.entries(vars)
-        .filter(([, info]) => !info.channel_managed && cats.includes(asText(info.category)))
-        .sort(([a], [b]) => a.localeCompare(b))
+    return Object.entries(vars)
+      .filter(([, info]) => !info.channel_managed && cats.includes(asText(info.category)))
+      .sort(([a], [b]) => a.localeCompare(b))
+  }, [vars, view])
 
-      return entries.length === 0 ? [] : [{ category: v, entries }]
-    })
-  }, [vars])
+  const searchItems = useMemo<ScopedCommandSearchItem[]>(
+    () =>
+      entries.map(([key, info]) => ({
+        description: info.description?.trim() || key,
+        id: key,
+        keywords: [
+          key,
+          asText(info.description),
+          asText(info.url),
+          ...(Array.isArray(info.tools) ? info.tools.map(asText) : [])
+        ].filter(Boolean),
+        label: credentialRowLabel(key, info)
+      })),
+    [entries]
+  )
+
+  const renderableKeys = useMemo(() => new Set(entries.map(([key]) => key)), [entries])
+
+  const resolveDeepLink = useCallback((key: string) => {
+    setQuery('')
+    setOpenKey(key)
+  }, [])
+
+  const deepLinkReady = useCallback((key: string) => renderableKeys.has(key), [renderableKeys])
+
+  const selectSearchResult = useCallback(
+    (item: ScopedCommandSearchItem) => {
+      setQuery('')
+      setSearchParams(
+        previous => {
+          const next = new URLSearchParams(previous)
+          next.set('key', item.id)
+
+          return next
+        },
+        { replace: true }
+      )
+    },
+    [setSearchParams]
+  )
+
+  // Deep link from Capabilities env-var rows (?tab=keys&key=<ENV_KEY>): scroll
+  // the credential card into view, flash it, and expand it. Only consume keys
+  // rendered by this sub-view so a stale Tools/Settings pairing cannot keep
+  // clearing the user's search while the target remains impossible to mount.
+  useDeepLinkHighlight({
+    elementId: credentialElementId,
+    onResolve: resolveDeepLink,
+    param: 'key',
+    ready: deepLinkReady
+  })
 
   if (!vars) {
-    return <SettingsSkeleton sections={[{ rows: 5 }]} />
+    return <SettingsSkeleton search sections={[{ rows: 5 }]} />
   }
 
-  const visible = groups.filter(g => g.category === view)
+  const searchLabel = view === 'tools' ? t.settings.keys.searchTools : t.settings.keys.searchSettings
 
   return (
     <SettingsContent>
-      {visible.map(group => (
-        <div className="grid gap-2" key={group.category}>
-          {group.entries.map(([key, info]: [string, EnvVarInfo]) => {
-            const label = credentialRowLabel(key, info)
+      {entries.length > 0 ? (
+        <>
+          <div className="pb-3">
+            <ScopedCommandSearch
+              emptyMessage={t.settings.keys.noMatch}
+              items={searchItems}
+              onSelect={selectSearchResult}
+              onValueChange={setQuery}
+              placeholder={searchLabel}
+              value={query}
+            />
+          </div>
 
-            return (
-              <div className="scroll-mt-6 rounded-[6px]" id={`credential-key-${key}`} key={key}>
-                <CredentialKeyCard
-                  expanded={openKey === key}
-                  info={info}
-                  label={label}
-                  onExpand={() => setOpenKey(key)}
-                  onToggle={() => setOpenKey(prev => (prev === key ? null : key))}
-                  placeholder={credentialPlaceholder(key, info, label)}
-                  rowProps={rowProps}
-                  varKey={key}
-                />
-              </div>
-            )
-          })}
-        </div>
-      ))}
+          <div className="grid gap-2">
+            {entries.map(([key, info]) => {
+              const label = credentialRowLabel(key, info)
 
-      {visible.length === 0 && (
+              return (
+                <div className="scroll-mt-6 rounded-[6px]" id={`credential-key-${key}`} key={key}>
+                  <CredentialKeyCard
+                    expanded={openKey === key}
+                    info={info}
+                    label={label}
+                    onExpand={() => setOpenKey(key)}
+                    onToggle={() => setOpenKey(prev => (prev === key ? null : key))}
+                    placeholder={credentialPlaceholder(key, info, label)}
+                    rowProps={rowProps}
+                    varKey={key}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        </>
+      ) : (
         <div className="rounded-lg border border-dashed border-(--ui-stroke-tertiary) px-4 py-8 text-center text-[length:var(--conversation-caption-font-size)] text-muted-foreground">
           {t.settings.keys.empty}
         </div>

--- a/apps/desktop/src/app/settings/primitives.tsx
+++ b/apps/desktop/src/app/settings/primitives.tsx
@@ -111,6 +111,7 @@ export function ListRow({
   hint,
   action,
   below,
+  id,
   wide = false,
   className
 }: {
@@ -119,6 +120,7 @@ export function ListRow({
   hint?: ReactNode
   action?: ReactNode
   below?: ReactNode
+  id?: string
   wide?: boolean
   className?: string
 }) {
@@ -126,7 +128,7 @@ export function ListRow({
     // Container-queried, not viewport-queried: the label/control split keys on
     // the row's own pane width, so a narrow detail column (messaging, split
     // views) stacks instead of squishing the label against minmax(15rem,…).
-    <div className={cn('@container', className)}>
+    <div className={cn('@container', className)} id={id}>
       <div
         className={cn(
           'grid gap-3 py-3',

--- a/apps/desktop/src/app/settings/settings-search.test.ts
+++ b/apps/desktop/src/app/settings/settings-search.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+
+import { Settings2, Wrench } from '@/lib/icons'
+import type { ConfigFieldSchema, EnvVarInfo, HermesConfigRecord } from '@/types/hermes'
+
+import {
+  buildConfigSearchEntries,
+  buildCredentialSearchEntries,
+  credentialSettingsView,
+  filterSettingsSearchEntries
+} from './settings-search'
+
+function envVar(category: string, patch: Partial<EnvVarInfo> = {}): EnvVarInfo {
+  return {
+    advanced: false,
+    category,
+    description: '',
+    is_password: true,
+    is_set: false,
+    redacted_value: null,
+    tools: [],
+    url: '',
+    ...patch
+  }
+}
+
+const searchCopy = {
+  fieldDescriptions: {
+    'display.personality': 'Choose how Hermes sounds in conversation.',
+    'tts.edge.voice': 'Voice used by Edge TTS.'
+  },
+  fieldLabels: {
+    'display.personality': 'Personality',
+    'tts.edge.voice': 'Edge voice',
+    'tts.openai.voice': 'OpenAI voice'
+  },
+  sections: {
+    chat: 'Chat',
+    voice: 'Voice'
+  }
+}
+
+describe('settings search index', () => {
+  it('builds config results from renderable schema fields with exact deep links', () => {
+    const schema: Record<string, ConfigFieldSchema> = {
+      'display.personality': { type: 'select' },
+      'tts.edge.voice': { type: 'string' },
+      'tts.openai.voice': { type: 'string' }
+    }
+
+    const config = {
+      display: { personality: 'default' },
+      tts: { provider: 'edge', edge: { voice: '' }, openai: { voice: '' } }
+    } as unknown as HermesConfigRecord
+
+    const entries = buildConfigSearchEntries(schema, config, searchCopy)
+
+    expect(entries.map(entry => entry.id)).toEqual([
+      'config-field:display.personality',
+      'config-field:tts.provider',
+      'config-field:tts.edge.voice'
+    ])
+    expect(entries[0]).toMatchObject({
+      context: 'Chat',
+      description: 'Choose how Hermes sounds in conversation.',
+      label: 'Personality',
+      target: { field: 'display.personality', view: 'config:chat' }
+    })
+    expect(entries.some(entry => entry.id === 'config-field:tts.openai.voice')).toBe(false)
+  })
+
+  it('discovers future tool and setting entries entirely from backend metadata', () => {
+    const vars = {
+      FUTURE_CRAWLER_API_KEY: envVar('tool', {
+        description: 'Fetch structured pages from a new crawler.',
+        tools: ['future_crawl'],
+        url: 'https://future.example/keys'
+      }),
+      FUTURE_GATEWAY_URL: envVar('setting', { description: 'Route gateway traffic.' }),
+      TELEGRAM_BOT_TOKEN: envVar('messaging', { channel_managed: true }),
+      MODEL_PROVIDER_API_KEY: envVar('provider')
+    }
+
+    const entries = buildCredentialSearchEntries(
+      vars,
+      { settings: 'Settings', tools: 'Tools' },
+      { settings: Settings2, tools: Wrench }
+    )
+
+    expect(entries.map(entry => entry.id)).toEqual([
+      'credential:FUTURE_CRAWLER_API_KEY',
+      'credential:FUTURE_GATEWAY_URL'
+    ])
+    expect(entries[0]).toMatchObject({
+      context: 'Tools',
+      label: 'FUTURE CRAWLER',
+      target: { key: 'FUTURE_CRAWLER_API_KEY', keysView: 'tools', view: 'keys' }
+    })
+    expect(filterSettingsSearchEntries(entries, 'structured crawler')).toHaveLength(1)
+    expect(filterSettingsSearchEntries(entries, 'future_crawl')[0]?.id).toBe('credential:FUTURE_CRAWLER_API_KEY')
+    expect(filterSettingsSearchEntries(entries, 'gateway traffic')[0]?.id).toBe('credential:FUTURE_GATEWAY_URL')
+  })
+
+  it('shares the Tools and Settings category boundary with the rendered page', () => {
+    expect(credentialSettingsView(envVar('tool'))).toBe('tools')
+    expect(credentialSettingsView(envVar('setting'))).toBe('settings')
+    expect(credentialSettingsView(envVar('messaging'))).toBe('settings')
+    expect(credentialSettingsView(envVar('messaging', { channel_managed: true }))).toBeNull()
+    expect(credentialSettingsView(envVar('provider'))).toBeNull()
+  })
+
+  it('uses AND matching across labels, context, descriptions, and raw keys', () => {
+    const entries = buildCredentialSearchEntries(
+      {
+        BRAVE_SEARCH_API_KEY: envVar('tool', { description: 'Search public web pages.' }),
+        FIRECRAWL_API_KEY: envVar('tool', { description: 'Extract public web pages.' })
+      },
+      { settings: 'Settings', tools: 'Tools' },
+      { settings: Settings2, tools: Wrench }
+    )
+
+    expect(filterSettingsSearchEntries(entries, 'brave tools')[0]?.id).toBe('credential:BRAVE_SEARCH_API_KEY')
+    expect(filterSettingsSearchEntries(entries, 'firecrawl extract')[0]?.id).toBe('credential:FIRECRAWL_API_KEY')
+    expect(filterSettingsSearchEntries(entries, 'brave extract')).toEqual([])
+  })
+})

--- a/apps/desktop/src/app/settings/settings-search.ts
+++ b/apps/desktop/src/app/settings/settings-search.ts
@@ -1,0 +1,194 @@
+import type { IconComponent } from '@/lib/icons'
+import { normalize } from '@/lib/text'
+import type { ConfigFieldSchema, EnvVarInfo, HermesConfigRecord } from '@/types/hermes'
+
+import { FIELD_LABELS, SECTIONS } from './constants'
+import { credentialRowLabel } from './credential-key-ui'
+import { fieldCopyForSchemaKey } from './field-copy'
+import { prettyName, sectionFieldEntries, voiceFieldVisible } from './helpers'
+import type { DesktopConfigSection, SettingsView } from './types'
+
+export type CredentialSettingsView = 'settings' | 'tools'
+
+export const APPEARANCE_SETTING_IDS = {
+  backdrop: 'appearance.backdrop',
+  embeds: 'appearance.embeds',
+  language: 'appearance.language',
+  theme: 'appearance.theme',
+  toolView: 'appearance.tool-view',
+  translucency: 'appearance.translucency',
+  uiScale: 'appearance.ui-scale'
+} as const
+
+export interface SettingsSearchTarget {
+  field?: string
+  key?: string
+  keysView?: CredentialSettingsView
+  providerView?: 'accounts' | 'custom-endpoints' | 'keys'
+  setting?: string
+  view: SettingsView
+}
+
+export interface SettingsSearchEntry {
+  context: string
+  description?: string
+  icon: IconComponent
+  id: string
+  keywords: string[]
+  label: string
+  target: SettingsSearchTarget
+}
+
+interface ConfigSearchCopy {
+  fieldDescriptions: Record<string, string>
+  fieldLabels: Record<string, string>
+  sections: Record<string, string>
+}
+
+interface CredentialSearchCopy {
+  settings: string
+  tools: string
+}
+
+export function credentialSettingsView(info: EnvVarInfo): CredentialSettingsView | null {
+  if (info.channel_managed) {
+    return null
+  }
+
+  if (info.category === 'tool') {
+    return 'tools'
+  }
+
+  if (info.category === 'setting' || info.category === 'messaging') {
+    return 'settings'
+  }
+
+  return null
+}
+
+function configFieldLabel(key: string, copy: ConfigSearchCopy): string {
+  return (
+    fieldCopyForSchemaKey(copy.fieldLabels, key) ??
+    fieldCopyForSchemaKey(FIELD_LABELS, key) ??
+    prettyName(key.split('.').pop() ?? key)
+  )
+}
+
+function configFieldDescription(key: string, field: ConfigFieldSchema, copy: ConfigSearchCopy): string {
+  return fieldCopyForSchemaKey(copy.fieldDescriptions, key) ?? field.description ?? ''
+}
+
+export function buildConfigSearchEntries(
+  schema: Record<string, ConfigFieldSchema> | null | undefined,
+  config: HermesConfigRecord | null | undefined,
+  copy: ConfigSearchCopy,
+  sections: DesktopConfigSection[] = SECTIONS
+): SettingsSearchEntry[] {
+  if (!schema || !config) {
+    return []
+  }
+
+  const sectionFields = sectionFieldEntries(schema, config)
+
+  return sections.flatMap(section => {
+    const context = copy.sections[section.id] ?? section.label
+    const fields = sectionFields.get(section.id) ?? []
+    const visibleFields = section.id === 'voice' ? fields.filter(([key]) => voiceFieldVisible(key, config)) : fields
+
+    return visibleFields.map(([key, field]) => ({
+      context,
+      description: configFieldDescription(key, field, copy),
+      icon: section.icon,
+      id: `config-field:${key}`,
+      keywords: ['settings', section.id, section.label, key],
+      label: configFieldLabel(key, copy),
+      target: {
+        field: key,
+        view: `config:${section.id}` as SettingsView
+      }
+    }))
+  })
+}
+
+export function buildCredentialSearchEntries(
+  vars: Record<string, EnvVarInfo> | null | undefined,
+  copy: CredentialSearchCopy,
+  icons: Record<CredentialSettingsView, IconComponent>
+): SettingsSearchEntry[] {
+  if (!vars) {
+    return []
+  }
+
+  return Object.entries(vars)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .flatMap(([key, info]) => {
+      const view = credentialSettingsView(info)
+
+      if (!view) {
+        return []
+      }
+
+      return [
+        {
+          context: view === 'tools' ? copy.tools : copy.settings,
+          description: info.description || undefined,
+          icon: icons[view],
+          id: `credential:${key}`,
+          keywords: [key, info.url ?? '', ...(Array.isArray(info.tools) ? info.tools : [])],
+          label: credentialRowLabel(key, info),
+          target: {
+            key,
+            keysView: view,
+            view: 'keys' as const
+          }
+        }
+      ]
+    })
+}
+
+function searchScore(entry: SettingsSearchEntry, query: string): number {
+  const needle = normalize(query)
+
+  if (!needle) {
+    return 0
+  }
+
+  const label = normalize(entry.label)
+  const context = normalize(entry.context)
+  const haystack = normalize([entry.label, entry.context, entry.description ?? '', ...entry.keywords].join(' '))
+  const terms = needle.split(/\s+/).filter(Boolean)
+
+  if (!terms.every(term => haystack.includes(term))) {
+    return 0
+  }
+
+  if (label === needle) {
+    return 100
+  }
+
+  if (label.startsWith(needle)) {
+    return 90
+  }
+
+  if (label.includes(needle)) {
+    return 80
+  }
+
+  if (context.includes(needle)) {
+    return 70
+  }
+
+  if (terms.every(term => label.includes(term) || context.includes(term))) {
+    return 60
+  }
+
+  return 50
+}
+
+export function filterSettingsSearchEntries(entries: SettingsSearchEntry[], query: string): SettingsSearchEntry[] {
+  return entries
+    .map((entry, index) => ({ entry, index, score: searchScore(entry, query) }))
+    .filter(result => result.score > 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map(result => result.entry)
+}

--- a/apps/desktop/src/app/settings/use-deep-link-highlight.ts
+++ b/apps/desktop/src/app/settings/use-deep-link-highlight.ts
@@ -47,6 +47,12 @@ export function useDeepLinkHighlight({
 
       if (element) {
         element.scrollIntoView({ behavior: 'smooth', block })
+
+        if (!element.hasAttribute('tabindex')) {
+          element.tabIndex = -1
+        }
+
+        element.focus({ preventScroll: true })
         element.classList.add('setting-field-highlight')
         window.setTimeout(() => element.classList.remove('setting-field-highlight'), 1600)
 

--- a/apps/desktop/src/app/settings/use-settings-search.ts
+++ b/apps/desktop/src/app/settings/use-settings-search.ts
@@ -1,0 +1,252 @@
+import { useQuery } from '@tanstack/react-query'
+import { useCallback } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import { getEnvVars, getHermesConfigSchema } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { Palette, Settings2, Wrench } from '@/lib/icons'
+import { normalize } from '@/lib/text'
+
+import { useHermesConfigRecord } from '../hooks/use-config-record'
+import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
+import type { OverlayNavGroup } from '../overlays/overlay-split-layout'
+
+import {
+  APPEARANCE_SETTING_IDS,
+  buildConfigSearchEntries,
+  buildCredentialSearchEntries,
+  filterSettingsSearchEntries,
+  type SettingsSearchEntry,
+  type SettingsSearchTarget
+} from './settings-search'
+import type { SettingsView as SettingsViewId } from './types'
+
+// Bespoke pages do not expose config-schema fields, so aliases make their
+// important controls discoverable without pretending they have field targets.
+const SETTINGS_PAGE_ALIASES: Record<string, string[]> = {
+  'pview:accounts': ['oauth', 'login', 'sign in', 'subscription'],
+  'pview:custom-endpoints': ['local model', 'ollama', 'vllm', 'openai compatible'],
+  'pview:keys': ['api key', 'token', 'secret'],
+  about: ['version', 'update'],
+  billing: ['balance', 'plan', 'credits', 'subscription'],
+  gateway: ['connection', 'remote', 'cloud'],
+  keybinds: ['keyboard', 'shortcut', 'hotkey'],
+  notifications: ['alerts', 'sound'],
+  plugins: ['extension', 'addon'],
+  sessions: ['archive', 'history']
+}
+
+function navSearchTarget(id: string): SettingsSearchTarget {
+  if (id.startsWith('pview:')) {
+    return { providerView: id.slice('pview:'.length) as SettingsSearchTarget['providerView'], view: 'providers' }
+  }
+
+  if (id.startsWith('kview:')) {
+    return { keysView: id.slice('kview:'.length) as SettingsSearchTarget['keysView'], view: 'keys' }
+  }
+
+  return { view: id as SettingsViewId }
+}
+
+export function useSettingsSearch({ groups, onSelect, query }: UseSettingsSearchOptions) {
+  const { t } = useI18n()
+  const navigate = useNavigate()
+  const { hash, pathname, search } = useLocation()
+  const configQuery = useHermesConfigRecord()
+
+  const schemaQuery = useQuery({
+    queryKey: ['hermes-config-schema'],
+    queryFn: getHermesConfigSchema,
+    staleTime: 5 * 60 * 1000
+  })
+
+  const {
+    data: envVars,
+    isError: envVarsError,
+    isFetching: envVarsFetching,
+    refetch: refetchEnvVars
+  } = useQuery({
+    queryKey: ['desktop-settings-search-env-vars'],
+    queryFn: getEnvVars,
+    staleTime: 5 * 60 * 1000
+  })
+
+  const refreshCatalog = useCallback(() => {
+    void refetchEnvVars()
+  }, [refetchEnvVars])
+
+  useOnProfileSwitch(refreshCatalog)
+
+  const pageEntries: SettingsSearchEntry[] = groups.flatMap(group => [
+    {
+      context: t.settings.search.root,
+      icon: group.icon,
+      id: `page:${group.id}`,
+      keywords: SETTINGS_PAGE_ALIASES[group.id] ?? [],
+      label: group.label,
+      target: navSearchTarget(group.id)
+    },
+    ...(group.children ?? []).map(child => ({
+      context: group.label,
+      icon: child.icon,
+      id: `page:${child.id}`,
+      keywords: SETTINGS_PAGE_ALIASES[child.id] ?? [],
+      label: child.label,
+      target: navSearchTarget(child.id)
+    }))
+  ])
+
+  // Never expose stale profile-scoped targets while a catalog is refreshing.
+  // Page destinations remain available, but field/key results wait for the
+  // current profile's data rather than briefly pointing into the previous one.
+  const configEntries =
+    configQuery.isFetching || schemaQuery.isFetching || configQuery.isError || schemaQuery.isError
+      ? []
+      : buildConfigSearchEntries(schemaQuery.data?.fields, configQuery.data, {
+          fieldDescriptions: t.settings.fieldDescriptions,
+          fieldLabels: t.settings.fieldLabels,
+          sections: t.settings.sections
+        })
+
+  const appearanceContext = t.settings.sections.appearance
+  const appearance = t.settings.appearance
+
+  const appearanceEntries: SettingsSearchEntry[] = [
+    {
+      context: appearanceContext,
+      description: t.language.description,
+      icon: Palette,
+      id: `setting:${APPEARANCE_SETTING_IDS.language}`,
+      keywords: ['locale'],
+      label: t.language.label,
+      target: { setting: APPEARANCE_SETTING_IDS.language, view: 'config:appearance' }
+    },
+    {
+      context: appearanceContext,
+      description: appearance.themeDesc,
+      icon: Palette,
+      id: `setting:${APPEARANCE_SETTING_IDS.theme}`,
+      keywords: ['color mode', 'skin'],
+      label: appearance.themeTitle,
+      target: { setting: APPEARANCE_SETTING_IDS.theme, view: 'config:appearance' }
+    },
+    {
+      context: appearanceContext,
+      icon: Palette,
+      id: `setting:${APPEARANCE_SETTING_IDS.uiScale}`,
+      keywords: ['zoom', 'size'],
+      label: appearance.uiScaleTitle,
+      target: { setting: APPEARANCE_SETTING_IDS.uiScale, view: 'config:appearance' }
+    },
+    {
+      context: appearanceContext,
+      description: appearance.translucencyDesc,
+      icon: Palette,
+      id: `setting:${APPEARANCE_SETTING_IDS.translucency}`,
+      keywords: ['opacity', 'transparent'],
+      label: appearance.translucencyTitle,
+      target: { setting: APPEARANCE_SETTING_IDS.translucency, view: 'config:appearance' }
+    },
+    {
+      context: appearanceContext,
+      description: appearance.backdropDesc,
+      icon: Palette,
+      id: `setting:${APPEARANCE_SETTING_IDS.backdrop}`,
+      keywords: ['background', 'blur'],
+      label: appearance.backdropTitle,
+      target: { setting: APPEARANCE_SETTING_IDS.backdrop, view: 'config:appearance' }
+    },
+    {
+      context: appearanceContext,
+      description: appearance.toolViewDesc,
+      icon: Palette,
+      id: `setting:${APPEARANCE_SETTING_IDS.toolView}`,
+      keywords: ['tool display', 'technical'],
+      label: appearance.toolViewTitle,
+      target: { setting: APPEARANCE_SETTING_IDS.toolView, view: 'config:appearance' }
+    },
+    {
+      context: appearanceContext,
+      description: appearance.embedsDesc,
+      icon: Palette,
+      id: `setting:${APPEARANCE_SETTING_IDS.embeds}`,
+      keywords: ['external content', 'privacy'],
+      label: appearance.embedsTitle,
+      target: { setting: APPEARANCE_SETTING_IDS.embeds, view: 'config:appearance' }
+    }
+  ]
+
+  const credentialEntries = buildCredentialSearchEntries(
+    envVarsFetching || envVarsError ? null : envVars,
+    {
+      settings: t.settings.nav.keysSettings,
+      tools: t.settings.nav.keysTools
+    },
+    { settings: Settings2, tools: Wrench }
+  )
+
+  const normalizedQuery = normalize(query)
+
+  const entries = filterSettingsSearchEntries(
+    [...pageEntries, ...appearanceEntries, ...configEntries, ...credentialEntries],
+    query
+  )
+
+  const loading = Boolean(normalizedQuery) && (configQuery.isFetching || schemaQuery.isFetching || envVarsFetching)
+  const error = configQuery.isError || schemaQuery.isError || envVarsError
+
+  const retry = () => {
+    void configQuery.refetch()
+    void schemaQuery.refetch()
+    void refetchEnvVars()
+  }
+
+  const selectEntry = (entry: SettingsSearchEntry) => {
+    const params = new URLSearchParams(search)
+    const target = entry.target
+
+    for (const param of ['field', 'key', 'kview', 'pview', 'setting']) {
+      params.delete(param)
+    }
+
+    params.set('tab', target.view)
+
+    if (target.providerView) {
+      params.set('pview', target.providerView)
+    }
+
+    if (target.keysView) {
+      params.set('kview', target.keysView)
+    }
+
+    if (target.field) {
+      params.set('field', target.field)
+    }
+
+    if (target.setting) {
+      params.set('setting', target.setting)
+    }
+
+    if (target.key) {
+      params.set('key', target.key)
+    }
+
+    const qs = params.toString()
+    navigate({ hash, pathname, search: qs ? `?${qs}` : '' }, { replace: true })
+    onSelect()
+  }
+
+  return {
+    entries,
+    error,
+    loading,
+    retry,
+    selectEntry
+  }
+}
+
+interface UseSettingsSearchOptions {
+  groups: OverlayNavGroup[]
+  onSelect: () => void
+  query: string
+}

--- a/apps/desktop/src/app/settings/voice-field-visible.test.ts
+++ b/apps/desktop/src/app/settings/voice-field-visible.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { HermesConfigRecord } from '@/types/hermes'
 
-import { voiceFieldVisible } from './config-settings'
+import { voiceFieldVisible } from './helpers'
 
 const cfg = (over: Record<string, unknown> = {}): HermesConfigRecord =>
   ({

--- a/apps/desktop/src/components/ui/scoped-command-search.tsx
+++ b/apps/desktop/src/components/ui/scoped-command-search.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
+import { ChevronRight } from '@/lib/icons'
+
+export interface ScopedCommandSearchItem {
+  description?: string
+  id: string
+  keywords?: string[]
+  label: string
+}
+
+/**
+ * Embeddable cmdk search whose caller owns the catalog and destination.
+ * Passing only the current pane's items keeps results scoped without teaching
+ * this component about settings, credentials, or routes.
+ */
+export function ScopedCommandSearch({
+  emptyMessage,
+  items,
+  onSelect,
+  onValueChange,
+  placeholder,
+  value
+}: ScopedCommandSearchProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const [dismissed, setDismissed] = useState(false)
+  const open = Boolean(value.trim()) && !dismissed
+
+  useLayoutEffect(() => {
+    inputRef.current?.setAttribute('aria-expanded', String(open))
+  }, [open])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const dismissOutside = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setDismissed(true)
+      }
+    }
+
+    globalThis.document.addEventListener('pointerdown', dismissOutside)
+
+    return () => globalThis.document.removeEventListener('pointerdown', dismissOutside)
+  }, [open])
+
+  const updateValue = (next: string) => {
+    setDismissed(false)
+    onValueChange(next)
+  }
+
+  return (
+    <Command
+      className="relative h-auto overflow-visible rounded-none bg-transparent"
+      label={placeholder}
+      loop
+      ref={rootRef}
+    >
+      <CommandInput
+        aria-expanded={open}
+        aria-label={placeholder}
+        className="text-xs"
+        onBlur={() => {
+          globalThis.requestAnimationFrame(() => {
+            if (!rootRef.current?.contains(globalThis.document.activeElement)) {
+              setDismissed(true)
+            }
+          })
+        }}
+        onFocus={() => setDismissed(false)}
+        onKeyDown={event => {
+          if (event.key === 'Escape' && open) {
+            event.preventDefault()
+            event.stopPropagation()
+            updateValue('')
+          }
+        }}
+        onValueChange={updateValue}
+        placeholder={placeholder}
+        ref={inputRef}
+        value={value}
+      />
+
+      <CommandList
+        className="dt-portal-scrollbar absolute inset-x-0 top-full z-30 mt-1 max-h-64 rounded-[6px] border border-border bg-popover p-1 shadow-nous"
+        hidden={!open}
+      >
+        <CommandEmpty>{emptyMessage}</CommandEmpty>
+        <CommandGroup className="p-0">
+          {open &&
+            items.map(item => (
+              <CommandItem
+                className="group grid grid-cols-[minmax(0,1fr)_auto] gap-3 px-3 py-2.5"
+                key={item.id}
+                keywords={item.keywords}
+                onSelect={() => onSelect(item)}
+                value={`${item.label}\u0001${item.id}`}
+              >
+                <span className="min-w-0">
+                  <span className="block truncate font-medium">{item.label}</span>
+                  <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                    {item.description || item.id}
+                  </span>
+                </span>
+                <ChevronRight className="size-4 self-center text-muted-foreground opacity-0 transition-opacity group-data-[selected=true]:opacity-100" />
+              </CommandItem>
+            ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}
+
+interface ScopedCommandSearchProps {
+  emptyMessage: string
+  items: ScopedCommandSearchItem[]
+  onSelect: (item: ScopedCommandSearchItem) => void
+  onValueChange: (value: string) => void
+  placeholder: string
+  value: string
+}

--- a/apps/desktop/src/components/ui/scoped-command-search.tsx
+++ b/apps/desktop/src/components/ui/scoped-command-search.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
 import { ChevronRight } from '@/lib/icons'
@@ -15,14 +15,22 @@ export interface ScopedCommandSearchItem {
  * Passing only the current pane's items keeps results scoped without teaching
  * this component about settings, credentials, or routes.
  */
-export function ScopedCommandSearch({
+export function ScopedCommandSearch<T extends ScopedCommandSearchItem>({
+  busy = false,
   emptyMessage,
   items,
+  itemClassName = 'grid-cols-[minmax(0,1fr)_auto]',
+  listClassName = 'max-h-64',
+  listHeader,
   onSelect,
   onValueChange,
   placeholder,
+  popoverClassName = 'inset-x-0',
+  renderItem,
+  resultSummary,
+  shouldFilter = true,
   value
-}: ScopedCommandSearchProps) {
+}: ScopedCommandSearchProps<T>) {
   const inputRef = useRef<HTMLInputElement>(null)
   const rootRef = useRef<HTMLDivElement>(null)
   const [dismissed, setDismissed] = useState(false)
@@ -59,6 +67,7 @@ export function ScopedCommandSearch({
       label={placeholder}
       loop
       ref={rootRef}
+      shouldFilter={shouldFilter}
     >
       <CommandInput
         aria-expanded={open}
@@ -85,41 +94,63 @@ export function ScopedCommandSearch({
         value={value}
       />
 
-      <CommandList
-        className="dt-portal-scrollbar absolute inset-x-0 top-full z-30 mt-1 max-h-64 rounded-[6px] border border-border bg-popover p-1 shadow-nous"
+      <div
+        className={`absolute top-full z-30 mt-1 rounded-[6px] border border-border bg-popover shadow-nous ${popoverClassName}`}
         hidden={!open}
       >
-        <CommandEmpty>{emptyMessage}</CommandEmpty>
-        <CommandGroup className="p-0">
-          {open &&
-            items.map(item => (
-              <CommandItem
-                className="group grid grid-cols-[minmax(0,1fr)_auto] gap-3 px-3 py-2.5"
-                key={item.id}
-                keywords={item.keywords}
-                onSelect={() => onSelect(item)}
-                value={`${item.label}\u0001${item.id}`}
-              >
-                <span className="min-w-0">
-                  <span className="block truncate font-medium">{item.label}</span>
-                  <span className="mt-0.5 block truncate text-xs text-muted-foreground">
-                    {item.description || item.id}
-                  </span>
-                </span>
-                <ChevronRight className="size-4 self-center text-muted-foreground opacity-0 transition-opacity group-data-[selected=true]:opacity-100" />
-              </CommandItem>
-            ))}
-        </CommandGroup>
-      </CommandList>
+        {resultSummary && (
+          <p aria-live="polite" className="sr-only" role="status">
+            {resultSummary}
+          </p>
+        )}
+        {listHeader}
+        <CommandList aria-busy={busy} className={`dt-portal-scrollbar p-1 ${listClassName}`}>
+          {emptyMessage && <CommandEmpty>{emptyMessage}</CommandEmpty>}
+          <CommandGroup className="p-0">
+            {open &&
+              items.map(item => (
+                <CommandItem
+                  className={`group grid gap-3 px-3 py-2.5 ${itemClassName}`}
+                  key={item.id}
+                  keywords={item.keywords}
+                  onSelect={() => onSelect(item)}
+                  value={`${item.label}\u0001${item.id}`}
+                >
+                  {renderItem ? (
+                    renderItem(item)
+                  ) : (
+                    <>
+                      <span className="min-w-0">
+                        <span className="block truncate font-medium">{item.label}</span>
+                        <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                          {item.description || item.id}
+                        </span>
+                      </span>
+                      <ChevronRight className="size-4 self-center text-muted-foreground opacity-0 transition-opacity group-data-[selected=true]:opacity-100" />
+                    </>
+                  )}
+                </CommandItem>
+              ))}
+          </CommandGroup>
+        </CommandList>
+      </div>
     </Command>
   )
 }
 
-interface ScopedCommandSearchProps {
-  emptyMessage: string
-  items: ScopedCommandSearchItem[]
-  onSelect: (item: ScopedCommandSearchItem) => void
+interface ScopedCommandSearchProps<T extends ScopedCommandSearchItem> {
+  busy?: boolean
+  emptyMessage: ReactNode
+  itemClassName?: string
+  items: T[]
+  listClassName?: string
+  listHeader?: ReactNode
+  onSelect: (item: T) => void
   onValueChange: (value: string) => void
   placeholder: string
+  popoverClassName?: string
+  renderItem?: (item: T) => ReactNode
+  resultSummary?: string
+  shouldFilter?: boolean
   value: string
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -703,7 +703,10 @@ export const en: Translations = {
     keys: {
       loading: 'Loading API keys and credentials...',
       failedLoad: 'API keys failed to load',
-      empty: 'Nothing configured in this category yet.'
+      empty: 'Nothing configured in this category yet.',
+      searchTools: 'Search tools…',
+      searchSettings: 'Search settings…',
+      noMatch: 'No entries match your search.'
     },
     mcp: {
       loading: 'Loading MCP servers...',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -708,6 +708,14 @@ export const en: Translations = {
       searchSettings: 'Search settings…',
       noMatch: 'No entries match your search.'
     },
+    search: {
+      root: 'Settings',
+      placeholder: 'Search all settings…',
+      loading: 'Searching settings…',
+      noResults: 'No settings match your search.',
+      catalogError: 'Some settings could not be searched.',
+      resultCount: count => `${count} matching ${count === 1 ? 'setting' : 'settings'}.`
+    },
     mcp: {
       loading: 'Loading MCP servers...',
       failedLoad: 'MCP config failed to load',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -784,7 +784,10 @@ export const ja = defineLocale({
     keys: {
       loading: 'API キーと認証情報を読み込み中...',
       failedLoad: 'API キーの読み込みに失敗しました',
-      empty: 'このカテゴリーにはまだ設定がありません。'
+      empty: 'このカテゴリーにはまだ設定がありません。',
+      searchTools: 'ツールを検索...',
+      searchSettings: '設定を検索...',
+      noMatch: '検索に一致する項目はありません。'
     },
     mcp: {
       loading: 'MCP サーバーを読み込み中...',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -789,6 +789,14 @@ export const ja = defineLocale({
       searchSettings: '設定を検索...',
       noMatch: '検索に一致する項目はありません。'
     },
+    search: {
+      root: '設定',
+      placeholder: 'すべての設定を検索...',
+      loading: '設定を検索中...',
+      noResults: '検索に一致する設定はありません。',
+      catalogError: '一部の設定を検索できませんでした。',
+      resultCount: count => `${count} 件の設定が一致しました。`
+    },
     mcp: {
       loading: 'MCP サーバーを読み込み中...',
       failedLoad: 'MCP 設定の読み込みに失敗しました',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -597,6 +597,9 @@ export interface Translations {
       loading: string
       failedLoad: string
       empty: string
+      searchTools: string
+      searchSettings: string
+      noMatch: string
     }
     mcp: {
       loading: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -601,6 +601,14 @@ export interface Translations {
       searchSettings: string
       noMatch: string
     }
+    search: {
+      root: string
+      placeholder: string
+      loading: string
+      noResults: string
+      catalogError: string
+      resultCount: (count: number) => string
+    }
     mcp: {
       loading: string
       failedLoad: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -761,7 +761,10 @@ export const zhHant = defineLocale({
     keys: {
       loading: '正在載入 API 金鑰和憑證...',
       failedLoad: 'API 金鑰載入失敗',
-      empty: '此類別尚未有任何設定。'
+      empty: '此類別尚未有任何設定。',
+      searchTools: '搜尋工具...',
+      searchSettings: '搜尋設定...',
+      noMatch: '沒有符合搜尋條件的項目。'
     },
     mcp: {
       loading: '正在載入 MCP 伺服器...',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -766,6 +766,14 @@ export const zhHant = defineLocale({
       searchSettings: '搜尋設定...',
       noMatch: '沒有符合搜尋條件的項目。'
     },
+    search: {
+      root: '設定',
+      placeholder: '搜尋所有設定...',
+      loading: '正在搜尋設定...',
+      noResults: '沒有符合搜尋條件的設定。',
+      catalogError: '部分設定無法搜尋。',
+      resultCount: count => `${count} 項設定符合。`
+    },
     mcp: {
       loading: '正在載入 MCP 伺服器...',
       failedLoad: 'MCP 設定載入失敗',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -905,7 +905,10 @@ export const zh: Translations = {
     keys: {
       loading: '正在加载 API 密钥和凭据...',
       failedLoad: 'API 密钥加载失败',
-      empty: '此类别暂时没有配置项。'
+      empty: '此类别暂时没有配置项。',
+      searchTools: '搜索工具...',
+      searchSettings: '搜索设置...',
+      noMatch: '没有与搜索匹配的条目。'
     },
     mcp: {
       loading: '正在加载 MCP 服务器...',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -910,6 +910,14 @@ export const zh: Translations = {
       searchSettings: '搜索设置...',
       noMatch: '没有与搜索匹配的条目。'
     },
+    search: {
+      root: '设置',
+      placeholder: '搜索所有设置...',
+      loading: '正在搜索设置...',
+      noResults: '没有与搜索匹配的设置。',
+      catalogError: '部分设置无法搜索。',
+      resultCount: count => `${count} 项设置匹配。`
+    },
     mcp: {
       loading: '正在加载 MCP 服务器...',
       failedLoad: 'MCP 配置加载失败',


### PR DESCRIPTION
## What does this PR do?

Adds global search to Desktop Settings using the shared `ScopedCommandSearch` component from #69950.

The search catalog covers:

- Settings pages and sub-pages
- Config fields that are currently visible in the Desktop schema
- Appearance controls with stable targets
- Tool and application credentials returned by the backend

Results open in a wide command menu from the Settings sidebar. The menu supports arrow-key navigation, Enter selection, Escape, outside-click dismissal, loading and error states, and live result counts. It is constrained to the available window height and becomes full-width in the narrow Settings layout.

Selecting a result opens the right page and, where possible, jumps to the exact field or credential. Field targets scroll into view, receive the normal temporary highlight, and take keyboard focus. The active Settings pane remains mounted while the menu is open, so drafts and pending autosaves are not disturbed.

The catalog stays data-driven. Config results come from the live schema and credential results come from the backend catalog, so new entries do not require a matching frontend allowlist.

This PR is currently stacked on #69950 because it uses the shared search component introduced there. Once #69950 lands, I will rebase this branch onto `main` so this PR contains only the global Settings search commit.

## Related Issue

Related to #69023.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added the global search catalog and ranked matching in `settings-search.ts`.
- Added `useSettingsSearch` to load page, schema, Appearance, and credential entries and resolve their navigation targets.
- Reused `ScopedCommandSearch` for the global Settings menu.
- Extended the shared component with typed caller-owned entries, custom result rendering, caller-controlled filtering, optional status content, live summaries, and configurable result sizing.
- Added exact deep links for searchable config fields, credentials, and supported Appearance controls.
- Kept the current Settings pane mounted while search is active.
- Made the wide result panel overlay the main pane without being clipped by the sidebar scroller.
- Kept the navigation list independently scrollable below the search field.
- Added responsive `OverlayNav` header support for the narrow layout.
- Added loading, retry, profile refresh, empty-result, and result-count behavior.
- Updated English, Japanese, Simplified Chinese, and Traditional Chinese strings.
- Added catalog, ranking, navigation, focus, loading, future backend entry, and mounted-pane tests.

## How to Test

1. Open Desktop Settings.
2. Search for a config field such as `temperature`, `approval`, or `fallback model`.
3. Use the arrow keys and Enter to select a result.
4. Confirm the correct page opens and the field scrolls into view, highlights, and receives focus.
5. Search for an Appearance control such as `theme` or `translucency`.
6. Search for a credential by display label, environment key, description, documentation URL, or associated tool name.
7. Click outside the menu and confirm it dismisses. Focus the search again and confirm the current query returns.
8. Press Escape and confirm the query clears.
9. Resize the window to the narrow Settings layout and confirm search moves below the title bar and results use the available width.
10. Reduce the window height and confirm the result list scrolls within the visible menu.
11. Start editing a setting, search and clear the query, and confirm the pending edit remains mounted.

Automated checks run:

```shell
cd apps/desktop
npx vitest run --project ui src/app/settings --exclude 'src/app/settings/billing/**'
npx tsc -p . --noEmit
npx eslint src/components/ui/scoped-command-search.tsx src/app/settings src/app/overlays/overlay-split-layout.tsx
npm run build
```

Results:

- Settings tests excluding the unrelated Billing suite: 141 passed
- TypeScript, ESLint, focused formatting checks, and `git diff --check`: passed
- Production Desktop build: passed on Windows 11

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass. N/A because this is a Desktop-only TypeScript change. The relevant checks are listed above.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation or N/A. The responsive `OverlayNav` header contract is documented in `apps/desktop/DESIGN.md`.
- [x] I've updated `cli-config.yaml.example` if I added or changed config keys or N/A. No config keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A. No contributor workflow changed.
- [x] I've considered cross-platform impact or N/A. The feature runs in the platform-independent renderer.
- [x] I've updated tool descriptions or schemas if I changed tool behavior or N/A. Tool behavior and schemas are unchanged.

## Screenshots / Logs

<img width="1220" height="800" alt="Hermes_2TXI8hevuE" src="https://github.com/user-attachments/assets/703c1532-8581-49ed-ac37-5321b932c95e" />


Tested with the packaged Windows Desktop app at wide, narrow, and reduced-height window sizes.
