### PR TITLE
fix(feishu): route audio messages through voice STT

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3870,7 +3870,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if preferred == "photo":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.PHOTO)
         if preferred == "audio":
-            return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.AUDIO)
+            return MessageType.VOICE
         if preferred == "document":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.DOCUMENT)
         return MessageType.TEXT

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1489,7 +1489,7 @@ class TestAdapterBehavior(unittest.TestCase):
         text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
 
         self.assertEqual(text, "")
-        self.assertEqual(msg_type.value, "audio")
+        self.assertEqual(msg_type.value, "voice")
         self.assertEqual(media_urls, ["/tmp/feishu-audio.ogg"])
         self.assertEqual(media_types, ["audio/ogg"])
 


### PR DESCRIPTION
## Summary

- classify native Feishu `audio` messages as `MessageType.VOICE`
- update the Feishu audio extraction regression test

## Root cause

Feishu native voice messages arrive with message type `audio`. During the platform adapter migration to bundled plugins, the Feishu adapter began resolving these messages from their `audio/*` MIME type, which classified them as `MessageType.AUDIO`.

The gateway intentionally skips automatic STT for `MessageType.AUDIO` because that type represents ordinary audio file attachments. As a result, native Feishu voice messages were downloaded successfully but bypassed the configured transcription provider.

## Impact

Native Feishu voice messages now enter the existing gateway STT pipeline again, while ordinary audio file attachments sent through file/document flows remain unaffected.

## Validation

- `python -m pytest -q tests/gateway/test_feishu.py -k 'extract_audio_message_downloads_and_caches'`
- `python -m pytest -q tests/gateway/test_telegram_audio_vs_voice.py tests/gateway/test_stt_config.py`

All 14 relevant tests pass.
