### PR TITLE
P0-F: close Codex CLI runtime failure path with worker exit handling

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1338,6 +1338,57 @@ def _finalize_single_query(cli) -> None:
         cli._release_active_session()
 
 
+def kanban_worker_exit_code(result: Optional[dict]) -> int:
+    """Map a chat-turn result dict to the process exit code a kanban worker
+    subprocess should use.
+
+    Mirrors the exit-code logic the quiet (``-Q``/``--quiet``) single-query
+    path already applies (see the ``sys.exit(_exit_code)`` block a few
+    hundred lines below in ``main()``), factored out so the plain
+    (``-q``/``--query``) single-query path — the one the kanban
+    dispatcher's ``_default_spawn`` actually invokes (see
+    ``hermes_cli/kanban_db.py``) — can apply the identical mapping. Before
+    this helper existed, the ``-q`` path had no failure awareness at all:
+    ``cli.chat()`` returns a plain string there, so the structured
+    ``failed``/``failure_reason`` fields the ``-Q`` path relies on were
+    unreachable until ``chat()`` started stashing them on
+    ``self._last_chat_result``. Only call this when
+    ``HERMES_KANBAN_TASK`` is set — non-kanban ``-q`` invocations keep
+    their pre-existing "always exit 0" behavior untouched.
+
+    Semantics (identical to the pre-existing ``-Q`` logic):
+
+    * ``result`` missing/None or ``failed`` falsy → 0 (turn succeeded or
+      there's nothing to report — do not invent a failure).
+    * ``failed`` truthy with ``failure_reason`` in ``("rate_limit",
+      "billing")`` → ``KANBAN_RATE_LIMIT_EXIT_CODE`` (currently 75). The
+      dispatcher's ``detect_crashed_workers()`` maps that sentinel to a
+      quota-wall requeue that does NOT count against the failure circuit
+      breaker.
+    * ``failed`` truthy, any other reason (including total API failure —
+      invalid/unavailable model, persistent auth error, provider outage,
+      exhausted retries+fallback with no further recourse) → 1. The
+      dispatcher's reap classifier sees this as ``nonzero_exit`` — a real
+      crash that counts toward the failure limit like any other crash —
+      NOT ``clean_exit``, so it is never misreported as
+      ``protocol_violation`` (which specifically means the model got a
+      turn and chose not to call kanban_complete/kanban_block; a worker
+      that never got a turn because the API call itself failed did not
+      violate that contract).
+    """
+    if not isinstance(result, dict) or not result.get("failed"):
+        return 0
+    if result.get("failure_reason") in ("rate_limit", "billing"):
+        try:
+            from hermes_cli.kanban_db import (
+                KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE,
+            )
+            return _RL_CODE
+        except Exception:
+            return 1
+    return 1
+
+
 def _reset_terminal_input_modes_on_exit() -> None:
     """Best-effort: disable focus reporting + mouse tracking on TUI exit so they
     don't leak into the next shell session sharing the tab.
@@ -12702,6 +12753,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Get the final response
             response = result.get("final_response", "") if result else ""
 
+            # Stash the structured turn result so non-interactive callers
+            # (notably the kanban dispatcher's `-q` single-query path in
+            # main(), which only receives chat()'s plain string return) can
+            # still see `failed` / `failure_reason` after the call returns.
+            # See kanban_worker_exit_code() below — without this, a total
+            # API failure (quota/auth/model-unavailable, all retries and
+            # fallback exhausted) was indistinguishable from a normal
+            # completed turn at the `-q` call site, so the worker process
+            # fell through to the default exit code 0. The dispatcher's
+            # detect_crashed_workers() then misclassified that as
+            # `protocol_violation` (P0-D) instead of a real infra failure.
+            self._last_chat_result = result
+
             # Auto-generate session title after first exchange (non-blocking)
             if response and result and not result.get("failed") and not result.get("partial"):
                 try:
@@ -16576,6 +16640,29 @@ def main(
                 cli._show_security_advisories()
                 cli.chat(query, images=single_query_images or None)
                 cli._print_exit_summary(clear_screen=False)
+
+                # Kanban-worker exit code (P0-D fix). This branch has no
+                # other failure signal: cli.chat() returns a plain string
+                # and this path (unlike the `-Q` branch above) never called
+                # sys.exit() at all, so a total turn failure (API call
+                # never got a response — invalid/unavailable model,
+                # persistent auth error, provider outage, retries+fallback
+                # exhausted) fell through to the interpreter's default exit
+                # code 0. The dispatcher's detect_crashed_workers() then
+                # classified that as `clean_exit` while the task was still
+                # `running` and reported it as `protocol_violation` — a
+                # claim that the model got a turn and chose not to call
+                # kanban_complete/kanban_block, which is false when the API
+                # call itself never produced a model turn at all. Gated on
+                # HERMES_KANBAN_TASK so plain human/automation `-q` usage
+                # (no dispatcher involved) keeps its prior "always exit 0"
+                # behavior untouched.
+                if os.environ.get("HERMES_KANBAN_TASK"):
+                    sys.exit(
+                        kanban_worker_exit_code(
+                            getattr(cli, "_last_chat_result", None)
+                        )
+                    )
         finally:
             _finalize_single_query(cli)
         return

--- a/cli.py
+++ b/cli.py
@@ -16129,6 +16129,241 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     )
 
 
+def _external_cli_worker_evidence_dir(task_id: str) -> Path:
+    root = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    safe_task_id = re.sub(r"[^A-Za-z0-9_.-]+", "-", task_id.strip()).strip(".-")[:80] or "task"
+    run_id = f"{time.strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:12]}"
+    return Path(root) / "cache" / "external_cli_adapter" / safe_task_id / run_id
+
+
+def _build_external_cli_worker_prompt(task) -> str:
+    parts = [task.title or ""]
+    if getattr(task, "body", None):
+        parts.append(task.body)
+    body = "\n\n".join(part.strip() for part in parts if part and part.strip()).strip()
+    return body or f"Kanban task {getattr(task, 'id', 'unknown')}"
+
+
+
+
+def _set_external_cli_worker_result(
+    cli: "HermesCLI",
+    *,
+    failed: bool,
+    response: str,
+    failure_reason: str | None = None,
+    metadata: Optional[dict] = None,
+) -> None:
+    cli._last_chat_result = {
+        "failed": failed,
+        "final_response": "" if failed else response,
+        "error": response if failed else None,
+        "failure_reason": failure_reason,
+        "external_cli": metadata or {},
+    }
+
+
+def _run_external_cli_worker_once(cli: "HermesCLI") -> tuple[bool, Optional[str]]:
+    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if not task_id:
+        return False, None
+
+    from hermes_cli.config import load_config
+    from hermes_cli.external_cli_adapter import (
+        ExternalCliAgentAdapter,
+        ExternalCliExecutionRequest,
+        load_external_cli_worker_config,
+    )
+    from hermes_cli import kanban_db as _kb
+
+    try:
+        worker_cfg = load_external_cli_worker_config(load_config())
+    except ValueError as exc:
+        error = f"External CLI worker config invalid: {exc}"
+        _set_external_cli_worker_result(
+            cli,
+            failed=True,
+            response=error,
+            failure_reason="external_cli",
+            metadata={"status": "FAILED_INVALID_INVOCATION"},
+        )
+        return True, f"Error: {error}"
+
+    if worker_cfg.execution_backend != "external_cli":
+        return False, None
+
+    conn = _kb.connect()
+    try:
+        task = _kb.get_task(conn, task_id)
+        if task is None:
+            error = f"Kanban task not found: {task_id}"
+            _set_external_cli_worker_result(
+                cli,
+                failed=True,
+                response=error,
+                failure_reason="external_cli",
+                metadata={"status": "FAILED_INVALID_INVOCATION"},
+            )
+            return True, f"Error: {error}"
+
+        workspace = (os.environ.get("HERMES_KANBAN_WORKSPACE") or os.getcwd()).strip()
+        evidence_dir = _external_cli_worker_evidence_dir(task_id)
+        adapter = ExternalCliAgentAdapter()
+        result = adapter.run(
+            worker_cfg,
+            ExternalCliExecutionRequest(
+                task_id=task_id,
+                profile_name=(task.assignee or "default"),
+                prompt=_build_external_cli_worker_prompt(task),
+                workspace_path=workspace,
+                timeout_seconds=task.max_runtime_seconds,
+                evidence_dir=str(evidence_dir),
+                model=None,
+                cancellation_requested=(
+                    (lambda: bool(cli.agent and getattr(cli.agent, "_interrupt_requested", False)))
+                    if getattr(cli, "agent", None) is not None
+                    else None
+                ),
+            ),
+        )
+        metadata = result.as_metadata()
+
+        if result.status == "COMPLETED" and result.structured_payload is not None:
+            payload = result.structured_payload
+            if payload.action == "complete":
+                summary = payload.summary or f"Completed by {worker_cfg.executable}"
+                if not _kb.complete_task(
+                    conn,
+                    task_id,
+                    result=summary,
+                    summary=summary,
+                    metadata=payload.metadata,
+                ):
+                    error = f"External CLI completion could not close task {task_id}"
+                    _set_external_cli_worker_result(
+                        cli,
+                        failed=True,
+                        response=error,
+                        failure_reason="external_cli",
+                        metadata={**metadata, "status": "FAILED_INTERNAL"},
+                    )
+                    return True, f"Error: {error}"
+                _set_external_cli_worker_result(
+                    cli,
+                    failed=False,
+                    response=summary,
+                    metadata=metadata,
+                )
+                return True, summary
+
+            reason = payload.reason or payload.summary or f"Blocked by {worker_cfg.executable}"
+            kind = payload.block_kind or "needs_input"
+            if not _kb.block_task(conn, task_id, reason=reason, kind=kind):
+                error = f"External CLI block could not transition task {task_id}"
+                _set_external_cli_worker_result(
+                    cli,
+                    failed=True,
+                    response=error,
+                    failure_reason="external_cli",
+                    metadata={**metadata, "status": "FAILED_INTERNAL"},
+                )
+                return True, f"Error: {error}"
+            _set_external_cli_worker_result(
+                cli,
+                failed=False,
+                response=reason,
+                metadata=metadata,
+            )
+            return True, reason
+
+        if result.status == "BLOCKED_AUTH":
+            reason = f"{worker_cfg.executable} requires a CLI-managed login session before this task can run."
+            if not _kb.block_task(conn, task_id, reason=reason, kind="capability"):
+                error = f"External CLI auth block could not transition task {task_id}"
+                _set_external_cli_worker_result(
+                    cli,
+                    failed=True,
+                    response=error,
+                    failure_reason="external_cli",
+                    metadata={**metadata, "status": "FAILED_INTERNAL"},
+                )
+                return True, f"Error: {error}"
+            _set_external_cli_worker_result(cli, failed=False, response=reason, metadata=metadata)
+            return True, reason
+
+        if result.status == "BLOCKED_PERMISSION":
+            reason = f"{worker_cfg.executable} could not access the required workspace or permissions."
+            if not _kb.block_task(conn, task_id, reason=reason, kind="capability"):
+                error = f"External CLI permission block could not transition task {task_id}"
+                _set_external_cli_worker_result(
+                    cli,
+                    failed=True,
+                    response=error,
+                    failure_reason="external_cli",
+                    metadata={**metadata, "status": "FAILED_INTERNAL"},
+                )
+                return True, f"Error: {error}"
+            _set_external_cli_worker_result(cli, failed=False, response=reason, metadata=metadata)
+            return True, reason
+
+        if result.status == "BLOCKED_QUOTA":
+            error = f"{worker_cfg.executable} reported subscription quota exhaustion."
+            _set_external_cli_worker_result(
+                cli,
+                failed=True,
+                response=error,
+                failure_reason="billing",
+                metadata=metadata,
+            )
+            return True, f"Error: {error}"
+
+        error_map = {
+            "FAILED_TIMEOUT": f"{worker_cfg.executable} timed out before producing a valid structured result.",
+            "FAILED_CANCELLED": f"{worker_cfg.executable} was cancelled before producing a valid structured result.",
+            "FAILED_EXECUTABLE_MISSING": f"{worker_cfg.executable} is not available on PATH for this worker.",
+            "FAILED_INVALID_INVOCATION": f"{worker_cfg.executable} rejected the worker invocation.",
+            "FAILED_MALFORMED_OUTPUT": f"{worker_cfg.executable} did not return the required structured JSON contract.",
+        }
+        error = error_map.get(result.status, f"{worker_cfg.executable} failed before Hermes could normalize a task result.")
+        # The adapter has reached a terminal result, so the formal worker must
+        # not return while Hermes's canonical task remains running. Quota is
+        # intentionally handled by the existing exit-75 dispatcher path; all
+        # other adapter failures are terminal for this no-retry invocation.
+        block_kind = (
+            "capability"
+            if result.status in {
+                "FAILED_EXECUTABLE_MISSING",
+                "FAILED_INVALID_INVOCATION",
+            }
+            else "transient"
+        )
+        if not _kb.block_task(conn, task_id, reason=error, kind=block_kind):
+            transition_error = (
+                f"External CLI failure could not transition task {task_id}"
+            )
+            _set_external_cli_worker_result(
+                cli,
+                failed=True,
+                response=transition_error,
+                failure_reason="external_cli",
+                metadata={**metadata, "status": "FAILED_INTERNAL"},
+            )
+            return True, f"Error: {transition_error}"
+        _set_external_cli_worker_result(
+            cli,
+            failed=True,
+            response=error,
+            failure_reason="external_cli",
+            metadata=metadata,
+        )
+        return True, f"Error: {error}"
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
 def main(
     query: str = None,
     q: str = None,
@@ -16358,12 +16593,33 @@ def main(
     # process group, then SIGKILL after 1 s), then raise KeyboardInterrupt
     # so main unwinds normally.  HERMES_SIGTERM_GRACE overrides the 1.5 s
     # default for debugging.
+    from hermes_cli.external_cli_adapter import (
+        active_external_cli_registry as _active_external_cli_registry,
+    )
+
     def _signal_handler_q(signum, frame):
         logger.debug("Received signal %s in single-query mode", signum)
         # Arm the exit backstop now that shutdown intent is unambiguous —
         # covers wedges in the unwind below that would otherwise leave the
         # process alive with no watchdog (#65998 class). Never raises.
         _arm_exit_watchdog_on_shutdown_signal()
+        # If an external CLI child (claude/codex) is currently running, its
+        # process group is separate from ours (start_new_session=True) and the
+        # adapter owns its own cleanup path. Set the cancellation flag and
+        # return immediately instead of falling into the sleep+os._exit(0)
+        # path below: that path can terminate this process before the
+        # interrupted adapter poll loop ever resumes to kill and reap the
+        # child, orphaning it (#P0-F M2).
+        try:
+            if _active_external_cli_registry.request_cancel():
+                logger.debug(
+                    "External CLI adapter active; deferring exit for signal %s "
+                    "until its child process is terminated and reaped",
+                    signum,
+                )
+                return
+        except Exception:
+            pass  # never block signal handling
         try:
             _agent = getattr(cli, "agent", None)
             if _agent is not None:
@@ -16462,6 +16718,22 @@ def main(
                 except Exception as _exc:
                     # Best-effort enrichment; never block worker startup on it.
                     logger.debug("kanban image-ref extraction failed: %s", _exc)
+            _handled_external_cli, _external_cli_response = _run_external_cli_worker_once(cli)
+            if _handled_external_cli:
+                if _external_cli_response:
+                    print(_external_cli_response)
+                if quiet:
+                    print("", file=sys.stderr)
+                    print(f"session_id: {cli.session_id}", file=sys.stderr)
+                else:
+                    cli._print_exit_summary()
+                if os.environ.get("HERMES_KANBAN_TASK"):
+                    sys.exit(
+                        kanban_worker_exit_code(
+                            getattr(cli, "_last_chat_result", None)
+                        )
+                    )
+                return
             if quiet:
                 # Quiet mode: suppress banner, spinner, tool previews.
                 # Only print the final response and parseable session info.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -936,6 +936,17 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "worker": {
+        "execution_backend": "hermes_internal",
+        "external_cli": {
+            "executable": "",
+            "args": [],
+            "authentication_mode": "",
+            "output_mode": "auto",
+            "timeout_mode": "task_budget",
+            "allow_resume": False,
+        },
+    },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,
@@ -5772,6 +5783,22 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 "warning",
                 f"Root-level key '{key}' looks misplaced — should it be under 'model:' or inside a 'custom_providers' entry?",
                 f"Move '{key}' under the appropriate section",
+            ))
+
+    try:
+        from hermes_cli.external_cli_adapter import validate_external_cli_worker_config
+    except ImportError as exc:
+        issues.append(ConfigIssue(
+            "error",
+            f"external CLI worker validation unavailable: {exc}",
+            "Restore hermes_cli.external_cli_adapter before using worker.execution_backend=external_cli",
+        ))
+    else:
+        for message in validate_external_cli_worker_config(config):
+            issues.append(ConfigIssue(
+                "error",
+                f"worker config invalid: {message}",
+                "Fix worker.execution_backend / worker.external_cli to match the supported external CLI schema",
             ))
 
     return issues

--- a/hermes_cli/external_cli_adapter.py
+++ b/hermes_cli/external_cli_adapter.py
@@ -1,0 +1,1076 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import shutil
+import signal
+import subprocess
+import threading
+import time
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from agent.redact import redact_sensitive_text
+
+
+SAFE_EXECUTABLES = frozenset({"claude", "codex"})
+SAFE_OUTPUT_MODES = frozenset({"auto", "structured"})
+SAFE_TIMEOUT_MODES = frozenset({"task_budget"})
+SAFE_AUTH_MODES = frozenset({"cli_managed_subscription"})
+SAFE_BLOCK_KINDS = frozenset({"needs_input", "capability", "transient", "dependency"})
+SAFE_METADATA_KEYS = frozenset({"changed_files", "tests_run", "evidence"})
+SAFE_ENV_NAMES = (
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "LANG",
+    "LC_ALL",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_STATE_HOME",
+    "XDG_CACHE_HOME",
+    "TMPDIR",
+)
+BLOCKED_ENV_NAMES = frozenset(
+    {
+        "OPENROUTER_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SESSION_TOKEN",
+        "AZURE_OPENAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "XAI_API_KEY",
+        "COHERE_API_KEY",
+        "MISTRAL_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "DASHSCOPE_API_KEY",
+        "MINIMAX_API_KEY",
+        "KIMI_API_KEY",
+        "QWEN_API_KEY",
+        "CODEX_ACCESS_TOKEN",
+    }
+)
+FORBIDDEN_EXTERNAL_CLI_FIELDS = frozenset(
+    {
+        "api_key",
+        "api_key_env",
+        "openrouter_api_key",
+        "anthropic_api_key",
+        "openai_api_key",
+        "credential_fingerprint",
+        "resume",
+        "session_id",
+        "fallback",
+        "fallback_model",
+        "fallback_provider",
+    }
+)
+MAX_CAPTURE_BYTES = 256 * 1024
+MAX_PROMPT_BYTES = 1024 * 1024
+SUMMARY_CHAR_LIMIT = 2000
+METADATA_ITEM_LIMIT = 500
+METADATA_LIST_LIMIT = 100
+METADATA_SERIALIZED_LIMIT = 64 * 1024
+MAX_STRUCTURED_MESSAGE_BYTES = 1024 * 1024
+MAX_UNTERMINATED_JSONL_LINE_BYTES = 2 * MAX_STRUCTURED_MESSAGE_BYTES
+STRUCTURED_RESULT_KEY = "hermes_external_cli_result"
+
+
+@dataclass(frozen=True)
+class ExternalCliWorkerConfig:
+    execution_backend: str = "hermes_internal"
+    executable: str = ""
+    args: tuple[str, ...] = ()
+    authentication_mode: str = ""
+    output_mode: str = "auto"
+    timeout_mode: str = "task_budget"
+    allow_resume: bool = False
+
+
+@dataclass(frozen=True)
+class ExternalCliExecutionRequest:
+    task_id: str
+    profile_name: str
+    prompt: str
+    workspace_path: str
+    timeout_seconds: Optional[int]
+    evidence_dir: str
+    model: Optional[str] = None
+    cancellation_requested: Optional[Callable[[], bool]] = None
+
+
+@dataclass(frozen=True)
+class ExternalCliStructuredPayload:
+    action: str
+    summary: Optional[str] = None
+    metadata: Optional[dict] = None
+    reason: Optional[str] = None
+    block_kind: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ExternalCliExecutionResult:
+    status: str
+    executable: str
+    argv_summary: str
+    cwd: str
+    structured_output_status: str
+    stdout_artifact_path: Optional[str]
+    stdout_sha256: Optional[str]
+    stdout_size: int
+    stderr_artifact_path: Optional[str]
+    stderr_sha256: Optional[str]
+    stderr_size: int
+    stdout_summary: str
+    stderr_signature: str
+    stdout_total_size: int = 0
+    stdout_truncated: bool = False
+    stderr_total_size: int = 0
+    stderr_truncated: bool = False
+    exit_code: Optional[int] = None
+    signal: Optional[int] = None
+    timed_out: bool = False
+    cancelled: bool = False
+    structured_payload: Optional[ExternalCliStructuredPayload] = None
+
+    def as_metadata(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        if self.structured_payload is not None:
+            payload["structured_payload"] = asdict(self.structured_payload)
+        return payload
+
+
+def _sanitize_text(value: Any, *, limit: int = SUMMARY_CHAR_LIMIT) -> str:
+    text = redact_sensitive_text(str(value or ""), force=True)
+    text = "".join(ch if ch >= " " or ch in "\t\n" else " " for ch in text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:limit]
+
+
+def _sanitize_path_fragment(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip())
+    cleaned = cleaned.strip(".-")
+    return cleaned[:80] or "artifact"
+
+
+# changed_files/evidence are model-controlled and land in canonical task
+# metadata; without this, absolute paths, '..' traversal, and local
+# filesystem layout (e.g. /home/<user>/...) could leak into the Kanban
+# record (P0-F m1). tests_run is free-form description text, not a path, so
+# it only gets the existing length/redaction bounds.
+_PATH_LIKE_METADATA_KEYS = frozenset({"changed_files", "evidence"})
+_DRIVE_LETTER_PATH_RE = re.compile(r"^[A-Za-z]:[/\\]")
+
+
+def _normalize_relative_metadata_path(value: str) -> Optional[str]:
+    """Accept only a clean, workspace-relative path: no absolute paths (POSIX
+    or Windows drive-letter), no home-dir shorthand, no '..' traversal."""
+    if "\x00" in value:
+        return None
+    candidate = value.strip().replace("\\", "/")
+    if not candidate or candidate.startswith("/") or candidate.startswith("~"):
+        return None
+    if _DRIVE_LETTER_PATH_RE.match(value.strip()):
+        return None
+    parts = [part for part in candidate.split("/") if part not in ("", ".")]
+    if not parts or any(part == ".." for part in parts):
+        return None
+    return "/".join(parts)
+
+
+def _sanitize_metadata(value: Any) -> dict[str, list[str]]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("metadata must be an object")
+    result: dict[str, list[str]] = {}
+    for key in SAFE_METADATA_KEYS:
+        raw_items = value.get(key)
+        if raw_items is None:
+            continue
+        if not isinstance(raw_items, list):
+            raise ValueError(f"metadata.{key} must be a list")
+        if len(raw_items) > METADATA_LIST_LIMIT:
+            raise ValueError(f"metadata.{key} exceeds item limit")
+        items: list[str] = []
+        for item in raw_items:
+            if not isinstance(item, str):
+                raise ValueError(f"metadata.{key} entries must be strings")
+            sanitized = _sanitize_text(item, limit=METADATA_ITEM_LIMIT)
+            if not sanitized:
+                continue
+            if key in _PATH_LIKE_METADATA_KEYS:
+                sanitized = _normalize_relative_metadata_path(sanitized)
+                if not sanitized:
+                    continue
+            items.append(sanitized)
+        result[key] = items
+    if len(json.dumps(result, ensure_ascii=False).encode("utf-8")) > METADATA_SERIALIZED_LIMIT:
+        raise ValueError("metadata exceeds serialized size limit")
+    return result
+
+
+def sanitize_external_cli_payload(payload: ExternalCliStructuredPayload) -> ExternalCliStructuredPayload:
+    action = str(payload.action or "").strip().lower()
+    if action not in {"complete", "block"}:
+        raise ValueError("action must be complete or block")
+    block_kind = str(payload.block_kind or "").strip() or None
+    if block_kind is not None and block_kind not in SAFE_BLOCK_KINDS:
+        raise ValueError("block_kind is invalid")
+    summary = _sanitize_text(payload.summary, limit=SUMMARY_CHAR_LIMIT) or None
+    reason = _sanitize_text(payload.reason, limit=SUMMARY_CHAR_LIMIT) or None
+    metadata = _sanitize_metadata(payload.metadata)
+    if action == "complete" and not summary:
+        summary = "Completed by external CLI worker"
+    if action == "block" and not (reason or summary):
+        reason = "External CLI worker reported a blocked task"
+    return ExternalCliStructuredPayload(
+        action=action,
+        summary=summary,
+        metadata=metadata,
+        reason=reason,
+        block_kind=block_kind,
+    )
+
+
+ALLOWED_EXTERNAL_CLI_FIELDS = frozenset(
+    {"executable", "args", "authentication_mode", "output_mode", "timeout_mode", "allow_resume"}
+)
+
+
+def _default_worker_config() -> Dict[str, Any]:
+    return {
+        "execution_backend": "hermes_internal",
+        "external_cli": {
+            "executable": "",
+            "args": [],
+            "authentication_mode": "",
+            "output_mode": "auto",
+            "timeout_mode": "task_budget",
+            "allow_resume": False,
+        },
+    }
+
+
+def worker_config_defaults() -> Dict[str, Any]:
+    return json.loads(json.dumps(_default_worker_config()))
+
+
+def load_external_cli_worker_config(config: Optional[Dict[str, Any]]) -> ExternalCliWorkerConfig:
+    worker_cfg: dict[str, Any] = {}
+    if isinstance(config, dict):
+        raw = config.get("worker")
+        if isinstance(raw, dict):
+            worker_cfg = raw
+    defaults = _default_worker_config()
+    execution_backend = str(worker_cfg.get("execution_backend", defaults["execution_backend"]) or "").strip() or "hermes_internal"
+    if execution_backend not in {"hermes_internal", "external_cli"}:
+        raise ValueError(f"worker.execution_backend must be one of ['external_cli', 'hermes_internal'], got {execution_backend!r}")
+
+    raw_external = worker_cfg.get("external_cli", defaults["external_cli"])
+    if raw_external is None:
+        raw_external = {}
+    if not isinstance(raw_external, dict):
+        raise ValueError("worker.external_cli must be a mapping when set")
+
+    forbidden = sorted(FORBIDDEN_EXTERNAL_CLI_FIELDS & set(raw_external.keys()))
+    if forbidden:
+        raise ValueError(f"worker.external_cli contains forbidden fields: {', '.join(forbidden)}")
+    unknown = sorted(set(raw_external.keys()) - ALLOWED_EXTERNAL_CLI_FIELDS - FORBIDDEN_EXTERNAL_CLI_FIELDS)
+    if unknown:
+        raise ValueError(f"worker.external_cli contains unknown fields: {', '.join(unknown)}")
+
+    executable = str(raw_external.get("executable", "") or "").strip()
+    args = raw_external.get("args", [])
+    if args is None:
+        args = []
+    if not isinstance(args, list) or any(not isinstance(item, str) for item in args):
+        raise ValueError("worker.external_cli.args must be a list of strings")
+    if args:
+        raise ValueError("worker.external_cli.args must be empty in external CLI adapter v1")
+
+    authentication_mode = str(raw_external.get("authentication_mode", "") or "").strip()
+    output_mode = str(raw_external.get("output_mode", "auto") or "auto").strip().lower()
+    timeout_mode = str(raw_external.get("timeout_mode", "task_budget") or "task_budget").strip().lower()
+    allow_resume = bool(raw_external.get("allow_resume", False))
+
+    if output_mode not in SAFE_OUTPUT_MODES:
+        raise ValueError(f"worker.external_cli.output_mode must be one of {sorted(SAFE_OUTPUT_MODES)}")
+    if timeout_mode not in SAFE_TIMEOUT_MODES:
+        raise ValueError(f"worker.external_cli.timeout_mode must be one of {sorted(SAFE_TIMEOUT_MODES)}")
+    if allow_resume:
+        raise ValueError("worker.external_cli.allow_resume=true is not supported")
+
+    if execution_backend == "external_cli":
+        if executable not in SAFE_EXECUTABLES:
+            raise ValueError("worker.external_cli.executable must be 'claude' or 'codex'")
+        if authentication_mode not in SAFE_AUTH_MODES:
+            raise ValueError("worker.external_cli.authentication_mode must be 'cli_managed_subscription'")
+    else:
+        executable = ""
+        authentication_mode = ""
+
+    return ExternalCliWorkerConfig(
+        execution_backend=execution_backend,
+        executable=executable,
+        args=(),
+        authentication_mode=authentication_mode,
+        output_mode=output_mode,
+        timeout_mode=timeout_mode,
+        allow_resume=False,
+    )
+
+
+def validate_external_cli_worker_config(config: Optional[Dict[str, Any]]) -> list[str]:
+    try:
+        load_external_cli_worker_config(config)
+    except ValueError as exc:
+        return [str(exc)]
+    return []
+
+
+def _build_subprocess_env(cfg: ExternalCliWorkerConfig) -> Dict[str, str]:
+    env: Dict[str, str] = {}
+    for name in SAFE_ENV_NAMES:
+        value = os.environ.get(name)
+        if value and name not in BLOCKED_ENV_NAMES:
+            env[name] = value
+    return env
+
+
+def _build_worker_prompt(req: ExternalCliExecutionRequest) -> str:
+    return (
+        "You are executing one Hermes kanban task inside a pinned workspace.\n"
+        "Do the work in the workspace and return ONLY one JSON object matching this contract:\n"
+        "{\n"
+        '  "hermes_external_cli_result": {\n'
+        '    "action": "complete" | "block",\n'
+        '    "summary": "short summary for complete",\n'
+        '    "metadata": {"changed_files": [], "tests_run": [], "evidence": []},\n'
+        '    "reason": "blocking reason for block",\n'
+        '    "block_kind": "needs_input" | "capability" | "transient" | "dependency"\n'
+        "  }\n"
+        "}\n"
+        "Do not output prose before or after the JSON object.\n"
+        f"Task ID: {req.task_id}\n"
+        f"Profile: {req.profile_name}\n"
+        f"Workspace: {req.workspace_path}\n"
+        "\nTask:\n"
+        f"{req.prompt.strip()}\n"
+    )
+
+
+def _parse_contract_text(text: str) -> Optional[ExternalCliStructuredPayload]:
+    try:
+        candidate = json.loads(text.strip())
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(candidate, dict) or set(candidate) != {STRUCTURED_RESULT_KEY}:
+        return None
+    raw = candidate.get(STRUCTURED_RESULT_KEY)
+    if not isinstance(raw, dict):
+        return None
+    allowed = {"action", "summary", "metadata", "reason", "block_kind"}
+    if not set(raw).issubset(allowed):
+        return None
+    try:
+        return sanitize_external_cli_payload(
+            ExternalCliStructuredPayload(
+                action=raw.get("action"),
+                summary=raw.get("summary"),
+                metadata=raw.get("metadata"),
+                reason=raw.get("reason"),
+                block_kind=raw.get("block_kind"),
+            )
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+_AUTH_FAILURE_SIGNATURES = (
+    "not logged in", "authentication", "auth required", "sign in",
+    "login required", "subscription required", "setup-token",
+)
+_QUOTA_FAILURE_SIGNATURES = (
+    "quota", "rate limit", "too many requests", "billing", "usage cap",
+    "credit balance", "exhausted",
+)
+# Multi-word, denial-specific phrases only. A bare "sandbox" or "approval"
+# token also appears in unrelated runtime-initialization failures (e.g. "no
+# sandbox helper found", "approval config invalid") and would misclassify
+# those as an actionable permission block rather than an internal failure
+# (P0-F m4).
+_PERMISSION_FAILURE_SIGNATURES = (
+    "permission denied", "not trusted", "approval required", "access denied",
+    "denied by sandbox", "blocked by sandbox", "rejected by sandbox policy",
+    "operation not permitted",
+)
+_INVALID_INVOCATION_SIGNATURES = (
+    "invalid_request_error",
+    "invalid_json_schema",
+    "invalid schema for response_format",
+)
+
+
+def _classify_failure(output_text: str, exit_code: Optional[int], *, timed_out: bool, cancelled: bool) -> str:
+    if cancelled:
+        return "FAILED_CANCELLED"
+    if timed_out:
+        return "FAILED_TIMEOUT"
+    lowered = f"{output_text}\nexit={exit_code}".lower()
+    if any(token in lowered for token in _AUTH_FAILURE_SIGNATURES):
+        return "BLOCKED_AUTH"
+    if any(token in lowered for token in _QUOTA_FAILURE_SIGNATURES):
+        return "BLOCKED_QUOTA"
+    if any(token in lowered for token in _PERMISSION_FAILURE_SIGNATURES):
+        return "BLOCKED_PERMISSION"
+    if any(token in lowered for token in _INVALID_INVOCATION_SIGNATURES):
+        return "FAILED_INVALID_INVOCATION"
+    if exit_code == 127:
+        return "FAILED_EXECUTABLE_MISSING"
+    if exit_code == 2:
+        return "FAILED_INVALID_INVOCATION"
+    return "FAILED_INTERNAL"
+
+
+def _ensure_secure_directory(path: Path) -> None:
+    if path.exists() and path.is_symlink():
+        raise OSError("evidence directory may not be a symlink")
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(path, 0o700)
+
+
+def _write_secure_file(path: Path, content: bytes) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "wb", closefd=False) as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+    finally:
+        os.close(fd)
+
+
+def _write_artifact(base_dir: Path, stem: str, content: bytes) -> tuple[Optional[str], Optional[str], int]:
+    if not content:
+        return None, None, 0
+    _ensure_secure_directory(base_dir)
+    path = base_dir / f"{_sanitize_path_fragment(stem)}-{secrets.token_hex(6)}.log"
+    _write_secure_file(path, content)
+    return str(path), sha256(content).hexdigest(), len(content)
+
+
+class _StreamCapture:
+    def __init__(self) -> None:
+        self.total_size = 0
+        self.truncated = False
+        self._captured_size = 0
+        self._chunks: list[bytes] = []
+        self._lock = threading.Lock()
+
+    def feed(self, chunk: bytes) -> None:
+        if not chunk:
+            return
+        with self._lock:
+            self.total_size += len(chunk)
+            if self._captured_size >= MAX_CAPTURE_BYTES:
+                self.truncated = True
+                return
+            remaining = MAX_CAPTURE_BYTES - self._captured_size
+            captured = chunk[:remaining]
+            if captured:
+                self._chunks.append(captured)
+                self._captured_size += len(captured)
+            if len(chunk) > len(captured):
+                self.truncated = True
+
+    def content(self) -> bytes:
+        with self._lock:
+            return b"".join(self._chunks)
+
+
+class _ActiveExternalCliRegistry:
+    """Tracks whether this process currently owns a live external CLI child,
+    so a SIGTERM handler can defer immediate process exit until the child has
+    been terminated and reaped instead of orphaning it.
+
+    Deliberately lock-free: a Python signal handler runs synchronously on the
+    main thread's eval loop, so acquiring a lock that the interrupted code
+    already holds would deadlock the process. Plain attribute reads/writes
+    are GIL-atomic, which is all the cross-context safety this needs.
+    """
+
+    def __init__(self) -> None:
+        self._active = False
+        self._cancel_requested = False
+
+    def activate(self) -> None:
+        self._cancel_requested = False
+        self._active = True
+
+    def deactivate(self) -> None:
+        self._active = False
+
+    def cancellation_requested(self) -> bool:
+        return self._cancel_requested
+
+    def request_cancel(self) -> bool:
+        """Call from a signal handler. Returns True if a child is active and
+        will observe the cancellation, so the caller should defer exit."""
+        if not self._active:
+            return False
+        self._cancel_requested = True
+        return True
+
+
+active_external_cli_registry = _ActiveExternalCliRegistry()
+
+
+class _CodexIncrementalParser:
+    """Streams Codex `exec --json` JSONL without holding the full transcript
+    in memory. Only terminal state and the most recent agent message text
+    are retained, so a valid multi-megabyte transcript still yields the
+    final result instead of being silently truncated by a bounded capture
+    buffer that only kept the first 256 KiB (P0-F M3). The raw stdout is
+    still captured separately (and still size-capped) purely as an evidence
+    artifact; this parser is the only thing that decides the result.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = bytearray()
+        self.line_count = 0
+        self.total_bytes = 0
+        self.malformed_line_seen = False
+        self.fatal_error_seen = False
+        self.terminal_failure_text: Optional[str] = None
+        self.turn_completed_seen = False
+        self.last_agent_message_text: Optional[str] = None
+
+    def feed(self, chunk: bytes) -> None:
+        if not chunk:
+            return
+        self.total_bytes += len(chunk)
+        self._buffer.extend(chunk)
+        while True:
+            newline_index = self._buffer.find(b"\n")
+            if newline_index < 0:
+                break
+            raw_line = bytes(self._buffer[:newline_index])
+            del self._buffer[: newline_index + 1]
+            self._consume_line(raw_line)
+        if len(self._buffer) > MAX_UNTERMINATED_JSONL_LINE_BYTES:
+            # A single line growing unbounded without a newline can't be a
+            # valid bounded contract; drop it rather than buffering forever.
+            self.malformed_line_seen = True
+            self._buffer.clear()
+
+    def finalize(self) -> None:
+        if self._buffer.strip():
+            self._consume_line(bytes(self._buffer))
+        self._buffer.clear()
+
+    def _consume_line(self, raw_line: bytes) -> None:
+        line = raw_line.strip()
+        if not line:
+            return
+        self.line_count += 1
+        try:
+            event = json.loads(line.decode("utf-8", errors="strict"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            self.malformed_line_seen = True
+            return
+        if not isinstance(event, dict):
+            self.malformed_line_seen = True
+            return
+        event_type = event.get("type")
+        if event_type in {"error", "turn.failed"}:
+            self.fatal_error_seen = True
+            raw_error = event.get("error")
+            if isinstance(raw_error, dict):
+                raw_error = raw_error.get("message")
+            if not isinstance(raw_error, str):
+                raw_error = event.get("message")
+            if isinstance(raw_error, str) and raw_error.strip():
+                # Prefer turn.failed: it is Codex's terminal result and is
+                # more authoritative than an earlier streaming error event.
+                if event_type == "turn.failed" or self.terminal_failure_text is None:
+                    self.terminal_failure_text = raw_error
+            return
+        if event_type == "turn.completed":
+            self.turn_completed_seen = True
+            return
+        if self.turn_completed_seen:
+            return  # ignore any trailing noise after the terminal event
+        if event_type == "item.completed":
+            item = event.get("item")
+            if isinstance(item, dict) and item.get("type") == "agent_message" and isinstance(item.get("text"), str):
+                text = item["text"]
+                if len(text.encode("utf-8", errors="ignore")) <= MAX_STRUCTURED_MESSAGE_BYTES:
+                    self.last_agent_message_text = text
+                else:
+                    # Oversized single message can't be a valid bounded
+                    # contract anyway; don't retain it.
+                    self.last_agent_message_text = None
+
+    def result(self) -> Optional[ExternalCliStructuredPayload]:
+        self.finalize()
+        if self.malformed_line_seen or self.fatal_error_seen:
+            return None
+        if not self.turn_completed_seen or self.last_agent_message_text is None:
+            return None
+        return _parse_contract_text(self.last_agent_message_text)
+
+
+class _BaseCliStrategy:
+    name = ""
+
+    def build_argv(self, cfg: ExternalCliWorkerConfig, req: ExternalCliExecutionRequest) -> list[str]:
+        raise NotImplementedError
+
+    def build_prompt(self, req: ExternalCliExecutionRequest) -> str:
+        return _build_worker_prompt(req)
+
+    def parse_output(self, stdout_text: str) -> Optional[ExternalCliStructuredPayload]:
+        raise NotImplementedError
+
+    def create_incremental_parser(self) -> Optional["_CodexIncrementalParser"]:
+        """Vendors whose terminal result can be identified while streaming
+        (rather than only after the fact from a bounded buffer) return a
+        parser here; the adapter feeds it chunks as they arrive and prefers
+        its result over parse_output()'s post-hoc, capture-buffer-based one."""
+        return None
+
+
+class ClaudeCliStrategy(_BaseCliStrategy):
+    name = "claude"
+
+    def build_argv(self, cfg: ExternalCliWorkerConfig, req: ExternalCliExecutionRequest) -> list[str]:
+        argv = [cfg.executable, "-p", "--output-format", "json"]
+        if req.model:
+            argv.extend(["--model", req.model])
+        return argv
+
+    def parse_output(self, stdout_text: str) -> Optional[ExternalCliStructuredPayload]:
+        try:
+            envelope = json.loads(stdout_text.strip())
+        except (TypeError, json.JSONDecodeError):
+            return None
+        if not isinstance(envelope, dict):
+            return None
+        if envelope.get("type") != "result" or envelope.get("subtype") != "success":
+            return None
+        if envelope.get("is_error") is not False:
+            return None
+        result_text = envelope.get("result")
+        if not isinstance(result_text, str):
+            return None
+        return _parse_contract_text(result_text)
+
+
+class CodexCliStrategy(_BaseCliStrategy):
+    name = "codex"
+
+    @staticmethod
+    def _schema_bytes() -> bytes:
+        string_list = {
+            "type": "array",
+            "items": {"type": "string", "maxLength": METADATA_ITEM_LIMIT},
+            "maxItems": METADATA_LIST_LIMIT,
+        }
+        schema = {
+            "type": "object",
+            "properties": {
+                STRUCTURED_RESULT_KEY: {
+                    "type": "object",
+                    "properties": {
+                        "action": {"type": "string", "enum": ["complete", "block"]},
+                        "summary": {
+                            "type": ["string", "null"],
+                            "maxLength": SUMMARY_CHAR_LIMIT,
+                        },
+                        "metadata": {
+                            "type": "object",
+                            "properties": {key: string_list for key in sorted(SAFE_METADATA_KEYS)},
+                            "required": sorted(SAFE_METADATA_KEYS),
+                            "additionalProperties": False,
+                        },
+                        "reason": {
+                            "type": ["string", "null"],
+                            "maxLength": SUMMARY_CHAR_LIMIT,
+                        },
+                        "block_kind": {
+                            "type": ["string", "null"],
+                            "enum": [*sorted(SAFE_BLOCK_KINDS), None],
+                        },
+                    },
+                    # Codex strict response formats require every property at
+                    # every object level to be named in required. Nullable
+                    # fields preserve the complete/block union semantics.
+                    "required": [
+                        "action",
+                        "summary",
+                        "metadata",
+                        "reason",
+                        "block_kind",
+                    ],
+                    "additionalProperties": False,
+                }
+            },
+            "required": [STRUCTURED_RESULT_KEY],
+            "additionalProperties": False,
+        }
+        return json.dumps(schema, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+    def build_argv(self, cfg: ExternalCliWorkerConfig, req: ExternalCliExecutionRequest) -> list[str]:
+        schema_dir = Path(req.evidence_dir)
+        _ensure_secure_directory(schema_dir)
+        schema_path = schema_dir / f"codex-output-schema-{secrets.token_hex(6)}.json"
+        _write_secure_file(schema_path, self._schema_bytes())
+        workspace = str(Path(req.workspace_path))
+        argv = [
+            cfg.executable,
+            "exec",
+            # Explicit execution-policy boundary (P0-F M4): a pinned Popen
+            # cwd is not itself a security boundary, and codex's effective
+            # sandbox authority can otherwise come from ambient
+            # $CODEX_HOME config or profiles instead of this invocation.
+            "--sandbox", "workspace-write",
+            "--cd", workspace,
+            "--ignore-user-config",
+            "--ignore-rules",
+            "--ephemeral",
+            "--skip-git-repo-check",
+            "--json",
+            "--output-schema", str(schema_path),
+        ]
+        if req.model:
+            argv.extend(["--model", req.model])
+        return argv
+
+    def parse_output(self, stdout_text: str) -> Optional[ExternalCliStructuredPayload]:
+        parser = self.create_incremental_parser()
+        parser.feed(stdout_text.encode("utf-8", errors="replace"))
+        return parser.result()
+
+    def create_incremental_parser(self) -> _CodexIncrementalParser:
+        return _CodexIncrementalParser()
+
+
+class ExternalCliAgentAdapter:
+    def __init__(self) -> None:
+        self._strategies = {"claude": ClaudeCliStrategy(), "codex": CodexCliStrategy()}
+
+    @staticmethod
+    def _empty_result(
+        cfg: ExternalCliWorkerConfig,
+        req: ExternalCliExecutionRequest,
+        *,
+        status: str,
+        structured_output_status: str,
+        stderr_signature: str,
+        exit_code: Optional[int] = None,
+        signal_number: Optional[int] = None,
+        timed_out: bool = False,
+        cancelled: bool = False,
+        argv_summary: Optional[str] = None,
+    ) -> ExternalCliExecutionResult:
+        return ExternalCliExecutionResult(
+            status=status,
+            executable=cfg.executable,
+            argv_summary=argv_summary or json.dumps([cfg.executable]),
+            cwd=req.workspace_path,
+            structured_output_status=structured_output_status,
+            stdout_artifact_path=None,
+            stdout_sha256=None,
+            stdout_size=0,
+            stderr_artifact_path=None,
+            stderr_sha256=None,
+            stderr_size=0,
+            stdout_summary="",
+            stderr_signature=_sanitize_text(stderr_signature),
+            stdout_total_size=0,
+            stdout_truncated=False,
+            stderr_total_size=0,
+            stderr_truncated=False,
+            exit_code=exit_code,
+            signal=signal_number,
+            timed_out=timed_out,
+            cancelled=cancelled,
+        )
+
+    def run(self, cfg: ExternalCliWorkerConfig, req: ExternalCliExecutionRequest) -> ExternalCliExecutionResult:
+        strategy = self._strategies.get(cfg.executable)
+        if strategy is None:
+            return self._empty_result(cfg, req, status="FAILED_INVALID_INVOCATION", structured_output_status="invalid_strategy", stderr_signature="unsupported executable", exit_code=2)
+
+        workspace = Path(req.workspace_path)
+        if not workspace.is_absolute() or not workspace.is_dir():
+            return self._empty_result(cfg, req, status="FAILED_INVALID_INVOCATION", structured_output_status="invalid_cwd", stderr_signature="workspace path is not an existing absolute directory", exit_code=2)
+
+        prompt_bytes = strategy.build_prompt(req).encode("utf-8")
+        if len(prompt_bytes) > MAX_PROMPT_BYTES:
+            return self._empty_result(cfg, req, status="FAILED_INVALID_INVOCATION", structured_output_status="prompt_too_large", stderr_signature="prompt exceeds size limit", exit_code=2)
+
+        executable_path = shutil.which(cfg.executable)
+        if not executable_path:
+            return self._empty_result(cfg, req, status="FAILED_EXECUTABLE_MISSING", structured_output_status="missing_executable", stderr_signature=f"{cfg.executable} not found on PATH", exit_code=127)
+
+        try:
+            _ensure_secure_directory(Path(req.evidence_dir))
+            argv = strategy.build_argv(cfg, req)
+        except (OSError, ValueError) as exc:
+            return self._empty_result(cfg, req, status="FAILED_INTERNAL", structured_output_status="artifact_setup_failed", stderr_signature=f"artifact setup failed: {type(exc).__name__}")
+
+        argv_summary = json.dumps([Path(argv[0]).name, *["<path>" if str(arg).startswith(req.evidence_dir) else str(arg) for arg in argv[1:]]])
+        env = _build_subprocess_env(cfg)
+        try:
+            proc = subprocess.Popen(
+                argv,
+                cwd=str(workspace),
+                env=env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False,
+                start_new_session=True,
+            )
+        except FileNotFoundError:
+            return self._empty_result(cfg, req, status="FAILED_EXECUTABLE_MISSING", structured_output_status="launch_failed", stderr_signature="executable not found", exit_code=127, argv_summary=argv_summary)
+        except PermissionError:
+            return self._empty_result(cfg, req, status="BLOCKED_PERMISSION", structured_output_status="launch_failed", stderr_signature="permission denied while launching external CLI", exit_code=126, argv_summary=argv_summary)
+        except OSError as exc:
+            return self._empty_result(cfg, req, status="FAILED_INTERNAL", structured_output_status="launch_failed", stderr_signature=f"launch failed: {type(exc).__name__}", argv_summary=argv_summary)
+
+        stdout_capture = _StreamCapture()
+        stderr_capture = _StreamCapture()
+        io_errors: list[str] = []
+        io_lock = threading.Lock()
+
+        def _record_error(label: str, exc: BaseException) -> None:
+            with io_lock:
+                io_errors.append(f"{label}:{type(exc).__name__}")
+
+        incremental_parser = strategy.create_incremental_parser()
+
+        def _reader(stream, capture: _StreamCapture, label: str, incremental=None) -> None:
+            if stream is None:
+                _record_error(label, RuntimeError("missing stream"))
+                return
+            try:
+                while True:
+                    chunk = stream.read(65536)
+                    if not chunk:
+                        break
+                    capture.feed(chunk)
+                    if incremental is not None:
+                        incremental.feed(chunk)
+            except Exception as exc:  # normalized below
+                _record_error(label, exc)
+            finally:
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+
+        def _writer() -> None:
+            if proc.stdin is None:
+                _record_error("stdin", RuntimeError("missing stdin"))
+                return
+            try:
+                proc.stdin.write(prompt_bytes)
+                proc.stdin.flush()
+            except Exception as exc:  # normalized below
+                _record_error("stdin", exc)
+            finally:
+                try:
+                    proc.stdin.close()
+                except Exception:
+                    pass
+
+        stdout_thread = threading.Thread(
+            target=_reader,
+            args=(proc.stdout, stdout_capture, "stdout"),
+            kwargs={"incremental": incremental_parser},
+            daemon=True,
+        )
+        stderr_thread = threading.Thread(target=_reader, args=(proc.stderr, stderr_capture, "stderr"), daemon=True)
+        stdin_thread = threading.Thread(target=_writer, daemon=True)
+        started_at = time.monotonic()
+        stdout_thread.start()
+        stderr_thread.start()
+        stdin_thread.start()
+
+        timed_out = False
+        cancelled = False
+        cleanup_failed = False
+        deadline = None
+        if req.timeout_seconds and req.timeout_seconds > 0:
+            deadline = started_at + float(req.timeout_seconds)
+
+        active_external_cli_registry.activate()
+        writer_failed = False
+        try:
+            while proc.poll() is None:
+                if req.cancellation_requested and req.cancellation_requested():
+                    cancelled = True
+                    self._terminate_process_tree(proc)
+                    break
+                if active_external_cli_registry.cancellation_requested():
+                    cancelled = True
+                    self._terminate_process_tree(proc)
+                    break
+                if deadline is not None and time.monotonic() >= deadline:
+                    timed_out = True
+                    self._terminate_process_tree(proc)
+                    break
+                with io_lock:
+                    writer_failed = any(item.startswith("stdin:") for item in io_errors)
+                if writer_failed:
+                    self._terminate_process_tree(proc)
+                    break
+                time.sleep(0.05)
+
+            # A blocked writer thread can be holding the stdin BufferedWriter's
+            # internal lock inside write(); closing stdin from this thread
+            # first would block on that same lock and never reach termination.
+            # Terminating the process group breaks the pipe (EPIPE), which
+            # unblocks the writer, so stdin is only closed below once the
+            # child has exited or the wait has been bounded by a force-kill.
+            try:
+                exit_code = proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                if not cancelled and not writer_failed:
+                    timed_out = True
+                self._terminate_process_tree(proc, force=True)
+                try:
+                    exit_code = proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    cleanup_failed = True
+                    exit_code = None
+        finally:
+            active_external_cli_registry.deactivate()
+            self._close_stream(proc.stdin)
+            stdin_thread.join(timeout=2)
+            stdout_thread.join(timeout=2)
+            stderr_thread.join(timeout=2)
+
+        stdout_bytes = stdout_capture.content()
+        stderr_bytes = stderr_capture.content()
+        try:
+            stdout_path, stdout_sha, stdout_size = _write_artifact(Path(req.evidence_dir), f"{req.task_id}-stdout", stdout_bytes)
+            stderr_path, stderr_sha, stderr_size = _write_artifact(Path(req.evidence_dir), f"{req.task_id}-stderr", stderr_bytes)
+        except OSError as exc:
+            return self._empty_result(cfg, req, status="FAILED_INTERNAL", structured_output_status="artifact_write_failed", stderr_signature=f"artifact write failed: {type(exc).__name__}", exit_code=exit_code, timed_out=timed_out, cancelled=cancelled, argv_summary=argv_summary)
+
+        stdout_text = stdout_bytes.decode("utf-8", errors="replace")
+        stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+        if incremental_parser is not None:
+            incremental_parser.finalize()
+        can_parse = exit_code == 0 and not timed_out and not cancelled and not cleanup_failed
+        if not can_parse:
+            structured_payload = None
+        elif incremental_parser is not None:
+            # Streamed while the process ran, so a valid result survives even
+            # when the raw stdout capture above was truncated at
+            # MAX_CAPTURE_BYTES (that capture is now evidence-only).
+            structured_payload = incremental_parser.result()
+        else:
+            structured_payload = strategy.parse_output(stdout_text)
+        signal_number = -exit_code if isinstance(exit_code, int) and exit_code < 0 else None
+
+        with io_lock:
+            captured_io_errors = tuple(io_errors)
+        if cancelled:
+            status = "FAILED_CANCELLED"
+            structured_status = "cancelled"
+        elif timed_out:
+            status = "FAILED_TIMEOUT"
+            structured_status = "timeout"
+        elif cleanup_failed or captured_io_errors:
+            status = "FAILED_INTERNAL"
+            structured_status = "io_failure" if captured_io_errors else "cleanup_failed"
+        elif exit_code == 0 and structured_payload is not None:
+            status = "COMPLETED"
+            structured_status = "parsed"
+        elif exit_code == 0:
+            status = "FAILED_MALFORMED_OUTPUT"
+            structured_status = "missing"
+        else:
+            terminal_failure = (
+                incremental_parser.terminal_failure_text
+                if incremental_parser is not None
+                else None
+            )
+            failure_text = terminal_failure or f"{stdout_text}\n{stderr_text}"
+            status = _classify_failure(
+                failure_text,
+                exit_code,
+                timed_out=timed_out,
+                cancelled=cancelled,
+            )
+            structured_status = (
+                "terminal_failure" if terminal_failure else "missing"
+            )
+
+        return ExternalCliExecutionResult(
+            status=status,
+            executable=cfg.executable,
+            argv_summary=argv_summary,
+            cwd=str(workspace),
+            structured_output_status=structured_status,
+            stdout_artifact_path=stdout_path,
+            stdout_sha256=stdout_sha,
+            stdout_size=stdout_size,
+            stderr_artifact_path=stderr_path,
+            stderr_sha256=stderr_sha,
+            stderr_size=stderr_size,
+            stdout_summary=_sanitize_text(stdout_text),
+            stderr_signature=_sanitize_text(";".join(captured_io_errors) or stderr_text),
+            stdout_total_size=stdout_capture.total_size,
+            stdout_truncated=stdout_capture.truncated,
+            stderr_total_size=stderr_capture.total_size,
+            stderr_truncated=stderr_capture.truncated,
+            exit_code=exit_code,
+            signal=signal_number,
+            timed_out=timed_out,
+            cancelled=cancelled,
+            structured_payload=structured_payload,
+        )
+
+    @staticmethod
+    def _close_stream(stream: Any) -> None:
+        try:
+            if stream is not None:
+                stream.close()
+        except Exception:
+            pass
+
+    @staticmethod
+    def _terminate_process_tree(proc: subprocess.Popen, force: bool = False) -> None:
+        try:
+            if os.name == "posix":
+                sig = signal.SIGKILL if force else signal.SIGTERM
+                os.killpg(os.getpgid(proc.pid), sig)
+            elif force:
+                proc.kill()
+            else:
+                proc.terminate()
+        except Exception:
+            try:
+                if force:
+                    proc.kill()
+                else:
+                    proc.terminate()
+            except Exception:
+                pass

--- a/tests/cli/test_external_cli_sigterm_orphan.py
+++ b/tests/cli/test_external_cli_sigterm_orphan.py
@@ -1,0 +1,177 @@
+"""P0-F M2 regression: formal-worker SIGTERM must not orphan an external CLI.
+
+Before the fix, cli.py's single-query SIGTERM handler (`_signal_handler_q`)
+ran `agent.interrupt()`, slept a grace window, then called `os._exit(0)`
+whenever `HERMES_KANBAN_TASK` was set — regardless of whether an
+`ExternalCliAgentAdapter` run was in flight. Because the external CLI child
+starts in its own session/process group (`start_new_session=True`), the
+handler's `os._exit(0)` terminated the formal worker before the adapter's
+poll loop (paused in the same interrupted `time.sleep(0.05)` on the main
+thread) ever got a chance to resume, detect cancellation, and kill/reap the
+child — orphaning it.
+
+This must run as a real, separate OS process: it installs real signal
+handlers and, if the bug regresses, would call `os._exit(0)` on itself. That
+must not be able to take down the pytest runner.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_WORKER_SCRIPT = textwrap.dedent(
+    """
+    import os
+    import signal
+    import subprocess
+    import sys
+    import threading
+    import time
+    from types import SimpleNamespace
+
+    repo_root, marker_path = sys.argv[1], sys.argv[2]
+    sys.path.insert(0, repo_root)
+
+    os.environ["HERMES_KANBAN_TASK"] = "t_fake"
+    os.environ.pop("HERMES_KANBAN_GOAL_MODE", None)
+
+    import cli as cli_mod
+    import hermes_cli.config as config_mod
+    import hermes_cli.kanban_db as kb_mod
+    import hermes_cli.external_cli_adapter as adapter_mod
+    from hermes_cli.external_cli_adapter import ClaudeCliStrategy
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = SimpleNamespace(print=lambda *a, **k: None)
+            self.session_id = "worker-session"
+            self.agent = SimpleNamespace(
+                session_id="worker-session", platform="cli",
+                interrupt=lambda *_a, **_k: None,
+            )
+            self._last_chat_result = None
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return True
+
+        def _show_security_advisories(self):
+            pass
+
+        def _print_exit_summary(self):
+            pass
+
+    cli_mod.HermesCLI = FakeCLI
+    cli_mod._finalize_single_query = lambda _cli: None
+    cli_mod.atexit.register = lambda *_a, **_k: None
+
+    config_mod.load_config = lambda: {
+        "worker": {
+            "execution_backend": "external_cli",
+            "external_cli": {
+                "executable": "claude",
+                "authentication_mode": "cli_managed_subscription",
+                "output_mode": "structured",
+            },
+        }
+    }
+
+    class _FakeConn:
+        def close(self):
+            return None
+
+    kb_mod.connect = lambda: _FakeConn()
+    kb_mod.get_task = lambda _conn, _task_id: SimpleNamespace(
+        id="t_fake", title="Ship it", body="Run tests",
+        assignee="claude-coder", max_runtime_seconds=30,
+    )
+
+    def _unexpected(name):
+        def _fail(*_a, **_k):
+            raise AssertionError(f"{name} should not be called")
+        return _fail
+
+    kb_mod.complete_task = _unexpected("complete_task")
+    kb_mod.block_task = _unexpected("block_task")
+
+    # A real child that never reads stdin and never exits on its own; the
+    # adapter (not this harness) is responsible for killing and reaping it.
+    ClaudeCliStrategy.build_argv = lambda self, cfg, req: [
+        sys.executable, "-c", "import time; time.sleep(30)",
+    ]
+    adapter_mod.shutil.which = lambda _n: "/usr/bin/claude"
+
+    real_popen = subprocess.Popen
+
+    def _capturing_popen(argv, **kwargs):
+        proc = real_popen(argv, **kwargs)
+        with open(marker_path, "w") as f:
+            f.write(str(proc.pid))
+        return proc
+
+    adapter_mod.subprocess.Popen = _capturing_popen
+
+    def _send_sigterm_soon():
+        time.sleep(1.0)
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    threading.Thread(target=_send_sigterm_soon, daemon=True).start()
+
+    cli_mod.main(query="work kanban task t_fake", quiet=True, toolsets="terminal")
+    """
+)
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+@pytest.mark.skipif(os.name != "posix", reason="SIGTERM/process-group semantics are POSIX-specific")
+def test_sigterm_during_external_cli_run_does_not_orphan_child(tmp_path):
+    script_path = tmp_path / "worker_harness.py"
+    marker_path = tmp_path / "child_pid.txt"
+    script_path.write_text(_WORKER_SCRIPT)
+
+    proc = subprocess.Popen(
+        [sys.executable, str(script_path), str(REPO_ROOT), str(marker_path)],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        stdout, _ = proc.communicate(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, _ = proc.communicate(timeout=5)
+        pytest.fail(f"formal-worker harness did not exit within 15s after SIGTERM:\n{stdout}")
+
+    deadline_msg = f"harness output:\n{stdout}"
+    assert marker_path.exists(), f"adapter never Popen'd the external CLI child.\n{deadline_msg}"
+    child_pid = int(marker_path.read_text().strip())
+
+    # Bounded wait: the child may take a beat to actually be reaped after the
+    # harness process itself has exited.
+    import time as _time
+
+    reap_deadline = _time.monotonic() + 5.0
+    while _time.monotonic() < reap_deadline and _pid_alive(child_pid):
+        _time.sleep(0.1)
+
+    assert not _pid_alive(child_pid), (
+        f"external CLI child pid={child_pid} survived formal-worker SIGTERM — "
+        f"orphan bug regressed (P0-F M2).\n{deadline_msg}"
+    )

--- a/tests/cli/test_external_cli_worker_integration.py
+++ b/tests/cli/test_external_cli_worker_integration.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import cli as cli_mod
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+
+
+class _FakeConn:
+    def close(self):
+        return None
+
+
+class _FakeCli:
+    def __init__(self):
+        self.session_id = "worker-session"
+        self.agent = SimpleNamespace(_interrupt_requested=False)
+        self._last_chat_result = None
+
+    def _print_exit_summary(self):
+        return None
+
+
+def test_default_spawn_remains_hermes_worker(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    seen = {}
+
+    def fake_popen(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return SimpleNamespace(pid=999)
+
+    monkeypatch.setattr("hermes_cli.kanban_db.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("hermes_cli.profiles.resolve_profile_env", lambda _profile: str(tmp_path / ".hermes" / "profiles" / "claude-coder"))
+
+    task = kb.Task(
+        id="task-1",
+        title="Title",
+        body="Body",
+        assignee="claude-coder",
+        status="running",
+        priority=0,
+        created_by=None,
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="scratch",
+        workspace_path=None,
+        claim_lock=None,
+        claim_expires=None,
+        tenant=None,
+        branch_name=None,
+        current_run_id=None,
+        goal_mode=False,
+        goal_max_turns=None,
+        skills=None,
+        max_runtime_seconds=None,
+    )
+    pid = kb._default_spawn(task, str(workspace))
+    assert pid == 999
+    assert Path(seen["argv"][0]).name == "hermes"
+    chat_index = seen["argv"].index("chat")
+    assert seen["argv"][chat_index + 1] == "-q"
+    assert "claude" not in seen["argv"]
+    assert "codex" not in seen["argv"]
+
+
+def test_external_cli_worker_helper_skips_internal_backend(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    handled, response = cli_mod._run_external_cli_worker_once(_FakeCli())
+    assert handled is False
+    assert response is None
+
+
+def test_external_cli_worker_helper_completes_task_inside_formal_worker(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "worker": {
+                "execution_backend": "external_cli",
+                "external_cli": {
+                    "executable": "claude",
+                    "authentication_mode": "cli_managed_subscription",
+                    "output_mode": "structured",
+                },
+            }
+        },
+    )
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: _FakeConn())
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.get_task",
+        lambda _conn, _task_id: SimpleNamespace(
+            id="task-1",
+            title="Ship it",
+            body="Run tests",
+            assignee="claude-coder",
+            max_runtime_seconds=30,
+        ),
+    )
+
+    completed = {}
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.complete_task",
+        lambda _conn, task_id, result=None, summary=None, metadata=None: completed.update(
+            task_id=task_id,
+            result=result,
+            summary=summary,
+            metadata=metadata,
+        )
+        or True,
+    )
+    monkeypatch.setattr("hermes_cli.kanban_db.block_task", lambda *_a, **_k: pytest.fail("adapter path should not block here"))
+
+    class _Adapter:
+        def run(self, cfg, req):
+            assert cfg.execution_backend == "external_cli"
+            assert req.task_id == "task-1"
+            assert req.workspace_path == str(tmp_path)
+            assert "Ship it" in req.prompt
+            return SimpleNamespace(
+                status="COMPLETED",
+                structured_payload=SimpleNamespace(
+                    action="complete",
+                    summary="done",
+                    metadata={"changed_files": ["cli.py"]},
+                    reason=None,
+                    block_kind=None,
+                ),
+                as_metadata=lambda: {
+                    "status": "COMPLETED",
+                    "stdout_artifact_path": str(tmp_path / "stdout.log"),
+                    "stderr_artifact_path": str(tmp_path / "stderr.log"),
+                    "stdout_summary": "done",
+                },
+            )
+
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.ExternalCliAgentAdapter", _Adapter)
+    cli = _FakeCli()
+    handled, response = cli_mod._run_external_cli_worker_once(cli)
+    assert handled is True
+    assert response == "done"
+    assert completed["task_id"] == "task-1"
+    assert completed["metadata"] == {"changed_files": ["cli.py"]}
+    assert cli._last_chat_result["failed"] is False
+    assert "stdout_text" not in cli._last_chat_result["external_cli"]
+    assert cli._last_chat_result["external_cli"]["status"] == "COMPLETED"
+
+
+def test_external_cli_worker_helper_maps_quota_to_existing_exit_75(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "worker": {
+                "execution_backend": "external_cli",
+                "external_cli": {
+                    "executable": "codex",
+                    "authentication_mode": "cli_managed_subscription",
+                },
+            }
+        },
+    )
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: _FakeConn())
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.get_task",
+        lambda _conn, _task_id: SimpleNamespace(
+            id="task-1",
+            title="Ship it",
+            body="Run tests",
+            assignee="codex-coder",
+            max_runtime_seconds=30,
+        ),
+    )
+    monkeypatch.setattr("hermes_cli.kanban_db.complete_task", lambda *_a, **_k: pytest.fail("quota should not complete task"))
+    monkeypatch.setattr("hermes_cli.kanban_db.block_task", lambda *_a, **_k: pytest.fail("quota should not block task directly"))
+
+    class _Adapter:
+        def run(self, cfg, req):
+            return SimpleNamespace(
+                status="BLOCKED_QUOTA",
+                structured_payload=None,
+                as_metadata=lambda: {"status": "BLOCKED_QUOTA", "stderr_signature": "quota exhausted"},
+            )
+
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.ExternalCliAgentAdapter", _Adapter)
+    cli = _FakeCli()
+    handled, response = cli_mod._run_external_cli_worker_once(cli)
+    assert handled is True
+    assert "quota exhaustion" in response
+    assert cli._last_chat_result["failed"] is True
+    assert cli._last_chat_result["failure_reason"] == "billing"
+    assert cli_mod.kanban_worker_exit_code(cli._last_chat_result) == KANBAN_RATE_LIMIT_EXIT_CODE
+
+
+def test_external_cli_terminal_failure_blocks_task_instead_of_leaving_running(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "worker": {
+                "execution_backend": "external_cli",
+                "external_cli": {
+                    "executable": "codex",
+                    "authentication_mode": "cli_managed_subscription",
+                },
+            }
+        },
+    )
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: _FakeConn())
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.get_task",
+        lambda _conn, _task_id: SimpleNamespace(
+            id="task-1",
+            title="Ship it",
+            body="Run tests",
+            assignee="codex-coder",
+            max_runtime_seconds=30,
+        ),
+    )
+    blocked = {}
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.block_task",
+        lambda _conn, task_id, reason=None, kind=None: blocked.update(
+            task_id=task_id, reason=reason, kind=kind
+        )
+        or True,
+    )
+
+    class _Adapter:
+        def run(self, cfg, req):
+            return SimpleNamespace(
+                status="FAILED_INVALID_INVOCATION",
+                structured_payload=None,
+                as_metadata=lambda: {
+                    "status": "FAILED_INVALID_INVOCATION",
+                    "structured_output_status": "terminal_failure",
+                },
+            )
+
+    monkeypatch.setattr(
+        "hermes_cli.external_cli_adapter.ExternalCliAgentAdapter", _Adapter
+    )
+    cli = _FakeCli()
+    handled, response = cli_mod._run_external_cli_worker_once(cli)
+
+    assert handled is True
+    assert response == "Error: codex rejected the worker invocation."
+    assert blocked == {
+        "task_id": "task-1",
+        "reason": "codex rejected the worker invocation.",
+        "kind": "capability",
+    }
+    assert cli._last_chat_result["failed"] is True
+
+
+def test_external_cli_worker_helper_blocks_auth_without_provider_fallback(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "worker": {
+                "execution_backend": "external_cli",
+                "external_cli": {
+                    "executable": "claude",
+                    "authentication_mode": "cli_managed_subscription",
+                },
+            }
+        },
+    )
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: _FakeConn())
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.get_task",
+        lambda _conn, _task_id: SimpleNamespace(
+            id="task-1",
+            title="Ship it",
+            body="Run tests",
+            assignee="claude-coder",
+            max_runtime_seconds=30,
+        ),
+    )
+    monkeypatch.setattr("hermes_cli.kanban_db.complete_task", lambda *_a, **_k: pytest.fail("auth block should not complete task"))
+    blocked = {}
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.block_task",
+        lambda _conn, task_id, reason=None, kind=None: blocked.update(task_id=task_id, reason=reason, kind=kind) or True,
+    )
+
+    calls = []
+
+    class _Adapter:
+        def run(self, cfg, req):
+            calls.append(cfg.executable)
+            return SimpleNamespace(
+                status="BLOCKED_AUTH",
+                structured_payload=None,
+                as_metadata=lambda: {"status": "BLOCKED_AUTH"},
+            )
+
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.ExternalCliAgentAdapter", _Adapter)
+    cli = _FakeCli()
+    handled, response = cli_mod._run_external_cli_worker_once(cli)
+    assert handled is True
+    assert "login session" in response
+    assert blocked == {
+        "task_id": "task-1",
+        "reason": "claude requires a CLI-managed login session before this task can run.",
+        "kind": "capability",
+    }
+    assert calls == ["claude"]
+    assert cli._last_chat_result["failed"] is False
+
+
+@pytest.mark.parametrize("status", ["BLOCKED_AUTH", "BLOCKED_PERMISSION"])
+def test_external_cli_worker_block_transition_failure_is_internal_failure(monkeypatch, tmp_path, status):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "worker": {
+                "execution_backend": "external_cli",
+                "external_cli": {
+                    "executable": "claude",
+                    "authentication_mode": "cli_managed_subscription",
+                },
+            }
+        },
+    )
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: _FakeConn())
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.get_task",
+        lambda _conn, _task_id: SimpleNamespace(
+            id="task-1",
+            title="Ship it",
+            body="Run tests",
+            assignee="claude-coder",
+            max_runtime_seconds=30,
+        ),
+    )
+    monkeypatch.setattr("hermes_cli.kanban_db.complete_task", lambda *_a, **_k: pytest.fail("blocked result must not complete"))
+    monkeypatch.setattr("hermes_cli.kanban_db.block_task", lambda *_a, **_k: False)
+
+    class _Adapter:
+        def run(self, cfg, req):
+            return SimpleNamespace(
+                status=status,
+                structured_payload=None,
+                as_metadata=lambda: {"status": status},
+            )
+
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.ExternalCliAgentAdapter", _Adapter)
+    cli = _FakeCli()
+    handled, response = cli_mod._run_external_cli_worker_once(cli)
+    assert handled is True
+    assert response.startswith("Error:")
+    assert cli._last_chat_result["failed"] is True
+    assert cli._last_chat_result["external_cli"]["status"] == "FAILED_INTERNAL"
+    assert cli_mod.kanban_worker_exit_code(cli._last_chat_result) == 1
+
+
+def test_external_cli_evidence_directory_sanitizes_task_and_is_collision_safe(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    first = cli_mod._external_cli_worker_evidence_dir("../../unsafe task")
+    second = cli_mod._external_cli_worker_evidence_dir("../../unsafe task")
+    root = tmp_path / ".hermes" / "cache" / "external_cli_adapter"
+    assert first.is_relative_to(root)
+    assert second.is_relative_to(root)
+    assert ".." not in first.parts
+    assert "unsafe-task" in first.parts
+    assert first != second

--- a/tests/cli/test_kanban_worker_exit_code.py
+++ b/tests/cli/test_kanban_worker_exit_code.py
@@ -1,0 +1,204 @@
+"""Regression coverage for P0-D: kanban workers spawned via the dispatcher's
+`-q` single-query path (see `hermes_cli/kanban_db.py::_default_spawn`) must
+never silently exit 0 on a total turn failure.
+
+Background: the dispatcher spawns workers as `hermes ... chat -q "<prompt>"`
+(lowercase `-q`, the query-text flag — NOT `-Q`/`--quiet`, the machine-
+readable flag). Before this fix, only the `-Q` branch of `cli.main()`
+translated a failed turn (`result["failed"]`) into a non-zero exit code
+(1, or KANBAN_RATE_LIMIT_EXIT_CODE for a quota/billing wall). The `-q`
+branch the dispatcher actually uses had no such logic at all — `cli.chat()`
+returns a plain string there, discarding `failed`/`failure_reason` — so a
+worker whose API calls failed completely (invalid/unavailable model,
+persistent auth error, provider outage, retries+fallback exhausted) fell
+through to the interpreter's default exit code 0. The dispatcher's
+`detect_crashed_workers()` then saw `clean_exit` on a still-`running` task
+and reported `protocol_violation` — a mischaracterization: the model never
+got a turn at all, so it never had a chance to call kanban_complete /
+kanban_block, let alone decline to.
+
+This observed exactly in a real incident: profile `claude-coder`'s
+provider/model config pointed at an unavailable free-tier OpenRouter slug
+(`tencent/hy3:free`, HTTP 404 "unavailable for free"), so every one of 3
+dispatcher-spawned worker runs failed at the very first API call (0 tool
+calls, 1 message, per the worker log) and one of the three was reaped as
+`protocol_violation` at rc=0.
+
+The fix: `HermesCLI.chat()` now stashes the structured turn result on
+`self._last_chat_result`; `cli.kanban_worker_exit_code()` maps that result
+to a process exit code using the exact same rules the `-Q` path already
+used; and the `-q` single-query branch in `main()` now calls
+`sys.exit(kanban_worker_exit_code(...))` whenever `HERMES_KANBAN_TASK` is
+set (dispatcher-spawned worker) — so a total failure becomes a real
+non-zero exit, which the dispatcher's reap classifier sees as
+`nonzero_exit` (a normal crash, using the default multi-strike failure
+limit) instead of `clean_exit` (`protocol_violation`, single-strike).
+
+Human / non-dispatcher `-q` usage (no `HERMES_KANBAN_TASK`) is completely
+unaffected — it keeps the pre-existing "always falls through, implicit
+exit 0" behavior.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import cli as cli_mod
+from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: cli.kanban_worker_exit_code()
+# ---------------------------------------------------------------------------
+
+def test_exit_code_none_result_is_zero():
+    assert cli_mod.kanban_worker_exit_code(None) == 0
+
+
+def test_exit_code_non_dict_result_is_zero():
+    assert cli_mod.kanban_worker_exit_code("not a dict") == 0
+
+
+def test_exit_code_succeeded_turn_is_zero():
+    assert cli_mod.kanban_worker_exit_code({"failed": False, "final_response": "ok"}) == 0
+
+
+def test_exit_code_missing_failed_key_is_zero():
+    # A dict without "failed" at all (e.g. an unexpected/partial shape)
+    # must not be treated as a failure — no invented non-zero exit.
+    assert cli_mod.kanban_worker_exit_code({"final_response": "ok"}) == 0
+
+
+@pytest.mark.parametrize("reason", ["rate_limit", "billing"])
+def test_exit_code_quota_wall_uses_rate_limit_sentinel(reason):
+    result = {"failed": True, "failure_reason": reason, "error": "quota exhausted"}
+    assert cli_mod.kanban_worker_exit_code(result) == KANBAN_RATE_LIMIT_EXIT_CODE
+
+
+def test_exit_code_total_api_failure_with_no_failure_reason_is_one():
+    """The exact shape observed in the real incident: the turn failed
+    (all retries + fallback exhausted on an invalid/unavailable model)
+    but `failure_reason` was never a quota/billing classification — it
+    must become a plain 1, NOT the rate-limit sentinel and NOT 0."""
+    result = {
+        "failed": True,
+        "final_response": "",
+        "error": "HTTP 404: This model is unavailable for free.",
+    }
+    assert cli_mod.kanban_worker_exit_code(result) == 1
+
+
+def test_exit_code_other_failure_reason_is_one():
+    result = {"failed": True, "failure_reason": "context_overflow", "error": "too big"}
+    assert cli_mod.kanban_worker_exit_code(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests: cli.main()'s `-q` single-query branch, driven the
+# same way tests/cli/test_single_query_session_finalize.py drives it — a
+# FakeCLI stand-in for HermesCLI so no real model/network call happens.
+# ---------------------------------------------------------------------------
+
+class _FakeCLIBase:
+    def __init__(self, **_kwargs):
+        self.console = SimpleNamespace(print=lambda *a, **k: None)
+        self.session_id = "worker-session"
+        self.agent = SimpleNamespace(session_id="worker-session", platform="cli")
+        self._last_chat_result = None
+
+    def _claim_active_session(self, surface, *, stderr=False):
+        return True
+
+    def _show_security_advisories(self):
+        pass
+
+    def _print_exit_summary(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _stub_finalize(monkeypatch):
+    monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda _cli: None)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_k: None)
+
+
+def test_kanban_worker_q_path_exits_zero_on_success(monkeypatch):
+    class FakeCLI(_FakeCLIBase):
+        def chat(self, query, images=None):
+            # Mirrors the real HermesCLI.chat(): stash the structured
+            # result, return a plain string.
+            self._last_chat_result = {"failed": False, "final_response": "done"}
+            return "done"
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake")
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(query="work kanban task t_fake", quiet=False, toolsets="terminal")
+    assert exc_info.value.code == 0
+
+
+def test_kanban_worker_q_path_exits_one_on_total_api_failure(monkeypatch):
+    """This is the exact regression case: the dispatcher's `-q` path, a
+    worker whose model is entirely unavailable, must exit non-zero — not
+    fall through silently to 0."""
+    class FakeCLI(_FakeCLIBase):
+        def chat(self, query, images=None):
+            self._last_chat_result = {
+                "failed": True,
+                "final_response": "",
+                "error": "HTTP 404: This model is unavailable for free.",
+            }
+            return "Error: HTTP 404: This model is unavailable for free."
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake")
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(query="work kanban task t_fake", quiet=False, toolsets="terminal")
+    assert exc_info.value.code == 1
+
+
+def test_kanban_worker_q_path_exits_rate_limit_sentinel_on_quota_wall(monkeypatch):
+    class FakeCLI(_FakeCLIBase):
+        def chat(self, query, images=None):
+            self._last_chat_result = {
+                "failed": True,
+                "final_response": "",
+                "error": "rate limited",
+                "failure_reason": "rate_limit",
+            }
+            return "Error: rate limited"
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake")
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(query="work kanban task t_fake", quiet=False, toolsets="terminal")
+    assert exc_info.value.code == KANBAN_RATE_LIMIT_EXIT_CODE
+
+
+def test_non_kanban_q_path_falls_through_on_failure_unchanged(monkeypatch):
+    """No HERMES_KANBAN_TASK set (plain human/automation `-q` usage, no
+    dispatcher involved) — behavior must be completely untouched: no
+    sys.exit() call at all, even when the turn failed."""
+    class FakeCLI(_FakeCLIBase):
+        def chat(self, query, images=None):
+            self._last_chat_result = {
+                "failed": True,
+                "final_response": "",
+                "error": "HTTP 404: This model is unavailable for free.",
+            }
+            return "Error: HTTP 404: This model is unavailable for free."
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+
+    # Must NOT raise SystemExit — falls through to the function's natural
+    # return, exactly as before this fix.
+    cli_mod.main(query="hello", quiet=False, toolsets="terminal")

--- a/tests/cli/test_kanban_worker_exit_code.py
+++ b/tests/cli/test_kanban_worker_exit_code.py
@@ -113,7 +113,7 @@ class _FakeCLIBase:
     def _show_security_advisories(self):
         pass
 
-    def _print_exit_summary(self):
+    def _print_exit_summary(self, clear_screen: bool = True):
         pass
 
 

--- a/tests/cli/test_r5h_smoke_harness.py
+++ b/tests/cli/test_r5h_smoke_harness.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+HARNESS = Path(
+    "/home/curioctylab/.claude/deployment-evidence/"
+    "p0f-r5-h-controlled-codex-smoke-20260723/run_r5h_codex_smoke_r3.py"
+)
+
+
+def _load_harness():
+    spec = importlib.util.spec_from_file_location("r5h_smoke_harness", HARNESS)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_argv_validation_does_not_match_claude_in_workspace_path():
+    harness = _load_harness()
+    argv = [
+        "codex",
+        "exec",
+        "--sandbox",
+        "workspace-write",
+        "--cd",
+        "/tmp/.claude/evidence/workspace",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--ephemeral",
+    ]
+    assert harness._validate_codex_argv_summary(json.dumps(argv)) == []
+
+
+def test_argv_validation_rejects_actual_forbidden_argument():
+    harness = _load_harness()
+    argv = [
+        "codex",
+        "exec",
+        "--sandbox",
+        "workspace-write",
+        "--cd",
+        "/tmp/workspace",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--ephemeral",
+        "--dangerously-bypass-approvals-and-sandbox",
+    ]
+    failures = harness._validate_codex_argv_summary(json.dumps(argv))
+    assert failures == [
+        "argv_summary contained forbidden argument "
+        "'--dangerously-bypass-approvals-and-sandbox'"
+    ]

--- a/tests/hermes_cli/fixtures/codex_invalid_schema_turn_failed.jsonl
+++ b/tests/hermes_cli/fixtures/codex_invalid_schema_turn_failed.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"fixture-thread"}
+{"type":"turn.started"}
+{"type":"error","message":"{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"code\":\"invalid_json_schema\",\"message\":\"Invalid schema for response_format 'codex_output_schema': metadata.required must include changed_files.\",\"param\":\"text.format.schema\"},\"status\":400}"}
+{"type":"turn.failed","error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"code\":\"invalid_json_schema\",\"message\":\"Invalid schema for response_format 'codex_output_schema': metadata.required must include changed_files.\",\"param\":\"text.format.schema\"},\"status\":400}"}}

--- a/tests/hermes_cli/test_external_cli_adapter.py
+++ b/tests/hermes_cli/test_external_cli_adapter.py
@@ -1,0 +1,671 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import stat
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.external_cli_adapter import (
+    BLOCKED_ENV_NAMES,
+    MAX_CAPTURE_BYTES,
+    ClaudeCliStrategy,
+    CodexCliStrategy,
+    ExternalCliAgentAdapter,
+    ExternalCliExecutionRequest,
+    ExternalCliStructuredPayload,
+    ExternalCliWorkerConfig,
+    _build_subprocess_env,
+    active_external_cli_registry,
+    load_external_cli_worker_config,
+    sanitize_external_cli_payload,
+    worker_config_defaults,
+)
+
+
+class _Readable:
+    def __init__(self, payload: bytes) -> None:
+        self._stream = io.BytesIO(payload)
+
+    def read(self, size: int = -1) -> bytes:
+        return self._stream.read(size)
+
+    def close(self) -> None:
+        return None
+
+
+class _Writable:
+    def __init__(self) -> None:
+        self.payload = b""
+        self.closed = False
+
+    def write(self, data: bytes) -> int:
+        if self.closed:
+            raise ValueError("closed")
+        self.payload += data
+        return len(data)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _BlockingWritable(_Writable):
+    def __init__(self) -> None:
+        super().__init__()
+        self.release = threading.Event()
+
+    def write(self, data: bytes) -> int:
+        self.release.wait(timeout=5)
+        if self.closed:
+            raise ValueError("closed")
+        return super().write(data)
+
+    def close(self) -> None:
+        self.closed = True
+        self.release.set()
+
+
+class _FakeProc:
+    def __init__(self, *, returncode=0, stdout=b"", stderr=b"", stdin=None) -> None:
+        self.args = []
+        self.pid = 4321
+        self.returncode = returncode
+        self.stdin = stdin or _Writable()
+        self.stdout = _Readable(stdout)
+        self.stderr = _Readable(stderr)
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        if self.returncode is None:
+            raise subprocess.TimeoutExpired(self.args, timeout or 0)
+        return self.returncode
+
+    def terminate(self):
+        self.returncode = self.returncode if self.returncode is not None else 143
+
+    def kill(self):
+        self.returncode = self.returncode if self.returncode is not None else 137
+
+
+def _request(tmp_path: Path, *, cancellation_requested=None, timeout_seconds=None, executable="claude") -> ExternalCliExecutionRequest:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    return ExternalCliExecutionRequest(
+        task_id="task-123",
+        profile_name=f"{executable}-coder",
+        prompt="Fix the failing test",
+        workspace_path=str(workspace),
+        timeout_seconds=timeout_seconds,
+        evidence_dir=str(tmp_path / "evidence"),
+        cancellation_requested=cancellation_requested,
+    )
+
+
+def _cfg(executable="claude") -> ExternalCliWorkerConfig:
+    return ExternalCliWorkerConfig(
+        execution_backend="external_cli",
+        executable=executable,
+        authentication_mode="cli_managed_subscription",
+        output_mode="structured",
+    )
+
+
+def _contract(summary="done", metadata=None) -> str:
+    return json.dumps({
+        "hermes_external_cli_result": {
+            "action": "complete",
+            "summary": summary,
+            "metadata": metadata or {"tests_run": ["pytest"]},
+        }
+    })
+
+
+def _claude_stdout(summary="done", metadata=None) -> bytes:
+    return json.dumps({
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "result": _contract(summary, metadata),
+        "session_id": "fixture",
+    }).encode()
+
+
+def _codex_stdout(messages: list[str], terminal="turn.completed") -> bytes:
+    events = [{"type": "item.completed", "item": {"type": "agent_message", "text": text}} for text in messages]
+    events.append({"type": terminal})
+    return ("\n".join(json.dumps(event) for event in events) + "\n").encode()
+
+
+def _run_with_output(tmp_path, monkeypatch, *, executable="claude", stdout=b"", stderr=b"", returncode=0, stdin=None):
+    proc = _FakeProc(returncode=returncode, stdout=stdout, stderr=stderr, stdin=stdin)
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.shutil.which", lambda _name: f"/usr/bin/{executable}")
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.subprocess.Popen", lambda argv, **kwargs: proc)
+    return ExternalCliAgentAdapter().run(_cfg(executable), _request(tmp_path, executable=executable)), proc
+
+
+def test_worker_config_defaults_shape():
+    defaults = worker_config_defaults()
+    assert defaults["execution_backend"] == "hermes_internal"
+    assert defaults["external_cli"]["output_mode"] == "auto"
+    assert defaults["external_cli"]["allow_resume"] is False
+
+
+def test_load_external_cli_worker_config_defaults_to_internal_backend():
+    cfg = load_external_cli_worker_config({})
+    assert cfg.execution_backend == "hermes_internal"
+    assert cfg.executable == ""
+    assert cfg.args == ()
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({"worker": {"execution_backend": "bogus"}}, "execution_backend"),
+        ({"worker": {"execution_backend": "external_cli", "external_cli": {"executable": "python", "authentication_mode": "cli_managed_subscription"}}}, "executable"),
+        ({"worker": {"execution_backend": "external_cli", "external_cli": {"executable": "claude", "authentication_mode": "oauth"}}}, "authentication_mode"),
+        ({"worker": {"execution_backend": "external_cli", "external_cli": {"executable": "claude", "authentication_mode": "cli_managed_subscription", "args": ["--sandbox", "workspace-write"]}}}, "must be empty"),
+        ({"worker": {"execution_backend": "external_cli", "external_cli": {"executable": "claude", "authentication_mode": "cli_managed_subscription", "api_key": "secret"}}}, "forbidden fields"),
+        ({"worker": {"execution_backend": "external_cli", "external_cli": {"executable": "claude", "authentication_mode": "cli_managed_subscription", "allow_resume": True}}}, "allow_resume"),
+    ],
+)
+def test_load_external_cli_worker_config_rejects_invalid_values(config, expected):
+    with pytest.raises(ValueError, match=expected):
+        load_external_cli_worker_config(config)
+
+
+def test_load_external_cli_worker_config_accepts_valid_external_cli():
+    cfg = load_external_cli_worker_config({
+        "worker": {
+            "execution_backend": "external_cli",
+            "external_cli": {
+                "executable": "codex",
+                "args": [],
+                "authentication_mode": "cli_managed_subscription",
+                "output_mode": "structured",
+            },
+        }
+    })
+    assert cfg.execution_backend == "external_cli"
+    assert cfg.executable == "codex"
+    assert cfg.args == ()
+
+
+def test_load_external_cli_worker_config_rejects_unknown_field():
+    with pytest.raises(ValueError, match="unknown fields"):
+        load_external_cli_worker_config({
+            "worker": {
+                "execution_backend": "external_cli",
+                "external_cli": {
+                    "executable": "codex",
+                    "authentication_mode": "cli_managed_subscription",
+                    "env_allowlist": ["HOME"],
+                },
+            }
+        })
+
+
+def test_build_subprocess_env_only_keeps_safe_names(monkeypatch):
+    monkeypatch.setenv("HOME", "/tmp/home")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("TMPDIR", "/tmp")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+    cfg = ExternalCliWorkerConfig(execution_backend="external_cli", executable="claude", authentication_mode="cli_managed_subscription")
+    env = _build_subprocess_env(cfg)
+    assert env["HOME"] == "/tmp/home"
+    assert env["PATH"] == "/usr/bin"
+    assert env["TMPDIR"] == "/tmp"
+    assert not (BLOCKED_ENV_NAMES & set(env))
+
+
+def test_claude_strategy_builds_non_shell_argv():
+    argv = ClaudeCliStrategy().build_argv(_cfg("claude"), ExternalCliExecutionRequest(
+        task_id="t1", profile_name="claude-coder", prompt="Do the task", workspace_path="/tmp/work",
+        timeout_seconds=30, evidence_dir="/tmp/evidence", model="claude-sonnet",
+    ))
+    assert argv == ["claude", "-p", "--output-format", "json", "--model", "claude-sonnet"]
+
+
+def test_codex_strategy_writes_strict_secure_schema_and_builds_argv(tmp_path):
+    req = _request(tmp_path, executable="codex")
+    req = ExternalCliExecutionRequest(**{**req.__dict__, "model": "gpt-5-codex"})
+    argv = CodexCliStrategy().build_argv(_cfg("codex"), req)
+    schema_index = argv.index("--output-schema") + 1
+    schema_path = Path(argv[schema_index])
+    assert argv[-2:] == ["--model", "gpt-5-codex"]
+    schema = json.loads(schema_path.read_text())
+    assert schema["additionalProperties"] is False
+    result_schema = schema["properties"]["hermes_external_cli_result"]
+    assert result_schema["additionalProperties"] is False
+    assert set(result_schema["required"]) == set(result_schema["properties"])
+    metadata_schema = result_schema["properties"]["metadata"]
+    assert set(metadata_schema["required"]) == set(metadata_schema["properties"])
+    assert stat.S_IMODE(schema_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(schema_path.parent.stat().st_mode) == 0o700
+
+
+def test_codex_strategy_forces_explicit_workspace_write_sandbox(tmp_path):
+    """P0-F M4: cwd alone is not a security boundary. Codex must always get
+    an explicit sandbox, an explicit --cd, and must never load ambient
+    $CODEX_HOME config/rules or persist a resumable session."""
+    req = _request(tmp_path, executable="codex")
+    argv = CodexCliStrategy().build_argv(_cfg("codex"), req)
+
+    assert argv[0:2] == ["codex", "exec"]
+    assert "--sandbox" in argv and argv[argv.index("--sandbox") + 1] == "workspace-write"
+    assert "--cd" in argv
+    workspace_arg = argv[argv.index("--cd") + 1]
+    assert Path(workspace_arg) == Path(req.workspace_path)
+    for required_flag in ("--ignore-user-config", "--ignore-rules", "--ephemeral", "--skip-git-repo-check"):
+        assert required_flag in argv, f"missing containment flag: {required_flag}"
+
+    forbidden_substrings = ("bypass", "resume", "--profile", "-p ", "danger-full-access", "read-only")
+    joined = " ".join(argv)
+    for forbidden in forbidden_substrings:
+        assert forbidden not in joined, f"forbidden token present in codex argv: {forbidden!r}"
+
+
+def test_codex_worker_config_cannot_inject_sandbox_bypass_args():
+    """Structural guarantee backing M4: v1 config has no args-passthrough at
+    all, so a misconfigured or compromised config cannot add
+    --dangerously-bypass-approvals-and-sandbox or similar to the real argv."""
+    with pytest.raises(ValueError, match="must be empty"):
+        load_external_cli_worker_config({
+            "worker": {
+                "execution_backend": "external_cli",
+                "external_cli": {
+                    "executable": "codex",
+                    "authentication_mode": "cli_managed_subscription",
+                    "args": ["--dangerously-bypass-approvals-and-sandbox"],
+                },
+            }
+        })
+
+
+def test_claude_documented_wrapper_success():
+    payload = ClaudeCliStrategy().parse_output(_claude_stdout().decode())
+    assert payload and payload.action == "complete" and payload.summary == "done"
+
+
+def test_claude_wrapper_error_is_rejected():
+    output = json.dumps({"type": "result", "subtype": "success", "is_error": True, "result": _contract()})
+    assert ClaudeCliStrategy().parse_output(output) is None
+
+
+def test_claude_invalid_result_string_is_rejected():
+    output = json.dumps({"type": "result", "subtype": "success", "is_error": False, "result": "not-json"})
+    assert ClaudeCliStrategy().parse_output(output) is None
+
+
+def test_codex_jsonl_chooses_last_agent_message():
+    stdout = _codex_stdout([_contract("early"), _contract("final")]).decode()
+    payload = CodexCliStrategy().parse_output(stdout)
+    assert payload and payload.summary == "final"
+
+
+@pytest.mark.parametrize("stdout", [
+    (json.dumps({"type": "turn.failed"}) + "\n").encode(),
+    (json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": _contract()}}) + "\n").encode(),
+    b"not-json\n",
+])
+def test_codex_invalid_terminal_stream_is_rejected(stdout):
+    assert CodexCliStrategy().parse_output(stdout.decode()) is None
+
+
+def test_payload_sanitizes_and_allowlists_metadata():
+    payload = sanitize_external_cli_payload(ExternalCliStructuredPayload(
+        action="complete",
+        summary="x" * 3000 + "\x00",
+        metadata={"changed_files": ["a.py"], "tests_run": ["pytest"], "unknown": {"raw": "data"}},
+    ))
+    assert len(payload.summary or "") <= 2000
+    assert payload.metadata == {"changed_files": ["a.py"], "tests_run": ["pytest"]}
+
+
+@pytest.mark.parametrize("bad_path", [
+    "/etc/passwd",
+    "/home/curioctylab/.hermes/secrets.env",
+    "../../etc/passwd",
+    "a/../../b",
+    "~/.ssh/id_rsa",
+    "C:/Users/admin/secrets.txt",
+])
+def test_path_like_metadata_rejects_absolute_and_traversal_paths(bad_path):
+    payload = sanitize_external_cli_payload(ExternalCliStructuredPayload(
+        action="complete",
+        summary="done",
+        metadata={"changed_files": [bad_path, "src/ok.py"], "evidence": [bad_path]},
+    ))
+    assert payload.metadata["changed_files"] == ["src/ok.py"]
+    assert payload.metadata.get("evidence", []) == []
+
+
+def test_path_like_metadata_accepts_clean_relative_paths():
+    payload = sanitize_external_cli_payload(ExternalCliStructuredPayload(
+        action="complete",
+        summary="done",
+        metadata={"changed_files": ["src/app.py", "./tests/test_app.py"], "evidence": ["logs/run.log"]},
+    ))
+    assert payload.metadata["changed_files"] == ["src/app.py", "tests/test_app.py"]
+    assert payload.metadata["evidence"] == ["logs/run.log"]
+
+
+def test_adapter_reports_missing_executable(tmp_path, monkeypatch):
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.shutil.which", lambda _name: None)
+    result = ExternalCliAgentAdapter().run(_cfg(), _request(tmp_path))
+    assert result.status == "FAILED_EXECUTABLE_MISSING"
+    assert result.exit_code == 127
+
+
+def test_adapter_normalizes_popen_file_not_found(tmp_path, monkeypatch):
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.shutil.which", lambda _name: "/usr/bin/claude")
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.subprocess.Popen", lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
+    result = ExternalCliAgentAdapter().run(_cfg(), _request(tmp_path))
+    assert result.status == "FAILED_EXECUTABLE_MISSING"
+
+
+def test_adapter_normalizes_invalid_cwd(tmp_path):
+    req = _request(tmp_path)
+    req = ExternalCliExecutionRequest(**{**req.__dict__, "workspace_path": str(tmp_path / "missing")})
+    result = ExternalCliAgentAdapter().run(_cfg(), req)
+    assert result.status == "FAILED_INVALID_INVOCATION"
+
+
+def test_adapter_uses_shell_false_start_new_session_and_stdin_prompt(tmp_path, monkeypatch):
+    created = {}
+    stdout = _claude_stdout()
+
+    def fake_popen(argv, **kwargs):
+        proc = _FakeProc(returncode=0, stdout=stdout)
+        proc.args = argv
+        created.update(argv=argv, kwargs=kwargs, proc=proc)
+        return proc
+
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.shutil.which", lambda _name: "/usr/bin/claude")
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.subprocess.Popen", fake_popen)
+    result = ExternalCliAgentAdapter().run(_cfg(), _request(tmp_path))
+    assert created["kwargs"]["shell"] is False
+    assert created["kwargs"]["start_new_session"] is True
+    assert b"Task ID: task-123" in created["proc"].stdin.payload
+    assert result.status == "COMPLETED"
+    assert result.structured_payload is not None
+    assert result.stdout_artifact_path
+    metadata = result.as_metadata()
+    assert "stdout_text" not in metadata and "stderr_text" not in metadata
+
+
+def test_adapter_codex_jsonl_success(tmp_path, monkeypatch):
+    result, _ = _run_with_output(tmp_path, monkeypatch, executable="codex", stdout=_codex_stdout([_contract("final")]))
+    assert result.status == "COMPLETED"
+    assert result.structured_payload and result.structured_payload.summary == "final"
+
+
+def test_adapter_classifies_preserved_codex_invalid_schema_terminal_failure(
+    tmp_path, monkeypatch
+):
+    fixture = (
+        Path(__file__).parent
+        / "fixtures"
+        / "codex_invalid_schema_turn_failed.jsonl"
+    ).read_bytes()
+    result, _ = _run_with_output(
+        tmp_path,
+        monkeypatch,
+        executable="codex",
+        stdout=fixture,
+        returncode=1,
+    )
+    assert result.status == "FAILED_INVALID_INVOCATION"
+    assert result.structured_output_status == "terminal_failure"
+    assert "invalid_json_schema" in result.stdout_summary
+
+
+def test_artifact_modes_are_private(tmp_path, monkeypatch):
+    result, _ = _run_with_output(tmp_path, monkeypatch, stdout=_claude_stdout())
+    assert result.stdout_artifact_path
+    assert stat.S_IMODE(Path(result.stdout_artifact_path).stat().st_mode) == 0o600
+    assert stat.S_IMODE(Path(result.stdout_artifact_path).parent.stat().st_mode) == 0o700
+
+
+def test_symlink_artifact_overwrite_is_rejected(tmp_path, monkeypatch):
+    evidence = tmp_path / "evidence"
+    evidence.mkdir(mode=0o700)
+    target = tmp_path / "target"
+    target.write_text("safe")
+    (evidence / "task-123-stdout-fixed.log").symlink_to(target)
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.secrets.token_hex", lambda _n: "fixed")
+    result, _ = _run_with_output(tmp_path, monkeypatch, stdout=_claude_stdout())
+    assert result.status == "FAILED_INTERNAL"
+    assert target.read_text() == "safe"
+
+
+@pytest.mark.parametrize(("stderr", "exit_code", "expected"), [
+    (b"login required", 1, "BLOCKED_AUTH"),
+    (b"quota exhausted", 1, "BLOCKED_QUOTA"),
+    (b"permission denied", 1, "BLOCKED_PERMISSION"),
+    (b"denied by sandbox policy", 1, "BLOCKED_PERMISSION"),
+    # P0-F m4: a bare mention of "sandbox" in an unrelated runtime-init
+    # failure must NOT be classified as an actionable permission block.
+    (b"fatal: no sandbox helper binary found on PATH", 1, "FAILED_INTERNAL"),
+    (b"invalid sandbox mode 'bogus' in config", 1, "FAILED_INTERNAL"),
+])
+def test_adapter_classifies_blocking_failures(tmp_path, monkeypatch, stderr, exit_code, expected):
+    result, _ = _run_with_output(tmp_path, monkeypatch, stderr=stderr, returncode=exit_code)
+    assert result.status == expected
+
+
+def test_adapter_timeout_remains_active_during_blocked_stdin(tmp_path, monkeypatch):
+    proc = _FakeProc(returncode=None, stdin=_BlockingWritable())
+    clock = {"now": 0.0}
+    terminations = []
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.shutil.which", lambda _name: "/usr/bin/claude")
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.subprocess.Popen", lambda *a, **k: proc)
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.time.sleep", lambda _s: None)
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.time.monotonic", lambda: clock.update(now=clock["now"] + 1.0) or clock["now"])
+    monkeypatch.setattr(ExternalCliAgentAdapter, "_terminate_process_tree", staticmethod(lambda p, force=False: (terminations.append(force), setattr(p, "returncode", 124))))
+    result = ExternalCliAgentAdapter().run(_cfg(), _request(tmp_path, timeout_seconds=1))
+    assert result.status == "FAILED_TIMEOUT"
+    assert terminations == [False]
+
+
+def test_adapter_cancellation_remains_active_during_blocked_stdin(tmp_path, monkeypatch):
+    proc = _FakeProc(returncode=None, stdin=_BlockingWritable())
+    terminations = []
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.shutil.which", lambda _name: "/usr/bin/claude")
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.subprocess.Popen", lambda *a, **k: proc)
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.time.sleep", lambda _s: None)
+    monkeypatch.setattr(ExternalCliAgentAdapter, "_terminate_process_tree", staticmethod(lambda p, force=False: (terminations.append(force), setattr(p, "returncode", 130))))
+    result = ExternalCliAgentAdapter().run(_cfg(), _request(tmp_path, cancellation_requested=lambda: True))
+    assert result.status == "FAILED_CANCELLED"
+    assert terminations == [False]
+
+
+# ---------------------------------------------------------------------------
+# P0-F M3 regression: Codex JSONL exceeding the bounded capture buffer.
+#
+# _StreamCapture only ever retains MAX_CAPTURE_BYTES for the on-disk evidence
+# artifact. Before the incremental parser, parsing ran against that truncated
+# buffer, so any valid Codex transcript longer than 256 KiB silently lost its
+# terminal turn.completed / last agent_message and was misreported as
+# FAILED_MALFORMED_OUTPUT. The incremental parser now runs off the live
+# stream instead, independent of the capture cap.
+# ---------------------------------------------------------------------------
+
+def test_adapter_codex_success_survives_output_exceeding_capture_cap(tmp_path, monkeypatch):
+    # Padding entries the incremental parser must not choke on before the
+    # true final agent_message + turn.completed arrive.
+    filler_events = [
+        json.dumps({"type": "item.completed", "item": {"type": "reasoning", "text": "x" * 4000}})
+        for _ in range(400)
+    ]
+    body = "\n".join(filler_events) + "\n"
+    stdout = (body.encode() + _codex_stdout([_contract("early"), _contract("final")]))
+    assert len(stdout) > MAX_CAPTURE_BYTES * 4, "fixture must exceed the bounded capture buffer by a wide margin"
+
+    result, _ = _run_with_output(tmp_path, monkeypatch, executable="codex", stdout=stdout)
+
+    assert result.status == "COMPLETED"
+    assert result.structured_payload is not None
+    assert result.structured_payload.summary == "final"
+    # The raw evidence artifact is still capped, independent of parsing.
+    assert result.stdout_truncated is True
+    assert result.stdout_total_size == len(stdout)
+
+
+def test_adapter_codex_incremental_parser_rejects_malformed_line_anywhere(tmp_path, monkeypatch):
+    filler = "\n".join(
+        json.dumps({"type": "item.completed", "item": {"type": "reasoning", "text": "x" * 4000}})
+        for _ in range(400)
+    )
+    stdout = (filler + "\nnot-json\n").encode() + _codex_stdout([_contract("final")])
+    assert len(stdout) > MAX_CAPTURE_BYTES * 4
+
+    result, _ = _run_with_output(tmp_path, monkeypatch, executable="codex", stdout=stdout)
+    assert result.status == "FAILED_MALFORMED_OUTPUT"
+
+
+def test_codex_incremental_parser_handles_chunk_split_mid_line():
+    from hermes_cli.external_cli_adapter import _CodexIncrementalParser
+
+    stdout = _codex_stdout([_contract("final")])
+    parser = _CodexIncrementalParser()
+    # Feed one byte at a time to force lines to split across feed() calls.
+    for i in range(0, len(stdout), 1):
+        parser.feed(stdout[i : i + 1])
+    payload = parser.result()
+    assert payload is not None
+    assert payload.summary == "final"
+
+
+def test_output_truncation_metadata(tmp_path, monkeypatch):
+    output = b"x" * (MAX_CAPTURE_BYTES + 100)
+    result, _ = _run_with_output(tmp_path, monkeypatch, stdout=output)
+    assert result.stdout_size == MAX_CAPTURE_BYTES
+    assert result.stdout_total_size == MAX_CAPTURE_BYTES + 100
+    assert result.stdout_truncated is True
+
+
+# ---------------------------------------------------------------------------
+# P0-F M1 regression: real OS subprocess/pipe fixtures.
+#
+# The fake fixtures above (_FakeProc, _BlockingWritable) cannot reproduce the
+# actual bug: a real io.BufferedWriter holds an internal lock while write()
+# blocks in the kernel. _BlockingWritable.close() releases its own test event
+# instead, so it can't catch a close-before-terminate ordering regression.
+# These tests spawn a real child that never reads stdin and never exits on
+# its own, forcing an actual blocked write() in the writer thread.
+# ---------------------------------------------------------------------------
+
+def _real_popen_capturing(monkeypatch, sink: list) -> None:
+    """Let subprocess.Popen run for real, but keep a handle to the child so
+    the test can assert on its actual OS-level lifecycle afterwards."""
+    real_popen = subprocess.Popen
+
+    def _capture(argv, **kwargs):
+        proc = real_popen(argv, **kwargs)
+        sink.append(proc)
+        return proc
+
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.subprocess.Popen", _capture)
+
+
+def _never_reads_stdin_argv() -> list[str]:
+    # Never touches stdin and never exits on its own; the adapter must be the
+    # one to terminate it.
+    return [sys.executable, "-c", "import time; time.sleep(30)"]
+
+
+def _assert_child_reaped(proc: subprocess.Popen) -> None:
+    proc.wait(timeout=5)
+    assert proc.returncode is not None
+    if os.name == "posix":
+        with pytest.raises(ProcessLookupError):
+            os.killpg(proc.pid, 0)
+
+
+def test_adapter_timeout_kills_real_child_blocked_on_stdin_write(tmp_path, monkeypatch):
+    procs: list[subprocess.Popen] = []
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.shutil.which", lambda _n: "/usr/bin/claude")
+    monkeypatch.setattr(ClaudeCliStrategy, "build_argv", lambda self, cfg, req: _never_reads_stdin_argv())
+    _real_popen_capturing(monkeypatch, procs)
+
+    req = _request(tmp_path, timeout_seconds=1)
+    # Comfortably larger than a pipe's kernel buffer (commonly 64 KiB on
+    # Linux) so the writer thread's stdin.write() actually blocks, and just
+    # under the adapter's own MAX_PROMPT_BYTES limit.
+    req = ExternalCliExecutionRequest(**{**req.__dict__, "prompt": "A" * 900_000})
+
+    started = time.monotonic()
+    result = ExternalCliAgentAdapter().run(_cfg("claude"), req)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 8.0, "adapter did not return boundedly; stdin-close-before-terminate deadlock regressed"
+    assert result.status == "FAILED_TIMEOUT"
+    assert result.timed_out is True
+    assert len(procs) == 1
+    _assert_child_reaped(procs[0])
+
+
+def test_adapter_cancellation_kills_real_child_blocked_on_stdin_write(tmp_path, monkeypatch):
+    procs: list[subprocess.Popen] = []
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.shutil.which", lambda _n: "/usr/bin/claude")
+    monkeypatch.setattr(ClaudeCliStrategy, "build_argv", lambda self, cfg, req: _never_reads_stdin_argv())
+    _real_popen_capturing(monkeypatch, procs)
+
+    req = _request(tmp_path, cancellation_requested=lambda: True)
+    req = ExternalCliExecutionRequest(**{**req.__dict__, "prompt": "A" * 900_000})
+
+    started = time.monotonic()
+    result = ExternalCliAgentAdapter().run(_cfg("claude"), req)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 8.0
+    assert result.status == "FAILED_CANCELLED"
+    assert result.cancelled is True
+    assert len(procs) == 1
+    _assert_child_reaped(procs[0])
+
+
+def test_active_external_cli_registry_cancel_kills_real_child(tmp_path, monkeypatch):
+    """Exercises the P0-F M2 mechanism directly: a request_cancel() call from
+    outside the adapter's own poll loop (as cli.py's SIGTERM handler makes)
+    must be observed and must terminate the real child boundedly."""
+    procs: list[subprocess.Popen] = []
+    monkeypatch.setattr("hermes_cli.external_cli_adapter.shutil.which", lambda _n: "/usr/bin/claude")
+    monkeypatch.setattr(ClaudeCliStrategy, "build_argv", lambda self, cfg, req: _never_reads_stdin_argv())
+    _real_popen_capturing(monkeypatch, procs)
+
+    def _fire_external_cancel() -> None:
+        # Give the adapter a moment to Popen() and register itself active.
+        for _ in range(100):
+            if active_external_cli_registry.request_cancel():
+                return
+            time.sleep(0.02)
+        pytest.fail("registry never became active; adapter did not start in time")
+
+    trigger = threading.Thread(target=_fire_external_cancel, daemon=True)
+    trigger.start()
+
+    req = _request(tmp_path, timeout_seconds=30)
+    started = time.monotonic()
+    result = ExternalCliAgentAdapter().run(_cfg("claude"), req)
+    elapsed = time.monotonic() - started
+    trigger.join(timeout=5)
+
+    assert elapsed < 8.0
+    assert result.status == "FAILED_CANCELLED"
+    assert len(procs) == 1
+    _assert_child_reaped(procs[0])
+    # Registry must be deactivated once the adapter returns, so a later
+    # signal doesn't mistake a stale flag for a still-live child.
+    assert active_external_cli_registry.request_cancel() is False


### PR DESCRIPTION
This PR supersedes and replaces #69999, which was contaminated with 5
unpublished local-only ancestor commits never merged to `NousResearch/hermes-agent:main`
(carried in unintentionally when that branch was first pushed). This branch
is built directly from current `origin/main` and contains exactly three
commits, in dependency order.

## Commit 1: P0-D formal-worker exit-code dependency

`fix(cli): translate kanban worker turn failure into a real exit code`

The dispatcher spawns formal kanban workers via the `-q`/`--query` single-turn
path. Unlike the sibling `-Q`/`--quiet` path, this path discarded
`cli.chat()`'s structured `failed`/`failure_reason` result and never called
`sys.exit()`, so a total turn failure (e.g. every configured model/fallback
unavailable) fell through to the interpreter's default exit code 0.
`detect_crashed_workers()` then misclassified that as `protocol_violation`
instead of a real failure. `kanban_worker_exit_code()` maps the stashed last
chat result to 0 (success), the existing `KANBAN_RATE_LIMIT_EXIT_CODE`
sentinel (quota/billing wall), or 1 (any other failure), and the `-q` branch
now calls `sys.exit()` with it whenever `HERMES_KANBAN_TASK` is set.

## Commit 2: P0-F-R7 external Codex CLI remediation

`fix: close Codex external CLI runtime failure path`

## Root cause

The R5-H-R3 smoke failed before sandboxed execution because the strict
structured-output JSON schema generated by the external CLI adapter had
incomplete `required` arrays at nested object levels. The Codex backend
rejected the schema with `invalid_json_schema` HTTP 400 and emitted
`turn.failed`.

Additional defects found and fixed:

- the adapter did not classify the exact Codex schema-rejection event correctly;
- the Hermes formal worker did not close the Kanban task after terminal adapter
  failure, leaving it in `running`;
- the smoke harness searched for the substring `claude` in a serialized argv,
  causing false positives for paths containing `.claude`.

## Changes

- corrected strict JSON-schema generation for nested objects;
- added exact Codex failure-event classification;
- ensured terminal adapter failures transition the Hermes task using existing
  canonical states;
- checked lifecycle transition return values;
- parsed harness argv as a token array instead of matching path substrings;
- preserved explicit Codex workspace containment arguments;
- added regression fixtures derived from the preserved real failure transcript.

## Commit 3: test-fixture compatibility with current upstream

`test: update P0-D fake CLI for exit summary signature`

The third commit only updates a private P0-D test double to accept the
current upstream `_print_exit_summary(clear_screen=...)` method contract.
It changes no production behavior or exit-code semantics. `_FakeCLIBase`
in `tests/cli/test_kanban_worker_exit_code.py` predates a later, unrelated
upstream change that added a `clear_screen` keyword argument to
`HermesCLI._print_exit_summary` and updated the single-query call site to
pass `clear_screen=False`; the private mock never learned the new parameter
and raised `TypeError` on any call. This commit adds the same keyword,
ignored, matching production. No assertions, expected exit codes, or test
case counts changed.

## Verification (this branch, against current origin/main)

- Python compile: PASS
- P0-D dependency tests (`tests/cli/test_kanban_worker_exit_code.py`): 12 PASS
- P0-F focused tests: 65 PASS
- `git diff --check`: PASS
- real Codex tasks: ZERO
- real Claude runtime tasks: ZERO
- credential access: ZERO
- live profile changes: ZERO
- production board writes: ZERO
- gateway restart: ZERO

## Regression verification against current upstream main

The combined regression command currently exposes one pre-existing
test-order-dependent failure on upstream `main`.

The exact same command was executed against:

- current `origin/main`;
- this PR branch.

Results:

- baseline failures: 1
- PR branch failures: 1
- failing node IDs: identical
- meaningful error signatures: identical
- isolated failing test: PASS on both
- PR-only failures: ZERO

Classification:

- combined regression: BASELINE PARITY PASS
- new regression introduced by this PR: ZERO

No tests were skipped, xfailed, deleted, reordered, or relaxed. The
unrelated upstream test-isolation defect is outside this PR's scope.

(An earlier verification against an older `main` reported "required
regression tests: 451 PASS" as a historical result; that number reflects a
prior upstream state and should not be conflated with the baseline
differential gate above, which is the current, authoritative check.)

## Architecture

- Hermes formal worker remains the execution owner.
- Hermes remains the sole canonical workflow-state authority.
- No canonical task status was added.
- No direct adapter board writes were added.
- No provider fallback was added.
- No Claude/Codex cross-fallback was added.
- Hermes manages no API keys for these CLI-managed subscription profiles.

## Remaining risk

Actual Codex workspace filesystem enforcement remains reserved for a
separately approved P0-F-R5-H-R4 controlled smoke.

`codex-coder` remains HOLD until that gate passes.

`claude-coder` remains HOLD and is outside this PR.

## Relationship to #69999

#69999 is not closed by this PR. It remains open pending a maintainer
decision; this PR is the clean replacement built from current `main` with
exactly the intended 3-commit history instead of #69999's 7 commits /
20 files (5 of which were unpublished, unrelated local-only ancestor
commits never merged upstream).

