### PR TITLE
fix(cli): resolve reasoning config for oneshot agents

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -407,6 +407,17 @@ def _run_agent(
         # gateway sessions.
         _fb = get_fallback_chain(cfg)
 
+        # Reasoning effort: oneshot bypasses HermesCLI, so the config the
+        # interactive path resolves (cli.py) and the gateway resolves
+        # (_load_reasoning_config) never reached this construction and
+        # AIAgent fell back to reasoning_config=None — scripted/cron -z runs
+        # silently ignored agent.reasoning_effort. Resolve through the same
+        # shared chokepoint, with the final effective model so per-model
+        # overrides apply.
+        from hermes_constants import resolve_reasoning_config
+
+        _reasoning = resolve_reasoning_config(cfg, effective_model)
+
         agent = AIAgent(
             api_key=runtime.get("api_key"),
             base_url=runtime.get("base_url"),
@@ -419,6 +430,7 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            reasoning_config=_reasoning,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction

--- a/tests/hermes_cli/test_oneshot_reasoning_config.py
+++ b/tests/hermes_cli/test_oneshot_reasoning_config.py
@@ -1,0 +1,111 @@
+"""Regression tests: hermes -z must honor ``agent.reasoning_effort``.
+
+The interactive chat path resolves reasoning config at startup (cli.py, via
+``hermes_constants.resolve_reasoning_config``) and forwards it to ``AIAgent``
+(``hermes_cli/cli_agent_setup_mixin.py``); the gateway resolves through the
+same chokepoint (``_load_reasoning_config``). Oneshot mode bypasses both --
+``hermes_cli/oneshot.py::_run_agent`` builds its own agent -- so
+``agent.reasoning_effort`` was silently ignored and every ``hermes -z`` run
+executed with ``reasoning_config=None`` (observable as
+``model_config.reasoning_config: null`` in the session record).
+"""
+
+import hermes_cli.config as config_mod
+import hermes_cli.runtime_provider as runtime_provider_mod
+import run_agent as run_agent_mod
+from hermes_cli import oneshot
+from hermes_constants import resolve_reasoning_config
+
+
+class _CapturingAgent:
+    """Stands in for AIAgent and records the constructor kwargs."""
+
+    captured: dict = {}
+
+    def __init__(self, **kwargs):
+        type(self).captured = dict(kwargs)
+        self.suppress_status_output = False
+        self.stream_delta_callback = None
+        self.tool_gen_callback = None
+
+    def run_conversation(self, prompt):
+        return {"final_response": "done"}
+
+    def shutdown_memory_provider(self, *args, **kwargs):
+        pass
+
+    def close(self):
+        pass
+
+
+def _wire_oneshot_stubs(monkeypatch, cfg):
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.setattr(config_mod, "load_config", lambda: cfg)
+    monkeypatch.setattr(
+        runtime_provider_mod,
+        "resolve_runtime_provider",
+        lambda **_kw: {
+            "api_key": "test-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "api_mode": None,
+            "command": None,
+            "args": None,
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(oneshot, "get_fallback_chain", lambda _cfg: None)
+    _CapturingAgent.captured = {}
+    monkeypatch.setattr(run_agent_mod, "AIAgent", _CapturingAgent)
+
+
+def test_oneshot_forwards_global_reasoning_effort(monkeypatch):
+    """``agent.reasoning_effort`` must reach the AIAgent constructor, resolved
+    through the shared chokepoint (same result the chat path would get)."""
+    cfg = {
+        "model": {"default": "test/model", "provider": "openrouter"},
+        "agent": {"reasoning_effort": "high"},
+    }
+    _wire_oneshot_stubs(monkeypatch, cfg)
+
+    response, _result = oneshot._run_agent("hello", use_config_toolsets=False)
+
+    assert response == "done"
+    captured = _CapturingAgent.captured
+    expected = resolve_reasoning_config(cfg, "test/model")
+    assert expected is not None  # guard: the fixture config must resolve
+    assert captured["reasoning_config"] == expected
+
+
+def test_oneshot_applies_per_model_reasoning_override(monkeypatch):
+    """Per-model ``agent.reasoning_overrides`` beat the global effort, using
+    the FINAL effective model -- same priority the chokepoint documents."""
+    cfg = {
+        "model": {"default": "test/model", "provider": "openrouter"},
+        "agent": {
+            "reasoning_effort": "low",
+            "reasoning_overrides": {"test/model": "high"},
+        },
+    }
+    _wire_oneshot_stubs(monkeypatch, cfg)
+
+    oneshot._run_agent("hello", use_config_toolsets=False)
+
+    captured = _CapturingAgent.captured
+    expected = resolve_reasoning_config(cfg, "test/model")
+    assert captured["reasoning_config"] == expected
+    assert captured["reasoning_config"] is not None
+
+
+def test_oneshot_reasoning_absent_config_passes_none(monkeypatch):
+    """No reasoning config anywhere -> the constructor receives None
+    (unchanged default behavior, pinned so the wiring can't invent one)."""
+    cfg = {"model": {"default": "test/model", "provider": "openrouter"}}
+    _wire_oneshot_stubs(monkeypatch, cfg)
+
+    oneshot._run_agent("hello", use_config_toolsets=False)
+
+    captured = _CapturingAgent.captured
+    assert "reasoning_config" in captured
+    assert captured["reasoning_config"] == resolve_reasoning_config(cfg, "test/model")

--- a/tests/hermes_cli/test_oneshot_reasoning_config.py
+++ b/tests/hermes_cli/test_oneshot_reasoning_config.py
@@ -98,6 +98,43 @@ def test_oneshot_applies_per_model_reasoning_override(monkeypatch):
     assert captured["reasoning_config"] is not None
 
 
+def test_oneshot_resolves_reasoning_for_remapped_model(monkeypatch):
+    """When provider auto-detection remaps an explicitly requested model
+    (oneshot.py's ``detect_provider_for_model`` branch), reasoning must be
+    resolved against the REMAPPED model, not the name the caller typed --
+    otherwise a per-model override keyed by the real model id is missed."""
+    import hermes_cli.models as models_mod
+    from hermes_cli import model_switch as ms_mod
+
+    cfg = {
+        "model": {"default": "cfg/unused"},
+        "agent": {
+            "reasoning_effort": "low",
+            "reasoning_overrides": {"real/remapped-model": "high"},
+        },
+    }
+    _wire_oneshot_stubs(monkeypatch, cfg)
+    # Force the catalog-detection branch: no direct alias, and detection
+    # remaps the requested name to the catalog's real model id.
+    monkeypatch.setattr(ms_mod, "_ensure_direct_aliases", lambda: None)
+    monkeypatch.setattr(ms_mod, "DIRECT_ALIASES", {})
+    monkeypatch.setattr(
+        models_mod,
+        "detect_provider_for_model",
+        lambda _model, _provider: ("openrouter", "real/remapped-model"),
+    )
+
+    oneshot._run_agent("hello", model="requested-alias", use_config_toolsets=False)
+
+    captured = _CapturingAgent.captured
+    assert captured["model"] == "real/remapped-model"
+    expected = resolve_reasoning_config(cfg, "real/remapped-model")
+    assert captured["reasoning_config"] == expected
+    # Guard that the assertion bites: resolving with the raw requested name
+    # would yield a different (global-effort) config.
+    assert expected != resolve_reasoning_config(cfg, "requested-alias")
+
+
 def test_oneshot_reasoning_absent_config_passes_none(monkeypatch):
     """No reasoning config anywhere -> the constructor receives None
     (unchanged default behavior, pinned so the wiring can't invent one)."""

--- a/tests/hermes_cli/test_oneshot_reasoning_config.py
+++ b/tests/hermes_cli/test_oneshot_reasoning_config.py
@@ -135,6 +135,41 @@ def test_oneshot_resolves_reasoning_for_remapped_model(monkeypatch):
     assert expected != resolve_reasoning_config(cfg, "requested-alias")
 
 
+def test_oneshot_resolves_reasoning_for_direct_alias_model(monkeypatch):
+    """The other remapping branch: a config.yaml ``model_aliases:`` hit
+    (``DIRECT_ALIASES``) also rewrites effective_model before construction,
+    so reasoning must likewise resolve against the alias TARGET."""
+    from hermes_cli import model_switch as ms_mod
+
+    cfg = {
+        "model": {"default": "cfg/unused"},
+        "agent": {
+            "reasoning_effort": "low",
+            "reasoning_overrides": {"real/alias-target": "high"},
+        },
+    }
+    _wire_oneshot_stubs(monkeypatch, cfg)
+    monkeypatch.setattr(ms_mod, "_ensure_direct_aliases", lambda: None)
+    monkeypatch.setattr(
+        ms_mod,
+        "DIRECT_ALIASES",
+        {
+            "my-alias": ms_mod.DirectAlias(
+                model="real/alias-target", provider="openrouter", base_url=""
+            )
+        },
+    )
+
+    # Mixed case exercises the .lower() lookup normalization too.
+    oneshot._run_agent("hello", model="My-Alias", use_config_toolsets=False)
+
+    captured = _CapturingAgent.captured
+    assert captured["model"] == "real/alias-target"
+    expected = resolve_reasoning_config(cfg, "real/alias-target")
+    assert captured["reasoning_config"] == expected
+    assert expected != resolve_reasoning_config(cfg, "my-alias")
+
+
 def test_oneshot_reasoning_absent_config_passes_none(monkeypatch):
     """No reasoning config anywhere -> the constructor receives None
     (unchanged default behavior, pinned so the wiring can't invent one)."""


### PR DESCRIPTION
## What does this PR do?

Makes `hermes -z` honor `agent.reasoning_effort` and per-model
`agent.reasoning_overrides`. Oneshot builds its own `AIAgent` and never
resolved reasoning config, so every scripted/cron one-shot ran with
`reasoning_config=None` regardless of configuration (observable as
`model_config.reasoning_config: null` in any oneshot session record). The fix
resolves through the same shared chokepoint the chat path (`cli.py`) and
gateway (`_load_reasoning_config`) use, with the FINAL effective model so
per-model overrides apply, and forwards the result.

Same wiring-gap family as #69737 / PR #69757 (oneshot dropped the checkpoints
config). The issue notes further config-shaped drops in the oneshot
construction (`service_tier`, `max_tokens`, provider-routing prefs,
`request_overrides`) for a future systematic pass; this PR deliberately fixes
only the proven-consequential one.

## Related Issue

Fixes #70022

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py` -- resolve `reasoning_config` via
  `hermes_constants.resolve_reasoning_config(cfg, effective_model)` after the
  effective model is final, and pass it to the `AIAgent` constructor.
- `tests/hermes_cli/test_oneshot_reasoning_config.py` -- three regression
  tests: global effort reaches the constructor resolved identically to the
  chat path; per-model override beats global using the effective model;
  unconfigured setups still pass the resolver's `None` through unchanged.

## How to Test

1. Red/green: with the `oneshot.py` change stashed,
   `pytest tests/hermes_cli/test_oneshot_reasoning_config.py -q` -> 3 failed;
   with it applied -> 3 passed.
2. Neighbors green: `tests/hermes_cli/test_oneshot_usage_file.py` +
   `tests/hermes_cli/test_tui_resume_flow.py` -> 77 passed.
3. Live: set `agent.reasoning_effort: high`, run `hermes -z "..."`, export the
   session -- `model_config.reasoning_config` is now populated.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(targeted suites above; the repo-wide run is blocked by two pre-existing suite bugs we filed separately: #70017 order pollution, #70018 silent exit-0 truncation)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux x86-64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(N/A: behavior now matches the documented config semantics)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A: no new keys)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(pure-Python config plumbing)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016e12GP7EHU2KeCGGYcfvBo
