### PR TITLE
fix(agent): redact secrets in Codex app-server exception errors

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -437,13 +437,14 @@ class CodexAppServerSession:
     ) -> str:
         """Build a user-facing error string for codex failures.
 
-        Appends the last few lines of codex's stderr buffer when available,
-        passed through agent.redact with force=True so secrets in provider
-        error responses (auth headers, query-string tokens, sk-* keys) never
-        leak into chat output or trajectories. The codex CLI's own error
-        text ('Internal error', 'turn/start failed: ...') is otherwise
-        opaque and forces users to re-run with verbose flags to diagnose
-        config / provider / auth-bridge problems.
+        Appends the last few lines of codex's stderr buffer when available.
+        The full user-facing string (prefix, exception / JSON-RPC message,
+        and stderr) is passed through agent.redact with force=True so secrets
+        in provider error responses (auth headers, query-string tokens,
+        sk-* keys) never leak into chat output or trajectories. The codex
+        CLI's own error text ('Internal error', 'turn/start failed: ...') is
+        otherwise opaque and forces users to re-run with verbose flags to
+        diagnose config / provider / auth-bridge problems.
 
         Use this for the generic / catch-all branches. Specific
         classifications (OAuth via _classify_oauth_failure, post-tool wedge
@@ -451,19 +452,19 @@ class CodexAppServerSession:
         """
         exc_str = str(exc) if exc != "" and exc is not None else ""
         base = f"{prefix}: {exc_str}" if exc_str else prefix
-        if self._client is None:
-            return base
-        try:
-            tail = self._client.stderr_tail(tail_lines)
-        except Exception:  # pragma: no cover - diagnostic best-effort
-            return base
-        if not tail:
-            return base
-        joined = "\n".join(line.rstrip() for line in tail if line)
-        if not joined.strip():
-            return base
-        redacted = redact_sensitive_text(joined, force=True)
-        return f"{base}\ncodex stderr (last {len(tail)} lines):\n{redacted}"
+        message = base
+        if self._client is not None:
+            try:
+                tail = self._client.stderr_tail(tail_lines)
+            except Exception:  # pragma: no cover - diagnostic best-effort
+                tail = None
+            if tail:
+                joined = "\n".join(line.rstrip() for line in tail if line)
+                if joined.strip():
+                    message = (
+                        f"{base}\ncodex stderr (last {len(tail)} lines):\n{joined}"
+                    )
+        return redact_sensitive_text(message, force=True)
 
     # ---------- per-turn ----------
 

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -464,7 +464,9 @@ class CodexAppServerSession:
                     message = (
                         f"{base}\ncodex stderr (last {len(tail)} lines):\n{joined}"
                     )
-        return redact_sensitive_text(message, force=True)
+        return redact_sensitive_text(
+            message, force=True, redact_url_credentials=True
+        )
 
     # ---------- per-turn ----------
 

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -517,6 +517,59 @@ class TestRunTurn:
         # Non-OAuth → should NOT retire (subprocess JSON-RPC is still healthy).
         assert r.should_retire is False
 
+    def test_turn_start_failure_redacts_secrets_in_exception_message(self):
+        """JSON-RPC / exception messages can echo Authorization headers or
+        sk-* keys. Those must be redacted in TurnResult.error even when the
+        secret is only in the exception text, not in stderr."""
+        client = FakeClient()
+        client.set_stderr_tail(["provider request failed"])
+        from agent.transports.codex_app_server import CodexAppServerError
+
+        secret = "sk-live-SECRETKEY999"
+
+        def boom(method, params):
+            if method == "turn/start":
+                raise CodexAppServerError(
+                    code=-32603,
+                    message=f"upstream failed Authorization: Bearer {secret}",
+                )
+            return {"thread": {"id": "t"}, "activePermissionProfile": {"id": "x"}}
+
+        client._request_handler = boom
+        s = make_session(client)
+        r = s.run_turn("hi", turn_timeout=2.0)
+        assert r.error is not None
+        assert "turn/start failed" in r.error
+        assert "codex stderr" in r.error
+        assert secret not in r.error
+        assert r.should_retire is False
+
+    def test_turn_start_failure_redacts_exception_secrets_without_stderr(self):
+        """Empty stderr used to early-return the raw exception prefix; secrets
+        in the JSON-RPC message must still be redacted on that path."""
+        client = FakeClient()
+        client.set_stderr_tail([])
+        from agent.transports.codex_app_server import CodexAppServerError
+
+        secret = "sk-live-SECRETKEY888"
+
+        def boom(method, params):
+            if method == "turn/start":
+                raise CodexAppServerError(
+                    code=-32603,
+                    message=f"upstream failed Authorization: Bearer {secret}",
+                )
+            return {"thread": {"id": "t"}, "activePermissionProfile": {"id": "x"}}
+
+        client._request_handler = boom
+        s = make_session(client)
+        r = s.run_turn("hi", turn_timeout=2.0)
+        assert r.error is not None
+        assert "turn/start failed" in r.error
+        assert "codex stderr" not in r.error
+        assert secret not in r.error
+        assert r.should_retire is False
+
     def test_turn_start_timeout_attaches_redacted_stderr_tail(self):
         """A non-OAuth TimeoutError on turn/start surfaces with codex stderr
         context attached and marks the session for retirement."""

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -488,8 +488,8 @@ class TestRunTurn:
         """When codex stderr has content (non-OAuth), the tail gets attached
         to the user-facing error so config/provider problems are debuggable
         instead of just 'Internal error'. Credential-shaped values in stderr
-        are redacted via agent.redact(force=True); web-URL query params pass
-        through (see fix(redact): pass web URLs through unchanged)."""
+        are redacted via agent.redact(force=True), including credential-named
+        URL query parameters at this non-navigation error sink."""
         client = FakeClient()
         client.set_stderr_tail([
             "ERROR: provider auth failed",
@@ -512,6 +512,7 @@ class TestRunTurn:
         # Stderr tail attached
         assert "codex stderr" in r.error
         assert "provider auth failed" in r.error
+        assert "querysecret12345" not in r.error
         # Credential-shaped values still redacted (sk- prefix + Bearer header)
         assert "sk-live-deadbeefdeadbeef" not in r.error
         # Non-OAuth → should NOT retire (subprocess JSON-RPC is still healthy).
@@ -569,6 +570,28 @@ class TestRunTurn:
         assert "codex stderr" not in r.error
         assert secret not in r.error
         assert r.should_retire is False
+
+    def test_turn_start_failure_redacts_opaque_url_credentials(self):
+        client = FakeClient()
+        client.set_stderr_tail([])
+        from agent.transports.codex_app_server import CodexAppServerError
+
+        secret = "opaque-query-value-12345"
+
+        def boom(method, params):
+            if method == "turn/start":
+                raise CodexAppServerError(
+                    code=-32603,
+                    message=f"provider failed https://api.example/v1?api_key={secret}",
+                )
+            return {"thread": {"id": "t"}, "activePermissionProfile": {"id": "x"}}
+
+        client._request_handler = boom
+        r = make_session(client).run_turn("hi", turn_timeout=2.0)
+
+        assert r.error is not None
+        assert "turn/start failed" in r.error
+        assert secret not in r.error
 
     def test_turn_start_timeout_attaches_redacted_stderr_tail(self):
         """A non-OAuth TimeoutError on turn/start surfaces with codex stderr
@@ -700,6 +723,26 @@ class TestRunTurn:
         s = make_session(client)
         r = s.run_turn("x", turn_timeout=1.0)
         assert r.error and "model error" in r.error
+
+    def test_failed_turn_redacts_opaque_url_credentials(self):
+        client = FakeClient()
+        secret = "opaque-query-value-67890"
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={
+                "id": "tu1",
+                "status": "failed",
+                "error": {
+                    "message": f"provider failed https://api.example/v1?token={secret}"
+                },
+            },
+        )
+
+        r = make_session(client).run_turn("x", turn_timeout=1.0)
+
+        assert r.error is not None
+        assert "turn ended status=failed" in r.error
+        assert secret not in r.error
 
     def test_run_turn_records_native_compaction_item(self):
         client = FakeClient()


### PR DESCRIPTION
## What does this PR do?

Codex app-server failures that surface via `_format_error_with_stderr` now redact the full user-facing error string (prefix + exception / JSON-RPC message + optional stderr), so credential-shaped values cannot leak into chat or trajectories.

### Bug Cause

`_format_error_with_stderr` in `agent/transports/codex_app_server_session.py` only ran `redact_sensitive_text(..., force=True)` on the stderr tail. The `prefix` + exception message (`base`) was returned raw on every path, including when stderr was attached. Provider/codex JSON-RPC errors that echo `Authorization: Bearer ...` or `sk-*` keys therefore appeared verbatim in `TurnResult.error`.

### Reproduction Steps

1. Drive `CodexAppServerSession.run_turn` with a FakeClient whose `turn/start` raises `CodexAppServerError` with message containing `Authorization: Bearer sk-live-SECRETKEY999`.
2. Optionally attach a non-OAuth stderr tail.
3. Inspect `TurnResult.error`.

Expected: the secret token is not present in `result.error`.
Before fix: the secret appeared verbatim in `result.error` even while stderr credentials were redacted.

### Fix

Build the full diagnostic string first, then return `redact_sensitive_text(message, force=True)` once so exception text and stderr share the same redaction path. Added regression tests for secrets in the exception message both with and without a stderr tail.

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

- `agent/transports/codex_app_server_session.py` - redact the full `_format_error_with_stderr` output, not only stderr
- `tests/agent/transports/test_codex_app_server_session.py` - cover exception-message secret leakage with and without stderr

## How to Test

1. Manual: raise `CodexAppServerError` on `turn/start` with a Bearer/`sk-*` message and confirm `TurnResult.error` no longer contains the raw secret.
2. Automated: `scripts/run_tests.sh tests/agent/transports/test_codex_app_server_session.py -q` (74 passed locally)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A (docstring updated in-code only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - N/A (string redaction only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
