### PR TITLE
fix(desktop): preserve free text after steer completion

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   desktopSkinSlashCompletions,
+  desktopSlashCommandTakesArgs,
   desktopSlashDescription,
   desktopSlashUnavailableMessage,
   filterDesktopCommandsCatalog,
@@ -120,6 +121,10 @@ describe('desktop slash command curation', () => {
     for (const name of ['/agents', '/steer', '/stop', '/usage']) {
       expect(resolveDesktopCommand(name)?.surface).toEqual({ kind: 'exec' })
     }
+  })
+
+  it('does not keep the completion popover open for /steer free text', () => {
+    expect(desktopSlashCommandTakesArgs('/steer')).toBe(false)
   })
 
   it('still routes commands without dedicated RPCs through exec()', () => {

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -236,7 +236,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     description: 'Show current session status',
     surface: rpc('session.status', ctx => ({ session_id: ctx.sessionId }))
   },
-  { name: '/steer', description: 'Steer the current run after the next tool call', surface: exec(), args: true },
+  { name: '/steer', description: 'Steer the current run after the next tool call', surface: exec() },
   { name: '/stop', description: 'Stop running background processes', surface: exec() },
   { name: '/tools', description: 'List or toggle tools available to the agent', surface: exec(), args: true },
   { name: '/undo', description: 'Remove the last user/assistant exchange', surface: exec() },


### PR DESCRIPTION
## Summary

- stop classifying `/steer` as a command with an enumerable inline options screen
- close slash completion after selecting `/steer` so the following words remain free text
- add a regression assertion for the argument-stage contract

Closes #69953

## Testing

- direct TypeScript module behavior check (`/steer` does not take inline options; `/tools` still does)
- `prettier --check src/lib/desktop-slash-commands.ts src/lib/desktop-slash-commands.test.ts`
- `git diff --check`

`npx vitest run src/lib/desktop-slash-commands.test.ts` could not start locally because the installed Rolldown process hangs before test discovery; CI should run the committed Vitest regression test.