### PR TITLE
fix: invalidate skills prompt cache after sync_skills copies new content

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -891,6 +891,19 @@ def _sync_bundled_skills_for_startup() -> bool:
 
     sync_skills(quiet=True)
     _mark_termux_bundled_skills_synced()
+
+    # Belt-and-suspenders: invalidate the skills prompt cache so the
+    # first agent turn in this process sees any newly-synced skills.
+    # sync_skills() already does this internally when it copies/updates
+    # files, but this covers edge cases (e.g. a prior partial sync that
+    # left files on disk without invalidating).
+    try:
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+    except Exception:
+        pass
+
     return True
 
 
@@ -2366,6 +2379,19 @@ def _sync_bundled_skills_quietly() -> None:
         from tools.skills_sync import sync_skills
 
         sync_skills(quiet=True)
+    except Exception:
+        pass
+
+    # Belt-and-suspenders: invalidate the skills prompt cache so the
+    # first agent turn in this process sees any newly-synced skills.
+    # sync_skills() already does this internally when it copies/updates
+    # files, but this covers edge cases (e.g. a prior partial sync that
+    # left files on disk without invalidating, or sync_skills returning
+    # early because the bundled dir is missing).
+    try:
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        clear_skills_system_prompt_cache(clear_snapshot=True)
     except Exception:
         pass
 

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -930,6 +930,48 @@ class TestSyncSkills:
         assert manifest["old-skill"] == new_bundled_hash
         assert manifest["old-skill"] != old_hash
 
+    def test_sync_invalidates_prompt_cache_on_copy(self, tmp_path):
+        """sync_skills() clears the prompt cache when it copies new skills."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        with (
+            self._patches(bundled, skills_dir, manifest_file),
+            patch(
+                "agent.prompt_builder.clear_skills_system_prompt_cache"
+            ) as mock_clear,
+        ):
+            result = sync_skills(quiet=True)
+
+        # A new skill was copied — cache must be invalidated
+        assert "new-skill" in result["copied"]
+        mock_clear.assert_called_once_with(clear_snapshot=True)
+
+    def test_sync_skips_invalidation_when_nothing_copied(self, tmp_path):
+        """sync_skills() does NOT clear the prompt cache when nothing changed."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        # First sync: copies skills
+        with self._patches(bundled, skills_dir, manifest_file):
+            sync_skills(quiet=True)
+
+        # Second sync: nothing to copy or update
+        with (
+            self._patches(bundled, skills_dir, manifest_file),
+            patch(
+                "agent.prompt_builder.clear_skills_system_prompt_cache"
+            ) as mock_clear,
+        ):
+            result = sync_skills(quiet=True)
+
+        # No new/updated skills — cache should not be invalidated
+        assert result["copied"] == []
+        assert result["updated"] == []
+        mock_clear.assert_not_called()
+
 
 class TestGetBundledDir:
     def test_env_var_override(self, tmp_path, monkeypatch):

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -706,6 +706,18 @@ def sync_skills(quiet: bool = False) -> dict:
     _write_manifest(manifest)
     optional_provenance_backfilled = _backfill_optional_provenance(quiet=quiet)
 
+    # ── Invalidate skills prompt cache when new content landed on disk ──
+    # After first-run sync or an update that copies/updates skill files,
+    # clear both the in-process LRU cache and the disk snapshot so agents
+    # see the new skills immediately — no /reload-skills required.
+    if copied or updated:
+        try:
+            from agent.prompt_builder import clear_skills_system_prompt_cache
+
+            clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            pass  # Best-effort — skills on disk are the source of truth
+
     return {
         "copied": copied,
         "updated": updated,


### PR DESCRIPTION
## Problem

On first install (and after `hermes update`), `sync_skills()` copies bundled skills into `~/.hermes/skills/` but the in-process prompt cache (`_SKILLS_PROMPT_CACHE`) and disk snapshot (`.skills_prompt_snapshot.json`) were not invalidated. Agents building their system prompt before the next cache miss would serve a stale empty `<available_skills>` block. This meant users on a fresh install saw zero skills until they manually ran `/reload-skills` or restarted the process.

## Root Cause

`clear_skills_system_prompt_cache(clear_snapshot=True)` already existed in `agent/prompt_builder.py` and was called by `learning_mutations.py`, `skill_manager_tool.py`, `skills_hub.py`, and `web_server.py` — but **not** by `sync_skills()`. The sync path is the primary mechanism that puts bundled skills onto disk, so its absence was the gap.

## Fix (3 files, +80 lines)

1. **`tools/skills_sync.py`** — `sync_skills()` now calls `clear_skills_system_prompt_cache(clear_snapshot=True)` when `copied` or `updated` is non-empty
2. **`hermes_cli/main.py`** — belt-and-suspenders call in both `_sync_bundled_skills_for_startup()` and `_sync_bundled_skills_quietly()` to cover edge cases (prior partial sync, early returns from `sync_skills()`)
3. **`tests/tools/test_skills_sync.py`** — 2 new tests: `test_sync_invalidates_prompt_cache_on_copy` and `test_sync_skips_invalidation_when_nothing_copied`

## Testing

```bash
# All 71 tests pass (69 existing + 2 new)
uv run python -m pytest tests/tools/test_skills_sync.py -v
```