### PR TITLE
fix(agent): strip UTF-8 BOM when loading profile .env into secret scope

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -184,10 +184,14 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
     ``set_secret_scope``. Mirrors python-dotenv's basic parsing (KEY=VALUE,
     ``export`` prefix, ``#`` comments, optional matching quotes) but never
     mutates the process environment — that isolation is the whole point.
+
+    Encoding is ``utf-8-sig`` so a leading UTF-8 BOM (Windows Notepad /
+    PowerShell ``Set-Content -Encoding UTF8``) does not prefix the first
+    key as ``\\ufeffNAME`` and make ``get_secret('NAME')`` miss under scope.
     """
     secrets: Dict[str, str] = {}
     try:
-        text = env_path.read_text(encoding="utf-8")
+        text = env_path.read_text(encoding="utf-8-sig")
     except (FileNotFoundError, OSError, UnicodeDecodeError):
         return secrets
 

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -170,6 +170,33 @@ class TestEnvFileParsing:
     def test_missing_file_returns_empty(self, tmp_path):
         assert ss.load_env_file(tmp_path / "nope.env") == {}
 
+    def test_strips_utf8_bom_from_first_key(self, tmp_path):
+        """Windows editors often save .env as UTF-8 with BOM (EF BB BF).
+
+        Plain utf-8 keeps U+FEFF on the first key name, so get_secret('NAME')
+        misses under an installed scope. utf-8-sig strips the leading BOM.
+        """
+        env = tmp_path / ".env"
+        env.write_bytes(
+            b"\xef\xbb\xbfANTHROPIC_API_KEY=sk-x\nOPENAI_API_KEY=sk-y\n"
+        )
+        out = ss.load_env_file(env)
+        assert out == {
+            "ANTHROPIC_API_KEY": "sk-x",
+            "OPENAI_API_KEY": "sk-y",
+        }
+        assert "\ufeffANTHROPIC_API_KEY" not in out
+
+        scope = ss.build_profile_secret_scope(tmp_path)
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope(scope)
+        try:
+            assert ss.get_secret("ANTHROPIC_API_KEY") == "sk-x"
+            assert ss.get_secret("OPENAI_API_KEY") == "sk-y"
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
     def test_build_profile_secret_scope(self, tmp_path):
         (tmp_path / ".env").write_text("ANTHROPIC_API_KEY=sk-profile\n")
         assert ss.build_profile_secret_scope(tmp_path) == {


### PR DESCRIPTION
## What does this PR do?

Profile multiplex secret scope loads each profile's `.env` via `load_env_file`. On Windows, Notepad / PowerShell often write a UTF-8 BOM (`EF BB BF`). Plain `utf-8` decoding left `U+FEFF` on the first key name, so `get_secret("NAME")` missed that credential under an installed scope (no `os.environ` fallthrough when multiplexing is on). This aligns the reader with `utf-8-sig`, matching `hermes_cli/config.py` `load_env()`.

### Bug Cause

`agent/secret_scope.py` `load_env_file` used `Path.read_text(encoding="utf-8")`. A leading BOM became part of the first assignment key (`\ufeffANTHROPIC_API_KEY` instead of `ANTHROPIC_API_KEY`). Under multiplex, a scope miss returns the default and does not fall through to `os.environ`.

### Reproduction Steps

1. Write a profile `.env` as bytes: `EF BB BF` + `ANTHROPIC_API_KEY=sk-x\nOPENAI_API_KEY=sk-y\n`.
2. `scope = build_profile_secret_scope(home)`; `set_multiplex_active(True)`; `set_secret_scope(scope)`.
3. Call `get_secret("ANTHROPIC_API_KEY")` and `get_secret("OPENAI_API_KEY")`.

Expected: both resolve to their values; keys have no `\ufeff` prefix.
Before fix: first key stored as `\ufeffANTHROPIC_API_KEY`; `get_secret("ANTHROPIC_API_KEY")` is `None`; second key still works.

### Fix

- Read with `encoding="utf-8-sig"` so a leading UTF-8 BOM is stripped (no-op for BOM-less UTF-8).
- Add `tests/agent/test_secret_scope.py::TestEnvFileParsing.test_strips_utf8_bom_from_first_key` covering parse + multiplex `get_secret`.

Distinct from #65124 (fixes `env_loader` / `hermes send` dotenv paths); this covers the isolated multiplex scope parser.

## Related Issue

No issue 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/secret_scope.py` - `load_env_file` uses `utf-8-sig`; docstring notes BOM tolerance
- `tests/agent/test_secret_scope.py` - BOM first-key + multiplex lookup regression test

## How to Test

1. Manual: write a BOM-prefixed `.env` as above; `build_profile_secret_scope` + multiplex `get_secret` should return the first credential under its canonical name.
2. Automated: `scripts/run_tests.sh tests/agent/test_secret_scope.py -q` (20 passed locally)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A (docstring only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - Windows BOM is the primary case; BOM-less UTF-8 unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A
