### PR TITLE
fix(installer): bound managed checkout updates

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1214,14 +1214,31 @@ clone_repo() {
             # every ref, and this repo carries thousands of auto-generated
             # branches — on a non-single-branch checkout that turns each update
             # into a multi-minute download that can stall the installer.
+            #
+            # Keep managed shallow clones shallow and bound the update to the
+            # new branch tip. Without --depth, updating a depth-1 desktop clone
+            # may negotiate and download hundreds of MB of repository history.
+            # Full/custom clones retain their existing history.
             git remote set-branches origin "$BRANCH" 2>/dev/null || true
-            git fetch origin "$BRANCH"
+            if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+                git fetch --depth 1 origin \
+                    "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+            else
+                git fetch origin \
+                    "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+            fi
             git checkout "$BRANCH"
-            # Managed installs should follow origin/$BRANCH exactly. If the
-            # checkout has diverged (or has local-only commits), ff-only pull
-            # cannot succeed — mirror ``hermes update`` and reset to the
-            # fetched remote so bootstrap/install can recover.
-            if ! git pull --ff-only origin "$BRANCH"; then
+            # Managed installs must follow origin/$BRANCH exactly. Fast-forward
+            # when the local commit is an ancestor; reset every other mismatch,
+            # including diverged and ahead-only histories. A plain ff-only
+            # merge reports success for ahead-only checkouts while leaving
+            # their local commits in place.
+            #
+            # This is intentionally local-only: the branch was already fetched
+            # above, and a pull would perform a second redundant network fetch.
+            if [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$BRANCH")" ] && \
+               ! { git merge-base --is-ancestor HEAD "origin/$BRANCH" && \
+                   git merge --ff-only "origin/$BRANCH"; }; then
                 log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
                 git reset --hard "origin/$BRANCH"
             fi

--- a/tests/test_install_diverged_update.py
+++ b/tests/test_install_diverged_update.py
@@ -1,9 +1,9 @@
 """Regression: installer/bootstrap must recover from diverged managed clones.
 
 When ``~/.hermes/hermes-agent`` has local-only commits (or diverged history),
-``git pull --ff-only`` fails with exit 128 and bootstrap aborts at the
-repository stage. ``hermes update`` already resets to ``origin/$BRANCH`` in
-that case; both installer scripts must do the same.
+an ff-only update fails and bootstrap aborts at the repository stage.
+``hermes update`` already resets to ``origin/$BRANCH`` in that case; both
+installer scripts must do the same.
 
 Fixes the bootstrap failure seen in #53257 and desktop update paths that run
 ``install.ps1`` / ``install.sh`` non-interactively.
@@ -15,19 +15,7 @@ import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
-
-
-def _extract_install_sh_update_block() -> str:
-    text = INSTALL_SH.read_text()
-    match = re.search(
-        r"(?P<block>git checkout \"\$BRANCH\".*?fi\n\n            if \[ -n \"\$autostash_ref\" \])",
-        text,
-        re.DOTALL,
-    )
-    assert match is not None, "managed-install update block not found in install.sh"
-    return match["block"]
 
 
 def _extract_install_ps1_branch_update_block() -> str:
@@ -39,19 +27,6 @@ def _extract_install_ps1_branch_update_block() -> str:
     )
     assert match is not None, "branch update block not found in install.ps1"
     return match["block"]
-
-
-def test_install_sh_resets_when_ff_only_pull_fails() -> None:
-    block = _extract_install_sh_update_block()
-
-    assert 'git pull --ff-only origin "$BRANCH"' in block
-    assert 'git reset --hard "origin/$BRANCH"' in block
-    assert "Fast-forward not possible" in block
-
-    pull_idx = block.find('git pull --ff-only origin "$BRANCH"')
-    reset_idx = block.find('git reset --hard "origin/$BRANCH"')
-    assert pull_idx != -1 and reset_idx != -1
-    assert pull_idx < reset_idx, "ff-only pull must be attempted before reset fallback"
 
 
 def test_install_ps1_resets_when_ff_only_pull_fails() -> None:

--- a/tests/test_install_repository_fetch.py
+++ b/tests/test_install_repository_fetch.py
@@ -1,0 +1,198 @@
+"""Behavior tests for the installer's managed-checkout update path."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="needs git and bash",
+)
+
+
+def _run(*args: str | Path, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(arg) for arg in args],
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return _run("git", *args, cwd=repo)
+
+
+def _make_remote(tmp_path: Path) -> tuple[Path, Path]:
+    remote = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    _run("git", "init", "--bare", remote)
+    _run("git", "init", seed)
+    _git(seed, "config", "user.email", "installer-test@example.invalid")
+    _git(seed, "config", "user.name", "Installer Test")
+    (seed / "base.txt").write_text("base\n", encoding="utf-8")
+    _git(seed, "add", "base.txt")
+    _git(seed, "commit", "-m", "initial")
+    _git(seed, "branch", "-M", "main")
+    _git(seed, "remote", "add", "origin", remote.as_uri())
+    _git(seed, "push", "-u", "origin", "main")
+    return remote, seed
+
+
+def _push_remote_update(seed: Path) -> str:
+    (seed / "remote.txt").write_text("remote update\n", encoding="utf-8")
+    _git(seed, "add", "remote.txt")
+    _git(seed, "commit", "-m", "remote update")
+    _git(seed, "push", "origin", "main")
+    return _git(seed, "rev-parse", "HEAD").stdout.strip()
+
+
+def _run_repository_stage(tmp_path: Path, install_dir: Path) -> list[list[str]]:
+    real_git = shutil.which("git")
+    assert real_git is not None
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    git_log = tmp_path / "git.log"
+    wrapper = bin_dir / "git"
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$*" >> "$HERMES_TEST_GIT_LOG"\n'
+        f"exec {shlex.quote(real_git)} \"$@\"\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "HERMES_HOME": str(tmp_path / "hermes-home"),
+            "HERMES_TEST_GIT_LOG": str(git_log),
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+        }
+    )
+    subprocess.run(
+        [
+            "bash",
+            str(INSTALL_SH),
+            "--stage",
+            "repository",
+            "--dir",
+            str(install_dir),
+            "--branch",
+            "main",
+            "--non-interactive",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return [line.split() for line in git_log.read_text(encoding="utf-8").splitlines()]
+
+
+def _network_update_commands(commands: list[list[str]]) -> list[list[str]]:
+    return [args for args in commands if args and args[0] in {"fetch", "pull"}]
+
+
+def test_shallow_managed_checkout_uses_one_bounded_fetch(tmp_path: Path) -> None:
+    remote, seed = _make_remote(tmp_path)
+    install_dir = tmp_path / "install"
+    _run(
+        "git",
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        "main",
+        remote.as_uri(),
+        install_dir,
+    )
+    expected_head = _push_remote_update(seed)
+
+    commands = _run_repository_stage(tmp_path, install_dir)
+
+    network_commands = _network_update_commands(commands)
+    assert len(network_commands) == 1, network_commands
+    assert network_commands[0][0] == "fetch"
+    if "--depth" in network_commands[0]:
+        depth_index = network_commands[0].index("--depth")
+        assert network_commands[0][depth_index + 1] == "1"
+    else:
+        assert "--depth=1" in network_commands[0]
+    assert _git(install_dir, "rev-parse", "HEAD").stdout.strip() == expected_head
+    assert _git(install_dir, "rev-parse", "--is-shallow-repository").stdout.strip() == "true"
+
+
+def test_shallow_ahead_only_checkout_resets_to_remote_tip(tmp_path: Path) -> None:
+    remote, seed = _make_remote(tmp_path)
+    install_dir = tmp_path / "install"
+    _run(
+        "git",
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        "main",
+        remote.as_uri(),
+        install_dir,
+    )
+    expected_head = _git(seed, "rev-parse", "HEAD").stdout.strip()
+    _git(install_dir, "config", "user.email", "installer-test@example.invalid")
+    _git(install_dir, "config", "user.name", "Installer Test")
+    (install_dir / "local-only.txt").write_text("local commit\n", encoding="utf-8")
+    _git(install_dir, "add", "local-only.txt")
+    _git(install_dir, "commit", "-m", "ahead-only local commit")
+
+    commands = _run_repository_stage(tmp_path, install_dir)
+
+    network_commands = _network_update_commands(commands)
+    assert len(network_commands) == 1, network_commands
+    assert network_commands[0][0] == "fetch"
+    assert "--depth" in network_commands[0] or "--depth=1" in network_commands[0]
+    assert _git(install_dir, "rev-parse", "HEAD").stdout.strip() == expected_head
+    assert _git(install_dir, "rev-parse", "origin/main").stdout.strip() == expected_head
+    assert not (install_dir / "local-only.txt").exists()
+    assert _git(install_dir, "rev-parse", "--is-shallow-repository").stdout.strip() == "true"
+
+
+def test_full_diverged_checkout_recovers_without_shallowing_or_losing_changes(
+    tmp_path: Path,
+) -> None:
+    remote, seed = _make_remote(tmp_path)
+    install_dir = tmp_path / "install"
+    _run("git", "clone", "--branch", "main", remote.as_uri(), install_dir)
+    _git(install_dir, "config", "user.email", "installer-test@example.invalid")
+    _git(install_dir, "config", "user.name", "Installer Test")
+
+    (install_dir / "local-only.txt").write_text("local commit\n", encoding="utf-8")
+    _git(install_dir, "add", "local-only.txt")
+    _git(install_dir, "commit", "-m", "local-only commit")
+    (install_dir / "base.txt").write_text("preserve this dirty change\n", encoding="utf-8")
+    expected_head = _push_remote_update(seed)
+
+    commands = _run_repository_stage(tmp_path, install_dir)
+
+    network_commands = _network_update_commands(commands)
+    assert len(network_commands) == 1, network_commands
+    assert network_commands[0][0] == "fetch"
+    assert "--depth" not in network_commands[0]
+    assert "--depth=1" not in network_commands[0]
+    assert _git(install_dir, "rev-parse", "HEAD").stdout.strip() == expected_head
+    assert _git(install_dir, "rev-parse", "--is-shallow-repository").stdout.strip() == "false"
+    assert (install_dir / "base.txt").read_text(encoding="utf-8") == (
+        "preserve this dirty change\n"
+    )


### PR DESCRIPTION
## Problem

The POSIX installer updates an existing managed checkout with both `git fetch origin "$BRANCH"` and `git pull --ff-only origin "$BRANCH"`. On a depth-1 Desktop install, the first fetch is not depth-bounded and can negotiate/download hundreds of MB of history; the pull then performs a second network fetch. This can leave first-launch setup apparently stuck at the Repository stage for a long time.

## Fix

- keep shallow managed checkouts shallow with one explicit `--depth 1` branch-tip fetch
- keep full/custom checkouts full with one branch-only fetch
- replace the network `pull` with a local exact-origin update
- fast-forward when possible, otherwise reset ahead-only, diverged, or disconnected shallow histories to `origin/$BRANCH`
- replace the prior source-regex POSIX assertion with real-Git behavior tests

The PowerShell path is unchanged.

## Validation

- `scripts/run_tests.sh tests/test_install_repository_fetch.py tests/test_install_diverged_update.py tests/test_install_autostash_conflict_recovery.py tests/test_install_lockfile_churn.py tests/test_install_no_initial_commit.py tests/test_install_unmerged_index.py`
- 17 tests passed
- three real-Git scenarios cover shallow remote update, shallow ahead-only reset, and full diverged update with dirty-change restoration
- `bash -n scripts/install.sh`
- Python compilation and `git diff --check` passed