### PR TITLE
fix(wecom): constrain outbound local media to trusted roots (#70069)

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -1178,6 +1178,32 @@ class WeComAdapter(BasePlatformAdapter):
         if not local_path.is_absolute():
             local_path = (Path.cwd() / local_path).resolve()
 
+        # Prevent path traversal: constrain the resolved media path to a file
+        # *inside* the Hermes working directory (cwd) or HERMES_HOME. This
+        # guard is fail-CLOSED: if path resolution itself fails for any reason
+        # (broken symlink, permission error, etc.) we refuse to serve the file
+        # rather than silently bypassing the allowlist. We require the path to
+        # be inside an allowed root, never the root directory itself (a dir is
+        # never a valid media file). Salvage of #32717 (@ErnestHysa) +
+        # @liuhao1024 hardening, re-targeted onto the bundled wecom plugin.
+        try:
+            local_path = local_path.resolve()
+            cwd = str(Path.cwd().resolve())
+            hermes_home = os.environ.get("HERMES_HOME", cwd)
+        except Exception as exc:
+            raise ValueError(
+                f"Refusing to serve media: unable to resolve path safely: {exc}"
+            ) from exc
+
+        local_path_str = str(local_path)
+        if not (
+            local_path_str.startswith(cwd + os.sep)
+            or local_path_str.startswith(hermes_home + os.sep)
+        ):
+            raise ValueError(
+                f"Media path {local_path} is outside the allowed directory"
+            )
+
         if not local_path.exists() or not local_path.is_file():
             raise FileNotFoundError(f"Media file not found: {local_path}")
 

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -44,6 +44,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import unquote, urlparse
 
+from hermes_constants import get_hermes_home
+
 try:
     import aiohttp
     AIOHTTP_AVAILABLE = True
@@ -1175,30 +1177,24 @@ class WeComAdapter(BasePlatformAdapter):
         else:
             local_path = Path(source).expanduser()
 
-        if not local_path.is_absolute():
-            local_path = (Path.cwd() / local_path).resolve()
-
-        # Prevent path traversal: constrain the resolved media path to a file
-        # *inside* the Hermes working directory (cwd) or HERMES_HOME. This
-        # guard is fail-CLOSED: if path resolution itself fails for any reason
-        # (broken symlink, permission error, etc.) we refuse to serve the file
-        # rather than silently bypassing the allowlist. We require the path to
-        # be inside an allowed root, never the root directory itself (a dir is
-        # never a valid media file). Salvage of #32717 (@ErnestHysa) +
-        # @liuhao1024 hardening, re-targeted onto the bundled wecom plugin.
+        # Outbound local media must remain strictly inside the process working
+        # directory or HERMES_HOME. Resolve every part of that boundary in one
+        # guarded block so resolution failures cannot bypass the check.
         try:
+            cwd = Path.cwd().resolve()
+            hermes_home = get_hermes_home().resolve()
+            if not local_path.is_absolute():
+                local_path = cwd / local_path
             local_path = local_path.resolve()
-            cwd = str(Path.cwd().resolve())
-            hermes_home = os.environ.get("HERMES_HOME", cwd)
         except Exception as exc:
             raise ValueError(
                 f"Refusing to serve media: unable to resolve path safely: {exc}"
             ) from exc
 
-        local_path_str = str(local_path)
-        if not (
-            local_path_str.startswith(cwd + os.sep)
-            or local_path_str.startswith(hermes_home + os.sep)
+        allowed_roots = (cwd, hermes_home)
+        if not any(
+            local_path != root and local_path.is_relative_to(root)
+            for root in allowed_roots
         ):
             raise ValueError(
                 f"Media path {local_path} is outside the allowed directory"

--- a/plugins/platforms/wecom/media.py
+++ b/plugins/platforms/wecom/media.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import unquote, urlparse
 
+from hermes_constants import get_hermes_home
+
 from gateway.platforms.base import SendResult, cache_document_from_bytes_async, cache_image_from_bytes_async
 
 logger = logging.getLogger("plugins.platforms.wecom.adapter")
@@ -234,8 +236,15 @@ class WeComMediaMixin:
             data, headers = await self._download_remote_bytes(source, max_bytes=ABSOLUTE_MAX_BYTES)
             resolved_name = file_name or self._guess_filename(source, headers.get("content-disposition"), headers.get("content-type", ""))
             return data, self._normalize_content_type(headers.get("content-type", ""), resolved_name), resolved_name
-        local_path = Path(unquote(parsed.path) if parsed.scheme == "file" else source).expanduser()
-        local_path = local_path if local_path.is_absolute() else (Path.cwd() / local_path).resolve()
+        try:
+            cwd = Path.cwd().resolve()
+            hermes_home = get_hermes_home().resolve()
+            local_path = Path(unquote(parsed.path) if parsed.scheme == "file" else source).expanduser()
+            local_path = (cwd / local_path).resolve()
+        except Exception as exc:
+            raise ValueError(f"Refusing to serve media: unable to resolve path safely: {exc}") from exc
+        if not any(local_path != root and local_path.is_relative_to(root) for root in (cwd, hermes_home)):
+            raise ValueError(f"Media path {local_path} is outside the allowed directory")
         if not local_path.is_file():
             raise FileNotFoundError(f"Media file not found: {local_path}")
         resolved_name = file_name or local_path.name

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -483,3 +483,88 @@ class TestTextBatchFlushRace:
             "superseded task must not pop the event"
         )
 
+
+class TestWeComOutboundMediaPathGuard:
+    """Fail-closed path-traversal guard on outbound media (#32717, #45734).
+
+    Salvage of #32717 by @ErnestHysa + @liuhao1024 hardening, re-targeted onto
+    the bundled wecom plugin (plugins/platforms/wecom/adapter.py).
+    """
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_serves_in_cwd_file(self, tmp_path, monkeypatch):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.chdir(tmp_path)
+        media = tmp_path / "hello.txt"
+        media.write_bytes(b"hello world")
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        data, _content_type, resolved_name = await adapter._load_outbound_media(
+            str(media)
+        )
+
+        assert data == b"hello world"
+        assert resolved_name == "hello.txt"
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_rejects_traversal(self, tmp_path, monkeypatch):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        # Working dir is a subdirectory; target escapes it via ``..``.
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        monkeypatch.chdir(workdir)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        secret = tmp_path / "secret.txt"
+        secret.write_bytes(b"top secret")
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            await adapter._load_outbound_media("../secret.txt")
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_fail_closed_on_resolve_error(
+        self, tmp_path, monkeypatch
+    ):
+        """If path resolution raises, the guard must refuse rather than bypass."""
+        import plugins.platforms.wecom.adapter as wecom_module
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.chdir(tmp_path)
+        media = tmp_path / "hello.txt"
+        media.write_bytes(b"hello world")
+
+        original_resolve = Path.resolve
+
+        def exploding_resolve(self, *args, **kwargs):
+            # Simulate resolution failure (broken symlink / OS error) for our
+            # absolute target path so the relative cwd-join earlier still works.
+            if self.name == "hello.txt":
+                raise OSError("simulated resolve failure")
+            return original_resolve(self, *args, **kwargs)
+
+        monkeypatch.setattr(wecom_module.Path, "resolve", exploding_resolve)
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        with pytest.raises(ValueError, match="unable to resolve path safely"):
+            await adapter._load_outbound_media(str(media))
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_rejects_allowed_root_directory(
+        self, tmp_path, monkeypatch
+    ):
+        """The allowed root directory itself is not a servable media file.
+
+        An exact match to cwd/HERMES_HOME must be rejected by the boundary,
+        not merely deferred to ``is_file()``.
+        """
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            await adapter._load_outbound_media(str(tmp_path))

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -492,7 +492,9 @@ class TestWeComOutboundMediaPathGuard:
     """
 
     @pytest.mark.asyncio
-    async def test_load_outbound_media_serves_in_cwd_file(self, tmp_path, monkeypatch):
+    async def test_load_outbound_media_serves_relative_file_in_cwd(
+        self, tmp_path, monkeypatch
+    ):
         from plugins.platforms.wecom.adapter import WeComAdapter
 
         monkeypatch.chdir(tmp_path)
@@ -501,10 +503,96 @@ class TestWeComOutboundMediaPathGuard:
 
         adapter = WeComAdapter(PlatformConfig(enabled=True))
         data, _content_type, resolved_name = await adapter._load_outbound_media(
-            str(media)
+            "hello.txt"
         )
 
         assert data == b"hello world"
+        assert resolved_name == "hello.txt"
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_serves_file_in_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        media = hermes_home / "hello.txt"
+        media.write_bytes(b"hello home")
+        monkeypatch.chdir(workdir)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        data, _content_type, resolved_name = await adapter._load_outbound_media(
+            str(media)
+        )
+
+        assert data == b"hello home"
+        assert resolved_name == "hello.txt"
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_uses_platform_default_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_constants
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        default_home = tmp_path / "platform-default-home"
+        default_home.mkdir()
+        media = default_home / "hello.txt"
+        media.write_bytes(b"hello default")
+        monkeypatch.chdir(workdir)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            hermes_constants,
+            "_get_platform_default_hermes_home",
+            lambda: default_home,
+        )
+
+        assert hermes_constants.get_hermes_home_override() is None
+        assert default_home != workdir
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        data, _content_type, resolved_name = await adapter._load_outbound_media(
+            str(media)
+        )
+
+        assert data == b"hello default"
+        assert resolved_name == "hello.txt"
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_uses_context_local_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        hermes_home = tmp_path / "profile-home"
+        hermes_home.mkdir()
+        media = hermes_home / "hello.txt"
+        media.write_bytes(b"hello profile")
+        monkeypatch.chdir(workdir)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        token = set_hermes_home_override(hermes_home)
+        try:
+            adapter = WeComAdapter(PlatformConfig(enabled=True))
+            data, _content_type, resolved_name = await adapter._load_outbound_media(
+                str(media)
+            )
+        finally:
+            reset_hermes_home_override(token)
+
+        assert data == b"hello profile"
         assert resolved_name == "hello.txt"
 
     @pytest.mark.asyncio
@@ -525,23 +613,19 @@ class TestWeComOutboundMediaPathGuard:
             await adapter._load_outbound_media("../secret.txt")
 
     @pytest.mark.asyncio
-    async def test_load_outbound_media_fail_closed_on_resolve_error(
+    async def test_load_outbound_media_wraps_relative_resolver_failure(
         self, tmp_path, monkeypatch
     ):
-        """If path resolution raises, the guard must refuse rather than bypass."""
         import plugins.platforms.wecom.adapter as wecom_module
         from plugins.platforms.wecom.adapter import WeComAdapter
 
         monkeypatch.chdir(tmp_path)
-        media = tmp_path / "hello.txt"
-        media.write_bytes(b"hello world")
+        target = tmp_path / "hello.txt"
 
         original_resolve = Path.resolve
 
         def exploding_resolve(self, *args, **kwargs):
-            # Simulate resolution failure (broken symlink / OS error) for our
-            # absolute target path so the relative cwd-join earlier still works.
-            if self.name == "hello.txt":
+            if self == target:
                 raise OSError("simulated resolve failure")
             return original_resolve(self, *args, **kwargs)
 
@@ -549,7 +633,7 @@ class TestWeComOutboundMediaPathGuard:
 
         adapter = WeComAdapter(PlatformConfig(enabled=True))
         with pytest.raises(ValueError, match="unable to resolve path safely"):
-            await adapter._load_outbound_media(str(media))
+            await adapter._load_outbound_media("hello.txt")
 
     @pytest.mark.asyncio
     async def test_load_outbound_media_rejects_allowed_root_directory(

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -1554,3 +1554,172 @@ class TestFinalFrameAckTimeoutSemantics:
                 {"msgtype": "stream", "stream": {"id": "stream_x", "content": "x", "finish": True}},
                 is_final=True,
             )
+
+
+class TestWeComOutboundMediaPathGuard:
+    """Fail-closed path-traversal guard on outbound media (#32717, #45734)."""
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_serves_relative_file_in_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.chdir(tmp_path)
+        media = tmp_path / "hello.txt"
+        media.write_bytes(b"hello world")
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        data, _content_type, resolved_name = await adapter._load_outbound_media(
+            "hello.txt"
+        )
+
+        assert data == b"hello world"
+        assert resolved_name == "hello.txt"
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_serves_file_in_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        media = hermes_home / "hello.txt"
+        media.write_bytes(b"hello home")
+        monkeypatch.chdir(workdir)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        data, _content_type, resolved_name = await adapter._load_outbound_media(
+            str(media)
+        )
+
+        assert data == b"hello home"
+        assert resolved_name == "hello.txt"
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_uses_platform_default_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_constants
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        default_home = tmp_path / "platform-default-home"
+        default_home.mkdir()
+        media = default_home / "hello.txt"
+        media.write_bytes(b"hello default")
+        monkeypatch.chdir(workdir)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            hermes_constants,
+            "_get_platform_default_hermes_home",
+            lambda: default_home,
+        )
+
+        assert hermes_constants.get_hermes_home_override() is None
+        assert default_home != workdir
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        data, _content_type, resolved_name = await adapter._load_outbound_media(
+            str(media)
+        )
+
+        assert data == b"hello default"
+        assert resolved_name == "hello.txt"
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_uses_context_local_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        hermes_home = tmp_path / "profile-home"
+        hermes_home.mkdir()
+        media = hermes_home / "hello.txt"
+        media.write_bytes(b"hello profile")
+        monkeypatch.chdir(workdir)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        token = set_hermes_home_override(hermes_home)
+        try:
+            adapter = WeComAdapter(PlatformConfig(enabled=True))
+            data, _content_type, resolved_name = await adapter._load_outbound_media(
+                str(media)
+            )
+        finally:
+            reset_hermes_home_override(token)
+
+        assert data == b"hello profile"
+        assert resolved_name == "hello.txt"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("source_kind", ["relative", "absolute", "file_uri", "symlink"])
+    async def test_load_outbound_media_rejects_traversal(self, tmp_path, monkeypatch, source_kind):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        monkeypatch.chdir(workdir)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        secret = tmp_path / "secret.txt"
+        secret.write_bytes(b"top secret")
+        source = {"relative": "../secret.txt", "absolute": str(secret), "file_uri": secret.as_uri()}.get(source_kind)
+        if source_kind == "symlink":
+            link = workdir / "linked.txt"
+            try:
+                link.symlink_to(secret)
+            except OSError:
+                pytest.skip("symlink creation unavailable")
+            source = str(link)
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            await adapter._load_outbound_media(source)
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_wraps_relative_resolver_failure(
+        self, tmp_path, monkeypatch
+    ):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.chdir(tmp_path)
+        target = tmp_path / "hello.txt"
+
+        original_resolve = Path.resolve
+
+        def exploding_resolve(self, *args, **kwargs):
+            if self == target:
+                raise OSError("simulated resolve failure")
+            return original_resolve(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", exploding_resolve)
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        with pytest.raises(ValueError, match="unable to resolve path safely"):
+            await adapter._load_outbound_media("hello.txt")
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_rejects_allowed_root_directory(
+        self, tmp_path, monkeypatch
+    ):
+        """The allowed root directory itself is not a servable media file."""
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            await adapter._load_outbound_media(str(tmp_path))


### PR DESCRIPTION
## Summary

Constrain WeCom outbound local media to files strictly below the process working directory or the active Hermes home. Current main's extracted `WeComMediaMixin._load_outbound_media` reads absolute paths and relative traversal paths without this containment check.

Resolve the source and both trusted roots inside one guarded block before reading. Canonical `get_hermes_home()` retains explicit environment, platform-default, and context-local profile behavior. Symlink targets and file URIs receive the same check; exact root directories and resolution failures are rejected. Remote URL handling and the upload flow remain unchanged.

## Attribution

Carries forward #32717, #41109, and #45734 on the current media-module layout. Preserve ErnestHysa, liuhao1024, Teknium, and Bartok9's concrete contributions in the commit trailers. Canonical-root resolution and fail-closed handling retain the reviewed behavior of this PR.

## Validation

Three containment/error-contract regressions failed on the base before the fix. Afterward, 73 WeCom tests pass through `scripts/run_tests.sh`; three existing obsolete stream-architecture tests are skipped. Coverage includes valid cwd and explicit/default/context-local Hermes homes, traversal, absolute outside paths, file URIs, symlink escapes, resolver errors, and exact-root rejection. Ruff and whitespace checks pass.

Not checked: live WeCom service, full repository suite, native Windows/macOS, or CodeRabbit (self-authored PR without a P0/P1 review route).

## Agent disclosure

Earlier preparation and review corrections used GPT-5.6-sol-xhigh in Codex. Maintenance: GPT-6 in Codex desktop (parent reasoning level unavailable). The account owner loosely reviews these actions and receives the usual GitHub notifications.
