### PR TITLE
feat(matrix): two-level drill-down model picker (provider → model)

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2480,9 +2480,11 @@ class MatrixAdapter(BasePlatformAdapter):
         if action_type == "page":
             delta = action[1]
             if sess.view == "providers":
-                sess.provider_page = max(0, sess.provider_page + delta)
+                total_pages = max(1, (len(sess.providers) + _MODEL_PICKER_PAGE_SIZE - 1) // _MODEL_PICKER_PAGE_SIZE)
+                sess.provider_page = max(0, min(sess.provider_page + delta, total_pages - 1))
             else:
-                sess.model_page = max(0, sess.model_page + delta)
+                total_pages = max(1, (len(sess.model_list) + _MODEL_PICKER_PAGE_SIZE - 1) // _MODEL_PICKER_PAGE_SIZE)
+                sess.model_page = max(0, min(sess.model_page + delta, total_pages - 1))
             # Pop old key before sending new view.
             self._model_picker_prompts_by_event.pop(reacts_to, None)
             await self._cleanup_model_picker_view(room_id, sess)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -324,18 +324,36 @@ class _MatrixApprovalPrompt:
 
 
 @dataclass
-class _MatrixModelPickerPrompt:
-    """Tracks a pending Matrix reaction-based model picker prompt."""
+class _MatrixModelPickerSession:
+    """Tracks a two-level drill-down model picker (provider → model).
+
+    Each navigation step sends a fresh message (avoiding the reaction-toggle
+    trap where the same emoji on the same event toggles off instead of firing
+    a second time).  The registry is re-keyed on every view change.
+    """
 
     chat_id: str
-    message_id: str
     session_key: str
-    choices: dict[str, tuple[str, str]]
+    providers: list
     on_model_selected: Any
+    current_model: str
+    current_provider: str
+    view: str = "providers"  # providers | models | confirm
+    provider_page: int = 0
+    selected_provider: str = ""
+    selected_provider_name: str = ""
+    model_list: list = field(default_factory=list)
+    model_page: int = 0
+    pending_model: str = ""  # model_id when confirm view is active
+    message_id: str = ""  # event_id of the CURRENT view message
+    bot_reaction_events: dict[str, str] = field(default_factory=dict)
     requester_user_id: str | None = None
     expires_at: float | None = None
     resolved: bool = False
-    bot_reaction_events: dict[str, str] = field(default_factory=dict)
+
+
+# Back-compat alias so existing references to the old name don't break.
+_MatrixModelPickerPrompt = _MatrixModelPickerSession
 
 
 @dataclass
@@ -431,6 +449,16 @@ _MATRIX_MODEL_PICKER_REACTIONS = (
     "9\ufe0f\u20e3",
     "\U0001f51f",
 )
+
+# Navigation emoji for the two-level model picker drill-down.
+_MODEL_PICKER_NAV_PREV = "⬅️"
+_MODEL_PICKER_NAV_NEXT = "➡️"
+_MODEL_PICKER_NAV_BACK = "🔙"
+_MODEL_PICKER_NAV_CANCEL = "❌"
+_MODEL_PICKER_NAV_CONFIRM = "✅"
+
+# Items per page in the model picker.
+_MODEL_PICKER_PAGE_SIZE = len(_MATRIX_MODEL_PICKER_REACTIONS)  # 10
 
 # Choice pickers (/reasoning, /fast) can need more than 10 slots
 # (8 effort levels + none + reset/show/hide = 12), so extend the keycap
@@ -1015,7 +1043,8 @@ class MatrixAdapter(BasePlatformAdapter):
             )
         except ValueError:
             self._approval_timeout_seconds = 300
-        self._model_picker_prompts_by_event: Dict[str, _MatrixModelPickerPrompt] = {}
+        self._model_picker_prompts_by_event: Dict[str, _MatrixModelPickerSession] = {}
+        self._model_picker_by_session: Dict[str, str] = {}  # session_key -> event_id
         self._choice_picker_prompts_by_event: Dict[str, _MatrixChoicePickerPrompt] = {}
         allowed_users_raw = os.getenv("MATRIX_ALLOWED_USERS", "")
         self._allowed_user_ids: Set[str] = {
@@ -2141,33 +2170,31 @@ class MatrixAdapter(BasePlatformAdapter):
         on_model_selected,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a Matrix reaction-based model picker."""
+        """Send a two-level reaction-based model picker (provider → model).
+
+        Each navigation step sends a fresh message (new event_id) to avoid the
+        reaction-toggle trap on Matrix where tapping the same emoji on the same
+        event toggles it off instead of firing again.
+        """
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        flat_choices: list[tuple[str, str, str, str]] = []
-        for provider in providers or []:
-            provider_slug = str(provider.get("slug") or "")
-            provider_name = str(provider.get("name") or provider_slug)
-            models = provider.get("models") or []
-            for model_id in models:
-                if len(flat_choices) >= len(_MATRIX_MODEL_PICKER_REACTIONS):
-                    break
-                flat_choices.append((
-                    _MATRIX_MODEL_PICKER_REACTIONS[len(flat_choices)],
-                    str(model_id),
-                    provider_slug,
-                    provider_name,
-                ))
-            if len(flat_choices) >= len(_MATRIX_MODEL_PICKER_REACTIONS):
-                break
-
-        if not flat_choices:
+        if not providers:
             return await self.send(
                 chat_id,
                 "No authenticated models are available for this session.",
                 metadata=metadata,
             )
+
+        # Expire any existing picker for this session.
+        old_event = self._model_picker_by_session.get(session_key)
+        if old_event:
+            old_sess = self._model_picker_prompts_by_event.pop(old_event, None)
+            if old_sess and not old_sess.resolved:
+                old_sess.resolved = True
+                # Best-effort cleanup of the old view.
+                await self._cleanup_model_picker_view(chat_id, old_sess)
+            self._model_picker_by_session.pop(session_key, None)
 
         try:
             from hermes_cli.providers import get_label
@@ -2175,42 +2202,411 @@ class MatrixAdapter(BasePlatformAdapter):
         except Exception:
             provider_label = current_provider
 
-        lines = [
-            "⚙ **Model Configuration**",
-            f"Current model: `{current_model or 'unknown'}`",
-            f"Provider: {provider_label or 'unknown'}",
-            "",
-            "React to choose a model:",
-        ]
-        choices: dict[str, tuple[str, str]] = {}
-        for emoji, model_id, provider_slug, provider_name in flat_choices:
-            choices[emoji] = (model_id, provider_slug)
-            lines.append(f"{emoji} `{model_id}` — {provider_name}")
-
-        result = await self.send(chat_id, "\n".join(lines), metadata=metadata)
-        if not result.success or not result.message_id:
-            return result
-
-        prompt = _MatrixModelPickerPrompt(
+        sess = _MatrixModelPickerSession(
             chat_id=chat_id,
-            message_id=result.message_id,
             session_key=session_key,
-            choices=choices,
+            providers=providers,
             on_model_selected=on_model_selected,
+            current_model=current_model or "unknown",
+            current_provider=current_provider or "unknown",
             requester_user_id=str((metadata or {}).get("requester_user_id") or "") or None,
             expires_at=time.monotonic() + max(self._approval_timeout_seconds, 0),
         )
-        self._model_picker_prompts_by_event[result.message_id] = prompt
 
-        for emoji in choices:
+        # Single-provider shortcut: skip provider list, go straight to models.
+        if len(providers) == 1:
+            p = providers[0]
+            sess.selected_provider = str(p.get("slug") or "")
+            sess.selected_provider_name = str(p.get("name") or sess.selected_provider)
+            sess.model_list = list(p.get("models") or [])
+            sess.view = "models"
+        else:
+            sess.view = "providers"
+
+        result = await self._send_model_picker_view(sess, metadata=metadata)
+        return result
+
+    # ------------------------------------------------------------------
+    # Model picker — view rendering & navigation helpers
+    # ------------------------------------------------------------------
+
+    async def _send_model_picker_view(
+        self,
+        sess: "_MatrixModelPickerSession",
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render and send the current picker view, update registry."""
+        text, reaction_order = self._build_model_picker_view_content(sess)
+
+        result = await self.send(sess.chat_id, text, metadata=metadata)
+        if not result.success or not result.message_id:
+            return result
+
+        sess.message_id = result.message_id
+        sess.bot_reaction_events = {}
+
+        # Register under the new event_id.
+        self._model_picker_prompts_by_event[result.message_id] = sess
+        self._model_picker_by_session[sess.session_key] = result.message_id
+
+        # Seed reactions in display order.
+        for emoji in reaction_order:
             try:
-                reaction_event_id = await self._send_reaction(chat_id, result.message_id, emoji)
-                if reaction_event_id:
-                    prompt.bot_reaction_events[emoji] = str(reaction_event_id)
+                evt_id = await self._send_reaction(sess.chat_id, result.message_id, emoji)
+                if evt_id:
+                    sess.bot_reaction_events[emoji] = str(evt_id)
             except Exception as exc:
-                logger.debug("Matrix: failed to add model picker reaction %s: %s", emoji, exc)
+                logger.debug("Matrix: failed to seed model picker reaction %s: %s", emoji, exc)
 
         return result
+
+    def _build_model_picker_view_content(
+        self,
+        sess: "_MatrixModelPickerSession",
+    ) -> tuple[str, list[str]]:
+        """Build (text, emoji_order) for the current view of a picker session."""
+        if sess.view == "providers":
+            return self._build_provider_list_view(sess)
+        elif sess.view == "models":
+            return self._build_model_list_view(sess)
+        elif sess.view == "confirm":
+            return self._build_confirm_view(sess)
+        # Fallback — shouldn't happen.
+        return ("⚙ **Model Configuration** — invalid state", [_MODEL_PICKER_NAV_CANCEL])
+
+    def _build_provider_list_view(
+        self,
+        sess: "_MatrixModelPickerSession",
+    ) -> tuple[str, list[str]]:
+        """Build the provider selection view (paginated, 10/page)."""
+        providers = sess.providers
+        page = sess.provider_page
+        page_size = _MODEL_PICKER_PAGE_SIZE
+        total_pages = max(1, (len(providers) + page_size - 1) // page_size)
+        page = min(page, total_pages - 1)
+        start = page * page_size
+        end = min(start + page_size, len(providers))
+        page_items = providers[start:end]
+
+        try:
+            from hermes_cli.providers import get_label
+            provider_label = get_label(sess.current_provider)
+        except Exception:
+            provider_label = sess.current_provider
+
+        lines = [
+            "⚙ **Model Configuration**",
+            f"Current model: `{sess.current_model}`",
+            f"Provider: {provider_label or 'unknown'}",
+            "",
+        ]
+        if total_pages > 1:
+            lines.append(f"React to choose a provider (page {page + 1}/{total_pages}):")
+        else:
+            lines.append("React to choose a provider:")
+
+        reaction_order: list[str] = []
+        for i, prov in enumerate(page_items):
+            emoji = _MATRIX_MODEL_PICKER_REACTIONS[i]
+            name = str(prov.get("name") or prov.get("slug") or "")
+            total = prov.get("total_models", len(prov.get("models") or []))
+            current_mark = " ← current" if prov.get("is_current") else ""
+            lines.append(f"{emoji} {name} ({total}){current_mark}")
+            reaction_order.append(emoji)
+
+        # Navigation footer.
+        nav_parts = []
+        if page > 0:
+            reaction_order.append(_MODEL_PICKER_NAV_PREV)
+            nav_parts.append("⬅️")
+        if page < total_pages - 1:
+            reaction_order.append(_MODEL_PICKER_NAV_NEXT)
+            nav_parts.append("➡️")
+        nav_parts.append("❌ cancel")
+        reaction_order.append(_MODEL_PICKER_NAV_CANCEL)
+
+        lines.append("")
+        lines.append(" · ".join(nav_parts))
+        return "\n".join(lines), reaction_order
+
+    def _build_model_list_view(
+        self,
+        sess: "_MatrixModelPickerSession",
+    ) -> tuple[str, list[str]]:
+        """Build the model selection view for a provider (paginated, 10/page)."""
+        models = sess.model_list
+        page = sess.model_page
+        page_size = _MODEL_PICKER_PAGE_SIZE
+        total_pages = max(1, (len(models) + page_size - 1) // page_size)
+        page = min(page, total_pages - 1)
+        start = page * page_size
+        end = min(start + page_size, len(models))
+        page_items = models[start:end]
+
+        total_models = len(models)
+        # Find the total from the provider entry if available.
+        for prov in sess.providers:
+            if str(prov.get("slug") or "") == sess.selected_provider:
+                total_models = prov.get("total_models", len(models))
+                break
+
+        lines = [
+            "⚙ **Model Configuration**",
+            f"Provider: **{sess.selected_provider_name}** (models {start + 1}–{end} of {total_models})",
+            "",
+            "React to choose a model:",
+        ]
+
+        reaction_order: list[str] = []
+        for i, model_id in enumerate(page_items):
+            emoji = _MATRIX_MODEL_PICKER_REACTIONS[i]
+            lines.append(f"{emoji} `{model_id}`")
+            reaction_order.append(emoji)
+
+        # Footnote when provider has more models than displayed.
+        if total_models > len(models):
+            lines.append(
+                f"_{total_models - len(models)} more available — type `/model <name>` directly_"
+            )
+
+        # Empty-provider edge case.
+        if not page_items and not models:
+            lines.append(
+                f"No models cached for this provider — type `/model <name> --provider {sess.selected_provider}`"
+            )
+
+        # Navigation footer.
+        nav_parts = []
+        if page > 0:
+            reaction_order.append(_MODEL_PICKER_NAV_PREV)
+            nav_parts.append("⬅️")
+        if page < total_pages - 1:
+            reaction_order.append(_MODEL_PICKER_NAV_NEXT)
+            nav_parts.append("➡️")
+        # Show 🔙 only if there is a provider list to go back to.
+        if len(sess.providers) > 1:
+            reaction_order.append(_MODEL_PICKER_NAV_BACK)
+            nav_parts.append("🔙 providers")
+        nav_parts.append("❌ cancel")
+        reaction_order.append(_MODEL_PICKER_NAV_CANCEL)
+
+        lines.append("")
+        lines.append(" · ".join(nav_parts))
+        return "\n".join(lines), reaction_order
+
+    def _build_confirm_view(
+        self,
+        sess: "_MatrixModelPickerSession",
+    ) -> tuple[str, list[str]]:
+        """Build the expensive-model confirmation view."""
+        lines = [
+            "⚠ **Expensive Model Warning**",
+            "",
+            getattr(sess, "_confirm_warning_text", "This model may be expensive."),
+            "",
+            "React ✅ to switch anyway, 🔙 to go back, or ❌ to cancel.",
+        ]
+        reaction_order = [
+            _MODEL_PICKER_NAV_CONFIRM,
+            _MODEL_PICKER_NAV_BACK,
+            _MODEL_PICKER_NAV_CANCEL,
+        ]
+        return "\n".join(lines), reaction_order
+
+    async def _cleanup_model_picker_view(
+        self,
+        room_id: str,
+        sess: "_MatrixModelPickerSession",
+    ) -> None:
+        """Best-effort cleanup of a picker view: redact message + seed reactions."""
+        if sess.message_id:
+            try:
+                redacted = await self.redact_message(room_id, sess.message_id, "model picker navigation")
+                if not redacted:
+                    # Fallback: edit to superseded notice.
+                    await self.edit_message(
+                        room_id, sess.message_id, "_(superseded — see below)_"
+                    )
+            except Exception as exc:
+                logger.debug("Matrix: model picker view cleanup failed: %s", exc)
+        # Redact seed reactions via delayed path.
+        for emoji, evt_id in sess.bot_reaction_events.items():
+            self._schedule_reaction_redaction(room_id, evt_id, "model picker navigation")
+
+    async def _handle_model_picker_reaction(
+        self,
+        room_id: str,
+        reacts_to: str,
+        key: str,
+        sender: str,
+    ) -> None:
+        """Dispatch a reaction on a model picker message."""
+        sess = self._model_picker_prompts_by_event.get(reacts_to)
+        if not sess or sess.resolved:
+            return
+        if room_id != sess.chat_id:
+            return
+        if self._matrix_prompt_expired(sess):
+            await self._expire_matrix_model_picker_prompt(room_id, reacts_to, sess)
+            return
+        if not await self._validate_matrix_prompt_reactor(
+            room_id, reacts_to, sender, sess, "model picker"
+        ):
+            return
+
+        # Refresh timeout on every interaction.
+        sess.expires_at = time.monotonic() + max(self._approval_timeout_seconds, 0)
+
+        # Determine action based on key.
+        action = self._resolve_model_picker_action(sess, key)
+        if action is None:
+            await self._send_invalid_reaction_feedback(
+                room_id, reacts_to,
+                "That reaction is not one of the available choices.",
+            )
+            return
+
+        action_type = action[0]
+
+        if action_type == "cancel":
+            sess.resolved = True
+            self._model_picker_prompts_by_event.pop(reacts_to, None)
+            self._model_picker_by_session.pop(sess.session_key, None)
+            await self._cleanup_model_picker_view(room_id, sess)
+            await self.send(room_id, "Model selection cancelled.")
+            return
+
+        if action_type == "page":
+            delta = action[1]
+            if sess.view == "providers":
+                sess.provider_page = max(0, sess.provider_page + delta)
+            else:
+                sess.model_page = max(0, sess.model_page + delta)
+            # Pop old key before sending new view.
+            self._model_picker_prompts_by_event.pop(reacts_to, None)
+            await self._cleanup_model_picker_view(room_id, sess)
+            await self._send_model_picker_view(sess)
+            return
+
+        if action_type == "back":
+            self._model_picker_prompts_by_event.pop(reacts_to, None)
+            await self._cleanup_model_picker_view(room_id, sess)
+            if sess.view == "confirm":
+                sess.view = "models"
+            else:
+                sess.view = "providers"
+            await self._send_model_picker_view(sess)
+            return
+
+        if action_type == "provider":
+            provider_slug = action[1]
+            # Find the provider dict.
+            for prov in sess.providers:
+                if str(prov.get("slug") or "") == provider_slug:
+                    sess.selected_provider = provider_slug
+                    sess.selected_provider_name = str(prov.get("name") or provider_slug)
+                    sess.model_list = list(prov.get("models") or [])
+                    break
+            sess.model_page = 0
+            sess.view = "models"
+            self._model_picker_prompts_by_event.pop(reacts_to, None)
+            await self._cleanup_model_picker_view(room_id, sess)
+            await self._send_model_picker_view(sess)
+            return
+
+        if action_type == "model":
+            model_id = action[1]
+            # Cost guard check.
+            warning = None
+            try:
+                warning = await asyncio.to_thread(
+                    self._get_expensive_model_warning, model_id, sess.selected_provider
+                )
+            except Exception:
+                warning = None
+
+            if warning is not None:
+                # Show confirm view.
+                sess.pending_model = model_id
+                sess._confirm_warning_text = getattr(warning, "message", str(warning))
+                sess.view = "confirm"
+                self._model_picker_prompts_by_event.pop(reacts_to, None)
+                await self._cleanup_model_picker_view(room_id, sess)
+                await self._send_model_picker_view(sess)
+                return
+            else:
+                # Switch immediately.
+                await self._execute_model_switch(room_id, reacts_to, sess, model_id)
+                return
+
+        if action_type == "confirm":
+            model_id = sess.pending_model
+            await self._execute_model_switch(room_id, reacts_to, sess, model_id)
+            return
+
+    def _resolve_model_picker_action(
+        self,
+        sess: "_MatrixModelPickerSession",
+        key: str,
+    ) -> tuple | None:
+        """Map an emoji key to a picker action tuple or None if invalid."""
+        if key == _MODEL_PICKER_NAV_CANCEL:
+            return ("cancel",)
+        if key == _MODEL_PICKER_NAV_PREV:
+            return ("page", -1)
+        if key == _MODEL_PICKER_NAV_NEXT:
+            return ("page", +1)
+        if key == _MODEL_PICKER_NAV_BACK:
+            return ("back",)
+        if key == _MODEL_PICKER_NAV_CONFIRM and sess.view == "confirm":
+            return ("confirm",)
+
+        # Item selection (keycap emoji → index).
+        if key in _MATRIX_MODEL_PICKER_REACTIONS:
+            idx = _MATRIX_MODEL_PICKER_REACTIONS.index(key)
+            if sess.view == "providers":
+                page_start = sess.provider_page * _MODEL_PICKER_PAGE_SIZE
+                abs_idx = page_start + idx
+                if abs_idx < len(sess.providers):
+                    return ("provider", str(sess.providers[abs_idx].get("slug") or ""))
+            elif sess.view == "models":
+                page_start = sess.model_page * _MODEL_PICKER_PAGE_SIZE
+                abs_idx = page_start + idx
+                if abs_idx < len(sess.model_list):
+                    return ("model", sess.model_list[abs_idx])
+        return None
+
+    async def _execute_model_switch(
+        self,
+        room_id: str,
+        reacts_to: str,
+        sess: "_MatrixModelPickerSession",
+        model_id: str,
+    ) -> None:
+        """Finalize model selection: call callback, clean up, confirm."""
+        sess.resolved = True
+        self._model_picker_prompts_by_event.pop(reacts_to, None)
+        self._model_picker_by_session.pop(sess.session_key, None)
+        try:
+            confirmation = await sess.on_model_selected(
+                room_id, model_id, sess.selected_provider
+            )
+            await self._cleanup_model_picker_view(room_id, sess)
+            if confirmation:
+                await self.send(room_id, confirmation)
+        except Exception as exc:
+            logger.error("Failed to switch model from Matrix reaction: %s", exc)
+            await self.send(room_id, f"Failed to switch model: {exc}")
+
+    @staticmethod
+    def _get_expensive_model_warning(model_id: str, provider: str):
+        """Synchronous wrapper for the cost guard (called via to_thread)."""
+        try:
+            from hermes_cli.model_cost_guard import expensive_model_warning
+            return expensive_model_warning(model_id, provider=provider)
+        except Exception:
+            return None
 
     async def send_choice_picker(
         self,
@@ -3428,40 +3824,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
             model_prompt = self._model_picker_prompts_by_event.get(reacts_to)
             if model_prompt and not model_prompt.resolved:
-                if room_id != model_prompt.chat_id:
-                    return
-                if self._matrix_prompt_expired(model_prompt):
-                    await self._expire_matrix_model_picker_prompt(room_id, reacts_to, model_prompt)
-                    return
-                if not await self._validate_matrix_prompt_reactor(
-                    room_id, reacts_to, sender, model_prompt, "model picker"
-                ):
-                    return
-                selection = model_prompt.choices.get(key)
-                if not selection:
-                    await self._send_invalid_reaction_feedback(
-                        room_id,
-                        reacts_to,
-                        "That reaction is not one of the available model choices.",
-                    )
-                    return
-                model_prompt.resolved = True
-                self._model_picker_prompts_by_event.pop(reacts_to, None)
-                model_id, provider_slug = selection
-                try:
-                    confirmation = await model_prompt.on_model_selected(
-                        room_id, model_id, provider_slug
-                    )
-                    await self._redact_bot_model_picker_reactions(room_id, model_prompt)
-                    if confirmation:
-                        await self.send(room_id, confirmation, reply_to=reacts_to)
-                except Exception as exc:
-                    logger.error("Failed to switch model from Matrix reaction: %s", exc)
-                    await self.send(
-                        room_id,
-                        f"Failed to switch model: {exc}",
-                        reply_to=reacts_to,
-                    )
+                await self._handle_model_picker_reaction(room_id, reacts_to, key, sender)
                 return
 
             choice_prompt = self._choice_picker_prompts_by_event.get(reacts_to)
@@ -3575,10 +3938,11 @@ class MatrixAdapter(BasePlatformAdapter):
         self,
         room_id: str,
         target_event_id: str,
-        prompt: "_MatrixModelPickerPrompt",
+        prompt: "_MatrixModelPickerSession",
     ) -> None:
         prompt.resolved = True
         self._model_picker_prompts_by_event.pop(target_event_id, None)
+        self._model_picker_by_session.pop(prompt.session_key, None)
         await self._redact_bot_model_picker_reactions(room_id, prompt)
         await self._send_invalid_reaction_feedback(
             room_id,
@@ -3599,7 +3963,7 @@ class MatrixAdapter(BasePlatformAdapter):
     async def _redact_bot_model_picker_reactions(
         self,
         room_id: str,
-        prompt: "_MatrixModelPickerPrompt",
+        prompt: "_MatrixModelPickerSession",
     ) -> None:
         """Redact the bot's seeded model picker reactions."""
         for emoji, evt_id in prompt.bot_reaction_events.items():

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5312,3 +5312,543 @@ class TestMatrixDispatchSyncIsolation:
 
         assert ran["ok"] is True  # the sibling handler still ran
         assert "event handler failed" in caplog.text  # failure surfaced, not swallowed
+
+
+# ---------------------------------------------------------------------------
+# Model picker drill-down (provider → model, two-level)
+# ---------------------------------------------------------------------------
+
+
+class TestMatrixModelPickerDrilldown:
+    """Tests for the two-level reaction-based model picker."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._client = MagicMock()
+        self.adapter._send_reaction = AsyncMock(return_value="$seed_reaction")
+        self.adapter.send = AsyncMock()
+        self.adapter.redact_message = AsyncMock(return_value=True)
+        self.adapter._schedule_reaction_redaction = MagicMock()
+        self.adapter._approval_timeout_seconds = 300
+        # Allow the test user for reaction validation.
+        self.adapter._allowed_user_ids = {"@user:ex"}
+        self.adapter._approval_require_sender = True
+
+    def _providers(self, n_providers=3, n_models=15):
+        """Generate test providers."""
+        providers = []
+        for i in range(n_providers):
+            models = [f"model-{i}-{j}" for j in range(n_models)]
+            providers.append({
+                "slug": f"provider_{i}",
+                "name": f"Provider {i}",
+                "models": models,
+                "total_models": n_models,
+                "is_current": (i == 0),
+            })
+        return providers
+
+    @pytest.mark.asyncio
+    async def test_provider_view_lists_all_providers(self):
+        """Picker with 3 providers shows all 3 on the provider view."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        providers = self._providers(3, 15)
+
+        result = await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="model-0-0",
+            current_provider="provider_0",
+            session_key="sess1",
+            on_model_selected=AsyncMock(),
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        assert result.success is True
+        # Verify the sent text contains all 3 providers
+        sent_text = self.adapter.send.call_args[0][1]
+        assert "Provider 0" in sent_text
+        assert "Provider 1" in sent_text
+        assert "Provider 2" in sent_text
+        # Should show item counts
+        assert "(15)" in sent_text
+
+    @pytest.mark.asyncio
+    async def test_provider_reaction_opens_model_view_and_redacts_old(self):
+        """Selecting a provider sends a new model-list view and redacts old."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        providers = self._providers(2, 5)
+        on_selected = AsyncMock(return_value="Switched!")
+
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="model-0-0",
+            current_provider="provider_0",
+            session_key="sess1",
+            on_model_selected=on_selected,
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        # Now simulate user reacting with 2️⃣ (second provider)
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker2")
+        )
+        self.adapter._send_reaction = AsyncMock(return_value="$seed2")
+
+        from plugins.platforms.matrix.adapter import _MATRIX_MODEL_PICKER_REACTIONS
+        key = _MATRIX_MODEL_PICKER_REACTIONS[1]  # 2️⃣
+
+        # Simulate the reaction handler
+        sess = self.adapter._model_picker_prompts_by_event.get("$picker1")
+        assert sess is not None, "Session should be registered under $picker1"
+
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$picker1",
+            key=key,
+            sender="@user:ex",
+        )
+
+        # The old message should be redacted
+        self.adapter.redact_message.assert_called()
+        # A new message with models should be sent
+        new_text = self.adapter.send.call_args[0][1]
+        assert "model-1-0" in new_text  # first model of provider_1
+        # Registry should be re-keyed to new event_id
+        assert "$picker1" not in self.adapter._model_picker_prompts_by_event
+        assert "$picker2" in self.adapter._model_picker_prompts_by_event
+
+    @pytest.mark.asyncio
+    async def test_model_pagination(self):
+        """15 models → page 0 has ➡️ no ⬅️; page 1 has ⬅️ no ➡️."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        providers = self._providers(1, 15)
+
+        # Single provider → should skip to model view directly
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="model-0-0",
+            current_provider="provider_0",
+            session_key="sess1",
+            on_model_selected=AsyncMock(),
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        # Should jump to model view for single provider
+        sent_text = self.adapter.send.call_args[0][1]
+        assert "model-0-0" in sent_text  # first model shown
+
+        # Check page 0 reactions: should have ➡️ (next) but no ⬅️ (prev)
+        seeded_emojis = [
+            call.args[2] for call in self.adapter._send_reaction.call_args_list
+        ]
+        assert "➡️" in seeded_emojis  # has next page
+        assert "⬅️" not in seeded_emojis  # no prev on page 0
+
+        # Navigate to page 1
+        self.adapter._send_reaction.reset_mock()
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker2")
+        )
+
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$picker1",
+            key="➡️",
+            sender="@user:ex",
+        )
+
+        # Page 1 should show models 10-14
+        new_text = self.adapter.send.call_args[0][1]
+        assert "model-0-10" in new_text
+
+        # Page 1 should have ⬅️ but no ➡️ (last page)
+        seeded_emojis_page2 = [
+            call.args[2] for call in self.adapter._send_reaction.call_args_list
+        ]
+        assert "⬅️" in seeded_emojis_page2
+        assert "➡️" not in seeded_emojis_page2
+
+    @pytest.mark.asyncio
+    async def test_model_selection_calls_on_model_selected(self):
+        """Selecting a model calls on_model_selected with correct args."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        on_selected = AsyncMock(return_value="Switched to model-0-2!")
+
+        # Single provider to skip to model view
+        providers = [
+            {
+                "slug": "prov",
+                "name": "MyProv",
+                "models": ["m-a", "m-b", "m-c"],
+                "total_models": 3,
+                "is_current": True,
+            }
+        ]
+
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="m-a",
+            current_provider="prov",
+            session_key="sess1",
+            on_model_selected=on_selected,
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        from plugins.platforms.matrix.adapter import _MATRIX_MODEL_PICKER_REACTIONS
+        # Select 3rd model (index 2)
+        key = _MATRIX_MODEL_PICKER_REACTIONS[2]
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$confirm1")
+        )
+
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$picker1",
+            key=key,
+            sender="@user:ex",
+        )
+
+        on_selected.assert_called_once_with("!room:ex", "m-c", "prov")
+
+    @pytest.mark.asyncio
+    async def test_expensive_model_confirm_view(self):
+        """expensive_model_warning returns a warning → confirm view shown."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        on_selected = AsyncMock(return_value="Switched!")
+
+        providers = [
+            {
+                "slug": "prov",
+                "name": "MyProv",
+                "models": ["expensive-model"],
+                "total_models": 1,
+                "is_current": True,
+            }
+        ]
+
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="old-model",
+            current_provider="prov",
+            session_key="sess1",
+            on_model_selected=on_selected,
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        from plugins.platforms.matrix.adapter import _MATRIX_MODEL_PICKER_REACTIONS
+        key = _MATRIX_MODEL_PICKER_REACTIONS[0]
+
+        # Mock expensive_model_warning to return a warning
+        warning_obj = MagicMock()
+        warning_obj.message = "This model costs $50/1M tokens!"
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$confirm1")
+        )
+        self.adapter._send_reaction = AsyncMock(return_value="$seed_confirm")
+
+        with patch(
+            "hermes_cli.model_cost_guard.expensive_model_warning",
+            return_value=warning_obj,
+        ):
+            await self.adapter._handle_model_picker_reaction(
+                room_id="!room:ex",
+                reacts_to="$picker1",
+                key=key,
+                sender="@user:ex",
+            )
+
+        # Should show confirm view with warning
+        confirm_text = self.adapter.send.call_args[0][1]
+        assert "$50/1M" in confirm_text or "Expensive" in confirm_text or "Warning" in confirm_text
+        # on_model_selected should NOT have been called yet
+        on_selected.assert_not_called()
+
+        # Now confirm with ✅
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$final")
+        )
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$confirm1",
+            key="✅",
+            sender="@user:ex",
+        )
+        on_selected.assert_called_once_with("!room:ex", "expensive-model", "prov")
+
+    @pytest.mark.asyncio
+    async def test_back_from_models_to_providers(self):
+        """🔙 from models returns to providers preserving provider_page."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        providers = self._providers(3, 5)
+
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="model-0-0",
+            current_provider="provider_0",
+            session_key="sess1",
+            on_model_selected=AsyncMock(),
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        # Select first provider
+        from plugins.platforms.matrix.adapter import _MATRIX_MODEL_PICKER_REACTIONS
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker2")
+        )
+        self.adapter._send_reaction = AsyncMock(return_value="$seed2")
+
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$picker1",
+            key=_MATRIX_MODEL_PICKER_REACTIONS[0],
+            sender="@user:ex",
+        )
+
+        # Now go back with 🔙
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker3")
+        )
+        self.adapter._send_reaction = AsyncMock(return_value="$seed3")
+
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$picker2",
+            key="🔙",
+            sender="@user:ex",
+        )
+
+        # Should show provider list again
+        back_text = self.adapter.send.call_args[0][1]
+        assert "Provider 0" in back_text
+        assert "Provider 1" in back_text
+
+    @pytest.mark.asyncio
+    async def test_cancel_drops_state(self):
+        """❌ cancels: state dropped, further reactions ignored."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        providers = self._providers(2, 5)
+
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="model-0-0",
+            current_provider="provider_0",
+            session_key="sess1",
+            on_model_selected=AsyncMock(),
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$cancel_msg")
+        )
+
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$picker1",
+            key="❌",
+            sender="@user:ex",
+        )
+
+        # State should be dropped
+        assert "$picker1" not in self.adapter._model_picker_prompts_by_event
+        # Confirm cancellation message
+        cancel_text = self.adapter.send.call_args[0][1]
+        assert "cancel" in cancel_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_expired_prompt(self):
+        """Expired prompt sends expiry message and redacts seeds."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        providers = self._providers(2, 5)
+
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="model-0-0",
+            current_provider="provider_0",
+            session_key="sess1",
+            on_model_selected=AsyncMock(),
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        # Force expiry
+        sess = self.adapter._model_picker_prompts_by_event["$picker1"]
+        sess.expires_at = time.monotonic() - 10
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$expired_msg")
+        )
+
+        from plugins.platforms.matrix.adapter import _MATRIX_MODEL_PICKER_REACTIONS
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$picker1",
+            key=_MATRIX_MODEL_PICKER_REACTIONS[0],
+            sender="@user:ex",
+        )
+
+        # Should be resolved and removed
+        assert "$picker1" not in self.adapter._model_picker_prompts_by_event
+        # Should send expiry message
+        expire_text = self.adapter.send.call_args[0][1]
+        assert "/model" in expire_text
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_rejected(self):
+        """Unauthorized user reaction on navigation is rejected."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        providers = self._providers(2, 5)
+
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="model-0-0",
+            current_provider="provider_0",
+            session_key="sess1",
+            on_model_selected=AsyncMock(),
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$rejected")
+        )
+        self.adapter._approval_require_sender = True
+
+        from plugins.platforms.matrix.adapter import _MATRIX_MODEL_PICKER_REACTIONS
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$picker1",
+            key=_MATRIX_MODEL_PICKER_REACTIONS[0],
+            sender="@other:ex",  # different user
+        )
+
+        # State should remain unchanged
+        assert "$picker1" in self.adapter._model_picker_prompts_by_event
+        # Should send rejection feedback
+        reject_text = self.adapter.send.call_args[0][1]
+        assert "requested" in reject_text.lower() or "user" in reject_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_single_provider_skips_to_model_view(self):
+        """Single provider → model view opens directly (provider view skipped)."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        providers = [
+            {
+                "slug": "single",
+                "name": "Solo Provider",
+                "models": ["m1", "m2", "m3"],
+                "total_models": 3,
+                "is_current": True,
+            }
+        ]
+
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="m1",
+            current_provider="single",
+            session_key="sess1",
+            on_model_selected=AsyncMock(),
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        # Should show models directly, not provider list
+        sent_text = self.adapter.send.call_args[0][1]
+        assert "m1" in sent_text
+        assert "m2" in sent_text
+        assert "m3" in sent_text
+        # No 🔙 since there's no provider list to go back to
+        seeded_emojis = [
+            call.args[2] for call in self.adapter._send_reaction.call_args_list
+        ]
+        assert "🔙" not in seeded_emojis
+
+    @pytest.mark.asyncio
+    async def test_new_model_command_expires_old_picker(self):
+        """New /model while a picker is active expires the old picker."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        providers = self._providers(2, 5)
+
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="model-0-0",
+            current_provider="provider_0",
+            session_key="sess1",
+            on_model_selected=AsyncMock(),
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        assert "$picker1" in self.adapter._model_picker_prompts_by_event
+
+        # Start a new picker for the same session
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker2")
+        )
+        self.adapter._send_reaction = AsyncMock(return_value="$seed_new")
+
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="model-0-0",
+            current_provider="provider_0",
+            session_key="sess1",
+            on_model_selected=AsyncMock(),
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        # Old picker should be gone, new one registered
+        assert "$picker1" not in self.adapter._model_picker_prompts_by_event
+        assert "$picker2" in self.adapter._model_picker_prompts_by_event

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5852,3 +5852,82 @@ class TestMatrixModelPickerDrilldown:
         # Old picker should be gone, new one registered
         assert "$picker1" not in self.adapter._model_picker_prompts_by_event
         assert "$picker2" in self.adapter._model_picker_prompts_by_event
+
+    @pytest.mark.asyncio
+    async def test_page_past_end_clamps_and_selection_stays_correct(self):
+        """➡️ past the last page must clamp; subsequent digit tap selects correctly."""
+        from gateway.platforms.base import SendResult as SR
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker1")
+        )
+        # Single provider with 15 models → 2 pages (0..9, 10..14)
+        providers = [
+            {
+                "slug": "prov",
+                "name": "MyProv",
+                "models": [f"m-{i}" for i in range(15)],
+                "total_models": 15,
+                "is_current": True,
+            }
+        ]
+
+        await self.adapter.send_model_picker(
+            chat_id="!room:ex",
+            providers=providers,
+            current_model="m-0",
+            current_provider="prov",
+            session_key="sess1",
+            on_model_selected=AsyncMock(),
+            metadata={"requester_user_id": "@user:ex"},
+        )
+
+        # Navigate to page 1 (last page)
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker2")
+        )
+        self.adapter._send_reaction = AsyncMock(return_value="$seed2")
+
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$picker1",
+            key="➡️",
+            sender="@user:ex",
+        )
+
+        # Verify we're on page 1
+        sess = self.adapter._model_picker_prompts_by_event["$picker2"]
+        assert sess.model_page == 1
+
+        # Now inject ➡️ again (not seeded on last page, but user can do it)
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$picker3")
+        )
+        self.adapter._send_reaction = AsyncMock(return_value="$seed3")
+
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$picker2",
+            key="➡️",
+            sender="@user:ex",
+        )
+
+        # Page must still be 1 (clamped), not 2
+        sess = self.adapter._model_picker_prompts_by_event["$picker3"]
+        assert sess.model_page == 1
+
+        # A 1️⃣ tap should select the first item on page 1 = model index 10
+        from plugins.platforms.matrix.adapter import _MATRIX_MODEL_PICKER_REACTIONS
+        on_selected = sess.on_model_selected
+
+        self.adapter.send = AsyncMock(
+            return_value=SR(success=True, message_id="$final")
+        )
+        await self.adapter._handle_model_picker_reaction(
+            room_id="!room:ex",
+            reacts_to="$picker3",
+            key=_MATRIX_MODEL_PICKER_REACTIONS[0],  # 1️⃣
+            sender="@user:ex",
+        )
+
+        on_selected.assert_called_once_with("!room:ex", "m-10", "prov")


### PR DESCRIPTION
## Problem

`/model` without arguments on Matrix shows a flat, reaction-based list capped at **10 models total** (keycap emoji 1️⃣–🔟). The gateway already hands the adapter the full provider→model structure (`list_picker_providers(..., max_models=50)`), but `send_model_picker` in the Matrix adapter flattens it and truncates at 10, so users see the first ~10 models of the first provider(s) and nothing else. Telegram, by contrast, gets a full two-level drill-down (providers paginated → models paginated → expensive-model confirm).

## What this PR does

Rebuilds the Matrix model picker as a **two-level reaction-based drill-down** with Telegram parity:

- **View 1 — providers**, paginated 10/page, `is_current` marked, model counts shown.
- **View 2 — models** of the selected provider, paginated 10/page, with the "N more available — type `/model <name>` directly" footnote when the provider list was truncated upstream.
- **View 3 — expensive-model confirmation** via `hermes_cli.model_cost_guard.expensive_model_warning` (run in `asyncio.to_thread`, same as Telegram). This guard was previously **missing** on Matrix — the flat picker switched immediately.
- Navigation: `⬅️`/`➡️` paging, `🔙` back, `❌` cancel, `✅` confirm; only valid navigation emoji are seeded per view.
- Single-provider shortcut (provider view skipped), at-most-one active picker per session (a new `/model` expires the old prompt), expiry refresh on every interaction, best-effort cleanup (redact superseded view + seed reactions, fall back to editing the old message to "(superseded)" when the bot lacks redaction power).

No gateway changes — the `send_model_picker` signature is unchanged; everything lives in `plugins/platforms/matrix/adapter.py`.

## Why new-message-per-view instead of edit-in-place (like Telegram)?

Matrix reactions aggregate **per event**, and clients (Element/Element X) treat a second tap of the same emoji key by the same user on the same event as a **toggle-off** — the client sends a redaction of the user's own reaction, not a new `m.reaction`. With edit-in-place navigation, a user who picked `3️⃣` at the provider level could never pick `3️⃣` again at the model level, and tapping `➡️` twice to page twice would silently do nothing the second time. Each navigation step therefore sends a **fresh message** (fresh event = fresh reaction state) and cleans up the previous view. The prompt registry is re-keyed to the new event id on every step, so stale taps on superseded views are ignored.

## Page-state hardening

The page-change handler clamps the stored page into `[0, total_pages-1]` at the write site. Element clients let users react with arbitrary emoji (including `➡️` when it isn't seeded, e.g. on the last page); without the write-site clamp the stored page could drift past the end while the view builders clamped only their local copy, desyncing the displayed items from what a digit tap selects. The builders keep their local clamps as defense in depth.

## Tests

`tests/gateway/test_matrix.py` — new `TestMatrixModelPickerDrilldown` class, 12 cases: provider view rendering, drill-down + registry re-keying + old-view redaction, model pagination, selection callback wiring, expensive-model confirm flow (`✅` switches / `🔙` returns), back navigation preserving provider page, cancel, expiry, unauthorized reactor rejection, single-provider shortcut, picker dedup on repeated `/model`, and page-past-end clamping.

```
tests/gateway/test_matrix.py: 263 passed
```

Full `tests/gateway` suite run as well; the only failures are pre-existing test-ordering issues in unrelated files (they pass in isolation, unaffected by this diff). `ruff check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
