### PR TITLE
fix(matrix): honor profile secrets during adapter checks

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -66,6 +66,8 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
+from agent.secret_scope import get_secret
+
 try:
     from mautrix.types import (
         ContentURI,
@@ -727,9 +729,9 @@ def check_matrix_requirements() -> bool:
     forever and broke E2EE connect with ``No module named 'asyncpg'``
     (#31116).  Rebinds module-level type globals on success.
     """
-    token = os.getenv("MATRIX_ACCESS_TOKEN", "")
-    password = os.getenv("MATRIX_PASSWORD", "")
-    homeserver = os.getenv("MATRIX_HOMESERVER", "")
+    token = get_secret("MATRIX_ACCESS_TOKEN", "") or ""
+    password = get_secret("MATRIX_PASSWORD", "") or ""
+    homeserver = get_secret("MATRIX_HOMESERVER", "") or ""
 
     if not token and not password:
         logger.debug("Matrix: neither MATRIX_ACCESS_TOKEN nor MATRIX_PASSWORD set")

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1237,6 +1237,33 @@ class TestMatrixRequirements:
         with patch("tools.lazy_deps.feature_missing", return_value=()):
             assert check_matrix_requirements() is True
 
+    def test_check_requirements_uses_multiplex_profile_secret_scope(self, monkeypatch):
+        from agent.secret_scope import (
+            is_multiplex_active,
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+        from plugins.platforms.matrix.adapter import check_matrix_requirements
+
+        monkeypatch.delenv("MATRIX_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("MATRIX_PASSWORD", raising=False)
+        monkeypatch.delenv("MATRIX_HOMESERVER", raising=False)
+        was_multiplexed = is_multiplex_active()
+        set_multiplex_active(True)
+        scope_token = set_secret_scope(
+            {
+                "MATRIX_HOMESERVER": "https://matrix.profile.example",
+                "MATRIX_PASSWORD": "profile-password",
+            }
+        )
+        try:
+            with patch("tools.lazy_deps.feature_missing", return_value=()):
+                assert check_matrix_requirements() is True
+        finally:
+            reset_secret_scope(scope_token)
+            set_multiplex_active(was_multiplexed)
+
     def test_check_requirements_without_creds(self, monkeypatch):
         monkeypatch.delenv("MATRIX_ACCESS_TOKEN", raising=False)
         monkeypatch.delenv("MATRIX_PASSWORD", raising=False)


### PR DESCRIPTION
Fixes #69943.

## Summary
- resolve Matrix access-token, password, and homeserver checks through the active profile secret scope
- retain existing environment lookup behavior for non-multiplexed gateways
- add a regression test for a password-authenticated secondary profile with no global Matrix credentials

## Validation
- `python -m pytest -q tests/gateway/test_matrix.py -k "MatrixRequirements or MatrixModuleImport"`
- `python -m pytest -q tests/agent/test_secret_scope.py tests/gateway/test_api_server_multiplex_secret_scope.py`
- `python -m ruff check plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py`