### PR TITLE
fix(agent): keep Codex cron calls on conversation thread

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -471,30 +471,27 @@ def should_use_direct_api_call(agent) -> bool:
     is pushed onto yet another daemon worker thread:
 
     - Gateway cron turns (#62151): gateway asyncio loop → cron thread →
-      interrupt worker. Fixed by running inline.
+      interrupt worker. Chat Completions and Codex Responses both use that
+      spawned worker, so cron keeps both OpenAI-wire modes inline.
     - Delegated children (#60203): gateway loop → async-delegation executor
       (module-lifetime daemon pool) → per-child timeout executor → interrupt
       worker. Same fingerprint after multi-day gateway uptime — children hang
-      at their FIRST API call with zero stale-detector output (the worker
-      never reaches dispatch), all providers, restart cures it. The cron fix
-      originally excluded delegation "for lack of evidence"; #60203 is that
-      evidence.
+      at their first API call before dispatch. Delegated Chat Completions run
+      inline; their native/Codex/Bedrock transports retain established workers.
 
     Running inline drops the deepest thread layer (whose only job is
     interactive-interrupt responsiveness). Interrupts still work: the inline
     path registers ``agent._active_request_abort``, which ``interrupt()``
     invokes cross-thread to shut the active sockets — the same mechanism the
     async-delegation stall monitor (#72227) relies on.
-
-    Keep native/Codex/Bedrock/MoA transports on their established workers:
-    their cancellation and client ownership differ.
     """
-    if getattr(agent, "api_mode", None) != "chat_completions":
-        return False
+    api_mode = getattr(agent, "api_mode", None)
     if getattr(agent, "provider", None) == "moa":
         return False
     if getattr(agent, "platform", None) == "cron":
-        return True
+        return api_mode in {"chat_completions", "codex_responses"}
+    if api_mode != "chat_completions":
+        return False
     # Delegated child (delegate_task sync or background) — detected via the
     # execution ContextVar set by _run_single_child, with the agent's own
     # platform stamp as a fallback for callers that bypass the runner.
@@ -517,7 +514,13 @@ def direct_api_call(agent, api_kwargs: dict):
     so the nested-pool deadlock (#62151, #60203) cannot occur. Because the
     request runs in-flight normally, the per-request OpenAI client's own httpx
     timeout (provider ``request_timeout_seconds`` / ``HERMES_API_TIMEOUT``) bounds
-    a genuinely hung provider — the same bound interactive calls already rely on.
+    a genuinely hung provider. Cron's outer inactivity watchdog can also call
+    ``AIAgent.interrupt``; ``_active_request_abort`` then shuts down the request
+    socket while this owner thread performs the final client close.
+
+    For Codex Responses this inline path intentionally bypasses the worker-only
+    TTFB and event-idle watchdogs in ``interruptible_api_call``. Cron Codex calls
+    therefore rely on the request timeout and outer cron inactivity watchdog.
     """
     _check_stale_giveup(agent)
     agent._touch_activity("waiting for non-streaming API response")
@@ -538,10 +541,10 @@ def direct_api_call(agent, api_kwargs: dict):
                 agent._abort_request_openai_client(request_client, reason=reason)
 
     def _make_client(reason: str, kind: str = "openai"):
-        # direct_api_call only runs for OpenAI-wire chat_completions cron
-        # requests (see should_use_direct_api_call), so the anthropic branch of
-        # the dispatch — the only caller that passes kind — is never reached
-        # here; the ``kind`` parameter exists purely for signature parity.
+        # direct_api_call only runs for OpenAI-wire chat_completions and Codex
+        # Responses cron requests (see should_use_direct_api_call), so the
+        # anthropic branch of the dispatch — the only caller that passes kind —
+        # is never reached here; ``kind`` exists purely for signature parity.
         client = agent._create_request_openai_client(reason=reason, api_kwargs=api_kwargs)
         with request_client_lock:
             request_client_holder["client"] = client
@@ -583,6 +586,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
     """
     Run the API call in a background thread so the main conversation loop
     can detect interrupts without waiting for the full HTTP round-trip.
+
+    Cron OpenAI-wire requests are the exception: they run inline via
+    ``direct_api_call`` to avoid the nested worker deadlock from #62151.
 
     Each worker thread gets its own OpenAI client instance. Interrupts only
     close that worker-local client, so retries and other requests never

--- a/tests/agent/test_cron_inline_api_call_62151.py
+++ b/tests/agent/test_cron_inline_api_call_62151.py
@@ -16,7 +16,7 @@ the shared dispatch closes the per-request client.
 
 import threading
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from run_agent import AIAgent
 
@@ -46,7 +46,7 @@ def test_should_use_direct_api_call_only_for_cron_openai_wire():
     assert should_use_direct_api_call(_make_agent(platform="telegram")) is False
     assert should_use_direct_api_call(_make_agent(platform=None)) is False
 
-    for api_mode in ("codex_responses", "anthropic_messages", "bedrock_converse"):
+    for api_mode in ("anthropic_messages", "bedrock_converse"):
         agent = _make_agent(platform="cron")
         agent.api_mode = api_mode
         assert should_use_direct_api_call(agent) is False
@@ -96,6 +96,76 @@ def test_interruptible_api_call_routes_cron_inline_no_worker_thread():
     assert ran_on["tid"] == caller_tid  # no daemon worker thread
 
 
+def test_interruptible_api_call_routes_cron_codex_inline_no_worker_thread():
+    """Codex cron calls must avoid the same nested worker as chat completions."""
+    agent = _make_agent()
+    agent.api_mode = "codex_responses"
+    agent.provider = "openai-codex"
+    agent._compute_non_stream_stale_timeout.return_value = 180.0
+    caller_tid = threading.get_ident()
+    fake_client = MagicMock()
+    created_on = {}
+    streamed_on = {}
+
+    def _create(**_kwargs):
+        created_on["tid"] = threading.get_ident()
+        return fake_client
+
+    def _run_codex_stream(_api_kwargs, **_kwargs):
+        streamed_on["tid"] = threading.get_ident()
+        return SimpleNamespace(id="codex")
+
+    agent._create_request_openai_client.side_effect = _create
+    agent._run_codex_stream.side_effect = _run_codex_stream
+
+    resp = interruptible_api_call(agent, {"model": "gpt-5.6-sol", "input": []})
+
+    assert resp is not None
+    assert resp.id == "codex"
+    assert created_on["tid"] == caller_tid
+    assert streamed_on["tid"] == caller_tid  # no daemon worker thread
+    agent._run_codex_stream.assert_called_once()
+
+
+def test_interruptible_api_call_routes_sequential_cron_codex_calls_inline():
+    """The reported 2nd+ Codex call must stay on the cron conversation thread."""
+    agent = _make_agent()
+    agent.api_mode = "codex_responses"
+    agent.provider = "openai-codex"
+    caller_tid = threading.get_ident()
+    clients = [MagicMock(name="first_client"), MagicMock(name="second_client")]
+    created_on = []
+    streamed_on = []
+
+    def _create(**_kwargs):
+        created_on.append(threading.get_ident())
+        return clients[len(created_on) - 1]
+
+    def _run_codex_stream(api_kwargs, **_kwargs):
+        streamed_on.append(threading.get_ident())
+        return SimpleNamespace(id=api_kwargs["input"][0])
+
+    agent._create_request_openai_client.side_effect = _create
+    agent._run_codex_stream.side_effect = _run_codex_stream
+
+    first = interruptible_api_call(
+        agent, {"model": "gpt-5.6-sol", "input": ["first"]}
+    )
+    second = interruptible_api_call(
+        agent, {"model": "gpt-5.6-sol", "input": ["second"]}
+    )
+
+    assert first is not None
+    assert second is not None
+    assert (first.id, second.id) == ("first", "second")
+    assert created_on == [caller_tid, caller_tid]
+    assert streamed_on == [caller_tid, caller_tid]
+    assert agent._close_request_openai_client.call_args_list == [
+        call(clients[0], reason="request_complete"),
+        call(clients[1], reason="request_complete"),
+    ]
+
+
 def test_direct_api_call_interrupt_aborts_active_client_and_raises():
     """Cron's outer watchdog interrupts from another thread while inline."""
     agent = _make_agent()
@@ -134,6 +204,72 @@ def test_direct_api_call_interrupt_aborts_active_client_and_raises():
     assert not worker.is_alive()
     assert isinstance(result.get("exception"), InterruptedError)
     assert agent._active_request_abort is None
+
+
+def test_direct_codex_call_interrupt_aborts_and_closes_on_owner_thread():
+    """Cron timeout interrupts inline Codex and leaves cleanup to its owner."""
+    agent = _make_agent()
+    agent.api_mode = "codex_responses"
+    agent.provider = "openai-codex"
+    stream_ready = threading.Event()
+    release_stream = threading.Event()
+    fake_client = MagicMock()
+    thread_ids = {}
+    result = {}
+
+    def _create(**_kwargs):
+        thread_ids["create"] = threading.get_ident()
+        return fake_client
+
+    def _run_codex_stream(_api_kwargs, **_kwargs):
+        thread_ids["stream"] = threading.get_ident()
+        stream_ready.set()
+        assert release_stream.wait(timeout=2)
+        raise RuntimeError("socket closed")
+
+    def _abort(_client, *, reason):
+        thread_ids["abort"] = threading.get_ident()
+        assert reason == "interrupt_abort"
+
+    def _close(_client, *, reason):
+        thread_ids["close"] = threading.get_ident()
+        assert reason == "request_error_cleanup"
+
+    agent._create_request_openai_client.side_effect = _create
+    agent._run_codex_stream.side_effect = _run_codex_stream
+    agent._abort_request_openai_client.side_effect = _abort
+    agent._close_request_openai_client.side_effect = _close
+
+    def _run():
+        thread_ids["owner"] = threading.get_ident()
+        try:
+            direct_api_call(agent, {"model": "gpt-5.6-sol", "input": []})
+        except Exception as exc:
+            result["exception"] = exc
+
+    owner = threading.Thread(target=_run)
+    owner.start()
+    assert stream_ready.wait(timeout=1)
+    assert callable(agent._active_request_abort)
+
+    interrupter_tid = threading.get_ident()
+    AIAgent.interrupt(agent, "cron inactivity timeout")
+    release_stream.set()
+    owner.join(timeout=2)
+
+    assert not owner.is_alive()
+    assert isinstance(result.get("exception"), InterruptedError)
+    assert agent._active_request_abort is None
+    agent._abort_request_openai_client.assert_called_once_with(
+        fake_client, reason="interrupt_abort"
+    )
+    agent._close_request_openai_client.assert_called_once_with(
+        fake_client, reason="request_error_cleanup"
+    )
+    assert thread_ids["abort"] == interrupter_tid
+    assert thread_ids["create"] == thread_ids["owner"]
+    assert thread_ids["stream"] == thread_ids["owner"]
+    assert thread_ids["close"] == thread_ids["owner"]
 
 
 def test_interruptible_streaming_api_call_routes_cron_via_nonstream_method():

--- a/tests/cron/test_cron_direct_api_call_62151.py
+++ b/tests/cron/test_cron_direct_api_call_62151.py
@@ -35,7 +35,12 @@ def test_should_use_direct_api_call_only_for_cron_openai_wire():
     assert should_use_direct_api_call(_make_agent(platform="telegram")) is False
     assert should_use_direct_api_call(_make_agent(platform=None)) is False
 
-    for api_mode in ("codex_responses", "anthropic_messages", "bedrock_converse"):
+    codex = _make_agent(platform="cron")
+    codex.api_mode = "codex_responses"
+    codex.provider = "openai-codex"
+    assert should_use_direct_api_call(codex) is True
+
+    for api_mode in ("anthropic_messages", "bedrock_converse"):
         agent = _make_agent(platform="cron")
         agent.api_mode = api_mode
         assert should_use_direct_api_call(agent) is False


### PR DESCRIPTION
## What does this PR do?

Keeps `codex_responses` cron requests on the cron conversation thread instead of spawning the interrupt worker.

Issue #62151 and PR #62315 introduced this behavior for cron `chat_completions` requests after reproducing a second-call deadlock in the gateway scheduler. Codex Responses uses the same spawned `_call` worker path and can wedge on later tool-loop calls for the same reason, but the existing predicate explicitly excluded it.

This extends the existing cron-only direct-call path to the other OpenAI-wire transport. Interactive calls and native Anthropic, Bedrock, and MoA transports are unchanged.

## Related Issue

Fixes #69734

Follow-up to #62151 and #62315.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Extend `should_use_direct_api_call()` to return true for cron `codex_responses` requests.
- Preserve the existing worker behavior for interactive calls and non-OpenAI-wire transports.
- Add regression tests proving two sequential Codex cron requests create and stream on the caller thread.
- Verify cross-thread cron interruption aborts the socket, raises `InterruptedError`, clears `_active_request_abort`, and closes the request-local client on its owner thread.
- Document that inline Codex cron calls use the request timeout plus outer cron inactivity watchdog rather than worker-only TTFB/event-idle watchdogs.
- Update the cron predicate coverage to treat Codex Responses as an inline cron transport.

## How to Test

1. Configure a cron agent with `provider: openai-codex` and a Codex Responses model.
2. Give it a task requiring at least two sequential tool rounds and a final answer.
3. Confirm every model turn completes and request-client logs remain on the cron conversation thread instead of a spawned `_call` worker.

Automated validation:

```text
171 passed  canonical `scripts/run_tests.sh` run covering:
            tests/agent/test_cron_inline_api_call_62151.py
            tests/cron/test_cron_direct_api_call_62151.py
            tests/cron/test_codex_execution_paths.py
            tests/hermes_cli/test_codex_runtime_switch.py
            tests/run_agent/test_run_agent_codex_responses.py
            tests/agent/test_codex_ttfb_watchdog.py

730 passed  standalone complete `tests/cron` run
7177 passed complete `tests/agent` + `tests/cron` canonical run
4 failed    two unrelated credential/OAuth files; all four reproduce
            identically in a pristine detached `origin/main` worktree
ruff clean  changed Python files
clean       Windows footgun scan, static security scan, git diff check
```

Live validation on macOS 26.5.2 with `openai-codex` / `gpt-5.6-sol`:

- Before: call #1 and its tool completed; call #2 entered the spawned `_call` worker and wedged.
- After: a minimal 3-call / 2-tool cron completed.
- Stress test: a real morning-brief cron completed 23 Codex API calls and 22 tool turns, ending normally after about eight minutes.
- Slack cron delivery then completed successfully.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Apple Silicon, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring updated; no user-facing behavior/config documentation needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — transport/thread predicate is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Relevant live agent log summary after the fix:

```text
API calls: 23/90
Tool turns: 22
End reason: text_response(finish_reason=stop)
Provider: openai-codex
Model: gpt-5.6-sol
```
