### PR TITLE
fix(background-review): make iteration budget configurable

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -27,6 +27,23 @@ from agent.thread_scoped_output import thread_scoped_silence
 
 logger = logging.getLogger(__name__)
 
+_BACKGROUND_REVIEW_DEFAULT_MAX_ITERATIONS = 16
+_BACKGROUND_REVIEW_MAX_ITERATIONS = 16
+
+
+def _resolve_background_review_max_iterations(task: Dict[str, Any]) -> int:
+    """Return the bounded agent-loop budget for one background review.
+
+    Keep the historical budget as the default and safety ceiling: operators
+    can reduce the cost of a review, but a config override cannot silently
+    increase its worst-case model-call count.
+    """
+    try:
+        value = int(task.get("max_iterations", _BACKGROUND_REVIEW_DEFAULT_MAX_ITERATIONS))
+    except (TypeError, ValueError):
+        value = _BACKGROUND_REVIEW_DEFAULT_MAX_ITERATIONS
+    return max(1, min(value, _BACKGROUND_REVIEW_MAX_ITERATIONS))
+
 
 # ---------------------------------------------------------------------------
 # Background-review aux-model selector + routed digest.
@@ -76,6 +93,8 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
         return parent
     aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
     task = aux.get("background_review", {}) if isinstance(aux.get("background_review"), dict) else {}
+    review_max_iterations = _resolve_background_review_max_iterations(task)
+    parent["max_iterations"] = review_max_iterations
     task_provider = (str(task.get("provider", "")).strip() or None)
     task_model = (str(task.get("model", "")).strip() or None)
     task_base_url = (str(task.get("base_url", "")).strip() or None)
@@ -104,6 +123,7 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
             "command": rp.get("command"),
             "args": list(rp.get("args") or []),
             "routed": True,
+            "max_iterations": review_max_iterations,
         }
     except Exception as e:
         logger.debug("background-review aux routing failed (%s); using main model", e)
@@ -711,7 +731,9 @@ def _run_review_in_thread(
                 _fork_kwargs["reasoning_config"] = getattr(agent, "reasoning_config", None)
             review_agent = AIAgent(
                 model=_rt.get("model") or agent.model,
-                max_iterations=16,
+                max_iterations=int(
+                    _rt.get("max_iterations") or _BACKGROUND_REVIEW_DEFAULT_MAX_ITERATIONS
+                ),
                 quiet_mode=True,
                 platform=agent.platform,
                 provider=_rt.get("provider") or agent.provider,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -584,6 +584,12 @@ prompt_caching:
 #                           # extra_body:
 #                           #   chat_template_kwargs:
 #                           #     enable_thinking: false
+#
+#   # Background memory/skill review after each turn
+#   background_review:
+#     provider: "auto"
+#     model: ""
+#     max_iterations: 16    # Review loop budget; values are clamped to 1–16
 
 # =============================================================================
 # Persistent Memory

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1782,6 +1782,7 @@ DEFAULT_CONFIG = {
             "base_url": "",
             "api_key": "",
             "timeout": 120,
+            "max_iterations": 16,
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
         },

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -118,6 +118,15 @@ class TestLoadConfigDefaults:
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
+            assert config["auxiliary"]["background_review"]["max_iterations"] == 16
+
+    def test_background_review_max_iterations_loads_from_yaml(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            (tmp_path / "config.yaml").write_text(
+                "auxiliary:\n  background_review:\n    max_iterations: 4\n"
+            )
+            config = load_config()
+            assert config["auxiliary"]["background_review"]["max_iterations"] == 4
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -40,6 +40,47 @@ class ImmediateThread:
         self._target()
 
 
+def test_background_review_uses_resolved_iteration_budget(monkeypatch):
+    import agent.background_review as bg_review
+
+    captured = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(
+        bg_review,
+        "_resolve_review_runtime",
+        lambda _agent: {
+            "provider": "openai",
+            "model": "fake-model",
+            "routed": False,
+            "max_iterations": 4,
+        },
+    )
+
+    AIAgent._spawn_background_review(
+        _bare_agent(),
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert captured["max_iterations"] == 4
+
+
 def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
     events = []
 

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -52,6 +52,34 @@ def test_routing_auto_inherits_parent_and_downgrades_codex_app_server():
     assert rt["api_mode"] == "codex_responses"  # downgraded so agent-loop tools dispatch
 
 
+def _iteration_budget(review_overrides):
+    agent = _FakeAgent()
+    cfg = {"auxiliary": {"background_review": {
+        "provider": "auto", "model": "", **review_overrides,
+    }}}
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        return br._resolve_review_runtime(agent)["max_iterations"]
+
+
+def test_background_review_iteration_budget_defaults_to_16_when_unset():
+    assert _iteration_budget({}) == 16
+
+
+def test_background_review_iteration_budget_accepts_and_clamps_1_to_16():
+    assert _iteration_budget({"max_iterations": 1}) == 1
+    assert _iteration_budget({"max_iterations": 16}) == 16
+    assert _iteration_budget({"max_iterations": 0}) == 1
+    assert _iteration_budget({"max_iterations": -8}) == 1
+    assert _iteration_budget({"max_iterations": 17}) == 16
+    assert _iteration_budget({"max_iterations": 500}) == 16
+
+
+def test_background_review_iteration_budget_falls_back_on_invalid_values():
+    assert _iteration_budget({"max_iterations": "plenty"}) == 16
+    assert _iteration_budget({"max_iterations": None}) == 16
+    assert _iteration_budget({"max_iterations": "4"}) == 4
+
+
 def test_routing_to_different_model_marks_routed_and_resolves_credentials():
     agent = _FakeAgent()
     cfg = {"auxiliary": {"background_review": {

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -282,6 +282,7 @@ auxiliary:
   background_review:
     provider: openrouter
     model: google/gemini-3-flash-preview   # auto (default) = main chat model
+    max_iterations: 8                      # review loop budget, 1–16 (default 16)
 ```
 
 When you point it at a model **different** from your main one, the review runs
@@ -291,6 +292,12 @@ replays a compact **digest** of the conversation (recent turns verbatim + a
 summary of older ones) rather than the full transcript — minimizing what it
 writes to the new cache. Capture holds: in testing, memory capture was
 identical and skill capture near-identical to the main-model review.
+
+`max_iterations` bounds the review fork's **agent-loop iterations** — its
+worst-case number of model calls per review. The default is `16`; out-of-range
+values clamp to the `1`–`16` range, and a non-numeric value falls back to the
+default. Lower it to cap the review's per-capture cost on slow or metered
+endpoints.
 
 Leave it at `auto` (or set it to your main model) and nothing changes — the
 review keeps running on the main model with the full warm-cache replay.


### PR DESCRIPTION
## Summary

- Add `auxiliary.background_review.max_iterations` to the canonical config with the historical default of `16`.
- Resolve the setting for both the main-model and routed background-review forks.
- Bound values to `1–16`, falling back to `16` for malformed values, and document the cost-control behavior.

## Relationship to #62391

This is a focused current-main support port of only the iteration-budget portion of [#62391](https://github.com/NousResearch/hermes-agent/pull/62391). That PR is still open and also contains independent `skill_view` idempotency and process-session guardrail changes across other files. This PR intentionally does not include those unrelated changes, and no commit was pushed to the contributor's fork. The original implementation intent is preserved and credited via the relationship link and commit co-author attribution.

`Related to #62391.`

## Behavior

`auxiliary.background_review.max_iterations` controls the maximum number of agent-loop iterations (and therefore worst-case model calls) for one background review:

- omitted: `16`
- `1–16`: accepted
- below `1`: clamped to `1`
- above `16`: clamped to `16`
- non-numeric: falls back to `16`

The existing default behavior is unchanged. The upper bound deliberately preserves the historical safety ceiling so a config override can reduce background-review cost without silently increasing it.

## Files

- `agent/background_review.py` — resolve and propagate the bounded budget to the forked `AIAgent`.
- `hermes_cli/config.py` — register the canonical default.
- `cli-config.yaml.example` and `website/docs/user-guide/features/memory.md` — document the setting.
- Focused regression coverage for config loading, normalization, boundaries, malformed values, and constructor propagation.

## Verification

- `uv run --frozen pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cost_controls.py tests/hermes_cli/test_config.py::TestLoadConfigDefaults -q -o 'addopts='` — **27 passed**
- `uv run --frozen pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cost_controls.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py -q -o 'addopts='` — **233 passed**
- `uvx ruff check agent/background_review.py hermes_cli/config.py tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cost_controls.py tests/hermes_cli/test_config.py` — **All checks passed**
- `compileall`, `git diff --check`, and YAML parsing — passed
- Isolated `HERMES_HOME` smoke test covering `set_config_value` → `load_config` → `_resolve_review_runtime` — passed (`4` reached the runtime)

Base reviewed: `upstream/main` `91546b8337068891cc0a6b834d89d0d9270fb3ec`

Reviewed commit: `8e13d138df747dab51cd7e000df792c3e267d545`
