### PR TITLE
feat(dashboard): HERMES_DASHBOARD_EXTRA_HOSTS for reverse-proxy WS Origin

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -441,6 +441,15 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
         host_only = h.rsplit(":", 1)[0] if ":" in h else h
     host_only = host_only.lower()
 
+    # Operator-defined extra accepted hosts (e.g. Tailscale MagicDNS names
+    # behind a reverse proxy). Allows the WS Origin check to accept proxied
+    # origins without binding publicly or disabling the Host/Origin guard.
+    _extra_hosts = os.environ.get("HERMES_DASHBOARD_EXTRA_HOSTS", "")
+    if _extra_hosts and host_only in {
+        h.strip().lower() for h in _extra_hosts.split(",") if h.strip()
+    }:
+        return True
+
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer
     # defence can protect that mode; rely on operator network controls.


### PR DESCRIPTION
## Summary

When the Hermes dashboard is bound to loopback (`127.0.0.1`) and served behind a reverse proxy (nginx → Tailscale Serve, Cloudflare Tunnel, etc.), HTTP pages work because the proxy rewrites the `Host` header. WebSocket upgrades fail because the browser's `Origin` header contains the proxy hostname (e.g. `srv1480921.tail230ee9.ts.net`) while `bound_host` is `127.0.0.1`.

The browser-set `Origin` is a security header — it **cannot be rewritten by the proxy**. So every WS endpoint (`/api/pty`, `/api/console`, `/api/ws`) is rejected with:

```
pty refused: origin_mismatch origin=https://<proxy-host> bound=127.0.0.1
```

This PR adds `HERMES_DASHBOARD_EXTRA_HOSTS` — a comma-separated env var of operator-defined trusted hostnames that `_is_accepted_host()` accepts in addition to the bound host and loopback aliases.

## Usage

```bash
# systemd unit / env
HERMES_DASHBOARD_EXTRA_HOSTS=srv1480921.tail230ee9.ts.net
```

For operators with multiple proxy hostnames:

```bash
HERMES_DASHBOARD_EXTRA_HOSTS=host1.ts.net,host2.ts.net
```

## Security

All existing security checks remain **fully intact**:

| Check | Status |
|-------|--------|
| DNS rebinding defense (GHSA-ppp5-vxwm-4cf7) | ✅ Non-allowlisted hosts still rejected |
| Loopback bind | ✅ Stays loopback — no public exposure |
| Auth gate | ✅ Non-loopback binds still require OAuth/password |
| Peer check | ✅ Unchanged |

Only hostnames the operator **explicitly lists** are accepted. This is strictly additive — it doesn't widen acceptance for any host not in the list.

## Changes

- `hermes_cli/web_server.py`: 9-line addition to `_is_accepted_host()` — checks `HERMES_DASHBOARD_EXTRA_HOSTS` env var before the existing bound-host validation

## Related

- Closes #70059
- Related: #34390 (same feature request), #55917 (same issue with CF Tunnel)

## Test plan

- [ ] Set `HERMES_DASHBOARD_EXTRA_HOSTS=<hostname>`, verify WS Origin with that hostname is accepted
- [ ] Verify loopback origins still accepted when env var is set
- [ ] Verify random/evil hostnames still rejected (DNS rebinding defense intact)
- [ ] Verify unset env var = existing behavior (no regression)
- [ ] Verify comma-separated multiple hosts work
- [ ] Verify port suffixes are handled correctly (stripped before comparison)
