### PR TITLE
fix(terminal): honor sudo cancellation before process startup (#14483)

### DIFF
--- a/apps/desktop/src/components/prompt-overlays.test.tsx
+++ b/apps/desktop/src/components/prompt-overlays.test.tsx
@@ -43,8 +43,49 @@ describe('PromptOverlays', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
 
     await waitFor(() => expect($sudoRequest.get()).toBeNull())
-    expect(request).toHaveBeenCalledWith('sudo.respond', { password: '', request_id: 'sudo-1' })
+    expect(request).toHaveBeenCalledWith('sudo.cancel', { request_id: 'sudo-1' })
+    expect(request).toHaveBeenCalledTimes(1)
     expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('interrupts the owning session when an older gateway lacks sudo.cancel', async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('unknown method: sudo.cancel'))
+      .mockResolvedValueOnce({ status: 'interrupted' })
+
+    $activeSessionId.set('s1')
+    $gateway.set({ request } as never)
+    setSudoRequest({ requestId: 'sudo-1', sessionId: 's1' })
+
+    renderPrompts()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect($sudoRequest.get()).toBeNull())
+    expect(request).toHaveBeenNthCalledWith(1, 'sudo.cancel', { request_id: 'sudo-1' })
+    expect(request).toHaveBeenNthCalledWith(2, 'session.interrupt', { session_id: 's1' })
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('preserves an explicitly submitted empty sudo password as the legacy skip value', async () => {
+    const request = vi.fn().mockResolvedValue({ status: 'ok' })
+
+    $activeSessionId.set('s1')
+    $gateway.set({ request } as never)
+    setSudoRequest({ requestId: 'sudo-1', sessionId: 's1' })
+
+    renderPrompts()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('sudo.respond', {
+        intent: 'submit',
+        password: '',
+        request_id: 'sudo-1'
+      })
+    )
   })
 
   it('dismisses a stale secret dialog when the gateway no longer has the value request', async () => {

--- a/apps/desktop/src/components/prompt-overlays.test.tsx
+++ b/apps/desktop/src/components/prompt-overlays.test.tsx
@@ -13,7 +13,7 @@ vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
 vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
 
 function renderPrompts(sessionId: string | null = 's1') {
-  render(
+  return render(
     <I18nProvider configClient={null}>
       <PromptOverlays sessionId={sessionId} />
     </I18nProvider>
@@ -43,10 +43,50 @@ describe('PromptOverlays', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
 
     await waitFor(() => expect($sudoRequest.get()).toBeNull())
-    expect(request).toHaveBeenCalledWith('sudo.respond', { password: '', request_id: 'sudo-1' })
+    expect(request).toHaveBeenCalledWith('sudo.cancel', { request_id: 'sudo-1' })
     expect(notifyError).not.toHaveBeenCalled()
   })
 
+  it.each(['current', 'legacy', 'transient'])('cancels through the %s backend without empty submission', async mode => {
+    const request = vi.fn().mockResolvedValue({ status: 'ok' })
+
+    if (mode === 'legacy') {request.mockRejectedValueOnce(Object.assign(new Error('method not found'), { code: -32601 }))}
+
+    if (mode === 'transient') {request.mockRejectedValueOnce(new Error('connection reset'))}
+    $activeSessionId.set('s1')
+    $gateway.set({ request } as never)
+    setSudoRequest({ requestId: 'sudo-1', sessionId: 's1' })
+    renderPrompts()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => {
+      if (mode === 'transient') {expect(notifyError).toHaveBeenCalled()}
+      else {expect($sudoRequest.get()).toBeNull()}
+    })
+    expect(request).toHaveBeenNthCalledWith(1, 'sudo.cancel', { request_id: 'sudo-1' })
+
+    if (mode === 'legacy') {expect(request).toHaveBeenNthCalledWith(2, 'session.interrupt', { session_id: 's1' })}
+    else {expect(request).toHaveBeenCalledTimes(1)}
+
+    if (mode === 'transient') {
+      expect($sudoRequest.get()?.requestId).toBe('sudo-1')
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+      await waitFor(() => expect($sudoRequest.get()).toBeNull())
+      expect(request).toHaveBeenCalledTimes(2)
+    }
+  })
+
+  it.each(['', 'test-password'])('marks the %j password as explicit submission', async password => {
+    const request = vi.fn().mockResolvedValue({ status: 'ok' })
+    $activeSessionId.set('s1')
+    $gateway.set({ request } as never)
+    setSudoRequest({ requestId: 'sudo-1', sessionId: 's1' })
+    const { baseElement } = renderPrompts()
+    const input = baseElement.querySelector('input[type="password"]')!
+    fireEvent.change(input, { target: { value: password } })
+    fireEvent.submit(input.closest('form')!)
+    await waitFor(() => expect($sudoRequest.get()).toBeNull())
+    expect(request).toHaveBeenCalledWith('sudo.respond', { intent: 'submit', password, request_id: 'sudo-1' })
+  })
   it('dismisses a stale secret dialog when the gateway no longer has the value request', async () => {
     const request = vi.fn().mockRejectedValue(new Error('no pending value request'))
 

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { useI18n } from '@/i18n'
-import { isMissingPendingPromptRequest } from '@/lib/gateway-rpc'
+import { isMissingPendingPromptRequest, isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { triggerHaptic } from '@/lib/haptics'
 import { KeyRound, Loader2, Lock } from '@/lib/icons'
 import { $gateway } from '@/store/gateway'
@@ -65,6 +65,7 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
 
       try {
         await gateway.request<{ status?: string }>('sudo.respond', {
+          intent: 'submit',
           password: value,
           request_id: request.requestId
         })
@@ -84,15 +85,67 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
     [copy.gatewayDisconnected, copy.sudoSendFailed, gateway, request]
   )
 
-  // Cancel → empty password. The backend treats an empty sudo response as a
-  // failed sudo (no command runs), so closing the dialog is a safe refusal.
+  const cancel = useCallback(async () => {
+    if (!request) {
+      return
+    }
+
+    if (!gateway) {
+      notifyError(new Error(copy.gatewayDisconnected), copy.sudoSendFailed)
+
+      return
+    }
+
+    setSubmitting(true)
+
+    try {
+      try {
+        // Intent-specific and probeable: a current backend resolves the prompt
+        // as cancellation without overloading an empty password.
+        await gateway.request<{ status?: string }>('sudo.cancel', {
+          request_id: request.requestId
+        })
+      } catch (error) {
+        if (isMissingPendingPromptRequest(error, 'password')) {
+          clearSudoRequest(request.sessionId, request.requestId)
+
+          return
+        }
+
+        if (!isMissingRpcMethod(error)) {
+          throw error
+        }
+
+        // Older backends do not expose sudo.cancel. Their established
+        // session-interrupt path is the only safe fallback: never send null or
+        // empty, both of which legacy code can interpret as "run without it".
+        await gateway.request<{ status?: string }>('session.interrupt', {
+          session_id: request.sessionId
+        })
+      }
+
+      triggerHaptic('submit')
+      clearSudoRequest(request.sessionId, request.requestId)
+    } catch (error) {
+      if (isMissingPendingPromptRequest(error, 'password')) {
+        clearSudoRequest(request.sessionId, request.requestId)
+
+        return
+      }
+
+      notifyError(error, copy.sudoSendFailed)
+      setSubmitting(false)
+    }
+  }, [copy.gatewayDisconnected, copy.sudoSendFailed, gateway, request])
+
+  // Explicit dismissal is distinct from submitting the empty legacy-skip.
   const onOpenChange = useCallback(
     (open: boolean) => {
       if (!open && !submitting && request) {
-        void send('')
+        void cancel()
       }
     },
-    [request, send, submitting]
+    [cancel, request, submitting]
   )
 
   const onSubmit = useCallback(
@@ -125,7 +178,7 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
             value={password}
           />
           <DialogFooter>
-            <Button disabled={submitting} onClick={() => void send('')} type="button" variant="ghost">
+            <Button disabled={submitting} onClick={() => void cancel()} type="button" variant="ghost">
               {t.common.cancel}
             </Button>
             <Button disabled={submitting} type="submit">

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -16,7 +16,7 @@ import {
 import { Field } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { useI18n } from '@/i18n'
-import { isMissingPendingPromptRequest } from '@/lib/gateway-rpc'
+import { isMissingPendingPromptRequest, isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { triggerHaptic } from '@/lib/haptics'
 import { KeyRound, Loader2, Lock, ShieldLock } from '@/lib/icons'
 import { $gateway } from '@/store/gateway'
@@ -64,10 +64,8 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
   }, [request?.requestId])
 
   const send = useCallback(
-    async (value: string) => {
-      if (!request) {
-        return
-      }
+    async (value: string | null) => {
+      if (!request) {return}
 
       if (!gateway) {
         notifyError(new Error(copy.gatewayDisconnected), copy.sudoSendFailed)
@@ -78,10 +76,18 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
       setSubmitting(true)
 
       try {
-        await gateway.request<{ status?: string }>('sudo.respond', {
-          password: value,
-          request_id: request.requestId
-        })
+        if (value === null) {
+          try {
+            await gateway.request('sudo.cancel', { request_id: request.requestId })
+          } catch (error) {
+            if (!isMissingRpcMethod(error)) {throw error}
+            // Older backends conflate empty replies with submission; interrupt its owner.
+            await gateway.request('session.interrupt', { session_id: request.sessionId })
+          }
+        } else {
+          await gateway.request('sudo.respond', { intent: 'submit', password: value, request_id: request.requestId })
+        }
+
         triggerHaptic('submit')
         clearSudoRequest(request.sessionId, request.requestId)
       } catch (error) {
@@ -98,13 +104,9 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
     [copy.gatewayDisconnected, copy.sudoSendFailed, gateway, request]
   )
 
-  // Cancel → empty password. The backend treats an empty sudo response as a
-  // failed sudo (no command runs), so closing the dialog is a safe refusal.
   const onOpenChange = useCallback(
     (open: boolean) => {
-      if (!open && !submitting && request) {
-        void send('')
-      }
+      if (!open && !submitting && request) {void send(null)}
     },
     [request, send, submitting]
   )
@@ -139,7 +141,7 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
             value={password}
           />
           <DialogFooter>
-            <Button disabled={submitting} onClick={() => void send('')} type="button" variant="ghost">
+            <Button disabled={submitting} onClick={() => void send(null)} type="button" variant="ghost">
               {t.common.cancel}
             </Button>
             <Button disabled={submitting} type="submit">

--- a/cli.py
+++ b/cli.py
@@ -93,6 +93,9 @@ except Exception:
 import threading
 import queue
 
+_sudo_response_queue_factory = queue.Queue
+
+
 def CanonicalUsage(*args, **kwargs):
     from agent.usage_pricing import CanonicalUsage as _CanonicalUsage
 
@@ -4678,6 +4681,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._clarify_multi_base = None
         self._sudo_state = None
         self._sudo_deadline = 0
+        self._sudo_lock = threading.Lock()
+        self._sudo_state_lock = threading.Lock()
+        self._sudo_interrupt_generation = 0
         self._modal_input_snapshot = None
         self._approval_state = None
         self._approval_deadline = 0
@@ -13296,7 +13302,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             "Use your best judgement to make the choice and proceed."
         )
 
-    def _sudo_password_callback(self) -> str:
+    def _resolve_sudo_prompt(
+        self, state: dict, result: str | None, *, reason: str = "response"
+    ) -> bool:
+        """Resolve *state* once if it is still the active sudo prompt."""
+        with self._sudo_state_lock:
+            if self._sudo_state is not state or state.get("resolved", False):
+                return False
+            state["resolved"] = True
+            state["resolution"] = reason
+            self._sudo_state = None
+            self._sudo_deadline = 0
+            state["response_queue"].put_nowait(result)
+            return True
+
+    def _sudo_password_callback(self) -> str | None:
         """
         Prompt for sudo password through the prompt_toolkit UI.
         
@@ -13306,43 +13326,51 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         """
         import time as _time
 
-        timeout = 45
-        response_queue = queue.Queue()
+        with self._sudo_state_lock:
+            interrupt_generation = self._sudo_interrupt_generation
 
-        self._capture_modal_input_snapshot()
-        self._sudo_state = {
-            "response_queue": response_queue,
-        }
-        self._sudo_deadline = _time.monotonic() + timeout
+        with self._sudo_lock:
+            timeout = 45
+            response_queue = _sudo_response_queue_factory()
+            deadline = _time.monotonic() + timeout
+            state = {
+                "response_queue": response_queue,
+                "deadline": deadline,
+                "resolved": False,
+            }
 
-        # Modal prompt — paint immediately, bypassing the throttle/resize guard
-        # so the prompt can't be dropped and time out unseen (#41098).
-        self._paint_now()
+            with self._sudo_state_lock:
+                if interrupt_generation != self._sudo_interrupt_generation:
+                    return None
+                self._capture_modal_input_snapshot()
+                self._sudo_state = state
+                self._sudo_deadline = deadline
 
-        while True:
-            try:
-                result = response_queue.get(timeout=1)
-                self._sudo_state = None
-                self._sudo_deadline = 0
-                self._restore_modal_input_snapshot()
-                self._paint_now()
-                if result:
-                    _cprint(f"\n{_DIM}  ✓ Password received (cached for session){_RST}")
-                else:
-                    _cprint(f"\n{_DIM}  ⏭ Skipped{_RST}")
-                return result
-            except queue.Empty:
-                remaining = self._sudo_deadline - _time.monotonic()
-                if remaining <= 0:
+            # Modal prompt — paint immediately, bypassing the throttle/resize guard
+            # so the prompt can't be dropped and time out unseen (#41098).
+            self._paint_now()
+
+            while True:
+                try:
+                    result = response_queue.get(timeout=1)
                     break
-                self._paint_now()
+                except queue.Empty:
+                    if deadline - _time.monotonic() <= 0:
+                        self._resolve_sudo_prompt(state, "", reason="timeout")
+                    else:
+                        self._paint_now()
 
-        self._sudo_state = None
-        self._sudo_deadline = 0
-        self._restore_modal_input_snapshot()
-        self._paint_now()
-        _cprint(f"\n{_DIM}  ⏱ Timeout — continuing without sudo{_RST}")
-        return ""
+            self._restore_modal_input_snapshot()
+            self._paint_now()
+            if result is None:
+                _cprint(f"\n{_DIM}  ⏭ Cancelled{_RST}")
+            elif result:
+                _cprint(f"\n{_DIM}  ✓ Password received (cached for session){_RST}")
+            elif state.get("resolution") == "timeout":
+                _cprint(f"\n{_DIM}  ⏱ Timeout — continuing without sudo{_RST}")
+            else:
+                _cprint(f"\n{_DIM}  ⏭ Skipped{_RST}")
+            return result
 
     def _approval_callback(self, command: str, description: str,
                            *, allow_permanent: bool = True,
@@ -13694,10 +13722,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         thread servicing the prompt.  The result is a frozen terminal until the
         prompt's own timeout expires.  Push a terminal value onto each queue so
         any still-blocked thread unblocks cleanly, then nil the state out and
-        restore the user's pre-modal draft (#14026).
+        restore the user's pre-modal draft (#14026).  Sudo callbacks already
+        serialized behind the active prompt are invalidated at the same
+        interrupt boundary so none can publish a successor modal.
 
-        Safe default per prompt: approval -> "deny", clarify/sudo/secret ->
-        cancel (None / empty).  Each step is wrapped so a dead queue can't
+        Safe default per prompt: approval -> "deny", clarify/sudo -> None,
+        secret -> empty.  Each step is wrapped so a dead queue can't
         prevent clearing the others.
         """
         if self._approval_state:
@@ -13716,13 +13746,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._clarify_state = None
             self._clarify_freetext = False
             self._clarify_multi_base = None
-        if self._sudo_state:
-            try:
-                self._sudo_state["response_queue"].put("")
-            except Exception:
-                pass
-            self._sudo_state = None
-            self._sudo_deadline = 0
+        sudo_state = None
+        try:
+            with self._sudo_state_lock:
+                # Invalidate callbacks already waiting on _sudo_lock as well as
+                # the currently published prompt. A callback starting after this
+                # boundary captures the new generation and proceeds normally.
+                self._sudo_interrupt_generation += 1
+                sudo_state = self._sudo_state
+                if sudo_state:
+                    self._sudo_state = None
+                    self._sudo_deadline = 0
+                    if not sudo_state.get("resolved", False):
+                        sudo_state["resolved"] = True
+                        sudo_state["resolution"] = "interrupt"
+                        sudo_state["response_queue"].put_nowait(None)
+        except Exception:
+            pass
+        if sudo_state:
             self._restore_modal_input_snapshot()
         if self._secret_state:
             try:
@@ -15245,6 +15286,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Sudo password prompt state (similar mechanism to clarify)
         self._sudo_state = None         # dict with response_queue when active
         self._sudo_deadline = 0
+        self._sudo_lock = threading.Lock()  # serialize concurrent sudo prompts
+        self._sudo_state_lock = threading.Lock()  # resolve active prompt exactly once
+        self._sudo_interrupt_generation = 0  # cancel pre-interrupt serialized waiters
         self._modal_input_snapshot = None
 
         # Dangerous command approval state (similar mechanism to clarify)
@@ -15324,10 +15368,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             handled as commands, not sent as interrupt text to the agent.
             """
             # --- Sudo password prompt: submit the typed password ---
-            if self._sudo_state:
+            sudo_state = self._sudo_state
+            if sudo_state:
                 text = event.app.current_buffer.text
-                self._sudo_state["response_queue"].put(text)
-                self._sudo_state = None
+                self._resolve_sudo_prompt(sudo_state, text)
                 event.app.invalidate()
                 return
 
@@ -16038,6 +16082,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 return
 
             if self._agent_running and self.agent:
+                if not _overlay_cleared:
+                    # A serialized sudo waiter can exist during the narrow
+                    # handoff where no prompt state is published yet.
+                    self._clear_active_overlays_for_interrupt()
                 if now - self._last_ctrl_c_time < 2.0:
                     print("\n⚡ Force exiting...")
                     self._should_exit = True
@@ -16123,6 +16171,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 return
 
             if self._agent_running and self.agent:
+                if not _overlay_cleared:
+                    # Advance the sudo interrupt generation even during the
+                    # serialized handoff between visible prompts.
+                    self._clear_active_overlays_for_interrupt()
                 print("\n⚡ Interrupting agent...")
                 request_hard_interrupt(self.agent)
             elif event.app.current_buffer.text or self._attached_images:
@@ -16162,9 +16214,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
-            if self._sudo_state:
-                self._sudo_state["response_queue"].put("")
-                self._sudo_state = None
+            sudo_state = self._sudo_state
+            if sudo_state:
+                self._resolve_sudo_prompt(sudo_state, None)
                 event.app.invalidate()
                 return
             if self._slash_confirm_state:
@@ -16578,7 +16630,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if cli_ref._voice_processing:
                 return "transcribing..."
             if cli_ref._sudo_state:
-                return "type password (hidden), Enter to submit · ESC to skip"
+                return "type password (hidden), Enter to submit · ESC to cancel"
             if cli_ref._secret_state:
                 return "type secret (hidden), Enter to submit · ESC to skip"
             if cli_ref._approval_state:

--- a/cli.py
+++ b/cli.py
@@ -2883,6 +2883,9 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         self._sudo_state = self._modal_input_snapshot = self._approval_state = None
         self._slash_confirm_state = self._model_picker_state = None
         self._clarify_deadline = self._sudo_deadline = self._approval_deadline = self._slash_confirm_deadline = 0
+        self._sudo_lock = threading.Lock()
+        self._sudo_state_lock = threading.Lock()
+        self._sudo_interrupt_generation = 0
         self._approval_lock = threading.Lock()
         try:  # composer placeholder chosen once so it stays stable on screen
             from hermes_cli.tips import get_random_composer_placeholder

--- a/hermes_cli/cli_modal_mixin.py
+++ b/hermes_cli/cli_modal_mixin.py
@@ -733,31 +733,54 @@ class CLIModalMixin:
         _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — locked answers returned){_RST}")
         return {"answers": partial, "timed_out": True}
 
-    def _sudo_password_callback(self) -> str:
-        """Prompt for a sudo password through the prompt_toolkit UI (agent thread); clarify-style
-        state + queue answered by the Enter binding."""
+    def _resolve_sudo_prompt(self, state: dict, response: str | None) -> bool:
+        """Resolve the visible prompt once; a stale UI event cannot answer its successor."""
+        with self._sudo_state_lock:
+            if self._sudo_state is not state:
+                return False
+            self._sudo_state = None
+            self._sudo_deadline = 0
+            state["response_queue"].put_nowait(response)
+            return True
+
+    def _sudo_password_callback(self) -> str | None:
+        """Serialize password prompts. None cancels; empty Enter and timeout remain skips."""
         from cli import _DIM, _RST, _cprint
 
-        response_queue = queue.Queue()
-        self._capture_modal_input_snapshot()
-        self._sudo_state = {"response_queue": response_queue}
-        self._sudo_deadline = _time.monotonic() + 45
-        self._ring_bell(prompt=True, context="sudo password")
-        self._paint_now()
-
-        result = self._poll_modal_queue(response_queue, "_sudo_deadline", refresh=0)
-        self._sudo_state = None
-        self._sudo_deadline = 0
-        self._restore_modal_input_snapshot()
-        self._paint_now()
-        if result is _TIMED_OUT:
-            _cprint(f"\n{_DIM}  ⏱ Timeout — continuing without sudo{_RST}")
-            return ""
-        if result:
-            _cprint(f"\n{_DIM}  ✓ Password received (cached for session){_RST}")
-        else:
-            _cprint(f"\n{_DIM}  ⏭ Skipped{_RST}")
-        return result
+        with self._sudo_state_lock:
+            generation = self._sudo_interrupt_generation
+        with self._sudo_lock:
+            state = {"response_queue": queue.Queue(), "deadline": _time.monotonic() + 45}
+            with self._sudo_state_lock:
+                if generation != self._sudo_interrupt_generation:
+                    return None
+                self._capture_modal_input_snapshot()
+                self._sudo_state = state
+                self._sudo_deadline = state["deadline"]
+            self._ring_bell(prompt=True, context="sudo password")
+            self._paint_now()
+            timed_out = False
+            while True:
+                try:
+                    result = state["response_queue"].get(timeout=1)
+                    break
+                except queue.Empty:
+                    if _time.monotonic() >= state["deadline"]:
+                        timed_out = self._resolve_sudo_prompt(state, "")
+            # Keep ownership until the draft is restored, before a queued callback opens.
+            self._resolve_sudo_prompt(state, result)
+            self._restore_modal_input_snapshot()
+            self._paint_now()
+            if result is None:
+                message = "⏭ Cancelled"
+            elif result:
+                message = "✓ Password received (cached for session)"
+            elif timed_out:
+                message = "⏱ Timeout — continuing without sudo"
+            else:
+                message = "⏭ Skipped"
+            _cprint(f"\n{_DIM}  {message}{_RST}")
+            return result
 
     def _approval_callback(self, command: str, description: str,
                            *, allow_permanent: bool = True,
@@ -975,11 +998,16 @@ class CLIModalMixin:
             self._clarify_state = None
             self._clarify_freetext = False
             self._clarify_multi_base = None
-        if self._sudo_state:
-            _put(self._sudo_state, "")
+        with self._sudo_state_lock:
+            self._sudo_interrupt_generation += 1
+            sudo_state = self._sudo_state
             self._sudo_state = None
             self._sudo_deadline = 0
-            self._restore_modal_input_snapshot()
+            if sudo_state:
+                # Finish this modal's draft before waking its worker or admitting
+                # a new generation; later cleanup must not consume a successor's snapshot.
+                self._restore_modal_input_snapshot()
+                _put(sudo_state, None)
         if self._secret_state:
             try:
                 self._cancel_secret_capture()

--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -1080,9 +1080,8 @@ class CLITuiMixin:
             self._cancel_secret_capture()
             event.app.current_buffer.reset()
             event.app.invalidate()
-        elif self._sudo_state:
-            self._sudo_state["response_queue"].put("")
-            self._sudo_state = None
+        elif state := self._sudo_state:
+            self._resolve_sudo_prompt(state, None)
             event.app.invalidate()
         elif self._slash_confirm_state:
             self._submit_slash_confirm_response("cancel")
@@ -1481,9 +1480,8 @@ class CLITuiMixin:
         """Enter while a modal overlay is up: submit it. True when handled."""
         from cli import _cprint
         buf = event.app.current_buffer
-        if self._sudo_state:
-            self._sudo_state["response_queue"].put(buf.text)
-            self._sudo_state = None
+        if state := self._sudo_state:
+            self._resolve_sudo_prompt(state, buf.text)
             event.app.invalidate()
             return True
         if self._secret_state:
@@ -1802,6 +1800,9 @@ class CLITuiMixin:
         self._modal_input_snapshot = None
         self._approval_state = None
         self._approval_deadline = 0
+        self._sudo_lock = threading.Lock()
+        self._sudo_state_lock = threading.Lock()
+        self._sudo_interrupt_generation = 0
         self._approval_lock = threading.Lock()  # serialize concurrent approval prompts (delegation race)
         # Destructive slash-command confirmations (/new, /clear, /undo) are answered through the
         # composer, not raw input(), so the labels stay visible and Enter can't EOF the app.

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -25,6 +25,9 @@ def _make_cli_stub():
     cli._approval_lock = threading.Lock()
     cli._sudo_state = None
     cli._sudo_deadline = 0
+    cli._sudo_lock = threading.Lock()
+    cli._sudo_state_lock = threading.Lock()
+    cli._sudo_interrupt_generation = 0
     cli._modal_input_snapshot = None
     cli._invalidate = MagicMock()
     cli._app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer())
@@ -67,6 +70,147 @@ def _make_background_cli_stub():
 
 
 class TestCliApprovalUi:
+    def test_concurrent_sudo_prompts_are_serialized_and_each_can_be_cancelled(self):
+        cli = _make_cli_stub()
+        results = {}
+        contended = threading.Event()
+
+        class _TrackingLock:
+            def __init__(self):
+                self._lock = threading.Lock()
+
+            def __enter__(self):
+                if not self._lock.acquire(blocking=False):
+                    contended.set()
+                    self._lock.acquire()
+                return self
+
+            def __exit__(self, *_args):
+                self._lock.release()
+
+        cli._sudo_lock = _TrackingLock()
+
+        def _run_callback(name):
+            results[name] = cli._sudo_password_callback()
+
+        with patch.object(cli_module, "_cprint"), patch.object(cli, "_paint_now"):
+            first_thread = threading.Thread(
+                target=_run_callback, args=("first",), daemon=True
+            )
+            first_thread.start()
+
+            deadline = time.time() + 2
+            while cli._sudo_state is None and time.time() < deadline:
+                time.sleep(0.01)
+            first_state = cli._sudo_state
+            assert first_state is not None
+
+            second_thread = threading.Thread(
+                target=_run_callback, args=("second",), daemon=True
+            )
+            second_thread.start()
+            assert contended.wait(timeout=2), "second prompt did not serialize"
+            assert cli._sudo_state is first_state
+
+            assert cli._resolve_sudo_prompt(first_state, None)
+            first_thread.join(timeout=2)
+            assert not first_thread.is_alive()
+
+            deadline = time.time() + 2
+            while (
+                (cli._sudo_state is None or cli._sudo_state is first_state)
+                and time.time() < deadline
+            ):
+                time.sleep(0.01)
+            second_state = cli._sudo_state
+            assert second_state is not None
+            assert second_state is not first_state
+            assert not cli._resolve_sudo_prompt(first_state, "late submission")
+            assert cli._sudo_state is second_state
+
+            assert cli._resolve_sudo_prompt(second_state, None)
+            second_thread.join(timeout=2)
+            assert not second_thread.is_alive()
+
+        assert results == {"first": None, "second": None}
+
+    def test_sudo_cancel_after_final_queue_timeout_wins_atomically(self):
+        cli = _make_cli_stub()
+        after_final_get = threading.Event()
+        cancellation_done = threading.Event()
+        monotonic_calls = 0
+        result = {}
+
+        class _DeadlineQueue(queue.Queue):
+            def __init__(self):
+                super().__init__()
+                self._first_get = True
+
+            def get(self, block=True, timeout=None):
+                if self._first_get:
+                    self._first_get = False
+                    raise queue.Empty
+                return super().get(block=block, timeout=timeout)
+
+        def _monotonic():
+            nonlocal monotonic_calls
+            monotonic_calls += 1
+            if monotonic_calls == 1:
+                return 0
+            if monotonic_calls == 2:
+                after_final_get.set()
+                assert cancellation_done.wait(timeout=2)
+            return 46
+
+        def _run_callback():
+            result["value"] = cli._sudo_password_callback()
+
+        with (
+            patch.object(cli_module.queue, "Queue", _DeadlineQueue),
+            patch.object(cli_module.time, "monotonic", side_effect=_monotonic),
+            patch.object(cli_module, "_cprint"),
+            patch.object(cli, "_paint_now"),
+        ):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            assert after_final_get.wait(timeout=2)
+
+            state = cli._sudo_state
+            assert state is not None
+            assert cli._resolve_sudo_prompt(state, None)
+            cancellation_done.set()
+
+            thread.join(timeout=2)
+            assert not thread.is_alive()
+
+        assert result["value"] is None
+        assert not cli._resolve_sudo_prompt(state, "late submission")
+
+    def test_sudo_prompt_distinguishes_cancel_from_empty_submission(self):
+        cli = _make_cli_stub()
+        results = []
+
+        def _run_callback():
+            results.append(cli._sudo_password_callback())
+
+        with patch.object(cli_module, "_cprint"):
+            for response in (None, ""):
+                thread = threading.Thread(target=_run_callback, daemon=True)
+                thread.start()
+
+                deadline = time.time() + 2
+                while cli._sudo_state is None and time.time() < deadline:
+                    time.sleep(0.01)
+
+                state = cli._sudo_state
+                assert state is not None
+                assert cli._resolve_sudo_prompt(state, response)
+                thread.join(timeout=2)
+                assert not thread.is_alive()
+                assert not cli._resolve_sudo_prompt(state, None)
+
+        assert results == [None, ""]
+
     def test_smart_denied_callback_offers_only_once_and_deny(self):
         cli = _make_cli_stub()
         result = {}
@@ -245,6 +389,9 @@ def _make_real_paint_cli_stub():
     cli._approval_lock = threading.Lock()
     cli._sudo_state = None
     cli._sudo_deadline = 0
+    cli._sudo_lock = threading.Lock()
+    cli._sudo_state_lock = threading.Lock()
+    cli._sudo_interrupt_generation = 0
     cli._clarify_state = None
     cli._clarify_freetext = False
     cli._clarify_deadline = 0
@@ -298,10 +445,14 @@ class TestModalPaintNow:
             # Reset so we can prove the response-received teardown also repaints
             # (the panel must clear at once, not be held by the throttle).
             cli._app.invalidate.reset_mock()
-            getattr(cli, state_attr)["response_queue"].put(
+            response = (
                 "deny" if state_attr == "_approval_state" else
                 ("a" if state_attr == "_clarify_state" else "pw")
             )
+            if state_attr == "_sudo_state":
+                cli._resolve_sudo_prompt(cli._sudo_state, response)
+            else:
+                getattr(cli, state_attr)["response_queue"].put(response)
             thread.join(timeout=2)
             # clarify returns immediately on a response (no teardown repaint);
             # approval and sudo repaint to tear the panel down.
@@ -502,7 +653,8 @@ class TestClearOverlaysForInterrupt:
         cli._approval_state = {"response_queue": approval_q}
         cli._clarify_state = {"response_queue": clarify_q}
         cli._clarify_freetext = True
-        cli._sudo_state = {"response_queue": sudo_q, "timeout": 60}
+        sudo_state = {"response_queue": sudo_q, "timeout": 60}
+        cli._sudo_state = sudo_state
         cli._sudo_deadline = 99999.0
         cli._secret_state = {"response_queue": secret_q, "var_name": "X"}
 
@@ -519,9 +671,81 @@ class TestClearOverlaysForInterrupt:
         # Each blocked thread would have received a terminal value.
         assert approval_q.get_nowait() == "deny"
         assert clarify_q.get_nowait()  # cancellation sentinel string
-        assert sudo_q.get_nowait() == ""
+        assert sudo_q.get_nowait() is None
+        assert not cli._resolve_sudo_prompt(sudo_state, "late submission")
+        assert sudo_q.empty()
         assert secret_q.get_nowait() == ""
 
+    def test_interrupt_cancels_active_and_waiting_sudo_prompts_but_not_later_one(self):
+        cli = self._make_cli()
+        results = {}
+        contended = threading.Event()
+
+        class _TrackingLock:
+            def __init__(self):
+                self._lock = threading.Lock()
+
+            def __enter__(self):
+                if not self._lock.acquire(blocking=False):
+                    contended.set()
+                    self._lock.acquire()
+                return self
+
+            def __exit__(self, *_args):
+                self._lock.release()
+
+        cli._sudo_lock = _TrackingLock()
+
+        def _run_callback(name):
+            results[name] = cli._sudo_password_callback()
+
+        with patch.object(cli_module, "_cprint"):
+            first_thread = threading.Thread(
+                target=_run_callback, args=("first",), daemon=True
+            )
+            first_thread.start()
+
+            deadline = time.time() + 2
+            while cli._sudo_state is None and time.time() < deadline:
+                time.sleep(0.01)
+            assert cli._sudo_state is not None
+
+            second_thread = threading.Thread(
+                target=_run_callback, args=("second",), daemon=True
+            )
+            second_thread.start()
+            assert contended.wait(timeout=2), "second prompt did not serialize"
+
+            cli._clear_active_overlays_for_interrupt()
+            first_thread.join(timeout=2)
+            second_thread.join(timeout=2)
+
+            both_cancelled = not first_thread.is_alive() and not second_thread.is_alive()
+            modal_remaining = cli._sudo_state
+            if modal_remaining is not None:
+                cli._resolve_sudo_prompt(modal_remaining, None)
+                second_thread.join(timeout=2)
+
+            assert both_cancelled
+            assert results == {"first": None, "second": None}
+            assert modal_remaining is None
+            assert cli._sudo_state is None
+
+            later_thread = threading.Thread(
+                target=_run_callback, args=("later",), daemon=True
+            )
+            later_thread.start()
+            deadline = time.time() + 2
+            while cli._sudo_state is None and time.time() < deadline:
+                time.sleep(0.01)
+            later_state = cli._sudo_state
+            assert later_state is not None
+            assert cli._resolve_sudo_prompt(later_state, "fresh-password")
+            later_thread.join(timeout=2)
+
+        assert not later_thread.is_alive()
+        assert results["later"] == "fresh-password"
+        assert cli._sudo_state is None
 
     def test_dead_queue_does_not_block_clearing_others(self):
         """A queue that raises on put() must not prevent the remaining
@@ -561,4 +785,3 @@ class TestClearOverlaysForInterrupt:
 
         assert not t.is_alive(), "worker thread never unblocked"
         assert result["value"] == "deny"
-

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -25,6 +25,9 @@ def _make_cli_stub():
     cli._approval_lock = threading.Lock()
     cli._sudo_state = None
     cli._sudo_deadline = 0
+    cli._sudo_lock = threading.Lock()
+    cli._sudo_state_lock = threading.Lock()
+    cli._sudo_interrupt_generation = 0
     cli._modal_input_snapshot = None
     cli._invalidate = MagicMock()
     cli._app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer())
@@ -277,6 +280,9 @@ def _make_real_paint_cli_stub():
     cli._approval_lock = threading.Lock()
     cli._sudo_state = None
     cli._sudo_deadline = 0
+    cli._sudo_lock = threading.Lock()
+    cli._sudo_state_lock = threading.Lock()
+    cli._sudo_interrupt_generation = 0
     cli._clarify_state = None
     cli._clarify_freetext = False
     cli._clarify_deadline = 0
@@ -551,7 +557,7 @@ class TestClearOverlaysForInterrupt:
         # Each blocked thread would have received a terminal value.
         assert approval_q.get_nowait() == "deny"
         assert clarify_q.get_nowait()  # cancellation sentinel string
-        assert sudo_q.get_nowait() == ""
+        assert sudo_q.get_nowait() is None
         assert secret_q.get_nowait() == ""
 
 

--- a/tests/cli/test_sudo_cancellation.py
+++ b/tests/cli/test_sudo_cancellation.py
@@ -10,6 +10,7 @@ import pytest
 
 from cli import HermesCLI
 from tools.environments.base import BaseEnvironment
+from tools.interrupt import set_interrupt
 import tools.terminal_tool as terminal
 import tools.terminal_tool_sudo as sudo
 
@@ -36,7 +37,7 @@ def _wait(predicate):
     assert predicate(), "worker did not reach expected state"
 
 
-@pytest.mark.parametrize("response", ["escape", "interrupt", "empty", "password", "timeout"])
+@pytest.mark.parametrize("response", ["escape", "interrupt", "empty", "password", "timeout", "post-submit-interrupt"])
 def test_sudo_ui_decision_controls_execution(monkeypatch, tmp_path, response):
     cli = _cli()
     calls = []
@@ -44,6 +45,12 @@ def test_sudo_ui_decision_controls_execution(monkeypatch, tmp_path, response):
     class Env(BaseEnvironment):
         def _before_execute(self):
             pass
+
+        def _prepare_command(self, command):
+            result = super()._prepare_command(command)
+            if response == "post-submit-interrupt":
+                set_interrupt(True)
+            return result
 
         def _run_bash(self, command, **kwargs):
             calls.append((command, kwargs.get("stdin_data")))
@@ -76,6 +83,7 @@ def test_sudo_ui_decision_controls_execution(monkeypatch, tmp_path, response):
             result.update(json.loads(terminal.terminal_tool("sudo true", force=True)))
         finally:
             terminal.set_sudo_password_callback(None)
+            set_interrupt(False)
 
     worker = threading.Thread(target=run, daemon=True)
     worker.start()
@@ -91,11 +99,11 @@ def test_sudo_ui_decision_controls_execution(monkeypatch, tmp_path, response):
             # The prompt owns its deadline; shortening its published state simulates expiry.
             cli._sudo_state["deadline"] = cli._sudo_deadline
         else:
-            cli._app.current_buffer.text = "secret" if response == "password" else ""
+            cli._app.current_buffer.text = "secret" if response in ("password", "post-submit-interrupt") else ""
             assert cli._tui_enter_overlay(SimpleNamespace(app=cli._app))
         worker.join(3)
         assert not worker.is_alive()
-        if response in ("escape", "interrupt"):
+        if response in ("escape", "interrupt", "post-submit-interrupt"):
             assert result.get("status") == "cancelled", result
             assert result["exit_code"] == 130
             assert calls == []

--- a/tests/cli/test_sudo_cancellation.py
+++ b/tests/cli/test_sudo_cancellation.py
@@ -1,0 +1,160 @@
+"""Sudo dismissal must reach execution as cancellation, while empty Enter remains a skip."""
+
+import json
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from cli import HermesCLI
+from tools.environments.base import BaseEnvironment
+import tools.terminal_tool as terminal
+import tools.terminal_tool_sudo as sudo
+
+
+def _cli():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._approval_state = cli._clarify_state = cli._secret_state = None
+    cli._slash_confirm_state = cli._sudo_state = cli._modal_input_snapshot = None
+    cli._sudo_deadline = 0
+    cli._sudo_lock = threading.Lock()
+    cli._sudo_state_lock = threading.Lock()
+    cli._sudo_interrupt_generation = 0
+    cli._paint_now = cli._ring_bell = MagicMock()
+    buffer = SimpleNamespace(text="draft", cursor_position=5)
+    buffer.reset = lambda: setattr(buffer, "text", "")
+    cli._app = SimpleNamespace(current_buffer=buffer, invalidate=MagicMock())
+    return cli
+
+
+def _wait(predicate):
+    deadline = time.monotonic() + 3
+    while not predicate() and time.monotonic() < deadline:
+        time.sleep(0.002)
+    assert predicate(), "worker did not reach expected state"
+
+
+@pytest.mark.parametrize("response", ["escape", "interrupt", "empty", "password", "timeout"])
+def test_sudo_ui_decision_controls_execution(monkeypatch, tmp_path, response):
+    cli = _cli()
+    calls = []
+
+    class Env(BaseEnvironment):
+        def _before_execute(self):
+            pass
+
+        def _run_bash(self, command, **kwargs):
+            calls.append((command, kwargs.get("stdin_data")))
+            return object()
+
+        def _wait_for_process(self, *_args, **_kwargs):
+            return {"output": "completed", "returncode": 0}
+
+        def cleanup(self):
+            pass
+
+    env = Env(cwd=str(tmp_path), timeout=5)
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    # Current BaseEnvironment owns the backend-scoped NOPASSWD probe; keep this
+    # fake environment explicitly password-requiring without probing the host.
+    monkeypatch.setattr(Env, "_sudo_nopasswd_works", lambda _self: False)
+    monkeypatch.setattr(terminal, "_resolve_container_task_id", lambda _: "sudo-test")
+    monkeypatch.setattr(terminal, "resolve_task_overrides", lambda _: {})
+    monkeypatch.setattr(terminal, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal, "_get_env_config", lambda: {
+        "env_type": "local", "cwd": str(tmp_path), "timeout": 5})
+    monkeypatch.setitem(terminal._active_environments, "sudo-test", env)
+    monkeypatch.setitem(terminal._last_activity, "sudo-test", 0)
+    sudo._reset_cached_sudo_passwords()
+    result = {}
+
+    def run():
+        terminal.set_sudo_password_callback(cli._sudo_password_callback)
+        try:
+            result.update(json.loads(terminal.terminal_tool("sudo true", force=True)))
+        finally:
+            terminal.set_sudo_password_callback(None)
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    try:
+        _wait(lambda: cli._sudo_state is not None or not worker.is_alive())
+        assert cli._sudo_state is not None
+        if response == "escape":
+            cli._tui_handle_escape_modal(SimpleNamespace(app=cli._app))
+        elif response == "interrupt":
+            cli._clear_active_overlays_for_interrupt()
+        elif response == "timeout":
+            cli._sudo_deadline = time.monotonic() - 1
+            # The prompt owns its deadline; shortening its published state simulates expiry.
+            cli._sudo_state["deadline"] = cli._sudo_deadline
+        else:
+            cli._app.current_buffer.text = "secret" if response == "password" else ""
+            assert cli._tui_enter_overlay(SimpleNamespace(app=cli._app))
+        worker.join(3)
+        assert not worker.is_alive()
+        if response in ("escape", "interrupt"):
+            assert result.get("status") == "cancelled", result
+            assert result["exit_code"] == 130
+            assert calls == []
+        else:
+            assert result["exit_code"] == 0, result
+            assert len(calls) == 1
+            assert calls[0][1] == ("secret\n" if response == "password" else None)
+        assert cli._sudo_state is None
+        assert cli._app.current_buffer.text == "draft"
+    finally:
+        if cli._sudo_state:
+            cli._sudo_state["response_queue"].put(None)
+        worker.join(3)
+        sudo._reset_cached_sudo_passwords()
+
+
+def test_concurrent_prompt_ownership_and_interrupt_generation():
+    cli = _cli()
+    results = []
+    waiting = threading.Event()
+    real_lock = cli._sudo_lock
+
+    class ObservedLock:
+        def __enter__(self):
+            waiting.set()
+            real_lock.acquire()
+
+        def __exit__(self, *_args):
+            real_lock.release()
+
+    workers = [threading.Thread(target=lambda: results.append(cli._sudo_password_callback()), daemon=True)
+               for _ in range(2)]
+    workers[0].start()
+    _wait(lambda: cli._sudo_state is not None)
+    first = cli._sudo_state
+    cli._sudo_lock = ObservedLock()
+    workers[1].start()
+    try:
+        # Main's unsynchronized callback replaces the first state; either event exposes it.
+        _wait(lambda: waiting.is_set() or cli._sudo_state is not first)
+        assert cli._sudo_state is first
+        cli._clear_active_overlays_for_interrupt()
+        for worker in workers:
+            worker.join(3)
+            assert not worker.is_alive()
+        assert results == [None, None]
+        assert cli._sudo_state is None
+        # A callback beginning after the interrupt remains usable.
+        fresh = threading.Thread(target=lambda: results.append(cli._sudo_password_callback()), daemon=True)
+        fresh.start()
+        _wait(lambda: cli._sudo_state is not None)
+        cli._app.current_buffer.text = "fresh"
+        cli._tui_enter_overlay(SimpleNamespace(app=cli._app))
+        fresh.join(3)
+        assert results[-1] == "fresh"
+        assert cli._app.current_buffer.text == "draft"
+    finally:
+        for state in (first, cli._sudo_state):
+            if state:
+                state["response_queue"].put(None)
+        for worker in workers:
+            worker.join(3)

--- a/tests/cli/test_sudo_snapshot_lifecycle.py
+++ b/tests/cli/test_sudo_snapshot_lifecycle.py
@@ -1,0 +1,55 @@
+"""An interrupted prompt must restore its own draft before a successor captures it."""
+
+import threading
+from types import SimpleNamespace
+
+from tests.cli.test_sudo_cancellation import _cli, _wait
+
+
+def test_interrupt_snapshot_restore_cannot_consume_successor():
+    cli = _cli()
+    results = []
+    restoring, release, old_done = threading.Event(), threading.Event(), threading.Event()
+    original_restore = cli._restore_modal_input_snapshot
+
+    def run_old():
+        results.append(cli._sudo_password_callback())
+        old_done.set()
+
+    old = threading.Thread(target=run_old, daemon=True)
+    old.start()
+    _wait(lambda: cli._sudo_state is not None)
+
+    def restore():
+        if threading.current_thread() is cancel:
+            restoring.set()
+            assert release.wait(3)
+        original_restore()
+
+    cli._restore_modal_input_snapshot = restore
+    cancel = threading.Thread(target=cli._clear_active_overlays_for_interrupt, daemon=True)
+    fresh = threading.Thread(target=lambda: results.append(cli._sudo_password_callback()), daemon=True)
+    cancel.start()
+    assert restoring.wait(3)
+    try:
+        worker_finished = old_done.wait(0.1)
+        fresh.start()
+        if worker_finished:
+            _wait(lambda: cli._sudo_state is not None)  # reproduced old cleanup can reach the new draft
+        release.set()
+        cancel.join(3)
+        _wait(lambda: cli._sudo_state is not None)
+        cli._app.current_buffer.text = "secret"
+        cli._tui_enter_overlay(SimpleNamespace(app=cli._app))
+        old.join(3)
+        fresh.join(3)
+        assert results == [None, "secret"]
+        assert cli._app.current_buffer.text == "draft"
+        assert cli._sudo_state is None
+    finally:
+        release.set()
+        if cli._sudo_state:
+            cli._sudo_state["response_queue"].put(None)
+        for thread in (old, cancel, fresh):
+            if thread.ident is not None:
+                thread.join(3)

--- a/tests/tools/test_background_start_cancellation.py
+++ b/tests/tools/test_background_start_cancellation.py
@@ -1,0 +1,87 @@
+"""Interrupted detached starts must remain distinguishable and accounted for."""
+
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+import tools.process_registry as processes
+from tools.interrupt import set_interrupt
+from tools.terminal_tool_background import spawn_background_process
+
+
+@pytest.mark.parametrize("pty", [False, True])
+def test_interrupted_local_start_does_not_spawn_or_fall_back(monkeypatch, tmp_path, pty):
+    registry = processes.ProcessRegistry()
+    calls = []
+    monkeypatch.setattr(processes, "process_registry", registry)
+    monkeypatch.setattr(registry, "_scope_argv", lambda *_: ["inert"])
+    monkeypatch.setattr(registry, "_spawn_env", lambda _: {})
+    monkeypatch.setattr(registry, "_track_started", lambda *_: None)
+    monkeypatch.setattr(subprocess, "Popen", lambda *_a, **_kw: calls.append("pipe") or SimpleNamespace(pid=42))
+    if pty:
+        module = pytest.importorskip("winpty" if processes._IS_WINDOWS else "ptyprocess")
+        monkeypatch.setattr(module.PtyProcess, "spawn", lambda *_a, **_kw: calls.append("pty") or SimpleNamespace(pid=42))
+    set_interrupt(True)
+    try:
+        result = json.loads(spawn_background_process(
+            command="true", env=SimpleNamespace(env={}), env_type="local", effective_task_id="test",
+            task_id="test", session_key="", workdir=None, cwd=str(tmp_path), effective_pty=pty,
+            notify_on_complete=False, watch_patterns=None, approval_note=None, pty_disabled_reason=None))
+        assert result.get("status") == "cancelled", result
+        assert result["exit_code"] == 130
+        assert calls == []
+        assert not registry._running
+    finally:
+        set_interrupt(False)
+
+
+@pytest.mark.parametrize("stage", ["before", "pid", "no-pid", "natural", "natural-marker"])
+def test_uncertain_sandbox_start_keeps_tracking_and_can_recover_pid(monkeypatch, tmp_path, stage):
+    registry = processes.ProcessRegistry()
+    monkeypatch.setattr(processes, "process_registry", registry)
+    monkeypatch.setattr(registry, "_env_temp_dir", lambda _: str(tmp_path))
+    monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
+    recorded = []
+
+    def track(session, target, name, extra_args=()):
+        registry._running[session.id] = session
+        recorded.append((target, extra_args))
+
+    monkeypatch.setattr(registry, "_track_started", track)
+    result = {"output": "42", "returncode": 130}
+    if stage == "before":
+        result.update(output="", _process_start_cancelled=True)
+    elif stage in ("pid", "no-pid"):
+        result.update(output="42\n[Command interrupted]" if stage == "pid" else "[Command interrupted]",
+                      _process_interrupted=True)
+    elif stage == "natural-marker":
+        result["output"] = "42\n[Command interrupted]"
+    env = SimpleNamespace(execute=lambda *_a, **_kw: result)
+    outcome = json.loads(spawn_background_process(
+        command="true", env=env, env_type="docker", effective_task_id="test", task_id="test",
+        session_key="", workdir=None, cwd=str(tmp_path), effective_pty=False,
+        notify_on_complete=False, watch_patterns=None, approval_note=None, pty_disabled_reason=None))
+    if stage == "before":
+        assert outcome.get("status") == "cancelled", outcome
+        assert not registry._running
+        return
+    session = registry.get(outcome["session_id"])
+    assert session is not None and not session.exited
+    if stage in ("pid", "no-pid"):
+        assert outcome["exit_code"] == 130
+        assert "may still be running" in outcome["error"]
+        assert session.pid == (42 if stage == "pid" else None)
+        if stage == "no-pid":
+            replies = iter([{"output": ""}, {"output": "42"}, {"output": "0 0\n"},
+                            {"output": "1"}, {"output": "7"}])
+            env.execute = lambda *_a, **_kw: next(replies)
+            monkeypatch.setattr(processes.time, "sleep", lambda _: None)
+            target, args = recorded[0]
+            target(session, *args)
+            assert session.pid == 42
+            assert session.exited and session.exit_code == 7
+    else:
+        assert outcome["exit_code"] == 0
+        assert not getattr(session, "start_interrupted", False)

--- a/tests/tools/test_interrupt_starts.py
+++ b/tests/tools/test_interrupt_starts.py
@@ -1,0 +1,89 @@
+"""Process-start interruption follows the owning tool thread across deadline workers."""
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from tools.environments.base import BaseEnvironment
+from tools.environments.managed_modal import ManagedModalEnvironment
+from tools.interrupt import is_interrupted, set_interrupt
+
+
+@pytest.mark.parametrize("backend", ["base", "managed"])
+@pytest.mark.parametrize("interrupted", [True, False])
+def test_interrupt_before_backend_start(monkeypatch, tmp_path, backend, interrupted):
+    starts = []
+
+    class Env(BaseEnvironment):
+        def _before_execute(self):
+            pass
+
+        def _run_bash(self, *_args, **_kwargs):
+            starts.append(threading.get_ident())
+            return object()
+
+        def _wait_for_process(self, *_args, **_kwargs):
+            return {"output": "natural exit", "returncode": 130}
+
+        def cleanup(self):
+            pass
+
+    if backend == "base":
+        env = Env(cwd=str(tmp_path), timeout=2)
+    else:
+        env = ManagedModalEnvironment.__new__(ManagedModalEnvironment)
+        env.cwd, env.timeout, env._sandbox_id = str(tmp_path), 2, "test"
+        monkeypatch.setattr(env, "_prepare_command", lambda command: (command, None))
+        monkeypatch.setattr(env, "cleanup", lambda: None)
+
+        def request(*_args, **_kwargs):
+            starts.append(threading.get_ident())
+            return SimpleNamespace(status_code=200, json=lambda: {
+                "status": "completed", "output": "natural exit", "returncode": 130})
+
+        monkeypatch.setattr(env, "_request", request)
+    try:
+        set_interrupt(interrupted)
+        result = env.execute("true")
+        assert result["returncode"] == 130
+        assert bool(result.get("_process_start_cancelled")) is interrupted
+        assert len(starts) == (0 if interrupted else 1)
+        if backend == "base" and not interrupted:
+            assert starts[0] != threading.get_ident()  # actual deadline-worker seam
+        set_interrupt(False)
+        fresh = env.execute("true")
+        assert not fresh.get("_process_start_cancelled")
+        assert len(starts) == (1 if interrupted else 2)
+    finally:
+        set_interrupt(False)
+
+
+def test_interrupt_publication_orders_only_its_owned_start():
+    import tools.interrupt as interrupts
+
+    entered, release, published = threading.Event(), threading.Event(), threading.Event()
+    result = []
+
+    def start():
+        entered.set()
+        assert release.wait(3)
+        return "process"
+
+    owner = threading.Thread(target=lambda: result.append(interrupts.start_if_not_interrupted(start)), daemon=True)
+    owner.start()
+    assert entered.wait(3)
+    publisher = threading.Thread(target=lambda: (set_interrupt(True, owner.ident), published.set()), daemon=True)
+    publisher.start()
+    try:
+        assert not published.wait(0.03)
+        # A different session is not serialized behind this process creation.
+        assert interrupts.start_if_not_interrupted(lambda: "other") == (True, "other")
+        assert not is_interrupted()
+    finally:
+        release.set()
+        owner.join(3)
+        publisher.join(3)
+        set_interrupt(False, owner.ident)
+    assert published.is_set()
+    assert result == [(True, "process")]

--- a/tests/tools/test_managed_modal_environment.py
+++ b/tests/tools/test_managed_modal_environment.py
@@ -63,9 +63,15 @@ def _install_fake_tools_package(*, credential_mounts=None):
     sys.modules["tools.environments"] = env_package
 
     interrupt_event = threading.Event()
+    def start_if_not_interrupted(start):
+        if interrupt_event.is_set():
+            return False, None
+        return True, start()
+
     sys.modules["tools.interrupt"] = types.SimpleNamespace(
         set_interrupt=lambda value=True: interrupt_event.set() if value else interrupt_event.clear(),
         is_interrupted=lambda: interrupt_event.is_set(),
+        start_if_not_interrupted=start_if_not_interrupted,
         _interrupt_event=interrupt_event,
     )
 
@@ -143,6 +149,36 @@ def test_managed_modal_execute_polls_until_completed(monkeypatch):
 
     assert result == {"output": "hello", "returncode": 0}
     assert any(call[0] == "POST" and call[1].endswith("/execs") for call in calls)
+
+
+def test_managed_modal_pre_start_interrupt_does_not_start_transport(monkeypatch):
+    interrupt_event = _install_fake_tools_package()
+    managed_modal = _load_tool_module("tools.environments.managed_modal", "environments/managed_modal.py")
+
+    calls = []
+
+    def fake_request(method, url, headers=None, json=None, timeout=None):
+        calls.append((method, url, json, timeout))
+        if method == "POST" and url.endswith("/v1/sandboxes"):
+            return _FakeResponse(200, {"id": "sandbox-1"})
+        if method == "POST" and url.endswith("/terminate"):
+            return _FakeResponse(200, {"status": "terminated"})
+        raise AssertionError(f"Unexpected transport start: {method} {url}")
+
+    monkeypatch.setattr(managed_modal.requests, "request", fake_request)
+
+    env = managed_modal.ManagedModalEnvironment(image="python:3.11")
+    interrupt_event.set()
+    result = env.execute("echo never-started")
+    interrupt_event.clear()
+    env.cleanup()
+
+    assert result == {
+        "output": "",
+        "returncode": 130,
+        "_process_start_cancelled": True,
+    }
+    assert not any(call[1].endswith("/execs") for call in calls)
 
 
 def test_managed_modal_rejects_host_credential_passthrough():

--- a/tests/tools/test_managed_modal_environment.py
+++ b/tests/tools/test_managed_modal_environment.py
@@ -66,6 +66,7 @@ def _install_fake_tools_package(*, credential_mounts=None):
     sys.modules["tools.interrupt"] = types.SimpleNamespace(
         set_interrupt=lambda value=True: interrupt_event.set() if value else interrupt_event.clear(),
         is_interrupted=lambda: interrupt_event.is_set(),
+        start_if_not_interrupted=lambda start: (False, None) if interrupt_event.is_set() else (True, start()),
         _interrupt_event=interrupt_event,
     )
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -14,6 +14,7 @@ from tools.environments.local import _HERMES_PROVIDER_ENV_FORCE_PREFIX
 from tools.process_registry import (
     ProcessRegistry,
     ProcessSession,
+    ProcessStartCancelled,
     FINISHED_TTL_SECONDS,
     MAX_PROCESSES,
     MAX_ACTIVE_PROCESS_AGE,
@@ -643,6 +644,109 @@ class TestPruning:
 # =========================================================================
 
 class TestSpawnEnvSanitization:
+    def test_spawn_local_pipe_does_not_start_after_interrupt(self, registry):
+        from tools.interrupt import set_interrupt
+
+        popen = MagicMock()
+        set_interrupt(True)
+        try:
+            with patch("tools.process_registry.subprocess.Popen", popen), \
+                patch("tools.process_registry.threading.Thread", return_value=MagicMock()), \
+                patch.object(registry, "_write_checkpoint"):
+                with pytest.raises(ProcessStartCancelled):
+                    registry.spawn_local("echo never-started", cwd="/tmp")
+        finally:
+            set_interrupt(False)
+
+        popen.assert_not_called()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Uses ptyprocess")
+    def test_spawn_local_pty_does_not_fallback_after_interrupt(self, registry):
+        from tools.interrupt import set_interrupt
+
+        pty_spawn = MagicMock()
+        popen = MagicMock()
+        set_interrupt(True)
+        try:
+            with patch("ptyprocess.PtyProcess.spawn", pty_spawn), \
+                patch("tools.process_registry.subprocess.Popen", popen), \
+                patch("tools.process_registry.threading.Thread", return_value=MagicMock()), \
+                patch.object(registry, "_write_checkpoint"):
+                with pytest.raises(ProcessStartCancelled):
+                    registry.spawn_local(
+                        "echo never-started",
+                        cwd="/tmp",
+                        use_pty=True,
+                    )
+        finally:
+            set_interrupt(False)
+
+        pty_spawn.assert_not_called()
+        popen.assert_not_called()
+
+    def test_spawn_local_stale_interrupt_clear_allows_start(self, registry):
+        from tools.interrupt import clear_current_thread_interrupt, set_interrupt
+
+        proc = MagicMock(pid=4321)
+        popen = MagicMock(return_value=proc)
+        fake_thread = MagicMock()
+        set_interrupt(True)
+        clear_current_thread_interrupt()
+
+        try:
+            with patch("tools.process_registry.subprocess.Popen", popen), \
+                patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
+                patch.object(registry, "_write_checkpoint"):
+                session = registry.spawn_local("echo approved", cwd="/tmp")
+        finally:
+            set_interrupt(False)
+
+        assert session.pid == 4321
+        popen.assert_called_once()
+        fake_thread.start.assert_called_once()
+
+    def test_spawn_local_start_wins_over_concurrent_interrupt(self, registry):
+        from tools.interrupt import set_interrupt
+
+        entered_start = threading.Event()
+        release_start = threading.Event()
+        result = {}
+        proc = MagicMock(pid=4321)
+        real_thread = threading.Thread
+
+        def fake_popen(*_args, **_kwargs):
+            entered_start.set()
+            assert release_start.wait(timeout=5)
+            return proc
+
+        def spawn():
+            result["thread_id"] = threading.get_ident()
+            result["session"] = registry.spawn_local("echo started", cwd="/tmp")
+
+        with patch("tools.process_registry.subprocess.Popen", side_effect=fake_popen), \
+            patch("tools.process_registry.threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            worker = real_thread(target=spawn)
+            worker.start()
+            assert entered_start.wait(timeout=5)
+
+            setter = real_thread(
+                target=set_interrupt,
+                kwargs={"active": True, "thread_id": worker.ident},
+            )
+            setter.start()
+            time.sleep(0.05)
+            assert setter.is_alive()
+
+            release_start.set()
+            worker.join(timeout=5)
+            setter.join(timeout=5)
+
+        set_interrupt(False, thread_id=result["thread_id"])
+        assert not worker.is_alive()
+        assert not setter.is_alive()
+        assert result["session"].pid == 4321
+
     def test_spawn_local_strips_blocked_vars_from_background_env(self, registry):
         captured = {}
 
@@ -708,6 +812,240 @@ class TestSpawnEnvSanitization:
         fake_thread.start.assert_not_called()
         # A failed launch must not be exposed as a running/tracked session.
         assert session.id not in registry._running
+
+    def test_spawn_via_env_tracks_a_dedicated_sandbox_process_group(self, registry):
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def execute(self, command, **kwargs):
+                self.commands.append((command, kwargs))
+                return {"output": "4321\n", "returncode": 0}
+
+        env = FakeEnv()
+        fake_thread = MagicMock()
+
+        with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(env, "sleep 60")
+
+        bg_command = env.commands[0][0]
+        assert "set -m; nohup bash -c" in bg_command
+        assert session.pid == 4321
+        assert session.pid_scope == "sandbox_group"
+
+    def test_kill_process_nonlocal_terminates_tracked_process_group(self, registry):
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def execute(self, command, **kwargs):
+                self.commands.append((command, kwargs))
+                return {
+                    "output": "__HERMES_PROCESS_TERMINATED__\n",
+                    "returncode": 0,
+                }
+
+        env = FakeEnv()
+        session = _make_session(sid="proc_remote_group")
+        session.pid = 4321
+        session.pid_scope = "sandbox_group"
+        session.env_ref = env
+        registry._running[session.id] = session
+
+        result = registry.kill_process(session.id)
+
+        assert result["status"] == "killed"
+        assert len(env.commands) == 1
+        kill_command, kill_kwargs = env.commands[0]
+        assert "_hermes_target=-4321" in kill_command
+        assert 'kill -TERM -- "$_hermes_target"' in kill_command
+        assert 'kill -0 -- "$_hermes_target"' in kill_command
+        assert 'kill -KILL -- "$_hermes_target"' in kill_command
+        assert kill_kwargs == {"timeout": 5}
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX-only: requires process groups",
+    )
+    def test_nonlocal_group_kill_reaps_real_supervisor_and_descendant(
+        self, registry, tmp_path
+    ):
+        import psutil
+
+        class LocalBashEnv:
+            def get_temp_dir(self):
+                return str(tmp_path)
+
+            def execute(self, command, **kwargs):
+                completed = subprocess.run(
+                    ["bash", "-c", command],
+                    capture_output=True,
+                    text=True,
+                    timeout=kwargs.get("timeout", 5),
+                )
+                return {
+                    "output": completed.stdout + completed.stderr,
+                    "returncode": completed.returncode,
+                }
+
+        def live_group_members(pgid):
+            members = []
+            for proc in psutil.process_iter(["status"]):
+                try:
+                    if (
+                        os.getpgid(proc.pid) == pgid
+                        and proc.info["status"] != psutil.STATUS_ZOMBIE
+                    ):
+                        members.append(proc.pid)
+                except (OSError, psutil.Error):
+                    continue
+            return members
+
+        env = LocalBashEnv()
+        session = None
+        try:
+            with patch(
+                "tools.process_registry.threading.Thread",
+                return_value=MagicMock(),
+            ), patch.object(registry, "_write_checkpoint"):
+                session = registry.spawn_via_env(env, "sleep 60")
+
+            assert session.pid_scope == "sandbox_group"
+            assert os.getpgid(session.pid) == session.pid
+            assert _wait_until(
+                lambda: len(live_group_members(session.pid)) >= 2
+            )
+
+            result = registry.kill_process(session.id)
+
+            assert result["status"] == "killed"
+            assert _wait_until(lambda: not live_group_members(session.pid))
+        finally:
+            if session is not None:
+                try:
+                    os.killpg(session.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+    def test_kill_process_nonlocal_keeps_unconfirmed_group_tracked(self, registry):
+        class FakeEnv:
+            def execute(self, _command, **_kwargs):
+                return {
+                    "output": "__HERMES_PROCESS_STILL_RUNNING__\n",
+                    "returncode": 1,
+                }
+
+        session = _make_session(sid="proc_remote_still_running")
+        session.pid = 4321
+        session.pid_scope = "sandbox_group"
+        session.env_ref = FakeEnv()
+        registry._running[session.id] = session
+
+        result = registry.kill_process(session.id)
+
+        assert result == {
+            "status": "error",
+            "error": (
+                "Sandbox process termination could not be confirmed; "
+                "the process remains tracked"
+            ),
+        }
+        assert session.exited is False
+        assert registry.get(session.id) is session
+
+    def test_spawn_via_env_propagates_sudo_prompt_cancellation(self, registry):
+        from tools.terminal_tool import SudoPasswordPromptCancelled
+
+        class FakeEnv:
+            def execute(self, _command, **_kwargs):
+                raise SudoPasswordPromptCancelled
+
+        with pytest.raises(SudoPasswordPromptCancelled):
+            registry.spawn_via_env(FakeEnv(), "sudo true")
+
+    def test_spawn_via_env_propagates_pre_start_interrupt(self, registry):
+        from tools.process_registry import ProcessStartCancelled
+
+        class FakeEnv:
+            def execute(self, _command, **_kwargs):
+                return {
+                    "output": "",
+                    "returncode": 130,
+                    "_process_start_cancelled": True,
+                }
+
+        with pytest.raises(ProcessStartCancelled):
+            registry.spawn_via_env(FakeEnv(), "echo never-started")
+
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            "[Command interrupted]",
+            "[Command interrupted - Modal sandbox exec cancelled]",
+        ],
+    )
+    def test_spawn_via_env_propagates_marker_bearing_interrupt(
+        self, registry, marker
+    ):
+        class FakeEnv:
+            def execute(self, _command, **_kwargs):
+                return {"output": marker, "returncode": 130}
+
+        with pytest.raises(ProcessStartCancelled) as exc_info:
+            registry.spawn_via_env(FakeEnv(), "echo interrupted")
+
+        assert exc_info.value.output == marker
+        assert exc_info.value.before_start is False
+
+    def test_spawn_via_ssh_retains_marker_bearing_pid_as_killable(self, registry):
+        marker = "[Command interrupted]"
+
+        class FakeSSHEnvironment:
+            def __init__(self):
+                self.commands = []
+
+            def execute(self, command, **kwargs):
+                self.commands.append((command, kwargs))
+                if len(self.commands) == 1:
+                    return {"output": f"4242\n{marker}", "returncode": 130}
+                return {
+                    "output": "__HERMES_PROCESS_TERMINATED__\n",
+                    "returncode": 0,
+                }
+
+        env = FakeSSHEnvironment()
+        fake_thread = MagicMock()
+        with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(env, "echo interrupted")
+            kill_result = registry.kill_process(session.id)
+
+        assert session.pid == 4242
+        assert session.start_interrupted is True
+        assert session.start_interrupt_output == f"4242\n{marker}"
+        assert kill_result["status"] == "killed"
+        assert "_hermes_target=-4242" in env.commands[1][0]
+        assert session.id not in registry._running
+        assert registry.get(session.id) is session
+
+    def test_spawn_via_env_keeps_unmarked_rc130_as_natural_child_result(
+        self, registry
+    ):
+        class FakeEnv:
+            def execute(self, _command, **_kwargs):
+                return {"output": "4242\nchild exited on SIGINT", "returncode": 130}
+
+        fake_thread = MagicMock()
+        with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(FakeEnv(), "exit 130")
+
+        assert session.pid == 4242
+        assert session.start_interrupted is False
+        assert session.start_interrupt_output == ""
+        assert session.id in registry._running
+        fake_thread.start.assert_called_once()
 
     def test_env_poller_quotes_temp_paths_with_spaces(self, registry):
         session = _make_session(sid="proc_space")
@@ -1634,7 +1972,6 @@ class TestReaderLoopOrphanedPipe:
                 os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
             except (ProcessLookupError, PermissionError):
                 pass
-
 # =========================================================================
 # systemd cgroup isolation for gateway-spawned local executors (#70716)
 # =========================================================================

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -1,11 +1,19 @@
 """Regression tests for sudo detection and sudo password handling."""
 
 import json
+import queue
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+import cli as cli_module
 import tools.terminal_tool as terminal_tool
+from cli import HermesCLI
 from tools.environments.base import BaseEnvironment
+from tools.interrupt import is_interrupted, set_interrupt
 
 
 def setup_function():
@@ -197,6 +205,182 @@ def test_nonlocal_sudo_dismissal_has_foreground_background_parity(
         "status": "cancelled",
     }
     assert calls == ["background" if background else "foreground"]
+
+
+@pytest.mark.parametrize("env_type", ["local", "docker"])
+def test_approved_background_clears_stale_interrupt_once_before_spawn(
+    monkeypatch, tmp_path, env_type
+):
+    import tools.interrupt as interrupt_module
+    import tools.process_registry as process_registry_module
+
+    task_id = f"approved-background-stale-{env_type}"
+    clear_calls = []
+    interrupt_states_at_spawn = []
+    real_clear = interrupt_module.clear_current_thread_interrupt
+
+    class FakeEnvironment:
+        cwd = str(tmp_path)
+        env = {}
+
+    class FakeRegistry:
+        pending_watchers = []
+
+        @staticmethod
+        def _session():
+            return SimpleNamespace(id="proc_approved", pid=1234)
+
+        def spawn_local(self, **_kwargs):
+            interrupt_states_at_spawn.append(is_interrupted())
+            return self._session()
+
+        def spawn_via_env(self, **_kwargs):
+            interrupt_states_at_spawn.append(is_interrupted())
+            return self._session()
+
+    def tracking_clear():
+        clear_calls.append("clear")
+        real_clear()
+
+    config = {
+        "env_type": env_type,
+        "cwd": str(tmp_path),
+        "timeout": 60,
+    }
+    if env_type == "docker":
+        config["docker_image"] = "inert-test-image"
+
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda _task_id: task_id)
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _task_id: {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(interrupt_module, "clear_current_thread_interrupt", tracking_clear)
+    monkeypatch.setitem(terminal_tool._active_environments, task_id, FakeEnvironment())
+    monkeypatch.setitem(terminal_tool._last_activity, task_id, 0.0)
+    monkeypatch.setattr(process_registry_module, "process_registry", FakeRegistry())
+
+    set_interrupt(True)
+    try:
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                "echo approved",
+                background=True,
+                task_id=task_id,
+                force=True,
+            )
+        )
+    finally:
+        set_interrupt(False)
+
+    assert result["output"] == "Background process started"
+    assert result["exit_code"] == 0
+    assert interrupt_states_at_spawn == [False]
+    assert clear_calls == ["clear"]
+
+
+def test_global_interrupt_after_sudo_response_dequeue_stops_process_start(
+    monkeypatch, tmp_path
+):
+    task_id = "sudo-post-dequeue-interrupt-test"
+    response_dequeued = threading.Event()
+    resume_callback = threading.Event()
+    real_queue = queue.Queue
+
+    class PausingQueue(real_queue):
+        def get(self, block=True, timeout=None):
+            result = super().get(block=block, timeout=timeout)
+            response_dequeued.set()
+            assert resume_callback.wait(timeout=2), "callback did not resume"
+            return result
+
+    class MinimalEnvironment(BaseEnvironment):
+        def __init__(self):
+            super().__init__(cwd=str(tmp_path), timeout=60)
+            self.run_bash_calls = 0
+
+        def _run_bash(self, *_args, **_kwargs):
+            self.run_bash_calls += 1
+            return object()
+
+        def _wait_for_process(self, *_args, **_kwargs):
+            return {"output": "executed", "returncode": 0}
+
+        def cleanup(self):
+            pass
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._approval_state = None
+    cli._clarify_state = None
+    cli._clarify_freetext = False
+    cli._sudo_state = None
+    cli._sudo_deadline = 0
+    cli._sudo_lock = threading.Lock()
+    cli._sudo_state_lock = threading.Lock()
+    cli._sudo_interrupt_generation = 0
+    cli._secret_state = None
+    cli._modal_input_snapshot = None
+    cli._app = SimpleNamespace(current_buffer=MagicMock())
+    cli._paint_now = MagicMock()
+    cli._capture_modal_input_snapshot = MagicMock()
+    cli._restore_modal_input_snapshot = MagicMock()
+
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda _task_id: task_id)
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _task_id: {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {"env_type": "local", "cwd": str(tmp_path), "timeout": 60},
+    )
+    environment = MinimalEnvironment()
+    monkeypatch.setitem(terminal_tool._active_environments, task_id, environment)
+    monkeypatch.setitem(terminal_tool._last_activity, task_id, 0.0)
+
+    result = {}
+
+    def run_terminal():
+        terminal_tool.set_sudo_password_callback(cli._sudo_password_callback)
+        try:
+            result["value"] = json.loads(
+                terminal_tool.terminal_tool("sudo shutdown now", force=True)
+            )
+        finally:
+            terminal_tool.set_sudo_password_callback(None)
+
+    with patch.object(
+        cli_module, "_sudo_response_queue_factory", PausingQueue
+    ), patch.object(cli_module, "_cprint"):
+        worker = threading.Thread(target=run_terminal, daemon=True)
+        worker.start()
+
+        deadline = time.time() + 2
+        while cli._sudo_state is None and time.time() < deadline:
+            time.sleep(0.01)
+        state = cli._sudo_state
+        assert state is not None
+        assert cli._resolve_sudo_prompt(state, "typed-password")
+        assert response_dequeued.wait(timeout=2), "sudo response was not dequeued"
+
+        generation_before = cli._sudo_interrupt_generation
+        cli._clear_active_overlays_for_interrupt()
+        assert cli._sudo_interrupt_generation == generation_before + 1
+        set_interrupt(True, thread_id=worker.ident)
+        resume_callback.set()
+
+        worker.join(timeout=2)
+        set_interrupt(False, thread_id=worker.ident)
+
+    assert not worker.is_alive()
+    assert result["value"] == {
+        "output": "[Command interrupted]",
+        "exit_code": 130,
+        "error": "Command cancelled before process start.",
+        "status": "cancelled",
+    }
+    assert environment.run_bash_calls == 0
 
 
 def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -14,6 +14,7 @@ import tools.terminal_tool as terminal_tool
 from cli import HermesCLI
 from tools.environments.base import BaseEnvironment
 from tools.interrupt import is_interrupted, set_interrupt
+from tools.process_registry import ProcessStartCancelled
 
 
 def setup_function():
@@ -207,6 +208,195 @@ def test_nonlocal_sudo_dismissal_has_foreground_background_parity(
     assert calls == ["background" if background else "foreground"]
 
 
+@pytest.mark.parametrize("background", [False, True])
+def test_nonlocal_pre_start_interrupt_has_foreground_background_parity(
+    monkeypatch, tmp_path, background
+):
+    import tools.process_registry as process_registry_module
+
+    task_id = f"interrupt-cancel-{'background' if background else 'foreground'}"
+    calls = []
+
+    class FakeEnvironment:
+        cwd = str(tmp_path)
+
+        def execute(self, *_args, **_kwargs):
+            calls.append("foreground")
+            return {
+                "output": "",
+                "returncode": 130,
+                "_process_start_cancelled": True,
+            }
+
+    class FakeRegistry:
+        def spawn_via_env(self, **_kwargs):
+            calls.append("background")
+            raise ProcessStartCancelled
+
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda _task_id: task_id)
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _task_id: {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "docker",
+            "docker_image": "inert-test-image",
+            "cwd": str(tmp_path),
+            "timeout": 60,
+        },
+    )
+    monkeypatch.setitem(terminal_tool._active_environments, task_id, FakeEnvironment())
+    monkeypatch.setitem(terminal_tool._last_activity, task_id, 0.0)
+    monkeypatch.setattr(process_registry_module, "process_registry", FakeRegistry())
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            "echo never-started",
+            background=background,
+            task_id=task_id,
+            force=True,
+        )
+    )
+
+    assert result == {
+        "output": "[Command interrupted]",
+        "exit_code": 130,
+        "error": "Command cancelled before process start.",
+        "status": "cancelled",
+    }
+    assert calls == ["background" if background else "foreground"]
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "[Command interrupted]",
+        "[Command interrupted - Modal sandbox exec cancelled]",
+    ],
+)
+def test_nonlocal_background_marker_interrupt_is_not_reported_started(
+    monkeypatch, tmp_path, marker
+):
+    import tools.process_registry as process_registry_module
+
+    task_id = "marker-interrupt-background"
+
+    class FakeEnvironment:
+        cwd = str(tmp_path)
+
+    class FakeRegistry:
+        def spawn_via_env(self, **_kwargs):
+            raise ProcessStartCancelled(marker, before_start=False)
+
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda _task_id: task_id)
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _task_id: {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "docker",
+            "docker_image": "inert-test-image",
+            "cwd": str(tmp_path),
+            "timeout": 60,
+        },
+    )
+    monkeypatch.setitem(terminal_tool._active_environments, task_id, FakeEnvironment())
+    monkeypatch.setitem(terminal_tool._last_activity, task_id, 0.0)
+    monkeypatch.setattr(process_registry_module, "process_registry", FakeRegistry())
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            "echo interrupted",
+            background=True,
+            task_id=task_id,
+            force=True,
+        )
+    )
+
+    assert result == {
+        "output": marker,
+        "exit_code": 130,
+        "error": "Background process start was interrupted.",
+        "status": "cancelled",
+    }
+    assert "session_id" not in result
+
+
+def test_nonlocal_background_marker_with_pid_is_reported_tracked(
+    monkeypatch, tmp_path
+):
+    import tools.process_registry as process_registry_module
+
+    task_id = "marker-interrupt-background-with-pid"
+    marker = "[Command interrupted]"
+
+    class FakeEnvironment:
+        cwd = str(tmp_path)
+
+    class FakeRegistry:
+        def spawn_via_env(self, **_kwargs):
+            return SimpleNamespace(
+                id="proc_interrupted",
+                pid=4242,
+                start_interrupted=True,
+                start_interrupt_output=f"4242\n{marker}",
+            )
+
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda _task_id: task_id)
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _task_id: {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "ssh",
+            "cwd": str(tmp_path),
+            "timeout": 60,
+        },
+    )
+    monkeypatch.setitem(terminal_tool._active_environments, task_id, FakeEnvironment())
+    monkeypatch.setitem(terminal_tool._last_activity, task_id, 0.0)
+    monkeypatch.setattr(process_registry_module, "process_registry", FakeRegistry())
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            "echo interrupted",
+            background=True,
+            task_id=task_id,
+            force=True,
+        )
+    )
+
+    assert result == {
+        "output": (
+            "4242\n[Command interrupted]\n"
+            "Background process start was interrupted; the process may still "
+            "be running and remains tracked."
+        ),
+        "session_id": "proc_interrupted",
+        "pid": 4242,
+        "exit_code": 130,
+        "error": (
+            "Background process start was interrupted after PID capture; "
+            "the process may still be running."
+        ),
+        "status": "running",
+        "hint": (
+            "background=true without notify_on_complete=true means this process "
+            "runs SILENTLY — you will not be told when it exits. If this is a "
+            "bounded task (test suite, build, CI poller, deploy, anything with "
+            "a defined end), you almost certainly wanted notify_on_complete=true "
+            "so the system pings you on exit. Re-launch with "
+            "notify_on_complete=true, or call process(action='poll') / "
+            "process(action='wait') yourself to learn the outcome. Only ignore "
+            "this hint for genuine long-lived processes that never exit "
+            "(servers, watchers, daemons)."
+        ),
+    }
+
+
 @pytest.mark.parametrize("env_type", ["local", "docker"])
 def test_approved_background_clears_stale_interrupt_once_before_spawn(
     monkeypatch, tmp_path, env_type
@@ -275,6 +465,70 @@ def test_approved_background_clears_stale_interrupt_once_before_spawn(
     assert result["output"] == "Background process started"
     assert result["exit_code"] == 0
     assert interrupt_states_at_spawn == [False]
+    assert clear_calls == ["clear"]
+
+
+def test_approved_nonlocal_background_preserves_genuine_interrupt_after_clear(
+    monkeypatch, tmp_path
+):
+    import tools.interrupt as interrupt_module
+    import tools.process_registry as process_registry_module
+
+    task_id = "approved-background-genuine-interrupt"
+    clear_calls = []
+    real_clear = interrupt_module.clear_current_thread_interrupt
+
+    class FakeEnvironment:
+        cwd = str(tmp_path)
+
+    class FakeRegistry:
+        def spawn_via_env(self, **_kwargs):
+            assert not is_interrupted()
+            set_interrupt(True)
+            raise ProcessStartCancelled
+
+    def tracking_clear():
+        clear_calls.append("clear")
+        real_clear()
+
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda _task_id: task_id)
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _task_id: {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "docker",
+            "docker_image": "inert-test-image",
+            "cwd": str(tmp_path),
+            "timeout": 60,
+        },
+    )
+    monkeypatch.setattr(interrupt_module, "clear_current_thread_interrupt", tracking_clear)
+    monkeypatch.setitem(terminal_tool._active_environments, task_id, FakeEnvironment())
+    monkeypatch.setitem(terminal_tool._last_activity, task_id, 0.0)
+    monkeypatch.setattr(process_registry_module, "process_registry", FakeRegistry())
+
+    set_interrupt(True)
+    try:
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                "echo interrupted",
+                background=True,
+                task_id=task_id,
+                force=True,
+            )
+        )
+        assert is_interrupted()
+    finally:
+        set_interrupt(False)
+
+    assert result == {
+        "output": "[Command interrupted]",
+        "exit_code": 130,
+        "error": "Command cancelled before process start.",
+        "status": "cancelled",
+    }
     assert clear_calls == ["clear"]
 
 

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -1,6 +1,11 @@
 """Regression tests for sudo detection and sudo password handling."""
 
+import json
+
+import pytest
+
 import tools.terminal_tool as terminal_tool
+from tools.environments.base import BaseEnvironment
 
 
 def setup_function():
@@ -75,6 +80,123 @@ def test_explicit_empty_sudo_password_tries_empty_without_prompt(monkeypatch):
 
     assert transformed == "sudo -S -p '' true"
     assert sudo_stdin == "\n"
+
+
+def test_registered_empty_sudo_callback_preserves_skip(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+    terminal_tool.set_sudo_password_callback(lambda: "")
+    try:
+        transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo true")
+    finally:
+        terminal_tool.set_sudo_password_callback(None)
+
+    assert transformed == "sudo true"
+    assert sudo_stdin is None
+
+
+def test_cancelled_sudo_prompt_stops_before_command_execution(monkeypatch, tmp_path):
+    task_id = "sudo-cancel-test"
+
+    class MinimalEnvironment(BaseEnvironment):
+        def __init__(self):
+            super().__init__(cwd=str(tmp_path), timeout=60)
+            self.run_bash_calls = 0
+
+        def _run_bash(self, *_args, **_kwargs):
+            self.run_bash_calls += 1
+            return object()
+
+        def _wait_for_process(self, *_args, **_kwargs):
+            return {"output": "executed", "returncode": 0}
+
+        def cleanup(self):
+            pass
+
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda _task_id: task_id)
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _task_id: {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {"env_type": "local", "cwd": str(tmp_path), "timeout": 60},
+    )
+    environment = MinimalEnvironment()
+    monkeypatch.setitem(terminal_tool._active_environments, task_id, environment)
+    monkeypatch.setitem(terminal_tool._last_activity, task_id, 0.0)
+    terminal_tool.set_sudo_password_callback(lambda: None)
+    try:
+        result = json.loads(terminal_tool.terminal_tool("sudo shutdown now", force=True))
+    finally:
+        terminal_tool.set_sudo_password_callback(None)
+
+    assert result == {
+        "output": "",
+        "exit_code": 130,
+        "error": "Command cancelled: sudo password prompt was dismissed.",
+        "status": "cancelled",
+    }
+    assert environment.run_bash_calls == 0
+
+
+@pytest.mark.parametrize("background", [False, True])
+def test_nonlocal_sudo_dismissal_has_foreground_background_parity(
+    monkeypatch, tmp_path, background
+):
+    import tools.process_registry as process_registry_module
+
+    task_id = f"sudo-cancel-{'background' if background else 'foreground'}"
+    calls = []
+
+    class FakeEnvironment:
+        cwd = str(tmp_path)
+
+        def execute(self, *_args, **_kwargs):
+            calls.append("foreground")
+            raise terminal_tool.SudoPasswordPromptCancelled
+
+    class FakeRegistry:
+        def spawn_via_env(self, **_kwargs):
+            calls.append("background")
+            raise terminal_tool.SudoPasswordPromptCancelled
+
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda _task_id: task_id)
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _task_id: {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "docker",
+            "docker_image": "inert-test-image",
+            "cwd": str(tmp_path),
+            "timeout": 60,
+        },
+    )
+    monkeypatch.setitem(terminal_tool._active_environments, task_id, FakeEnvironment())
+    monkeypatch.setitem(terminal_tool._last_activity, task_id, 0.0)
+    monkeypatch.setattr(process_registry_module, "process_registry", FakeRegistry())
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            "sudo true",
+            background=background,
+            task_id=task_id,
+            force=True,
+        )
+    )
+
+    assert result == {
+        "output": "",
+        "exit_code": 130,
+        "error": "Command cancelled: sudo password prompt was dismissed.",
+        "status": "cancelled",
+    }
+    assert calls == ["background" if background else "foreground"]
 
 
 def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -1,3 +1,8 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
 """Regression tests for sudo detection and sudo password handling."""
 
 import tools.terminal_tool as terminal_tool
@@ -146,3 +151,55 @@ def test_sudo_rewrite_preserves_env_operands_and_prose(monkeypatch):
 def test_count_real_sudo_invocations_ignores_mentions(monkeypatch):
     assert terminal_tool_sudo._count_real_sudo_invocations("grep sudo README.md") == 0
     assert terminal_tool_sudo._count_real_sudo_invocations("sudo a; sudo b") == 2
+
+
+@pytest.mark.parametrize("kind", ["foreground", "background"])
+@pytest.mark.parametrize("response", [None, "", "secret", "cached", "configured", "nopasswd"])
+def test_sudo_callback_outcome_and_credential_precedence(monkeypatch, tmp_path, kind, response):
+    """Both dispatch wrappers preserve dismissal; existing credential sources bypass prompting."""
+    import tools.process_registry as registry_module
+    sudo = terminal_tool_sudo
+    calls = []
+    callback_calls = []
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    if response == "configured":
+        monkeypatch.setenv("SUDO_PASSWORD", "configured-secret")
+    terminal_tool.set_sudo_password_callback(lambda: callback_calls.append(True) or response)
+    if response == "cached":
+        sudo._set_cached_sudo_password("cached-secret")
+
+    def execute(*_args, **_kwargs):
+        # NOPASSWD is now a backend-scoped probe supplied by BaseEnvironment;
+        # exercise that callback seam without probing the host in this fake env.
+        transformed = sudo._transform_sudo_command(
+            "sudo true", sudo_nopasswd_check=lambda: response == "nopasswd")
+        calls.append(transformed)
+        return {"output": "done", "returncode": 0}
+
+    class Registry:
+        def spawn_via_env(self, **_kwargs):
+            execute()
+            return SimpleNamespace(id="test", pid=42)
+
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda _: "sudo-dispatch")
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _: {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: {
+        "env_type": "docker", "docker_image": "inert", "cwd": str(tmp_path), "timeout": 5})
+    monkeypatch.setitem(terminal_tool._active_environments, "sudo-dispatch", SimpleNamespace(execute=execute))
+    monkeypatch.setitem(terminal_tool._last_activity, "sudo-dispatch", 0)
+    monkeypatch.setattr(registry_module, "process_registry", Registry())
+    try:
+        result = json.loads(terminal_tool.terminal_tool("sudo true", background=kind == "background", force=True))
+        if response is None:
+            assert result["status"] == "cancelled"
+            assert result["exit_code"] == 130
+            assert calls == []
+        else:
+            assert result["exit_code"] == 0
+            assert len(calls) == 1
+            expected = {"secret": "secret\n", "cached": "cached-secret\n", "configured": "configured-secret\n"}
+            assert calls[0][1] == expected.get(response)
+        assert len(callback_calls) == (0 if response in ("cached", "configured", "nopasswd") else 1)
+    finally:
+        terminal_tool.set_sudo_password_callback(None)

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -158,6 +158,7 @@ def test_count_real_sudo_invocations_ignores_mentions(monkeypatch):
 def test_sudo_callback_outcome_and_credential_precedence(monkeypatch, tmp_path, kind, response):
     """Both dispatch wrappers preserve dismissal; existing credential sources bypass prompting."""
     import tools.process_registry as registry_module
+    from tools.interrupt import is_interrupted, set_interrupt
     sudo = terminal_tool_sudo
     calls = []
     callback_calls = []
@@ -169,6 +170,7 @@ def test_sudo_callback_outcome_and_credential_precedence(monkeypatch, tmp_path, 
         sudo._set_cached_sudo_password("cached-secret")
 
     def execute(*_args, **_kwargs):
+        assert not is_interrupted()  # stale approval-wait interrupt cleared in either dispatch mode
         # NOPASSWD is now a backend-scoped probe supplied by BaseEnvironment;
         # exercise that callback seam without probing the host in this fake env.
         transformed = sudo._transform_sudo_command(
@@ -190,6 +192,7 @@ def test_sudo_callback_outcome_and_credential_precedence(monkeypatch, tmp_path, 
     monkeypatch.setitem(terminal_tool._last_activity, "sudo-dispatch", 0)
     monkeypatch.setattr(registry_module, "process_registry", Registry())
     try:
+        set_interrupt(True)
         result = json.loads(terminal_tool.terminal_tool("sudo true", background=kind == "background", force=True))
         if response is None:
             assert result["status"] == "cancelled"
@@ -203,3 +206,4 @@ def test_sudo_callback_outcome_and_credential_precedence(monkeypatch, tmp_path, 
         assert len(callback_calls) == (0 if response in ("cached", "configured", "nopasswd") else 1)
     finally:
         terminal_tool.set_sudo_password_callback(None)
+        set_interrupt(False)

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -10,6 +10,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import tools.terminal_tool as terminal_tool
+from tools.environments.base import BaseEnvironment
+
 _original_stdout = sys.stdout
 
 
@@ -282,6 +285,150 @@ def test_clear_pending(server):
 
     assert ev.is_set()
     assert server._answers["r1"] == ""
+
+
+def test_late_sudo_cancel_is_idempotent(server):
+    response = server.handle_request(
+        {
+            "id": "late-sudo-cancel",
+            "method": "sudo.cancel",
+            "params": {"request_id": "expired-request"},
+        }
+    )
+
+    assert response["result"] == {"status": "expired"}
+
+
+def test_gateway_sudo_timeout_translates_to_cancellation(server, monkeypatch):
+    monkeypatch.setattr(server, "_block", lambda *_args, **_kwargs: "")
+
+    assert server._gateway_sudo_password_callback("sid-x") is None
+
+
+def test_gateway_explicit_empty_sudo_submission_survives_translation(
+    server, monkeypatch
+):
+    monkeypatch.setattr(
+        server,
+        "_block",
+        lambda *_args, **_kwargs: server._SUDO_EMPTY_SUBMISSION,
+    )
+
+    assert server._gateway_sudo_password_callback("sid-x") == ""
+
+
+@pytest.mark.parametrize(
+    ("method", "password", "intent", "expected"),
+    [
+        ("sudo.cancel", "ignored", None, None),
+        ("sudo.respond", None, None, None),
+        ("sudo.respond", "", None, None),
+        ("sudo.respond", "", "submit", "empty-submission"),
+    ],
+)
+def test_sudo_response_preserves_versioned_cancel_and_empty_submission(
+    server, method, password, intent, expected
+):
+    ev = threading.Event()
+    server._pending["sudo-1"] = ("sid-x", ev)
+    params = {"request_id": "sudo-1", "password": password}
+    if intent is not None:
+        params["intent"] = intent
+
+    response = server.handle_request(
+        {
+            "id": "sudo-response",
+            "method": method,
+            "params": params,
+        }
+    )
+
+    assert response["result"] == {"status": "ok"}
+    assert ev.is_set()
+    if expected is None:
+        assert server._answers["sudo-1"] is None
+    elif expected == "empty-submission":
+        assert server._answers["sudo-1"] is server._SUDO_EMPTY_SUBMISSION
+    else:
+        assert server._answers["sudo-1"] == expected
+
+
+def test_clear_pending_sudo_uses_null_but_secret_remains_empty(server):
+    events = {
+        "sudo": ("sudo.request", None),
+        "secret": ("secret.request", ""),
+    }
+    for rid, (event, _expected) in events.items():
+        server._pending[rid] = ("sid-x", threading.Event())
+        server._pending_prompt_payloads[rid] = (event, {})
+
+    server._clear_pending()
+
+    assert server._answers["sudo"] is None
+    assert server._answers["secret"] == ""
+
+
+def test_gateway_sudo_dismissal_cancels_before_backend_start(
+    server, monkeypatch, tmp_path
+):
+    task_id = "gateway-sudo-cancel-test"
+
+    class MinimalEnvironment(BaseEnvironment):
+        def __init__(self):
+            super().__init__(cwd=str(tmp_path), timeout=60)
+            self.run_bash_calls = 0
+
+        def _run_bash(self, *_args, **_kwargs):
+            self.run_bash_calls += 1
+            return object()
+
+        def _wait_for_process(self, *_args, **_kwargs):
+            return {"output": "executed", "returncode": 0}
+
+        def cleanup(self):
+            pass
+
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_resolve_container_task_id",
+        lambda _task_id: task_id,
+    )
+    monkeypatch.setattr(terminal_tool, "resolve_task_overrides", lambda _task_id: {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {"env_type": "local", "cwd": str(tmp_path), "timeout": 60},
+    )
+    monkeypatch.setattr(server, "_block", lambda *_args, **_kwargs: None)
+    environment = MinimalEnvironment()
+    monkeypatch.setitem(terminal_tool._active_environments, task_id, environment)
+    monkeypatch.setitem(terminal_tool._last_activity, task_id, 0.0)
+
+    callback = lambda: server._gateway_sudo_password_callback("sid-x")
+    assert callback() is None
+
+    terminal_tool.set_sudo_password_callback(callback)
+    try:
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                "sudo true",
+                task_id=task_id,
+                force=True,
+            )
+        )
+    finally:
+        terminal_tool.set_sudo_password_callback(None)
+
+    assert result == {
+        "output": "",
+        "exit_code": 130,
+        "error": "Command cancelled: sudo password prompt was dismissed.",
+        "status": "cancelled",
+    }
+    assert environment.run_bash_calls == 0
 
 
 # ── Session lookup ───────────────────────────────────────────────────

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1504,3 +1504,58 @@ def test_unregister_live_transport_stops_delivery(capture):
     assert a.frames == []
     # No live transports left → fell back to stdio.
     assert json.loads(buf.getvalue())["params"]["type"] == "skin.changed"
+
+
+@pytest.mark.parametrize("decision", ["cancel", "legacy-empty", "submit-empty", "password", "interrupt", "timeout"])
+def test_sudo_wire_decision_reaches_password_bridge(server, monkeypatch, decision):
+    import tools.terminal_tool as terminal
+    import tools.terminal_tool_sudo as sudo
+
+    seen = []
+
+    def emit(event, sid, payload):
+        seen.append((event, sid, payload))
+        if event != "sudo.request":
+            return
+        params = {"request_id": payload["request_id"]}
+        if decision == "timeout":
+            return
+        if decision == "interrupt":
+            server._clear_pending(sid)
+            return
+        method = "sudo.cancel" if decision == "cancel" else "sudo.respond"
+        if decision == "submit-empty":
+            params.update(intent="submit", password="")
+        elif decision == "password":
+            params["password"] = "test-password"
+        elif decision == "legacy-empty":
+            params["password"] = ""
+        response = server._methods.get(method, lambda *_: {"error": "unknown method"})("rpc", params)
+        assert "error" not in response, response
+
+    monkeypatch.setattr(server, "_emit", emit)
+    real_block = server._block
+    monkeypatch.setattr(server, "_block", lambda event, sid, payload, **kw: real_block(event, sid, payload, timeout=0))
+    server._wire_callbacks("sudo-session")
+    try:
+        if decision in ("cancel", "legacy-empty", "interrupt"):
+            with pytest.raises(sudo.SudoPasswordPromptCancelled):
+                sudo._prompt_for_sudo_password()
+        else:
+            assert sudo._prompt_for_sudo_password() == ("test-password" if decision == "password" else "")
+        assert not server._pending
+        assert not server._answers
+        assert any(event == "sudo.request" for event, _, _ in seen)
+    finally:
+        terminal.set_sudo_password_callback(None)
+
+
+def test_sudo_cancel_is_late_safe_and_does_not_resolve_other_prompt(server, monkeypatch):
+    ev = threading.Event()
+    server._pending["other-request"] = ("owner", ev)
+    monkeypatch.setitem(server._pending_prompt_payloads, "other-request", ("secret.request", {}))
+    method = server._methods.get("sudo.cancel", lambda *_: {"error": "unknown method"})
+    assert "error" in method("rpc", {"request_id": "other-request"})
+    assert not ev.is_set()
+    assert "other-request" not in server._answers
+    assert method("rpc", {"request_id": "already-expired"})["result"]["status"] == "expired"

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -24,7 +24,7 @@ from typing import IO, Callable, Iterable, Protocol
 
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
-from tools.interrupt import is_interrupted
+from tools.interrupt import is_interrupted, start_if_not_interrupted
 
 logger = logging.getLogger(__name__)
 
@@ -1408,9 +1408,20 @@ class BaseEnvironment(ABC):
         # unless login itself is broken — then non-login is the only path.
         login = not self._snapshot_ready and not self._prefer_nonlogin
 
-        proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+        process_started, proc = start_if_not_interrupted(
+            lambda: self._run_bash(
+                wrapped,
+                login=login,
+                timeout=effective_timeout,
+                stdin_data=effective_stdin,
+            )
         )
+        if not process_started:
+            return {
+                "output": "",
+                "returncode": 130,
+                "_process_start_cancelled": True,
+            }
         result = self._wait_for_process(
             proc, timeout=effective_timeout, bounded_capture=bounded_capture
         )

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -384,7 +384,8 @@ class BaseEnvironment(ABC):
                 if is_interrupted() or is_thread_interrupted(watch_interrupt_tid):
                     trace.interrupted()
                     _kill_and_join()
-                    return self._finalize_wait_result(output, output.render(suffix="\n[Command interrupted]"), 130)
+                    return {**self._finalize_wait_result(output, output.render(suffix="\n[Command interrupted]"), 130),
+                            "_process_interrupted": True}
                 if yield_handler is not None and consume_yield(watch_interrupt_tid):
                     drain_stop.set()
                     drain_thread.join(timeout=1)

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Callable, Iterable
 
 from hermes_constants import get_hermes_home
-from tools.interrupt import consume_yield, is_interrupted, is_thread_interrupted
+from tools.interrupt import consume_yield, is_interrupted, is_thread_interrupted, start_if_not_interrupted
 from tools.environments.base_output import (
     ProcessHandle, _finalize_wait_result, _new_output_collector, _start_drain_thread,
 )
@@ -530,7 +530,11 @@ class BaseEnvironment(ABC):
         def _spawn_and_wait() -> dict:
             if parent_activity_cb is not None:
                 set_activity_callback(parent_activity_cb)
-            spawned = self._run_bash(wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin)
+            started, spawned = start_if_not_interrupted(
+                lambda: self._run_bash(wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin),
+                thread_id=parent_tid)
+            if not started:
+                return {"output": "", "returncode": 130, "_process_start_cancelled": True}
             proc_holder.append(spawned)
             return self._wait_for_process(
                 spawned, timeout=effective_timeout, bounded_capture=bounded_capture,

--- a/tools/environments/managed_modal.py
+++ b/tools/environments/managed_modal.py
@@ -112,7 +112,8 @@ class ManagedModalEnvironment(BaseEnvironment):
         while True:
             if is_interrupted():
                 self._cancel_exec(exec_id)
-                return _result("[Command interrupted - Modal sandbox exec cancelled]", 130)
+                return {**_result("[Command interrupted - Modal sandbox exec cancelled]", 130),
+                        "_process_interrupted": True}
             try:
                 if (result := self._poll_exec(exec_id)) is not None:
                     return result

--- a/tools/environments/managed_modal.py
+++ b/tools/environments/managed_modal.py
@@ -17,7 +17,7 @@ import uuid
 from typing import Any, Dict, Optional
 
 from tools.environments.base import BaseEnvironment
-from tools.interrupt import is_interrupted
+from tools.interrupt import is_interrupted, start_if_not_interrupted
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 
 logger = logging.getLogger(__name__)
@@ -93,7 +93,10 @@ class ManagedModalEnvironment(BaseEnvironment):
         if stdin_data is not None:
             payload["stdinData"] = stdin_data
         try:
-            response = self._request("POST", f"/v1/sandboxes/{self._sandbox_id}/execs", json=payload, timeout=10)
+            started, response = start_if_not_interrupted(
+                lambda: self._request("POST", f"/v1/sandboxes/{self._sandbox_id}/execs", json=payload, timeout=10))
+            if not started:
+                return {"output": "", "returncode": 130, "_process_start_cancelled": True}
             body = response.json() if response.status_code < 400 else None
         except Exception as exc:
             return _result(f"Managed Modal exec failed: {exc}")

--- a/tools/environments/modal_utils.py
+++ b/tools/environments/modal_utils.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from tools.environments.base import BaseEnvironment
-from tools.interrupt import is_interrupted
+from tools.interrupt import is_interrupted, start_if_not_interrupted
 
 
 @dataclass(frozen=True)
@@ -100,10 +100,20 @@ class BaseModalExecutionEnvironment(BaseEnvironment):
         )
 
         try:
-            start = self._start_modal_exec(prepared)
+            transport_started, start = start_if_not_interrupted(
+                lambda: self._start_modal_exec(prepared)
+            )
         except Exception as exc:
             return self._error_result(f"{self._unexpected_error_prefix}: {exc}")
 
+        if not transport_started:
+            return {
+                "output": "",
+                "returncode": 130,
+                "_process_start_cancelled": True,
+            }
+
+        assert start is not None
         if start.immediate_result is not None:
             return start.immediate_result
 

--- a/tools/interrupt.py
+++ b/tools/interrupt.py
@@ -17,6 +17,9 @@ Usage in tools:
 import logging
 import os
 import threading
+import weakref
+from collections.abc import Callable
+from typing import TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +37,20 @@ if _DEBUG_INTERRUPT:
 # Set of thread idents that have been interrupted.
 _interrupted_threads: set[int] = set()
 _lock = threading.Lock()
+_process_start_locks: weakref.WeakValueDictionary[int, threading.RLock] = (
+    weakref.WeakValueDictionary()
+)
+_T = TypeVar("_T")
+
+
+def _process_start_lock(thread_id: int) -> threading.RLock:
+    """Return the per-thread lock that orders interrupts with external starts."""
+    with _lock:
+        start_lock = _process_start_locks.get(thread_id)
+        if start_lock is None:
+            start_lock = threading.RLock()
+            _process_start_locks[thread_id] = start_lock
+        return start_lock
 
 
 def set_interrupt(active: bool, thread_id: int | None = None) -> None:
@@ -45,12 +62,14 @@ def set_interrupt(active: bool, thread_id: int | None = None) -> None:
                    current thread (backward compat for CLI/tests).
     """
     tid = thread_id if thread_id is not None else threading.current_thread().ident
-    with _lock:
-        if active:
-            _interrupted_threads.add(tid)
-        else:
-            _interrupted_threads.discard(tid)
-        _snapshot = set(_interrupted_threads) if _DEBUG_INTERRUPT else None
+    start_lock = _process_start_lock(tid)
+    with start_lock:
+        with _lock:
+            if active:
+                _interrupted_threads.add(tid)
+            else:
+                _interrupted_threads.discard(tid)
+            _snapshot = set(_interrupted_threads) if _DEBUG_INTERRUPT else None
     if _DEBUG_INTERRUPT:
         logger.info(
             "[interrupt-debug] set_interrupt(active=%s, target_tid=%s) "
@@ -68,6 +87,23 @@ def is_interrupted() -> bool:
     tid = threading.current_thread().ident
     with _lock:
         return tid in _interrupted_threads
+
+
+def start_if_not_interrupted(start: Callable[[], _T]) -> tuple[bool, _T | None]:
+    """Linearize an external effect's creation with the current-thread interrupt.
+
+    A per-thread start lock remains held while ``start`` crosses the backend
+    process/transport creation boundary. Therefore either an already-published
+    interrupt prevents creation, or creation wins and a concurrent interrupt is
+    published immediately afterward for the normal process wait loop to observe.
+    """
+    tid = threading.current_thread().ident
+    start_lock = _process_start_lock(tid)
+    with start_lock:
+        with _lock:
+            if tid in _interrupted_threads:
+                return False, None
+        return True, start()
 
 
 def clear_current_thread_interrupt() -> None:

--- a/tools/interrupt.py
+++ b/tools/interrupt.py
@@ -6,6 +6,8 @@ is_interrupted(), which checks the CURRENT thread."""
 import logging
 import os
 import threading
+import weakref
+from typing import TypeVar
 from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
@@ -24,21 +26,48 @@ _interrupt_reasons: dict[int, str] = {}
 # instead of killing it, so a mid-turn user message is not parked behind it.
 _yield_threads: set[int] = set()
 _lock = threading.Lock()
+_process_start_locks: weakref.WeakValueDictionary[int, threading.RLock] = weakref.WeakValueDictionary()
+_T = TypeVar("_T")
+
+
+def _process_start_lock(thread_id: int) -> threading.RLock:
+    with _lock:
+        lock = _process_start_locks.get(thread_id)
+        if lock is None:
+            lock = threading.RLock()
+            _process_start_locks[thread_id] = lock
+        return lock
+
+
+def start_if_not_interrupted(start: Callable[[], _T], *, thread_id: int | None = None) -> tuple[bool, _T | None]:
+    """Order a process/transport start with its owner's interrupt publication.
+
+    Deadline workers pass the originating tool thread ID. If creation wins,
+    interruption becomes visible to the normal wait loop immediately afterward.
+    The per-owner lock leaves other sessions free to start and interrupt.
+    """
+    tid = threading.get_ident() if thread_id is None else thread_id
+    with _process_start_lock(tid):
+        if is_thread_interrupted(tid):
+            return False, None
+        return True, start()
+
 
 
 def set_interrupt(active: bool, thread_id: int | None = None, *, reason: str | None = None) -> None:
     """Set or clear the interrupt for *thread_id* (default: current thread); ``reason`` is
     an optional user-safe cause. Clearing also drops a pending yield request."""
     tid = thread_id if thread_id is not None else threading.current_thread().ident
-    with _lock:
-        (_interrupted_threads.add if active else _interrupted_threads.discard)(tid)
-        if active and reason:
-            _interrupt_reasons[tid] = reason
-        else:
-            _interrupt_reasons.pop(tid, None)
-        if not active:
-            _yield_threads.discard(tid)
-        _snapshot = set(_interrupted_threads) if _DEBUG_INTERRUPT else None
+    with _process_start_lock(tid):
+        with _lock:
+            (_interrupted_threads.add if active else _interrupted_threads.discard)(tid)
+            if active and reason:
+                _interrupt_reasons[tid] = reason
+            else:
+                _interrupt_reasons.pop(tid, None)
+            if not active:
+                _yield_threads.discard(tid)
+            _snapshot = set(_interrupted_threads) if _DEBUG_INTERRUPT else None
     if _DEBUG_INTERRUPT:
         logger.info(
             "[interrupt-debug] set_interrupt(active=%s, target_tid=%s) "

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -49,10 +49,40 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
+from tools.interrupt import start_if_not_interrupted
 
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
+
+_ENV_TERMINATED_MARKER = "__HERMES_PROCESS_TERMINATED__"
+
+
+class ProcessStartCancelled(RuntimeError):
+    """Raised when an environment interrupt wins before background start."""
+
+    def __init__(
+        self,
+        output: str = "[Command interrupted]",
+        *,
+        before_start: bool = True,
+    ):
+        super().__init__(output)
+        self.output = output
+        self.before_start = before_start
+
+
+def _is_marker_bearing_interrupt_result(result: dict) -> bool:
+    """Recognize executor-owned interrupt results, not natural child rc=130."""
+    try:
+        returncode = int(result.get("returncode", -1))
+    except (TypeError, ValueError):
+        return False
+    output = str(result.get("output", ""))
+    return returncode == 130 and (
+        "[Command interrupted]" in output
+        or "[Command interrupted -" in output
+    )
 
 
 # Checkpoint file for crash recovery (gateway only)
@@ -358,8 +388,10 @@ class ProcessSession:
     output_buffer: str = ""                     # Rolling output (last MAX_OUTPUT_CHARS)
     max_output_chars: int = MAX_OUTPUT_CHARS
     detached: bool = False                      # True if recovered from crash (no pipe)
-    pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
+    pid_scope: str = "host"                     # host|sandbox|sandbox_group
     systemd_unit: str = ""                      # transient scope unit name when spawned under systemd-run (#70716)
+    start_interrupted: bool = False              # Bootstrap was interrupted after producing a PID
+    start_interrupt_output: str = ""             # Executor marker retained for the immediate caller
     # Watcher/notification metadata (persisted for crash recovery)
     watcher_platform: str = ""
     watcher_chat_id: str = ""
@@ -1022,12 +1054,16 @@ class ProcessRegistry:
                     except Exception:
                         pass
 
-                pty_proc = _PtyProcessCls.spawn(
-                    pty_argv,
-                    cwd=session.cwd,
-                    env=pty_env,
-                    dimensions=(30, 120),
+                process_started, pty_proc = start_if_not_interrupted(
+                    lambda: _PtyProcessCls.spawn(
+                        pty_argv,
+                        cwd=session.cwd,
+                        env=pty_env,
+                        dimensions=(30, 120),
+                    )
                 )
+                if not process_started:
+                    raise ProcessStartCancelled
                 session.pid = pty_proc.pid
                 session.host_start_time = self._safe_host_start_time(session.pid)
                 # Store the pty handle on the session for read/write
@@ -1050,6 +1086,8 @@ class ProcessRegistry:
                 self._write_checkpoint()
                 return session
 
+            except ProcessStartCancelled:
+                raise
             except ImportError:
                 logger.warning("ptyprocess not installed, falling back to pipe mode")
             except Exception as e:
@@ -1123,19 +1161,23 @@ class ProcessRegistry:
                     _systemd_run_user_scope_available(),
                 )
 
-        proc = subprocess.Popen(
-            spawn_argv,
-            text=True,
-            cwd=session.cwd,
-            env=bg_env,
-            encoding="utf-8",
-            errors="replace",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.DEVNULL,
-            start_new_session=popen_start_new_session,
-            **_popen_kwargs,
+        process_started, proc = start_if_not_interrupted(
+            lambda: subprocess.Popen(
+                spawn_argv,
+                text=True,
+                cwd=session.cwd,
+                env=bg_env,
+                encoding="utf-8",
+                errors="replace",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                start_new_session=popen_start_new_session,
+                **_popen_kwargs,
+            )
         )
+        if not process_started:
+            raise ProcessStartCancelled
 
         session.process = proc
         session.pid = proc.pid
@@ -1215,7 +1257,7 @@ class ProcessRegistry:
             cwd=cwd,
             started_at=time.time(),
             env_ref=env,
-            pid_scope="sandbox",
+            pid_scope="sandbox_group",
         )
 
         # Run the command in the sandbox with output capture
@@ -1228,11 +1270,27 @@ class ProcessRegistry:
         quoted_log_path = shlex.quote(log_path)
         quoted_pid_path = shlex.quote(pid_path)
         quoted_exit_path = shlex.quote(exit_path)
+        # Run a supervisor as a new process-group leader. The
+        # supervisor waits for the requested login shell and records its exit
+        # status, while the recorded PID is also the process-group ID. This
+        # lets kill_process() terminate the supervisor and its descendants
+        # together instead of killing only an outer nohup wrapper and
+        # orphaning the requested command. ``set -m`` asks the already-required
+        # bash to assign a dedicated group to the background job, avoiding a
+        # dependency on the optional external ``setsid`` utility.
+        supervisor_script = (
+            'printf \'%s\\n\' "$$" > "$2"; '
+            'bash -lc "$1"; rc=$?; printf \'%s\\n\' "$rc" > "$3"'
+        )
+        quoted_supervisor_script = shlex.quote(supervisor_script)
         bg_command = (
-            f"mkdir -p {quoted_temp_dir} && "
-            f"( nohup bash -lc {quoted_command} > {quoted_log_path} 2>&1; "
-            f"rc=$?; printf '%s\\n' \"$rc\" > {quoted_exit_path} ) & "
-            f"echo $! > {quoted_pid_path} && cat {quoted_pid_path}"
+            f"mkdir -p {quoted_temp_dir} && {{ "
+            f"set -m; nohup bash -c {quoted_supervisor_script} "
+            f"hermes-bg {quoted_command} {quoted_pid_path} {quoted_exit_path} "
+            f"> {quoted_log_path} 2>&1 < /dev/null & "
+            f"for _hermes_wait in {{1..100}}; do "
+            f"test -s {quoted_pid_path} && break; sleep 0.01; done; "
+            f"cat {quoted_pid_path}; }}"
         )
 
         try:
@@ -1248,6 +1306,21 @@ class ProcessRegistry:
                 if line.isdigit():
                     session.pid = int(line)
                     break
+            pre_start_cancelled = bool(result.get("_process_start_cancelled"))
+            marker_bearing_interrupt = _is_marker_bearing_interrupt_result(result)
+            if session.pid is None and pre_start_cancelled:
+                raise ProcessStartCancelled
+            if session.pid is None and marker_bearing_interrupt:
+                raise ProcessStartCancelled(output, before_start=False)
+            if session.pid is not None and (
+                pre_start_cancelled or marker_bearing_interrupt
+            ):
+                # The detached child may have outlived the interrupted outer
+                # executor (notably for SSH). Keep it observable and killable
+                # instead of reporting clean cancellation and discarding its PID.
+                session.start_interrupted = True
+                session.start_interrupt_output = output
+                session.output_buffer = output
             # If the wrapper couldn't produce a PID (for example, syntax
             # error or broken redirect), treat it as a failed launch instead
             # of exposing a fake running session.
@@ -1259,7 +1332,16 @@ class ProcessRegistry:
                 session.completion_reason = "failed_start"
                 session.termination_source = "failed_start"
                 session.output_buffer = result.get("output", "").strip()
+        except ProcessStartCancelled:
+            raise
         except Exception as e:
+            # The terminal layer owns the user-facing cancellation payload.
+            # Preserve explicit sudo dismissal instead of converting it into a
+            # fake failed background session.
+            from tools.terminal_tool import SudoPasswordPromptCancelled
+
+            if isinstance(e, SudoPasswordPromptCancelled):
+                raise
             session.exited = True
             session.exit_code = -1
             session.completion_reason = "failed_start"
@@ -1286,6 +1368,25 @@ class ProcessRegistry:
             self._write_checkpoint()
 
         return session
+
+    @staticmethod
+    def _env_termination_command(pid: int, *, process_group: bool) -> str:
+        """Build a bounded, self-verifying sandbox termination command."""
+        target = f"-{pid}" if process_group else str(pid)
+        return (
+            f"_hermes_target={target}; "
+            f"kill -TERM -- \"$_hermes_target\" 2>/dev/null || true; "
+            f"for _hermes_probe in {{1..20}}; do "
+            f"kill -0 -- \"$_hermes_target\" 2>/dev/null || {{ "
+            f"printf '%s\\n' {_ENV_TERMINATED_MARKER}; exit 0; }}; "
+            f"sleep 0.05; done; "
+            f"kill -KILL -- \"$_hermes_target\" 2>/dev/null || true; "
+            f"for _hermes_probe in {{1..20}}; do "
+            f"kill -0 -- \"$_hermes_target\" 2>/dev/null || {{ "
+            f"printf '%s\\n' {_ENV_TERMINATED_MARKER}; exit 0; }}; "
+            f"sleep 0.05; done; "
+            f"printf '%s\\n' __HERMES_PROCESS_STILL_RUNNING__; exit 1"
+        )
 
     # ----- Reader / Poller Threads -----
 
@@ -2038,8 +2139,36 @@ class ProcessRegistry:
                 # shell wrapper and leaves Git Bash descendants behind.
                 self._terminate_host_pid(session.process.pid, session.host_start_time)
             elif session.env_ref and session.pid:
-                # Non-local -- kill inside sandbox
-                session.env_ref.execute(f"kill {session.pid} 2>/dev/null", timeout=5)
+                # Non-local -- new sessions track a dedicated sandbox process
+                # group so the requested shell and all ordinary descendants
+                # are terminated with their supervisor. Verify the target is
+                # gone (with bounded SIGKILL escalation) before dropping the
+                # session from tracking or reporting success. Keep the
+                # single-PID path for legacy/injected sessions.
+                termination_command = self._env_termination_command(
+                    session.pid,
+                    process_group=session.pid_scope == "sandbox_group",
+                )
+                termination = session.env_ref.execute(
+                    termination_command,
+                    timeout=5,
+                )
+                termination_output = str(termination.get("output", ""))
+                try:
+                    termination_rc = int(termination.get("returncode", -1))
+                except (TypeError, ValueError):
+                    termination_rc = -1
+                if (
+                    termination_rc != 0
+                    or _ENV_TERMINATED_MARKER not in termination_output
+                ):
+                    return {
+                        "status": "error",
+                        "error": (
+                            "Sandbox process termination could not be confirmed; "
+                            "the process remains tracked"
+                        ),
+                    }
             elif session.detached and session.pid_scope == "host" and session.pid:
                 # Identity check, not bare liveness: if the PID is gone OR was
                 # recycled onto an unrelated process, treat our process as

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1031,6 +1031,9 @@ class ProcessRegistry(ProcessCheckpointMixin):
                 session.mark_exited(int(result.get("returncode", -1)) or -1, "failed_start", "failed_start")
                 session.output_buffer = output
         except Exception as e:
+            from tools.terminal_tool_sudo import SudoPasswordPromptCancelled
+            if isinstance(e, SudoPasswordPromptCancelled):
+                raise
             session.mark_exited(-1, "failed_start", "failed_start")
             session.output_buffer = f"Failed to start: {e}"
         if session.exited:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -34,6 +34,12 @@ from hermes_cli.config import get_hermes_home
 from tools.process_registry_notifications import format_process_notification
 from tools.process_registry_checkpoint import ProcessCheckpointMixin
 from tools.process_registry_results import load_completed_results, save_completed_result
+from tools.interrupt import start_if_not_interrupted
+
+
+class ProcessStartCancelled(RuntimeError):
+    """A published interrupt prevented detached process creation."""
+
 
 logger = logging.getLogger(__name__)
 
@@ -401,6 +407,7 @@ class ProcessSession:
     termination_source: str = ""                # process.kill|kill_all|backend_lost|failed_start
     output_buffer: str = ""                     # Rolling tail (last max_output_chars)
     max_output_chars: int = MAX_OUTPUT_CHARS
+    start_interrupted: bool = False             # The detached start outcome is uncertain
     detached: bool = False                      # Recovered from checkpoint (no pipe)
     pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
     systemd_unit: str = ""                      # transient scope unit name when spawned under systemd-run
@@ -900,7 +907,10 @@ class ProcessRegistry(ProcessCheckpointMixin):
         # hang waiting for `q` — default them to cat, honoring any pager the user set.
         pty_env.setdefault("GIT_PAGER", "cat")
         pty_env.setdefault("PAGER", "cat")
-        pty_proc = _PtyProcessCls.spawn(pty_argv, cwd=session.cwd, env=pty_env, dimensions=(30, 120))
+        started, pty_proc = start_if_not_interrupted(
+            lambda: _PtyProcessCls.spawn(pty_argv, cwd=session.cwd, env=pty_env, dimensions=(30, 120)))
+        if not started:
+            raise ProcessStartCancelled
         session.pid = pty_proc.pid
         session.host_start_time = self._safe_host_start_time(session.pid)
         session._pty = pty_proc
@@ -925,6 +935,8 @@ class ProcessRegistry(ProcessCheckpointMixin):
         if use_pty:
             try:
                 return self._spawn_local_pty(session, safe_command, env_vars)
+            except ProcessStartCancelled:
+                raise
             except ImportError:
                 logger.warning("ptyprocess not installed, falling back to pipe mode")
             except Exception as e:
@@ -949,10 +961,12 @@ class ProcessRegistry(ProcessCheckpointMixin):
         # share the foreground process group and background spawns would stop the whole
         # session (observed as dead TUIs in state T). Cgroup isolation is unaffected —
         # the scope attaches to the invoked process, not the spawning session.
-        proc = subprocess.Popen(
+        started, proc = start_if_not_interrupted(lambda: subprocess.Popen(
             spawn_argv, text=True, cwd=session.cwd, env=spawn_env, encoding="utf-8",
             errors="replace", stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL,
-            start_new_session=True, **_popen_kwargs)
+            start_new_session=True, **_popen_kwargs))
+        if not started:
+            raise ProcessStartCancelled
         session.process = proc
         session.pid = proc.pid
         session.host_start_time = self._safe_host_start_time(session.pid)
@@ -1025,11 +1039,20 @@ class ProcessRegistry(ProcessCheckpointMixin):
             result = env.execute(bg_command, timeout=timeout, rewrite_compound_background=False)
             output = result.get("output", "").strip()
             session.pid = next((int(ln) for ln in map(str.strip, output.splitlines()) if ln.isdigit()), None)
-            # No PID from the wrapper (syntax error, broken redirect): a failed launch,
-            # not a fake running session.
-            if session.pid is None:
+            if session.pid is None and result.get("_process_start_cancelled"):
+                raise ProcessStartCancelled
+            # Executor-owned metadata distinguishes interruption from arbitrary
+            # child output or a natural exit 130. An uncertain start stays tracked
+            # even before PID capture; the poller can recover its persisted PID.
+            session.start_interrupted = bool(result.get("_process_interrupted") or result.get("_process_start_cancelled"))
+            if session.start_interrupted:
+                session.output_buffer = output[-session.max_output_chars:]
+            # A definite failed launch without a PID is not a running session.
+            if session.pid is None and not session.start_interrupted:
                 session.mark_exited(int(result.get("returncode", -1)) or -1, "failed_start", "failed_start")
                 session.output_buffer = output
+        except ProcessStartCancelled:
+            raise
         except Exception as e:
             from tools.terminal_tool_sudo import SudoPasswordPromptCancelled
             if isinstance(e, SudoPasswordPromptCancelled):
@@ -1182,6 +1205,12 @@ class ProcessRegistry(ProcessCheckpointMixin):
         while not session.exited:
             time.sleep(2)
             try:
+                if session.start_interrupted and session.pid is None:
+                    pid_text = env.execute(f"cat {q(pid_path)} 2>/dev/null", timeout=5).get("output", "")
+                    session.pid = next((int(line) for line in map(str.strip, pid_text.splitlines())
+                                        if line.isdigit() and int(line) > 0), None)
+                    if session.pid is None:
+                        continue  # absence of a PID does not disprove an uncertain remote start
                 # Read only the bytes written since the last poll.
                 raw = env.execute(self._log_delta_command(q(log_path), prev_output_bytes),
                                   timeout=10).get("output", "")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -267,6 +267,10 @@ _sudo_password_cache_lock = threading.Lock()
 _callback_tls = threading.local()
 
 
+class SudoPasswordPromptCancelled(Exception):
+    """Raised when the user explicitly cancels a sudo password prompt."""
+
+
 def _get_sudo_password_callback():
     return getattr(_callback_tls, "sudo_password", None)
 
@@ -494,8 +498,9 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
     
     Only works in interactive mode (HERMES_INTERACTIVE=1).
     If a _sudo_password_callback is registered (by the CLI), delegates to it
-    so the prompt integrates with prompt_toolkit's UI.  Otherwise reads
-    directly from /dev/tty with echo disabled.
+    so the prompt integrates with prompt_toolkit's UI. A callback result of
+    ``None`` means explicit cancellation and aborts the pending command.
+    Otherwise reads directly from /dev/tty with echo disabled.
     """
     import sys
     
@@ -503,7 +508,12 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
     _sudo_cb = _get_sudo_password_callback()
     if _sudo_cb is not None:
         try:
-            return _sudo_cb() or ""
+            password = _sudo_cb()
+            if password is None:
+                raise SudoPasswordPromptCancelled
+            return password or ""
+        except SudoPasswordPromptCancelled:
+            raise
         except Exception:
             return ""
 
@@ -3038,6 +3048,8 @@ def terminal_tool(
                     result_data["watch_patterns"] = proc_session.watch_patterns
 
                 return json.dumps(result_data, ensure_ascii=False)
+            except SudoPasswordPromptCancelled:
+                raise
             except Exception as e:
                 return json.dumps({
                     "output": "",
@@ -3081,6 +3093,8 @@ def terminal_tool(
                         "bounded_capture": True,
                     }
                     result = env.execute(command, **execute_kwargs)
+                except SudoPasswordPromptCancelled:
+                    raise
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:
@@ -3347,6 +3361,13 @@ def terminal_tool(
             "error": f"Terminal backend degraded: {e.reason}",
         }, ensure_ascii=False)
 
+    except SudoPasswordPromptCancelled:
+        return json.dumps({
+            "output": "",
+            "exit_code": 130,
+            "error": "Command cancelled: sudo password prompt was dismissed.",
+            "status": "cancelled",
+        }, ensure_ascii=False)
     except Exception as e:
         import traceback
         tb_str = traceback.format_exc()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2807,6 +2807,15 @@ def terminal_tool(
             )
 
         # The session key is already computed above the gateway guard.
+        # Clean the interrupt slate for an approved command exactly once, after
+        # approval/workdir preparation but before either foreground or
+        # background dispatch. A stale bit from the approval wait must not
+        # cancel the approved start; a genuine interrupt arriving after this
+        # boundary remains visible to the spawn/start guard and wait loop.
+        if _approved_run:
+            from tools.interrupt import clear_current_thread_interrupt
+
+            clear_current_thread_interrupt()
         if background:
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.
@@ -3065,16 +3074,6 @@ def terminal_tool(
             result = None
             command_cwd = None
 
-            # Clean interrupt slate for an approved command, ONCE before the
-            # retry loop: drop a stale bit that landed on this thread during the
-            # approval-wait so it can't SIGINT the just-approved run.  Do NOT
-            # re-clear inside the loop -- a genuine interrupt arriving during the
-            # backoff sleep between retries must survive and abort the command
-            # (caught by the next attempt's _wait_for_process poll loop -> 130).
-            if _approved_run:
-                from tools.interrupt import clear_current_thread_interrupt
-                clear_current_thread_interrupt()
-
             while retry_count <= max_retries:
                 try:
                     command_cwd = _resolve_command_cwd(
@@ -3147,6 +3146,14 @@ def terminal_tool(
             # output overflowed the capture window (see _wait_for_process).
             spill_total_chars = result.get("output_total_chars")
             spill_file_path = result.get("full_output_path")
+
+            if result.get("_process_start_cancelled"):
+                return json.dumps({
+                    "output": "[Command interrupted]",
+                    "exit_code": 130,
+                    "error": "Command cancelled before process start.",
+                    "status": "cancelled",
+                }, ensure_ascii=False)
 
             # Add helpful message for sudo failures in messaging context
             output = _handle_sudo_failure(output, env_type)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2820,7 +2820,7 @@ def terminal_tool(
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.
             # For non-local backends: runs inside the sandbox via env.execute().
-            from tools.process_registry import process_registry
+            from tools.process_registry import ProcessStartCancelled, process_registry
 
             effective_cwd = _resolve_command_cwd(
                 workdir=workdir,
@@ -2846,13 +2846,37 @@ def terminal_tool(
                         session_key=session_key,
                     )
 
-                result_data = {
-                    "output": "Background process started",
-                    "session_id": proc_session.id,
-                    "pid": proc_session.pid,
-                    "exit_code": 0,
-                    "error": None,
-                }
+                if getattr(proc_session, "start_interrupted", False) is True:
+                    interrupt_output = (
+                        getattr(proc_session, "start_interrupt_output", "") or ""
+                    ).strip()
+                    tracking_note = (
+                        "Background process start was interrupted; the process "
+                        "may still be running and remains tracked."
+                    )
+                    result_data = {
+                        "output": (
+                            f"{interrupt_output}\n{tracking_note}"
+                            if interrupt_output
+                            else tracking_note
+                        ),
+                        "session_id": proc_session.id,
+                        "pid": proc_session.pid,
+                        "exit_code": 130,
+                        "error": (
+                            "Background process start was interrupted after PID "
+                            "capture; the process may still be running."
+                        ),
+                        "status": "running",
+                    }
+                else:
+                    result_data = {
+                        "output": "Background process started",
+                        "session_id": proc_session.id,
+                        "pid": proc_session.pid,
+                        "exit_code": 0,
+                        "error": None,
+                    }
                 # Background spawns detached and returns exit_code 0 immediately;
                 # it never inline-polls is_interrupted(), so the stale-bit kill
                 # cannot occur here and this note never co-occurs with rc=130.
@@ -3059,6 +3083,17 @@ def terminal_tool(
                 return json.dumps(result_data, ensure_ascii=False)
             except SudoPasswordPromptCancelled:
                 raise
+            except ProcessStartCancelled as exc:
+                return json.dumps({
+                    "output": exc.output,
+                    "exit_code": 130,
+                    "error": (
+                        "Command cancelled before process start."
+                        if exc.before_start
+                        else "Background process start was interrupted."
+                    ),
+                    "status": "cancelled",
+                }, ensure_ascii=False)
             except Exception as e:
                 return json.dumps({
                     "output": "",

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -152,6 +152,7 @@ def _check_all_guards(command: str, env_type: str,
 
 
 from tools.environments.base import EnvironmentConnectionError
+from tools.terminal_tool_sudo import SudoPasswordPromptCancelled
 
 
 # Tool description for LLM
@@ -1098,6 +1099,8 @@ def _run_foreground(
                                 task_id=task_id, session_key=session_key),
             )
             break
+        except SudoPasswordPromptCancelled:
+            raise
         except Exception as e:
             if "timeout" in str(e).lower():
                 return _error_json(f"Command timed out after {effective_timeout} seconds", exit_code=124)
@@ -1250,6 +1253,9 @@ def terminal_tool(
         return r.result_json
     except EnvironmentConnectionError as e:
         return _degraded_result(e, task_id)
+    except SudoPasswordPromptCancelled:
+        return _error_json("Command cancelled: sudo password prompt was dismissed.",
+                           exit_code=130, status="cancelled")
     except Exception as e:
         return _fatal_error_json(e)
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1070,20 +1070,11 @@ def _yield_kwargs(command: str, **ctx) -> dict:
 def _run_foreground(
     command: str, env: Any, plan: _ExecPlan, *,
     task_id: Optional[str], session_id: Optional[str], session_key: str,
-    workdir: Optional[str], approval_note: Optional[str], clear_interrupt: bool,
+    workdir: Optional[str], approval_note: Optional[str],
 ) -> str:
     """Execute in the foreground with retry on transient errors, then finalize."""
     max_retries = 3
     env_type, eff, effective_timeout = plan.env_type, plan.effective_task_id, plan.effective_timeout
-
-    # Clean interrupt slate for an approved command, ONCE before the retry
-    # loop: drop a stale bit that landed during the approval-wait so it
-    # can't SIGINT the just-approved run. Do NOT re-clear inside the loop —
-    # a genuine interrupt during the backoff sleep must survive and abort
-    # the next attempt (rc 130).
-    if clear_interrupt:
-        from tools.interrupt import clear_current_thread_interrupt
-        clear_current_thread_interrupt()
 
     for retry_count in range(max_retries + 1):
         try:
@@ -1115,6 +1106,9 @@ def _run_foreground(
                          max_retries, _safe_command_preview(command), type(e).__name__, e, eff, env_type)
             return _error_json(_redact_terminal_error_text(f"Command execution failed: {type(e).__name__}: {e}"))
 
+    if result.get("_process_start_cancelled"):
+        return _error_json("Command cancelled before process start.", output="[Command interrupted]",
+                           exit_code=130, status="cancelled")
     if result.get("yielded_session_id"):
         return json.dumps({
             "output": result.get("output", ""), "exit_code": None, "error": None,
@@ -1228,6 +1222,11 @@ def terminal_tool(
         # force=True means the user already confirmed.
         verdict = _run_approval_guards(command, env_type, plan.config, force=force)
 
+        # Clear stale approval-wait interruption once for either dispatch mode;
+        # later cancellation remains visible through password prompts and backend starts.
+        if verdict.approved_run:
+            from tools.interrupt import clear_current_thread_interrupt
+            clear_current_thread_interrupt()
         pty_disabled = pty and _command_requires_pipe_stdin(command)
         if plan.promoted_from_foreground_timeout is not None:
             # Promotion implies notify_on_complete; watch_patterns is a background-only flag the
@@ -1247,7 +1246,7 @@ def terminal_tool(
         return _run_foreground(
             command, env, plan,
             task_id=task_id, session_id=session_id, session_key=session_key,
-            workdir=workdir, approval_note=verdict.note, clear_interrupt=verdict.approved_run,
+            workdir=workdir, approval_note=verdict.note,
         )
     except _Rejected as r:
         return r.result_json

--- a/tools/terminal_tool_background.py
+++ b/tools/terminal_tool_background.py
@@ -186,6 +186,9 @@ def spawn_background_process(
             result_data["watch_patterns"] = proc_session.watch_patterns
         return json.dumps(result_data, ensure_ascii=False)
     except Exception as e:
+        from tools.terminal_tool_sudo import SudoPasswordPromptCancelled
+        if isinstance(e, SudoPasswordPromptCancelled):
+            raise
         return json.dumps({
             "output": "", "exit_code": -1,
             "error": _redact_terminal_error_text(f"Failed to start background process: {e}"),

--- a/tools/terminal_tool_background.py
+++ b/tools/terminal_tool_background.py
@@ -134,10 +134,10 @@ def spawn_background_process(
 ) -> str:
     """Spawn *command* as a tracked background process and return the JSON result.
 
-    Never inline-polls ``is_interrupted()``: the spawn detaches and returns
-    exit_code 0 immediately, so the stale-interrupt kill cannot occur here.
+    Definite pre-start cancellation has no session. An uncertain remote start
+    remains tracked, including when its PID still needs to be recovered.
     """
-    from tools.process_registry import process_registry
+    from tools.process_registry import ProcessStartCancelled, process_registry
     from tools.terminal_tool import (
         _redact_terminal_error_text, _resolve_command_cwd, _resolve_notification_flag_conflict,
     )
@@ -153,6 +153,10 @@ def spawn_background_process(
         )
         result_data = {"output": "Background process started", "session_id": proc_session.id,
                        "pid": proc_session.pid, "exit_code": 0, "error": None}
+        if getattr(proc_session, "start_interrupted", False) is True:
+            note = "Background start was interrupted; the process may still be running and remains tracked."
+            result_data.update(output=note, exit_code=130, error=note,
+                               status="running" if proc_session.pid is not None else "unknown")
         if approval_note:
             result_data["approval"] = approval_note
         if pty_disabled_reason:
@@ -185,6 +189,9 @@ def spawn_background_process(
             proc_session.watch_patterns = list(watch_patterns)
             result_data["watch_patterns"] = proc_session.watch_patterns
         return json.dumps(result_data, ensure_ascii=False)
+    except ProcessStartCancelled:
+        return json.dumps({"output": "[Command interrupted]", "exit_code": 130,
+                           "error": "Command cancelled before process start.", "status": "cancelled"})
     except Exception as e:
         from tools.terminal_tool_sudo import SudoPasswordPromptCancelled
         if isinstance(e, SudoPasswordPromptCancelled):

--- a/tools/terminal_tool_sudo.py
+++ b/tools/terminal_tool_sudo.py
@@ -173,9 +173,13 @@ def _read_hidden_password(result: dict) -> None:
         result["done"] = True
 
 
+class SudoPasswordPromptCancelled(Exception):
+    """An explicit UI dismissal aborts the command instead of trying without a password."""
+
+
 def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
     """Prompt for a sudo password; "" on skip (empty Enter), timeout, or error. Prefers the
-    CLI-registered callback (prompt_toolkit-integrated); otherwise reads /dev/tty (msvcrt on
+    CLI-registered callback (None raises SudoPasswordPromptCancelled); otherwise reads /dev/tty (msvcrt on
     Windows) with echo disabled. Human wait time is excluded from tool deadlines (``human_wait_window``)."""
     from tools.terminal_tool import _get_sudo_password_callback
     _sudo_cb = _get_sudo_password_callback()
@@ -183,7 +187,12 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
         try:
             from tools.approval_human_wait import human_wait_window
             with human_wait_window():
-                return _sudo_cb() or ""
+                password = _sudo_cb()
+            if password is None:
+                raise SudoPasswordPromptCancelled
+            return password or ""
+        except SudoPasswordPromptCancelled:
+            raise
         except Exception:
             return ""
 

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -947,7 +947,33 @@ def _(rid, params: dict) -> dict:
 
 @method("sudo.respond")
 def _(rid, params: dict) -> dict:
-    return _respond(rid, params, "password", allow_expired=True)
+    # Before ``sudo.cancel`` existed, clients used an empty password for both
+    # dismissal and intentional empty submission. Treat that unmarked legacy
+    # value as cancellation so an old UI cannot wake a new backend into
+    # starting the pending command. New clients mark submissions explicitly,
+    # preserving Enter-on-empty as the legacy "try without a password" action.
+    response_params = params
+    if params.get("password", "") == "":
+        response_params = {
+            **params,
+            "password": (
+                _SUDO_EMPTY_SUBMISSION
+                if params.get("intent") == "submit"
+                else None
+            ),
+        }
+    return _respond(rid, response_params, "password", allow_expired=True)
+
+
+@method("sudo.cancel")
+def _(rid, params: dict) -> dict:
+    """Probeable, intent-specific cancellation for version-skewed UIs."""
+    return _respond(
+        rid,
+        {**params, "password": None},
+        "password",
+        allow_expired=True,
+    )
 
 
 @method("secret.respond")

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1113,11 +1113,30 @@ def _(rid, params: dict) -> dict:
 _LATE_RESPOND_KEYS = {
     "terminal.read.respond": "text", "preview.read.respond": "text", "preview.act.respond": "text",
     "window.read.respond": "text", "tour.respond": "text", "mcp.setup.respond": "result",
-    "sudo.respond": "password", "secret.respond": "value", "vault.unlock.respond": "password",
+    "secret.respond": "value", "vault.unlock.respond": "password",
     "vault.save_login.respond": "login", "vault.code.respond": "code"}
 for _name, _key in _LATE_RESPOND_KEYS.items():
     method(_name)(lambda rid, params, _k=_key: _respond(rid, params, _k, allow_expired=True))
 del _name, _key
+
+
+@method("sudo.respond")
+def _(rid, params: dict) -> dict:
+    # Legacy empty replies conflate dismissal and Enter; only marked submissions
+    # may preserve the empty-password skip on a newer backend.
+    if params.get("password", "") == "" and params.get("intent") != "submit":
+        params = {**params, "password": None}
+    return _respond(rid, params, "password", allow_expired=True)
+
+
+@method("sudo.cancel")
+def _(rid, params: dict) -> dict:
+    """Probeable cancellation; a sudo RPC cannot answer an unrelated prompt."""
+    with _prompt_lock:
+        prompt = _pending_prompt_payloads.get(params.get("request_id", ""))
+        if prompt and prompt[0] != "sudo.request":
+            return _err(rid, 4009, "no pending password request")
+    return _respond(rid, {**params, "password": None}, "password", allow_expired=True)
 
 
 # ── approvals ───────────────────────────────────────────────────────────────

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -144,7 +144,14 @@ _sessions: dict[str, dict] = {}
 _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}
-_answers: dict[str, str] = {}
+
+
+class _SudoEmptySubmission(str):
+    """Identity-bearing empty string used only across the blocking bridge."""
+
+
+_SUDO_EMPTY_SUBMISSION = _SudoEmptySubmission()
+_answers: dict[str, str | None] = {}
 _db = None
 _db_error: str | None = None
 _stdout_lock = threading.Lock()
@@ -3275,7 +3282,10 @@ def _clear_pending(sid: str | None = None) -> None:
     with _prompt_lock:
         for rid, (owner_sid, ev) in list(_pending.items()):
             if sid is None or owner_sid == sid:
-                _answers[rid] = ""
+                prompt = _pending_prompt_payloads.get(rid)
+                _answers[rid] = (
+                    None if prompt and prompt[0] == "sudo.request" else ""
+                )
                 ev.set()
 
 
@@ -5900,12 +5910,24 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
         logger.debug("failed to emit session.info after project workspace move", exc_info=True)
 
 
+def _gateway_sudo_password_callback(sid: str) -> str | None:
+    answer = _block(
+        "sudo.request",
+        sid,
+        {},
+        timeout=120,
+    )
+    if answer is _SUDO_EMPTY_SUBMISSION:
+        return ""
+    return answer or None
+
+
 def _wire_callbacks(sid: str):
     from tools.terminal_tool import set_sudo_password_callback
     from tools.skills_tool import set_secret_capture_callback
     from tools.project_tools import set_project_workspace_callback
 
-    set_sudo_password_callback(lambda: _block("sudo.request", sid, {}, timeout=120))
+    set_sudo_password_callback(lambda: _gateway_sudo_password_callback(sid))
     set_project_workspace_callback(_apply_project_workspace)
 
     def secret_cb(env_var, prompt, metadata=None):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -84,7 +84,7 @@ _sessions: dict[str, dict] = {}
 _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}
-_answers: dict[str, str] = {}
+_answers: dict[str, str | None] = {}
 # Batch clarify accumulators: rid → {"qids": [...], "answers": {qid: answer}}. Written by
 # clarify.respond (per-question lock, update-in-place), read out by _block on resolution/timeout
 # so locked answers survive the deadline.
@@ -1259,7 +1259,7 @@ _EXPIRING_REQUESTS = frozenset({
 })
 
 
-def _block(event: str, sid: str, payload: dict, timeout: float | None = 300, batch_qids: list[str] | None = None) -> str:
+def _block(event: str, sid: str, payload: dict, timeout: float | None = 300, batch_qids: list[str] | None = None) -> str | None:
     rid = uuid.uuid4().hex[:8]
     ev = threading.Event()
     with _prompt_lock:
@@ -1369,7 +1369,8 @@ def _clear_pending(sid: str | None = None) -> None:
     with _prompt_lock:
         for rid, (owner_sid, ev) in list(_pending.items()):
             if sid is None or owner_sid == sid:
-                _answers[rid] = ""
+                prompt = _pending_prompt_payloads.get(rid)
+                _answers[rid] = None if prompt and prompt[0] == "sudo.request" else ""
                 ev.set()
 
 

--- a/ui-tui/src/__tests__/rpc.test.ts
+++ b/ui-tui/src/__tests__/rpc.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
+import {
+  asRpcResult,
+  rpcErrorMessage,
+  RpcMethodUnavailableError,
+  shouldRethrowRpcError
+} from '../lib/rpc.js'
 
 describe('asRpcResult', () => {
   it('keeps plain object payloads', () => {
@@ -23,5 +28,22 @@ describe('rpcErrorMessage', () => {
   it('falls back for unknown errors', () => {
     expect(rpcErrorMessage('broken')).toBe('broken')
     expect(rpcErrorMessage({ code: 500 })).toBe('request failed')
+  })
+})
+
+describe('shouldRethrowRpcError', () => {
+  const unavailable = Object.assign(new Error('unknown method: sudo.cancel'), { code: -32601 })
+
+  it('preserves the default null-on-error RPC contract', () => {
+    expect(shouldRethrowRpcError(unavailable)).toBe(false)
+    expect(shouldRethrowRpcError(unavailable, {})).toBe(false)
+  })
+
+  it('opts into method-unavailable propagation without propagating transient errors', () => {
+    expect(shouldRethrowRpcError(unavailable, { rethrowMethodUnavailable: true })).toBe(true)
+    expect(
+      shouldRethrowRpcError(new Error('timeout: sudo.cancel'), { rethrowMethodUnavailable: true })
+    ).toBe(false)
+    expect(new RpcMethodUnavailableError('unknown method: sudo.cancel')).toBeInstanceOf(Error)
   })
 })

--- a/ui-tui/src/__tests__/rpc.test.ts
+++ b/ui-tui/src/__tests__/rpc.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
+import { asRpcResult, rpcErrorMessage, shouldRethrowRpcError } from '../lib/rpc.js'
 
 describe('asRpcResult', () => {
   it('keeps plain object payloads', () => {
@@ -23,5 +23,17 @@ describe('rpcErrorMessage', () => {
   it('falls back for unknown errors', () => {
     expect(rpcErrorMessage('broken')).toBe('broken')
     expect(rpcErrorMessage({ code: 500 })).toBe('request failed')
+  })
+})
+
+describe('method-unavailable opt-in', () => {
+  it.each([
+    [Object.assign(new Error('localized'), { code: -32601 }), true],
+    [new Error('unknown method: sudo.cancel'), true],
+    [new Error('connection reset'), false],
+    [Object.assign(new Error('denied'), { code: 4003 }), false]
+  ])('preserves ordinary error handling for %s', (error, unavailable) => {
+    expect(shouldRethrowRpcError(error)).toBe(false)
+    expect(shouldRethrowRpcError(error, { rethrowMethodUnavailable: true })).toBe(unavailable)
   })
 })

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -6,8 +6,10 @@ import {
   dismissSensitivePrompt,
   handleIdleHotkeyExit,
   shouldAllowIdleHotkeyExit,
-  shouldFallThroughForScroll
+  shouldFallThroughForScroll,
+  sudoSubmissionParams
 } from '../app/useInputHandlers.js'
+import { RpcMethodUnavailableError } from '../lib/rpc.js'
 
 const baseKey = {
   downArrow: false,
@@ -116,18 +118,69 @@ describe('applyVoiceRecordResponse', () => {
 })
 
 describe('dismissSensitivePrompt', () => {
+  it('marks an explicit empty sudo submission for versioned backends', () => {
+    expect(sudoSubmissionParams('', 'sudo-1')).toEqual({
+      intent: 'submit',
+      password: '',
+      request_id: 'sudo-1'
+    })
+  })
+
   it('clears a sudo overlay before a stale cancel RPC resolves', async () => {
+    resetOverlayState()
+    patchOverlayState({ sudo: { requestId: 'sudo-1' } })
+    const rpc = vi.fn().mockResolvedValue({ status: 'expired' })
+    const sys = vi.fn()
+
+    const pending = dismissSensitivePrompt(getOverlayState(), rpc, sys, 's1')
+
+    expect(getOverlayState().sudo).toBeNull()
+    expect(sys).toHaveBeenCalledWith('sudo cancelled')
+    expect(rpc).toHaveBeenCalledWith(
+      'sudo.cancel',
+      { request_id: 'sudo-1' },
+      { rethrowMethodUnavailable: true }
+    )
+    await pending
+    expect(rpc).toHaveBeenCalledTimes(1)
+  })
+
+  it('interrupts the owning session when the sudo.cancel probe fails', async () => {
+    resetOverlayState()
+    patchOverlayState({ sudo: { requestId: 'sudo-1' } })
+
+    const rpc = vi
+      .fn()
+      .mockRejectedValueOnce(new RpcMethodUnavailableError('unknown method: sudo.cancel'))
+      .mockResolvedValueOnce({ status: 'interrupted' })
+
+    const sys = vi.fn()
+
+    await dismissSensitivePrompt(getOverlayState(), rpc, sys, 's1')
+
+    expect(rpc).toHaveBeenNthCalledWith(
+      1,
+      'sudo.cancel',
+      { request_id: 'sudo-1' },
+      { rethrowMethodUnavailable: true }
+    )
+    expect(rpc).toHaveBeenNthCalledWith(2, 'session.interrupt', { session_id: 's1' })
+  })
+
+  it('does not interrupt the owning session when sudo.cancel fails transiently', async () => {
     resetOverlayState()
     patchOverlayState({ sudo: { requestId: 'sudo-1' } })
     const rpc = vi.fn().mockResolvedValue(null)
     const sys = vi.fn()
 
-    const pending = dismissSensitivePrompt(getOverlayState(), rpc, sys)
+    await dismissSensitivePrompt(getOverlayState(), rpc, sys, 's1')
 
-    expect(getOverlayState().sudo).toBeNull()
-    expect(sys).toHaveBeenCalledWith('sudo cancelled')
-    expect(rpc).toHaveBeenCalledWith('sudo.respond', { password: '', request_id: 'sudo-1' })
-    await pending
+    expect(rpc).toHaveBeenCalledTimes(1)
+    expect(rpc).toHaveBeenCalledWith(
+      'sudo.cancel',
+      { request_id: 'sudo-1' },
+      { rethrowMethodUnavailable: true }
+    )
   })
 
   it('clears a secret overlay before a stale cancel RPC resolves', async () => {

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -10,6 +10,7 @@ import {
   shouldDetachEditedHistoryInput,
   shouldFallThroughForScroll
 } from '../app/useInputHandlers.js'
+import { RpcMethodUnavailableError } from '../lib/rpc.js'
 
 const baseKey = {
   downArrow: false,
@@ -156,18 +157,42 @@ describe('applyVoiceRecordResponse', () => {
 })
 
 describe('dismissSensitivePrompt', () => {
-  it('clears a sudo overlay before a stale cancel RPC resolves', async () => {
+  it('clears a sudo overlay when a stale cancel RPC resolves', async () => {
     resetOverlayState()
     patchOverlayState({ sudo: { requestId: 'sudo-1' } })
-    const rpc = vi.fn().mockResolvedValue(null)
+    const rpc = vi.fn().mockResolvedValue({ status: 'expired' })
     const sys = vi.fn()
 
     const pending = dismissSensitivePrompt(getOverlayState(), rpc, sys)
 
+    await pending
     expect(getOverlayState().sudo).toBeNull()
     expect(sys).toHaveBeenCalledWith('sudo cancelled')
-    expect(rpc).toHaveBeenCalledWith('sudo.respond', { password: '', request_id: 'sudo-1' })
+    expect(rpc).toHaveBeenCalledWith('sudo.cancel', { request_id: 'sudo-1' }, { rethrowMethodUnavailable: true })
+  })
+
+  it.each(['current', 'legacy', 'transient'])('retains cancellation intent across %s RPC results', async mode => {
+    resetOverlayState()
+    patchOverlayState({ sudo: { requestId: 'sudo-1' } })
+    const rpc = vi.fn().mockResolvedValue({ status: 'ok' })
+
+    if (mode === 'legacy') {rpc.mockRejectedValueOnce(new RpcMethodUnavailableError('method not found'))}
+
+    if (mode === 'transient') {rpc.mockResolvedValueOnce(null)}
+    const pending = dismissSensitivePrompt(getOverlayState(), rpc, vi.fn(), 'owner')
+    expect(getOverlayState().sudo?.requestId).toBe('sudo-1')
     await pending
+    expect(rpc).toHaveBeenNthCalledWith(1, 'sudo.cancel', { request_id: 'sudo-1' }, { rethrowMethodUnavailable: true })
+
+    if (mode === 'legacy') {expect(rpc).toHaveBeenNthCalledWith(2, 'session.interrupt', { session_id: 'owner' })}
+    else {expect(rpc).toHaveBeenCalledTimes(1)}
+
+    if (mode === 'transient') {
+      expect(getOverlayState().sudo?.requestId).toBe('sudo-1')
+      await dismissSensitivePrompt(getOverlayState(), rpc, vi.fn(), 'owner')
+    }
+
+    expect(getOverlayState().sudo).toBeNull()
   })
 
   it('clears a secret overlay before a stale cancel RPC resolves', async () => {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -14,7 +14,7 @@ import type {
 } from '../gatewayTypes.js'
 import type { QueueItem } from '../hooks/useQueue.js'
 import type { ParsedVoiceRecordKey } from '../lib/platform.js'
-import type { RpcResult } from '../lib/rpc.js'
+import type { RpcCallOptions, RpcResult } from '../lib/rpc.js'
 import type { ActiveWidget } from '../sdk/types.js'
 import type { Theme } from '../theme.js'
 import type {
@@ -96,7 +96,11 @@ export interface CompletionItem {
 }
 
 export interface GatewayRpc {
-  <T extends RpcResult = RpcResult>(method: string, params?: Record<string, unknown>): Promise<null | T>
+  <T extends RpcResult = RpcResult>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: RpcCallOptions
+  ): Promise<null | T>
 }
 
 export interface GatewayServices {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -14,7 +14,7 @@ import type {
 } from '../gatewayTypes.js'
 import type { QueueItem } from '../hooks/useQueue.js'
 import type { ParsedVoiceRecordKey } from '../lib/platform.js'
-import type { RpcResult } from '../lib/rpc.js'
+import type { RpcCallOptions, RpcResult } from '../lib/rpc.js'
 import type { ActiveWidget } from '../sdk/types.js'
 import type { Theme } from '../theme.js'
 import type {
@@ -97,7 +97,11 @@ export interface CompletionItem {
 }
 
 export interface GatewayRpc {
-  <T extends RpcResult = RpcResult>(method: string, params?: Record<string, unknown>): Promise<null | T>
+  <T extends RpcResult = RpcResult>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: RpcCallOptions
+  ): Promise<null | T>
 }
 
 export interface GatewayServices {

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -14,6 +14,7 @@ import type {
 } from '../gatewayTypes.js'
 import { isAction, isCopyShortcut, isMac, isVoiceToggleKey } from '../lib/platform.js'
 import { computePrecisionWheelStep, initPrecisionWheel } from '../lib/precisionWheel.js'
+import { RpcMethodUnavailableError } from '../lib/rpc.js'
 import { computeWheelStep, initWheelAccelForHost } from '../lib/wheelAccel.js'
 import { closeWidget, dispatchWidgetInput } from '../sdk/host.js'
 
@@ -105,10 +106,15 @@ export function applyVoiceRecordResponse(
   }
 }
 
+export function sudoSubmissionParams(password: string, requestId: string) {
+  return { intent: 'submit', password, request_id: requestId }
+}
+
 export function dismissSensitivePrompt(
   overlay: Pick<OverlayState, 'secret' | 'sudo'>,
   rpc: GatewayRpc,
-  sys: (text: string) => void
+  sys: (text: string) => void,
+  sessionId: null | string = null
 ) {
   if (overlay.sudo) {
     const requestId = overlay.sudo.requestId
@@ -116,7 +122,22 @@ export function dismissSensitivePrompt(
     patchOverlayState({ sudo: null })
     sys('sudo cancelled')
 
-    return rpc<SudoRespondResponse>('sudo.respond', { password: '', request_id: requestId })
+    return rpc<SudoRespondResponse>(
+      'sudo.cancel',
+      { request_id: requestId },
+      { rethrowMethodUnavailable: true }
+    ).catch(error => {
+      if (!(error instanceof RpcMethodUnavailableError)) {
+        throw error
+      }
+
+      // Older backends have no sudo.cancel method. Interrupt the owning turn
+      // instead of sending a null/empty password that legacy code can treat as
+      // submission. Other RPC failures must not escalate cancellation intent.
+      return sessionId
+        ? rpc<SudoRespondResponse>('session.interrupt', { session_id: sessionId })
+        : null
+    })
   }
 
   if (overlay.secret) {
@@ -184,7 +205,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (overlay.sudo || overlay.secret) {
-      return dismissSensitivePrompt(overlay, gateway.rpc, actions.sys)
+      return dismissSensitivePrompt(overlay, gateway.rpc, actions.sys, getUiState().sid)
     }
 
     if (overlay.modelPicker) {

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -14,6 +14,7 @@ import type {
 } from '../gatewayTypes.js'
 import { isAction, isCopyShortcut, isMac, isVoiceToggleKey } from '../lib/platform.js'
 import { computePrecisionWheelStep, initPrecisionWheel } from '../lib/precisionWheel.js'
+import { RpcMethodUnavailableError } from '../lib/rpc.js'
 import { computeWheelStep, initWheelAccelForHost } from '../lib/wheelAccel.js'
 import { closeWidget, dispatchWidgetInput } from '../sdk/host.js'
 
@@ -26,7 +27,7 @@ import {
   type InputHandlerResult,
   type OverlayState
 } from './interfaces.js'
-import { $isBlocked, $overlayState, patchOverlayState } from './overlayStore.js'
+import { $isBlocked, $overlayState, getOverlayState, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
 import { getUiState } from './uiStore.js'
@@ -142,18 +143,38 @@ export function applyVoiceRecordResponse(
   }
 }
 
+export function sudoSubmissionParams(password: string, requestId: string) {
+  return { intent: 'submit', password, request_id: requestId }
+}
+
 export function dismissSensitivePrompt(
   overlay: Pick<OverlayState, 'secret' | 'sudo' | 'vaultUnlock'>,
   rpc: GatewayRpc,
-  sys: (text: string) => void
+  sys: (text: string) => void,
+  sessionId: null | string = null
 ) {
   if (overlay.sudo) {
     const requestId = overlay.sudo.requestId
 
-    patchOverlayState({ sudo: null })
-    sys('sudo cancelled')
+    return rpc<SudoRespondResponse>('sudo.cancel', { request_id: requestId }, { rethrowMethodUnavailable: true })
+      .catch(error => {
+        if (!(error instanceof RpcMethodUnavailableError)) {
+          throw error
+        }
 
-    return rpc<SudoRespondResponse>('sudo.respond', { password: '', request_id: requestId })
+        // Older backends have no sudo.cancel method. Interrupt the owning turn
+        // instead of sending a null/empty password that legacy code can treat as
+        // submission. Other RPC failures must not escalate cancellation intent.
+        return sessionId ? rpc<SudoRespondResponse>('session.interrupt', { session_id: sessionId }) : null
+      })
+      .then(result => {
+        if (result) {
+          if (getOverlayState().sudo?.requestId === requestId) {patchOverlayState({ sudo: null })}
+          sys('sudo cancelled')
+        }
+
+        return result
+      })
   }
 
   if (overlay.secret) {
@@ -234,7 +255,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (overlay.sudo || overlay.secret || overlay.vaultUnlock) {
-      return dismissSensitivePrompt(overlay, gateway.rpc, actions.sys)
+      return dismissSensitivePrompt(overlay, gateway.rpc, actions.sys, getUiState().sid)
     }
 
     if (overlay.modelPicker) {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -33,7 +33,13 @@ import { composerPromptWidth } from '../lib/inputMetrics.js'
 import { appendTranscriptMessage, capTranscriptHistory } from '../lib/messages.js'
 import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
 import { createResizeCoalescer } from '../lib/resizeCoalescer.js'
-import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
+import {
+  asRpcResult,
+  type RpcCallOptions,
+  rpcErrorMessage,
+  RpcMethodUnavailableError,
+  shouldRethrowRpcError
+} from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
 import { buildToolTrailLine, formatAbandonedClarify, sameToolTrailGroup, toolTrailLabel } from '../lib/text.js'
 import { estimatedMsgHeight, messageHeightKey } from '../lib/virtualHeights.js'
@@ -54,7 +60,7 @@ import { $uiState, getUiState, patchUiState } from './uiStore.js'
 import { useBatteryPoll } from './useBatteryPoll.js'
 import { useComposerState } from './useComposerState.js'
 import { useConfigSync } from './useConfigSync.js'
-import { useInputHandlers } from './useInputHandlers.js'
+import { sudoSubmissionParams, useInputHandlers } from './useInputHandlers.js'
 import { useLongRunToolCharms } from './useLongRunToolCharms.js'
 import { useSessionLifecycle } from './useSessionLifecycle.js'
 import { useSubmission } from './useSubmission.js'
@@ -488,7 +494,8 @@ export function useMainApp(gw: GatewayClient) {
   const rpc: GatewayRpc = useCallback(
     async <T extends Record<string, any> = Record<string, any>>(
       method: string,
-      params: Record<string, unknown> = {}
+      params: Record<string, unknown> = {},
+      options: RpcCallOptions = {}
     ) => {
       try {
         const result = asRpcResult<T>(await gw.request<T>(method, params))
@@ -499,7 +506,13 @@ export function useMainApp(gw: GatewayClient) {
 
         sys(`error: invalid response: ${method}`)
       } catch (e) {
-        sys(`error: ${rpcErrorMessage(e)}`)
+        const message = rpcErrorMessage(e)
+
+        sys(`error: ${message}`)
+
+        if (shouldRethrowRpcError(e, options)) {
+          throw new RpcMethodUnavailableError(message)
+        }
       }
 
       return null
@@ -950,7 +963,7 @@ export function useMainApp(gw: GatewayClient) {
         patchOverlayState({ sudo: null })
       }
 
-      return respondWith('sudo.respond', { password: pw, request_id: requestId }, () => {
+      return respondWith('sudo.respond', sudoSubmissionParams(pw, requestId), () => {
         patchOverlayState({ sudo: null })
         patchUiState({ status: 'running…' })
       })

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -34,7 +34,13 @@ import { composerPromptWidth } from '../lib/inputMetrics.js'
 import { appendTranscriptMessage, capTranscriptHistory } from '../lib/messages.js'
 import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
 import { createResizeCoalescer } from '../lib/resizeCoalescer.js'
-import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
+import {
+  asRpcResult,
+  type RpcCallOptions,
+  rpcErrorMessage,
+  RpcMethodUnavailableError,
+  shouldRethrowRpcError
+} from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
 import {
   buildToolTrailLine,
@@ -62,7 +68,7 @@ import { $uiState, getUiState, patchUiState } from './uiStore.js'
 import { useBatteryPoll } from './useBatteryPoll.js'
 import { useComposerState } from './useComposerState.js'
 import { useConfigSync } from './useConfigSync.js'
-import { shouldDetachEditedHistoryInput, useInputHandlers } from './useInputHandlers.js'
+import { shouldDetachEditedHistoryInput, sudoSubmissionParams, useInputHandlers } from './useInputHandlers.js'
 import { useLongRunToolCharms } from './useLongRunToolCharms.js'
 import { useSessionLifecycle } from './useSessionLifecycle.js'
 import { useSubmission } from './useSubmission.js'
@@ -504,7 +510,8 @@ export function useMainApp(gw: GatewayClient) {
   const rpc: GatewayRpc = useCallback(
     async <T extends Record<string, any> = Record<string, any>>(
       method: string,
-      params: Record<string, unknown> = {}
+      params: Record<string, unknown> = {},
+      options: RpcCallOptions = {}
     ) => {
       try {
         const result = asRpcResult<T>(await gw.request<T>(method, params))
@@ -515,7 +522,12 @@ export function useMainApp(gw: GatewayClient) {
 
         sys(`error: invalid response: ${method}`)
       } catch (e) {
-        sys(`error: ${rpcErrorMessage(e)}`)
+        const message = rpcErrorMessage(e)
+        sys(`error: ${message}`)
+
+        if (shouldRethrowRpcError(e, options)) {
+          throw new RpcMethodUnavailableError(message)
+        }
       }
 
       return null
@@ -1042,7 +1054,7 @@ export function useMainApp(gw: GatewayClient) {
         patchOverlayState({ sudo: null })
       }
 
-      return respondWith('sudo.respond', { password: pw, request_id: requestId }, () => {
+      return respondWith('sudo.respond', sudoSubmissionParams(pw, requestId), () => {
         patchOverlayState({ sudo: null })
         patchUiState({ status: 'running…' })
       })

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -567,9 +567,14 @@ export class GatewayClient extends EventEmitter {
   }
 
   private toError(raw: unknown): Error {
-    const err = raw as { message?: unknown } | null | undefined
+    const err = raw as { code?: unknown; message?: unknown } | null | undefined
+    const error = new Error(typeof err?.message === 'string' ? err.message : 'request failed')
 
-    return new Error(typeof err?.message === 'string' ? err.message : 'request failed')
+    if (typeof err?.code === 'number') {
+      Object.assign(error, { code: err.code })
+    }
+
+    return error
   }
 
   private settle(p: Pending, err: Error | null, result: unknown) {

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -714,9 +714,14 @@ export class GatewayClient extends EventEmitter {
   }
 
   private toError(raw: unknown): Error {
-    const err = raw as { message?: unknown } | null | undefined
+    const err = raw as { code?: unknown; message?: unknown } | null | undefined
+    const error = new Error(typeof err?.message === 'string' ? err.message : 'request failed')
 
-    return new Error(typeof err?.message === 'string' ? err.message : 'request failed')
+    if (typeof err?.code === 'number') {
+      Object.assign(error, { code: err.code })
+    }
+
+    return error
   }
 
   private settle(p: Pending, err: Error | null, result: unknown) {

--- a/ui-tui/src/lib/rpc.ts
+++ b/ui-tui/src/lib/rpc.ts
@@ -1,6 +1,9 @@
 import type { CommandDispatchResponse } from '../gatewayTypes.js'
 
 export type RpcResult = Record<string, any>
+export interface RpcCallOptions {
+  rethrowMethodUnavailable?: boolean
+}
 
 export const asRpcResult = <T extends RpcResult = RpcResult>(value: unknown): T | null =>
   !value || typeof value !== 'object' || Array.isArray(value) ? null : (value as T)
@@ -50,3 +53,23 @@ export const asCommandDispatch = (value: unknown): CommandDispatchResponse | nul
 
 export const rpcErrorMessage = (err: unknown) =>
   err instanceof Error && err.message ? err.message : typeof err === 'string' && err.trim() ? err : 'request failed'
+
+export class RpcMethodUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RpcMethodUnavailableError'
+  }
+}
+
+export const isRpcMethodUnavailable = (err: unknown) => {
+  if ((err as { code?: unknown } | null)?.code === -32601) {
+    return true
+  }
+
+  const message = rpcErrorMessage(err).toLowerCase()
+
+  return message.startsWith('unknown method:') || message === 'method not found'
+}
+
+export const shouldRethrowRpcError = (err: unknown, options: RpcCallOptions = {}) =>
+  options.rethrowMethodUnavailable === true && isRpcMethodUnavailable(err)


### PR DESCRIPTION
Dismissing a sudo password prompt could run the original command because cancellation and an intentionally empty password both became an empty string. Concurrent prompts and process-start races could also let an interrupted command begin execution.

This PR separates cancellation from submission across the CLI, terminal, gateway, desktop, and TUI. Escape, dialog dismissal, and explicit cancellation return a cancelled result with exit code 130. Pressing Enter with an empty password keeps the existing skip behavior; configured, cached, and passwordless sudo paths retain their precedence. A command that naturally exits 130 is not classified as a prompt cancellation.

Four independently validated commits preserve complete behavior at each boundary:

1. Serialize CLI sudo prompt ownership, distinguish `None` cancellation from empty submission, restore the interrupted draft before a successor prompt can open, and propagate cancellation without running the command.
2. Order local process creation and managed Modal start requests with the owning thread's interrupt state. Later commands can start after a prior interrupt; unrelated threads keep independent start gates.
3. Version gateway intent through `sudo.cancel` and explicit `sudo.respond` submissions. New clients fall back to session interruption only when an older gateway lacks the cancellation method; transient failures retain the prompt for retry. Legacy unmarked empty responses cancel, while marked empty submissions and prompt timeouts preserve their existing meanings.
4. Distinguish definite pre-start cancellation from an uncertain interrupted background start. Keep uncertain sessions tracked, including before PID capture, and let the existing poller recover the PID when it appears.

The independent active sandbox process-group termination fix was split into #104597. Teknium's concrete suggestion to place the response handlers in `tui_gateway/methods_prompt.py` is incorporated and credited in the protocol commit.

Validation:

- Reproduced prompt dismissal, queued-prompt ownership, stale draft restoration, process-start interruption, client version skew, and uncertain background-start failures before their fixes.
- Tested every complete commit prefix against main `693641aa8b4359c602283bdbbc14041e03bc47bc`: 52, 99, 174, and 284 Python tests passed, respectively. The final suite skipped four native-Windows cases on Linux.
- Full TUI check passed: 1,753 tests, build, types, and lint; two existing lint warnings remain. Desktop full type checks and lint passed, along with seven focused prompt tests.
- Ruff, compatibility-pointer checks, and `git diff --check` passed. The Windows checker found no findings in the changed Python files on either the base or final tree.

Not checked and scope limits:

- Native Windows/macOS execution and live cloud services. Direct Modal, Daytona, and Vercel SDK adapters dispatch remote work after constructing a threaded handle; the start gate does not make that later SDK request atomic with interruption. Their cancellation remains best effort.
- Unknown sandbox starts are retained only within the running Hermes process. Existing checkpoint recovery deliberately skips PID-less and non-host sessions because their remote environment handles do not survive restart; this PR does not add durable sandbox recovery.
- Prompt timeout continues to skip password entry. A failed cancellation RPC keeps the client prompt available for retry; it cannot guarantee that a disconnected server received the cancellation.
- CodeRabbit: skipped for self-authored P2 maintenance under the repository's reviewer routing policy.

Updated by GPT-6 Astra with ultra reasoning in Codex Desktop. The account owner loosely reviews these actions and receives the usual GitHub notifications.

Fixes #14483
