### PR TITLE
fix(code-exec): bind execute_code child to the current request's session id (#69820)

### DIFF
--- a/tests/tools/test_execute_code_session_id_leak.py
+++ b/tests/tools/test_execute_code_session_id_leak.py
@@ -1,0 +1,129 @@
+"""execute_code must not leak another request's session id via env (#69820).
+
+`_scrub_child_env` sources from the process-global os.environ, whose
+HERMES_SESSION_* mirror is last-writer-wins across concurrent gateway turns.
+When a session var is passthrough-allowed (so scrubbing keeps it), the child
+must carry THIS task's ContextVar value, not the stale global — the same
+leak `tools/environments/local.py` already guards for terminal subprocesses.
+
+These test `_inject_session_context_env(..., present_only=True)`, the shared
+reconciliation execute_code now applies after `_scrub_child_env`.
+"""
+import contextlib
+import os
+
+import pytest
+
+import gateway.session_context as sc
+from gateway.session_context import _VAR_MAP
+from tools.environments.local import _inject_session_context_env
+
+SESSION_VARS = list(_VAR_MAP.keys())
+
+
+@pytest.fixture(autouse=True)
+def _clean_session_state():
+    saved_env = {k: os.environ.get(k) for k in SESSION_VARS}
+    saved_ctx = {name: var.get() for name, var in _VAR_MAP.items()}
+    saved_engaged = sc._session_context_engaged
+    for var in _VAR_MAP.values():
+        var.set(sc._UNSET)
+    sc._session_context_engaged = False
+    try:
+        yield
+    finally:
+        for var, val in zip(_VAR_MAP.values(), saved_ctx.values()):
+            var.set(val)
+        sc._session_context_engaged = saved_engaged
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def test_present_only_corrects_passthrough_value_to_this_task(monkeypatch):
+    """The reported bug: request A's child env must carry request A's session
+    id, even though the process-global mirror holds a concurrent request B's."""
+    sc._session_context_engaged = True
+    sc._SESSION_ID.set("request-A")  # this task's ContextVar
+    # Stale process-global mirror written by concurrent request B, and kept in
+    # the child env because HERMES_SESSION_ID was passthrough-allowed.
+    child_env = {"HERMES_SESSION_ID": "request-B-FOREIGN"}
+
+    _inject_session_context_env(child_env, present_only=True)
+
+    assert child_env["HERMES_SESSION_ID"] == "request-A"
+
+
+def test_present_only_does_not_add_scrubbed_vars(monkeypatch):
+    """present_only corrects values of vars already present; it must not
+    re-introduce a session var that scrubbing filtered out by default."""
+    sc._session_context_engaged = True
+    sc._SESSION_ID.set("request-A")
+    child_env = {"PATH": "/usr/bin"}  # HERMES_SESSION_ID scrubbed out
+
+    _inject_session_context_env(child_env, present_only=True)
+
+    assert "HERMES_SESSION_ID" not in child_env
+    assert child_env == {"PATH": "/usr/bin"}
+
+
+def test_present_only_strips_foreign_global_when_unset_and_engaged():
+    """This task never bound a session id, but a concurrent host is engaged and
+    a passthrough kept a foreign global — it must be stripped, not inherited."""
+    sc._session_context_engaged = True
+    # _SESSION_ID stays _UNSET for this task.
+    child_env = {"HERMES_SESSION_ID": "request-B-FOREIGN"}
+
+    _inject_session_context_env(child_env, present_only=True)
+
+    assert "HERMES_SESSION_ID" not in child_env
+
+
+def test_present_only_preserves_value_when_not_engaged():
+    """Pure CLI/cron (never engaged): no concurrency to leak across, so a
+    passthrough-kept value is left as-is."""
+    sc._session_context_engaged = False
+    child_env = {"HERMES_SESSION_ID": "cli-session"}
+
+    _inject_session_context_env(child_env, present_only=True)
+
+    assert child_env["HERMES_SESSION_ID"] == "cli-session"
+
+
+def test_default_mode_still_adds_bound_vars():
+    """Without present_only (the terminal path), a bound var is added even if
+    absent — regression guard that the new param defaults off."""
+    sc._session_context_engaged = True
+    sc._SESSION_ID.set("request-A")
+    child_env: dict = {}
+
+    _inject_session_context_env(child_env)  # default present_only=False
+
+    assert child_env["HERMES_SESSION_ID"] == "request-A"
+
+
+def test_execute_code_scrub_then_reconcile_corrects_foreign_id():
+    """Mirror execute_code's exact sequence — scrub the process env, then
+    reconcile — and assert a passthrough-allowed foreign session id is
+    corrected to this task's id while unrelated vars are untouched."""
+    from tools.code_execution_tool import _scrub_child_env
+
+    sc._session_context_engaged = True
+    sc._SESSION_ID.set("request-A")
+
+    # Passthrough allows HERMES_SESSION_ID, so scrubbing keeps the (foreign)
+    # global; PATH is an ordinary inherited var.
+    source = {
+        "HERMES_SESSION_ID": "request-B-FOREIGN",
+        "PATH": "/usr/bin",
+    }
+    child_env = _scrub_child_env(
+        source, is_passthrough=lambda name: name == "HERMES_SESSION_ID"
+    )
+    assert child_env.get("HERMES_SESSION_ID") == "request-B-FOREIGN"  # pre-fix state
+
+    _inject_session_context_env(child_env, present_only=True)  # the fix
+    assert child_env["HERMES_SESSION_ID"] == "request-A"
+    assert child_env.get("PATH") == "/usr/bin"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1341,6 +1341,19 @@ def execute_code(
         # passed through — without those, the child can't create a socket
         # or spawn a subprocess.  See ``_scrub_child_env`` for the rules.
         child_env = _scrub_child_env(os.environ)
+        # #69820: _scrub_child_env sources from the process-global os.environ,
+        # whose HERMES_SESSION_* mirror is last-writer-wins across concurrent
+        # gateway turns. A session var that survived scrubbing (passthrough-
+        # allowed) would otherwise carry another request's id. Reconcile any
+        # such var against THIS task's ContextVar (present_only: correct the
+        # value, don't re-add scrubbed vars); under a concurrent host an unset
+        # ContextVar strips the possibly-foreign global. Same leak guard the
+        # terminal backend already applies to its subprocesses.
+        try:
+            from tools.environments.local import _inject_session_context_env
+            _inject_session_context_env(child_env, present_only=True)
+        except Exception:
+            logger.debug("session-context env reconcile skipped", exc_info=True)
         child_env["HERMES_RPC_SOCKET"] = rpc_endpoint
         child_env["HERMES_RPC_TOKEN"] = rpc_token
         child_env["PYTHONDONTWRITEBYTECODE"] = "1"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -401,11 +401,19 @@ def _inject_context_hermes_home(env: dict) -> None:
         pass
 
 
-def _inject_session_context_env(env: dict) -> None:
+def _inject_session_context_env(env: dict, present_only: bool = False) -> None:
     """Bridge gateway session ContextVars into a subprocess environment dict.
 
     ContextVars don't propagate to child processes, so the live session vars
     (HERMES_SESSION_*) are bridged onto the child env here.
+
+    ``present_only=True`` restricts the "explicitly bound" case to keys already
+    in *env*: the value of a session var that a caller's own scrubbing chose to
+    keep is corrected to this task's ContextVar, but no new session vars are
+    added. ``execute_code`` uses this so a passthrough-allowed HERMES_SESSION_ID
+    carries the current request's id rather than the stale global, without
+    re-introducing vars its ``_scrub_child_env`` filtered (#69820). The strip
+    branch is unaffected — dropping a possibly-foreign global is always safe.
 
     🔴 Cross-session leak guard. The session vars also have a process-global
     os.environ mirror (written last-writer-wins as a CLI/cron fallback, never
@@ -441,10 +449,16 @@ def _inject_session_context_env(env: dict) -> None:
         value = var.get()
         if value is not _UNSET:
             # Explicitly bound (including "") — authoritative for this task.
+            if present_only and var_name not in env:
+                # Caller only wants the VALUE of vars already in the env
+                # corrected, not new vars added (execute_code's scrubbing may
+                # have deliberately filtered this one). See #69820.
+                continue
             env[var_name] = "" if value is None else str(value)
         elif _engaged:
             # Unset for THIS task while a concurrent host is engaged: drop any
             # inherited global so a sibling session's value can't leak in.
+            # (pop is a no-op when absent, so present_only needs no guard here.)
             env.pop(var_name, None)
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #69820: `execute_code` can hand a child process another concurrent request's session id.

`execute_code` builds the child environment from `_scrub_child_env(os.environ)` (`tools/code_execution_tool.py`). `HERMES_SESSION_ID` is filtered by default, but when it's passthrough-allowed (`terminal.env_passthrough` or programmatic registration), the scrubbed env keeps the value from the **process-global `os.environ` mirror** — which `set_current_session_id()` writes last-writer-wins across concurrent gateway turns, while the authoritative per-request value lives in the `_SESSION_ID` **ContextVar**. So a child spawned for request A can receive request B's id (or, for a task that never bound one under a concurrent host, a foreign session's), and any child that reads `HERMES_SESSION_ID` — `--resume`, cross-session coordination, session logging — acts under the wrong identity. `sweeper:risk-session-state`, and the same bug *class* as the terminal-subprocess leak already guarded in `tools/environments/local.py`.

**Fix — reuse the existing guard, don't invent one.** `tools/environments/local.py::_inject_session_context_env` already reconciles the child env against the request-local session ContextVars for terminal subprocesses (the `session_context_engaged` latch + ContextVar authority documented there). `execute_code` simply never called it. This PR:

- Adds a `present_only` flag to `_inject_session_context_env`: when set, the "explicitly bound" branch only overrides session vars **already present** in the child env — correcting a passthrough-allowed var's *value* without re-introducing vars `execute_code`'s scrubbing deliberately filtered. The strip branch (drop a possibly-foreign global when this task's ContextVar is unset under an engaged host) is unchanged.
- Calls `_inject_session_context_env(child_env, present_only=True)` in `execute_code` right after `_scrub_child_env`.

Behavior by context, unchanged elsewhere:
- **Concurrent host + this task bound** → child gets this request's id (was: foreign global).
- **Concurrent host + this task unbound** → foreign global stripped (was: inherited).
- **Pure CLI/cron (never engaged)** → inherited fallback preserved (no concurrency to leak across).
- **Var scrubbed by default (no passthrough)** → still absent; `present_only` never re-adds it.

## Related Issue

Fixes #69820.

## Type of Change

- [x] 🐛 Bug fix (non-breaking; session-state correctness)

## Changes Made

- `tools/environments/local.py` — `_inject_session_context_env(env, present_only=False)`; new flag gates the bound-var override to keys already in `env`.
- `tools/code_execution_tool.py` — reconcile the scrubbed child env against session ContextVars before spawning (guarded import, best-effort).
- `tests/tools/test_execute_code_session_id_leak.py` — 6 tests: value-correction of a passthrough-kept foreign id, no re-adding scrubbed vars, strip-when-unset-and-engaged, CLI fallback preserved, default-mode still adds bound vars, and an end-to-end-shaped scrub-then-reconcile through `execute_code`'s real `_scrub_child_env`.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_execute_code_session_id_leak.py` — 6 passed.
2. Regression: `tests/tools/test_local_env_session_leak.py` (12 passed) — the terminal path's default behavior is unchanged. (On native Windows, `tests/tools/test_local_env_relative_cwd.py` shows 2 pre-existing path-separator failures identical with and without this diff — unrelated.)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing issues/PRs — no open PR references #69820
- [x] Single-topic
- [x] Test suite run — see How to Test
- [x] Tests added (required for bug fixes)
- [x] Tested on: Windows 11 (native)

### Documentation & Housekeeping

- [x] Documentation — helper docstring updated for the new flag
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING/AGENTS — N/A
- [x] Cross-platform — pure-Python; no platform surface (reuses an existing cross-platform helper)
