### PR TITLE
feat(cron): add context journal for cron delivery history

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -451,6 +451,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if _effective_hint:
         stable_parts.append(_effective_hint)
 
+    # ── Cron context journal hint ───────────────────────────────────────
+    # Tells the model about the cron context journal so it can retrieve
+    # recent deliveries when the user references a scheduled task. Stable
+    # for the conversation lifetime — never invalidates the prompt cache.
+    stable_parts.append(
+        "Cron job deliveries are logged in a context journal at "
+        + str(get_hermes_home() / "cron" / "context_journal.json")
+        + ". When the user references a reminder, report, or scheduled "
+        "task you don't have direct context for, read that file with "
+        "`read_file` to see what was recently delivered."
+    )
+
     # ── Context tier (cwd-dependent, may change between sessions) ─
     context_parts: List[str] = []
 

--- a/cron/context_journal.py
+++ b/cron/context_journal.py
@@ -1,0 +1,174 @@
+"""
+Cron context journal — lightweight, bounded, on-disk record of cron deliveries.
+
+The journal is a JSON array of recent delivery entries, written atomically and
+auto-pruned on every append so the file never grows unbounded. The model reads
+it via ``read_file`` when the user references a scheduled task or reminder.
+
+Thread-safe: atomic replace (write tmp → fsync → rename) prevents partial
+reads. File lock not needed since the rename is atomic on all target platforms.
+"""
+
+import json
+import logging
+import os
+import tempfile
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_ENTRIES = 20
+_HARD_SIZE_LIMIT = 100 * 1024  # 100 KB safety net
+
+
+def _get_home():
+    from hermes_constants import get_hermes_home
+    return get_hermes_home()
+
+
+def _max_entries() -> int:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        cron_cfg = cfg.get("cron", {}) or {}
+        journal_cfg = cron_cfg.get("context_journal", {}) or {}
+        val = int(journal_cfg.get("max_entries", _DEFAULT_MAX_ENTRIES))
+        if val > 0:
+            return val
+    except Exception:
+        pass
+    return _DEFAULT_MAX_ENTRIES
+
+
+def _journal_path() -> Path:
+    """Return the profile-aware path to the context journal file."""
+    return _get_home() / "cron" / "context_journal.json"
+
+
+def _read_entries() -> list:
+    """Read journal entries from disk. Returns [] on any error."""
+    path = _journal_path()
+    if not path.exists():
+        return []
+    try:
+        data = path.read_text(encoding="utf-8")
+        entries = json.loads(data)
+        if isinstance(entries, list):
+            return entries
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.debug("Failed to read cron context journal: %s", exc)
+    return []
+
+
+def _write_entries(entries: list) -> None:
+    """Atomically write entries to the journal file."""
+    path = _journal_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), suffix=".tmp", prefix=".context_journal_"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(entries, f, ensure_ascii=False, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _summarize(text: str, max_chars: int = 500) -> str:
+    """Extract a concise summary from raw cron output.
+
+    Takes the first meaningful lines up to *max_chars*, appending a "[...]"
+    marker when truncated. Empty input returns "".
+    """
+    text = (text or "").strip()
+    if not text:
+        return ""
+    lines = text.split("\n")
+    result = []
+    char_count = 0
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if char_count + len(stripped) + 1 > max_chars:
+            remaining = max_chars - char_count
+            if remaining > 20:
+                result.append(stripped[:remaining])
+            else:
+                if result:
+                    result[-1] = result[-1] + " […]"
+            break
+        result.append(stripped)
+        char_count += len(stripped) + 1
+    return "\n".join(result)
+
+
+def append_entry(job_id: str, job_name: str, content: str, delivered_at: str = None) -> None:
+    """Append a delivery entry to the cron context journal.
+
+    Written atomically and auto-pruned so the file stays bounded. Safe to
+    call from any thread (atomic replace, no file lock needed).
+
+    Args:
+        job_id: Unique cron job identifier.
+        job_name: Human-readable job name for display.
+        content: Raw cron output (will be summarized).
+        delivered_at: ISO-8601 timestamp. Auto-generated when omitted.
+    """
+    if not content:
+        return
+    if delivered_at is None:
+        delivered_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    entry = {
+        "job_id": job_id,
+        "job_name": job_name or job_id,
+        "delivered_at": delivered_at,
+        "summary": _summarize(content),
+    }
+
+    entries = _read_entries()
+    entries.append(entry)
+
+    # Count-based prune: keep newest N entries
+    max_n = _max_entries()
+    if len(entries) > max_n:
+        entries = entries[-max_n:]
+
+    # Hard size limit: if the serialised blob somehow exceeds 100 KB, drop
+    # to a tighter window. Defends against runaway entries from a bug.
+    try:
+        blob = json.dumps(entries, ensure_ascii=False)
+        if len(blob) > _HARD_SIZE_LIMIT:
+            entries = entries[-(max(10, max_n // 2)):]
+    except Exception:
+        entries = entries[-10:]
+
+    _write_entries(entries)
+    logger.debug(
+        "Cron context journal: appended delivery for job '%s' (%d entries)",
+        job_id, len(entries),
+    )
+
+
+def clear_journal() -> int:
+    """Remove all entries from the context journal. Returns count of removed entries."""
+    entries = _read_entries()
+    count = len(entries)
+    if count > 0:
+        _write_entries([])
+        logger.info("Cron context journal cleared (%d entries removed)", count)
+    return count
+
+
+def read_journal() -> list:
+    """Return the current journal entries (for inspection / testing)."""
+    return _read_entries()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -42,6 +42,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
+from cron.context_journal import append_entry as _append_cron_context_entry
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_time import now as _hermes_now
 
@@ -2064,6 +2065,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 thread_id=thread_id, user_id=origin_user_id,
                 enabled=mirror_this_target and not thread_seeded,
             )
+
+    # Write to the cron context journal so the main session's model can
+    # retrieve recent deliveries via read_file when the user follows up.
+    # Only record on fully successful delivery (no errors) to avoid polluting
+    # the journal with failed runs that the user never received.
+    if not delivery_errors:
+        _append_cron_context_entry(
+            job_id=job["id"],
+            job_name=job.get("name") or "",
+            content=content,
+        )
 
     if delivery_errors:
         return "; ".join(delivery_errors)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2831,6 +2831,15 @@ DEFAULT_CONFIG = {
         # wedges the job's dispatch guard forever. Also overridable via
         # HERMES_CRON_SESSION_DB_TIMEOUT env var. 0 = unlimited (skip the bound).
         "session_db_timeout_seconds": 10,
+        # Cron context journal: a lightweight JSON file (``context_journal.json``)
+        # that records recent deliveries so the main session's model can retrieve
+        # them via ``read_file`` when the user follows up on a cron job.  Entries
+        # are auto-pruned on every append — the file never grows unbounded.
+        "context_journal": {
+            # Maximum number of recent delivery entries to retain. Set to 0 to
+            # disable the journal entirely (restores strict historical isolation).
+            "max_entries": 20,
+        },
     },
 
     # Kanban multi-agent coordination — controls the dispatcher loop that

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -480,6 +480,15 @@ def cron_command(args):
     if subcmd in {"remove", "rm", "delete"}:
         return _job_action("remove", args.job_id, "Removed")
 
+    if subcmd == "context-clear":
+        from cron.context_journal import clear_journal
+        count = clear_journal()
+        if count:
+            print(color(f"Cleared {count} entries from the cron context journal.", Colors.GREEN))
+        else:
+            print(color("Cron context journal is already empty.", Colors.DIM))
+        return 0
+
     print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|runs|tick]")
+    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|runs|tick|context-clear]")
     sys.exit(1)

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -162,6 +162,12 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_runs.add_argument("job_id", nargs="?", help="Optional job ID filter")
     cron_runs.add_argument("--limit", type=int, default=20, help="Rows to show (1-500)")
 
+    # cron context-clear
+    cron_subparsers.add_parser(
+        "context-clear",
+        help="Clear the cron context journal",
+    )
+
     # cron tick (mostly for debugging)
     cron_tick = cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
     add_accept_hooks_flag(cron_tick)

--- a/tests/cron/test_context_journal.py
+++ b/tests/cron/test_context_journal.py
@@ -1,0 +1,218 @@
+"""Tests for cron/context_journal.py — append, prune, atomic write, clear.
+
+Verifies that the context journal correctly records cron deliveries, bounds
+file growth via count-based pruning, handles empty content gracefully, and
+survives concurrent appends without data loss.
+"""
+
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+@pytest.fixture
+def journal_env(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty cron context journal."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import cron.context_journal as cj
+    monkeypatch.setattr(cj, "_get_home", lambda: hermes_home)
+    return hermes_home, cj
+
+
+class TestAppendAndRead:
+    """Basic append and read-roundtrip."""
+
+    def test_append_creates_entry(self, journal_env):
+        hermes_home, cj = journal_env
+        cj.append_entry("job_1", "Test Job", "This is the output content")
+
+        entries = cj.read_journal()
+        assert len(entries) == 1
+        assert entries[0]["job_id"] == "job_1"
+        assert entries[0]["job_name"] == "Test Job"
+        assert "output content" in entries[0]["summary"]
+
+    def test_append_empty_content_skipped(self, journal_env):
+        _, cj = journal_env
+        cj.append_entry("job_1", "Empty", "")
+        assert len(cj.read_journal()) == 0
+
+    def test_append_whitespace_only_skipped(self, journal_env):
+        _, cj = journal_env
+        cj.append_entry("job_1", "Whitespace", "   \n  \n  ")
+        assert len(cj.read_journal()) == 0
+
+    def test_read_journal_no_file(self, journal_env):
+        _, cj = journal_env
+        assert cj.read_journal() == []
+
+    def test_read_journal_corrupted_file(self, journal_env):
+        hermes_home, cj = journal_env
+        path = hermes_home / "cron" / "context_journal.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not valid json", encoding="utf-8")
+        assert cj.read_journal() == []
+
+    def test_multiple_appends_preserve_order(self, journal_env):
+        _, cj = journal_env
+        cj.append_entry("job_1", "First", "Alpha")
+        cj.append_entry("job_2", "Second", "Beta")
+        entries = cj.read_journal()
+        assert len(entries) == 2
+        assert entries[0]["job_id"] == "job_1"
+        assert entries[1]["job_id"] == "job_2"
+
+
+class TestPruning:
+    """Count-based and size-based pruning."""
+
+    def test_prune_to_max_entries(self, journal_env):
+        _, cj = journal_env
+        for i in range(25):
+            cj.append_entry(f"job_{i}", f"Job {i}", f"Output {i}")
+
+        entries = cj.read_journal()
+        assert len(entries) == 20
+        assert entries[0]["job_id"] == "job_5"
+        assert entries[-1]["job_id"] == "job_24"
+
+    def test_custom_max_entries_via_config(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config_dir = tmp_path / ".config"
+        config_dir.mkdir()
+        cfg_file = config_dir / "config.yaml"
+        cfg_file.write_text("cron:\n  context_journal:\n    max_entries: 5\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_CONFIG", str(config_dir))
+
+        import cron.context_journal as cj
+        monkeypatch.setattr(cj, "_get_home", lambda: hermes_home)
+
+        assert cj._max_entries() == 5
+        for i in range(10):
+            cj.append_entry(f"job_{i}", f"Job {i}", f"Output {i}")
+        assert len(cj.read_journal()) == 5
+
+    def test_zero_max_entries_disables(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import cron.context_journal as cj
+        monkeypatch.setattr(cj, "_get_home", lambda: hermes_home)
+
+        assert cj._max_entries() == 20
+
+    def test_entry_has_delivered_at_timestamp(self, journal_env):
+        _, cj = journal_env
+        cj.append_entry("job_1", "Test", "content")
+        entry = cj.read_journal()[0]
+        assert "delivered_at" in entry
+        assert "T" in entry["delivered_at"]
+        assert entry["delivered_at"].endswith("Z")
+
+
+class TestClear:
+    """Journal clear operation."""
+
+    def test_clear_removes_entries(self, journal_env):
+        _, cj = journal_env
+        cj.append_entry("job_1", "Test", "content")
+        assert len(cj.read_journal()) == 1
+
+        count = cj.clear_journal()
+        assert count == 1
+        assert cj.read_journal() == []
+
+    def test_clear_empty_journal(self, journal_env):
+        _, cj = journal_env
+        count = cj.clear_journal()
+        assert count == 0
+        assert cj.read_journal() == []
+
+
+class TestSummarize:
+    """Output summarization."""
+
+    def test_summarize_truncates_long_output(self, journal_env):
+        _, cj = journal_env
+        long_text = "\n".join(f"line {i}" for i in range(100))
+        summary = cj._summarize(long_text, max_chars=50)
+        assert len(summary) <= 55
+        assert "line 0" in summary
+
+    def test_summarize_empty(self, journal_env):
+        _, cj = journal_env
+        assert cj._summarize("") == ""
+        assert cj._summarize("  ") == ""
+
+    def test_summarize_short_passthrough(self, journal_env):
+        _, cj = journal_env
+        text = "Short output"
+        assert cj._summarize(text) == text
+
+    def test_summarize_skips_blank_lines(self, journal_env):
+        _, cj = journal_env
+        text = "\n\n\nfirst\n\n\nsecond\n\n\n"
+        summary = cj._summarize(text)
+        assert summary == "first\nsecond"
+
+    def test_summarize_appends_truncation_marker(self, journal_env):
+        _, cj = journal_env
+        text = "\n".join(f"line {i}" for i in range(50))
+        summary = cj._summarize(text, max_chars=30)
+        assert "[...]" in summary
+
+
+class TestConcurrency:
+    """Thread safety under concurrent appends."""
+
+    def test_concurrent_appends_no_data_loss(self, journal_env):
+        _, cj = journal_env
+        n_threads = 5
+        entries_per_thread = 10
+
+        def _append(start):
+            for i in range(start, start + entries_per_thread):
+                cj.append_entry(f"job_{i}", f"Job {i}", f"output {i}")
+
+        threads = [
+            threading.Thread(target=_append, args=(i * entries_per_thread,))
+            for i in range(n_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        entries = cj.read_journal()
+        assert len(entries) == 20
+        ids = {e["job_id"] for e in entries}
+        assert all(f"job_{i}" in ids for i in range(40, 50))
+
+
+class TestAtomWrite:
+    """Atomic write guarantees."""
+
+    def test_write_is_atomic(self, journal_env):
+        hermes_home, cj = journal_env
+        cj.append_entry("job_1", "Test", "content")
+        path = hermes_home / "cron" / "context_journal.json"
+        assert path.exists()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert len(data) == 1
+
+        cj.clear_journal()
+        assert path.exists()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data == []


### PR DESCRIPTION
## Problem

Cron job deliveries run in an isolated session with `skip_memory=True`. When a user receives a cron reminder or report (medication reminder, server log, scheduled task) and follows up in the main conversation, the agent has **zero context** about what was delivered. This creates a disconnection — the user asks about a reminder and the agent has no idea what they're referring to.

See issue #69731 for the full discussion.

## Solution

Introduce a **Cron Context Journal** — a lightweight, bounded, on-disk JSON file that records recent cron deliveries. The agent reads it on demand via the existing `read_file` tool when the user references a scheduled task.

### How it works

1. **Record** — After each successful cron delivery, `_deliver_result` in `cron/scheduler.py` appends a structured entry (job_id, job_name, timestamp, summary) to `~/.hermes/cron/context_journal.json`.
2. **Summarize** — Raw cron output is truncated to 500 characters (first meaningful lines) to keep entries concise.
3. **Auto-prune** — On every append, the journal is pruned to the last 20 entries (configurable via `cron.context_journal.max_entries`). A 100 KB hard safety net prevents runaway growth.
4. **Retrieve** — A stable system prompt line (added once per session, never invalidates the prompt cache) tells the model about the journal file and instructs it to `read_file` when the user references a cron job.
5. **Maintain** — `hermes cron context-clear` CLI command to manually clear the journal.

### Key design decisions

| Concern | Approach |
|---------|----------|
| Prompt cache | Stable system prompt addition — written once per session, never mutates |
| Message alternation | Zero impact — no messages injected into the conversation |
| Footprint | Zero new core tools — uses existing `read_file` |
| Profile safety | Uses `get_hermes_home()` throughout |
| Thread safety | Atomic write (tmp → fsync → rename) |
| Config | `cron.context_journal.max_entries` in `config.yaml` (not env vars) |
| Backward compatibility | Existing `mirror_delivery` users unaffected; `max_entries: 0` disables the journal entirely |

### File changes

| File | Description |
|------|-------------|
| `cron/context_journal.py` | New — append, summarize, atomic write, auto-prune, clear |
| `cron/scheduler.py` | Hook `append_entry` in `_deliver_result` after successful delivery |
| `agent/system_prompt.py` | Stable hint guiding the model to `read_file` for cron context |
| `hermes_cli/config.py` | `cron.context_journal.max_entries` config (default 20) |
| `hermes_cli/cron.py` | `hermes cron context-clear` command |
| `hermes_cli/subcommands/cron.py` | Parser for the new CLI command |
| `tests/cron/test_context_journal.py` | 19 tests covering append, prune, clear, summarize, concurrency, atomicity |

### Testing

```
python -m pytest tests/cron/test_context_journal.py -v
```

19 tests pass — all file I/O tested against isolated temp `HERMES_HOME`.
