### PR TITLE
fix(desktop): make the conversation timeline keyboard-accessible

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/timeline.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ThreadTimeline } from './timeline'
+
+afterEach(() => cleanup())
+
+// Stub AUI: useAuiState receives the selector and is called immediately inside
+// the component. We feed a stable messages array so deriveTimelineEntries
+// returns predictable entries. The hook below supports per-test overrides by
+// letting the test set the active mock before render.
+const useAuiStateMock = vi.fn()
+
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: (selector: (s: unknown) => unknown) => useAuiStateMock(selector)
+}))
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: () => {} }))
+
+function messagesWith(rows: Array<{ id: string; text: string }>) {
+  return { thread: { messages: rows.map(r => ({ id: r.id, role: 'user', content: r.text })) } }
+}
+
+const fourPrompts = messagesWith([
+  { id: 'u1', text: 'first prompt' },
+  { id: 'u2', text: 'second prompt' },
+  { id: 'u3', text: 'third prompt' },
+  { id: 'u4', text: 'fourth prompt' }
+])
+
+const threePrompts = messagesWith([
+  { id: 'u1', text: 'one' },
+  { id: 'u2', text: 'two' },
+  { id: 'u3', text: 'three' }
+])
+
+const whitespaceOnly = messagesWith([
+  { id: 'u1', text: '   ' },
+  { id: 'u2', text: '\n\n' },
+  { id: 'u3', text: '\t' },
+  { id: 'u4', text: 'real prompt' }
+])
+
+describe('ThreadTimeline (keyboard accessibility)', () => {
+  it('renders a button trigger with the screen-reader-meaningful ARIA attributes', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    render(<ThreadTimeline />)
+
+    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(trigger.getAttribute('aria-controls')).toBeTruthy()
+  })
+
+  it('opens the popover on Enter and closes on Escape (trigger has focus)', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    render(<ThreadTimeline />)
+
+    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
+
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.keyDown(trigger, { key: 'Escape' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('opens the popover on Space', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    render(<ThreadTimeline />)
+
+    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
+
+    fireEvent.keyDown(trigger, { key: ' ' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('uses a positional, preview-bearing accessible name on every popover row', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    render(<ThreadTimeline />)
+    fireEvent.keyDown(screen.getByRole('button', { name: /conversation timeline/i }), { key: 'Enter' })
+
+    const group = screen.getByRole('group', { name: /past user prompts/i })
+    expect(group).toBeTruthy()
+
+    // 4 rows; each should read "Prompt N of 4: <preview>"
+    expect(within(group).getByRole('button', { name: /prompt 1 of 4: first prompt/i })).toBeTruthy()
+    expect(within(group).getByRole('button', { name: /prompt 2 of 4: second prompt/i })).toBeTruthy()
+    expect(within(group).getByRole('button', { name: /prompt 3 of 4: third prompt/i })).toBeTruthy()
+    expect(within(group).getByRole('button', { name: /prompt 4 of 4: fourth prompt/i })).toBeTruthy()
+  })
+
+  it('returns null when there are fewer than 4 user prompts (MIN_ENTRIES invariant)', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(threePrompts))
+    const { container } = render(<ThreadTimeline />)
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('Escape on the popover container closes the popover and returns focus to the trigger', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    render(<ThreadTimeline />)
+    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
+
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+
+    // Fire Escape on the popover container; the listener calls closeNow() and triggerRef.current?.focus()
+    const group = screen.getByRole('group', { name: /past user prompts/i })
+    fireEvent.keyDown(group, { key: 'Escape' })
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -1,5 +1,5 @@
 import { useAuiState } from '@assistant-ui/react'
-import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type FC, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
@@ -139,6 +139,8 @@ export const ThreadTimeline: FC = () => {
   const [activeIndex, setActiveIndex] = useState(0)
   const [open, setOpen] = useState(false)
   const closeTimerRef = useRef<number | undefined>(undefined)
+  const triggerRef = useRef<HTMLDivElement | null>(null)
+  const popoverId = useId()
 
   // Hover sync lives on the DOM, not in React state — the tick and its popover
   // row are siblings in different subtrees, so a shared index-keyed paint() lights
@@ -172,6 +174,51 @@ export const ThreadTimeline: FC = () => {
     window.clearTimeout(closeTimerRef.current)
     closeTimerRef.current = window.setTimeout(() => setOpen(false), HOVER_CLOSE_MS)
   }, [])
+
+  const closeNow = useCallback(() => {
+    window.clearTimeout(closeTimerRef.current)
+    setOpen(false)
+  }, [])
+
+  const toggle = useCallback(() => {
+    setOpen(prev => {
+      if (prev) {
+        window.clearTimeout(closeTimerRef.current)
+        return false
+      }
+      return true
+    })
+  }, [])
+
+  // Keyboard activation for the rail trigger: Enter/Space toggle, Escape close.
+  // Without this, a NVDA user can see the rail in the DOM (via object navigation)
+  // but has no path to actually open the popover or reach its rows.
+  const onTriggerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault()
+        toggle()
+      } else if (event.key === 'Escape' && open) {
+        event.preventDefault()
+        closeNow()
+      }
+    },
+    [open, toggle, closeNow]
+  )
+
+  // Inside the popover, Escape closes AND moves focus back to the trigger so a
+  // screen-reader user lands somewhere predictable after dismissal (no transient
+  // focus trap; matches what hover-off does for sighted users).
+  const onPopoverKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        closeNow()
+        triggerRef.current?.focus()
+      }
+    },
+    [closeNow]
+  )
 
   useEffect(() => () => window.clearTimeout(closeTimerRef.current), [])
 
@@ -230,13 +277,21 @@ export const ThreadTimeline: FC = () => {
 
   return (
     <div
+      aria-controls={popoverId}
+      aria-expanded={open}
       aria-label="Conversation timeline"
-      className="group/timeline pointer-events-auto absolute right-0 top-1/2 z-40 flex -translate-y-1/2 flex-col items-end"
+      className="group/timeline pointer-events-auto absolute right-0 top-1/2 z-40 flex -translate-y-1/2 cursor-pointer flex-col items-end"
       data-slot="thread-timeline"
       data-suppress-pane-reveal=""
+      onBlur={closeSoon}
+      onClick={toggle}
+      onFocus={keepOpen}
+      onKeyDown={onTriggerKeyDown}
       onMouseEnter={keepOpen}
       onMouseLeave={closeSoon}
-      role="navigation"
+      ref={triggerRef}
+      role="button"
+      tabIndex={0}
     >
       <TimelineTicks
         activeIndex={activeIndex}
@@ -244,14 +299,18 @@ export const ThreadTimeline: FC = () => {
         onHover={paint}
         onJump={scrollToPrompt}
         tickRefs={tickRefs}
+        totalEntries={entries.length}
       />
       <TimelinePopover
         activeIndex={activeIndex}
         entries={entries}
+        id={popoverId}
         onHover={paint}
         onJump={scrollToPrompt}
+        onKeyDown={onPopoverKeyDown}
         open={open}
         rowRefs={rowRefs}
+        totalEntries={entries.length}
       />
     </div>
   )
@@ -260,21 +319,32 @@ export const ThreadTimeline: FC = () => {
 const TimelinePopover: FC<{
   activeIndex: number
   entries: TimelineEntry[]
+  id: string
   onHover: (index: number, on: boolean) => void
   onJump: (id: string) => void
+  onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void
   open: boolean
   rowRefs: React.RefObject<(HTMLButtonElement | null)[]>
-}> = ({ activeIndex, entries, onHover, onJump, open, rowRefs }) => (
+  totalEntries: number
+}> = ({ activeIndex, entries, onHover, onJump, onKeyDown, open, id, rowRefs, totalEntries }) => (
   <div
+    aria-label="Past user prompts"
     className={cn(
       POPOVER_SHELL,
       open ? 'pointer-events-auto opacity-100 translate-x-0' : 'pointer-events-none translate-x-1 opacity-0'
     )}
     data-slot="thread-timeline-popover"
+    id={id}
+    onKeyDown={onKeyDown}
+    role="group"
   >
     {entries.map((entry, index) => (
       <button
-        aria-label={entry.preview}
+        aria-label={
+          entry.preview
+            ? `Prompt ${index + 1} of ${totalEntries}: ${entry.preview}`
+            : `Prompt ${index + 1} of ${totalEntries} (no preview)`
+        }
         className={cn(ROW_CLASS, index === activeIndex && 'bg-(--ui-row-active-background) text-foreground')}
         key={entry.id}
         onClick={() => onJump(entry.id)}
@@ -294,11 +364,16 @@ const TimelineTicks: FC<{
   onHover: (index: number, on: boolean) => void
   onJump: (id: string) => void
   tickRefs: React.RefObject<(HTMLSpanElement | null)[]>
-}> = ({ activeIndex, entries, onHover, onJump, tickRefs }) => (
+  totalEntries: number
+}> = ({ activeIndex, entries, onHover, onJump, tickRefs, totalEntries }) => (
   <div className="flex flex-col items-end py-1" data-slot="thread-timeline-ticks">
     {entries.map((entry, index) => (
       <button
-        aria-label={entry.preview}
+        aria-label={
+          entry.preview
+            ? `Prompt ${index + 1} of ${totalEntries}: ${entry.preview}`
+            : `Prompt ${index + 1} of ${totalEntries} (no preview)`
+        }
         className="flex h-2 w-7 cursor-pointer items-center justify-end pr-1"
         key={entry.id}
         onClick={() => onJump(entry.id)}


### PR DESCRIPTION
> **Note:** This is the first of two PRs that together address #70014. The companion PR is #70032 (`feat(desktop): add a toggle for the conversation-timeline rail and make ticks jump to the prompt`) — the second half of the fix (toggle shortcut, Tab-order suppression when hidden, click/Enter jump on ticks).

## Summary

The right-edge conversation-timeline rail that lets a user jump to a past
prompt is hover-only: a `<div role="navigation">` opens and closes the
popover via `onMouseEnter` / `onMouseLeave`, but the trigger is not
focusable and there is no keyboard handler. An NVDA user can see the rail
in the DOM via object navigation, but has no path to actually open the
popover or reach its rows in normal Tab order.

## Fix

- Promote the rail trigger from `<div role="navigation">` to
  `<div role="button" tabIndex={0}>` so it picks up keyboard activation.
  `<button>` cannot be used here because the trigger wraps `<button>`
  rows in the popover and the ticks are also `<button>`s, and HTML
  forbids nested interactive elements.
- Add `onClick` (toggle), `onFocus` / `onBlur` (open / close), and
  `onKeyDown` for Enter / Space / Escape so the focus lifecycle matches
  the hover lifecycle.
- Return focus to the rail trigger when the user presses Escape inside
  the popover, so a keyboard user has a predictable landing after
  dismissal.
- Widen each prompt row `aria-label` from the truncated preview to
  `"Prompt N of M: <preview>"` with a positional fallback when the
  preview is empty (e.g. an image-only prompt).
- Add `timeline.test.tsx` covering the open / close / Space / Escape /
  focus-restoration lifecycle and the row `aria-label` widening.

## Testing

```sh
cd apps/desktop
npx vitest run src/components/assistant-ui/thread/timeline.test.tsx
```

→ 6 tests pass.

## Refs

- NVDA-tested locally on Windows 10 by Tracy Smith (`trasles16-ux`).
- Bug: hover-only timeline rail was reported as "in the way" / unusable
  for keyboard / screen-reader navigation.
