### PR TITLE
fix(slack): acknowledge user lifecycle events

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1731,6 +1731,18 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_file_change(event, say):
                 pass
 
+            @self._app.event("user_change")
+            async def handle_user_change(event, say):
+                pass
+
+            @self._app.event("user_profile_changed")
+            async def handle_user_profile_changed(event, say):
+                pass
+
+            @self._app.event("user_status_changed")
+            async def handle_user_status_changed(event, say):
+                pass
+
             # Reactions are useful lightweight acknowledgements in Slack, but
             # Hermes does not currently need to route them into the agent loop.
             # Ack the events explicitly so high-traffic channels do not fill

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -284,6 +284,9 @@ class TestAppMentionHandler:
         assert "app_context_changed" in registered_events
         assert "reaction_added" in registered_events
         assert "reaction_removed" in registered_events
+        assert "user_change" in registered_events
+        assert "user_profile_changed" in registered_events
+        assert "user_status_changed" in registered_events
         assert "assistant_thread_started" in registered_events
         assert "assistant_thread_context_changed" in registered_events
         # Slack slash commands are registered via a single regex matcher


### PR DESCRIPTION
## Summary
- acknowledge Slack `user_change`, `user_profile_changed`, and `user_status_changed` events with explicit no-op listeners
- prevent Slack Bolt from emitting an `Unhandled request` warning for every such event
- cover the event registration contract in the Slack adapter test

## Validation
- `PYTHONPATH=/tmp/hermes-slack-user-lifecycle-ack /Users/n.liu/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_slack.py::TestAppMentionHandler::test_app_mention_registered_on_connect -q`
- `git diff --check`