### PR TITLE
fix(codex): label usage windows by published duration

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -92,6 +92,17 @@ def _format_reset(dt: Optional[datetime]) -> str:
     return f"{rel} ({local_dt.strftime('%Y-%m-%d %H:%M %Z')})"
 
 
+def _label_openai_codex_window(key: str, window: dict[str, Any]) -> str:
+    seconds = window.get("limit_window_seconds")
+    if isinstance(seconds, (int, float)):
+        total = int(seconds)
+        if total == 5 * 3600:
+            return "Session"
+        if total == 7 * 86400:
+            return "Weekly"
+    return "Session" if key == "primary_window" else "Weekly"
+
+
 def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, markdown: bool = False) -> list[str]:
     if not snapshot:
         return []
@@ -525,14 +536,14 @@ def _fetch_codex_account_usage(
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
-    for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
+    for key in ("primary_window", "secondary_window"):
         window = rate_limit.get(key) or {}
         used = window.get("used_percent")
         if used is None:
             continue
         windows.append(
             AccountUsageWindow(
-                label=label,
+                label=_label_openai_codex_window(key, window),
                 used_percent=float(used),
                 reset_at=_parse_dt(window.get("reset_at")),
             )

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -90,9 +90,86 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot.plan == "Pro"
     assert len(snapshot.windows) == 2
     assert snapshot.windows[0].label == "Session"
+    assert snapshot.windows[1].label == "Weekly"
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+
+
+def test_fetch_account_usage_codex_labels_primary_window_as_weekly_when_duration_says_so(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "access-token",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage._read_codex_tokens",
+        lambda: {"tokens": {"account_id": "acct_123"}},
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "plan_type": "plus",
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 40,
+                        "reset_at": 1_900_500_000,
+                        "limit_window_seconds": 604800,
+                    },
+                },
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert len(snapshot.windows) == 1
+    assert snapshot.windows[0].label == "Weekly"
+
+
+def test_fetch_account_usage_codex_preserves_positional_fallback_for_unknown_durations(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "access-token",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage._read_codex_tokens",
+        lambda: {"tokens": {"account_id": "acct_123"}},
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "plan_type": "plus",
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 10,
+                        "reset_at": 1_900_000_000,
+                        "limit_window_seconds": 14400,
+                    },
+                    "secondary_window": {
+                        "used_percent": 20,
+                        "reset_at": 1_900_500_000,
+                        "limit_window_seconds": 6 * 86400,
+                    },
+                },
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert [w.label for w in snapshot.windows] == ["Session", "Weekly"]
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():


### PR DESCRIPTION
## What does this PR do?

Fixes Hermes' Codex account-usage parsing when the upstream Codex payload no longer preserves the old semantic slot mapping.

Hermes previously assumed:

- `primary_window` = Session
- `secondary_window` = Weekly

That assumption no longer holds. Upstream Codex can omit the 5-hour window entirely, leaving the weekly window in `primary_window`. Hermes then mislabels that weekly quota as `Session`.

This PR uses the published `limit_window_seconds` metadata to identify known Codex windows:

- `18000` seconds → `Session`
- `604800` seconds → `Weekly`

When duration metadata is absent or unrecognised, Hermes preserves the established positional fallback (`primary_window` → `Session`; `secondary_window` → `Weekly`) for compatibility with existing payloads.

## Related Issue

Fixes #65387

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## Changes Made

- Updated `agent/account_usage.py` to classify known Codex usage windows by published duration instead of fixed slot position.
- Maps the known Codex windows:
  - `18000` seconds → `Session`
  - `604800` seconds → `Weekly`
- Preserves the existing positional `Session` / `Weekly` fallback when duration metadata is absent or unrecognised.
- Added/updated tests in:
  - `tests/test_account_usage.py`
  - `tests/agent/test_account_usage.py`

## How to Test

1. Reproduce the bug with a Codex usage payload where:
   - `primary_window.limit_window_seconds == 604800`
   - `secondary_window == null` or absent
2. Confirm Hermes labels that window as `Weekly` rather than `Session`.
3. Run:
   - `scripts/run_tests.sh tests/test_account_usage.py tests/agent/test_account_usage.py`
4. Verify:
   - canonical 5h + weekly windows are labeled `Session` and `Weekly`
   - weekly-only `primary_window` is labeled `Weekly`
   - duration-less and unrecognised-duration payloads retain the legacy positional `Session` / `Weekly` fallback

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  > Note: I ran the preferred suite command `scripts/run_tests.sh tests/`. The focused tests for this fix pass. The full suite completed with 24,975 passed and 50 unrelated failures in optional-dependency, provider/tool-surface, and timing-sensitive test areas on this host; none are in the Codex account-usage code or tests changed by this PR.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Debian 13 ARM64)

### Documentation & Housekeeping

- [x] N/A — no user-facing documentation needed; this PR fixes Codex account-usage parsing only
- [x] N/A — no config keys changed, so `cli-config.yaml.example` was not updated
- [x] N/A — no architecture or workflow changes, so `CONTRIBUTING.md` / `AGENTS.md` were not updated
- [x] Cross-platform impact considered — change is pure usage-window labeling logic and does not add OS-specific behavior
- [x] N/A — no tool descriptions or tool schemas changed

## Screenshots / Logs

Targeted test run:
```text
scripts/run_tests.sh tests/test_account_usage.py tests/agent/test_account_usage.py

=== Summary: 2 files, 10 tests passed, 0 failed (100% complete) ===```