### PR TITLE
fix(agent): normalize Codex prompt cache writes

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1235,9 +1235,14 @@ def normalize_usage(
         output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
         details = getattr(response_usage, "input_tokens_details", None)
         cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
-        cache_write_tokens = _to_int(
-            getattr(details, "cache_creation_tokens", 0) if details else 0
-        )
+        # Primary: input_tokens_details.cache_write_tokens (current Responses
+        # shape). Legacy input_tokens_details.cache_creation_tokens is only a
+        # fallback when the primary attribute is absent or None — an explicit
+        # cache_write_tokens=0 wins over a non-zero legacy value.
+        cache_write_raw = getattr(details, "cache_write_tokens", None) if details else None
+        if cache_write_raw is None:
+            cache_write_raw = getattr(details, "cache_creation_tokens", 0) if details else 0
+        cache_write_tokens = _to_int(cache_write_raw)
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
         prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -15,6 +15,85 @@ from agent.usage_pricing import (
 
 
 
+def test_normalize_usage_codex_reads_cache_write_tokens():
+    """Current Responses shape: input_tokens_details.cache_write_tokens."""
+    usage = SimpleNamespace(
+        input_tokens=3000,
+        output_tokens=700,
+        input_tokens_details=SimpleNamespace(cached_tokens=1800, cache_write_tokens=400),
+    )
+
+    normalized = normalize_usage(usage, api_mode="codex_responses")
+
+    assert normalized.cache_read_tokens == 1800
+    assert normalized.cache_write_tokens == 400
+    # input = 3000 - 1800 - 400
+    assert normalized.input_tokens == 800
+    assert normalized.output_tokens == 700
+
+
+def test_normalize_usage_codex_falls_back_to_legacy_cache_creation_tokens():
+    """Legacy details objects only carry cache_creation_tokens; when the
+    primary cache_write_tokens attribute is absent we still read it."""
+    usage = SimpleNamespace(
+        input_tokens=3000,
+        output_tokens=700,
+        input_tokens_details=SimpleNamespace(cached_tokens=1800, cache_creation_tokens=400),
+    )
+
+    normalized = normalize_usage(usage, api_mode="codex_responses")
+
+    assert normalized.cache_write_tokens == 400
+    assert normalized.input_tokens == 800
+
+
+def test_normalize_usage_codex_prefers_cache_write_tokens_over_legacy():
+    usage = SimpleNamespace(
+        input_tokens=3000,
+        output_tokens=700,
+        input_tokens_details=SimpleNamespace(
+            cached_tokens=1800, cache_write_tokens=400, cache_creation_tokens=999
+        ),
+    )
+
+    normalized = normalize_usage(usage, api_mode="codex_responses")
+
+    assert normalized.cache_write_tokens == 400
+    assert normalized.input_tokens == 800
+
+
+def test_normalize_usage_codex_explicit_zero_cache_write_wins_over_legacy():
+    """An explicit cache_write_tokens=0 is authoritative — the legacy
+    cache_creation_tokens value must not resurrect a non-zero count."""
+    usage = SimpleNamespace(
+        input_tokens=3000,
+        output_tokens=700,
+        input_tokens_details=SimpleNamespace(
+            cached_tokens=1800, cache_write_tokens=0, cache_creation_tokens=999
+        ),
+    )
+
+    normalized = normalize_usage(usage, api_mode="codex_responses")
+
+    assert normalized.cache_write_tokens == 0
+    assert normalized.input_tokens == 1200
+
+
+def test_normalize_usage_codex_none_cache_write_falls_back_to_legacy():
+    usage = SimpleNamespace(
+        input_tokens=3000,
+        output_tokens=700,
+        input_tokens_details=SimpleNamespace(
+            cached_tokens=1800, cache_write_tokens=None, cache_creation_tokens=400
+        ),
+    )
+
+    normalized = normalize_usage(usage, api_mode="codex_responses")
+
+    assert normalized.cache_write_tokens == 400
+    assert normalized.input_tokens == 800
+
+
 def test_normalize_usage_reads_deepseek_native_cache_hit_tokens():
     """DeepSeek's native API (api.deepseek.com) reports context-cache hits as
     top-level prompt_cache_hit_tokens / prompt_cache_miss_tokens (with


### PR DESCRIPTION
## Summary

- read Codex Responses cache writes from `input_tokens_details.cache_write_tokens`
- retain `cache_creation_tokens` as a legacy fallback only when the primary field is absent or `None`
- preserve an explicit `cache_write_tokens=0` as authoritative
- keep the existing Insights display policy unchanged

## Why

Codex Responses can report cache-write usage through `cache_write_tokens`, while the normalizer only read the legacy `cache_creation_tokens` field. This hid cache writes and overstated uncached input tokens.

Per maintainer review, this PR now contains only the accounting normalization and its regression coverage. The earlier terminal/gateway Insights display changes have been removed.

## Testing

- `uv run --extra dev python -m pytest tests/agent/test_usage_pricing.py tests/hermes_state/test_aux_usage_accounting.py tests/agent/test_billing_usage.py tests/agent/test_account_usage.py -o 'addopts=' -q`
  - `37 passed in 5.07s`
- `uv run --extra dev pytest tests/agent/test_insights.py -o 'addopts=' -q`
  - `27 passed in 2.33s`
- `uv run --extra dev ruff check agent/usage_pricing.py tests/agent/test_usage_pricing.py`
  - passed
- `git diff --check upstream/main...HEAD`
  - passed

## Scope

Changed files:

- `agent/usage_pricing.py`
- `tests/agent/test_usage_pricing.py`
