### PR TITLE
fix(memory): harden Hindsight auto-retention

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -114,12 +114,12 @@ Before automatic retention, Hermes strips injected `<memory-context>` blocks
 from both user and assistant text to prevent recalled memory from becoming new
 evidence. Partial batches are flushed on session switch and clean shutdown. The
 queue/sentinel transition is serialized with `sync_turn()`. Connection failures
-that prove no request reached Hindsight are retried once before newer work or
-shutdown. Ambiguous failed append operations are **not** replayed automatically:
-a timeout can occur after the server committed, so blind retry could duplicate
-content. Failures remain observable through the provider's failure count and
-last-error state. Prefetch results are generation-scoped so a timed-out old
-session cannot repopulate the next session's context.
+that prove no request reached Hindsight are retried once inline by the single
+writer, preserving append order. Ambiguous failed append operations are **not**
+replayed automatically: a timeout can occur after the server committed, so blind
+retry could duplicate content. Failures remain observable through the provider's
+failure count and last-error state. Prefetch results are generation-scoped so a
+timed-out old session cannot repopulate the next session's context.
 
 ### Integration
 

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -120,8 +120,10 @@ replayed automatically: a timeout can occur after the server committed, so blind
 retry could duplicate content. Failures remain observable through the provider's
 failure count and last-error state. Prefetch results are generation-scoped so a
 timed-out old session cannot repopulate the next session's context. Embedded
-daemon startup observes an early shutdown request before and after blocking
-manager probes, keeping shutdown bounded without a late restart.
+daemon configuration is prepared in the background, but startup stays lazy on
+the first proxied API operation; the provider never launches an unbounded
+`_ensure_started()` call that could complete after bounded shutdown. Concurrent
+shutdown callers share the same completion barrier.
 
 ### Integration
 

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -113,10 +113,13 @@ operation. This also applies to dynamically templated per-user banks.
 Before automatic retention, Hermes strips injected `<memory-context>` blocks
 from both user and assistant text to prevent recalled memory from becoming new
 evidence. Partial batches are flushed on session switch and clean shutdown. The
-queue/sentinel transition is serialized with `sync_turn()`. Ambiguous failed
-append operations are **not** replayed automatically: a timeout can occur after
-the server committed, so blind retry could duplicate content. Failures remain
-observable through the provider's failure count and last-error state.
+queue/sentinel transition is serialized with `sync_turn()`. Connection failures
+that prove no request reached Hindsight are retried once before newer work or
+shutdown. Ambiguous failed append operations are **not** replayed automatically:
+a timeout can occur after the server committed, so blind retry could duplicate
+content. Failures remain observable through the provider's failure count and
+last-error state. Prefetch results are generation-scoped so a timed-out old
+session cannot repopulate the next session's context.
 
 ### Integration
 

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -119,7 +119,9 @@ writer, preserving append order. Ambiguous failed append operations are **not**
 replayed automatically: a timeout can occur after the server committed, so blind
 retry could duplicate content. Failures remain observable through the provider's
 failure count and last-error state. Prefetch results are generation-scoped so a
-timed-out old session cannot repopulate the next session's context.
+timed-out old session cannot repopulate the next session's context. Embedded
+daemon startup observes an early shutdown request before and after blocking
+manager probes, keeping shutdown bounded without a late restart.
 
 ### Integration
 

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -63,6 +63,15 @@ Config file: `~/.hermes/hindsight/config.json`
 | `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
 | `bank_mission` | — | Reflect mission (identity/framing for reflect reasoning). Applied via Banks API. |
 | `bank_retain_mission` | — | Retain mission (steers what gets extracted). Applied via Banks API. |
+| `bank_observations_mission` | — | Rules for consolidating raw facts into observations. Applied via Banks API. |
+| `bank_retain_extraction_mode` | — | Bank extraction mode: `concise`, `verbose`, or `custom`. |
+| `bank_enable_observations` | — | Enable or disable observation consolidation for the bank. |
+| `bank_disposition_skepticism` | — | Bank skepticism disposition (1–5). |
+| `bank_disposition_literalism` | — | Bank literalism disposition (1–5). |
+| `bank_disposition_empathy` | — | Bank empathy disposition (1–5). |
+
+Configured bank guardrails are created/updated before the provider's first
+operation. This also applies to dynamically templated per-user banks.
 
 ### Recall
 
@@ -91,6 +100,7 @@ Config file: `~/.hermes/hindsight/config.json`
 | Key | Default | Description |
 |-----|---------|-------------|
 | `auto_retain` | `true` | Automatically retain conversation turns |
+| `auto_retain_require_user_id` | `false` | Skip auto-retain when the integration has no stable user ID; useful for multi-user gateways and stateless automations. |
 | `retain_async` | `true` | Process retain asynchronously on the Hindsight server |
 | `retain_every_n_turns` | `1` | Retain every N turns (1 = every turn) |
 | `retain_context` | `conversation between Hermes Agent and the User` | Context label for retained memories |
@@ -98,6 +108,15 @@ Config file: `~/.hermes/hindsight/config.json`
 | `retain_source` | — | Optional `metadata.source` attached to retained memories |
 | `retain_user_prefix` | `User` | Label used before user turns in auto-retained transcripts |
 | `retain_assistant_prefix` | `Assistant` | Label used before assistant turns in auto-retained transcripts |
+| `retain_roles` | `user,assistant` | Roles included in automatic retention. Accepts a comma-separated string or list. |
+
+Before automatic retention, Hermes strips injected `<memory-context>` blocks
+from both user and assistant text to prevent recalled memory from becoming new
+evidence. Partial batches are flushed on session switch and clean shutdown. The
+queue/sentinel transition is serialized with `sync_turn()`. Ambiguous failed
+append operations are **not** replayed automatically: a timeout can occur after
+the server committed, so blind retry could duplicate content. Failures remain
+observable through the provider's failure count and last-error state.
 
 ### Integration
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -718,6 +718,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._lifecycle_lock = threading.RLock()
         self._shutdown_requested = threading.Event()
         self._shutting_down = threading.Event()
+        self._shutdown_complete = threading.Event()
         self._atexit_registered = False
         # Legacy alias — older tests/callers reference _sync_thread directly.
         # Points at _writer_thread once the writer is running.
@@ -1654,11 +1655,13 @@ class HindsightMemoryProvider(MemoryProvider):
                             if self._shutdown_requested.is_set() or self._shutting_down.is_set():
                                 return
 
-                    if self._shutdown_requested.is_set() or self._shutting_down.is_set():
-                        return
-                    client._ensure_started()
+                    # HindsightEmbedded starts lazily on the first proxied API
+                    # operation. Do not call its unbounded _ensure_started()
+                    # from this background thread: shutdown cannot cancel that
+                    # call, so it could otherwise start the daemon after the
+                    # bounded startup-thread join has returned.
                     with open(log_path, "a", encoding="utf-8") as f:
-                        f.write("\n=== Daemon started successfully ===\n")
+                        f.write("\n=== Daemon configuration prepared (lazy startup) ===\n")
                 except Exception as e:
                     with open(log_path, "a", encoding="utf-8") as f:
                         f.write(f"\n=== Daemon startup failed: {e} ===\n")
@@ -2221,23 +2224,31 @@ class HindsightMemoryProvider(MemoryProvider):
         # Publish cancellation before waiting for the lifecycle lock so a
         # blocked daemon-start worker can observe it within the bounded join.
         if self._shutting_down.is_set():
+            self._shutdown_complete.wait()
             return
         self._shutdown_requested.set()
         # Serialize the final flush/sentinel boundary with sync_turn(). A turn
         # either queues before this block or observes _shutting_down afterwards;
         # it can never land behind the sentinel.
+        shutdown_owner = False
+        writer = None
+        daemon_start = None
         with self._lifecycle_lock:
-            if self._shutting_down.is_set():
-                return
-            self._enqueue_pending_turn_flush(reason="shutdown")
-            writer = self._writer_thread
-            daemon_start = self._daemon_start_thread
-            self._shutting_down.set()
-            if writer is not None and writer.is_alive():
-                try:
-                    self._retain_queue.put(_WRITER_SENTINEL)
-                except Exception:
-                    pass
+            if not self._shutting_down.is_set():
+                self._enqueue_pending_turn_flush(reason="shutdown")
+                writer = self._writer_thread
+                daemon_start = self._daemon_start_thread
+                self._shutting_down.set()
+                shutdown_owner = True
+                if writer is not None and writer.is_alive():
+                    try:
+                        self._retain_queue.put(_WRITER_SENTINEL)
+                    except Exception:
+                        pass
+
+        if not shutdown_owner:
+            self._shutdown_complete.wait()
+            return
 
         # Drain daemon startup before client cleanup. The startup thread may be
         # inside _get_client(), so closing first would let it publish/use a new
@@ -2305,6 +2316,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # / "Unclosed connector" warnings reported in #11923. The loop
         # runs on a daemon thread and is reclaimed on process exit;
         # per-session cleanup happens via self._client.aclose() above.
+        self._shutdown_complete.set()
 
 
 def register(ctx) -> None:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -716,6 +716,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._failed_retain_jobs: list = []
         self._failed_retain_lock = threading.Lock()
         self._lifecycle_lock = threading.RLock()
+        self._shutdown_requested = threading.Event()
         self._shutting_down = threading.Event()
         self._atexit_registered = False
         # Legacy alias — older tests/callers reference _sync_thread directly.
@@ -1615,7 +1616,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 log_dir.mkdir(parents=True, exist_ok=True)
                 log_path = log_dir / "hindsight-embed.log"
                 try:
-                    if self._shutting_down.is_set():
+                    if self._shutdown_requested.is_set() or self._shutting_down.is_set():
                         return
                     # Redirect the daemon manager's Rich console to our log file
                     # instead of stderr. This avoids global fd redirects that
@@ -1626,33 +1627,38 @@ class HindsightMemoryProvider(MemoryProvider):
 
                     client: Any = self._get_client()
                     config = self._config or {}
-                    # Serialize every daemon-manager mutation with shutdown.
-                    # If shutdown wins the lock, this worker exits without
-                    # touching the shared daemon. If startup wins, shutdown
-                    # waits until stop/start has completed before it can return.
-                    with self._lifecycle_lock:
-                        if self._shutting_down.is_set():
+                    if self._shutdown_requested.is_set() or self._shutting_down.is_set():
+                        return
+                    profile = config.get("profile", "hermes")
+
+                    # Update the profile .env to match our current config so
+                    # the daemon always starts with the right settings.
+                    profile_env = _embedded_profile_env_path(config)
+                    expected_env = _build_embedded_profile_env(config)
+                    saved = _load_simple_env(profile_env)
+                    config_changed = saved != expected_env
+
+                    if config_changed:
+                        _materialize_embedded_profile_env(config)
+                        if self._shutdown_requested.is_set() or self._shutting_down.is_set():
                             return
-                        profile = config.get("profile", "hermes")
+                        running = client._manager.is_running(profile)
+                        # is_running() may block beyond shutdown's join budget.
+                        # Never let a late result mutate or restart the daemon.
+                        if self._shutdown_requested.is_set() or self._shutting_down.is_set():
+                            return
+                        if running:
+                            with open(log_path, "a", encoding="utf-8") as f:
+                                f.write("\n=== Config changed, restarting daemon ===\n")
+                            client._manager.stop(profile)
+                            if self._shutdown_requested.is_set() or self._shutting_down.is_set():
+                                return
 
-                        # Update the profile .env to match our current config so
-                        # the daemon always starts with the right settings.
-                        # If the config changed and the daemon is running, stop it.
-                        profile_env = _embedded_profile_env_path(config)
-                        expected_env = _build_embedded_profile_env(config)
-                        saved = _load_simple_env(profile_env)
-                        config_changed = saved != expected_env
-
-                        if config_changed:
-                            profile_env = _materialize_embedded_profile_env(config)
-                            if client._manager.is_running(profile):
-                                with open(log_path, "a", encoding="utf-8") as f:
-                                    f.write("\n=== Config changed, restarting daemon ===\n")
-                                client._manager.stop(profile)
-
-                        client._ensure_started()
-                        with open(log_path, "a", encoding="utf-8") as f:
-                            f.write("\n=== Daemon started successfully ===\n")
+                    if self._shutdown_requested.is_set() or self._shutting_down.is_set():
+                        return
+                    client._ensure_started()
+                    with open(log_path, "a", encoding="utf-8") as f:
+                        f.write("\n=== Daemon started successfully ===\n")
                 except Exception as e:
                     with open(log_path, "a", encoding="utf-8") as f:
                         f.write(f"\n=== Daemon startup failed: {e} ===\n")
@@ -2212,10 +2218,17 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
+        # Publish cancellation before waiting for the lifecycle lock so a
+        # blocked daemon-start worker can observe it within the bounded join.
+        if self._shutting_down.is_set():
+            return
+        self._shutdown_requested.set()
         # Serialize the final flush/sentinel boundary with sync_turn(). A turn
         # either queues before this block or observes _shutting_down afterwards;
         # it can never land behind the sentinel.
         with self._lifecycle_lock:
+            if self._shutting_down.is_set():
+                return
             self._enqueue_pending_turn_flush(reason="shutdown")
             writer = self._writer_thread
             daemon_start = self._daemon_start_thread

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -703,6 +703,8 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
+        self._prefetch_generation = 0
+        self._daemon_start_thread: threading.Thread | None = None
         # Single-writer model for retain. sync_turn() enqueues; the writer
         # thread drains sequentially. Avoids spawning ad-hoc threads that
         # can race the interpreter shutdown and emit "cannot schedule new
@@ -712,6 +714,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_failure_count = 0
         self._last_retain_error: Exception | None = None
         self._failed_retain_jobs: list = []
+        self._retryable_retain_jobs: list = []
         self._failed_retain_lock = threading.Lock()
         self._lifecycle_lock = threading.RLock()
         self._shutting_down = threading.Event()
@@ -1147,6 +1150,30 @@ class HindsightMemoryProvider(MemoryProvider):
             )
         )
 
+    @staticmethod
+    def _is_definite_precommit_connection_error(exc: Exception) -> bool:
+        """Return True only when no request could have reached Hindsight."""
+        current: BaseException | None = exc
+        seen: set[int] = set()
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            if isinstance(current, ConnectionRefusedError):
+                return True
+            module = type(current).__module__
+            name = type(current).__name__
+            if module.startswith("httpx") and name in {
+                "ConnectError", "ConnectTimeout", "PoolTimeout",
+            }:
+                return True
+            if module.startswith("aiohttp") and name in {
+                "ClientConnectorError",
+                "ClientConnectorDNSError",
+                "ClientProxyConnectionError",
+            }:
+                return True
+            current = current.__cause__ or current.__context__
+        return False
+
     def _ensure_writer(self) -> None:
         """Lazy-start the single retain-writer thread.
 
@@ -1192,12 +1219,30 @@ class HindsightMemoryProvider(MemoryProvider):
                     self._retain_failure_count += 1
                     self._last_retain_error = exc
                     logger.warning("Hindsight retain failed: %s", exc, exc_info=True)
-                    # Treat a failed append as terminal. A timeout/disconnect
-                    # does not prove the server failed to commit; replaying the
-                    # same delta can duplicate conversation content and pollute
-                    # derived memories. Keep a bounded in-memory audit trail
-                    # instead. Safe connection-refused recovery already happens
-                    # inside _run_hindsight_operation before this point.
+                    safe_retry = (
+                        self._is_definite_precommit_connection_error(exc)
+                        and not getattr(job, "_hindsight_retry_attempted", False)
+                    )
+                    if safe_retry:
+                        setattr(job, "_hindsight_retry_attempted", True)
+                        if self._shutting_down.is_set():
+                            try:
+                                job()
+                                continue
+                            except Exception as retry_exc:
+                                self._retain_failure_count += 1
+                                self._last_retain_error = retry_exc
+                                logger.warning(
+                                    "Hindsight retain safe retry failed: %s",
+                                    retry_exc,
+                                    exc_info=True,
+                                )
+                        else:
+                            with self._failed_retain_lock:
+                                self._retryable_retain_jobs.append(job)
+                            continue
+                    # Ambiguous failures and exhausted safe retries are
+                    # terminal: replay could duplicate a committed append.
                     with self._failed_retain_lock:
                         if len(self._failed_retain_jobs) >= _MAX_TERMINAL_RETAIN_FAILURES:
                             self._failed_retain_jobs.pop(0)
@@ -1574,6 +1619,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 log_dir.mkdir(parents=True, exist_ok=True)
                 log_path = log_dir / "hindsight-embed.log"
                 try:
+                    if self._shutting_down.is_set():
+                        return
                     # Redirect the daemon manager's Rich console to our log file
                     # instead of stderr. This avoids global fd redirects that
                     # would capture output from other threads.
@@ -1582,6 +1629,8 @@ class HindsightMemoryProvider(MemoryProvider):
                     dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
 
                     client = self._get_client()
+                    if self._shutting_down.is_set():
+                        return
                     profile = self._config.get("profile", "hermes")
 
                     # Update the profile .env to match our current config so
@@ -1607,8 +1656,12 @@ class HindsightMemoryProvider(MemoryProvider):
                         f.write(f"\n=== Daemon startup failed: {e} ===\n")
                         traceback.print_exc(file=f)
 
-            t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
-            t.start()
+            self._daemon_start_thread = threading.Thread(
+                target=_start_daemon,
+                daemon=True,
+                name="hindsight-daemon-start",
+            )
+            self._daemon_start_thread.start()
 
     def system_prompt_block(self) -> str:
         if self._memory_mode == "context":
@@ -1664,15 +1717,19 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
             query = query[:self._recall_max_input_chars]
 
+        with self._prefetch_lock:
+            generation = self._prefetch_generation
+            bank_id = self._bank_id
+
         def _run():
             try:
                 if self._prefetch_method == "reflect":
-                    logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
+                    logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", bank_id, len(query))
+                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=bank_id, query=query, budget=self._budget), bank_id=bank_id)
                     text = resp.text or ""
                 else:
                     recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
+                        "bank_id": bank_id, "query": query,
                         "budget": self._budget, "max_tokens": self._recall_max_tokens,
                     }
                     if self._recall_tags:
@@ -1688,7 +1745,8 @@ class HindsightMemoryProvider(MemoryProvider):
                     text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
                 if text:
                     with self._prefetch_lock:
-                        self._prefetch_result = text
+                        if generation == self._prefetch_generation and not self._shutting_down.is_set():
+                            self._prefetch_result = text
             except Exception as e:
                 logger.debug("Hindsight prefetch failed: %s", e, exc_info=True)
 
@@ -1801,6 +1859,8 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("sync_turn: skipped (shutting down)")
             return
 
+        self._requeue_retryable_retain_jobs()
+
         if session_id:
             incoming_session_id = str(session_id).strip()
             if self._session_id and incoming_session_id != self._session_id:
@@ -1903,6 +1963,15 @@ class HindsightMemoryProvider(MemoryProvider):
         # append mode it selects the next delta; in legacy overwrite mode it
         # tells session-switch/shutdown flushing whether any newer turns exist.
         self._last_retained_turn_count = len(self._session_turns)
+
+    def _requeue_retryable_retain_jobs(self) -> int:
+        """Replay once only when failure proves the request never connected."""
+        with self._failed_retain_lock:
+            jobs = self._retryable_retain_jobs
+            self._retryable_retain_jobs = []
+        for job in jobs:
+            self._retain_queue.put(job)
+        return len(jobs)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
@@ -2114,6 +2183,9 @@ class HindsightMemoryProvider(MemoryProvider):
 
         # 2. Drain any in-flight prefetch from the old session and drop
         # its cached result so the new session doesn't see stale recall.
+        with self._prefetch_lock:
+            self._prefetch_generation = getattr(self, "_prefetch_generation", 0) + 1
+            self._prefetch_result = ""
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
@@ -2154,6 +2226,9 @@ class HindsightMemoryProvider(MemoryProvider):
         with self._lifecycle_lock:
             self._enqueue_pending_turn_flush(reason="shutdown")
             writer = self._writer_thread
+            daemon_start = self._daemon_start_thread
+            if writer is not None and writer.is_alive():
+                self._requeue_retryable_retain_jobs()
             self._shutting_down.set()
             if writer is not None and writer.is_alive():
                 try:
@@ -2161,9 +2236,20 @@ class HindsightMemoryProvider(MemoryProvider):
                 except Exception:
                     pass
 
+        # Drain daemon startup before client cleanup. The startup thread may be
+        # inside _get_client(), so closing first would let it publish/use a new
+        # client after shutdown returned.
+        background_work_alive = False
+        if daemon_start is not None and daemon_start.is_alive():
+            daemon_start.join(timeout=10.0)
+            if daemon_start.is_alive():
+                background_work_alive = True
+                logger.warning(
+                    "Hindsight daemon startup did not stop within 10s; leaving the client open"
+                )
+
         # Drain the writer: it will finish in-flight work, then exit on the
         # sentinel. Ambiguous append failures are deliberately not replayed.
-        background_work_alive = False
         if writer is not None and writer.is_alive():
             writer.join(timeout=10.0)
             if writer.is_alive():

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -43,10 +43,39 @@ import threading
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
+from agent.memory_manager import sanitize_context
 from agent.memory_provider import MemoryProvider
 from hermes_constants import get_hermes_home
 from tools.registry import tool_error
 from hermes_cli.config import cfg_get
+
+
+def _sanitize_retain_content(text: str) -> str:
+    """Strip complete, nested, or malformed memory-context fences fail-closed."""
+    text = text or ""
+    opening = "<memory-context>"
+    closing = "</memory-context>"
+    output: list[str] = []
+    cursor = 0
+    depth = 0
+    while cursor < len(text):
+        open_at = text.find(opening, cursor)
+        close_at = text.find(closing, cursor)
+        candidates = [pos for pos in (open_at, close_at) if pos >= 0]
+        if not candidates:
+            if depth == 0:
+                output.append(text[cursor:])
+            break
+        tag_at = min(candidates)
+        if depth == 0:
+            output.append(text[cursor:tag_at])
+        if tag_at == open_at:
+            depth += 1
+            cursor = tag_at + len(opening)
+        else:
+            depth = max(0, depth - 1)
+            cursor = tag_at + len(closing)
+    return sanitize_context("".join(output))
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +92,7 @@ _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # unique document_id fallback for older APIs.
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
 _VALID_BUDGETS = {"low", "mid", "high"}
+_MAX_TERMINAL_RETAIN_FAILURES = 100
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
     "anthropic": "claude-haiku-4-5",
@@ -238,6 +268,17 @@ def _check_api_supports_update_mode_append(api_url: str,
         logger.debug("Hindsight API %s version %s supports update_mode='append'",
                      api_url, version)
     return supported
+
+
+def _get_embedded_api_version() -> str | None:
+    """Return the API version bundled with HindsightEmbedded, if available."""
+    try:
+        import importlib
+        hindsight_api = importlib.import_module("hindsight_api")
+        version = getattr(hindsight_api, "__version__", None)
+        return str(version) if version else None
+    except Exception:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -645,6 +686,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_source = ""
         self._retain_user_prefix = "User"
         self._retain_assistant_prefix = "Assistant"
+        self._retain_roles = {"user", "assistant"}
         self._platform = ""
         self._user_id = ""
         self._user_name = ""
@@ -667,6 +709,11 @@ class HindsightMemoryProvider(MemoryProvider):
         # futures after interpreter shutdown" / "Unclosed client session".
         self._retain_queue: queue.Queue = queue.Queue()
         self._writer_thread: threading.Thread | None = None
+        self._retain_failure_count = 0
+        self._last_retain_error: Exception | None = None
+        self._failed_retain_jobs: list = []
+        self._failed_retain_lock = threading.Lock()
+        self._lifecycle_lock = threading.RLock()
         self._shutting_down = threading.Event()
         self._atexit_registered = False
         # Legacy alias — older tests/callers reference _sync_thread directly.
@@ -683,6 +730,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
         # Retain controls
         self._auto_retain = True
+        self._auto_retain_require_user_id = False
         self._retain_every_n_turns = 1
         self._retain_async = True
         self._retain_context = "conversation between Hermes Agent and the User"
@@ -711,7 +759,17 @@ class HindsightMemoryProvider(MemoryProvider):
         # Bank
         self._bank_mission = ""
         self._bank_retain_mission: str | None = None
+        self._bank_observations_mission: str | None = None
+        self._bank_retain_extraction_mode: str | None = None
+        self._bank_enable_observations: bool | None = None
+        self._bank_disposition_skepticism: int | None = None
+        self._bank_disposition_literalism: int | None = None
+        self._bank_disposition_empathy: int | None = None
+        self._bank_config_applied = False
+        self._bank_config_applied_for: set[str] = set()
+        self._bank_config_lock = asyncio.Lock()
         self._bank_id_template = ""
+        self._static_bank_id = "hermes"
 
     @property
     def name(self) -> str:
@@ -985,6 +1043,12 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
             {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
+            {"key": "bank_observations_mission", "description": "Custom rules for synthesizing observations"},
+            {"key": "bank_retain_extraction_mode", "description": "Bank fact extraction mode", "default": "concise", "choices": ["concise", "verbose", "custom"]},
+            {"key": "bank_enable_observations", "description": "Enable observation consolidation for this bank", "default": True},
+            {"key": "bank_disposition_skepticism", "description": "Bank skepticism level (1-5)"},
+            {"key": "bank_disposition_literalism", "description": "Bank literalism level (1-5)"},
+            {"key": "bank_disposition_empathy", "description": "Bank empathy level (1-5)"},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
             {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
             {"key": "recall_prefetch_method", "description": "Auto-recall method", "default": "recall", "choices": ["recall", "reflect"]},
@@ -993,11 +1057,13 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_source", "description": "Metadata source value attached to retained memories", "default": ""},
             {"key": "retain_user_prefix", "description": "Label used before user turns in retained transcripts", "default": "User"},
             {"key": "retain_assistant_prefix", "description": "Label used before assistant turns in retained transcripts", "default": "Assistant"},
+            {"key": "retain_roles", "description": "Conversation roles included in automatic retention (comma-separated or list)", "default": "user,assistant"},
             {"key": "recall_tags", "description": "Tags to filter when searching memories (comma-separated)", "default": ""},
             {"key": "recall_tags_match", "description": "Tag matching mode for recall", "default": "any", "choices": ["any", "all", "any_strict", "all_strict"]},
             {"key": "recall_types", "description": "Fact types to surface on recall — applies to both auto-recall and the hindsight_recall tool (comma-separated or list). Defaults to observation-only — observations are Hindsight's consolidated, deduplicated, evidence-grounded knowledge layer; raw world/experience facts are the supporting evidence observations already summarize. Set to e.g. 'observation,world,experience' to also include raw facts.", "default": "observation"},
             {"key": "auto_recall", "description": "Automatically recall memories before each turn", "default": True},
             {"key": "auto_retain", "description": "Automatically retain conversation turns", "default": True},
+            {"key": "auto_retain_require_user_id", "description": "Skip automatic retention when the integration provides no stable user ID", "default": False},
             {"key": "retain_every_n_turns", "description": "Retain every N turns (1 = every turn)", "default": 1},
             {"key": "retain_async","description": "Process retain asynchronously on the Hindsight server", "default": True},
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
@@ -1123,7 +1189,19 @@ class HindsightMemoryProvider(MemoryProvider):
                 try:
                     job()
                 except Exception as exc:
+                    self._retain_failure_count += 1
+                    self._last_retain_error = exc
                     logger.warning("Hindsight retain failed: %s", exc, exc_info=True)
+                    # Treat a failed append as terminal. A timeout/disconnect
+                    # does not prove the server failed to commit; replaying the
+                    # same delta can duplicate conversation content and pollute
+                    # derived memories. Keep a bounded in-memory audit trail
+                    # instead. Safe connection-refused recovery already happens
+                    # inside _run_hindsight_operation before this point.
+                    with self._failed_retain_lock:
+                        if len(self._failed_retain_jobs) >= _MAX_TERMINAL_RETAIN_FAILURES:
+                            self._failed_retain_jobs.pop(0)
+                        self._failed_retain_jobs.append(job)
             finally:
                 self._retain_queue.task_done()
 
@@ -1148,11 +1226,17 @@ class HindsightMemoryProvider(MemoryProvider):
         except Exception as exc:
             logger.debug("Hindsight atexit shutdown failed: %s", exc)
 
-    def _run_hindsight_operation(self, operation):
+    def _run_hindsight_operation(self, operation, *, bank_id: str | None = None):
         """Run an async Hindsight client operation, retrying once after idle shutdown."""
+        target_bank_id = bank_id or self._bank_id
+
+        async def _configured_operation(client):
+            await self._ensure_bank_config(client, bank_id=target_bank_id)
+            return await operation(client)
+
         client = self._get_client()
         try:
-            return self._run_sync(operation(client))
+            return self._run_sync(_configured_operation(client))
         except Exception as exc:
             if not self._is_retriable_embedded_connection_error(exc):
                 raise
@@ -1163,7 +1247,52 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client = None
             client = self._get_client()
             self._client = client
-            return self._run_sync(operation(client))
+            return self._run_sync(_configured_operation(client))
+
+    async def _ensure_bank_config(self, client, *, bank_id: str | None = None) -> None:
+        """Create/update one bank with configured guardrails once per provider."""
+        target_bank_id = bank_id or self._bank_id
+        if target_bank_id in self._bank_config_applied_for:
+            if target_bank_id == self._bank_id:
+                self._bank_config_applied = True
+            return
+        async with self._bank_config_lock:
+            if target_bank_id in self._bank_config_applied_for:
+                if target_bank_id == self._bank_id:
+                    self._bank_config_applied = True
+                return
+            values = {
+                "reflect_mission": self._bank_mission or None,
+                "retain_mission": self._bank_retain_mission,
+                "observations_mission": self._bank_observations_mission,
+                "retain_extraction_mode": self._bank_retain_extraction_mode,
+                "enable_observations": self._bank_enable_observations,
+                "disposition_skepticism": self._bank_disposition_skepticism,
+                "disposition_literalism": self._bank_disposition_literalism,
+                "disposition_empathy": self._bank_disposition_empathy,
+            }
+            configured = {key: value for key, value in values.items() if value is not None}
+            if configured:
+                # Newer Hindsight APIs expose bank configuration via PATCH
+                # /banks/{bank_id}/config.  acreate_bank still accepts these
+                # fields for backwards compatibility, but current servers may
+                # silently ignore them on PUT, leaving missions/dispositions at
+                # their defaults.  Ensure the bank exists, then use the async
+                # config endpoint when the installed client exposes it.
+                update_config = getattr(client, "_aupdate_bank_config", None)
+                if update_config is not None and asyncio.iscoroutinefunction(update_config):
+                    await client.acreate_bank(bank_id=target_bank_id)
+                    await update_config(target_bank_id, configured)
+                else:
+                    await client.acreate_bank(bank_id=target_bank_id, **configured)
+                logger.info(
+                    "Hindsight bank guardrails applied: bank=%s fields=%s",
+                    target_bank_id,
+                    sorted(configured),
+                )
+            self._bank_config_applied_for.add(target_bank_id)
+            if target_bank_id == self._bank_id:
+                self._bank_config_applied = True
 
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
@@ -1194,6 +1323,24 @@ class HindsightMemoryProvider(MemoryProvider):
         retains fire.
         """
         if not self._session_id:
+            return fallback_document_id, None
+        # Before HindsightEmbedded has started, its dynamic daemon URL is not
+        # available. Probing the remote-mode placeholder (normally :8888)
+        # incorrectly classified modern bundled APIs as legacy. The embedded
+        # daemon and hindsight_api module are the same installation, so its
+        # package version is the authoritative pre-start capability signal.
+        if self._mode == "local_embedded" and self._client is None:
+            embedded_version = _get_embedded_api_version()
+            if _meets_minimum_version(
+                embedded_version, _MIN_VERSION_FOR_UPDATE_MODE_APPEND
+            ):
+                return self._session_id, "append"
+            logger.warning(
+                "Bundled Hindsight API reports version %r, older than %s; "
+                "using legacy per-process document IDs",
+                embedded_version,
+                _MIN_VERSION_FOR_UPDATE_MODE_APPEND,
+            )
             return fallback_document_id, None
         if _check_api_supports_update_mode_append(self._probe_url(), self._api_key):
             return self._session_id, "append"
@@ -1285,6 +1432,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
         banks = cfg_get(self._config, "banks", "hermes", default={})
         static_bank_id = self._config.get("bank_id") or banks.get("bankId", "hermes")
+        self._static_bank_id = static_bank_id
         self._bank_id_template = self._config.get("bank_id_template", "") or ""
         self._bank_id = _resolve_bank_id_template(
             self._bank_id_template,
@@ -1307,6 +1455,15 @@ class HindsightMemoryProvider(MemoryProvider):
         # Bank options
         self._bank_mission = self._config.get("bank_mission", "")
         self._bank_retain_mission = self._config.get("bank_retain_mission") or None
+        self._bank_observations_mission = self._config.get("bank_observations_mission") or None
+        self._bank_retain_extraction_mode = self._config.get("bank_retain_extraction_mode") or None
+        self._bank_enable_observations = self._config.get("bank_enable_observations")
+        self._bank_disposition_skepticism = self._config.get("bank_disposition_skepticism")
+        self._bank_disposition_literalism = self._config.get("bank_disposition_literalism")
+        self._bank_disposition_empathy = self._config.get("bank_disposition_empathy")
+        self._bank_config_applied = False
+        self._bank_config_applied_for = set()
+        self._bank_config_lock = asyncio.Lock()
 
         # Tags
         self._retain_tags = _normalize_retain_tags(
@@ -1329,9 +1486,21 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_assistant_prefix = str(
             self._config.get("retain_assistant_prefix") or os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant")
         ).strip() or "Assistant"
+        configured_roles = self._config.get("retain_roles", ["user", "assistant"])
+        if isinstance(configured_roles, str):
+            configured_roles = [role.strip() for role in configured_roles.split(",")]
+        valid_roles = {
+            str(role).strip().lower()
+            for role in (configured_roles or [])
+            if str(role).strip().lower() in {"user", "assistant"}
+        }
+        self._retain_roles = valid_roles or {"user", "assistant"}
 
         # Retain controls
         self._auto_retain = self._config.get("auto_retain", True)
+        self._auto_retain_require_user_id = bool(
+            self._config.get("auto_retain_require_user_id", False)
+        )
         self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", 1)))
         self._retain_context = self._config.get("retain_context", "conversation between Hermes Agent and the User")
 
@@ -1528,18 +1697,25 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
-        return [
-            {
+        messages: List[Dict[str, str]] = []
+        if "user" in self._retain_roles and user_content:
+            messages.append({
                 "role": "user",
                 "content": f"{self._retain_user_prefix}: {user_content}",
                 "timestamp": now,
-            },
-            {
+            })
+        if "assistant" in self._retain_roles and assistant_content:
+            messages.append({
                 "role": "assistant",
                 "content": f"{self._retain_assistant_prefix}: {assistant_content}",
                 "timestamp": now,
-            },
-        ]
+            })
+        return messages
+
+    @staticmethod
+    def _message_count(turns: List[str]) -> int:
+        """Count serialized messages; retain_roles can make turns asymmetric."""
+        return sum(len(json.loads(turn)) for turn in turns)
 
     def _build_metadata(self, *, message_count: int, turn_index: int) -> Dict[str, str]:
         metadata: Dict[str, str] = {
@@ -1601,6 +1777,13 @@ class HindsightMemoryProvider(MemoryProvider):
         return kwargs
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Atomically enqueue one turn against session/shutdown transitions."""
+        with self._lifecycle_lock:
+            self._sync_turn_locked(user_content, assistant_content, session_id=session_id)
+
+    def _sync_turn_locked(
+        self, user_content: str, assistant_content: str, *, session_id: str = ""
+    ) -> None:
         """Enqueue a retain for the current turn. Non-blocking.
 
         The actual aretain_batch runs on a single long-lived writer thread
@@ -1611,14 +1794,39 @@ class HindsightMemoryProvider(MemoryProvider):
         if not self._auto_retain:
             logger.debug("sync_turn: skipped (auto_retain disabled)")
             return
+        if self._auto_retain_require_user_id and not self._user_id:
+            logger.debug("sync_turn: skipped (stable user_id required for auto-retain)")
+            return
         if self._shutting_down.is_set():
             logger.debug("sync_turn: skipped (shutting down)")
             return
 
         if session_id:
-            self._session_id = str(session_id).strip()
+            incoming_session_id = str(session_id).strip()
+            if self._session_id and incoming_session_id != self._session_id:
+                # Some integrations can pass a fresh session_id directly to
+                # sync_turn without dispatching the formal lifecycle hook.
+                # Route it through the same flush/reset path rather than mix
+                # two sessions in one document and buffer.
+                self.on_session_switch(incoming_session_id)
+            else:
+                self._session_id = incoming_session_id
 
-        turn = json.dumps(self._build_turn_messages(user_content, assistant_content), ensure_ascii=False)
+        # Auto-recall context is appended to the visible user message inside a
+        # <memory-context> fence.  Never feed that injected context back into
+        # retain: doing so turns an old recall into fresh evidence and creates
+        # a self-reinforcing memory loop.  Apply the same scrubber to assistant
+        # text defensively because models occasionally echo the fence.
+        clean_user_content = _sanitize_retain_content(user_content or "").strip()
+        clean_assistant_content = _sanitize_retain_content(assistant_content or "").strip()
+        messages = self._build_turn_messages(clean_user_content, clean_assistant_content)
+        if not messages:
+            logger.debug("sync_turn: skipped (no retainable content after filtering)")
+            return
+        turn = json.dumps(
+            messages,
+            ensure_ascii=False,
+        )
         self._session_turns.append(turn)
         self._turn_counter += 1
         self._turn_index = self._turn_counter
@@ -1656,7 +1864,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # Snapshot the state needed for the retain. The writer may run after
         # _session_turns / _turn_index are mutated by a later sync_turn().
         metadata_snapshot = self._build_metadata(
-            message_count=len(turns_to_retain) * 2,
+            message_count=self._message_count(turns_to_retain),
             turn_index=self._turn_index,
         )
         num_turns = len(turns_to_retain)
@@ -1683,17 +1891,18 @@ class HindsightMemoryProvider(MemoryProvider):
                     items=[item],
                     document_id=document_id,
                     retain_async=retain_async_flag,
-                )
+                ),
+                bank_id=bank_id,
             )
             logger.debug("Hindsight retain succeeded")
 
         self._ensure_writer()
         self._register_atexit()
         self._retain_queue.put(_do_retain)
-        # Advance the append watermark only after the delta is queued, so a
-        # later retain doesn't re-ship turns we've already handed to the writer.
-        if update_mode == "append":
-            self._last_retained_turn_count = len(self._session_turns)
+        # Advance the handoff watermark only after the retain is queued.  In
+        # append mode it selects the next delta; in legacy overwrite mode it
+        # tells session-switch/shutdown flushing whether any newer turns exist.
+        self._last_retained_turn_count = len(self._session_turns)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
@@ -1773,7 +1982,90 @@ class HindsightMemoryProvider(MemoryProvider):
 
         return tool_error(f"Unknown tool: {tool_name}")
 
+    def _enqueue_pending_turn_flush(self, *, reason: str) -> bool:
+        """Queue unsent buffered turns under the current session identifiers."""
+        if not getattr(self, "_auto_retain", False) or self._shutting_down.is_set():
+            return False
+        if len(self._session_turns) <= self._last_retained_turn_count:
+            return False
+
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        if update_mode == "append":
+            turns = list(self._session_turns[self._last_retained_turn_count:])
+        else:
+            turns = list(self._session_turns)
+        content = "[" + ",".join(turns) + "]"
+        metadata = self._build_metadata(
+            message_count=self._message_count(turns),
+            turn_index=self._turn_index,
+        )
+        lineage_tags: list[str] = []
+        if self._session_id:
+            lineage_tags.append(f"session:{self._session_id}")
+        if self._parent_session_id:
+            lineage_tags.append(f"parent:{self._parent_session_id}")
+        bank_id = self._bank_id
+        retain_context = self._retain_context
+        retain_async_flag = self._retain_async
+
+        def _flush() -> None:
+            item = self._build_retain_kwargs(
+                content,
+                context=retain_context,
+                metadata=metadata,
+                tags=lineage_tags or None,
+            )
+            item.pop("bank_id", None)
+            item.pop("retain_async", None)
+            if update_mode is not None:
+                item["update_mode"] = update_mode
+            logger.debug(
+                "Hindsight flush-%s: bank=%s, doc=%s, mode=%s, num_turns=%d",
+                reason, bank_id, document_id, update_mode, len(turns),
+            )
+            self._run_hindsight_operation(
+                lambda client: client.aretain_batch(
+                    bank_id=bank_id,
+                    items=[item],
+                    document_id=document_id,
+                    retain_async=retain_async_flag,
+                ),
+                bank_id=bank_id,
+            )
+
+        self._ensure_writer()
+        self._register_atexit()
+        self._retain_queue.put(_flush)
+        self._last_retained_turn_count = len(self._session_turns)
+        return True
+
     def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        **kwargs,
+    ) -> None:
+        """Atomically rotate session state against retain and shutdown calls."""
+        lifecycle_lock = getattr(self, "_lifecycle_lock", None)
+        if lifecycle_lock is None:
+            self._on_session_switch_locked(
+                new_session_id,
+                parent_session_id=parent_session_id,
+                reset=reset,
+                **kwargs,
+            )
+            return
+        with lifecycle_lock:
+            self._on_session_switch_locked(
+                new_session_id,
+                parent_session_id=parent_session_id,
+                reset=reset,
+                **kwargs,
+            )
+
+    def _on_session_switch_locked(
         self,
         new_session_id: str,
         *,
@@ -1816,69 +2108,9 @@ class HindsightMemoryProvider(MemoryProvider):
         if not new_id:
             return
 
-        # 1. Flush any buffered turns under the OLD identifiers. Snapshot
-        # everything before mutating self._* so metadata + tags + doc_id
-        # all reference the old session consistently.
-        if self._session_turns:
-            old_turns = list(self._session_turns)
-            old_session_id = self._session_id
-            old_parent_session_id = self._parent_session_id
-            old_turn_index = self._turn_index
-            old_metadata = self._build_metadata(
-                message_count=len(old_turns) * 2,
-                turn_index=old_turn_index,
-            )
-            old_lineage_tags: list[str] = []
-            if old_session_id:
-                old_lineage_tags.append(f"session:{old_session_id}")
-            if old_parent_session_id:
-                old_lineage_tags.append(f"parent:{old_parent_session_id}")
-            old_content = "[" + ",".join(old_turns) + "]"
-            # Resolve doc_id + update_mode against the OLD session BEFORE
-            # we rotate _session_id, so the flush lands in the old
-            # session's document either way (legacy: per-process unique;
-            # ≥0.5.0: stable session-scoped + append).
-            old_document_id, old_update_mode = self._resolve_retain_target(
-                self._document_id
-            )
-
-            def _flush():
-                try:
-                    item = self._build_retain_kwargs(
-                        old_content,
-                        context=self._retain_context,
-                        metadata=old_metadata,
-                        tags=old_lineage_tags or None,
-                    )
-                    item.pop("bank_id", None)
-                    item.pop("retain_async", None)
-                    if old_update_mode is not None:
-                        item["update_mode"] = old_update_mode
-                    logger.debug(
-                        "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
-                        self._bank_id, old_document_id, old_update_mode, len(old_turns),
-                    )
-                    self._run_hindsight_operation(
-                        lambda client: client.aretain_batch(
-                            bank_id=self._bank_id,
-                            items=[item],
-                            document_id=old_document_id,
-                            retain_async=self._retain_async,
-                        )
-                    )
-                except Exception as e:
-                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
-
-            # Route the flush through the same writer queue sync_turn
-            # uses. That serializes it behind any still-queued retains
-            # from the old session (FIFO by document_id), avoids racing
-            # two threads on aretain_batch against the same document, and
-            # keeps shutdown's drain semantics intact. Skip enqueue if
-            # shutdown has already fired — the writer is draining/gone.
-            if not self._shutting_down.is_set():
-                self._ensure_writer()
-                self._register_atexit()
-                self._retain_queue.put(_flush)
+        # 1. Flush only turns not yet handed to the writer, under the OLD
+        # identifiers. The helper snapshots all state before we rotate below.
+        self._enqueue_pending_turn_flush(reason="session-switch")
 
         # 2. Drain any in-flight prefetch from the old session and drop
         # its cached result so the new session doesn't see stale recall.
@@ -1893,6 +2125,18 @@ class HindsightMemoryProvider(MemoryProvider):
         self._session_id = new_id
         start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         self._document_id = f"{self._session_id}-{start_ts}"
+        new_bank_id = _resolve_bank_id_template(
+            getattr(self, "_bank_id_template", ""),
+            fallback=getattr(self, "_static_bank_id", self._bank_id),
+            profile=self._agent_identity,
+            workspace=self._agent_workspace,
+            platform=self._platform,
+            user=self._user_id,
+            session=self._session_id,
+        )
+        if new_bank_id != self._bank_id:
+            self._bank_id = new_bank_id
+            self._bank_config_applied = False
         self._session_turns = []
         self._turn_counter = 0
         self._turn_index = 0
@@ -1904,28 +2148,39 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
-        # Stop accepting new retain jobs first so anyone still calling
-        # sync_turn() during teardown is dropped, not enqueued.
-        self._shutting_down.set()
-        # Drain the writer: it will finish in-flight work, then exit on
-        # the sentinel. Bounded join keeps shutdown predictable even if
-        # the daemon is wedged.
-        writer = self._writer_thread
+        # Serialize the final flush/sentinel boundary with sync_turn(). A turn
+        # either queues before this block or observes _shutting_down afterwards;
+        # it can never land behind the sentinel.
+        with self._lifecycle_lock:
+            self._enqueue_pending_turn_flush(reason="shutdown")
+            writer = self._writer_thread
+            self._shutting_down.set()
+            if writer is not None and writer.is_alive():
+                try:
+                    self._retain_queue.put(_WRITER_SENTINEL)
+                except Exception:
+                    pass
+
+        # Drain the writer: it will finish in-flight work, then exit on the
+        # sentinel. Ambiguous append failures are deliberately not replayed.
+        background_work_alive = False
         if writer is not None and writer.is_alive():
-            try:
-                self._retain_queue.put(_WRITER_SENTINEL)
-            except Exception:
-                pass
             writer.join(timeout=10.0)
             if writer.is_alive():
+                background_work_alive = True
                 logger.warning(
-                    "Hindsight writer did not stop within 10s; "
-                    "abandoning %d pending retain(s)",
+                    "Hindsight writer did not stop within 10s; leaving the client open "
+                    "for %d pending retain(s)",
                     self._retain_queue.qsize(),
                 )
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=5.0)
-        if self._client is not None:
+            if self._prefetch_thread.is_alive():
+                background_work_alive = True
+                logger.warning(
+                    "Hindsight prefetch did not stop within 5s; leaving the client open"
+                )
+        if self._client is not None and not background_work_alive:
             try:
                 if self._mode == "local_embedded":
                     # HindsightEmbedded.close() delegates to its sync client.close().

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -714,7 +714,6 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_failure_count = 0
         self._last_retain_error: Exception | None = None
         self._failed_retain_jobs: list = []
-        self._retryable_retain_jobs: list = []
         self._failed_retain_lock = threading.Lock()
         self._lifecycle_lock = threading.RLock()
         self._shutting_down = threading.Event()
@@ -1225,22 +1224,19 @@ class HindsightMemoryProvider(MemoryProvider):
                     )
                     if safe_retry:
                         setattr(job, "_hindsight_retry_attempted", True)
-                        if self._shutting_down.is_set():
-                            try:
-                                job()
-                                continue
-                            except Exception as retry_exc:
-                                self._retain_failure_count += 1
-                                self._last_retain_error = retry_exc
-                                logger.warning(
-                                    "Hindsight retain safe retry failed: %s",
-                                    retry_exc,
-                                    exc_info=True,
-                                )
-                        else:
-                            with self._failed_retain_lock:
-                                self._retryable_retain_jobs.append(job)
+                        try:
+                            # Retry inline in the single writer so no newer
+                            # append can overtake the failed older delta.
+                            job()
                             continue
+                        except Exception as retry_exc:
+                            self._retain_failure_count += 1
+                            self._last_retain_error = retry_exc
+                            logger.warning(
+                                "Hindsight retain safe retry failed: %s",
+                                retry_exc,
+                                exc_info=True,
+                            )
                     # Ambiguous failures and exhausted safe retries are
                     # terminal: replay could duplicate a committed append.
                     with self._failed_retain_lock:
@@ -1628,29 +1624,35 @@ class HindsightMemoryProvider(MemoryProvider):
                     from rich.console import Console
                     dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
 
-                    client = self._get_client()
-                    if self._shutting_down.is_set():
-                        return
-                    profile = self._config.get("profile", "hermes")
+                    client: Any = self._get_client()
+                    config = self._config or {}
+                    # Serialize every daemon-manager mutation with shutdown.
+                    # If shutdown wins the lock, this worker exits without
+                    # touching the shared daemon. If startup wins, shutdown
+                    # waits until stop/start has completed before it can return.
+                    with self._lifecycle_lock:
+                        if self._shutting_down.is_set():
+                            return
+                        profile = config.get("profile", "hermes")
 
-                    # Update the profile .env to match our current config so
-                    # the daemon always starts with the right settings.
-                    # If the config changed and the daemon is running, stop it.
-                    profile_env = _embedded_profile_env_path(self._config)
-                    expected_env = _build_embedded_profile_env(self._config)
-                    saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                        # Update the profile .env to match our current config so
+                        # the daemon always starts with the right settings.
+                        # If the config changed and the daemon is running, stop it.
+                        profile_env = _embedded_profile_env_path(config)
+                        expected_env = _build_embedded_profile_env(config)
+                        saved = _load_simple_env(profile_env)
+                        config_changed = saved != expected_env
 
-                    if config_changed:
-                        profile_env = _materialize_embedded_profile_env(self._config)
-                        if client._manager.is_running(profile):
-                            with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
+                        if config_changed:
+                            profile_env = _materialize_embedded_profile_env(config)
+                            if client._manager.is_running(profile):
+                                with open(log_path, "a", encoding="utf-8") as f:
+                                    f.write("\n=== Config changed, restarting daemon ===\n")
+                                client._manager.stop(profile)
 
-                    client._ensure_started()
-                    with open(log_path, "a", encoding="utf-8") as f:
-                        f.write("\n=== Daemon started successfully ===\n")
+                        client._ensure_started()
+                        with open(log_path, "a", encoding="utf-8") as f:
+                            f.write("\n=== Daemon started successfully ===\n")
                 except Exception as e:
                     with open(log_path, "a", encoding="utf-8") as f:
                         f.write(f"\n=== Daemon startup failed: {e} ===\n")
@@ -1859,8 +1861,6 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("sync_turn: skipped (shutting down)")
             return
 
-        self._requeue_retryable_retain_jobs()
-
         if session_id:
             incoming_session_id = str(session_id).strip()
             if self._session_id and incoming_session_id != self._session_id:
@@ -1964,14 +1964,6 @@ class HindsightMemoryProvider(MemoryProvider):
         # tells session-switch/shutdown flushing whether any newer turns exist.
         self._last_retained_turn_count = len(self._session_turns)
 
-    def _requeue_retryable_retain_jobs(self) -> int:
-        """Replay once only when failure proves the request never connected."""
-        with self._failed_retain_lock:
-            jobs = self._retryable_retain_jobs
-            self._retryable_retain_jobs = []
-        for job in jobs:
-            self._retain_queue.put(job)
-        return len(jobs)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
@@ -2227,8 +2219,6 @@ class HindsightMemoryProvider(MemoryProvider):
             self._enqueue_pending_turn_flush(reason="shutdown")
             writer = self._writer_thread
             daemon_start = self._daemon_start_thread
-            if writer is not None and writer.is_alive():
-                self._requeue_retryable_retain_jobs()
             self._shutting_down.set()
             if writer is not None and writer.is_alive():
                 try:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -10,6 +10,7 @@ import os
 import re
 import stat
 import sys
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -948,6 +949,93 @@ class TestSyncTurn:
         item = p._client.aretain_batch.call_args.kwargs["items"][0]
         assert item["context"] == "my-agent"
 
+    def test_sync_turn_strips_injected_memory_context_before_retain(self, provider):
+        p = provider
+        p.sync_turn(
+            "Visible user request\n<memory-context>stale recalled claim</memory-context>",
+            "<memory-context>another recalled claim</memory-context>\nVisible answer",
+        )
+        p._retain_queue.join()
+
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        content = item["content"]
+        assert "Visible user request" in content
+        assert "Visible answer" in content
+        assert "stale recalled claim" not in content
+        assert "another recalled claim" not in content
+        assert "memory-context" not in content
+
+    def test_sync_turn_strips_nested_and_unclosed_memory_context_fail_closed(self, provider):
+        provider.sync_turn(
+            "Visible request <memory-context>outer <memory-context>inner</memory-context> tail</memory-context> after",
+            "Visible answer <memory-context>unclosed recalled secret",
+        )
+        provider._retain_queue.join()
+
+        content = provider._client.aretain_batch.call_args.kwargs["items"][0]["content"]
+        assert "Visible request" in content
+        assert "after" in content
+        assert "Visible answer" in content
+        assert "outer" not in content
+        assert "inner" not in content
+        assert "unclosed recalled secret" not in content
+        assert "memory-context" not in content
+
+    def test_sync_turn_respects_retain_roles(self, provider_with_config):
+        p = provider_with_config(retain_roles=["user"])
+        p.sync_turn("Confirmed user preference", "Unverified assistant claim")
+        p._retain_queue.join()
+
+        content = json.loads(
+            p._client.aretain_batch.call_args.kwargs["items"][0]["content"]
+        )
+        assert len(content[0]) == 1
+        assert content[0][0]["role"] == "user"
+        assert "Confirmed user preference" in content[0][0]["content"]
+        assert "Unverified assistant claim" not in json.dumps(content)
+
+    def test_sync_turn_drops_memory_only_turn_after_sanitizing(self, provider):
+        p = provider
+        p.sync_turn(
+            "<memory-context>recalled user context</memory-context>",
+            "<memory-context>echoed assistant context</memory-context>",
+        )
+        assert p._retain_queue.empty()
+        p._client.aretain_batch.assert_not_called()
+
+    def test_first_operation_applies_configured_bank_guardrails(self, provider_with_config):
+        p = provider_with_config(
+            bank_mission="Fracto memory reasoning",
+            bank_retain_mission="Retain only durable confirmed facts",
+            bank_observations_mission="Exclude transient and unverified claims",
+            bank_retain_extraction_mode="concise",
+            bank_enable_observations=True,
+            bank_disposition_skepticism=4,
+            bank_disposition_literalism=4,
+            bank_disposition_empathy=2,
+        )
+        p._client.acreate_bank = AsyncMock()
+        p._client._aupdate_bank_config = AsyncMock()
+
+        p.sync_turn("Remember my stable preference", "Acknowledged")
+        p._retain_queue.join()
+
+        p._client.acreate_bank.assert_awaited_once_with(bank_id="test-bank")
+        p._client._aupdate_bank_config.assert_awaited_once_with(
+            "test-bank",
+            {
+                "reflect_mission": "Fracto memory reasoning",
+                "retain_mission": "Retain only durable confirmed facts",
+                "observations_mission": "Exclude transient and unverified claims",
+                "retain_extraction_mode": "concise",
+                "enable_observations": True,
+                "disposition_skepticism": 4,
+                "disposition_literalism": 4,
+                "disposition_empathy": 2,
+            },
+        )
+        p._client.aretain_batch.assert_awaited_once()
+
     def test_sync_turn_every_n_turns(self, provider_with_config):
         p = provider_with_config(retain_every_n_turns=3, retain_async=False)
         p.sync_turn("turn1-user", "turn1-asst")
@@ -1101,10 +1189,76 @@ class TestSyncTurn:
         assert "session:child-session" in item["tags"]
         assert "parent:parent-session" in item["tags"]
 
+    def test_sync_turn_requires_stable_user_when_configured(self, provider_with_config):
+        p = provider_with_config(auto_retain_require_user_id=True)
+        p._user_id = ""
+
+        p.sync_turn("automation input", "automation output")
+
+        assert p._retain_queue.empty()
+        p._client.aretain_batch.assert_not_called()
+
     def test_sync_turn_error_does_not_raise(self, provider):
         provider._client.aretain_batch.side_effect = RuntimeError("network error")
         provider.sync_turn("hello", "hi")
         provider._retain_queue.join()
+
+    def test_writer_records_auto_retain_failure_for_audit(self, provider):
+        provider._client.aretain_batch.side_effect = RuntimeError("retain transport failed")
+
+        provider.sync_turn("hello", "hi")
+        provider._retain_queue.join()
+
+        assert provider._retain_failure_count == 1
+        assert "retain transport failed" in str(provider._last_retain_error)
+
+    def test_next_turn_does_not_replay_ambiguous_failed_append(self, provider, monkeypatch):
+        monkeypatch.setattr(
+            provider,
+            "_resolve_retain_target",
+            lambda fallback_document_id: ("test-session", "append"),
+        )
+        provider._client.aretain_batch.side_effect = RuntimeError("first delta failed")
+        provider.sync_turn("missed-user", "missed-assistant")
+        provider._retain_queue.join()
+
+        provider._client.aretain_batch.side_effect = None
+        provider.sync_turn("new-user", "new-assistant")
+        provider._retain_queue.join()
+
+        calls = provider._client.aretain_batch.await_args_list
+        assert len(calls) == 2
+        assert "missed-user" in calls[0].kwargs["items"][0]["content"]
+        assert "new-user" in calls[1].kwargs["items"][0]["content"]
+        assert "missed-user" not in calls[1].kwargs["items"][0]["content"]
+        assert len(provider._failed_retain_jobs) == 1
+
+    def test_shutdown_does_not_replay_ambiguous_failed_append(self, provider):
+        provider._client.aretain_batch.side_effect = RuntimeError("first delta failed")
+        provider.sync_turn("missed-user", "missed-assistant")
+        provider._retain_queue.join()
+
+        provider._client.aretain_batch.side_effect = None
+        client = provider._client
+        provider.shutdown()
+
+        calls = client.aretain_batch.await_args_list
+        assert len(calls) == 1
+        assert len(provider._failed_retain_jobs) == 1
+
+    def test_repeated_shutdown_keeps_terminal_failure_out_of_dead_queue(self, provider):
+        provider._client.aretain_batch.side_effect = RuntimeError("offline")
+        provider.sync_turn("missed-user", "missed-assistant")
+        provider._retain_queue.join()
+
+        provider.shutdown()
+        assert not provider._writer_thread.is_alive()
+        assert provider._retain_queue.empty()
+        assert len(provider._failed_retain_jobs) == 1
+
+        provider.shutdown()
+        assert provider._retain_queue.empty()
+        assert len(provider._failed_retain_jobs) == 1
 
     def test_sync_turn_preserves_unicode(self, provider_with_config):
         """Non-ASCII text (CJK, ZWJ emoji) must survive JSON round-trip intact."""
@@ -1180,12 +1334,39 @@ class TestShutdownRace:
         assert client.aretain_batch.call_count == 2
         assert provider._retain_queue.empty()
 
+    def test_shutdown_flushes_partial_turn_batch(self, provider_with_config):
+        """Turns below retain_every_n_turns must not disappear on process exit."""
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        client = p._client
+        p.sync_turn("partial-user-1", "partial-assistant-1")
+        p.sync_turn("partial-user-2", "partial-assistant-2")
+        client.aretain_batch.assert_not_called()
+
+        p.shutdown()
+
+        client.aretain_batch.assert_awaited_once()
+        content = client.aretain_batch.call_args.kwargs["items"][0]["content"]
+        assert "partial-user-1" in content
+        assert "partial-user-2" in content
+
     def test_shutdown_is_idempotent(self, provider):
         provider.sync_turn("a", "b")
         provider.shutdown()
         # Second shutdown shouldn't blow up or re-close the client.
         provider.shutdown()
         assert provider._shutting_down.is_set()
+
+    def test_shutdown_does_not_close_client_under_live_writer(self, provider):
+        client = provider._client
+        writer = MagicMock()
+        writer.is_alive.return_value = True
+        provider._writer_thread = writer
+
+        provider.shutdown()
+
+        writer.join.assert_called_once_with(timeout=10.0)
+        client.aclose.assert_not_awaited()
+        assert provider._client is client
 
 
 # ---------------------------------------------------------------------------
@@ -1240,6 +1421,113 @@ class TestSessionSwitchBufferFlush:
         provider._retain_queue.join()
         provider._client.aretain_batch.assert_not_called()
         assert provider._session_id == "new-sid"
+
+    def test_sync_turn_with_new_session_id_uses_full_switch_lifecycle(
+        self, provider_with_config
+    ):
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        old_document_id = p._document_id
+        p.sync_turn("old-user", "old-assistant")
+
+        p.sync_turn("new-user", "new-assistant", session_id="new-session")
+        p._retain_queue.join()
+
+        flush = p._client.aretain_batch.call_args_list[0].kwargs
+        assert flush["document_id"] == old_document_id
+        assert "old-user" in flush["items"][0]["content"]
+        assert "new-user" not in flush["items"][0]["content"]
+        assert p._session_id == "new-session"
+        assert len(p._session_turns) == 1
+        assert "new-user" in p._session_turns[0]
+        assert "old-user" not in p._session_turns[0]
+
+    def test_session_switch_re_resolves_session_scoped_bank_template(
+        self, provider_with_config
+    ):
+        p = provider_with_config(bank_id_template="fracto-{session}")
+        assert p._bank_id == "fracto-test-session"
+        p._bank_config_applied = True
+
+        p.on_session_switch("new-session")
+
+        assert p._bank_id == "fracto-new-session"
+        assert p._bank_config_applied is False
+
+    def test_session_switch_serializes_against_concurrent_sync_turn(
+        self, provider_with_config
+    ):
+        p = provider_with_config(retain_every_n_turns=3)
+        p.sync_turn("old-user", "old-assistant")
+        entered_flush = threading.Event()
+        release_flush = threading.Event()
+        original_flush = p._enqueue_pending_turn_flush
+
+        def blocking_flush(*, reason):
+            result = original_flush(reason=reason)
+            entered_flush.set()
+            assert release_flush.wait(timeout=2)
+            return result
+
+        p._enqueue_pending_turn_flush = blocking_flush
+        switch_thread = threading.Thread(target=lambda: p.on_session_switch("new-session"))
+        switch_thread.start()
+        assert entered_flush.wait(timeout=2)
+
+        sync_thread = threading.Thread(
+            target=lambda: p.sync_turn("racing-user", "racing-assistant")
+        )
+        sync_thread.start()
+        assert sync_thread.is_alive()
+
+        release_flush.set()
+        switch_thread.join(timeout=2)
+        sync_thread.join(timeout=2)
+        assert not switch_thread.is_alive()
+        assert not sync_thread.is_alive()
+        assert p._session_id == "new-session"
+        assert any("racing-user" in turn for turn in p._session_turns)
+
+    def test_old_session_flush_applies_guardrails_to_captured_bank(
+        self, provider_with_config
+    ):
+        p = provider_with_config(
+            bank_id_template="fracto-{session}",
+            retain_every_n_turns=3,
+            bank_retain_mission="retain durable facts only",
+        )
+        p._client.acreate_bank = AsyncMock()
+        p.sync_turn("old-user", "old-assistant")
+
+        p.on_session_switch("new-session")
+        p._retain_queue.join()
+
+        assert p._client.acreate_bank.await_args_list[-1].kwargs["bank_id"] == "fracto-test-session"
+        assert p._client.aretain_batch.await_args_list[-1].kwargs["bank_id"] == "fracto-test-session"
+
+    def test_append_mode_does_not_flush_already_retained_turns(
+        self, provider_with_config, monkeypatch
+    ):
+        """A session switch must not append an already-shipped turn twice."""
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        from plugins.memory.hindsight import _append_capability_cache, _append_capability_lock
+        with _append_capability_lock:
+            _append_capability_cache.clear()
+        try:
+            p = provider_with_config(retain_every_n_turns=1, retain_async=False)
+            p.sync_turn("already-retained-user", "already-retained-assistant")
+            p._retain_queue.join()
+            p._client.aretain_batch.reset_mock()
+
+            p.on_session_switch("new-sid")
+            p._retain_queue.join()
+
+            p._client.aretain_batch.assert_not_called()
+        finally:
+            with _append_capability_lock:
+                _append_capability_cache.clear()
 
     def test_prefetch_result_cleared_on_switch(self, provider):
         """Stale recall text from the old session must not leak into the
@@ -1342,6 +1630,29 @@ class TestUpdateModeAppendCapability:
         from plugins.memory.hindsight import _append_capability_cache, _append_capability_lock
         with _append_capability_lock:
             _append_capability_cache.clear()
+
+    def test_embedded_mode_uses_bundled_api_version_before_daemon_url_exists(
+        self, provider, monkeypatch
+    ):
+        """Embedded mode must not probe the placeholder remote api_url."""
+        provider._mode = "local_embedded"
+        provider._client = None
+        provider._api_url = "http://localhost:8888"
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._get_embedded_api_version",
+            lambda: "0.8.4",
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: (_ for _ in ()).throw(
+                AssertionError("placeholder api_url must not be probed")
+            ),
+        )
+
+        document_id, update_mode = provider._resolve_retain_target("fallback-doc")
+
+        assert document_id == "test-session"
+        assert update_mode == "append"
 
     def test_legacy_api_falls_back_to_per_process_doc_id(self, provider, monkeypatch):
         """API returns no /version (or pre-0.5.0) — sync_turn must use the

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1246,6 +1246,44 @@ class TestSyncTurn:
         assert len(calls) == 1
         assert len(provider._failed_retain_jobs) == 1
 
+    def test_next_turn_retries_definite_precommit_connection_failure(self, provider):
+        provider._client.aretain_batch.side_effect = [ConnectionRefusedError("offline"), None, None]
+        provider.sync_turn("missed-user", "missed-assistant")
+        provider._retain_queue.join()
+
+        provider.sync_turn("new-user", "new-assistant")
+        provider._retain_queue.join()
+
+        calls = provider._client.aretain_batch.await_args_list
+        assert len(calls) == 3
+        assert "missed-user" in calls[0].kwargs["items"][0]["content"]
+        assert "missed-user" in calls[1].kwargs["items"][0]["content"]
+        assert "new-user" in calls[2].kwargs["items"][0]["content"]
+        assert provider._retryable_retain_jobs == []
+
+    def test_shutdown_retries_definite_precommit_connection_failure(self, provider):
+        provider._client.aretain_batch.side_effect = [ConnectionRefusedError("offline"), None]
+        provider.sync_turn("missed-user", "missed-assistant")
+        provider._retain_queue.join()
+
+        client = provider._client
+        provider.shutdown()
+
+        assert len(client.aretain_batch.await_args_list) == 2
+        assert provider._retryable_retain_jobs == []
+
+    def test_definite_precommit_failure_is_retried_only_once(self, provider):
+        provider._client.aretain_batch.side_effect = ConnectionRefusedError("offline")
+        provider.sync_turn("missed-user", "missed-assistant")
+        provider._retain_queue.join()
+
+        assert provider._requeue_retryable_retain_jobs() == 1
+        provider._retain_queue.join()
+
+        assert provider._client.aretain_batch.await_count == 2
+        assert provider._retryable_retain_jobs == []
+        assert len(provider._failed_retain_jobs) == 1
+
     def test_repeated_shutdown_keeps_terminal_failure_out_of_dead_queue(self, provider):
         provider._client.aretain_batch.side_effect = RuntimeError("offline")
         provider.sync_turn("missed-user", "missed-assistant")
@@ -1563,6 +1601,27 @@ class TestSessionSwitchBufferFlush:
 
         assert finished.is_set(), "switch returned before prefetch thread settled"
         assert provider._prefetch_result == ""
+
+    def test_timed_out_old_prefetch_cannot_repopulate_new_session(self, provider, monkeypatch):
+        import threading
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _blocked_operation(_operation):
+            started.set()
+            release.wait(timeout=5.0)
+            return SimpleNamespace(results=[SimpleNamespace(text="stale-result")])
+
+        monkeypatch.setattr(provider, "_run_hindsight_operation", _blocked_operation)
+        provider.queue_prefetch("old-session-query")
+        assert started.wait(timeout=1.0)
+
+        provider.on_session_switch("new-sid")
+        release.set()
+        provider._prefetch_thread.join(timeout=1.0)
+
+        assert provider.prefetch("new-session-query") == ""
 
     def test_flush_serializes_behind_pending_retains_via_writer_queue(
         self, provider_with_config
@@ -2104,6 +2163,43 @@ class TestSharedEventLoopLifecycle:
 
 
 class TestShutdown:
+    def test_shutdown_waits_for_embedded_daemon_startup_thread(self):
+        import threading
+
+        started = threading.Event()
+        release = threading.Event()
+        shutdown_done = threading.Event()
+        embedded = MagicMock()
+        embedded._client = None
+        embedded._manager = MagicMock()
+        provider = HindsightMemoryProvider()
+        provider._mode = "local_embedded"
+
+        def _blocked_startup():
+            started.set()
+            release.wait(timeout=5.0)
+            provider._client = embedded
+
+        provider._daemon_start_thread = threading.Thread(target=_blocked_startup, daemon=True)
+        provider._daemon_start_thread.start()
+        assert started.wait(timeout=1.0)
+
+        def _shutdown():
+            provider.shutdown()
+            shutdown_done.set()
+
+        shutdown_thread = threading.Thread(target=_shutdown, daemon=True)
+        shutdown_thread.start()
+        returned_while_startup_blocked = shutdown_done.wait(timeout=0.1)
+        release.set()
+        shutdown_thread.join(timeout=2.0)
+
+        assert not returned_while_startup_blocked
+        assert shutdown_done.is_set()
+        assert not provider._daemon_start_thread.is_alive()
+        embedded.close.assert_called_once()
+        assert provider._client is None
+
     def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(self, provider):
         inner_client = _make_mock_client()
         embedded = MagicMock()

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1246,7 +1246,7 @@ class TestSyncTurn:
         assert len(calls) == 1
         assert len(provider._failed_retain_jobs) == 1
 
-    def test_next_turn_retries_definite_precommit_connection_failure(self, provider):
+    def test_writer_retries_definite_precommit_connection_failure_inline(self, provider):
         provider._client.aretain_batch.side_effect = [ConnectionRefusedError("offline"), None, None]
         provider.sync_turn("missed-user", "missed-assistant")
         provider._retain_queue.join()
@@ -1259,7 +1259,6 @@ class TestSyncTurn:
         assert "missed-user" in calls[0].kwargs["items"][0]["content"]
         assert "missed-user" in calls[1].kwargs["items"][0]["content"]
         assert "new-user" in calls[2].kwargs["items"][0]["content"]
-        assert provider._retryable_retain_jobs == []
 
     def test_shutdown_retries_definite_precommit_connection_failure(self, provider):
         provider._client.aretain_batch.side_effect = [ConnectionRefusedError("offline"), None]
@@ -1270,19 +1269,41 @@ class TestSyncTurn:
         provider.shutdown()
 
         assert len(client.aretain_batch.await_args_list) == 2
-        assert provider._retryable_retain_jobs == []
 
     def test_definite_precommit_failure_is_retried_only_once(self, provider):
         provider._client.aretain_batch.side_effect = ConnectionRefusedError("offline")
         provider.sync_turn("missed-user", "missed-assistant")
         provider._retain_queue.join()
 
-        assert provider._requeue_retryable_retain_jobs() == 1
+        assert provider._client.aretain_batch.await_count == 2
+        assert len(provider._failed_retain_jobs) == 1
+
+    def test_definite_precommit_retry_preserves_append_order(self, provider):
+        import threading
+
+        started = threading.Event()
+        release = threading.Event()
+        order = []
+
+        async def _retain(**kwargs):
+            content = kwargs["items"][0]["content"]
+            label = "old" if "old-user" in content else "new"
+            order.append(label)
+            if label == "old" and order.count("old") == 1:
+                started.set()
+                assert release.wait(timeout=2.0)
+                raise ConnectionRefusedError("definite precommit")
+
+        provider._client.aretain_batch = AsyncMock(side_effect=_retain)
+        provider._append_updates_supported = True
+        provider._resolve_retain_target = lambda fallback: ("session-doc", "append")
+        provider.sync_turn("old-user", "old-assistant")
+        assert started.wait(timeout=1.0)
+        provider.sync_turn("new-user", "new-assistant")
+        release.set()
         provider._retain_queue.join()
 
-        assert provider._client.aretain_batch.await_count == 2
-        assert provider._retryable_retain_jobs == []
-        assert len(provider._failed_retain_jobs) == 1
+        assert order == ["old", "old", "new"]
 
     def test_repeated_shutdown_keeps_terminal_failure_out_of_dead_queue(self, provider):
         provider._client.aretain_batch.side_effect = RuntimeError("offline")
@@ -2196,9 +2217,92 @@ class TestShutdown:
 
         assert not returned_while_startup_blocked
         assert shutdown_done.is_set()
+        assert provider._daemon_start_thread is not None
         assert not provider._daemon_start_thread.is_alive()
         embedded.close.assert_called_once()
         assert provider._client is None
+
+    def test_shutdown_cannot_return_before_embedded_manager_mutation_finishes(
+        self, tmp_path, monkeypatch
+    ):
+        import sys
+        import threading
+        import types
+
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(json.dumps({
+            "mode": "local_embedded",
+            "profile": "hermes",
+            "bank_id": "test-bank",
+            "memory_mode": "hybrid",
+        }))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr("plugins.memory.hindsight.os.geteuid", lambda: 501)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._embedded_profile_env_path",
+            lambda config: tmp_path / "profile.env",
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._build_embedded_profile_env", lambda config: {"X": "1"}
+        )
+        monkeypatch.setattr("plugins.memory.hindsight._load_simple_env", lambda path: {})
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._materialize_embedded_profile_env",
+            lambda config: tmp_path / "profile.env",
+        )
+
+        entered = threading.Event()
+        release = threading.Event()
+        shutdown_done = threading.Event()
+        calls = []
+        manager = MagicMock()
+
+        def _is_running(profile):
+            calls.append("is_running")
+            entered.set()
+            assert release.wait(timeout=2.0)
+            return True
+
+        manager.is_running.side_effect = _is_running
+        manager.stop.side_effect = lambda profile: calls.append("stop")
+        client = SimpleNamespace(
+            _manager=manager,
+            _ensure_started=lambda: calls.append("ensure_started"),
+        )
+        monkeypatch.setattr(HindsightMemoryProvider, "_get_client", lambda self: client)
+        package = types.ModuleType("hindsight_embed")
+        daemon_module = types.ModuleType("hindsight_embed.daemon_embed_manager")
+        setattr(daemon_module, "console", None)
+        setattr(package, "daemon_embed_manager", daemon_module)
+        monkeypatch.setitem(sys.modules, "hindsight_embed", package)
+        monkeypatch.setitem(
+            sys.modules, "hindsight_embed.daemon_embed_manager", daemon_module
+        )
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(session_id="s", hermes_home=str(tmp_path), platform="test")
+        assert entered.wait(timeout=1.0)
+        daemon_thread = provider._daemon_start_thread
+        assert daemon_thread is not None
+        real_join = daemon_thread.join
+        daemon_thread.join = lambda timeout=None: None
+
+        shutdown_thread = threading.Thread(
+            target=lambda: (provider.shutdown(), shutdown_done.set()), daemon=True
+        )
+        shutdown_thread.start()
+        returned_while_manager_blocked = shutdown_done.wait(timeout=0.1)
+        release.set()
+        shutdown_thread.join(timeout=2.0)
+        real_join(timeout=1.0)
+
+        assert not returned_while_manager_blocked
+        assert shutdown_done.is_set()
+        assert calls == ["is_running", "stop", "ensure_started"]
 
     def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(self, provider):
         inner_client = _make_mock_client()

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -2222,7 +2222,7 @@ class TestShutdown:
         embedded.close.assert_called_once()
         assert provider._client is None
 
-    def test_shutdown_cannot_return_before_embedded_manager_mutation_finishes(
+    def test_shutdown_timeout_blocks_late_embedded_daemon_restart(
         self, tmp_path, monkeypatch
     ):
         import sys
@@ -2295,14 +2295,16 @@ class TestShutdown:
             target=lambda: (provider.shutdown(), shutdown_done.set()), daemon=True
         )
         shutdown_thread.start()
-        returned_while_manager_blocked = shutdown_done.wait(timeout=0.1)
+        returned_while_manager_blocked = shutdown_done.wait(timeout=0.5)
+        assert returned_while_manager_blocked
+        assert calls == ["is_running"]
+
         release.set()
         shutdown_thread.join(timeout=2.0)
         real_join(timeout=1.0)
 
-        assert not returned_while_manager_blocked
         assert shutdown_done.is_set()
-        assert calls == ["is_running", "stop", "ensure_started"]
+        assert calls == ["is_running"]
 
     def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(self, provider):
         inner_client = _make_mock_client()

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -2184,6 +2184,40 @@ class TestSharedEventLoopLifecycle:
 
 
 class TestShutdown:
+    def test_concurrent_shutdown_callers_share_flush_barrier(self, provider):
+        import threading
+
+        retain_started = threading.Event()
+        release_retain = threading.Event()
+        first_done = threading.Event()
+        second_done = threading.Event()
+
+        async def _blocked_retain(**kwargs):
+            retain_started.set()
+            assert release_retain.wait(timeout=5.0)
+
+        provider._client.aretain_batch = AsyncMock(side_effect=_blocked_retain)
+        provider.sync_turn("user", "assistant")
+        assert retain_started.wait(timeout=1.0)
+
+        first = threading.Thread(
+            target=lambda: (provider.shutdown(), first_done.set()), daemon=True
+        )
+        second = threading.Thread(
+            target=lambda: (provider.shutdown(), second_done.set()), daemon=True
+        )
+        first.start()
+        second.start()
+
+        assert not first_done.wait(timeout=0.1)
+        assert not second_done.wait(timeout=0.1)
+        release_retain.set()
+        first.join(timeout=2.0)
+        second.join(timeout=2.0)
+
+        assert first_done.is_set()
+        assert second_done.is_set()
+
     def test_shutdown_waits_for_embedded_daemon_startup_thread(self):
         import threading
 
@@ -2305,6 +2339,53 @@ class TestShutdown:
 
         assert shutdown_done.is_set()
         assert calls == ["is_running"]
+
+    def test_embedded_initialization_keeps_daemon_startup_lazy(self, tmp_path, monkeypatch):
+        import sys
+        import types
+
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(json.dumps({
+            "mode": "local_embedded",
+            "profile": "hermes",
+            "bank_id": "test-bank",
+        }))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr("plugins.memory.hindsight.os.geteuid", lambda: 501)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._embedded_profile_env_path",
+            lambda config: tmp_path / "profile.env",
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._build_embedded_profile_env", lambda config: {"X": "1"}
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._load_simple_env", lambda path: {"X": "1"}
+        )
+        client = SimpleNamespace(_manager=MagicMock(), _ensure_started=MagicMock())
+        monkeypatch.setattr(HindsightMemoryProvider, "_get_client", lambda self: client)
+        package = types.ModuleType("hindsight_embed")
+        daemon_module = types.ModuleType("hindsight_embed.daemon_embed_manager")
+        setattr(daemon_module, "console", None)
+        setattr(package, "daemon_embed_manager", daemon_module)
+        monkeypatch.setitem(sys.modules, "hindsight_embed", package)
+        monkeypatch.setitem(
+            sys.modules, "hindsight_embed.daemon_embed_manager", daemon_module
+        )
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(session_id="s", hermes_home=str(tmp_path), platform="test")
+        daemon_thread = provider._daemon_start_thread
+        assert daemon_thread is not None
+        daemon_thread.join(timeout=1.0)
+
+        assert not daemon_thread.is_alive()
+        client._ensure_started.assert_not_called()
+        provider.shutdown()
 
     def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(self, provider):
         inner_client = _make_mock_client()


### PR DESCRIPTION
## Summary
- isolate dynamic Hindsight banks by stable profile/user/session metadata and fail closed when configured user identity is missing
- strip injected memory context before retain, add role filtering, and apply bank missions/dispositions through the current bank config API
- serialize session-switch/shutdown lifecycle, flush partial batches, avoid unsafe append replay, and keep clients open while background work is still active
- document the new retention and guardrail behavior

## Verification
- [x] 134/134 Hindsight provider tests
- [x] 138/138 adjacent memory and gateway tests
- [x] Python compile check
- [x] git diff --check
- [x] isolated retain/recall/observation audit against Hindsight 0.6.1 with live bank guardrails
- [x] daemon PID unchanged before/after remote audit

## Safety
- no credentials or profile-specific values are included
- existing legacy banks are not deleted or migrated
- ambiguous failed append requests are not replayed automatically because the server may have committed before the client observed a timeout