### PR TITLE
fix(codex): enable 24h prompt cache retention on Bedrock Mantle

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1060,7 +1060,7 @@ class _CodexCompletionsAdapter:
         try:
             from agent.transports.codex import (
                 _content_cache_key,
-                _prompt_cache_retention_for_model,
+                _default_prompt_cache_retention_for_request,
             )
             from utils import base_url_host_matches
 
@@ -1070,21 +1070,15 @@ class _CodexCompletionsAdapter:
                 base_url_host_matches(_host_src, "githubcopilot.com")
                 or base_url_host_matches(_host_src, "models.github.ai")
             )
-            _is_codex_backend = (
-                base_url_host_matches(_host_src, "chatgpt.com")
-                and "/backend-api/codex" in _host_src.lower()
-            )
             if not _is_xai and not _is_github and "prompt_cache_key" not in resp_kwargs:
                 _cache_key = _content_cache_key(instructions, resp_kwargs.get("tools"))
                 if _cache_key:
                     resp_kwargs["prompt_cache_key"] = _cache_key
-            if (
-                not _is_xai
-                and not _is_github
-                and not _is_codex_backend
-                and "prompt_cache_retention" not in resp_kwargs
-            ):
-                _cache_retention = _prompt_cache_retention_for_model(model)
+            if "prompt_cache_retention" not in resp_kwargs:
+                _cache_retention = _default_prompt_cache_retention_for_request(
+                    model,
+                    _host_src,
+                )
                 if _cache_retention:
                     resp_kwargs["prompt_cache_retention"] = _cache_retention
         except Exception:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1058,7 +1058,10 @@ class _CodexCompletionsAdapter:
         # key in extra_body (not top-level) and GitHub/Copilot Responses opts
         # out of cache-key routing entirely — for those hosts, skip it here.
         try:
-            from agent.transports.codex import _content_cache_key
+            from agent.transports.codex import (
+                _content_cache_key,
+                _prompt_cache_retention_for_model,
+            )
             from utils import base_url_host_matches
 
             _host_src = str(getattr(self._client, "base_url", "") or "")
@@ -1068,6 +1071,10 @@ class _CodexCompletionsAdapter:
                 _cache_key = _content_cache_key(instructions, resp_kwargs.get("tools"))
                 if _cache_key:
                     resp_kwargs["prompt_cache_key"] = _cache_key
+            if not _is_xai and not _is_github and "prompt_cache_retention" not in resp_kwargs:
+                _cache_retention = _prompt_cache_retention_for_model(model)
+                if _cache_retention:
+                    resp_kwargs["prompt_cache_retention"] = _cache_retention
         except Exception:
             logger.debug(
                 "Codex auxiliary: prompt_cache_key derivation skipped", exc_info=True

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1067,11 +1067,20 @@ class _CodexCompletionsAdapter:
             _host_src = str(getattr(self._client, "base_url", "") or "")
             _is_xai = base_url_host_matches(_host_src, "x.ai") or base_url_host_matches(_host_src, "api.x.ai")
             _is_github = base_url_host_matches(_host_src, "githubcopilot.com")
+            _is_codex_backend = (
+                base_url_host_matches(_host_src, "chatgpt.com")
+                and "/backend-api/codex" in _host_src.lower()
+            )
             if not _is_xai and not _is_github and "prompt_cache_key" not in resp_kwargs:
                 _cache_key = _content_cache_key(instructions, resp_kwargs.get("tools"))
                 if _cache_key:
                     resp_kwargs["prompt_cache_key"] = _cache_key
-            if not _is_xai and not _is_github and "prompt_cache_retention" not in resp_kwargs:
+            if (
+                not _is_xai
+                and not _is_github
+                and not _is_codex_backend
+                and "prompt_cache_retention" not in resp_kwargs
+            ):
                 _cache_retention = _prompt_cache_retention_for_model(model)
                 if _cache_retention:
                     resp_kwargs["prompt_cache_retention"] = _cache_retention

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1066,7 +1066,10 @@ class _CodexCompletionsAdapter:
 
             _host_src = str(getattr(self._client, "base_url", "") or "")
             _is_xai = base_url_host_matches(_host_src, "x.ai") or base_url_host_matches(_host_src, "api.x.ai")
-            _is_github = base_url_host_matches(_host_src, "githubcopilot.com")
+            _is_github = (
+                base_url_host_matches(_host_src, "githubcopilot.com")
+                or base_url_host_matches(_host_src, "models.github.ai")
+            )
             _is_codex_backend = (
                 base_url_host_matches(_host_src, "chatgpt.com")
                 and "/backend-api/codex" in _host_src.lower()

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1076,6 +1076,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             tools=tools_for_api,
             reasoning_config=agent.reasoning_config,
             session_id=getattr(agent, "session_id", None),
+            base_url=agent.base_url,
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
             request_overrides=agent.request_overrides,

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -912,7 +912,8 @@ def _preflight_codex_api_kwargs(
     allowed_keys = {
         "model", "instructions", "input", "tools", "store",
         "reasoning", "include", "max_output_tokens", "temperature",
-        "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
+        "tool_choice", "parallel_tool_calls", "prompt_cache_key",
+        "prompt_cache_retention", "service_tier",
         "extra_headers", "extra_body", "timeout",
     }
     normalized: Dict[str, Any] = {
@@ -950,8 +951,13 @@ def _preflight_codex_api_kwargs(
     if isinstance(temperature, (int, float)):
         normalized["temperature"] = float(temperature)
 
-    # Pass through tool_choice, parallel_tool_calls, prompt_cache_key
-    for passthrough_key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key"):
+    # Pass through cache routing/retention and tool-dispatch hints.
+    for passthrough_key in (
+        "tool_choice",
+        "parallel_tool_calls",
+        "prompt_cache_key",
+        "prompt_cache_retention",
+    ):
         val = api_kwargs.get(passthrough_key)
         if val is not None:
             normalized[passthrough_key] = val

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -48,8 +48,23 @@ _EXTENDED_PROMPT_CACHE_MODEL_RE = re.compile(
 )
 
 
-def _prompt_cache_retention_for_model(model: str) -> Optional[str]:
-    """Return ``24h`` for models documented to support extended retention."""
+def _default_prompt_cache_retention_for_request(
+    model: str,
+    base_url: Any,
+) -> Optional[str]:
+    """Return ``24h`` for supported models on Amazon Bedrock Mantle."""
+    from utils import base_url_hostname
+
+    hostname_parts = base_url_hostname(str(base_url or "")).split(".")
+    is_bedrock_mantle = (
+        len(hostname_parts) == 4
+        and hostname_parts[0] == "bedrock-mantle"
+        and bool(hostname_parts[1])
+        and hostname_parts[2:] == ["api", "aws"]
+    )
+    if not is_bedrock_mantle:
+        return None
+
     normalized = str(model or "").strip().lower().replace("_", "-")
     if _EXTENDED_PROMPT_CACHE_MODEL_RE.search(normalized):
         return "24h"
@@ -313,13 +328,11 @@ class ResponsesApiTransport(ProviderTransport):
         if not is_github_responses and not is_xai_responses and cache_key:
             kwargs["prompt_cache_key"] = cache_key
 
-        cache_retention = _prompt_cache_retention_for_model(model)
-        if (
-            cache_retention
-            and not is_github_responses
-            and not is_xai_responses
-            and not is_codex_backend
-        ):
+        cache_retention = _default_prompt_cache_retention_for_request(
+            model,
+            params.get("base_url"),
+        )
+        if cache_retention:
             kwargs.setdefault("prompt_cache_retention", cache_retention)
 
         if reasoning_enabled and is_xai_responses:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -7,6 +7,7 @@ streaming, or the _run_codex_stream() call path.
 
 import hashlib
 import json
+import re
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
@@ -27,19 +28,30 @@ def _bounded_prompt_cache_key(value: Any) -> Optional[str]:
     return f"pck_{digest}"
 
 
-def _prompt_cache_retention_for_model(model: str) -> Optional[str]:
-    """Return the OpenAI Responses prompt-cache retention policy for models
-    that require an explicit policy.
+_EXTENDED_PROMPT_CACHE_MODELS = (
+    "gpt-5.5-pro",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.2",
+    "gpt-5.1-codex-max",
+    "gpt-5.1-codex-mini",
+    "gpt-5.1-chat-latest",
+    "gpt-5.1-codex",
+    "gpt-5.1",
+    "gpt-5-codex",
+    "gpt-5",
+    "gpt-4.1",
+)
+_EXTENDED_PROMPT_CACHE_MODEL_RE = re.compile(
+    rf"(?:^|[./:])(?:{'|'.join(re.escape(name) for name in _EXTENDED_PROMPT_CACHE_MODELS)})"
+    r"(?:-\d{4}-\d{2}-\d{2})?$"
+)
 
-    OpenAI documents GPT-5.5 / GPT-5.5 Pro as extended-cache-only
-    (``prompt_cache_retention: "24h"``).  Sending the field only for
-    those model families keeps older/OpenAI-compatible relays on their
-    default behavior.
-    """
-    normalized = str(model or "").lower().replace("_", "-")
-    # Custom relays commonly prefix provider namespaces, e.g.
-    # ``openai.gpt-5.5``.  Match both bare and namespaced model ids.
-    if normalized.endswith("gpt-5.5") or "gpt-5.5-" in normalized:
+
+def _prompt_cache_retention_for_model(model: str) -> Optional[str]:
+    """Return ``24h`` for models documented to support extended retention."""
+    normalized = str(model or "").strip().lower().replace("_", "-")
+    if _EXTENDED_PROMPT_CACHE_MODEL_RE.search(normalized):
         return "24h"
     return None
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -27,6 +27,23 @@ def _bounded_prompt_cache_key(value: Any) -> Optional[str]:
     return f"pck_{digest}"
 
 
+def _prompt_cache_retention_for_model(model: str) -> Optional[str]:
+    """Return the OpenAI Responses prompt-cache retention policy for models
+    that require an explicit policy.
+
+    OpenAI documents GPT-5.5 / GPT-5.5 Pro as extended-cache-only
+    (``prompt_cache_retention: "24h"``).  Sending the field only for
+    those model families keeps older/OpenAI-compatible relays on their
+    default behavior.
+    """
+    normalized = str(model or "").lower().replace("_", "-")
+    # Custom relays commonly prefix provider namespaces, e.g.
+    # ``openai.gpt-5.5``.  Match both bare and namespaced model ids.
+    if normalized.endswith("gpt-5.5") or "gpt-5.5-" in normalized:
+        return "24h"
+    return None
+
+
 def _content_cache_key(instructions: str, tools: Optional[List[Dict[str, Any]]]) -> Optional[str]:
     """Content-address the prompt cache key from the static request prefix.
 
@@ -283,6 +300,15 @@ class ResponsesApiTransport(ProviderTransport):
         # down); GitHub Models opts out of cache-key routing entirely.
         if not is_github_responses and not is_xai_responses and cache_key:
             kwargs["prompt_cache_key"] = cache_key
+
+        cache_retention = _prompt_cache_retention_for_model(model)
+        if (
+            cache_retention
+            and not is_github_responses
+            and not is_xai_responses
+            and not is_codex_backend
+        ):
+            kwargs.setdefault("prompt_cache_retention", cache_retention)
 
         if reasoning_enabled and is_xai_responses:
             from agent.model_metadata import grok_supports_reasoning_effort

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4413,6 +4413,29 @@ class TestCodexAdapterPromptCacheKey:
         ])
         assert "prompt_cache_key" not in captured
 
+    def test_gpt55_sets_prompt_cache_retention(self):
+        adapter, captured = self._build_adapter(base_url="https://bedrock-mantle.us-east-1.api.aws/openai/v1")
+        adapter.create(messages=[
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ])
+        assert captured["prompt_cache_retention"] == "24h"
+
+    def test_prompt_cache_retention_skipped_for_xai_and_github_hosts(self):
+        adapter, captured = self._build_adapter(base_url="https://api.x.ai/v1")
+        adapter.create(messages=[
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ])
+        assert "prompt_cache_retention" not in captured
+
+        adapter, captured = self._build_adapter(base_url="https://api.githubcopilot.com")
+        adapter.create(messages=[
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ])
+        assert "prompt_cache_retention" not in captured
+
 
 class TestCodexAdapterGithubResponsesMessageIdDrop:
     """_CodexCompletionsAdapter must drop codex_message_items ``id`` when

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4420,7 +4420,7 @@ class TestCodexAdapterPromptCacheKey:
     ])
     def test_extended_cache_models_set_prompt_cache_retention(self, model):
         adapter, captured = self._build_adapter(
-            base_url="https://responses.example.com/v1",
+            base_url="https://bedrock-mantle.us-west-2.api.aws/v1",
             model=model,
         )
         adapter.create(messages=[
@@ -4431,6 +4431,19 @@ class TestCodexAdapterPromptCacheKey:
 
     def test_prompt_cache_retention_skipped_for_codex_backend(self):
         adapter, captured = self._build_adapter()
+        adapter.create(messages=[
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ])
+        assert "prompt_cache_retention" not in captured
+
+    @pytest.mark.parametrize("base_url", [
+        "https://api.openai.com/v1",
+        "https://example.services.ai.azure.com/openai/v1",
+        "https://responses.example.com/v1",
+    ])
+    def test_prompt_cache_retention_skipped_for_other_compatible_endpoints(self, base_url):
+        adapter, captured = self._build_adapter(base_url=base_url)
         adapter.create(messages=[
             {"role": "system", "content": "SYS"},
             {"role": "user", "content": "hi"},

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4327,7 +4327,7 @@ class TestCodexAdapterPromptCacheKey:
     """
 
     @staticmethod
-    def _build_adapter(base_url="https://chatgpt.com/backend-api/codex"):
+    def _build_adapter(base_url="https://chatgpt.com/backend-api/codex", model="gpt-5.5"):
         from agent.auxiliary_client import _CodexCompletionsAdapter
         from types import SimpleNamespace
 
@@ -4360,7 +4360,7 @@ class TestCodexAdapterPromptCacheKey:
         real_client = MagicMock()
         real_client.base_url = base_url
         real_client.responses.create = _create
-        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.5")
+        adapter = _CodexCompletionsAdapter(real_client, model)
         return adapter, captured_kwargs
 
     def test_cache_key_set_and_prefixed(self):
@@ -4413,8 +4413,16 @@ class TestCodexAdapterPromptCacheKey:
         ])
         assert "prompt_cache_key" not in captured
 
-    def test_gpt55_sets_prompt_cache_retention(self):
-        adapter, captured = self._build_adapter(base_url="https://bedrock-mantle.us-east-1.api.aws/openai/v1")
+    @pytest.mark.parametrize("model", [
+        "gpt-4.1",
+        "gpt-5.1-codex-max",
+        "openai.gpt-5.5-pro",
+    ])
+    def test_extended_cache_models_set_prompt_cache_retention(self, model):
+        adapter, captured = self._build_adapter(
+            base_url="https://responses.example.com/v1",
+            model=model,
+        )
         adapter.create(messages=[
             {"role": "system", "content": "SYS"},
             {"role": "user", "content": "hi"},

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4421,6 +4421,14 @@ class TestCodexAdapterPromptCacheKey:
         ])
         assert captured["prompt_cache_retention"] == "24h"
 
+    def test_prompt_cache_retention_skipped_for_codex_backend(self):
+        adapter, captured = self._build_adapter()
+        adapter.create(messages=[
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ])
+        assert "prompt_cache_retention" not in captured
+
     def test_prompt_cache_retention_skipped_for_xai_and_github_hosts(self):
         adapter, captured = self._build_adapter(base_url="https://api.x.ai/v1")
         adapter.create(messages=[

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4444,6 +4444,17 @@ class TestCodexAdapterPromptCacheKey:
         ])
         assert "prompt_cache_retention" not in captured
 
+    def test_prompt_cache_retention_skipped_for_github_models_host(self):
+        """models.github.ai is a GitHub Responses host in the main transport
+        (agent/chat_completion_helpers.py) — the auxiliary path must exclude
+        it from cache-retention emission the same way as githubcopilot.com."""
+        adapter, captured = self._build_adapter(base_url="https://models.github.ai/inference")
+        adapter.create(messages=[
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ])
+        assert "prompt_cache_retention" not in captured
+
 
 class TestCodexAdapterGithubResponsesMessageIdDrop:
     """_CodexCompletionsAdapter must drop codex_message_items ``id`` when

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -264,6 +264,7 @@ class TestCodexBuildKwargs:
         kw = transport.build_kwargs(
             model=model, messages=messages, tools=[],
             session_id="test-session",
+            base_url="https://bedrock-mantle.us-west-2.api.aws/v1",
         )
         assert kw["prompt_cache_retention"] == "24h"
 
@@ -274,20 +275,29 @@ class TestCodexBuildKwargs:
             messages=[{"role": "user", "content": "Hi"}],
             tools=[],
             session_id="test-session",
+            base_url="https://bedrock-mantle.us-west-2.api.aws/v1",
         )
         assert "prompt_cache_retention" not in kw
 
-    def test_prompt_cache_retention_skipped_for_known_incompatible_backends(self, transport):
-        messages = [{"role": "user", "content": "Hi"}]
-        assert "prompt_cache_retention" not in transport.build_kwargs(
-            model="gpt-5.4", messages=messages, tools=[], is_xai_responses=True
+    @pytest.mark.parametrize("base_url", [
+        "https://api.openai.com/v1",
+        "https://example.openai.azure.com/openai/v1",
+        "https://api.x.ai/v1",
+        "https://models.github.ai/inference",
+        "https://api.githubcopilot.com",
+        "https://chatgpt.com/backend-api/codex",
+        "https://responses.example.com/v1",
+        "https://bedrock-mantle.us-west-2.api.aws.example/v1",
+        "https://example.com/bedrock-mantle.us-west-2.api.aws/v1",
+    ])
+    def test_prompt_cache_retention_omitted_for_non_mantle_endpoints(self, transport, base_url):
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url=base_url,
         )
-        assert "prompt_cache_retention" not in transport.build_kwargs(
-            model="gpt-5.4", messages=messages, tools=[], is_github_responses=True
-        )
-        assert "prompt_cache_retention" not in transport.build_kwargs(
-            model="gpt-5.4", messages=messages, tools=[], is_codex_backend=True
-        )
+        assert "prompt_cache_retention" not in kw
 
     def test_xai_responses_sends_cache_key_via_extra_body(self, transport):
         """xAI's Responses API documents ``prompt_cache_key`` as the

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -243,6 +243,26 @@ class TestCodexBuildKwargs:
         message_item = next(item for item in kw["input"] if item.get("type") == "message")
         assert message_item["id"] == "msg_short_id"
 
+    def test_gpt55_sets_prompt_cache_retention(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="openai.gpt-5.5", messages=messages, tools=[],
+            session_id="test-session",
+        )
+        assert kw["prompt_cache_retention"] == "24h"
+
+    def test_gpt55_prompt_cache_retention_skipped_for_known_incompatible_backends(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        assert "prompt_cache_retention" not in transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[], is_xai_responses=True
+        )
+        assert "prompt_cache_retention" not in transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[], is_github_responses=True
+        )
+        assert "prompt_cache_retention" not in transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[], is_codex_backend=True
+        )
+
     def test_xai_responses_sends_cache_key_via_extra_body(self, transport):
         """xAI's Responses API documents ``prompt_cache_key`` as the
         body-level cache-routing key (the ``x-grok-conv-id`` header is

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -243,24 +243,50 @@ class TestCodexBuildKwargs:
         message_item = next(item for item in kw["input"] if item.get("type") == "message")
         assert message_item["id"] == "msg_short_id"
 
-    def test_gpt55_sets_prompt_cache_retention(self, transport):
+    @pytest.mark.parametrize("model", [
+        "gpt-5.5",
+        "gpt-5.5-pro",
+        "gpt-5.4",
+        "gpt-5.2",
+        "gpt-5.1-codex-max",
+        "gpt-5.1",
+        "gpt-5.1-codex",
+        "gpt-5.1-codex-mini",
+        "gpt-5.1-chat-latest",
+        "gpt-5",
+        "gpt-5-codex",
+        "gpt-4.1",
+        "openai.gpt-5.5-pro",
+        "openai/gpt-5.1-codex-2026-01-01",
+    ])
+    def test_extended_cache_models_set_24h_prompt_cache_retention(self, transport, model):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
-            model="openai.gpt-5.5", messages=messages, tools=[],
+            model=model, messages=messages, tools=[],
             session_id="test-session",
         )
         assert kw["prompt_cache_retention"] == "24h"
 
-    def test_gpt55_prompt_cache_retention_skipped_for_known_incompatible_backends(self, transport):
+    @pytest.mark.parametrize("model", ["gpt-5.6", "gpt-4o", "o3"])
+    def test_prompt_cache_retention_omitted_for_other_model_families(self, transport, model):
+        kw = transport.build_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            session_id="test-session",
+        )
+        assert "prompt_cache_retention" not in kw
+
+    def test_prompt_cache_retention_skipped_for_known_incompatible_backends(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         assert "prompt_cache_retention" not in transport.build_kwargs(
-            model="gpt-5.5", messages=messages, tools=[], is_xai_responses=True
+            model="gpt-5.4", messages=messages, tools=[], is_xai_responses=True
         )
         assert "prompt_cache_retention" not in transport.build_kwargs(
-            model="gpt-5.5", messages=messages, tools=[], is_github_responses=True
+            model="gpt-5.4", messages=messages, tools=[], is_github_responses=True
         )
         assert "prompt_cache_retention" not in transport.build_kwargs(
-            model="gpt-5.5", messages=messages, tools=[], is_codex_backend=True
+            model="gpt-5.4", messages=messages, tools=[], is_codex_backend=True
         )
 
     def test_xai_responses_sends_cache_key_via_extra_body(self, transport):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -396,6 +396,25 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert "extra_body" not in kwargs
 
 
+def test_build_api_kwargs_mantle_sets_extended_prompt_cache_retention(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="openai.gpt-5.5",
+        provider="custom",
+        api_mode="codex_responses",
+        base_url="https://bedrock-mantle.us-west-2.api.aws/v1",
+        api_key="test-token",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Ping"}])
+
+    assert kwargs["prompt_cache_retention"] == "24h"
+
+
 def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):
     """'minimal' reasoning effort is clamped to 'low' on the Responses API.
 


### PR DESCRIPTION
## What & why

Amazon Bedrock Mantle supports extended prompt-cache retention for documented pre-GPT-5.6 models, but Hermes' Responses transport did not select it. At the same time, `prompt_cache_retention` is not part of every OpenAI-compatible Responses implementation; automatically sending it to endpoints such as GitHub Models can cause compatibility failures.

This PR deliberately applies the automatic `prompt_cache_retention: "24h"` default only when both conditions hold:

1. The parsed hostname exactly matches the public Mantle form `bedrock-mantle.<region>.api.aws`.
2. The model is documented to support extended retention.

Other endpoints—including direct OpenAI, Azure OpenAI, xAI, GitHub Models, Copilot, ChatGPT Codex, and arbitrary compatible relays—do not receive the automatic field.

## Implementation

- Adds a shared request-capability helper used by both main and auxiliary Responses paths.
- Passes the resolved base URL into the main Responses transport.
- Parses and validates the hostname rather than using substring matching; suffix and path spoof cases remain excluded.
- Preserves explicit caller overrides and existing prompt-cache-key behavior.

## Models

The model gate covers the documented extended-retention set: GPT-5.5/Pro, GPT-5.4, GPT-5.2, GPT-5.1 and its listed variants, GPT-5/Codex, and GPT-4.1, including provider-prefixed and dated IDs. GPT-5.6+ and unknown model families remain excluded.

## Tests

```bash
bash scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py -q
```

Result: **544 passed, 0 failed**.

Also verified:

```bash
python scripts/check-windows-footguns.py agent/transports/codex.py agent/auxiliary_client.py agent/codex_responses_adapter.py agent/chat_completion_helpers.py
git diff --check
```
