### PR TITLE
fix(anthropic): synthesized leading user turn must be non-whitespace

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2427,7 +2427,15 @@ def _ensure_leading_user_turn(result: List[Dict[str, Any]]) -> None:
     (convert_messages_to_converse).
     """
     if result and result[0].get("role") != "user":
-        result.insert(0, {"role": "user", "content": [{"type": "text", "text": " "}]})
+        # The filler text MUST be non-whitespace: Anthropic's Messages API rejects
+        # any text content block whose text is empty or whitespace-only with
+        # HTTP 400 "messages: text content blocks must contain non-whitespace text".
+        # A single space (" ") trips that guard whenever a resumed session's active
+        # window opens on an assistant turn. Use the same "(empty)" sentinel the rest
+        # of this adapter (lines ~2061/2136/2325/2368) and the Bedrock adapter's
+        # _EMPTY_TEXT_PLACEHOLDER already rely on, so the synthesized leading user
+        # turn always carries printable text.
+        result.insert(0, {"role": "user", "content": [{"type": "text", "text": "(empty)"}]})
 
 
 def convert_messages_to_anthropic(

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1394,7 +1394,10 @@ class TestConvertMessages:
 
         assert system == "You are helpful."
         assert result[0]["role"] == "user"
-        assert result[0]["content"] == [{"type": "text", "text": " "}]
+        # Filler text must be non-whitespace or Anthropic 400s the request with
+        # "messages: text content blocks must contain non-whitespace text".
+        assert result[0]["content"] == [{"type": "text", "text": "(empty)"}]
+        assert result[0]["content"][0]["text"].strip() != ""
         assert result[1]["role"] == "assistant"
         assert any(
             m["role"] == "assistant" and "Context compaction summary" in str(m["content"])
@@ -1418,9 +1421,41 @@ class TestConvertMessages:
 
         assert system is None
         assert result[0]["role"] == "user"
-        assert result[0]["content"] == [{"type": "text", "text": " "}]
+        # Filler text must be non-whitespace or Anthropic 400s the request with
+        # "messages: text content blocks must contain non-whitespace text".
+        assert result[0]["content"] == [{"type": "text", "text": "(empty)"}]
+        assert result[0]["content"][0]["text"].strip() != ""
         assert result[1]["role"] == "assistant"
         assert "Context compaction summary" in str(result[1]["content"])
+
+    def test_synthesized_leading_user_turn_is_non_whitespace(self):
+        """Resumed sessions whose active window opens on an assistant tool-call
+        turn must get a NON-whitespace leading user turn.
+
+        Regression for the Anthropic HTTP 400 "messages: text content blocks
+        must contain non-whitespace text". The synthesized filler previously used
+        a single space (" "), which Anthropic rejects. Any resumed/compacted
+        session whose first live message is an assistant turn tripped it.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",  # tool-call turn with no preamble text
+                "tool_calls": [
+                    {"id": "toolu_1", "function": {"name": "terminal", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "ok"},
+            {"role": "user", "content": "continue"},
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        assert result[0]["role"] == "user"
+        block = result[0]["content"][0]
+        assert block["type"] == "text"
+        # The property that actually matters to the Messages API: printable text.
+        assert block["text"].strip() != ""
 
     def test_leading_user_message_is_not_modified(self):
         """A normal transcript that already starts with user must be untouched."""


### PR DESCRIPTION
## Problem

Resuming a session whose active window opens on a non-user role (e.g. a resumed or double-compacted session whose first live message is an **assistant tool-call turn**) fails on the very first request with:

```
HTTP 400: messages: text content blocks must contain non-whitespace text
Provider: anthropic  Model: claude-opus-4-8
```

Non-retryable — the whole request is rejected before any tokens are generated, so the session becomes unresumable.

## Root cause

`_ensure_leading_user_turn()` (in `agent/anthropic_adapter.py`) backstops Anthropic's requirement that `messages[0].role == "user"` by prepending a filler user turn. That filler used a **single space** as its text:

```python
result.insert(0, {"role": "user", "content": [{"type": "text", "text": " "}]})
```

A single space is whitespace-only, which the Messages API rejects with the 400 above. The bug is latent: it only fires when the converted message list actually opens on a non-user role, which happens on resumed/compacted sessions whose active head is an assistant turn.

Two existing tests (`test_leading_assistant_after_compaction_gets_user_turn_prepended`, `test_double_compaction_no_system_in_messages_leads_with_user`) asserted the `" "` value, but only checked output **shape** — never that Anthropic would accept it. That's why it shipped.

## Fix

Use the `"(empty)"` sentinel already used by every other empty-content path in this same adapter (lines ~2061 / 2136 / 2325 / 2368) and by the Bedrock adapter's `_EMPTY_TEXT_PLACEHOLDER = "(empty)"`. The synthesized leading user turn now always carries printable text.

## Tests

- Updated the two existing assertions from `" "` to `"(empty)"` and added a `.strip() != ""` invariant so a future whitespace regression fails loudly.
- Added `test_synthesized_leading_user_turn_is_non_whitespace` reproducing the real-world shape (assistant tool-call turn as `messages[0]`), asserting the property that actually matters to the API: non-whitespace filler text.

## Verification

Reproduced against a real affected session by rebuilding its active window and running it through `convert_messages_to_anthropic()`: before the fix, one `{"type":"text","text":" "}` block was emitted as `messages[0]`; after, zero empty/whitespace text blocks across the full converted payload. The three relevant tests pass against the patched adapter.