### PR TITLE
fix(update): bootstrap declared build backend before editable recovery (ASH-2106)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8246,6 +8246,126 @@ def _refresh_active_lazy_features() -> None:
         print("  `hermes update` once the upstream issue is resolved.")
 
 
+def _load_build_system_requirements() -> list[str]:
+    """Return the PEP 517 backend requirements declared by this checkout."""
+    try:
+        import tomllib
+
+        with (PROJECT_ROOT / "pyproject.toml").open("rb") as handle:
+            requires = tomllib.load(handle).get("build-system", {}).get("requires", [])
+    except Exception as exc:
+        logger.debug("Could not read build-system requirements: %s", exc)
+        return []
+
+    if not isinstance(requires, list):
+        return []
+    return [requirement for requirement in requires if isinstance(requirement, str)]
+
+
+def _build_requirement_is_satisfied(
+    requirement: str,
+    install_cmd_prefix: list[str],
+    env: dict[str, str] | None,
+) -> bool:
+    """Check one build requirement in the environment the install targets."""
+    try:
+        import json
+
+        from packaging.requirements import Requirement
+
+        parsed = Requirement(requirement)
+        target_python = _resolve_install_target_python(install_cmd_prefix, env)
+        if target_python is None:
+            # Do not add a new install side effect when the caller does not
+            # expose a target interpreter (notably dry-run/test and custom
+            # installer paths). The editable install remains authoritative.
+            return True
+        probe_env = dict(env) if env is not None else dict(os.environ)
+        # The Desktop launcher may carry the running Hermes venv on
+        # PYTHONPATH. Letting that leak into the target interpreter makes an
+        # old target setuptools look healthy because it imports the running
+        # environment's newer copy instead.
+        probe_env.pop("PYTHONPATH", None)
+        probe_env.pop("PYTHONHOME", None)
+        probe_script = (
+            "import importlib.metadata as md, json, os, platform, sys\n"
+            "iv = sys.implementation.version\n"
+            "suffix = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc'}.get(iv.releaselevel, '')\n"
+            "implementation_version = f'{iv.major}.{iv.minor}.{iv.micro}'\n"
+            "if suffix: implementation_version += suffix + str(iv.serial)\n"
+            "try: installed = md.version(sys.argv[1])\n"
+            "except md.PackageNotFoundError: installed = None\n"
+            "environment = {\n"
+            " 'implementation_name': sys.implementation.name,\n"
+            " 'implementation_version': implementation_version,\n"
+            " 'os_name': os.name,\n"
+            " 'platform_machine': platform.machine(),\n"
+            " 'platform_python_implementation': platform.python_implementation(),\n"
+            " 'platform_release': platform.release(),\n"
+            " 'platform_system': platform.system(),\n"
+            " 'platform_version': platform.version(),\n"
+            " 'python_full_version': platform.python_version(),\n"
+            " 'python_version': '.'.join(platform.python_version_tuple()[:2]),\n"
+            " 'sys_platform': sys.platform,\n"
+            "}\n"
+            "print(json.dumps({'version': installed, 'environment': environment}))\n"
+        )
+        result = subprocess.run(
+            [
+                str(target_python),
+                "-c",
+                probe_script,
+                parsed.name,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=probe_env,
+        )
+        if result.returncode != 0:
+            return False
+        payload = json.loads(result.stdout)
+        marker_environment = payload.get("environment")
+        if not isinstance(marker_environment, dict):
+            return False
+        if parsed.marker is not None and not parsed.marker.evaluate(
+            environment=marker_environment
+        ):
+            return True
+        installed = payload.get("version")
+        if not isinstance(installed, str):
+            return False
+        return not parsed.specifier or parsed.specifier.contains(
+            installed, prereleases=True
+        )
+    except Exception:
+        return False
+
+
+def _ensure_build_system_requirements(
+    install_cmd_prefix: list[str], *, env: dict[str, str] | None = None
+) -> None:
+    """Establish the declared build backend before editable metadata is read.
+
+    Build isolation normally installs these requirements in a temporary
+    environment. Recovery cannot rely on that default, though: an inherited
+    no-isolation setting or an older installer can execute ``build_editable``
+    against the target venv. In that state setuptools 65.5 rejects Hermes'
+    PEP 639 license metadata before the normal editable install can repair it.
+    """
+    requirements = _load_build_system_requirements()
+    if not requirements or all(
+        _build_requirement_is_satisfied(requirement, install_cmd_prefix, env)
+        for requirement in requirements
+    ):
+        return
+
+    print("  → Bootstrapping the declared Python build backend...")
+    _run_install_with_heartbeat(
+        install_cmd_prefix + ["install", *requirements], env=env
+    )
+
+
 def _install_python_dependencies_with_optional_fallback(
     install_cmd_prefix: list[str],
     *,
@@ -8262,6 +8382,7 @@ def _install_python_dependencies_with_optional_fallback(
     copies (Windows blocks REPLACE on a running .exe but allows RENAME). See
     ``_quarantine_running_hermes_exe`` for the rationale.
     """
+    _ensure_build_system_requirements(install_cmd_prefix, env=env)
     scripts_dir = _venv_scripts_dir() if _is_windows() else None
 
     def _install(args: list[str]) -> None:

--- a/tests/hermes_cli/test_update_interrupted_recovery.py
+++ b/tests/hermes_cli/test_update_interrupted_recovery.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import hermes_cli.main as m
+import pytest
 
 
 def test_marker_round_trip(tmp_path, monkeypatch):
@@ -300,3 +301,159 @@ def test_recovery_output_goes_to_stderr(tmp_path, monkeypatch, capfd):
     assert "interrupted mid-install" not in out
     assert "interrupted mid-install" in err
     assert "recovered" in err
+
+
+def test_stale_setuptools_is_bootstrapped_before_editable_install(tmp_path, monkeypatch):
+    """Recovery must satisfy [build-system] before reading editable metadata."""
+    import json
+    import subprocess
+
+    from packaging.markers import default_environment
+
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        "[build-system]\n"
+        'requires = ["setuptools>=77.0,<83"]\n'
+        'build-backend = "setuptools.build_meta"\n'
+    )
+    monkeypatch.setattr(m, "_is_windows", lambda: False)
+    target_python = tmp_path / "venv" / "bin" / "python"
+    monkeypatch.setattr(
+        m, "_resolve_install_target_python", lambda prefix, env: target_python
+    )
+
+    probe_env = {}
+
+    def report_stale_setuptools(*args, **kwargs):
+        probe_env.update(kwargs["env"])
+        payload = json.dumps(
+            {"version": "65.5.0", "environment": default_environment()}
+        )
+        return subprocess.CompletedProcess(args[0], 0, payload, "")
+
+    monkeypatch.setattr(
+        m.subprocess,
+        "run",
+        report_stale_setuptools,
+    )
+
+    events = []
+
+    def record_backend(cmd, *, env=None, **kwargs):
+        events.append(("backend", cmd, env))
+
+    def record_editable(cmd, *, env=None, scripts_dir=None):
+        events.append(("editable", cmd, env))
+
+    monkeypatch.setattr(m, "_run_install_with_heartbeat", record_backend)
+    monkeypatch.setattr(m, "_run_quarantined_install", record_editable)
+    monkeypatch.setattr(m, "_verify_console_scripts_installed", lambda *a, **k: None)
+
+    env = {
+        "VIRTUAL_ENV": str(tmp_path / "venv"),
+        "PYTHONPATH": "/running/hermes/venv",
+    }
+    m._install_python_dependencies_with_optional_fallback(
+        ["uv", "pip"], env=env
+    )
+
+    assert events == [
+        (
+            "backend",
+            ["uv", "pip", "install", "setuptools>=77.0,<83"],
+            env,
+        ),
+        (
+            "editable",
+            ["uv", "pip", "install", "-e", ".[all]"],
+            env,
+        ),
+    ]
+    assert "PYTHONPATH" not in probe_env
+
+
+def test_current_build_backend_is_not_reinstalled(tmp_path, monkeypatch):
+    import json
+    import subprocess
+
+    from packaging.markers import default_environment
+
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        "[build-system]\n"
+        'requires = ["setuptools>=77.0,<83"]\n'
+    )
+    monkeypatch.setattr(
+        m,
+        "_resolve_install_target_python",
+        lambda prefix, env: tmp_path / "venv" / "bin" / "python",
+    )
+    monkeypatch.setattr(
+        m.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(
+            a[0],
+            0,
+            json.dumps(
+                {"version": "81.0.0", "environment": default_environment()}
+            ),
+            "",
+        ),
+    )
+    monkeypatch.setattr(
+        m,
+        "_run_install_with_heartbeat",
+        lambda *a, **k: pytest.fail("healthy build backend must stay unchanged"),
+    )
+
+    m._ensure_build_system_requirements(
+        ["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path / "venv")}
+    )
+
+
+def test_target_environment_controls_build_requirement_marker(tmp_path, monkeypatch):
+    import json
+    import subprocess
+
+    from packaging.markers import default_environment
+
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        "[build-system]\n"
+        'requires = ["setuptools>=77.0,<83; python_version == \'9.9\'"]\n'
+    )
+    monkeypatch.setattr(
+        m,
+        "_resolve_install_target_python",
+        lambda prefix, env: tmp_path / "venv" / "bin" / "python",
+    )
+    target_environment = default_environment()
+    target_environment["python_version"] = "9.9"
+    target_environment["python_full_version"] = "9.9.0"
+    payload = json.dumps(
+        {"version": "65.5.0", "environment": target_environment}
+    )
+    monkeypatch.setattr(
+        m.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 0, payload, ""),
+    )
+    calls = []
+    monkeypatch.setattr(
+        m,
+        "_run_install_with_heartbeat",
+        lambda cmd, **kwargs: calls.append(cmd),
+    )
+
+    m._ensure_build_system_requirements(
+        ["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path / "venv")}
+    )
+
+    assert calls == [
+        [
+            "uv",
+            "pip",
+            "install",
+            "setuptools>=77.0,<83; python_version == '9.9'",
+        ]
+    ]


### PR DESCRIPTION
## Summary

Fixes stale-setuptools failures during interrupted `hermes update` recovery (ASH-2106).

When an update is interrupted, recovery can execute `build_editable` against the target venv **without** build isolation (inherited no-isolation setting or an older installer). In that state, a stale **setuptools 65.5** rejects Hermes' PEP 639 license metadata before the normal editable install can repair it — leaving the environment wedged.

## What changed

- **`_ensure_build_system_requirements`** now runs at the very start of `_install_python_dependencies_with_optional_fallback`, establishing the declared `[build-system].requires` backend *before* editable metadata is read.
- **Target-interpreter marker evaluation**: satisfaction is decided by probing the *actual* target interpreter (`_resolve_install_target_python`) and evaluating environment markers against that interpreter's environment — not the running Hermes process. When no target interpreter is exposed (dry-run/test/custom installer paths), it adds no install side effect.
- **PYTHONPATH/PYTHONHOME isolation**: the probe strips `PYTHONPATH`/`PYTHONHOME` so a Desktop-launcher venv leaked onto the path cannot make an old target setuptools import the running environment's newer copy and look healthy.

## Verification

- 15 tests in `tests/hermes_cli/test_update_interrupted_recovery.py` pass (deterministic), covering stale-setuptools bootstrap, healthy-backend no-op, and target-environment marker control.
- Ruff clean; `git diff --check` clean.
- Real fixture recovered setuptools 65.5.0 → 82.0.1.
- Independent GPT-5.6 review approved.

Scope is exactly two files: `hermes_cli/main.py` and `tests/hermes_cli/test_update_interrupted_recovery.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)