### PR TITLE
test(line): lock interactive setup config contract (#70013)

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1671,13 +1671,13 @@ def interactive_setup() -> None:
     print()
 
     try:
-        from hermes_cli.config import get_env_var, set_env_var
+        from hermes_cli.config import get_env_value as _get_env, save_env_value as _set_env
     except ImportError:
         print("hermes_cli.config not available; set LINE_* vars manually in ~/.hermes/.env")
         return
 
     def _prompt(var: str, prompt: str, *, secret: bool = False) -> None:
-        existing = get_env_var(var) if callable(get_env_var) else None
+        existing = _get_env(var) if callable(_get_env) else None
         suffix = " [keep current]" if existing else ""
         try:
             if secret:
@@ -1689,7 +1689,7 @@ def interactive_setup() -> None:
             print()
             return
         if value:
-            set_env_var(var, value)
+            _set_env(var, value)
 
     _prompt("LINE_CHANNEL_ACCESS_TOKEN", "Channel access token", secret=True)
     _prompt("LINE_CHANNEL_SECRET", "Channel secret", secret=True)

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -20,7 +20,7 @@ import hashlib
 import hmac
 import base64
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -46,6 +46,7 @@ validate_config = _line.validate_config
 _standalone_send = _line._standalone_send
 _env_enablement = _line._env_enablement
 _MessageDeduplicator = _line._MessageDeduplicator
+interactive_setup = _line.interactive_setup
 
 
 # ---------------------------------------------------------------------------
@@ -542,6 +543,40 @@ class TestRegister:
         register(ctx)
         # LINE per-bubble limit is 5000; we register 4500 to leave headroom.
         assert ctx.kwargs["max_message_length"] <= 5000
+
+
+class TestInteractiveSetup:
+
+    def test_supplied_credentials_use_config_helpers(self, monkeypatch):
+        from hermes_cli import config
+        from hermes_cli import secret_prompt
+
+        get_env_value = MagicMock(return_value=None)
+        save_env_value = MagicMock()
+        masked_secret_prompt = MagicMock(side_effect=["access-token", "channel-secret"])
+        input_prompt = MagicMock(side_effect=["", ""])
+        monkeypatch.setattr(config, "get_env_value", get_env_value)
+        monkeypatch.setattr(config, "save_env_value", save_env_value)
+        monkeypatch.setattr(secret_prompt, "masked_secret_prompt", masked_secret_prompt)
+        monkeypatch.setattr("builtins.input", input_prompt)
+
+        interactive_setup()
+
+        assert get_env_value.call_args_list == [
+            call("LINE_CHANNEL_ACCESS_TOKEN"),
+            call("LINE_CHANNEL_SECRET"),
+            call("LINE_PUBLIC_URL"),
+            call("LINE_ALLOWED_USERS"),
+        ]
+        assert save_env_value.call_args_list == [
+            call("LINE_CHANNEL_ACCESS_TOKEN", "access-token"),
+            call("LINE_CHANNEL_SECRET", "channel-secret"),
+        ]
+        assert masked_secret_prompt.call_args_list == [
+            call("Channel access token: "),
+            call("Channel secret: "),
+        ]
+        assert input_prompt.call_count == 2
 
 
 class TestEnvEnablement:

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -20,7 +20,7 @@ import hashlib
 import hmac
 import base64
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -46,6 +46,7 @@ validate_config = _line.validate_config
 _standalone_send = _line._standalone_send
 _env_enablement = _line._env_enablement
 _MessageDeduplicator = _line._MessageDeduplicator
+interactive_setup = _line.interactive_setup
 
 
 # ---------------------------------------------------------------------------
@@ -356,6 +357,40 @@ class TestSlowLLMPostbackRegression:
         adapter._client.reply.assert_awaited_once()
         assert adapter._client.reply.await_args.args[1][0]["text"] == adapter.expired_text
         assert "Uchat" not in adapter._pending_buttons
+
+
+class TestInteractiveSetup:
+
+    def test_supplied_credentials_use_config_helpers(self, monkeypatch):
+        from hermes_cli import config
+        from hermes_cli import secret_prompt
+
+        get_env_value = MagicMock(return_value=None)
+        save_env_value = MagicMock()
+        masked_secret_prompt = MagicMock(side_effect=["access-token", "channel-secret"])
+        input_prompt = MagicMock(side_effect=["", ""])
+        monkeypatch.setattr(config, "get_env_value", get_env_value)
+        monkeypatch.setattr(config, "save_env_value", save_env_value)
+        monkeypatch.setattr(secret_prompt, "masked_secret_prompt", masked_secret_prompt)
+        monkeypatch.setattr("builtins.input", input_prompt)
+
+        interactive_setup()
+
+        assert get_env_value.call_args_list == [
+            call("LINE_CHANNEL_ACCESS_TOKEN"),
+            call("LINE_CHANNEL_SECRET"),
+            call("LINE_PUBLIC_URL"),
+            call("LINE_ALLOWED_USERS"),
+        ]
+        assert save_env_value.call_args_list == [
+            call("LINE_CHANNEL_ACCESS_TOKEN", "access-token"),
+            call("LINE_CHANNEL_SECRET", "channel-secret"),
+        ]
+        assert masked_secret_prompt.call_args_list == [
+            call("Channel access token: "),
+            call("Channel secret: "),
+        ]
+        assert input_prompt.call_count == 2
 
 
 class TestEnvEnablement:


### PR DESCRIPTION
The LINE setup wizard already uses the correct config helpers on current `main`. This PR adds the missing regression test: it exercises the public wizard entry point, verifies reads of all supported keys, saves supplied credentials through `save_env_value`, keeps secret input on masked prompts, and leaves blank optional values unsaved.

This retains the regression coverage from the salvage of #32701 by Ernest Hysa. His authorship credit remains in the commit; the production import correction is already upstream.

Validation on `485aaf69b7f0930a5f6631752172d90a4a5575c6`:
- `scripts/run_tests.sh tests/gateway/test_line_plugin.py -q`: 32 passed (base: 31 passed).
- `git diff --check origin/main...HEAD`: passed.

Not checked: full suite; CodeRabbit skipped for this author-side maintenance without a P0/P1 priority.

Agent disclosure: original change by GPT-5.6-sol, xhigh reasoning, in Codex. Maintenance by GPT-6 in Codex desktop (parent reasoning level unavailable). The account owner loosely reviews these actions and receives the usual GitHub notifications.
