### PR TITLE
fix(qqbot): accept dm session keys in approval button auth

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1100,7 +1100,10 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        # Gateway sessions for QQ private chats use chat_type="dm" (see
+        # _handle_c2c MessageSource), while QQ's INTERACTION scene and some
+        # older button payloads use "c2c". Treat them as the same DM surface.
+        if chat_type in {"c2c", "dm", "direct", "private"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1686,6 +1686,49 @@ class TestDefaultInteractionDispatch:
         assert resolve_calls == []
 
     @pytest.mark.asyncio
+    async def test_approval_click_accepts_dm_session_key(self):
+        """Gateway stores private-chat sessions as chat_type=dm, not c2c.
+
+        Real QQ C2C approval buttons embed session keys like
+        agent:main:qqbot:dm:<openid>. Auth must accept that, otherwise the
+        button click is rejected and users fall back to typing /approve.
+        """
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "C66791973CD59173F10CC7FA50BB8C38",
+                "data": {
+                    "resolved": {
+                        "button_data": (
+                            "approve:agent:main:qqbot:dm:"
+                            "C66791973CD59173F10CC7FA50BB8C38:allow-once"
+                        )
+                    }
+                },
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [(
+            "agent:main:qqbot:dm:C66791973CD59173F10CC7FA50BB8C38",
+            "once",
+            False,
+        )]
+
+    @pytest.mark.asyncio
     async def test_update_prompt_click_writes_response_file(self, tmp_path, monkeypatch):
         """update_prompt:y click writes 'y' to ~/.hermes/.update_response."""
         adapter = self._make_adapter()


### PR DESCRIPTION
## Bug Description

On QQ private chats, tapping the approval keyboard buttons (e.g. **执行一次 / 允许一次**, **始终允许**, **拒绝**) did not resolve the pending dangerous-command approval. The click was received by the gateway but rejected as unauthorized, so users had to fall back to typing `/approve`.

## Root Cause

Gateway private-chat sessions store `chat_type=dm` in the session key (`agent:main:qqbot:dm:<openid>`), which is what gets embedded in the approval button payload.

QQBot approval-button auth only treated `chat_type == "c2c"` as a private-chat surface. Real DM keys therefore failed `_is_authorized_interaction_for_session`, producing:

```
Rejected unauthorized approval click for session agent:main:qqbot:dm:...
```

Text `/approve` still worked because it does not go through this button-auth path.

## Fix

- Treat `dm` / `direct` / `private` as the same DM surface as `c2c` in QQ approval button authorization.
- Add a regression test that exercises a real `qqbot:dm:<openid>` button payload.

## How to Verify

1. Start Hermes gateway with QQ connected.
2. Trigger a dangerous-command approval prompt in a QQ C2C/DM chat (approval keyboard appears).
3. Tap **允许一次** / **始终允许** / **拒绝**.
4. Confirm the agent resumes (or is denied) without typing `/approve`.
5. Confirm an unauthorized operator in a group chat still cannot approve someone else's pending command.

## Test Plan

- [x] Added regression test for this bug (`test_approval_click_accepts_dm_session_key`)
- [x] Manual script verification: `dm` accepted, `c2c` still accepted, group unauthorized still rejected
- [ ] Full `pytest tests/gateway/test_qqbot.py` (local venv lacks pytest package; CI should cover)

## Risk Assessment

**Low** — only widens private-chat chat_type aliases in QQ button auth. Group/guild auth and operator-must-match-chat_id checks are unchanged. No new config, tools, or core agent behavior.