### PR TITLE
fix(terminal): keep external-source secrets out of snapshots (#62336)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -40,6 +40,9 @@ _SECRET_SOURCES: dict[str, str] = {}
 # Applied values are immutable per-home snapshots.  ``os.environ`` is shared
 # across profiles and may be overwritten by a later home's source apply.
 _SECRET_SOURCE_VALUES_BY_HOME: dict[str, dict[str, str]] = {}
+# Bootstrap-auth variable names are also profile/config scoped, but their raw
+# values must not enter the provider secret scope above.
+_SECRET_SOURCE_PROTECTED_VARS_BY_HOME: dict[str, frozenset[str]] = {}
 
 # HERMES_HOME paths we've already pulled external secrets for during this
 # process.  ``load_hermes_dotenv()`` is called at module-import time from
@@ -166,6 +169,20 @@ def get_secret_source_values(
     return dict(_SECRET_SOURCE_VALUES_BY_HOME.get(home_key, {}))
 
 
+def get_external_secret_env_vars(
+    hermes_home: str | os.PathLike,
+) -> frozenset[str]:
+    """Return external-source and bootstrap-auth names for ``hermes_home``.
+
+    Subprocess boundaries need provenance metadata, not raw vault values,
+    when excluding credentials from model-driven shells.
+    """
+    home_key = str(Path(hermes_home).resolve())
+    return frozenset(get_secret_source_values(hermes_home)) | (
+        _SECRET_SOURCE_PROTECTED_VARS_BY_HOME.get(home_key, frozenset())
+    )
+
+
 def hydrate_profile_secret_sources(
     hermes_home: str | os.PathLike,
 ) -> dict[str, str]:
@@ -225,6 +242,21 @@ def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
     if not report.sources:
         return {}
 
+    protected_vars: set[str] = set()
+    try:
+        from agent.secret_sources.registry import get_source
+
+        for source_report in report.sources:
+            source = get_source(source_report.name)
+            if source is None:
+                continue
+            source_cfg = cfg.get(source_report.name)
+            source_cfg = source_cfg if isinstance(source_cfg, dict) else {}
+            protected_vars.update(source.protected_env_vars(source_cfg))
+    except Exception:  # noqa: BLE001 — metadata lookup must remain fail-open
+        pass
+    _SECRET_SOURCE_PROTECTED_VARS_BY_HOME[home_key] = frozenset(protected_vars)
+
     _APPLIED_HOMES.add(home_key)
     values: dict[str, str] = {}
     for name, applied in report.provenance.items():
@@ -251,6 +283,7 @@ def reset_secret_source_cache() -> None:
     _APPLIED_HOMES.clear()
     _SECRET_SOURCES.clear()
     _SECRET_SOURCE_VALUES_BY_HOME.clear()
+    _SECRET_SOURCE_PROTECTED_VARS_BY_HOME.clear()
 
 
 def format_secret_source_suffix(env_var: str) -> str:
@@ -603,6 +636,24 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         # (no fetch happens for disabled sources) so flipping a source on
         # mid-process takes effect on the next call.
         return
+
+    protected_vars: set[str] = set()
+    try:
+        from agent.secret_sources.registry import get_source
+    except ImportError:
+        get_source = None
+    if get_source is not None:
+        for source_report in report.sources:
+            try:
+                source = get_source(source_report.name)
+                if source is None:
+                    continue
+                source_cfg = cfg.get(source_report.name)
+                source_cfg = source_cfg if isinstance(source_cfg, dict) else {}
+                protected_vars.update(source.protected_env_vars(source_cfg))
+            except Exception:  # noqa: BLE001 — one plugin must not hide others
+                continue
+    _SECRET_SOURCE_PROTECTED_VARS_BY_HOME[home_key] = frozenset(protected_vars)
 
     # A real fetch attempt happened (success OR error).  Mark the home now
     # so the 3-5 import-time load_hermes_dotenv() calls per startup don't

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -30,6 +30,8 @@ _SCOPED_SKIP_LOGGED: set[str] = set()   # routed profile homes whose multiplex d
 _SECRET_SOURCES: dict[str, str] = {}
 # Immutable per-home snapshots: os.environ is shared across profiles and a later home's apply may overwrite it.
 _SECRET_SOURCE_VALUES_BY_HOME: dict[str, dict[str, str]] = {}
+# Names only: bootstrap values never belong in a provider secret scope.
+_SECRET_SOURCE_PROTECTED_VARS_BY_HOME: dict[str, frozenset[str]] = {}
 # HERMES_HOME paths already pulled external secrets for: load_hermes_dotenv() runs at import time from
 # several hot modules, so without this the Bitwarden status line prints 3-5x per startup and the config
 # re-parse + ASCII sweep re-run each time (Bitwarden's own cache only saves the network call).
@@ -99,6 +101,34 @@ def get_secret_source_values(hermes_home: str | os.PathLike) -> dict[str, str]:
     return dict(_SECRET_SOURCE_VALUES_BY_HOME.get(str(Path(hermes_home).resolve()), {}))
 
 
+def get_external_secret_env_vars(hermes_home: str | os.PathLike) -> frozenset[str]:
+    """External-source and bootstrap-auth names for the resolved profile home."""
+    home_key = str(Path(hermes_home).resolve())
+    return frozenset(_SECRET_SOURCE_VALUES_BY_HOME.get(home_key, {})) | (
+        _SECRET_SOURCE_PROTECTED_VARS_BY_HOME.get(home_key, frozenset())
+    )
+
+
+def _record_secret_source_protected_vars(home_key, cfg, sources) -> None:
+    """One broken source's metadata must not hide another source's credentials."""
+    protected: set[str] = set()
+    try:
+        from agent.secret_sources.registry import get_source
+    except ImportError:
+        return
+    for source_report in sources:
+        try:
+            source = get_source(source_report.name, scope=home_key)
+            if source is not None:
+                source_cfg = cfg.get(source_report.name)
+                protected.update(source.protected_env_vars(
+                    source_cfg if isinstance(source_cfg, dict) else {}
+                ))
+        except Exception:  # metadata lookup must not prevent other source protection
+            continue
+    _SECRET_SOURCE_PROTECTED_VARS_BY_HOME[home_key] = frozenset(protected)
+
+
 def hydrate_profile_secret_sources(hermes_home: str | os.PathLike) -> dict[str, str]:
     """Resolve one profile's configured sources without mutating ``os.environ``: multiplex gateways route
     turns to profiles that never ran the process-global dotenv path, so resolve against a private mapping
@@ -143,6 +173,7 @@ def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
     if not report.sources:
         return {}
 
+    _record_secret_source_protected_vars(home_key, cfg, report.sources)
     _APPLIED_HOMES.add(home_key)
     values: dict[str, str] = {}
     for name, applied in report.provenance.items():
@@ -167,10 +198,12 @@ def reset_secret_source_cache(hermes_home: str | os.PathLike | None = None) -> N
         _APPLIED_HOMES.clear()
         _SECRET_SOURCES.clear()
         _SECRET_SOURCE_VALUES_BY_HOME.clear()
+        _SECRET_SOURCE_PROTECTED_VARS_BY_HOME.clear()
         return
     home_key = str(Path(hermes_home).resolve())
     _APPLIED_HOMES.discard(home_key)
     _SECRET_SOURCE_VALUES_BY_HOME.pop(home_key, None)
+    _SECRET_SOURCE_PROTECTED_VARS_BY_HOME.pop(home_key, None)
 
 
 def format_secret_source_suffix(env_var: str) -> str:
@@ -484,6 +517,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     # A real fetch attempt happened (success OR error): mark the home so the 3-5 import-time calls per
     # startup don't re-fetch / re-print (error retries are opt-in via reset_secret_source_cache()).
     # Marking AFTER the attempt keeps the earlier failure paths retryable.
+    _record_secret_source_protected_vars(home_key, cfg, report.sources)
     _APPLIED_HOMES.add(home_key)
 
     if report.applied_any:

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -26,10 +26,12 @@ def _reset_sources():
     """Each test starts with a clean source map and applied-home guard."""
     env_loader._SECRET_SOURCES.clear()
     env_loader._SECRET_SOURCE_VALUES_BY_HOME.clear()
+    env_loader._SECRET_SOURCE_PROTECTED_VARS_BY_HOME.clear()
     env_loader.reset_secret_source_cache()
     yield
     env_loader._SECRET_SOURCES.clear()
     env_loader._SECRET_SOURCE_VALUES_BY_HOME.clear()
+    env_loader._SECRET_SOURCE_PROTECTED_VARS_BY_HOME.clear()
     env_loader.reset_secret_source_cache()
 
 
@@ -61,6 +63,26 @@ def test_get_secret_source_values_returns_home_snapshot_copy(tmp_path):
     assert env_loader.get_secret_source_values(home_a) == {
         "ANTHROPIC_API_KEY": "sk-profile-a"
     }
+
+
+def test_get_external_secret_env_vars_returns_scoped_names_only(tmp_path):
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+
+    env_loader._SECRET_SOURCE_VALUES_BY_HOME[str(home_a.resolve())] = {
+        "CUSTOM_DEPLOY_CREDENTIAL": "inert-secret-value"
+    }
+    env_loader._SECRET_SOURCE_PROTECTED_VARS_BY_HOME[str(home_a.resolve())] = (
+        frozenset({"CUSTOM_BWS_ACCESS_TOKEN"})
+    )
+
+    assert env_loader.get_external_secret_env_vars(home_a) == frozenset({
+        "CUSTOM_BWS_ACCESS_TOKEN",
+        "CUSTOM_DEPLOY_CREDENTIAL",
+    })
+    assert env_loader.get_external_secret_env_vars(home_b) == frozenset()
 
 
 def test_format_secret_source_suffix_empty_for_untracked():
@@ -100,7 +122,7 @@ def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkey
     end up in ``_SECRET_SOURCES`` so the UI can label them."""
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.test-token")
+    monkeypatch.setenv("CUSTOM_BWS_ACCESS_TOKEN", "0.test-token")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
@@ -108,7 +130,7 @@ def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkey
         "  bitwarden:\n"
         "    enabled: true\n"
         "    project_id: test-project\n"
-        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        "    access_token_env: CUSTOM_BWS_ACCESS_TOKEN\n",
         encoding="utf-8",
     )
 
@@ -129,6 +151,10 @@ def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkey
     env_loader._apply_external_secret_sources(tmp_path)
 
     assert env_loader.get_secret_source("ANTHROPIC_API_KEY") == "bitwarden"
+    assert env_loader.get_external_secret_env_vars(tmp_path) == frozenset({
+        "ANTHROPIC_API_KEY",
+        "CUSTOM_BWS_ACCESS_TOKEN",
+    })
     assert (
         env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")
         == " (from Bitwarden)"
@@ -314,6 +340,10 @@ def test_apply_external_secret_sources_dedupes_within_process(tmp_path, monkeypa
     assert env_loader.get_secret_source_values(tmp_path) == {
         "ANTHROPIC_API_KEY": "sk-ant-test"
     }
+    assert env_loader.get_external_secret_env_vars(tmp_path) == frozenset({
+        "ANTHROPIC_API_KEY",
+        "BWS_ACCESS_TOKEN",
+    })
 
     # reset_secret_source_cache() forces a fresh pull on the next call.
     env_loader.reset_secret_source_cache()

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -26,10 +26,12 @@ def _reset_sources():
     """Each test starts with a clean source map and applied-home guard."""
     env_loader._SECRET_SOURCES.clear()
     env_loader._SECRET_SOURCE_VALUES_BY_HOME.clear()
+    env_loader._SECRET_SOURCE_PROTECTED_VARS_BY_HOME.clear()
     env_loader.reset_secret_source_cache()
     yield
     env_loader._SECRET_SOURCES.clear()
     env_loader._SECRET_SOURCE_VALUES_BY_HOME.clear()
+    env_loader._SECRET_SOURCE_PROTECTED_VARS_BY_HOME.clear()
     env_loader.reset_secret_source_cache()
 
 
@@ -62,6 +64,85 @@ def test_get_secret_source_values_returns_home_snapshot_copy(tmp_path):
         "ANTHROPIC_API_KEY": "sk-profile-a"
     }
 
+
+def test_get_external_secret_env_vars_returns_scoped_names_only(tmp_path):
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+
+    env_loader._SECRET_SOURCE_VALUES_BY_HOME[str(home_a.resolve())] = {
+        "CUSTOM_DEPLOY_CREDENTIAL": "inert-secret-value"
+    }
+    env_loader._SECRET_SOURCE_PROTECTED_VARS_BY_HOME[str(home_a.resolve())] = (
+        frozenset({"CUSTOM_BWS_ACCESS_TOKEN"})
+    )
+
+    assert env_loader.get_external_secret_env_vars(home_a) == frozenset({
+        "CUSTOM_BWS_ACCESS_TOKEN",
+        "CUSTOM_DEPLOY_CREDENTIAL",
+    })
+    assert env_loader.get_external_secret_env_vars(home_b) == frozenset()
+
+
+
+@pytest.mark.parametrize("hydrate", [False, True])
+@pytest.mark.parametrize("broken_metadata", [False, True])
+def test_bootstrap_metadata_uses_requested_home_and_survives_other_source_failure(
+    tmp_path, monkeypatch, hydrate, broken_metadata
+):
+    from agent.secret_sources import registry
+    from agent.secret_sources.base import FetchResult, SecretSource
+
+    class ScopedSource(SecretSource):
+        name = "scoped_test_vault"
+        label = "test vault"
+        shape = "bulk"
+
+        def fetch(self, cfg, home_path):
+            return FetchResult(secrets={"LC_DEPLOY_VALUE": "inert-vault-value"})
+
+        def protected_env_vars(self, cfg):
+            return frozenset({"LC_BOOTSTRAP_VALUE"})
+
+    class BrokenSource(ScopedSource):
+        name = "broken_test_vault"
+
+        def fetch(self, cfg, home_path):
+            return FetchResult()
+
+        def protected_env_vars(self, cfg):
+            raise RuntimeError("unavailable source metadata")
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "process-home"))
+    monkeypatch.delenv("LC_DEPLOY_VALUE", raising=False)
+    monkeypatch.setattr(registry, "_SCOPED_SOURCES", {})
+    assert registry.register_source(ScopedSource(), scope=str(home.resolve()))
+    cfg = {"scoped_test_vault": {"enabled": True}}
+    if broken_metadata:
+        assert registry.register_source(BrokenSource(), scope=str(home.resolve()))
+        cfg["broken_test_vault"] = {"enabled": True}
+        cfg["sources"] = ["broken_test_vault", "scoped_test_vault"]
+    monkeypatch.setattr(env_loader, "_load_secrets_config", lambda _home: cfg)
+
+    try:
+        if hydrate:
+            assert env_loader.hydrate_profile_secret_sources(home) == {
+                "LC_DEPLOY_VALUE": "inert-vault-value"
+            }
+            assert "LC_DEPLOY_VALUE" not in os.environ
+        else:
+            env_loader._apply_external_secret_sources(home)
+        assert env_loader.get_external_secret_env_vars(home) == frozenset({
+            "LC_DEPLOY_VALUE", "LC_BOOTSTRAP_VALUE",
+        })
+        assert env_loader.get_external_secret_env_vars(tmp_path / "process-home") == frozenset()
+        env_loader.reset_secret_source_cache()
+        assert env_loader.get_external_secret_env_vars(home) == frozenset()
+    finally:
+        os.environ.pop("LC_DEPLOY_VALUE", None)
 
 def test_format_secret_source_suffix_empty_for_untracked():
     # Credentials from .env or the shell shouldn't add noise — the
@@ -100,7 +181,7 @@ def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkey
     end up in ``_SECRET_SOURCES`` so the UI can label them."""
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.test-token")
+    monkeypatch.setenv("CUSTOM_BWS_ACCESS_TOKEN", "0.test-token")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
@@ -108,7 +189,7 @@ def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkey
         "  bitwarden:\n"
         "    enabled: true\n"
         "    project_id: test-project\n"
-        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        "    access_token_env: CUSTOM_BWS_ACCESS_TOKEN\n",
         encoding="utf-8",
     )
 
@@ -129,6 +210,10 @@ def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkey
     env_loader._apply_external_secret_sources(tmp_path)
 
     assert env_loader.get_secret_source("ANTHROPIC_API_KEY") == "bitwarden"
+    assert env_loader.get_external_secret_env_vars(tmp_path) == frozenset({
+        "ANTHROPIC_API_KEY",
+        "CUSTOM_BWS_ACCESS_TOKEN",
+    })
     assert (
         env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")
         == " (from Bitwarden)"
@@ -393,6 +478,10 @@ def test_apply_external_secret_sources_dedupes_within_process(tmp_path, monkeypa
     assert env_loader.get_secret_source_values(tmp_path) == {
         "ANTHROPIC_API_KEY": "sk-ant-test"
     }
+    assert env_loader.get_external_secret_env_vars(tmp_path) == frozenset({
+        "ANTHROPIC_API_KEY",
+        "BWS_ACCESS_TOKEN",
+    })
 
     # reset_secret_source_cache() forces a fresh pull on the next call.
     env_loader.reset_secret_source_cache()
@@ -621,6 +710,9 @@ def _register_fake_bulk_source(value_for_home):
         label = "Fake"
         shape = "bulk"
 
+        def protected_env_vars(self, cfg):
+            return frozenset({"FAKE_BOOTSTRAP_TOKEN"})
+
         def fetch(self, cfg, home_path):
             result = FetchResult()
             result.secrets = {"GLM_API_KEY": value_for_home(Path(home_path))}
@@ -675,3 +767,10 @@ def test_home_scoped_reset_preserves_sibling_snapshot(tmp_path, monkeypatch, _fr
     assert env_loader.get_secret_source_values(home) == {}
     assert env_loader.get_secret_source_values(sibling) == {"GLM_API_KEY": "vault-b"}
     assert str(sibling.resolve()) in env_loader._APPLIED_HOMES
+    assert env_loader.get_external_secret_env_vars(home) == frozenset()
+    assert env_loader.get_external_secret_env_vars(sibling) == frozenset({
+        "GLM_API_KEY", "FAKE_BOOTSTRAP_TOKEN",
+    })
+
+    env_loader.reset_secret_source_cache()
+    assert env_loader.get_external_secret_env_vars(sibling) == frozenset()

--- a/tests/tools/test_code_execution_windows_env.py
+++ b/tests/tools/test_code_execution_windows_env.py
@@ -38,6 +38,39 @@ def _no_passthrough(_name):
     return False
 
 
+def test_external_secret_provenance_precedes_safe_prefix(
+    tmp_path, monkeypatch
+):
+    """Vault provenance blocks safe-prefix names unless explicitly passed."""
+    from hermes_cli import env_loader
+
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+        str(tmp_path.resolve()),
+        {"LC_VAULT_VALUE": "inert-secret-value"},
+    )
+    source_env = {
+        "HERMES_HOME": str(tmp_path),
+        "LC_ALL": "C.UTF-8",
+        "LC_VAULT_VALUE": "inert-secret-value",
+    }
+
+    scrubbed = _scrub_child_env(
+        source_env,
+        is_passthrough=_no_passthrough,
+        is_windows=False,
+    )
+    assert scrubbed["LC_ALL"] == "C.UTF-8"
+    assert "LC_VAULT_VALUE" not in scrubbed
+
+    explicit = _scrub_child_env(
+        source_env,
+        is_passthrough=lambda name: name == "LC_VAULT_VALUE",
+        is_windows=False,
+    )
+    assert explicit["LC_VAULT_VALUE"] == "inert-secret-value"
+
+
 class TestWindowsEssentialAllowlist:
     """The allowlist itself — contents, shape, and invariants."""
 

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -420,6 +420,40 @@ def test_forward_env_overrides_docker_env_in_init_args(monkeypatch):
     assert "MY_KEY=static_value" not in args_str
 
 
+def test_external_secret_source_var_is_not_implicitly_forwarded(monkeypatch):
+    """Implicit passthrough must not persist a vault-injected value in Docker."""
+    env = _make_execute_only_env()
+
+    monkeypatch.setenv("CUSTOM_DEPLOY_CREDENTIAL", "inert-secret-value")
+    monkeypatch.setattr(
+        "tools.env_passthrough.get_all_passthrough",
+        lambda: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+    )
+    monkeypatch.setattr(
+        docker_env,
+        "_external_secret_env_vars",
+        lambda _env=None: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+        raising=False,
+    )
+
+    assert "CUSTOM_DEPLOY_CREDENTIAL" not in " ".join(env._build_init_env_args())
+
+
+def test_external_secret_source_var_can_be_explicitly_forwarded(monkeypatch):
+    """docker_forward_env remains the operator-controlled compatibility escape."""
+    env = _make_execute_only_env(forward_env=["CUSTOM_DEPLOY_CREDENTIAL"])
+
+    monkeypatch.setenv("CUSTOM_DEPLOY_CREDENTIAL", "inert-secret-value")
+    monkeypatch.setattr(
+        docker_env,
+        "_external_secret_env_vars",
+        lambda _env=None: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+        raising=False,
+    )
+
+    assert "CUSTOM_DEPLOY_CREDENTIAL=inert-secret-value" in env._build_init_env_args()
+
+
 def test_normalize_env_dict_filters_invalid_keys():
     """_normalize_env_dict should reject invalid variable names."""
     result = docker_env._normalize_env_dict({

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -442,6 +442,41 @@ def test_forward_env_overrides_docker_env_in_init_args(monkeypatch):
     assert not any("static_value" in a for a in args)
 
 
+def test_external_secret_source_var_is_not_implicitly_forwarded(monkeypatch):
+    """Implicit passthrough must not persist a vault-injected value in Docker."""
+    env = _make_execute_only_env()
+
+    monkeypatch.setenv("CUSTOM_DEPLOY_CREDENTIAL", "inert-secret-value")
+    monkeypatch.setattr(
+        "tools.env_passthrough.get_all_passthrough",
+        lambda: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+    )
+    monkeypatch.setattr(
+        "tools.environments.local_env_policy._external_secret_env_vars",
+        lambda _env=None: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+        raising=False,
+    )
+
+    assert "CUSTOM_DEPLOY_CREDENTIAL" not in " ".join(env._build_init_env_args())
+
+
+def test_external_secret_source_var_can_be_explicitly_forwarded(monkeypatch):
+    """docker_forward_env remains the operator-controlled compatibility escape."""
+    env = _make_execute_only_env(forward_env=["CUSTOM_DEPLOY_CREDENTIAL"])
+
+    monkeypatch.setenv("CUSTOM_DEPLOY_CREDENTIAL", "inert-secret-value")
+    monkeypatch.setattr(
+        "tools.environments.local_env_policy._external_secret_env_vars",
+        lambda _env=None: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+        raising=False,
+    )
+
+    args = env._build_init_env_args()
+    assert "CUSTOM_DEPLOY_CREDENTIAL" in args
+    assert not any("inert-secret-value" in arg for arg in args)
+    assert env._init_env_values["CUSTOM_DEPLOY_CREDENTIAL"] == "inert-secret-value"
+
+
 def test_normalize_env_dict_filters_invalid_keys():
     """_normalize_env_dict should reject invalid variable names."""
     result = docker_env._normalize_env_dict({

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -10,6 +10,7 @@ See: https://github.com/NousResearch/hermes-agent/issues/1264
 
 import os
 import threading
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -74,6 +75,104 @@ class TestProviderEnvBlocklist:
 
         for var in leaked_vars:
             assert var not in result_env, f"{var} leaked into subprocess env"
+
+    @pytest.mark.parametrize(
+        "name,value",
+        [
+            ("BWS_ACCESS_TOKEN", "0.inert-test-token"),
+            ("OP_SERVICE_ACCOUNT_TOKEN", "ops_inert_test_token"),
+        ],
+    )
+    def test_secret_source_bootstrap_tokens_are_stripped(self, name, value):
+        """Secret-manager bootstrap credentials must not reach terminal shells."""
+        result_env = _run_with_env(extra_os_env={name: value})
+
+        assert name not in result_env
+
+    def test_external_secret_source_vars_are_stripped(self, monkeypatch):
+        """Vault-injected custom names must not be serialized by export -p."""
+        from hermes_cli import env_loader
+
+        monkeypatch.setattr(
+            env_loader,
+            "get_external_secret_env_vars",
+            lambda _home: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+            raising=False,
+        )
+        result_env = _run_with_env(extra_os_env={
+            "CUSTOM_DEPLOY_CREDENTIAL": "inert-secret-value",
+        })
+
+        assert "CUSTOM_DEPLOY_CREDENTIAL" not in result_env
+
+    def test_external_secret_source_var_preserves_explicit_passthrough(
+        self, monkeypatch
+    ):
+        """Existing trusted passthrough remains an explicit compatibility path."""
+        from hermes_cli import env_loader
+
+        monkeypatch.setattr(
+            env_loader,
+            "get_external_secret_env_vars",
+            lambda _home: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+        )
+        monkeypatch.setattr(
+            "tools.env_passthrough.is_env_passthrough",
+            lambda name: name == "CUSTOM_DEPLOY_CREDENTIAL",
+        )
+
+        result_env = _run_with_env(extra_os_env={
+            "CUSTOM_DEPLOY_CREDENTIAL": "inert-secret-value",
+        })
+
+        assert result_env["CUSTOM_DEPLOY_CREDENTIAL"] == "inert-secret-value"
+
+    def test_external_secret_source_vars_never_reach_snapshot(
+        self, monkeypatch, tmp_path
+    ):
+        """Behavioral regression for #62336 using the real export snapshot."""
+        from hermes_cli import env_loader
+
+        monkeypatch.setattr(
+            env_loader,
+            "get_external_secret_env_vars",
+            lambda _home: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+            raising=False,
+        )
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("CUSTOM_DEPLOY_CREDENTIAL", "inert-secret-value")
+        monkeypatch.setenv("SNAPSHOT_POSITIVE_CONTROL", "keep-this")
+
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        try:
+            snapshot = Path(env._snapshot_path).read_text(encoding="utf-8")
+            assert "CUSTOM_DEPLOY_CREDENTIAL" not in snapshot
+            assert "inert-secret-value" not in snapshot
+            assert "SNAPSHOT_POSITIVE_CONTROL" in snapshot
+            assert "keep-this" in snapshot
+        finally:
+            env.cleanup()
+
+    def test_external_secret_names_are_scoped_to_effective_home(
+        self, monkeypatch, tmp_path
+    ):
+        """A secret from profile A must not suppress profile B's ordinary var."""
+        from hermes_cli import env_loader
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        home_a.mkdir()
+        home_b.mkdir()
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME[str(home_a.resolve())] = {
+            "CUSTOM_DEPLOY_CREDENTIAL": "profile-a-secret"
+        }
+
+        result_env = _run_with_env(
+            extra_os_env={"CUSTOM_DEPLOY_CREDENTIAL": "profile-b-ordinary"},
+            self_env={"HERMES_HOME": str(home_b)},
+        )
+
+        assert result_env["CUSTOM_DEPLOY_CREDENTIAL"] == "profile-b-ordinary"
 
     def test_registry_derived_vars_are_stripped(self):
         """Vars from the provider registry (ANTHROPIC_TOKEN, ZAI_API_KEY, etc.)

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -83,6 +83,125 @@ class TestProviderEnvBlocklist:
         for var in leaked_vars:
             assert var not in result_env, f"{var} leaked into subprocess env"
 
+    @pytest.mark.parametrize(
+        "name,value",
+        [
+            ("BWS_ACCESS_TOKEN", "0.inert-test-token"),
+            ("OP_SERVICE_ACCOUNT_TOKEN", "ops_inert_test_token"),
+        ],
+    )
+    def test_secret_source_bootstrap_tokens_are_stripped(self, name, value):
+        """Secret-manager bootstrap credentials must not reach terminal shells."""
+        result_env = _run_with_env(extra_os_env={name: value})
+
+        assert name not in result_env
+
+    def test_external_secret_source_vars_are_stripped(self, monkeypatch):
+        """Vault-injected custom names must not be serialized by export -p."""
+        from hermes_cli import env_loader
+
+        monkeypatch.setattr(
+            env_loader,
+            "get_external_secret_env_vars",
+            lambda _home: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+            raising=False,
+        )
+        result_env = _run_with_env(extra_os_env={
+            "CUSTOM_DEPLOY_CREDENTIAL": "inert-secret-value",
+        })
+
+        assert "CUSTOM_DEPLOY_CREDENTIAL" not in result_env
+
+    def test_external_secret_source_var_preserves_explicit_passthrough(
+        self, monkeypatch
+    ):
+        """Existing trusted passthrough remains an explicit compatibility path."""
+        from hermes_cli import env_loader
+
+        monkeypatch.setattr(
+            env_loader,
+            "get_external_secret_env_vars",
+            lambda _home: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+        )
+        monkeypatch.setattr(
+            "tools.env_passthrough.is_env_passthrough",
+            lambda name: name == "CUSTOM_DEPLOY_CREDENTIAL",
+        )
+
+        result_env = _run_with_env(extra_os_env={
+            "CUSTOM_DEPLOY_CREDENTIAL": "inert-secret-value",
+        })
+
+        assert result_env["CUSTOM_DEPLOY_CREDENTIAL"] == "inert-secret-value"
+
+    @pytest.mark.parametrize("inherit_credentials", [False, True])
+    def test_nonterminal_children_obey_external_secret_inheritance(
+        self, monkeypatch, tmp_path, inherit_credentials
+    ):
+        from hermes_cli import env_loader
+        from tools.environments.local import hermes_subprocess_env
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("CUSTOM_DEPLOY_CREDENTIAL", "inert-secret-value")
+        monkeypatch.setenv("SOURCE_PROVENANCE_POSITIVE_CONTROL", "ordinary")
+        monkeypatch.setattr(env_loader, "_SECRET_SOURCE_VALUES_BY_HOME", {
+            str(tmp_path.resolve()): {"CUSTOM_DEPLOY_CREDENTIAL": "inert-secret-value"}
+        })
+
+        result = hermes_subprocess_env(inherit_credentials=inherit_credentials)
+
+        assert ("CUSTOM_DEPLOY_CREDENTIAL" in result) is inherit_credentials
+        if inherit_credentials:
+            assert result["CUSTOM_DEPLOY_CREDENTIAL"] == "inert-secret-value"
+        assert result["SOURCE_PROVENANCE_POSITIVE_CONTROL"] == "ordinary"
+
+    def test_external_secret_source_vars_never_reach_snapshot(
+        self, monkeypatch, tmp_path
+    ):
+        """Behavioral regression for #62336 using the real export snapshot."""
+        from hermes_cli import env_loader
+
+        monkeypatch.setattr(
+            env_loader,
+            "get_external_secret_env_vars",
+            lambda _home: frozenset({"CUSTOM_DEPLOY_CREDENTIAL"}),
+            raising=False,
+        )
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("CUSTOM_DEPLOY_CREDENTIAL", "inert-secret-value")
+        monkeypatch.setenv("SNAPSHOT_POSITIVE_CONTROL", "keep-this")
+
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        try:
+            snapshot = Path(env._snapshot_path).read_text(encoding="utf-8")
+            assert "CUSTOM_DEPLOY_CREDENTIAL" not in snapshot
+            assert "inert-secret-value" not in snapshot
+            assert "SNAPSHOT_POSITIVE_CONTROL" in snapshot
+            assert "keep-this" in snapshot
+        finally:
+            env.cleanup()
+
+    def test_external_secret_names_are_scoped_to_effective_home(
+        self, monkeypatch, tmp_path
+    ):
+        """A secret from profile A must not suppress profile B's ordinary var."""
+        from hermes_cli import env_loader
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        home_a.mkdir()
+        home_b.mkdir()
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME[str(home_a.resolve())] = {
+            "CUSTOM_DEPLOY_CREDENTIAL": "profile-a-secret"
+        }
+
+        result_env = _run_with_env(
+            extra_os_env={"CUSTOM_DEPLOY_CREDENTIAL": "profile-b-ordinary"},
+            self_env={"HERMES_HOME": str(home_b)},
+        )
+
+        assert result_env["CUSTOM_DEPLOY_CREDENTIAL"] == "profile-b-ordinary"
+
     def test_registry_derived_vars_are_stripped(self):
         """Vars from the provider registry (ANTHROPIC_TOKEN, ZAI_API_KEY, etc.)
         must also be blocked — not just the hand-written extras."""

--- a/tools/code_execution_env.py
+++ b/tools/code_execution_env.py
@@ -54,7 +54,8 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
 
     Rules, in order: (1) passthrough vars (skill/config-declared) resolve
     through the active profile secret scope — an absent scoped value is
-    omitted; (2) secret-substring names are blocked; (3) safe prefixes pass;
+    omitted; (2) external-source names and secret-substring names are blocked;
+    (3) safe prefixes pass;
     (4) operational HERMES_* pass by exact name; (5) on Windows the
     OS-essential allowlist passes by exact name.
     """
@@ -67,6 +68,8 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
         is_passthrough = is_env_passthrough
     if is_windows is None:
         is_windows = _IS_WINDOWS
+    from tools.environments.local_env_policy import _external_secret_env_vars
+    source_secrets = _external_secret_env_vars(source_env)
     scrubbed = {}
     # Non-secret HERMES_* vars no allowlist admits are dropped on purpose; a script importing a
     # repo module that reads one would see it silently unset — log the drop, point at the opt-in.
@@ -76,6 +79,8 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
             resolved = resolve_passthrough_value(k, v)
             if resolved is not None:
                 scrubbed[k] = resolved
+            continue
+        if k in source_secrets:
             continue
         if any(s in k.upper() for s in _SECRET_SUBSTRINGS):
             continue

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -211,10 +211,11 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
       1. Passthrough vars (skill- or config-declared) pass through the active
          profile secret scope; an absent scoped value is omitted and an
          unscoped multiplex read fails closed.
-      2. Secret-substring names (KEY/TOKEN/DSN/WEBHOOK/etc.) are blocked.
-      3. Names matching a safe prefix pass.
-      4. Operational HERMES_* vars (_HERMES_CHILD_ALLOWED) pass by exact name.
-      5. On Windows, a small OS-essential allowlist passes by exact name
+      2. External-secret-source vars are blocked by provenance.
+      3. Secret-substring names (KEY/TOKEN/DSN/WEBHOOK/etc.) are blocked.
+      4. Names matching a safe prefix pass.
+      5. Operational HERMES_* vars (_HERMES_CHILD_ALLOWED) pass by exact name.
+      6. On Windows, a small OS-essential allowlist passes by exact name
          — without these the child can't even create a socket or spawn a
          subprocess.
 
@@ -240,6 +241,13 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
     if is_windows is None:
         is_windows = _IS_WINDOWS
 
+    try:
+        from tools.environments.local import _external_secret_env_vars
+
+        source_secrets = _external_secret_env_vars(source_env)
+    except Exception:
+        source_secrets = frozenset()
+
     scrubbed = {}
     # Non-secret HERMES_* vars dropped by the tightened allowlist (#27303). The
     # broad "HERMES_" prefix used to pass these through; now only the
@@ -254,6 +262,8 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
             resolved = resolve_passthrough_value(k, v)
             if resolved is not None:
                 scrubbed[k] = resolved
+            continue
+        if k in source_secrets:
             continue
         if any(s in k.upper() for s in _SECRET_SUBSTRINGS):
             continue

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -21,6 +21,7 @@ from typing import Optional
 from tools.environments.base import BaseEnvironment, _popen_bash
 from tools.environments.local import (
     _HERMES_PROVIDER_ENV_BLOCKLIST,
+    _external_secret_env_vars,
     _is_hermes_internal_secret,
 )
 
@@ -1551,7 +1552,10 @@ class DockerEnvironment(BaseEnvironment):
         _implicit_forward = {
             k for k in passthrough_keys if not _is_hermes_internal_secret(k)
         }
-        forward_keys = explicit_forward_keys | (_implicit_forward - _HERMES_PROVIDER_ENV_BLOCKLIST)
+        blocked_implicit = (
+            _HERMES_PROVIDER_ENV_BLOCKLIST | _external_secret_env_vars(os.environ)
+        )
+        forward_keys = explicit_forward_keys | (_implicit_forward - blocked_implicit)
         hermes_env = _load_hermes_env_vars() if forward_keys else {}
         unset_names: set[str] = set()
         for key in sorted(forward_keys):

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -827,7 +827,11 @@ class DockerEnvironment(BaseEnvironment):
 
     def _resolve_passthrough_env(self) -> tuple[dict[str, str], set[str]]:
         """See ``remote_common.resolve_passthrough_env``; explicit docker_forward_env bypasses the blocklist."""
-        return resolve_passthrough_env(self._forward_env, hermes_env_loader=_load_hermes_env_vars)
+        from tools.environments.local_env_policy import _external_secret_env_vars
+        return resolve_passthrough_env(
+            self._forward_env, hermes_env_loader=_load_hermes_env_vars,
+            blocked_implicit=_external_secret_env_vars(os.environ),
+        )
 
     def _build_runtime_env_args_with_unsets(self) -> tuple[list[str], tuple[str, ...], dict[str, str]]:
         """Runtime name-only forwarding args, names absent from scope, and the values

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -249,6 +249,12 @@ def _build_provider_env_blocklist() -> frozenset:
         pass
 
     blocked.update({
+        # External secret-manager bootstrap credentials authorize bulk reads
+        # from the configured vault. Model-driven subprocesses do not need
+        # them, and allowing them into a shell makes export snapshots persist
+        # the highest-value credential in the source chain.
+        "BWS_ACCESS_TOKEN",
+        "OP_SERVICE_ACCOUNT_TOKEN",
         "OPENAI_BASE_URL",
         "OPENAI_API_KEY",
         "OPENAI_API_BASE",
@@ -335,6 +341,30 @@ def _build_provider_env_blocklist() -> frozenset:
 
 
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
+
+
+def _external_secret_env_vars(env: dict | None = None) -> frozenset[str]:
+    """Return vault-populated names for the subprocess's effective profile.
+
+    The context-local override wins because ``_inject_context_hermes_home``
+    applies the same precedence to the child environment. An explicit
+    ``HERMES_HOME`` in ``env`` is next, followed by the normal process/default
+    resolution. Fail open to the established static blocklist if provenance is
+    unavailable so terminal startup remains resilient.
+    """
+    try:
+        from hermes_constants import get_hermes_home, get_hermes_home_override
+        from hermes_cli.env_loader import get_external_secret_env_vars
+
+        home = get_hermes_home_override()
+        if not home and env:
+            home = env.get("HERMES_HOME")
+        if not home:
+            home = get_hermes_home()
+        return get_external_secret_env_vars(home)
+    except Exception:
+        return frozenset()
+
 
 # Active-virtualenv markers that must NOT leak into terminal subprocesses.
 # The gateway runs inside its own venv, so its process environment carries
@@ -465,6 +495,9 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         _resolve_passthrough_value = lambda _name, fallback: fallback  # noqa: E731
 
     sanitized: dict[str, str] = {}
+    source_secrets = _external_secret_env_vars(
+        dict((base_env or {}) | (extra_env or {}))
+    )
 
     for key, value in (base_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
@@ -472,7 +505,9 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         if _is_hermes_internal_secret(key):
             continue
         passthrough = _is_passthrough(key)
-        if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+        if (
+            key in _HERMES_PROVIDER_ENV_BLOCKLIST or key in source_secrets
+        ) and not passthrough:
             continue
         resolved = _resolve_passthrough_value(key, value) if passthrough else value
         if resolved is not None:
@@ -488,7 +523,9 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             continue
         else:
             passthrough = _is_passthrough(key)
-            if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+            if (
+                key in _HERMES_PROVIDER_ENV_BLOCKLIST or key in source_secrets
+            ) and not passthrough:
                 continue
             resolved = _resolve_passthrough_value(key, value) if passthrough else value
             if resolved is not None:
@@ -1277,6 +1314,7 @@ def _make_run_env(env: dict) -> dict:
         _resolve_passthrough_value = lambda _name, fallback: fallback  # noqa: E731
 
     merged = dict(os.environ | env)
+    source_secrets = _external_secret_env_vars(merged)
     run_env = {}
     for k, v in merged.items():
         if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
@@ -1288,7 +1326,9 @@ def _make_run_env(env: dict) -> dict:
             continue
         else:
             passthrough = _is_passthrough(k)
-            if k in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+            if (
+                k in _HERMES_PROVIDER_ENV_BLOCKLIST or k in source_secrets
+            ) and not passthrough:
                 continue
             value = _resolve_passthrough_value(k, v) if passthrough else v
             if value is not None:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -22,6 +22,7 @@ from tools.environments.base_output import _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.environments.local_env_policy import (
     _ALWAYS_STRIP_KEYS, _HERMES_PROVIDER_ENV_BLOCKLIST, _HERMES_PROVIDER_ENV_FORCE_PREFIX,
+    _external_secret_env_vars,
     _is_hermes_internal_secret, _is_terminal_first_party_env,
     _matches_terminal_first_party_prefix, _plugin_terminal_env_strip_keys)
 from tools.environments.local_gitbash_probe import (
@@ -234,7 +235,7 @@ def _inject_session_context_env(env: dict) -> None:
 
 def _filter_secret_env(
     items: Mapping[str, str], out: dict, *, unwrap_force: bool,
-    plugin_strip: frozenset = frozenset()) -> None:
+    plugin_strip: frozenset = frozenset(), source_secrets: frozenset = frozenset()) -> None:
     """Copy *items* into *out*, dropping Hermes-managed secrets. ``_HERMES_FORCE_<NAME>``
     unwraps to ``NAME`` when ``unwrap_force`` (caller extras / terminal env), else is
     dropped. Blocklisted names survive only via env_passthrough registration or as
@@ -256,7 +257,7 @@ def _filter_secret_env(
             continue
         first_party = _is_terminal_first_party_env(key)
         passthrough = is_env_passthrough(key)
-        if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not (passthrough or first_party):
+        if (key in _HERMES_PROVIDER_ENV_BLOCKLIST or key in source_secrets) and not (passthrough or first_party):
             continue
         if passthrough and not first_party:
             value = resolve_passthrough_value(key, value)
@@ -280,9 +281,12 @@ def _scrubbed_env(parts, plugin_strip: frozenset, fix_path) -> dict:
     """Filter each ``(items, unwrap_force)`` in *parts* into one env, rewrite PATH via
     *fix_path* (always prepending the hermes install dir so bare ``hermes`` resolves
     for children of a systemd/cron-launched gateway), then apply the shared guards."""
+    merged = {key: value for items, _unwrap in parts for key, value in items.items()}
+    source_secrets = _external_secret_env_vars(merged)
     out: dict[str, str] = {}
     for items, unwrap_force in parts:
-        _filter_secret_env(items, out, unwrap_force=unwrap_force, plugin_strip=plugin_strip)
+        _filter_secret_env(items, out, unwrap_force=unwrap_force, plugin_strip=plugin_strip,
+                           source_secrets=source_secrets)
     path_key = _path_env_key(out)
     # Keep bare ``hermes`` invocations available to child jobs even when the gateway was launched by a
     # service manager or cron without the console script's directory on PATH. The terminal environment
@@ -303,13 +307,13 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     """Sanitized env for the **non-terminal** spawn surface (browser, ACP/CLI executors,
     computer-use driver, TUI Node host). Tier 1 (``_ALWAYS_STRIP_KEYS``, plugin keys,
     force-prefixed hints, dynamic internal secrets) is always removed; Tier 2 (the
-    provider/tool blocklist) unless ``inherit_credentials`` — pass that **only** for
+    provider/tool blocklist and external-source names) unless ``inherit_credentials`` — pass that **only** for
     children that legitimately need LLM credentials (user-blessed claude/codex/gemini
     CLI, TUI Node host). Terminal/execute_code use ``_sanitize_subprocess_env``."""
     env = os.environ.copy()
     strip = _ALWAYS_STRIP_KEYS | _plugin_terminal_env_strip_keys()
     if not inherit_credentials:
-        strip |= _HERMES_PROVIDER_ENV_BLOCKLIST
+        strip |= _HERMES_PROVIDER_ENV_BLOCKLIST | _external_secret_env_vars(env)
     for key in list(env):
         if (key in strip or key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX)
                 or _is_hermes_internal_secret(key)):

--- a/tools/environments/local_env_policy.py
+++ b/tools/environments/local_env_policy.py
@@ -15,6 +15,7 @@ _HERMES_PROVIDER_ENV_FORCE_PREFIX = "_HERMES_FORCE_"
 _AWS_SDK_CREDENTIAL_ENV_VARS = frozenset({"AWS_BEARER_TOKEN_BEDROCK"})
 
 _STATIC_PROVIDER_ENV_BLOCKLIST = frozenset({
+    "BWS_ACCESS_TOKEN", "OP_SERVICE_ACCOUNT_TOKEN",
     "OPENAI_BASE_URL", "OPENAI_API_KEY", "OPENAI_API_BASE", "OPENAI_ORG_ID",
     "OPENAI_ORGANIZATION", "OPENROUTER_API_KEY", "ANTHROPIC_BASE_URL",
     "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "LLM_MODEL", "GOOGLE_API_KEY",
@@ -39,6 +40,17 @@ _STATIC_PROVIDER_ENV_BLOCKLIST = frozenset({
     "GATEWAY_RELAY_DELIVERY_KEY", "VERCEL_OIDC_TOKEN", "VERCEL_TOKEN",
     "VERCEL_PROJECT_ID", "VERCEL_TEAM_ID",
 })
+
+
+def _external_secret_env_vars(env=None) -> frozenset[str]:
+    """Names owned by the effective profile, matching child HERMES_HOME precedence."""
+    try:
+        from hermes_constants import get_hermes_home, get_hermes_home_override
+        from hermes_cli.env_loader import get_external_secret_env_vars
+        home = get_hermes_home_override() or (env or {}).get("HERMES_HOME") or get_hermes_home()
+        return get_external_secret_env_vars(home)
+    except Exception:
+        return frozenset()  # preserve established startup fallback to static policy
 
 
 def _build_provider_env_blocklist() -> frozenset:

--- a/tools/environments/remote_common.py
+++ b/tools/environments/remote_common.py
@@ -22,6 +22,7 @@ def load_hermes_env_vars() -> dict[str, str]:
 
 def resolve_passthrough_env(explicit_forward: Iterable[str] = (),
                             hermes_env_loader: Callable[[], dict[str, str]] = load_hermes_env_vars,
+                            blocked_implicit: Iterable[str] = (),
                             ) -> tuple[dict[str, str], set[str]]:
     """Values to forward into a remote shell plus the scoped names that must be unset there.
 
@@ -44,7 +45,9 @@ def resolve_passthrough_env(explicit_forward: Iterable[str] = (),
     except Exception:
         pass
     implicit_forward = {k for k in passthrough_keys if not _is_hermes_internal_secret(k)}
-    forward_keys = set(explicit_forward) | (implicit_forward - _HERMES_PROVIDER_ENV_BLOCKLIST)
+    forward_keys = set(explicit_forward) | (
+        implicit_forward - _HERMES_PROVIDER_ENV_BLOCKLIST - set(blocked_implicit)
+    )
     hermes_env = hermes_env_loader() if forward_keys else {}
     exec_env: dict[str, str] = {}
     unset_names: set[str] = set()


### PR DESCRIPTION
Local terminal and code-execution shells inherit environment values before
BaseEnvironment serializes their state with export -p. Owner-only snapshot
permissions prevent cross-user disclosure, but Hermes-managed vault values and
bootstrap credentials can still be persisted for later model-driven access.

Track exact external-source and bootstrap variable names per resolved
HERMES_HOME, including cold-profile hydration and profile-scoped sources. Remove
those names from default local shells, sanitized non-terminal children,
execute_code children, and implicit
Docker forwarding. Preserve ordinary shell state, the general AWS chain,
permitted env_passthrough, and explicit docker_forward_env. Docker continues
to forward names in argv and supplies values through its client environment.

This is scoped defense-in-depth: names outside Hermes external-source
provenance and secrets exported inside a running shell remain governed by the
owner-only snapshot boundary rather than heuristic filtering.

Related #62336

Co-authored-by: Teknium <127238744+teknium1@users.noreply.github.com>

Validation: 300 tests passed across environment provenance, local shells and real export snapshots, code execution, Docker forwarding, passthrough policy, and profile secret scopes. Six platform-specific tests were skipped on Linux. The regressions reproduced before the fix; Ruff and the repository compatibility-pointer check passed.

Not checked: live vault services, Windows/macOS execution, and CodeRabbit (self-authored P3 maintenance). This does not filter secrets newly exported inside a running shell or implement value-based filtering across other profiles.

Prepared with GPT-6 Astra, ultra reasoning, in Codex Desktop. The account owner loosely reviews my actions and receives usual notifications from GitHub.
