### PR TITLE
fix(desktop): prevent chat scroll freeze after session switch or aborted inline edit

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -275,6 +275,10 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       return
     }
 
+    // Clear any lingering inline-edit hold from the previous session before
+    // calling stopScroll — otherwise data-editing persists into the new session
+    // and the scroll container stays frozen after the switch.
+    endEditHold()
     stopScroll()
     el.scrollTop = el.scrollHeight
 
@@ -286,6 +290,11 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       const node = scrollRef.current
 
       if (!node) {
+        // Component unmounted while the settle loop was still running.
+        // stopScroll() was already called — hand back to the library so the
+        // scroll container is never left permanently locked if it re-mounts.
+        void scrollToBottom('instant')
+
         return
       }
 
@@ -310,7 +319,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     let rafId = requestAnimationFrame(settle)
 
     return () => cancelAnimationFrame(rafId)
-  }, [scrollRef, scrollToBottom, sessionKey, stopScroll])
+  }, [endEditHold, scrollRef, scrollToBottom, sessionKey, stopScroll])
 
   // Prepend an older page while preserving the on-screen position. The user is
   // scrolled up (reading history) so the stick-to-bottom lock is escaped and


### PR DESCRIPTION
## Problem

The chat thread occasionally becomes completely unscrollable — the viewport stops responding to mouse wheel / trackpad scroll. The only recovery is restarting the app.

## Root Causes

Two bugs in `apps/desktop/src/components/assistant-ui/thread/list.tsx` conspire to permanently freeze the scroll container:

### Bug 1 — `data-editing` / `stopScroll` leak across session switches

When the user **switches sessions while a message inline-edit is open**, the flow is:

1. `notifyThreadEditOpen()` fires on `pointerDown` → `beginEditHold()` calls `stopScroll()` and sets `data-editing` on the viewport.
2. The session switch happens → `sessionKey` changes → the session-switch `useLayoutEffect` fires.
3. `endEditHold()` should clear `data-editing` on `onThreadEditClose`, but the inline-edit composer is already gone — the close event never fires.
4. The new session inherits `data-editing` on the scroll element and scroll is permanently suppressed.

**Fix:** Call `endEditHold()` at the start of the session-switch `useLayoutEffect`, before `stopScroll()`, so any leftover edit hold from the previous session is always cleared.

### Bug 2 — `settle()` rAF loop exits without releasing `stopScroll` on unmount

The settle loop that stabilises `scrollTop` after a session switch has an early-exit guard:

```ts
const settle = () => {
  const node = scrollRef.current
  if (!node) {
    return  // ← stopScroll was called but scrollToBottom never called
  }
  ...
}
```

If the component unmounts (or the ref is cleared) while the loop is running, `stopScroll()` has already been called but `scrollToBottom()` — which hands control back to `use-stick-to-bottom` — is never called. On re-mount (same scroll container, different session), the library remains permanently locked.

**Fix:** Call `scrollToBottom('instant')` before returning from the null-node guard.

## Changes

- `apps/desktop/src/components/assistant-ui/thread/list.tsx`
  - Call `endEditHold()` before `stopScroll()` in the session-switch layout effect
  - Call `scrollToBottom('instant')` in the null-node guard inside `settle()`
  - Add `endEditHold` to the `useLayoutEffect` dependency array (was missing; already stable via `useCallback` so no behaviour change)

## Testing

Reproduce freeze before this fix:
1. Open a session, click the edit (pencil) icon on a user message
2. While the inline editor is open, switch to a different session in the sidebar
3. Try to scroll the new session → scroll is frozen

After this fix, scroll works normally after the session switch.