### PR TITLE
fix: set chrome-sandbox setuid after desktop rebuild in hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10797,6 +10797,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
             else:
                 print("  ✓ Desktop app up to date")
 
+                # Ensure the freshly-rebuilt chrome-sandbox has the
+                # required root:root + setuid (4755) so Electron can
+                # launch without "manual-restart". Without this, every
+                # `hermes update` that touches the desktop rebuild leaves
+                # the sandbox broken until the user manually restarts.
+                _rebuilt_exe = _desktop_packaged_executable(desktop_dir)
+                if _rebuilt_exe:
+                    _desktop_linux_sandbox_fixup(_rebuilt_exe)
+
         print()
         print("✓ Code updated!")
 


### PR DESCRIPTION
## Problem

After `hermes update` rebuilds the desktop app via `hermes desktop --build-only`, the freshly-rebuilt `chrome-sandbox` can lose the required `root:root` + setuid (4755) permissions. This causes Electron's sandbox preflight check to fail, forcing a manual restart instead of auto-relaunch.

## Fix

Call `_desktop_linux_sandbox_fixup()` after a successful `--build-only` to ensure `chrome-sandbox` has correct permissions before the next desktop launch.

## Testing

- Verified syntax: `ast.parse()` passes
- Function `_desktop_linux_sandbox_fixup` already exists and handles sudo gracefully (fails without crashing)
- Tested on Linux (Ubuntu 22.04, Dell Vostro 14-5480)