### PR TITLE
fix(update): protect git checkouts from ZIP fallback

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -560,6 +560,25 @@ def _update_via_zip(args):
             f"--branch {branch}`, or update against main with `hermes update`."
         )
         _m().sys.exit(1)
+
+    # A source install has a Git checkout that is authoritative for both the
+    # current revision and a contributor's local work. Copying an archive over
+    # it while preserving .git leaves HEAD at the old commit and can overwrite
+    # uncommitted changes. The ZIP path remains available for non-Git installs,
+    # but a checkout must be repaired through Git so its history and files stay
+    # in sync.
+    if (_m().PROJECT_ROOT / ".git").exists():
+        print("✗ ZIP fallback cannot safely update a Git checkout.")
+        print(
+            "  It would replace source files while leaving the checkout's Git "
+            "history behind origin/main."
+        )
+        print(
+            "  The ZIP fallback did not modify source files. Resolve the Git error and "
+            "rerun `hermes update`."
+        )
+        _m().sys.exit(1)
+
     zip_url = (
         f"https://github.com/NousResearch/hermes-agent/archive/refs/heads/{branch}.zip"
     )

--- a/hermes_cli/update_cmd_zip.py
+++ b/hermes_cli/update_cmd_zip.py
@@ -188,6 +188,19 @@ def _abort_zip_update_if_dirty_tree() -> None:
     _m().sys.exit(1)
 
 
+def _is_git_checkout(root: Path) -> bool:
+    """Whether ``root`` has Git checkout metadata, not just a placeholder ``.git`` path."""
+    git_path = root / ".git"
+    if git_path.is_dir():
+        return (git_path / "HEAD").is_file()
+    if not git_path.is_file():
+        return False
+    try:
+        return git_path.read_text(encoding="utf-8", errors="replace").lstrip().startswith("gitdir:")
+    except OSError:
+        return False
+
+
 def _extract_zip_safely(zip_path: str, tmp_dir: str) -> None:
     """Extract, rejecting zip-slip AND symlink members: a source ZIP never legitimately contains
     symlinks, and a compromised mirror could use them to plant files anywhere."""
@@ -377,6 +390,15 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
             "or NTFS filter holding files open) and rerun `hermes update "
             f"--branch {branch}`, or update against main with `hermes update`."
         )
+        _m().sys.exit(1)
+    # A ZIP overlay preserves .git while replacing source files, leaving the
+    # checkout history behind origin/main and potentially overwriting local work.
+    # Source checkouts must be repaired through Git; non-Git installs retain the
+    # fallback path.
+    if _is_git_checkout(_m().PROJECT_ROOT):
+        print("✗ ZIP fallback cannot safely update a Git checkout.")
+        print("  It would replace source files while leaving the checkout's Git history behind origin/main.")
+        print("  The ZIP fallback did not modify source files. Resolve the Git error and rerun `hermes update`.")
         _m().sys.exit(1)
     _abort_zip_update_if_dirty_tree()
     _download_and_swap_zip(branch, f"https://github.com/NousResearch/hermes-agent/archive/refs/heads/{branch}.zip")

--- a/tests/hermes_cli/test_update_zip_symlink_reject.py
+++ b/tests/hermes_cli/test_update_zip_symlink_reject.py
@@ -87,6 +87,33 @@ def test_update_via_zip_rejects_symlink_member(tmp_path, monkeypatch):
         )
 
 
+def test_update_via_zip_refuses_to_overwrite_git_checkout(tmp_path, monkeypatch, capsys):
+    """A ZIP fallback must leave a source checkout and its local work intact."""
+    fake_root = tmp_path / "install_dir"
+    fake_root.mkdir()
+    (fake_root / ".git").mkdir()
+    (fake_root / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    local_file = fake_root / "local-change.txt"
+    local_file.write_text("keep me\n", encoding="utf-8")
+
+    from hermes_cli import main as hermes_main
+
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", fake_root)
+    args = type("Args", (), {})()
+
+    with patch("urllib.request.urlretrieve") as download:
+        with pytest.raises(SystemExit) as exc_info:
+            update_cmd._update_via_zip(args)
+
+    assert exc_info.value.code == 1
+    assert local_file.read_text(encoding="utf-8") == "keep me\n"
+    download.assert_not_called()
+
+    output = capsys.readouterr().out
+    assert "The ZIP fallback did not modify source files" in output
+    assert "Git checkout" in output
+
+
 def test_update_via_zip_accepts_normal_member(tmp_path, monkeypatch, capsys):
     """A ZIP with only regular file members must extract without raising.
 
@@ -135,4 +162,4 @@ def test_update_via_zip_accepts_normal_member(tmp_path, monkeypatch, capsys):
     # The fake README from the ZIP should have landed in our sandbox root,
     # confirming the extraction + copy phases ran past the validation gate.
     assert (fake_root / "README.md").exists()
-    assert (fake_root / "README.md").read_text() == "ok\n"
+    assert (fake_root / "README.md").read_text(encoding="utf-8") == "ok\n"

--- a/tests/hermes_cli/test_update_zip_symlink_reject.py
+++ b/tests/hermes_cli/test_update_zip_symlink_reject.py
@@ -80,6 +80,32 @@ def test_update_via_zip_rejects_symlink_member(tmp_path, monkeypatch):
         )
 
 
+def test_update_via_zip_refuses_to_overwrite_git_checkout(tmp_path, monkeypatch, capsys):
+    """A ZIP fallback must leave a source checkout and its local work intact."""
+    fake_root = tmp_path / "install_dir"
+    fake_root.mkdir()
+    (fake_root / ".git").mkdir()
+    local_file = fake_root / "local-change.txt"
+    local_file.write_text("keep me\n", encoding="utf-8")
+
+    from hermes_cli import main as hermes_main
+
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", fake_root)
+    args = type("Args", (), {})()
+
+    with patch("urllib.request.urlretrieve") as download:
+        with pytest.raises(SystemExit) as exc_info:
+            hermes_main._update_via_zip(args)
+
+    assert exc_info.value.code == 1
+    assert local_file.read_text(encoding="utf-8") == "keep me\n"
+    download.assert_not_called()
+
+    output = capsys.readouterr().out
+    assert "The ZIP fallback did not modify source files" in output
+    assert "Git checkout" in output
+
+
 def test_update_via_zip_accepts_normal_member(tmp_path, monkeypatch, capsys):
     """A ZIP with only regular file members must extract without raising.
 


### PR DESCRIPTION
## What does this PR do?

Prevents the Windows ZIP fallback from overwriting a source Git checkout while preserving its old `.git` state. Source installs now stop without mutating files when Git update fails, so users can repair Git and rerun `hermes update`; non-Git installs retain the ZIP fallback.

## Related Issue

Fixes #69908

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: refuse the ZIP update path before downloading or modifying a Git checkout, with actionable recovery guidance.
- `tests/hermes_cli/test_update_zip_symlink_reject.py`: cover the Git-checkout guard and retain the non-Git ZIP happy-path coverage.

## How to Test

1. Run `/opt/homebrew/bin/timeout -k 30 480 $VIRTUAL_ENV/bin/python -m pytest tests/hermes_cli/test_update_zip_symlink_reject.py -q --timeout=60` and confirm all tests pass.
2. Run `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` and confirm the suite passes.
3. On a Windows source checkout with a `.git` directory, force the ZIP fallback and confirm it exits before downloading or changing local files; on a non-Git install, confirm the existing ZIP path remains available.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

### What platforms tested on

- macOS (Darwin arm64) — full pytest suite, scoped Ruff, `git diff --check`, and Windows-footgun scan.
- Windows — not run locally; the Windows-specific path is covered by unit tests and `scripts/check-windows-footguns.py`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

<!-- autocontrib:worker-id=issue-new-81b34ecb kind=pr-open -->