### PR TITLE
fix(agent): fail closed when protected_env_vars raises

### DIFF
--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -386,13 +386,28 @@ def apply_all(secrets_cfg: dict, home_path: Path,
     for source in ordered:
         cfg = secrets_cfg.get(source.name)
         cfg = cfg if isinstance(cfg, dict) else {}
-        result = _fetch_with_timeout(source, cfg, home_path, env)
-        fetches.append((source, cfg, result))
+        # Resolve protected vars before fetch so a broken hook cannot
+        # fail-open after secrets are already in memory, and so we never
+        # apply without a known bootstrap-auth guard set.
         try:
             for var in source.protected_env_vars(cfg):
                 protected.setdefault(var, source.name)
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Secret source '%s' protected_env_vars() raised; "
+                "refusing to apply its secrets",
+                source.name,
+                exc_info=True,
+            )
+            failed = FetchResult()
+            failed.error = (
+                f"protected_env_vars raised {type(exc).__name__}: {exc}"
+            )
+            failed.error_kind = ErrorKind.INTERNAL
+            fetches.append((source, cfg, failed))
+            continue
+        result = _fetch_with_timeout(source, cfg, home_path, env)
+        fetches.append((source, cfg, result))
 
     # Every var any source supplies directly — an alias never shadows a
     # var that some source will (or tried to) claim by its real name.

--- a/tests/secret_sources/test_secret_source_registry.py
+++ b/tests/secret_sources/test_secret_source_registry.py
@@ -51,6 +51,7 @@ def _make_source(
     scheme=None,
     override=False,
     protected=(),
+    protected_raises=False,
     api_version=SECRET_SOURCE_API_VERSION,
     fetch_fn=None,
 ):
@@ -72,6 +73,8 @@ def _make_source(
             return override
 
         def protected_env_vars(self, cfg):
+            if protected_raises:
+                raise RuntimeError("boom in protected_env_vars")
             return frozenset(protected)
 
     _Src.name = name
@@ -94,12 +97,6 @@ class TestRegistration:
 
     def test_rejects_non_secretsource_instance(self):
         assert reg.register_source(object()) is False
-
-
-
-
-
-
 
 
 # ---------------------------------------------------------------------------
@@ -132,10 +129,28 @@ class TestApplyAll:
         assert report.provenance["API_KEY"].overrode_env is False
 
 
+    def test_protected_env_vars_raise_refuses_apply(self, tmp_path):
+        """If protected_env_vars() raises, fail closed — do not apply secrets.
 
-
-
-
+        Otherwise override_existing sources can clobber bootstrap-auth env
+        vars that the hook was supposed to protect.
+        """
+        reg.register_source(
+            _make_source(
+                name="vault",
+                secrets={"BOOT_TOKEN": "stolen", "OTHER_KEY": "v"},
+                override=True,
+                protected_raises=True,
+            )
+        )
+        env = {"BOOT_TOKEN": "real-bootstrap"}
+        report = reg.apply_all({"vault": {"enabled": True}}, tmp_path, environ=env)
+        assert env["BOOT_TOKEN"] == "real-bootstrap"
+        assert "OTHER_KEY" not in env
+        sr = report.sources[0]
+        assert not sr.result.ok
+        assert sr.result.error_kind is ErrorKind.INTERNAL
+        assert sr.applied == []
 
 
     def test_failed_source_does_not_block_others(self, tmp_path):
@@ -151,8 +166,6 @@ class TestApplyAll:
         assert env["K"] == "v"
         broken = [s for s in report.sources if s.name == "broken"][0]
         assert broken.result.error_kind is ErrorKind.NETWORK
-
-
 
 
     def test_malformed_secrets_cfg_shapes_are_safe(self, tmp_path):
@@ -192,18 +205,12 @@ class TestHelpers:
         assert "NO_COLOR" in child_env
 
 
-
-
-
 # ---------------------------------------------------------------------------
 # Bitwarden adapter
 # ---------------------------------------------------------------------------
 
 
 class TestBitwardenSource:
-
-
-
 
 
     def test_fetch_delegates_to_fetch_bitwarden_secrets(self, tmp_path, monkeypatch):
@@ -275,11 +282,6 @@ class TestBitwardenConformance(SecretSourceConformance):
 
 
 class TestOnePasswordSource:
-
-
-
-
-
 
 
     def test_mapped_op_beats_bulk_bitwarden_through_orchestrator(


### PR DESCRIPTION
## What does this PR do?

When a secret source's `protected_env_vars()` hook raised, `apply_all` swallowed the exception and continued apply with an empty protected set. That silently disabled bootstrap-token protection and allowed `override_existing` sources to overwrite auth env vars (e.g. `BWS_ACCESS_TOKEN`). This PR fails closed: log a warning and refuse to apply that source's secrets.

### Bug Cause

In `agent/secret_sources/registry.py`, the fetch-phase collector wrapped `protected_env_vars()` in `except Exception: pass`. Unlike `override_existing` (fails closed to `False`) and `is_enabled` (logs and skips), this path failed open.

### Reproduction Steps

1. Register a source whose `protected_env_vars()` raises, with `override_existing=True` and secrets that include the bootstrap token name.
2. Call `apply_all` with that token already present in the environ.
3. Observe the env value after apply.

Expected: bootstrap token unchanged; source not applied (or recorded as protected skip).
Before fix: token overwritten; `skipped_protected` empty.

### Fix

Resolve `protected_env_vars` before `fetch`. On exception, warn (same style as `is_enabled`) and append an `ErrorKind.INTERNAL` `FetchResult` so the apply phase skips that source. Added `test_protected_env_vars_raise_refuses_apply`.

## Related Issue

No issue - discovered via adversarial scan (SSR-002).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

- `agent/secret_sources/registry.py` - fail closed + log when `protected_env_vars()` raises; resolve guard before fetch
- `tests/secret_sources/test_secret_source_registry.py` - regression test for the fail-closed path

## How to Test

1. Manual: run a source whose `protected_env_vars` raises with `override_existing=True` and confirm the bootstrap env var is unchanged and the source reports `INTERNAL`.
2. Automated: `scripts/run_tests.sh tests/secret_sources/ -q` (93 passed locally)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A