### PR TITLE
fix(webhook): support provider contracts and safe route skills

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -631,6 +631,7 @@ class WebhookAdapter(BasePlatformAdapter):
             or request.headers.get("X-GitLab-Event", "")
             or payload.get("event_type", "")
             or payload.get("type", "")
+            or payload.get("action", "")
             or "unknown"
         )
         allowed_events = route_config.get("events", [])
@@ -699,33 +700,49 @@ class WebhookAdapter(BasePlatformAdapter):
             try:
                 from agent.skill_commands import (
                     build_skill_invocation_message,
+                    build_stacked_skill_invocation_message,
                     get_skill_commands,
                 )
 
                 skill_cmds = get_skill_commands()
+                matched_skill_keys = []
                 for skill_name in skills:
                     cmd_key = f"/{skill_name}"
                     if cmd_key in skill_cmds:
-                        skill_content = build_skill_invocation_message(
-                            cmd_key, user_instruction=prompt
-                        )
-                        if skill_content:
-                            prompt = skill_content
-                            break  # Load the first matching skill
+                        matched_skill_keys.append(cmd_key)
                     else:
                         logger.warning(
                             "[webhook] Skill '%s' not found", skill_name
                         )
+
+                if len(matched_skill_keys) == 1:
+                    skill_content = build_skill_invocation_message(
+                        matched_skill_keys[0], user_instruction=prompt
+                    )
+                    if skill_content:
+                        prompt = skill_content
+                elif matched_skill_keys:
+                    stacked = build_stacked_skill_invocation_message(
+                        matched_skill_keys, user_instruction=prompt
+                    )
+                    if stacked:
+                        prompt, _loaded, missing = stacked
+                        for skill_name in missing:
+                            logger.warning(
+                                "[webhook] Skill '%s' could not be loaded",
+                                skill_name,
+                            )
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
         # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
-            ),
+        delivery_id = (
+            request.headers.get("X-GitHub-Delivery", "")
+            or request.headers.get("svix-id", "")
+            or request.headers.get("X-Request-ID", "")
+            or hashlib.sha256(
+                route_name.encode("utf-8") + b"\0" + raw_body
+            ).hexdigest()
         )
 
         # ── Idempotency ─────────────────────────────────────────
@@ -957,7 +974,7 @@ class WebhookAdapter(BasePlatformAdapter):
     def _validate_signature(
         self, request: "web.Request", body: bytes, secret: str
     ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, GitLab, Ashby, Svix, generic HMAC-SHA256)."""
         def _header(name: str) -> str:
             return (
                 request.headers.get(name, "")
@@ -990,6 +1007,14 @@ class WebhookAdapter(BasePlatformAdapter):
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
             return _hmac_str_equal(gh_sig, expected)
+
+        # Ashby: Ashby-Signature = sha256=<hex HMAC-SHA256 of raw body>
+        ashby_sig = _header("Ashby-Signature")
+        if ashby_sig:
+            expected = "sha256=" + hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(ashby_sig, expected)
 
         # GitLab: X-Gitlab-Token = <plain secret>
         gl_token = request.headers.get("X-Gitlab-Token", "")

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -104,6 +104,13 @@ def _generic_signature(body: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
+def _ashby_signature(body: bytes, secret: str) -> str:
+    """Compute Ashby-Signature for *body* using *secret*."""
+    return "sha256=" + hmac.new(
+        secret.encode(), body, hashlib.sha256
+    ).hexdigest()
+
+
 def _generic_v2_signature(body: bytes, secret: str, timestamp: str) -> str:
     """Compute X-Webhook-Signature-V2 (HMAC-SHA256 of "<timestamp>.<body>")."""
     signed_content = timestamp.encode() + b"." + body
@@ -146,6 +153,23 @@ class TestValidateSignature:
         secret = "webhook-secret-42"
         req = _mock_request(headers={"X-Hub-Signature-256": "sha256=deadbeef"})
         assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_ashby_signature_valid(self):
+        adapter = _make_adapter()
+        body = b'{"action":"applicationSubmit","data":{}}'
+        secret = "ashby-webhook-secret"
+        req = _mock_request(
+            headers={"Ashby-Signature": _ashby_signature(body, secret)}
+        )
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_ashby_signature_invalid(self):
+        adapter = _make_adapter()
+        body = b'{"action":"applicationSubmit","data":{}}'
+        req = _mock_request(
+            headers={"Ashby-Signature": "sha256=deadbeef"}
+        )
+        assert adapter._validate_signature(req, body, "correct-secret") is False
 
     def test_validate_gitlab_token(self):
         """GitLab plain-token match via X-Gitlab-Token."""
@@ -653,6 +677,96 @@ class TestEventFilter:
                 json={"type": "message.received"},
             )
             assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_event_filter_accepts_ashby_action_field(self):
+        routes = {
+            "ashby": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["applicationSubmit"],
+                "prompt": "got it",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/ashby",
+                json={"action": "applicationSubmit", "data": {}},
+            )
+            assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_body_digest_deduplicates_retries_without_delivery_id(self):
+        routes = {
+            "ashby": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["applicationSubmit"],
+                "prompt": "got it",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+        payload = {"action": "applicationSubmit", "data": {"id": "app-1"}}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post("/webhooks/ashby", json=payload)
+            second = await cli.post("/webhooks/ashby", json=payload)
+
+            assert first.status == 202
+            assert second.status == 200
+            assert (await second.json())["status"] == "duplicate"
+            adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_route_loads_all_configured_skills(self, monkeypatch):
+        routes = {
+            "ashby": {
+                "secret": _INSECURE_NO_AUTH,
+                "skills": ["workflow", "operations", "calibration"],
+                "prompt": "qualify this application",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+        monkeypatch.setattr(
+            "agent.skill_commands.get_skill_commands",
+            lambda: {
+                "/workflow": {},
+                "/operations": {},
+                "/calibration": {},
+            },
+        )
+        stacked = MagicMock(
+            return_value=(
+                "all three skills loaded\n\nqualify this application",
+                ["workflow", "operations", "calibration"],
+                [],
+            )
+        )
+        monkeypatch.setattr(
+            "agent.skill_commands.build_stacked_skill_invocation_message",
+            stacked,
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/ashby", json={"type": "test"})
+
+        assert resp.status == 202
+        assert captured[0].text.startswith("all three skills loaded")
+        stacked.assert_called_once_with(
+            ["/workflow", "/operations", "/calibration"],
+            user_instruction="qualify this application",
+        )
 
 
 # ===================================================================

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -55,6 +55,11 @@ class TestResolveToolset:
         tools = resolve_toolset("web")
         assert set(tools) == {"web_search", "web_extract"}
 
+    def test_readonly_skills_excludes_mutation(self):
+        tools = resolve_toolset("skills_readonly")
+        assert set(tools) == {"skills_list", "skill_view"}
+        assert "skill_manage" not in tools
+
     def test_composite_toolset(self):
         tools = resolve_toolset("debugging")
         assert "terminal" in tools

--- a/toolsets.py
+++ b/toolsets.py
@@ -169,6 +169,12 @@ TOOLSETS = {
         "tools": ["skills_list", "skill_view", "skill_manage"],
         "includes": []
     },
+
+    "skills_readonly": {
+        "description": "Read skill documents without exposing skill mutation",
+        "tools": ["skills_list", "skill_view"],
+        "includes": []
+    },
     
     "browser": {
         "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click) with web search for finding URLs",


### PR DESCRIPTION
## Summary
- accept Ashby `Ashby-Signature` HMAC headers and top-level `action` event names
- derive stable body-digest delivery IDs when providers omit one
- load every configured webhook route skill through existing stacked-skill scaffolding
- add a read-only skills toolset for externally triggered routes

## Verification
- `scripts/run_tests.sh tests/gateway/test_webhook_adapter.py` (100 passed)
- `scripts/run_tests.sh tests/test_toolsets.py` (33 passed)
- Ruff and `git diff --check` passed
