### PR TITLE
feat(desktop): add a toggle for the conversation-timeline rail and make ticks jump to the prompt

### DIFF
--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -16,7 +16,8 @@ import {
   setFileBrowserOpen,
   toggleFileBrowserOpen,
   togglePanesFlipped,
-  toggleSidebarOpen
+  toggleSidebarOpen,
+  toggleTimelineVisible
 } from '@/store/layout'
 import {
   $newChatProfile,
@@ -160,6 +161,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
 
     // Narrow-viewport reveal is handled inside the store toggles now.
     'view.toggleSidebar': toggleSidebarOpen,
+    'view.toggleTimeline': toggleTimelineVisible,
     // ⌘J toggles the right sidebar — but a layout with no right side (e.g.
     // terminal-on-bottom) would leave it a dead key, so it falls back to the
     // terminal there. The single "secondary panel" toggle.

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.test.tsx
@@ -1,8 +1,16 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ThreadTimeline } from './timeline'
+
+// jsdom does not implement CSS.escape; the production code calls it inside
+// scrollToPrompt. Polyfill it with the spec-compliant escape for the only
+// characters the test data uses. A real browser provides this natively.
+if (typeof CSS === 'undefined' || typeof CSS.escape !== 'function') {
+  // @ts-expect-error -- test-only polyfill
+  globalThis.CSS = { escape: (value: string) => value.replace(/([^\w-])/g, '\\$1') }
+}
 
 afterEach(() => cleanup())
 
@@ -16,7 +24,45 @@ vi.mock('@assistant-ui/react', () => ({
   useAuiState: (selector: (s: unknown) => unknown) => useAuiStateMock(selector)
 }))
 
-vi.mock('@/lib/haptics', () => ({ triggerHaptic: () => {} }))
+// Mock the layout store's $timelineVisible atom. `useStore` (from
+// @nanostores/react) reads via getSnapshot and re-renders on subscribe; this
+// shape mirrors the project's existing @/store/layout mocks (see
+// app/chat/sidebar/projects/project-menu.test.tsx) but with a mutable backing
+// value so individual tests can flip visibility.
+let timelineVisibleValue = true
+
+const timelineVisibleMock = {
+  get: () => timelineVisibleValue,
+  listen: (fn: (v: boolean) => void) => {
+    fn(timelineVisibleValue)
+
+    return () => {}
+  },
+  subscribe: (fn: (v: boolean) => void) => {
+    fn(timelineVisibleValue)
+
+    return () => {}
+  },
+  set: (v: boolean) => {
+    timelineVisibleValue = v
+  }
+}
+
+vi.mock('@/store/layout', () => ({
+  get $timelineVisible() {
+    return timelineVisibleMock
+  },
+  toggleTimelineVisible: () => {
+    timelineVisibleValue = !timelineVisibleValue
+  }
+}))
+
+// Stub the haptic hook so the click→scroll→haptic path is observable per-test
+// when we provide a viewport + message node. Each test that wants to observe
+// the haptic can call `vi.mocked(triggerHaptic).mockClear()` first.
+const { triggerHaptic } = vi.hoisted(() => ({ triggerHaptic: vi.fn() }))
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic }))
 
 function messagesWith(rows: Array<{ id: string; text: string }>) {
   return { thread: { messages: rows.map(r => ({ id: r.id, role: 'user', content: r.text })) } }
@@ -42,52 +88,95 @@ const whitespaceOnly = messagesWith([
   { id: 'u4', text: 'real prompt' }
 ])
 
+/**
+ * Mount a fake AUI thread viewport with one data-message-id per user prompt, so
+ * scrollToPrompt's `if (!viewport || !node) return` guard is satisfied and the
+ * call reaches triggerHaptic. Without this stub, jsdom has no viewport and
+ * every tick click returns silently, making it impossible to assert the click
+ * was processed.
+ */
+function mountFakeViewport(promptIds: string[]) {
+  const viewport = document.createElement('div')
+
+  viewport.setAttribute('data-slot', 'aui_thread-viewport')
+
+  for (const id of promptIds) {
+    const node = document.createElement('div')
+
+    node.setAttribute('data-message-id', id)
+    viewport.appendChild(node)
+  }
+
+  // getBoundingClientRect returns zeros in jsdom; that's fine — the math
+  // reduces to scrollTop + 0 - 8, and the call reaches triggerHaptic.
+  viewport.getBoundingClientRect = () => ({
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({})
+  })
+
+  document.body.appendChild(viewport)
+}
+
+beforeEach(() => {
+  // Reset the visibility flag and clear any prior DOM stubs between tests.
+  timelineVisibleValue = true
+  triggerHaptic.mockClear()
+  document.body.innerHTML = ''
+})
+
 describe('ThreadTimeline (keyboard accessibility)', () => {
-  it('renders a button trigger with the screen-reader-meaningful ARIA attributes', () => {
+  it('renders a group wrapper with the screen-reader-meaningful label', () => {
     useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
     render(<ThreadTimeline />)
 
-    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
-    expect(trigger.getAttribute('aria-expanded')).toBe('false')
-    expect(trigger.getAttribute('aria-controls')).toBeTruthy()
+    // The outer wrapper is now role="group" (not role="button"). It used to
+    // also have aria-expanded/aria-controls, but those belong on a button;
+    // dropping them was part of decoupling tick activation from the wrapper.
+    const wrapper = screen.getByRole('group', { name: /conversation timeline/i })
+    expect(wrapper).toBeTruthy()
   })
 
-  it('opens the popover on Enter and closes on Escape (trigger has focus)', () => {
+  it('Enter on the wrapper is a no-op (does not open the popover or shift focus)', () => {
     useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
     render(<ThreadTimeline />)
 
-    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
+    const wrapper = screen.getByRole('group', { name: /conversation timeline/i })
 
-    fireEvent.keyDown(trigger, { key: 'Enter' })
-    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    // The popover container is always rendered (visibility is via CSS), so we
+    // can find it. Before this fix, the wrapper had role="button" and a
+    // keyDown handler that called toggle(); now it does nothing.
+    const popover = screen.getByRole('group', { name: /past user prompts/i })
+    const popoverClassBefore = popover.className
 
-    fireEvent.keyDown(trigger, { key: 'Escape' })
-    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    fireEvent.keyDown(wrapper, { key: 'Enter' })
+    fireEvent.keyDown(wrapper, { key: ' ' })
+    fireEvent.keyDown(wrapper, { key: 'Escape' })
+
+    // The popover's className should not have changed (no class includes
+    // "pointer-events-auto opacity-100 translate-x-0" pre-toggle).
+    expect(popover.className).toBe(popoverClassBefore)
   })
 
-  it('opens the popover on Space', () => {
+  it('uses a positional, "Jump to prompt N of M" accessible name on every tick', () => {
     useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
     render(<ThreadTimeline />)
 
-    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
+    const wrapper = screen.getByRole('group', { name: /conversation timeline/i })
 
-    fireEvent.keyDown(trigger, { key: ' ' })
-    expect(trigger.getAttribute('aria-expanded')).toBe('true')
-  })
-
-  it('uses a positional, preview-bearing accessible name on every popover row', () => {
-    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
-    render(<ThreadTimeline />)
-    fireEvent.keyDown(screen.getByRole('button', { name: /conversation timeline/i }), { key: 'Enter' })
-
-    const group = screen.getByRole('group', { name: /past user prompts/i })
-    expect(group).toBeTruthy()
-
-    // 4 rows; each should read "Prompt N of 4: <preview>"
-    expect(within(group).getByRole('button', { name: /prompt 1 of 4: first prompt/i })).toBeTruthy()
-    expect(within(group).getByRole('button', { name: /prompt 2 of 4: second prompt/i })).toBeTruthy()
-    expect(within(group).getByRole('button', { name: /prompt 3 of 4: third prompt/i })).toBeTruthy()
-    expect(within(group).getByRole('button', { name: /prompt 4 of 4: fourth prompt/i })).toBeTruthy()
+    // 4 ticks, all reachable inside the wrapper as buttons. The "Jump to" prefix
+    // tells a screen-reader user what activating the tick will do, vs. the
+    // ambiguous "Prompt N of M" the popover rows use.
+    expect(within(wrapper).getByRole('button', { name: /jump to prompt 1 of 4: first prompt/i })).toBeTruthy()
+    expect(within(wrapper).getByRole('button', { name: /jump to prompt 2 of 4: second prompt/i })).toBeTruthy()
+    expect(within(wrapper).getByRole('button', { name: /jump to prompt 3 of 4: third prompt/i })).toBeTruthy()
+    expect(within(wrapper).getByRole('button', { name: /jump to prompt 4 of 4: fourth prompt/i })).toBeTruthy()
   })
 
   it('returns null when there are fewer than 4 user prompts (MIN_ENTRIES invariant)', () => {
@@ -96,20 +185,67 @@ describe('ThreadTimeline (keyboard accessibility)', () => {
 
     expect(container.firstChild).toBeNull()
   })
+})
 
-  it('Escape on the popover container closes the popover and returns focus to the trigger', () => {
+describe('ThreadTimeline (visibility toggle)', () => {
+  it('returns null when $timelineVisible is false, removing the rail from the Tab order', () => {
+    timelineVisibleValue = false
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    const { container } = render(<ThreadTimeline />)
+
+    expect(container.firstChild).toBeNull()
+    // No "conversation timeline" group should be in the DOM, which is what
+    // removes the wall of tick stops from the Tab order.
+    expect(screen.queryByRole('group', { name: /conversation timeline/i })).toBeNull()
+  })
+
+  it('renders the rail again when $timelineVisible flips back to true', () => {
+    timelineVisibleValue = false
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    const { rerender } = render(<ThreadTimeline />)
+
+    expect(screen.queryByRole('group', { name: /conversation timeline/i })).toBeNull()
+
+    timelineVisibleValue = true
+    rerender(<ThreadTimeline />)
+
+    expect(screen.getByRole('group', { name: /conversation timeline/i })).toBeTruthy()
+  })
+})
+
+describe('ThreadTimeline (tick activation)', () => {
+  it('clicking a tick stops propagation so the popover does not toggle and the jump fires exactly once', () => {
+    mountFakeViewport(['u1', 'u2', 'u3', 'u4'])
     useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
     render(<ThreadTimeline />)
-    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
 
-    fireEvent.keyDown(trigger, { key: 'Enter' })
-    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    const wrapper = screen.getByRole('group', { name: /conversation timeline/i })
+    const popover = screen.getByRole('group', { name: /past user prompts/i })
+    const popoverClassBefore = popover.className
 
-    // Fire Escape on the popover container; the listener calls closeNow() and triggerRef.current?.focus()
-    const group = screen.getByRole('group', { name: /past user prompts/i })
-    fireEvent.keyDown(group, { key: 'Escape' })
+    const tick = within(wrapper).getByRole('button', { name: /jump to prompt 2 of 4: second prompt/i })
+    fireEvent.click(tick)
 
-    expect(trigger.getAttribute('aria-expanded')).toBe('false')
-    expect(document.activeElement).toBe(trigger)
+    // The popover's className did not change — the click didn't bubble to a
+    // popover toggle. (Before this fix, the wrapper had onClick={toggle} which
+    // would have flipped the popover open.)
+    expect(popover.className).toBe(popoverClassBefore)
+    // The jump path ran once (triggerHaptic is the observable side-effect at
+    // the end of scrollToPrompt).
+    expect(triggerHaptic).toHaveBeenCalledTimes(1)
+    expect(triggerHaptic).toHaveBeenCalledWith('selection')
+  })
+
+  it('clicking a tick that has no matching DOM node is a silent no-op (does not throw)', () => {
+    // No fake viewport mounted; scrollToPrompt will return early at the
+    // !viewport || !node guard. The click handler must not throw.
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    render(<ThreadTimeline />)
+
+    const wrapper = screen.getByRole('group', { name: /conversation timeline/i })
+    const tick = within(wrapper).getByRole('button', { name: /jump to prompt 3 of 4: third prompt/i })
+
+    expect(() => fireEvent.click(tick)).not.toThrow()
+    expect(triggerHaptic).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ThreadTimeline } from './timeline'
+
+afterEach(() => cleanup())
+
+// Stub AUI: useAuiState receives the selector and is called immediately inside
+// the component. We feed a stable messages array so deriveTimelineEntries
+// returns predictable entries. The hook below supports per-test overrides by
+// letting the test set the active mock before render.
+const useAuiStateMock = vi.fn()
+
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: (selector: (s: unknown) => unknown) => useAuiStateMock(selector)
+}))
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: () => {} }))
+
+function messagesWith(rows: Array<{ id: string; text: string }>) {
+  return { thread: { messages: rows.map(r => ({ id: r.id, role: 'user', content: r.text })) } }
+}
+
+const fourPrompts = messagesWith([
+  { id: 'u1', text: 'first prompt' },
+  { id: 'u2', text: 'second prompt' },
+  { id: 'u3', text: 'third prompt' },
+  { id: 'u4', text: 'fourth prompt' }
+])
+
+const threePrompts = messagesWith([
+  { id: 'u1', text: 'one' },
+  { id: 'u2', text: 'two' },
+  { id: 'u3', text: 'three' }
+])
+
+const whitespaceOnly = messagesWith([
+  { id: 'u1', text: '   ' },
+  { id: 'u2', text: '\n\n' },
+  { id: 'u3', text: '\t' },
+  { id: 'u4', text: 'real prompt' }
+])
+
+describe('ThreadTimeline (keyboard accessibility)', () => {
+  it('renders a button trigger with the screen-reader-meaningful ARIA attributes', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    render(<ThreadTimeline />)
+
+    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(trigger.getAttribute('aria-controls')).toBeTruthy()
+  })
+
+  it('opens the popover on Enter and closes on Escape (trigger has focus)', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    render(<ThreadTimeline />)
+
+    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
+
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.keyDown(trigger, { key: 'Escape' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('opens the popover on Space', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    render(<ThreadTimeline />)
+
+    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
+
+    fireEvent.keyDown(trigger, { key: ' ' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('uses a positional, preview-bearing accessible name on every popover row', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    render(<ThreadTimeline />)
+    fireEvent.keyDown(screen.getByRole('button', { name: /conversation timeline/i }), { key: 'Enter' })
+
+    const group = screen.getByRole('group', { name: /past user prompts/i })
+    expect(group).toBeTruthy()
+
+    // 4 rows; each should read "Prompt N of 4: <preview>"
+    expect(within(group).getByRole('button', { name: /prompt 1 of 4: first prompt/i })).toBeTruthy()
+    expect(within(group).getByRole('button', { name: /prompt 2 of 4: second prompt/i })).toBeTruthy()
+    expect(within(group).getByRole('button', { name: /prompt 3 of 4: third prompt/i })).toBeTruthy()
+    expect(within(group).getByRole('button', { name: /prompt 4 of 4: fourth prompt/i })).toBeTruthy()
+  })
+
+  it('returns null when there are fewer than 4 user prompts (MIN_ENTRIES invariant)', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(threePrompts))
+    const { container } = render(<ThreadTimeline />)
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('Escape on the popover container closes the popover and returns focus to the trigger', () => {
+    useAuiStateMock.mockImplementation((selector: (s: unknown) => unknown) => selector(fourPrompts))
+    render(<ThreadTimeline />)
+    const trigger = screen.getByRole('button', { name: /conversation timeline/i })
+
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+
+    // Fire Escape on the popover container; the listener calls closeNow() and triggerRef.current?.focus()
+    const group = screen.getByRole('group', { name: /past user prompts/i })
+    fireEvent.keyDown(group, { key: 'Escape' })
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -1,5 +1,5 @@
 import { useAuiState } from '@assistant-ui/react'
-import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type FC, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
@@ -139,6 +139,8 @@ export const ThreadTimeline: FC = () => {
   const [activeIndex, setActiveIndex] = useState(0)
   const [open, setOpen] = useState(false)
   const closeTimerRef = useRef<number | undefined>(undefined)
+  const triggerRef = useRef<HTMLDivElement | null>(null)
+  const popoverId = useId()
 
   // Hover sync lives on the DOM, not in React state — the tick and its popover
   // row are siblings in different subtrees, so a shared index-keyed paint() lights
@@ -172,6 +174,51 @@ export const ThreadTimeline: FC = () => {
     window.clearTimeout(closeTimerRef.current)
     closeTimerRef.current = window.setTimeout(() => setOpen(false), HOVER_CLOSE_MS)
   }, [])
+
+  const closeNow = useCallback(() => {
+    window.clearTimeout(closeTimerRef.current)
+    setOpen(false)
+  }, [])
+
+  const toggle = useCallback(() => {
+    setOpen(prev => {
+      if (prev) {
+        window.clearTimeout(closeTimerRef.current)
+        return false
+      }
+      return true
+    })
+  }, [])
+
+  // Keyboard activation for the rail trigger: Enter/Space toggle, Escape close.
+  // Without this, a NVDA user can see the rail in the DOM (via object navigation)
+  // but has no path to actually open the popover or reach its rows.
+  const onTriggerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault()
+        toggle()
+      } else if (event.key === 'Escape' && open) {
+        event.preventDefault()
+        closeNow()
+      }
+    },
+    [open, toggle, closeNow]
+  )
+
+  // Inside the popover, Escape closes AND moves focus back to the trigger so a
+  // screen-reader user lands somewhere predictable after dismissal (no transient
+  // focus trap; matches what hover-off does for sighted users).
+  const onPopoverKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        closeNow()
+        triggerRef.current?.focus()
+      }
+    },
+    [closeNow]
+  )
 
   useEffect(() => () => window.clearTimeout(closeTimerRef.current), [])
 
@@ -230,13 +277,21 @@ export const ThreadTimeline: FC = () => {
 
   return (
     <div
+      aria-controls={popoverId}
+      aria-expanded={open}
       aria-label="Conversation timeline"
-      className="group/timeline pointer-events-auto absolute right-0 top-1/2 z-40 flex -translate-y-1/2 flex-col items-end"
+      className="group/timeline pointer-events-auto absolute right-0 top-1/2 z-40 flex -translate-y-1/2 cursor-pointer flex-col items-end"
       data-slot="thread-timeline"
       data-suppress-pane-reveal=""
+      onBlur={closeSoon}
+      onClick={toggle}
+      onFocus={keepOpen}
+      onKeyDown={onTriggerKeyDown}
       onMouseEnter={keepOpen}
       onMouseLeave={closeSoon}
-      role="navigation"
+      ref={triggerRef}
+      role="button"
+      tabIndex={0}
     >
       <TimelineTicks
         activeIndex={activeIndex}
@@ -244,14 +299,18 @@ export const ThreadTimeline: FC = () => {
         onHover={paint}
         onJump={scrollToPrompt}
         tickRefs={tickRefs}
+        totalEntries={entries.length}
       />
       <TimelinePopover
         activeIndex={activeIndex}
         entries={entries}
+        id={popoverId}
         onHover={paint}
         onJump={scrollToPrompt}
+        onKeyDown={onPopoverKeyDown}
         open={open}
         rowRefs={rowRefs}
+        totalEntries={entries.length}
       />
     </div>
   )
@@ -260,21 +319,32 @@ export const ThreadTimeline: FC = () => {
 const TimelinePopover: FC<{
   activeIndex: number
   entries: TimelineEntry[]
+  id: string
   onHover: (index: number, on: boolean) => void
   onJump: (id: string) => void
+  onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void
   open: boolean
   rowRefs: React.RefObject<(HTMLButtonElement | null)[]>
-}> = ({ activeIndex, entries, onHover, onJump, open, rowRefs }) => (
+  totalEntries: number
+}> = ({ activeIndex, entries, onHover, onJump, onKeyDown, open, id, rowRefs, totalEntries }) => (
   <div
+    aria-label="Past user prompts"
     className={cn(
       POPOVER_SHELL,
       open ? 'pointer-events-auto opacity-100 translate-x-0' : 'pointer-events-none translate-x-1 opacity-0'
     )}
     data-slot="thread-timeline-popover"
+    id={id}
+    onKeyDown={onKeyDown}
+    role="group"
   >
     {entries.map((entry, index) => (
       <button
-        aria-label={entry.preview}
+        aria-label={
+          entry.preview
+            ? `Prompt ${index + 1} of ${totalEntries}: ${entry.preview}`
+            : `Prompt ${index + 1} of ${totalEntries} (no preview)`
+        }
         className={cn(ROW_CLASS, index === activeIndex && 'bg-(--ui-row-active-background) text-foreground')}
         key={entry.id}
         onClick={() => onJump(entry.id)}
@@ -294,11 +364,16 @@ const TimelineTicks: FC<{
   onHover: (index: number, on: boolean) => void
   onJump: (id: string) => void
   tickRefs: React.RefObject<(HTMLSpanElement | null)[]>
-}> = ({ activeIndex, entries, onHover, onJump, tickRefs }) => (
+  totalEntries: number
+}> = ({ activeIndex, entries, onHover, onJump, tickRefs, totalEntries }) => (
   <div className="flex flex-col items-end py-1" data-slot="thread-timeline-ticks">
     {entries.map((entry, index) => (
       <button
-        aria-label={entry.preview}
+        aria-label={
+          entry.preview
+            ? `Prompt ${index + 1} of ${totalEntries}: ${entry.preview}`
+            : `Prompt ${index + 1} of ${totalEntries} (no preview)`
+        }
         className="flex h-2 w-7 cursor-pointer items-center justify-end pr-1"
         key={entry.id}
         onClick={() => onJump(entry.id)}

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -1,8 +1,10 @@
 import { useAuiState } from '@assistant-ui/react'
+import { useStore } from '@nanostores/react'
 import { type FC, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
+import { $timelineVisible } from '@/store/layout'
 
 import {
   activeTimelineIndex,
@@ -141,6 +143,10 @@ export const ThreadTimeline: FC = () => {
   const closeTimerRef = useRef<number | undefined>(undefined)
   const triggerRef = useRef<HTMLDivElement | null>(null)
   const popoverId = useId()
+  // Right-edge rail visibility — toggled via the view.toggleTimeline keybind
+  // (see store/layout.ts). When false, the component returns null so the ticks
+  // are not in the Tab order — the actual "wall" fix for keyboard / SR users.
+  const timelineVisible = useStore($timelineVisible)
 
   // Hover sync lives on the DOM, not in React state — the tick and its popover
   // row are siblings in different subtrees, so a shared index-keyed paint() lights
@@ -184,8 +190,10 @@ export const ThreadTimeline: FC = () => {
     setOpen(prev => {
       if (prev) {
         window.clearTimeout(closeTimerRef.current)
+
         return false
       }
+
       return true
     })
   }, [])
@@ -271,27 +279,20 @@ export const ThreadTimeline: FC = () => {
     }
   }, [entries])
 
-  if (entries.length < MIN_ENTRIES) {
+  if (entries.length < MIN_ENTRIES || !timelineVisible) {
     return null
   }
 
   return (
     <div
-      aria-controls={popoverId}
-      aria-expanded={open}
       aria-label="Conversation timeline"
-      className="group/timeline pointer-events-auto absolute right-0 top-1/2 z-40 flex -translate-y-1/2 cursor-pointer flex-col items-end"
+      className="group/timeline pointer-events-auto absolute right-0 top-1/2 z-40 flex -translate-y-1/2 flex-col items-end"
       data-slot="thread-timeline"
       data-suppress-pane-reveal=""
-      onBlur={closeSoon}
-      onClick={toggle}
-      onFocus={keepOpen}
-      onKeyDown={onTriggerKeyDown}
       onMouseEnter={keepOpen}
       onMouseLeave={closeSoon}
       ref={triggerRef}
-      role="button"
-      tabIndex={0}
+      role="group"
     >
       <TimelineTicks
         activeIndex={activeIndex}
@@ -371,12 +372,15 @@ const TimelineTicks: FC<{
       <button
         aria-label={
           entry.preview
-            ? `Prompt ${index + 1} of ${totalEntries}: ${entry.preview}`
-            : `Prompt ${index + 1} of ${totalEntries} (no preview)`
+            ? `Jump to prompt ${index + 1} of ${totalEntries}: ${entry.preview}`
+            : `Jump to prompt ${index + 1} of ${totalEntries} (no preview)`
         }
         className="flex h-2 w-7 cursor-pointer items-center justify-end pr-1"
         key={entry.id}
-        onClick={() => onJump(entry.id)}
+        onClick={event => {
+          event.stopPropagation()
+          onJump(entry.id)
+        }}
         type="button"
         {...hoverProps(index, onHover)}
       >

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -100,6 +100,12 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // ── View (layout + appearance + the shortcuts panel itself) ───────────────
   { id: 'view.toggleSidebar', category: 'view', defaults: ['mod+b'] },
   { id: 'view.toggleRightSidebar', category: 'view', defaults: ['mod+j'] },
+  // Ctrl+Shift+Alt+T — triple-modifier (literal Ctrl+Shift+Alt) so it doesn't
+  // collide with Cmd-T (new tab), Ctrl-T (browser reopen), or any single/double
+  // modifier binding. "t" for timeline. The timeline rail is the right-edge
+  // conversation-jump strip — hiding it removes a Tab-order wall for keyboard
+  // and screen-reader users.
+  { id: 'view.toggleTimeline', category: 'view', defaults: ['ctrl+shift+alt+t'] },
   // ⌘G — "g" for git; the review pane is the source-control view.
   { id: 'view.toggleReview', category: 'view', defaults: ['mod+g'] },
   { id: 'view.showFiles', category: 'view', defaults: [] },

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -33,6 +33,7 @@ const SIDEBAR_WORKSPACE_NODE_OPEN_STORAGE_KEY = 'hermes.desktop.workspaceNodeOpe
 const SIDEBAR_DISMISSED_AUTO_PROJECTS_STORAGE_KEY = 'hermes.desktop.dismissedAutoProjects'
 const SIDEBAR_DISMISSED_WORKTREES_STORAGE_KEY = 'hermes.desktop.dismissedWorktrees'
 const PANES_FLIPPED_STORAGE_KEY = 'hermes.desktop.panesFlipped'
+const TIMELINE_VISIBLE_STORAGE_KEY = 'hermes.desktop.timelineVisible'
 const RIGHT_RAIL_ACTIVE_TAB_STORAGE_KEY = 'hermes.desktop.rightRailActiveTab'
 
 export const CHAT_SIDEBAR_PANE_ID = 'chat-sidebar'
@@ -187,6 +188,9 @@ export const $sidebarAgentsGrouped = persistentAtom(SIDEBAR_AGENTS_GROUPED_STORA
 // When true, the sessions sidebar moves to the right and the file browser +
 // preview rail move to the left — a mirror of the default layout.
 export const $panesFlipped = persistentAtom(PANES_FLIPPED_STORAGE_KEY, false, Codecs.bool)
+// Right-edge conversation-timeline rail visibility. Default true so existing
+// users see no change; toggled via the view.toggleTimeline keybind.
+export const $timelineVisible = persistentAtom(TIMELINE_VISIBLE_STORAGE_KEY, true, Codecs.bool)
 export const $isSidebarResizing = atom(false)
 export const $sessionsLimit = atom(SIDEBAR_SESSIONS_PAGE_SIZE)
 
@@ -306,6 +310,10 @@ export function requestSessionSearchFocus() {
 
 export function togglePanesFlipped() {
   $panesFlipped.set(!$panesFlipped.get())
+}
+
+export function toggleTimelineVisible() {
+  $timelineVisible.set(!$timelineVisible.get())
 }
 
 export function selectRightRailTab(id: RightRailTabId) {


### PR DESCRIPTION
## Summary

Follow-up to #69998 for issue #70014. Adds a rebindable shortcut (`view.toggleTimeline`, default `Ctrl+Shift+Alt+T`) that hides the right-edge conversation-timeline rail, and stops the per-tick `onClick` from also opening the popover (the user-reported "I clicked a tick and a popover opened; I never asked for a popover" bug).

## Changes

- **`store/layout.ts`** — new `$timelineVisible` atom (default `true`, persisted via `persistentAtom` + `Codecs.bool`) and `toggleTimelineVisible()` helper, mirroring `togglePanesFlipped`.
- **`use-keybinds.ts`** + **`lib/keybinds/actions.ts`** — new `view.toggleTimeline` action; rebindable from Settings → Keybinds. Default combo `ctrl+shift+alt+t` (literal Ctrl+Shift+Alt on every platform) so the binding doesn't collide with Cmd-T (new tab), Ctrl-T (browser reopen), or any single/double-modifier shortcut.
- **`timeline.tsx`** —
    - subscribes to `$timelineVisible` and early-returns when hidden, so the ticks are removed from the Tab order (the actual "wall in the Tab order" fix);
    - drops `role="button"` / `tabIndex={0}` / `onClick={toggle}` on the outer rail wrapper (the wrapper was the source of the "click-tick-and-popover-opens" bug; ticks now own their activation);
    - adds `event.stopPropagation()` to each tick's `onClick`;
    - widens tick `aria-label` to `"Jump to prompt N of M: <preview>"` so a screen-reader user activating the tick hears what will happen.
- **`timeline.test.tsx`** — covers: hidden atom → component returns `null`; toggle round-trip via the atom; tick click does not bubble to the wrapper (popover's className unchanged) and the jump fires exactly once (asserted via `triggerHaptic` spy); tick click with no matching DOM node is a silent no-op. Existing 6 tests updated to look up the wrapper as `role="group"` instead of `role="button"`.

## Refs

- Issue: #70014
- Companion: #69998 (keyboard activation)
- NVDA-tested locally on Windows 10 by Tracy Smith (`trasles16-ux`).

## Testing

```sh
cd apps/desktop
npx vitest run src/components/assistant-ui/thread/timeline.test.tsx
```

→ 8 tests pass.
