### PR TITLE
feat(lsp): configure Node package manager

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -46,7 +46,7 @@ logger = logging.getLogger("agent.lsp.install")
 # Optional fields:
 #   - ``extra_pkgs``: list of sibling packages to install alongside
 #     ``pkg`` in the same node_modules tree.  Used when an LSP server
-#     has a runtime peer dependency that npm doesn't auto-pull (e.g.
+#     has a runtime peer dependency that the Node package manager won't auto-pull (e.g.
 #     typescript-language-server needs ``typescript``).
 INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
     # Python
@@ -169,6 +169,58 @@ def _get_lock(pkg: str) -> threading.Lock:
         return lock
 
 
+def _selected_package_manager() -> str:
+    """Return the Node package manager configured for LSP installs.
+
+    The LSP workspace keeps its Node-based language server dependencies in a
+    Hermes-owned staging directory. Users can choose whether that staging tree
+    is managed by pnpm, yarn, or npm via ``lsp.package_manager`` in config.yaml.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception:
+        return "npm"
+
+    lsp_cfg = (cfg.get("lsp") or {}) if isinstance(cfg, dict) else {}
+    if not isinstance(lsp_cfg, dict):
+        lsp_cfg = {}
+    manager = str(lsp_cfg.get("package_manager", "npm")).strip().lower()
+    if manager not in {"pnpm", "yarn", "npm"}:
+        logger.warning(
+            "[install] unsupported lsp.package_manager=%r; falling back to npm",
+            manager,
+        )
+        return "npm"
+    return manager
+
+
+def _package_manager_command(package_manager: str) -> Optional[list[str]]:
+    """Return the command prefix for the selected Node package manager.
+
+    Corepack is preferred when present so Hermes can honor the user's
+    configured package-manager toolchain without requiring the direct binary
+    to be installed globally. If Corepack is unavailable, we fall back to the
+    package-manager binary itself.
+    """
+    corepack = shutil.which("corepack")
+    if corepack is not None:
+        return [corepack, package_manager]
+
+    direct = shutil.which(package_manager)
+    if direct is not None:
+        return [direct]
+
+    if package_manager == "npm":
+        # Some environments only ship npm via Node rather than the standalone
+        # package-manager shims. Try the bundled npm binary last.
+        npm = shutil.which("npm")
+        if npm is not None:
+            return [npm]
+    return None
+
+
 def try_install(pkg: str, strategy: str = "auto") -> Optional[str]:
     """Try to install ``pkg`` and return the binary path if successful.
 
@@ -219,7 +271,7 @@ def _do_install(pkg: str) -> Optional[str]:
         return None
 
     if strategy == "npm":
-        return _install_npm(
+        return _install_node_package(
             recipe.get("pkg", pkg),
             bin_name,
             extra_pkgs=recipe.get("extra_pkgs") or [],
@@ -233,50 +285,84 @@ def _do_install(pkg: str) -> Optional[str]:
     return None
 
 
-def _install_npm(
+def _install_node_package(
     pkg: str,
     bin_name: str,
     extra_pkgs: Optional[list] = None,
 ) -> Optional[str]:
-    """Install an npm package into our staging dir.
+    """Install a Node package into our staging dir.
 
-    Uses ``npm install --prefix`` so the binaries land in
-    ``<staging>/node_modules/.bin/<bin_name>`` and we symlink them up
-    one level for direct PATH-style access.
+    Uses the package manager configured in ``lsp.package_manager``.
+    pnpm and yarn use ``add`` in ``<staging>`` so the binaries land in
+    ``<staging>/node_modules/.bin/<bin_name>`` and we symlink them up one
+    level for direct PATH-style access. npm keeps its current
+    ``npm install --prefix`` behavior for backwards compatibility.
 
     ``extra_pkgs`` is a list of sibling packages to install in the
     same ``node_modules`` tree.  Used for LSP servers with runtime
-    peer deps that npm doesn't auto-pull (typescript-language-server
-    needs ``typescript`` next to it; intelephense ships standalone).
+    peer deps that the Node installer doesn't auto-pull
+    (typescript-language-server needs ``typescript`` next to it;
+    intelephense ships standalone).
     """
-    npm = shutil.which("npm")
-    if npm is None:
-        logger.info("[install] cannot install %s: npm not on PATH", pkg)
+    package_manager = _selected_package_manager()
+    installer_cmd = _package_manager_command(package_manager)
+    if installer_cmd is None:
+        logger.info(
+            "[install] cannot install %s: %s/corepack not on PATH",
+            pkg,
+            package_manager,
+        )
         return None
     staging = hermes_lsp_bin_dir().parent  # <HERMES_HOME>/lsp/
     install_targets = [pkg] + list(extra_pkgs or [])
     try:
-        logger.info(
-            "[install] npm install --prefix %s %s",
-            staging,
-            " ".join(install_targets),
-        )
+        if package_manager in {"pnpm", "yarn"}:
+            cmd = [*installer_cmd, "add", "--silent", *install_targets]
+            logger.info(
+                "[install] %s add (cwd=%s) %s",
+                " ".join(installer_cmd),
+                staging,
+                " ".join(install_targets),
+            )
+        else:
+            cmd = [
+                *installer_cmd,
+                "install",
+                "--prefix",
+                str(staging),
+                "--silent",
+                "--no-fund",
+                "--no-audit",
+                *install_targets,
+            ]
+            logger.info(
+                "[install] %s install --prefix %s %s",
+                " ".join(installer_cmd),
+                staging,
+                " ".join(install_targets),
+            )
         proc = subprocess.run(
-            [npm, "install", "--prefix", str(staging), "--silent", "--no-fund", "--no-audit", *install_targets],
+            cmd,
             check=False,
             capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=300,
             stdin=subprocess.DEVNULL,
+            cwd=staging,
             creationflags=windows_hide_flags(),
         )
         if proc.returncode != 0:
             logger.warning(
-                "[install] npm install failed for %s: %s", pkg, proc.stderr.strip()[:500]
+                "[install] %s install failed for %s: %s",
+                package_manager,
+                pkg,
+                proc.stderr.strip()[:500],
             )
             return None
     except (subprocess.TimeoutExpired, OSError) as e:
-        logger.warning("[install] npm install errored for %s: %s", pkg, e)
+        logger.warning("[install] %s install errored for %s: %s", package_manager, pkg, e)
         return None
 
     # Find the bin
@@ -295,7 +381,12 @@ def _install_npm(
                     except OSError:
                         return str(c)
             return str(link if link.exists() else c)
-    logger.warning("[install] npm install for %s succeeded but bin %s not found", pkg, bin_name)
+    logger.warning(
+        "[install] %s install for %s succeeded but bin %s not found",
+        package_manager,
+        pkg,
+        bin_name,
+    )
     return None
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2710,6 +2710,12 @@ DEFAULT_CONFIG = {
         # ``"off"`` — alias for ``manual``.
         "install_strategy": "auto",
 
+        # Node package manager used for Node-based LSP installs. Hermes
+        # prefers Corepack when available, but the configured value is
+        # still the package manager name itself. Supported values:
+        # ``npm`` (default), ``pnpm``, and ``yarn``.
+        "package_manager": "npm",
+
         # Idle language servers are shut down automatically after this
         # many seconds with no file activity, then respawned on demand.
         # Prevents long-running gateway/CLI processes from accumulating

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -3,7 +3,7 @@
 Covers:
 
 1. ``typescript-language-server`` install recipe pulls in ``typescript``
-   alongside the server, so the npm install command targets both.
+   alongside the server, so the configured Node package manager targets both.
 2. ``hermes lsp status`` surfaces a ``Backend warnings`` section when
    bash-language-server is installed but ``shellcheck`` is missing.
 3. ``_check_lint`` returns ``skipped`` (not ``error``) when the linter
@@ -15,6 +15,7 @@ Covers:
 from __future__ import annotations
 
 import io
+import os
 from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 
@@ -28,37 +29,206 @@ from agent.lsp.install import INSTALL_RECIPES
 # ---------------------------------------------------------------------------
 
 
+def _write_fake_node_installer(bin_dir, name):
+    script = bin_dir / name
+    script.write_text(
+        "#!/bin/sh\n"
+        "set -eu\n"
+        "printf '%s\n' \"$PWD\" > \"$FAKE_NODE_LOG_DIR/cwd\"\n"
+        "printf '%s\n' \"$@\" > \"$FAKE_NODE_LOG_DIR/args\"\n"
+        "mkdir -p node_modules/.bin\n"
+        "printf '#!/bin/sh\\n' > \"node_modules/.bin/$FAKE_NODE_BIN_NAME\"\n"
+        "chmod +x \"node_modules/.bin/$FAKE_NODE_BIN_NAME\"\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return script
 
 
+def _fake_node_env(tmp_path, monkeypatch, manager, bin_name, *, corepack=False):
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    if corepack:
+        _write_fake_node_installer(fake_bin, "corepack")
+    else:
+        _write_fake_node_installer(fake_bin, manager)
+    log_dir = tmp_path / "node-log"
+    log_dir.mkdir()
+    # Keep the fake toolchain first and exclude developer Node shims so a real
+    # Corepack installation cannot mask the direct-binary fallback path.
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}/bin{os.pathsep}/usr/bin")
+    monkeypatch.setenv("FAKE_NODE_LOG_DIR", str(log_dir))
+    monkeypatch.setenv("FAKE_NODE_BIN_NAME", bin_name)
+    return log_dir
 
 
-def test_install_npm_works_without_extras(tmp_path, monkeypatch):
+def _set_lsp_package_manager(monkeypatch, manager):
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"lsp": {"package_manager": manager}},
+    )
+
+
+def _read_fake_invocation(log_dir):
+    return (
+        (log_dir / "cwd").read_text(encoding="utf-8").strip(),
+        (log_dir / "args").read_text(encoding="utf-8").splitlines(),
+    )
+
+
+def test_install_uses_corepack_pnpm_and_passes_extras(tmp_path, monkeypatch):
+    """Configured pnpm runs through Corepack in the managed staging tree."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    _set_lsp_package_manager(monkeypatch, "pnpm")
+    log_dir = _fake_node_env(
+        tmp_path, monkeypatch, "pnpm", "typescript-language-server", corepack=True
+    )
+
+    resolved = install_mod._install_node_package(
+        "typescript-language-server",
+        "typescript-language-server",
+        extra_pkgs=["typescript"],
+    )
+
+    staging = tmp_path / "lsp"
+    cwd, args = _read_fake_invocation(log_dir)
+    assert cwd == str(staging)
+    assert args == [
+        "pnpm",
+        "add",
+        "--silent",
+        "typescript-language-server",
+        "typescript",
+    ]
+    assert resolved is not None
+    assert (install_mod.hermes_lsp_bin_dir() / "typescript-language-server").exists()
+
+
+def test_install_falls_back_to_direct_pnpm_when_corepack_missing(tmp_path, monkeypatch):
     """Backwards compat: pyright-style recipes (no extras) still install."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    _set_lsp_package_manager(monkeypatch, "pnpm")
+    log_dir = _fake_node_env(tmp_path, monkeypatch, "pnpm", "pyright-langserver")
+
+    resolved = install_mod._install_node_package("pyright", "pyright-langserver")
+
+    staging = tmp_path / "lsp"
+    cwd, args = _read_fake_invocation(log_dir)
+    assert cwd == str(staging)
+    assert args == ["add", "--silent", "pyright"]
+    assert resolved is not None
+
+
+def test_install_uses_yarn_add_in_staging(tmp_path, monkeypatch):
+    """Yarn adds requested packages; ``yarn install <pkg>`` is not valid."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    _set_lsp_package_manager(monkeypatch, "yarn")
+    log_dir = _fake_node_env(
+        tmp_path, monkeypatch, "yarn", "typescript-language-server"
+    )
+
+    resolved = install_mod._install_node_package(
+        "typescript-language-server",
+        "typescript-language-server",
+        extra_pkgs=["typescript"],
+    )
+
+    staging = tmp_path / "lsp"
+    cwd, args = _read_fake_invocation(log_dir)
+    assert cwd == str(staging)
+    assert args == ["add", "--silent", "typescript-language-server", "typescript"]
+    assert resolved is not None
+
+
+def test_install_defaults_to_npm_when_package_manager_unset(tmp_path, monkeypatch):
+    """Hermes' upstream default stays npm unless lsp.package_manager is set."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: {"lsp": {}})
+    log_dir = _fake_node_env(tmp_path, monkeypatch, "npm", "pyright-langserver", corepack=True)
+
+    resolved = install_mod._install_node_package("pyright", "pyright-langserver")
+
+    staging = tmp_path / "lsp"
+    cwd, args = _read_fake_invocation(log_dir)
+    assert cwd == str(staging)
+    assert args == [
+        "npm",
+        "install",
+        "--prefix",
+        str(staging),
+        "--silent",
+        "--no-fund",
+        "--no-audit",
+        "pyright",
+    ]
+    assert resolved is not None
+
+
+def test_node_installer_retains_windows_safe_subprocess_kwargs(tmp_path, monkeypatch):
+    """Node installs preserve UTF-8 decoding and Windows hide flags from main."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+    import hermes_cli.config as config_mod
 
     captured = {}
 
     def fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        bin_dir = kwargs["cwd"] / "node_modules" / ".bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        launcher = bin_dir / "pyright-langserver"
+        launcher.write_text("#!/bin/sh\n", encoding="utf-8")
+        launcher.chmod(0o755)
         return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: {"lsp": {}})
+    monkeypatch.setattr(install_mod.shutil, "which", lambda c: "/usr/bin/npm" if c == "npm" else None)
+    monkeypatch.setattr(install_mod, "windows_hide_flags", lambda: 12345)
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+
+    resolved = install_mod._install_node_package("pyright", "pyright-langserver")
+
+    assert resolved is not None
+    assert captured["kwargs"]["text"] is True
+    assert captured["kwargs"]["encoding"] == "utf-8"
+    assert captured["kwargs"]["errors"] == "replace"
+    assert captured["kwargs"]["creationflags"] == 12345
+    assert captured["kwargs"]["stdin"] is install_mod.subprocess.DEVNULL
+
+
+def test_existing_binary_finds_windows_wrapper_in_staging(tmp_path, monkeypatch):
+    """Installed Windows shims should satisfy later status/probe calls."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     from agent.lsp import install as install_mod
 
-    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
-    monkeypatch.setattr(install_mod.shutil, "which", lambda c: "/usr/bin/npm" if c == "npm" else None)
+    wrapper = install_mod.hermes_lsp_bin_dir() / "pyright-langserver.cmd"
+    wrapper.write_text("@echo off\n")
+    wrapper.chmod(0o755)
 
-    install_mod._install_npm("pyright", "pyright-langserver")
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
 
-    cmd = captured["cmd"]
-    assert "pyright" in cmd
-    # Should not blow up when extra_pkgs is omitted/None
-    install_targets = [c for c in cmd if not c.startswith("-") and c not in {
-        "install", "--prefix", str(install_mod.hermes_lsp_bin_dir().parent),
-        "/usr/bin/npm",
-    }]
-    assert install_targets == ["pyright"]
-
-
+    assert install_mod._existing_binary("pyright-langserver") == str(wrapper)
+    assert install_mod.detect_status("pyright") == "installed"
 
 
 def test_install_pip_finds_windows_scripts_launcher(tmp_path, monkeypatch):

--- a/tests/agent/lsp/test_powershell_server.py
+++ b/tests/agent/lsp/test_powershell_server.py
@@ -27,8 +27,11 @@ def test_powershell_extensions_route_to_pses():
 
 
 
-
-
+def test_powershell_install_status_is_manual_tier():
+    # PSES has no auto-install recipe; it's manual-only (like rust-analyzer).
+    # When pwsh isn't on PATH the status is manual-only, not "missing".
+    status = detect_status("powershell")
+    assert status in {"manual-only", "installed"}
 
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -75,6 +75,7 @@ class TestLoadConfigDefaults:
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
+            assert config["lsp"]["package_manager"] == DEFAULT_CONFIG["lsp"]["package_manager"]
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -60,20 +60,20 @@ agent sees a syntax-clean file with semantic problems as
 
 | Language | Server | Auto-install |
 |----------|--------|--------------|
-| Python | `pyright-langserver` | npm |
-| TypeScript / JavaScript / JSX / TSX | `typescript-language-server` | npm |
-| Vue | `@vue/language-server` | npm |
-| Svelte | `svelte-language-server` | npm |
-| Astro | `@astrojs/language-server` | npm |
+| Python | `pyright-langserver` | Node pkg manager |
+| TypeScript / JavaScript / JSX / TSX | `typescript-language-server` | Node pkg manager |
+| Vue | `@vue/language-server` | Node pkg manager |
+| Svelte | `svelte-language-server` | Node pkg manager |
+| Astro | `@astrojs/language-server` | Node pkg manager |
 | Go | `gopls` | `go install` |
 | Rust | `rust-analyzer` | manual (rustup) |
 | C / C++ | `clangd` | manual (LLVM) |
-| Bash / Zsh | `bash-language-server` | npm |
-| YAML | `yaml-language-server` | npm |
+| Bash / Zsh | `bash-language-server` | Node pkg manager |
+| YAML | `yaml-language-server` | Node pkg manager |
 | Lua | `lua-language-server` | manual (GitHub releases) |
-| PHP | `intelephense` | npm |
+| PHP | `intelephense` | Node pkg manager |
 | OCaml | `ocaml-lsp` | manual (opam) |
-| Dockerfile | `dockerfile-language-server-nodejs` | npm |
+| Dockerfile | `dockerfile-language-server-nodejs` | Node pkg manager |
 | Terraform | `terraform-ls` | manual |
 | Dart | `dart language-server` | manual (dart sdk) |
 | Haskell | `haskell-language-server` | manual (ghcup) |
@@ -115,12 +115,12 @@ host. Setup:
 bundle is missing you'll see a one-time warning in the logs with the
 download link.
 
-A few servers are installed alongside a peer dependency that npm
-won't auto-pull. The current case is `typescript-language-server`,
-which requires the `typescript` SDK importable from the same
-`node_modules` tree — Hermes installs both packages together when you
-run `hermes lsp install typescript` or auto-install fires on first
-use.
+A few servers are installed alongside a peer dependency that the
+configured Node package manager won't auto-pull. The current case is
+`typescript-language-server`, which requires the `typescript` SDK
+importable from the same `node_modules` tree — Hermes installs both
+packages together when you run `hermes lsp install typescript` or
+auto-install fires on first use.
 
 ## CLI
 
@@ -160,9 +160,16 @@ lsp:
   wait_timeout: 5.0
 
   # How to handle missing server binaries.
-  #   auto    — install via npm/pip/go install into <HERMES_HOME>/lsp/bin
+  #   auto    — install via the configured Node package manager / pip / go
+  #             into <HERMES_HOME>/lsp/bin
   #   manual  — only use binaries already on PATH
   install_strategy: auto
+
+  # Node package manager used for Node-based LSP installs.
+  # Hermes prefers Corepack when available, but the configured value
+  # is still the package manager name itself.
+  # Supported values: npm (default), pnpm, yarn
+  package_manager: npm
 
   # How long an unused language-server client stays alive (seconds).
   # Idle servers are shut down automatically and respawned on the next
@@ -199,7 +206,7 @@ lsp:
 ## Installation locations
 
 When `install_strategy: auto`, Hermes installs binaries into
-`<HERMES_HOME>/lsp/bin/`. NPM packages land in
+`<HERMES_HOME>/lsp/bin/`. Node packages land in
 `<HERMES_HOME>/lsp/node_modules/` with bin symlinks one level up.
 Go binaries come from `go install` with `GOBIN` pointed at the
 staging dir.


### PR DESCRIPTION
## Summary
- add `lsp.package_manager` so Node-based LSP auto-installs can use npm, pnpm, or yarn
- keep npm as the default/fallback for backwards compatibility
- prefer Corepack when available, with direct package-manager binary fallback
- update LSP docs and tests for configurable Node package-manager behavior

## Details
- `lsp.package_manager` defaults to `npm`
- explicit `pnpm` uses `corepack pnpm add ...` when Corepack exists, otherwise direct `pnpm add ...`
- explicit `yarn`/`npm` use `corepack <manager> install ...` when Corepack exists, otherwise direct binary fallback
- Node LSP installs remain scoped to `<HERMES_HOME>/lsp/`

## Test Plan
- `scripts/run_tests.sh tests/hermes_cli/test_config.py tests/agent/lsp/test_install_and_lint_fixes.py tests/agent/lsp/test_powershell_server.py`
  - 207 tests passed, 0 failed

Closes #35448
