### PR TITLE
fix(desktop): stream remote media through gateway

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -26,8 +26,8 @@ import {
   mediaKind,
   mediaName,
   mediaPathFromMarkdownHref,
-  mediaStreamUrl,
-  resolveMediaDisplaySrc
+  resolveMediaDisplaySrc,
+  resolveMediaPlaybackSrc
 } from '@/lib/media'
 import { previewTargetFromMarkdownHref } from '@/lib/preview-targets'
 import { cn } from '@/lib/utils'
@@ -57,16 +57,6 @@ function preprocessWithTailRepair(text: string): string {
   } catch {
     return text
   }
-}
-
-async function mediaSrc(path: string): Promise<string> {
-  // Stream audio/video through the custom protocol: data URLs are capped and
-  // load the whole file into memory, which broke playback for larger videos.
-  if (window.hermesDesktop && ['audio', 'video'].includes(mediaKind(path))) {
-    return mediaStreamUrl(path)
-  }
-
-  return resolveMediaDisplaySrc(path)
 }
 
 function useOpenMediaFile(path: string) {
@@ -131,7 +121,7 @@ function MediaAttachment({ path }: { path: string }) {
       }
     }
 
-    void mediaSrc(path)
+    void resolveMediaPlaybackSrc(path)
       .then(value => {
         if (value.startsWith('blob:')) {
           objectUrl = value

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -11,7 +11,8 @@ import {
   isInlineMediaSrc,
   isRemoteGateway,
   mediaExternalUrl,
-  resolveMediaDisplaySrc
+  resolveMediaDisplaySrc,
+  resolveMediaPlaybackSrc
 } from './media'
 
 describe('isRemoteGateway', () => {
@@ -136,6 +137,40 @@ describe('resolveMediaDisplaySrc', () => {
       'data:image/png;base64,bG9jYWw='
     )
     expect(readFileDataUrl).toHaveBeenCalledWith('/Users/me/project/a b.png')
+  })
+})
+
+describe('resolveMediaPlaybackSrc', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    $connection.set(null)
+  })
+
+  it('keeps a remote HTTPS video URL unchanged', async () => {
+    vi.stubGlobal('window', { hermesDesktop: { api: vi.fn() } })
+    $connection.set({ mode: 'remote', baseUrl: 'https://gateway.test', token: 'secret' } as never)
+
+    await expect(resolveMediaPlaybackSrc('https://cdn.example.com/render.mp4')).resolves.toBe(
+      'https://cdn.example.com/render.mp4'
+    )
+  })
+
+  it('routes gateway-local video through the authenticated download endpoint', async () => {
+    vi.stubGlobal('window', { hermesDesktop: { api: vi.fn() } })
+    $connection.set({ mode: 'remote', baseUrl: 'https://gateway.test', token: 's e/cret' } as never)
+
+    await expect(resolveMediaPlaybackSrc('/root/outputs/render.mp4')).resolves.toBe(
+      'https://gateway.test/api/files/download?path=%2Froot%2Foutputs%2Frender.mp4&token=s%20e%2Fcret'
+    )
+  })
+
+  it('uses the Electron streaming protocol for local desktop video', async () => {
+    vi.stubGlobal('window', { hermesDesktop: { api: vi.fn() } })
+    $connection.set({ mode: 'local' } as never)
+
+    await expect(resolveMediaPlaybackSrc('C:\\renders\\demo.mp4')).resolves.toBe(
+      'hermes-media://stream/C%3A%5Crenders%5Cdemo.mp4'
+    )
   })
 })
 

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -82,6 +82,22 @@ export async function resolveMediaDisplaySrc(path: string): Promise<string> {
   return window.hermesDesktop.readFileDataUrl(filePathFromMediaPath(path))
 }
 
+// Audio/video need a seekable source instead of a whole-file data URL. Keep
+// remote URLs untouched, route gateway-local files through the authenticated
+// download endpoint, and reserve the Electron protocol for files on this
+// desktop machine.
+export async function resolveMediaPlaybackSrc(path: string): Promise<string> {
+  if (isInlineMediaSrc(path)) {
+    return path
+  }
+
+  if (window.hermesDesktop && ['audio', 'video'].includes(mediaKind(path))) {
+    return isRemoteGateway() ? mediaExternalUrl(path) : mediaStreamUrl(path)
+  }
+
+  return resolveMediaDisplaySrc(path)
+}
+
 // Resolve a media path to a URL the shell can open. Remote mode rewrites
 // gateway-local paths to an authenticated /api/files/download URL (the file
 // lives on the gateway, not this disk); local mode keeps the file:// form.


### PR DESCRIPTION
## What does this PR do?

Fixes 0-second audio/video attachments in Hermes Desktop when the Desktop app is connected to a remote gateway.

The current playback resolver sends every audio/video path through the local `hermes-media://` Electron protocol before checking whether the file lives on a remote gateway. Electron then tries to open the VPS path on the Windows/macOS client, so the media element renders but never loads metadata or playback.

This change centralizes playback source resolution in `lib/media.ts` and preserves seekable streaming semantics:

- HTTP(S) media URLs remain unchanged.
- Gateway-local audio/video paths use the existing authenticated `/api/files/download` endpoint.
- Files on the local Desktop machine continue to use the Range-aware `hermes-media://` protocol.
- Non-audio/video media keeps the existing display resolver behavior.

## Why not use a data URL?

Related PR #46143 fixes the same check-order bug by routing remote audio/video through `gatewayMediaDataUrl()`. That loads the entire file into memory and remains subject to data-URL/file-read caps, which is the limitation the local audio/video streaming path was introduced to avoid.

Using the existing authenticated `FileResponse` download route preserves progressive loading and HTTP Range support for remote video while keeping the current managed-file policy, sensitive-path checks, authentication, MIME detection, and 100 MB limit.

## Reproduction

Verified with Hermes Desktop on Windows connected to a Linux VPS after updating both sides from the official distribution:

1. Return a `MEDIA:/absolute/path/video.mp4` attachment from the remote agent.
2. Desktop renders the video controls.
3. The player remains black at `0:00`, with no duration metadata.
4. The same video converted to an animated WebP displays correctly, confirming that the remote image bridge works while video playback source resolution does not.

The reproduced MP4 was H.264 + AAC, 720x1280, 10.1 seconds, 5.2 MB.

## Tests

- `npm --workspace apps/desktop run test:ui -- src/components/assistant-ui/markdown-text.media.test.tsx src/lib/media.remote.test.ts`
  - 20 tests passed
- `npm --workspace apps/desktop run typecheck`
  - passed
- Desktop lint
  - 0 errors (existing unrelated warnings only)

Added playback resolver coverage for:

- remote HTTPS video passthrough;
- remote gateway-local video through the authenticated download endpoint;
- local Windows video through `hermes-media://`.

## Security

No new endpoint, permission, token mechanism, port, dependency, or service is introduced. The remote path reuses the existing managed-file download route, including authentication, sensitive-path denial, managed-root policy, MIME detection, and file-size enforcement.

## Type of change

- [x] Bug fix
- [x] Desktop remote/local boundary fix
- [x] Tests added
