### PR TITLE
fix(cli): hermes memory status now reads actual config instead of hardcoded 'always active'

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -428,15 +428,11 @@ def cmd_status(args) -> None:
     mem_mark = "enabled ✓" if memory_enabled else "disabled ✗"
     user_mark = "enabled ✓" if user_profile_enabled else "disabled ✗"
 
-    # Check if the memory toolset is enabled for the CLI platform
-    # platform_toolsets.cli is either None (default = all enabled) or
-    # an explicit list of enabled toolset names.
-    platform_toolsets = config.get("platform_toolsets", {}) or {}
-    cli_toolsets = platform_toolsets.get("cli")
-    memory_tool_enabled = (
-        cli_toolsets is None
-        or (isinstance(cli_toolsets, list) and "memory" in cli_toolsets)
-    )
+    # Check if the memory tool is enabled for the CLI platform via the
+    # canonical resolver (handles composite toolsets like hermes-cli).
+    from hermes_cli.tools_config import _get_platform_tools
+    cli_tools = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+    memory_tool_enabled = "memory" in cli_tools
     tool_mark = "enabled ✓" if memory_tool_enabled else "disabled ✗"
 
     print("\nMemory status\n" + "─" * 40)

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -422,8 +422,28 @@ def cmd_status(args) -> None:
     mem_config = config.get("memory", {})
     provider_name = mem_config.get("provider", "")
 
+    memory_enabled = mem_config.get("memory_enabled", True)
+    user_profile_enabled = mem_config.get("user_profile_enabled", True)
+
+    mem_mark = "enabled ✓" if memory_enabled else "disabled ✗"
+    user_mark = "enabled ✓" if user_profile_enabled else "disabled ✗"
+
+    # Check if the memory toolset is enabled for the CLI platform
+    # platform_toolsets.cli is either None (default = all enabled) or
+    # an explicit list of enabled toolset names.
+    platform_toolsets = config.get("platform_toolsets", {}) or {}
+    cli_toolsets = platform_toolsets.get("cli")
+    memory_tool_enabled = (
+        cli_toolsets is None
+        or (isinstance(cli_toolsets, list) and "memory" in cli_toolsets)
+    )
+    tool_mark = "enabled ✓" if memory_tool_enabled else "disabled ✗"
+
     print("\nMemory status\n" + "─" * 40)
-    print("  Built-in:  always active")
+    print("  Built-in (MEMORY.md / USER.md):")
+    print(f"    Memory injection:   {mem_mark}")
+    print(f"    User profile:       {user_mark}")
+    print(f"    Memory tool:        {tool_mark}")
     print(f"  Provider:  {provider_name or '(none — built-in only)'}")
 
     providers = _get_available_providers()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -919,6 +919,7 @@ LEGACY_AUTHOR_MAP = {
     "thomasjhon6666@gmail.com": "ThomassJonax",
     "focusflow.app.help@gmail.com": "yes999zc",
     "rob@atlas.lan": "rmoen",
+    "huajiang@tubi.tv": "thirstycrow",  # PR #23630 salvage (config-aware memory status labels)
     # Slack ephemeral slash-ack salvage (May 2026)
     "probepark@users.noreply.github.com": "probepark",
     # Slack batch salvage (May 2026)

--- a/tests/hermes_cli/test_memory_status.py
+++ b/tests/hermes_cli/test_memory_status.py
@@ -1,0 +1,105 @@
+"""Tests for `hermes memory status` CLI command.
+
+Covers:
+- Status output shows config-aware indicators instead of hardcoded 'always active'
+- memory_enabled, user_profile_enabled, and memory toolset are each reflected
+- Original issue: 'Built-in: always active' was misleading when features were disabled
+"""
+
+import pytest
+from unittest.mock import patch
+
+
+def _run_cmd_status(capfd, mem_config=None, platform_toolsets=None):
+    """Run cmd_status with a mocked config and return captured stdout."""
+    from hermes_cli.memory_setup import cmd_status
+
+    config = {"memory": mem_config or {}}
+    if platform_toolsets is not None:
+        config["platform_toolsets"] = platform_toolsets
+
+    with patch("hermes_cli.config.load_config", return_value=config):
+        with patch("hermes_cli.memory_setup._get_available_providers", return_value=[]):
+            cmd_status(args=None)
+
+    captured = capfd.readouterr()
+    return captured.out
+
+
+class TestMemoryStatusLabels:
+    """Status output should reflect actual config, not a hardcoded string."""
+
+    def test_no_hardcoded_always_active(self, capfd):
+        """The old 'always active' label must not appear."""
+        out = _run_cmd_status(capfd)
+        assert "always active" not in out
+
+    def test_shows_memory_injection_enabled_by_default(self, capfd):
+        """Memory injection defaults to enabled."""
+        out = _run_cmd_status(capfd)
+        assert "Memory injection:" in out
+        assert "enabled ✓" in out
+
+    def test_shows_memory_injection_disabled(self, capfd):
+        """When memory_enabled is false, status reflects it."""
+        out = _run_cmd_status(capfd, mem_config={"memory_enabled": False})
+        assert "Memory injection:" in out
+        assert "disabled ✗" in out
+
+    def test_shows_user_profile_disabled(self, capfd):
+        """When user_profile_enabled is false, status reflects it."""
+        out = _run_cmd_status(
+            capfd, mem_config={"user_profile_enabled": False}
+        )
+        assert "User profile:" in out
+        assert "disabled ✗" in out
+
+    def test_shows_user_profile_enabled(self, capfd):
+        """When user_profile_enabled is true, status reflects it."""
+        out = _run_cmd_status(
+            capfd, mem_config={"user_profile_enabled": True}
+        )
+        assert "User profile:" in out
+        assert "enabled ✓" in out
+
+    def test_memory_tool_enabled_by_default(self, capfd):
+        """Memory tool is enabled by default (no platform_toolsets = all enabled)."""
+        out = _run_cmd_status(capfd)
+        assert "Memory tool:" in out
+        assert "enabled ✓" in out
+
+    def test_memory_tool_disabled_via_toolset(self, capfd):
+        """When CLI toolset excludes 'memory', the tool shows disabled."""
+        out = _run_cmd_status(
+            capfd,
+            platform_toolsets={"cli": ["terminal", "file"]},
+        )
+        assert "Memory tool:" in out
+        assert "disabled ✗" in out
+
+    def test_memory_tool_enabled_via_toolset(self, capfd):
+        """When CLI toolset includes 'memory', the tool shows enabled."""
+        out = _run_cmd_status(
+            capfd,
+            platform_toolsets={"cli": ["terminal", "file", "memory"]},
+        )
+        assert "Memory tool:" in out
+        assert "enabled ✓" in out
+
+    def test_provider_still_shown(self, capfd):
+        """Provider line still appears alongside the config indicators."""
+        out = _run_cmd_status(
+            capfd, mem_config={"provider": "honcho", "memory_enabled": True}
+        )
+        assert "honcho" in out
+        assert "Memory injection:" in out
+
+    def test_all_disabled(self, capfd):
+        """All three indicators show disabled when everything is off."""
+        out = _run_cmd_status(
+            capfd,
+            mem_config={"memory_enabled": False, "user_profile_enabled": False},
+            platform_toolsets={"cli": ["terminal"]},
+        )
+        assert out.count("disabled ✗") == 3
+        assert "always active" not in out

--- a/tests/hermes_cli/test_memory_status.py
+++ b/tests/hermes_cli/test_memory_status.py
@@ -2,7 +2,8 @@
 
 Covers:
 - Status output shows config-aware indicators instead of hardcoded 'always active'
-- memory_enabled, user_profile_enabled, and memory toolset are each reflected
+- memory_enabled, user_profile_enabled, and memory tool are each reflected
+- Memory tool resolution uses the canonical _get_platform_tools resolver
 - Original issue: 'Built-in: always active' was misleading when features were disabled
 """
 
@@ -10,17 +11,27 @@ import pytest
 from unittest.mock import patch
 
 
-def _run_cmd_status(capfd, mem_config=None, platform_toolsets=None):
-    """Run cmd_status with a mocked config and return captured stdout."""
+def _run_cmd_status(capfd, mem_config=None, memory_tools=None):
+    """Run cmd_status with a mocked config and return captured stdout.
+
+    Args:
+        mem_config: The "memory" section of config.
+        memory_tools: Set of tool names returned by _get_platform_tools.
+                      Defaults to {"memory"} (tool enabled).
+    """
     from hermes_cli.memory_setup import cmd_status
 
     config = {"memory": mem_config or {}}
-    if platform_toolsets is not None:
-        config["platform_toolsets"] = platform_toolsets
+    if memory_tools is None:
+        memory_tools = {"memory"}
 
     with patch("hermes_cli.config.load_config", return_value=config):
         with patch("hermes_cli.memory_setup._get_available_providers", return_value=[]):
-            cmd_status(args=None)
+            with patch(
+                "hermes_cli.tools_config._get_platform_tools",
+                return_value=memory_tools,
+            ):
+                cmd_status(args=None)
 
     captured = capfd.readouterr()
     return captured.out
@@ -63,7 +74,7 @@ class TestMemoryStatusLabels:
         assert "enabled ✓" in out
 
     def test_memory_tool_enabled_by_default(self, capfd):
-        """Memory tool is enabled by default (no platform_toolsets = all enabled)."""
+        """Memory tool is enabled by default."""
         out = _run_cmd_status(capfd)
         assert "Memory tool:" in out
         assert "enabled ✓" in out
@@ -72,7 +83,7 @@ class TestMemoryStatusLabels:
         """When CLI toolset excludes 'memory', the tool shows disabled."""
         out = _run_cmd_status(
             capfd,
-            platform_toolsets={"cli": ["terminal", "file"]},
+            memory_tools={"terminal", "file"},
         )
         assert "Memory tool:" in out
         assert "disabled ✗" in out
@@ -81,7 +92,7 @@ class TestMemoryStatusLabels:
         """When CLI toolset includes 'memory', the tool shows enabled."""
         out = _run_cmd_status(
             capfd,
-            platform_toolsets={"cli": ["terminal", "file", "memory"]},
+            memory_tools={"terminal", "file", "memory"},
         )
         assert "Memory tool:" in out
         assert "enabled ✓" in out
@@ -99,7 +110,7 @@ class TestMemoryStatusLabels:
         out = _run_cmd_status(
             capfd,
             mem_config={"memory_enabled": False, "user_profile_enabled": False},
-            platform_toolsets={"cli": ["terminal"]},
+            memory_tools=set(),
         )
         assert out.count("disabled ✗") == 3
         assert "always active" not in out


### PR DESCRIPTION
## Summary
`hermes memory status` now shows actual config state for memory injection, user profile, and memory tool instead of a hardcoded "always active" label.

## Changes
- `hermes_cli/memory_setup.py`: `cmd_status()` reads `memory_enabled`, `user_profile_enabled`, and uses the canonical `_get_platform_tools()` resolver to check if the memory tool is enabled for the CLI platform. Displays three config-aware indicators with ✓/✗ marks.
- `tests/hermes_cli/test_memory_status.py`: 10 tests covering all indicators, disabled states, toolset resolution, and provider display.
- `scripts/release.py`: AUTHOR_MAP entry for `huajiang@tubi.tv` → `thirstycrow`.

## Validation
| Check | Result |
|---|---|
| `tests/hermes_cli/test_memory_status.py` | 10 passed |
| E2E smoke (real imports, config loading) | 5/5 passed |
| Ruff | clean |
| 2c angle-4 Hermes checks | all pass |

## Notes
- The original PR's inline toolset check was incorrect for composite toolsets (e.g. `hermes-cli` expands to include `memory` but the inline `in` check missed it). Fixed by using the canonical `_get_platform_tools()` resolver from `tools_config.py`.
- Also closes #18491 (duplicate PR by @onurkarali — simpler approach, submitted first). Both contributors credited.

Closes #23630. Based on #23630 by @thirstycrow and #18491 by @onurkarali.
