### PR TITLE
feat(auth): machine-wide Anthropic OAuth shared credential pool

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -969,7 +969,7 @@ def init_agent(
             # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
             # Falling back would send Anthropic credentials to third-party endpoints (Fixes #1739, #minimax-401).
             _is_native_anthropic = agent.provider == "anthropic"
-            effective_key = (api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or "")
+            effective_key = (resolve_anthropic_token(explicit_api_key=api_key, provider=agent.provider) or "") if _is_native_anthropic else (api_key or "")
 
             # MiniMax OAuth issues short-lived (~15-min) access tokens. The
             # Anthropic SDK caches ``api_key`` as a static string at client

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2122,7 +2122,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own
             # API key — falling back would send Anthropic credentials to third-party endpoints.
             _is_native_anthropic = new_provider == "anthropic"
-            effective_key = (api_key or agent.api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or agent.api_key or "")
+            effective_key = (resolve_anthropic_token(explicit_api_key=(api_key or agent.api_key), provider=new_provider) or "") if _is_native_anthropic else (api_key or agent.api_key or "")
 
             # MiniMax OAuth: swap static string for a per-request callable token
             # provider so the rebuilt client survives 15-min token expiry. See

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1295,19 +1295,68 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
     return None
 
 
-def resolve_anthropic_token() -> Optional[str]:
+def resolve_anthropic_token(
+    *,
+    purpose: str = "inference",
+    api_mode: Optional[str] = None,
+    base_url: Optional[str] = None,
+    explicit_api_key: Optional[str] = None,
+    provider: str = "anthropic",
+) -> Optional[str]:
     """Resolve an Anthropic token from all available sources.
 
-    Priority:
-      1. ANTHROPIC_TOKEN env var (OAuth/setup token saved by Hermes)
-      2. CLAUDE_CODE_OAUTH_TOKEN env var
-      3. Claude Code credentials (~/.claude.json or ~/.claude/.credentials.json)
+    When machine-wide Anthropic shared OAuth scope is active and the target is
+    the official native Anthropic API, ONLY the shared root pool is used —
+    env vars, Claude Code files, explicit keys, and profile pools are ignored.
+
+    Legacy priority (shared scope inactive or non-official target):
+      1. explicit_api_key argument (when provided)
+      2. ANTHROPIC_TOKEN env var (OAuth/setup token saved by Hermes)
+      3. CLAUDE_CODE_OAUTH_TOKEN env var
+      4. Claude Code credentials (~/.claude.json or ~/.claude/.credentials.json)
          — with automatic refresh if expired and a refresh token is available
-      4. Anthropic credential_pool OAuth entry (~/.hermes/auth.json)
-      5. ANTHROPIC_API_KEY env var (regular API key, or legacy fallback)
+      5. Anthropic credential_pool OAuth entry (~/.hermes/auth.json)
+      6. ANTHROPIC_API_KEY env var (regular API key, or legacy fallback)
 
     Returns the token string or None.
     """
+    # Shared-scope authoritative gate for official native Anthropic targets.
+    try:
+        from agent.anthropic_shared_pool import (
+            is_official_anthropic_oauth_target,
+            is_shared_scope_active,
+            resolve_shared_anthropic_credential,
+        )
+
+        if is_shared_scope_active() and is_official_anthropic_oauth_target(
+            provider, purpose, api_mode, base_url
+        ):
+            ctx = resolve_shared_anthropic_credential(
+                provider=provider,
+                purpose=purpose,
+                api_mode=api_mode,
+                base_url=base_url,
+            )
+            return ctx.access_token
+    except Exception as exc:
+        # AuthError / corrupt marker must fail closed for official targets.
+        from hermes_cli.auth import AuthError
+
+        if isinstance(exc, AuthError):
+            raise
+        # Import / unexpected errors: if we cannot evaluate shared scope, do not
+        # silently fall through with env keys when marker may be active.
+        try:
+            from agent.anthropic_shared_pool import scope_marker_path
+
+            if scope_marker_path().exists() or scope_marker_path().is_symlink():
+                raise
+        except Exception:
+            raise exc from exc
+
+    if explicit_api_key and str(explicit_api_key).strip():
+        return str(explicit_api_key).strip()
+
     creds = read_claude_code_credentials()
 
     # 1. Hermes-managed OAuth/setup token env var

--- a/agent/anthropic_shared_pool.py
+++ b/agent/anthropic_shared_pool.py
@@ -1,0 +1,1888 @@
+"""Machine-wide Anthropic OAuth shared credential pool.
+
+Canonical store: root ``auth.json`` under ``shared_credential_pools.anthropic``.
+Scope marker: ``<root>/shared/anthropic_pool_scope.json``.
+
+See the universal Anthropic OAuth pool design for the full contract.
+This module is the single authoritative surface for shared-scope resolution,
+mutation, and refresh. Callers must not reimplement bypasses around it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import stat
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from urllib.parse import urlparse
+
+import hermes_cli.auth as auth_mod
+from hermes_cli.auth import AuthError, _auth_store_lock
+from hermes_constants import get_default_hermes_root, secure_parent_dir
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+MARKER_VERSION = 1
+PROVIDER = "anthropic"
+SOURCE_HERMES_PKCE = "manual:hermes_pkce"
+AUTH_TYPE_OAUTH = "oauth"
+STRATEGY_FILL_FIRST = "fill_first"
+GRANT_FINGERPRINT_PREFIX = "hmac-sha256:"
+GRANT_HMAC_CONTEXT = b"hermes-anthropic-grant-v1\0"
+
+ENDPOINT_PLATFORM = "platform_claude_v1"
+ENDPOINT_CONSOLE = "console_anthropic_v1"
+ENDPOINT_URLS = {
+    ENDPOINT_PLATFORM: "https://platform.claude.com/v1/oauth/token",
+    ENDPOINT_CONSOLE: "https://console.anthropic.com/v1/oauth/token",
+}
+URL_TO_ENDPOINT = {v: k for k, v in ENDPOINT_URLS.items()}
+
+STATUS_OK = "ok"
+STATUS_EXHAUSTED = "exhausted"
+STATUS_DEAD = "dead"
+
+REASON_RATE_LIMIT = "rate_limit"
+REASON_BILLING = "billing"
+REASON_AUTH_TERMINAL = "auth_terminal"
+REASON_REFRESH_UNKNOWN = "refresh_outcome_unknown"
+REASON_OTHER = "other_sanitized"
+
+ATTEMPT_INFLIGHT = "inflight"
+ATTEMPT_UNKNOWN = "unknown"
+ATTEMPT_TERMINAL = "terminal"
+
+REQUIRED_POOL_KEYS = (
+    "schema_version",
+    "revision",
+    "strategy",
+    "account_distinctness_attested",
+    "account_distinctness_attested_at",
+    "entries",
+)
+REQUIRED_ROW_KEYS = (
+    "id",
+    "provider",
+    "auth_type",
+    "source",
+    "label",
+    "grant_fingerprint",
+    "token_generation",
+    "oauth_token_endpoint",
+    "access_token",
+    "refresh_token",
+    "expires_at_ms",
+    "priority",
+    "request_count",
+    "last_status",
+    "last_status_at",
+    "last_error_code",
+    "last_error_reason",
+    "last_error_message",
+    "last_error_reset_at",
+    "last_refresh",
+    "refresh_attempt",
+)
+
+OFFICIAL_ANTHROPIC_HOSTS = frozenset({"api.anthropic.com"})
+OFFICIAL_PURPOSES = frozenset({"inference", "account_usage", "model_discovery"})
+
+# Process-local epoch snapshot taken at first shared observation.
+_startup_epoch: Optional[str] = None
+_startup_epoch_lock = threading.Lock()
+_inprocess_pool_lock = threading.RLock()
+_active_leases: Dict[Tuple[str, int], int] = {}
+_cached_clients_generation: int = 0
+
+
+class SharedMutationCapability:
+    """Unforgeable capability token — only constructed inside this module."""
+
+    __slots__ = ("_token",)
+
+    def __init__(self) -> None:
+        self._token = object()
+
+
+_SHARED_MUTATION_CAP = SharedMutationCapability()
+
+
+def get_shared_mutation_capability() -> SharedMutationCapability:
+    """Return the internal capability for explicit ``hermes auth ... --shared`` paths."""
+    return _SHARED_MUTATION_CAP
+
+
+def _require_capability(cap: Optional[SharedMutationCapability]) -> None:
+    if cap is None or getattr(cap, "_token", None) is not _SHARED_MUTATION_CAP._token:
+        raise AuthError(
+            "Shared Anthropic pool mutation requires explicit CLI --shared capability. "
+            "Use: hermes auth add/remove/reset/logout anthropic --shared "
+            "(or hermes auth scope / backup / restore).",
+            provider=PROVIDER,
+            code="shared_mutation_forbidden",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def root_hermes_path() -> Path:
+    return get_default_hermes_root()
+
+
+def root_auth_path() -> Path:
+    return root_hermes_path() / "auth.json"
+
+
+def shared_dir() -> Path:
+    return root_hermes_path() / "shared"
+
+
+def scope_marker_path() -> Path:
+    return shared_dir() / "anthropic_pool_scope.json"
+
+
+def grant_salt_path() -> Path:
+    return shared_dir() / "anthropic_grant_salt"
+
+
+def recovery_dir() -> Path:
+    return shared_dir() / "recovery"
+
+
+# ---------------------------------------------------------------------------
+# Filesystem safety
+# ---------------------------------------------------------------------------
+
+
+def _fsync_dir(path: Path) -> None:
+    try:
+        dir_fd = os.open(str(path), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
+
+
+def _path_is_safe_regular_file(path: Path, *, must_exist: bool) -> None:
+    """Fail closed on symlink / wrong owner / group-world writable paths."""
+    if path.exists() or path.is_symlink():
+        if path.is_symlink():
+            raise AuthError(
+                f"Refusing symlinked path: {path}",
+                provider=PROVIDER,
+                code="shared_path_unsafe",
+            )
+        st = path.lstat()
+        if not stat.S_ISREG(st.st_mode):
+            raise AuthError(
+                f"Path is not a regular file: {path}",
+                provider=PROVIDER,
+                code="shared_path_unsafe",
+            )
+        if st.st_nlink != 1:
+            raise AuthError(
+                f"Refusing hard-linked path: {path}",
+                provider=PROVIDER,
+                code="shared_path_unsafe",
+            )
+        if hasattr(os, "getuid"):
+            if st.st_uid != os.getuid():
+                raise AuthError(
+                    f"Path not owned by current user: {path}",
+                    provider=PROVIDER,
+                    code="shared_path_unsafe",
+                )
+        mode = stat.S_IMODE(st.st_mode)
+        if mode & (stat.S_IRWXG | stat.S_IRWXO):
+            raise AuthError(
+                f"Path has group/world permissions: {path}",
+                provider=PROVIDER,
+                code="shared_path_unsafe",
+            )
+    elif must_exist:
+        raise AuthError(
+            f"Required path missing: {path}",
+            provider=PROVIDER,
+            code="shared_path_missing",
+        )
+
+
+def _ensure_owner_only_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        path.chmod(0o700)
+    except OSError:
+        pass
+    if path.is_symlink():
+        raise AuthError(
+            f"Refusing symlinked directory: {path}",
+            provider=PROVIDER,
+            code="shared_path_unsafe",
+        )
+    st = path.lstat()
+    if not stat.S_ISDIR(st.st_mode):
+        raise AuthError(
+            f"Expected directory: {path}",
+            provider=PROVIDER,
+            code="shared_path_unsafe",
+        )
+    if hasattr(os, "getuid") and st.st_uid != os.getuid():
+        raise AuthError(
+            f"Directory not owned by current user: {path}",
+            provider=PROVIDER,
+            code="shared_path_unsafe",
+        )
+    mode = stat.S_IMODE(st.st_mode)
+    if mode & (stat.S_IRWXG | stat.S_IRWXO):
+        raise AuthError(
+            f"Directory has group/world permissions: {path}",
+            provider=PROVIDER,
+            code="shared_path_unsafe",
+        )
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Strict atomic write: temp + fsync + os.replace + dir fsync. No copy fallback."""
+    if path.exists() or path.is_symlink():
+        _path_is_safe_regular_file(path, must_exist=True)
+    _ensure_owner_only_dir(path.parent)
+    secure_parent_dir(path)
+    tmp = path.with_name(f".{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    try:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(str(tmp), flags, stat.S_IRUSR | stat.S_IWUSR)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except Exception:
+            try:
+                os.close(fd)
+            except Exception:
+                pass
+            raise
+        # Refuse replace onto a symlink target path.
+        if path.is_symlink():
+            raise AuthError(
+                f"Refusing to replace symlinked path: {path}",
+                provider=PROVIDER,
+                code="shared_path_unsafe",
+            )
+        os.replace(str(tmp), str(path))
+        _fsync_dir(path.parent)
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass
+    finally:
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except OSError:
+            pass
+
+
+def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
+    data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    _atomic_write_bytes(path, data)
+
+
+# ---------------------------------------------------------------------------
+# Scope marker
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScopeState:
+    mode: str  # "profile" | "shared"
+    epoch: Optional[str] = None
+    raw: Optional[Dict[str, Any]] = None
+
+
+def read_scope_state() -> ScopeState:
+    """Read and validate the scope marker. Fail closed on malformed/unsafe marker."""
+    path = scope_marker_path()
+    if not path.exists() and not path.is_symlink():
+        return ScopeState(mode="profile")
+    _path_is_safe_regular_file(path, must_exist=True)
+    try:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(str(path), flags)
+        try:
+            with os.fdopen(fd, "r", encoding="utf-8") as handle:
+                raw = json.load(handle)
+        except Exception:
+            try:
+                os.close(fd)
+            except Exception:
+                pass
+            raise
+    except AuthError:
+        raise
+    except Exception as exc:
+        raise AuthError(
+            f"Malformed Anthropic shared scope marker: {exc}",
+            provider=PROVIDER,
+            code="shared_scope_corrupt",
+        ) from exc
+    if not isinstance(raw, dict):
+        raise AuthError(
+            "Malformed Anthropic shared scope marker: not an object",
+            provider=PROVIDER,
+            code="shared_scope_corrupt",
+        )
+    if raw.get("version") != MARKER_VERSION:
+        raise AuthError(
+            f"Unsupported scope marker version: {raw.get('version')!r}",
+            provider=PROVIDER,
+            code="shared_scope_corrupt",
+        )
+    if raw.get("scope") != "shared":
+        raise AuthError(
+            f"Invalid scope marker value: {raw.get('scope')!r}",
+            provider=PROVIDER,
+            code="shared_scope_corrupt",
+        )
+    epoch = raw.get("epoch")
+    if not isinstance(epoch, str) or not epoch.strip():
+        raise AuthError(
+            "Scope marker missing epoch",
+            provider=PROVIDER,
+            code="shared_scope_corrupt",
+        )
+    return ScopeState(mode="shared", epoch=epoch.strip(), raw=raw)
+
+
+def is_shared_scope_active() -> bool:
+    return read_scope_state().mode == "shared"
+
+
+def observe_startup_epoch() -> Optional[str]:
+    """Snapshot the shared epoch for this process (idempotent)."""
+    global _startup_epoch
+    with _startup_epoch_lock:
+        if _startup_epoch is not None:
+            return _startup_epoch
+        state = read_scope_state()
+        if state.mode == "shared":
+            _startup_epoch = state.epoch
+        else:
+            _startup_epoch = ""
+        return _startup_epoch
+
+
+def reset_startup_epoch_for_tests() -> None:
+    global _startup_epoch
+    with _startup_epoch_lock:
+        _startup_epoch = None
+
+
+def assert_epoch_unchanged() -> None:
+    """Fail if scope changed since process startup (no hot-switch)."""
+    observed = observe_startup_epoch()
+    current = read_scope_state()
+    if observed == "":
+        # Started in profile mode.
+        if current.mode == "shared":
+            raise AuthError(
+                "Anthropic shared scope changed; restart Hermes",
+                provider=PROVIDER,
+                code="shared_scope_changed",
+            )
+        return
+    if current.mode != "shared" or current.epoch != observed:
+        raise AuthError(
+            "Anthropic shared scope changed; restart Hermes",
+            provider=PROVIDER,
+            code="shared_scope_changed",
+        )
+
+
+def write_scope_marker(*, epoch: Optional[str] = None) -> str:
+    """Atomically publish shared scope marker (last step of enable)."""
+    _ensure_owner_only_dir(shared_dir())
+    epoch_val = epoch or str(uuid.uuid4())
+    payload = {"version": MARKER_VERSION, "scope": "shared", "epoch": epoch_val}
+    _atomic_write_json(scope_marker_path(), payload)
+    return epoch_val
+
+
+def remove_scope_marker() -> None:
+    """Remove marker first (disable / logout). Idempotent."""
+    path = scope_marker_path()
+    if not path.exists() and not path.is_symlink():
+        return
+    _path_is_safe_regular_file(path, must_exist=True)
+    path.unlink()
+    _fsync_dir(path.parent)
+
+
+# ---------------------------------------------------------------------------
+# Grant salt + fingerprints
+# ---------------------------------------------------------------------------
+
+
+def ensure_grant_salt() -> bytes:
+    path = grant_salt_path()
+    if path.exists() or path.is_symlink():
+        _path_is_safe_regular_file(path, must_exist=True)
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(str(path), flags)
+        try:
+            with os.fdopen(fd, "rb") as handle:
+                data = handle.read()
+        except Exception:
+            try:
+                os.close(fd)
+            except Exception:
+                pass
+            raise
+        if len(data) < 16:
+            raise AuthError(
+                "Grant salt file is too short",
+                provider=PROVIDER,
+                code="shared_salt_corrupt",
+            )
+        return data
+    salt = os.urandom(32)
+    _ensure_owner_only_dir(shared_dir())
+    _atomic_write_bytes(path, salt)
+    return salt
+
+
+def grant_fingerprint(initial_refresh_token: str) -> str:
+    salt = ensure_grant_salt()
+    digest = hmac.new(
+        salt,
+        GRANT_HMAC_CONTEXT + initial_refresh_token.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{GRANT_FINGERPRINT_PREFIX}{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+def _utc_now_rfc3339() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _is_rfc3339(value: Any) -> bool:
+    if value is None:
+        return True
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return True
+    except ValueError:
+        return False
+
+
+def _normalize_label(label: str) -> str:
+    cleaned = "".join(ch if ch.isprintable() else " " for ch in (label or ""))
+    cleaned = " ".join(cleaned.split()).strip()
+    if not cleaned:
+        raise AuthError(
+            "Shared Anthropic label must be 1-64 printable characters",
+            provider=PROVIDER,
+            code="shared_row_invalid",
+        )
+    if len(cleaned) > 64:
+        cleaned = cleaned[:64].rstrip()
+    return cleaned
+
+
+def _validate_refresh_attempt(attempt: Any, token_generation: int) -> None:
+    if attempt is None:
+        return
+    if not isinstance(attempt, dict):
+        raise AuthError("refresh_attempt must be object or null", provider=PROVIDER, code="shared_row_invalid")
+    required = {"attempt_id", "expected_generation", "started_at", "outcome"}
+    if set(attempt.keys()) != required:
+        raise AuthError("refresh_attempt has unexpected keys", provider=PROVIDER, code="shared_row_invalid")
+    if not isinstance(attempt.get("attempt_id"), str) or not attempt["attempt_id"]:
+        raise AuthError("refresh_attempt.attempt_id invalid", provider=PROVIDER, code="shared_row_invalid")
+    if attempt.get("expected_generation") != token_generation:
+        raise AuthError(
+            "refresh_attempt.expected_generation must equal token_generation",
+            provider=PROVIDER,
+            code="shared_row_invalid",
+        )
+    if not _is_rfc3339(attempt.get("started_at")) or attempt.get("started_at") is None:
+        raise AuthError("refresh_attempt.started_at invalid", provider=PROVIDER, code="shared_row_invalid")
+    if attempt.get("outcome") not in {ATTEMPT_INFLIGHT, ATTEMPT_UNKNOWN, ATTEMPT_TERMINAL}:
+        raise AuthError("refresh_attempt.outcome invalid", provider=PROVIDER, code="shared_row_invalid")
+
+
+def validate_shared_row(row: Dict[str, Any], *, at_enrollment: bool = False) -> Dict[str, Any]:
+    if not isinstance(row, dict):
+        raise AuthError("Shared row must be an object", provider=PROVIDER, code="shared_row_invalid")
+    missing = [k for k in REQUIRED_ROW_KEYS if k not in row]
+    if missing:
+        raise AuthError(
+            f"Shared row missing required fields: {', '.join(missing)}",
+            provider=PROVIDER,
+            code="shared_row_invalid",
+        )
+    extra = set(row.keys()) - set(REQUIRED_ROW_KEYS)
+    if extra:
+        raise AuthError(
+            f"Shared row has forbidden fields: {', '.join(sorted(extra))}",
+            provider=PROVIDER,
+            code="shared_row_invalid",
+        )
+    try:
+        uuid.UUID(str(row["id"]))
+    except Exception as exc:
+        raise AuthError("Shared row id must be a UUID", provider=PROVIDER, code="shared_row_invalid") from exc
+    if row["provider"] != PROVIDER:
+        raise AuthError("Shared row provider must be anthropic", provider=PROVIDER, code="shared_row_invalid")
+    if row["auth_type"] != AUTH_TYPE_OAUTH:
+        raise AuthError("Shared rows must be oauth", provider=PROVIDER, code="shared_row_invalid")
+    if row["source"] != SOURCE_HERMES_PKCE:
+        raise AuthError(
+            "Shared rows must use source manual:hermes_pkce",
+            provider=PROVIDER,
+            code="shared_row_invalid",
+        )
+    label = _normalize_label(str(row["label"]))
+    fp = row["grant_fingerprint"]
+    if not isinstance(fp, str) or not fp.startswith(GRANT_FINGERPRINT_PREFIX) or len(fp) < 20:
+        raise AuthError("Invalid grant_fingerprint", provider=PROVIDER, code="shared_row_invalid")
+    if not isinstance(row["access_token"], str) or not row["access_token"].strip():
+        raise AuthError("access_token required", provider=PROVIDER, code="shared_row_invalid")
+    if not isinstance(row["refresh_token"], str) or not row["refresh_token"].strip():
+        raise AuthError("refresh_token required", provider=PROVIDER, code="shared_row_invalid")
+    if not isinstance(row["token_generation"], int) or row["token_generation"] < 1:
+        raise AuthError("token_generation must be int >= 1", provider=PROVIDER, code="shared_row_invalid")
+    if row["oauth_token_endpoint"] not in ENDPOINT_URLS:
+        raise AuthError("oauth_token_endpoint invalid", provider=PROVIDER, code="shared_row_invalid")
+    if not isinstance(row["expires_at_ms"], int) or row["expires_at_ms"] <= 0:
+        raise AuthError("expires_at_ms must be positive int", provider=PROVIDER, code="shared_row_invalid")
+    if at_enrollment and row["expires_at_ms"] <= int(time.time() * 1000):
+        raise AuthError("expires_at_ms must be future at enrollment", provider=PROVIDER, code="shared_row_invalid")
+    if not isinstance(row["priority"], int) or row["priority"] < 0:
+        raise AuthError("priority must be int >= 0", provider=PROVIDER, code="shared_row_invalid")
+    if not isinstance(row["request_count"], int) or row["request_count"] < 0:
+        raise AuthError("request_count must be int >= 0", provider=PROVIDER, code="shared_row_invalid")
+
+    status = row["last_status"]
+    if status not in (None, STATUS_OK, STATUS_EXHAUSTED, STATUS_DEAD):
+        raise AuthError("last_status invalid", provider=PROVIDER, code="shared_row_invalid")
+    for ts_key in ("last_status_at", "last_error_reset_at"):
+        val = row[ts_key]
+        if val is not None and not isinstance(val, (int, float)):
+            raise AuthError(f"{ts_key} must be number or null", provider=PROVIDER, code="shared_row_invalid")
+    if row["last_error_code"] is not None and not isinstance(row["last_error_code"], int):
+        raise AuthError("last_error_code must be int or null", provider=PROVIDER, code="shared_row_invalid")
+    reason = row["last_error_reason"]
+    if reason not in (
+        None,
+        REASON_RATE_LIMIT,
+        REASON_BILLING,
+        REASON_AUTH_TERMINAL,
+        REASON_REFRESH_UNKNOWN,
+        REASON_OTHER,
+    ):
+        raise AuthError("last_error_reason invalid", provider=PROVIDER, code="shared_row_invalid")
+    msg = row["last_error_message"]
+    if msg is not None:
+        if not isinstance(msg, str) or len(msg) > 256:
+            raise AuthError("last_error_message invalid", provider=PROVIDER, code="shared_row_invalid")
+    if not _is_rfc3339(row["last_refresh"]):
+        raise AuthError("last_refresh invalid", provider=PROVIDER, code="shared_row_invalid")
+
+    _validate_refresh_attempt(row["refresh_attempt"], row["token_generation"])
+    attempt = row["refresh_attempt"]
+    outcome = attempt.get("outcome") if isinstance(attempt, dict) else None
+
+    # Cross-field rules
+    if status in (None, STATUS_OK):
+        if any(
+            row[k] is not None
+            for k in ("last_error_code", "last_error_reason", "last_error_message", "last_error_reset_at")
+        ):
+            raise AuthError("ok/null status requires null error/reset state", provider=PROVIDER, code="shared_row_invalid")
+        if attempt is not None and outcome != ATTEMPT_INFLIGHT:
+            raise AuthError("ok/null status permits only null or inflight attempt", provider=PROVIDER, code="shared_row_invalid")
+    elif status == STATUS_EXHAUSTED:
+        if reason not in (REASON_RATE_LIMIT, REASON_BILLING):
+            raise AuthError("exhausted requires rate_limit|billing", provider=PROVIDER, code="shared_row_invalid")
+        if row["last_error_reset_at"] is None:
+            raise AuthError("exhausted requires reset time", provider=PROVIDER, code="shared_row_invalid")
+    elif status == STATUS_DEAD:
+        if reason not in (REASON_AUTH_TERMINAL, REASON_REFRESH_UNKNOWN):
+            raise AuthError("dead permits only auth_terminal|refresh_outcome_unknown", provider=PROVIDER, code="shared_row_invalid")
+        if row["last_error_reset_at"] is not None:
+            raise AuthError("dead must not have reset time", provider=PROVIDER, code="shared_row_invalid")
+        if outcome == ATTEMPT_UNKNOWN and reason != REASON_REFRESH_UNKNOWN:
+            raise AuthError("unknown attempt requires refresh_outcome_unknown", provider=PROVIDER, code="shared_row_invalid")
+        if outcome == ATTEMPT_TERMINAL and reason != REASON_AUTH_TERMINAL:
+            raise AuthError("terminal attempt requires auth_terminal", provider=PROVIDER, code="shared_row_invalid")
+
+    out = dict(row)
+    out["label"] = label
+    return out
+
+
+def validate_shared_pool(pool: Dict[str, Any], *, require_three: bool = False) -> Dict[str, Any]:
+    if not isinstance(pool, dict):
+        raise AuthError("Shared pool must be an object", provider=PROVIDER, code="shared_pool_invalid")
+    missing = [k for k in REQUIRED_POOL_KEYS if k not in pool]
+    if missing:
+        raise AuthError(
+            f"Shared pool missing fields: {', '.join(missing)}",
+            provider=PROVIDER,
+            code="shared_pool_invalid",
+        )
+    extra = set(pool.keys()) - set(REQUIRED_POOL_KEYS)
+    if extra:
+        raise AuthError(
+            f"Shared pool has unknown fields: {', '.join(sorted(extra))}",
+            provider=PROVIDER,
+            code="shared_pool_invalid",
+        )
+    if pool.get("schema_version") != SCHEMA_VERSION:
+        raise AuthError(
+            f"Unsupported shared pool schema_version: {pool.get('schema_version')!r}",
+            provider=PROVIDER,
+            code="shared_pool_invalid",
+        )
+    if not isinstance(pool.get("revision"), int) or pool["revision"] < 1:
+        raise AuthError("revision must be int >= 1", provider=PROVIDER, code="shared_pool_invalid")
+    if pool.get("strategy") != STRATEGY_FILL_FIRST:
+        raise AuthError("strategy must be fill_first", provider=PROVIDER, code="shared_pool_invalid")
+    if not isinstance(pool.get("account_distinctness_attested"), bool):
+        raise AuthError("account_distinctness_attested must be bool", provider=PROVIDER, code="shared_pool_invalid")
+    if not _is_rfc3339(pool.get("account_distinctness_attested_at")):
+        raise AuthError("account_distinctness_attested_at invalid", provider=PROVIDER, code="shared_pool_invalid")
+    entries = pool.get("entries")
+    if not isinstance(entries, list):
+        raise AuthError("entries must be a list", provider=PROVIDER, code="shared_pool_invalid")
+    validated = [validate_shared_row(e) for e in entries]
+    ids = [e["id"] for e in validated]
+    fps = [e["grant_fingerprint"] for e in validated]
+    if len(ids) != len(set(ids)):
+        raise AuthError("Duplicate shared row ids", provider=PROVIDER, code="shared_pool_invalid")
+    if len(fps) != len(set(fps)):
+        raise AuthError("Duplicate grant fingerprints", provider=PROVIDER, code="shared_pool_invalid")
+    prios = sorted(e["priority"] for e in validated)
+    if prios != list(range(len(validated))):
+        raise AuthError(
+            "priorities must be unique contiguous 0..n-1",
+            provider=PROVIDER,
+            code="shared_pool_invalid",
+        )
+    if require_three:
+        if len(validated) != 3:
+            raise AuthError(
+                f"Shared scope requires exactly 3 OAuth grants (found {len(validated)})",
+                provider=PROVIDER,
+                code="shared_pool_count",
+            )
+        if not pool["account_distinctness_attested"]:
+            raise AuthError(
+                "Shared scope requires account distinctness attestation",
+                provider=PROVIDER,
+                code="shared_attestation_required",
+            )
+    validated.sort(key=lambda e: e["priority"])
+    out = dict(pool)
+    out["entries"] = validated
+    return out
+
+
+def empty_shared_pool() -> Dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "revision": 1,
+        "strategy": STRATEGY_FILL_FIRST,
+        "account_distinctness_attested": False,
+        "account_distinctness_attested_at": None,
+        "entries": [],
+    }
+
+
+def new_shared_row(
+    *,
+    access_token: str,
+    refresh_token: str,
+    expires_at_ms: int,
+    oauth_token_endpoint: str,
+    label: str,
+    priority: int,
+    initial_refresh_token: Optional[str] = None,
+) -> Dict[str, Any]:
+    fp_source = initial_refresh_token or refresh_token
+    row = {
+        "id": str(uuid.uuid4()),
+        "provider": PROVIDER,
+        "auth_type": AUTH_TYPE_OAUTH,
+        "source": SOURCE_HERMES_PKCE,
+        "label": label,
+        "grant_fingerprint": grant_fingerprint(fp_source),
+        "token_generation": 1,
+        "oauth_token_endpoint": oauth_token_endpoint,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "expires_at_ms": int(expires_at_ms),
+        "priority": int(priority),
+        "request_count": 0,
+        "last_status": None,
+        "last_status_at": None,
+        "last_error_code": None,
+        "last_error_reason": None,
+        "last_error_message": None,
+        "last_error_reset_at": None,
+        "last_refresh": None,
+        "refresh_attempt": None,
+    }
+    return validate_shared_row(row, at_enrollment=True)
+
+
+# ---------------------------------------------------------------------------
+# Strict root auth load/save
+# ---------------------------------------------------------------------------
+
+
+def _kernel_lock_available() -> bool:
+    return auth_mod.fcntl is not None or auth_mod.msvcrt is not None
+
+
+@contextmanager
+def root_auth_lock(timeout_seconds: Optional[float] = None):
+    if not _kernel_lock_available():
+        raise AuthError(
+            "Shared Anthropic scope requires a kernel cross-process lock primitive",
+            provider=PROVIDER,
+            code="shared_lock_unavailable",
+        )
+    timeout = (
+        float(timeout_seconds)
+        if timeout_seconds is not None
+        else max(float(auth_mod.AUTH_LOCK_TIMEOUT_SECONDS), 15.0)
+    )
+    with _auth_store_lock(timeout_seconds=timeout, target_path=root_auth_path()):
+        yield
+
+
+def load_root_auth_strict() -> Dict[str, Any]:
+    """Load root auth.json without corruption-recovery empty-store fallback."""
+    path = root_auth_path()
+    if not path.exists() and not path.is_symlink():
+        return {"version": getattr(auth_mod, "AUTH_STORE_VERSION", 1), "providers": {}}
+    _path_is_safe_regular_file(path, must_exist=True)
+    try:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(str(path), flags)
+        try:
+            with os.fdopen(fd, "r", encoding="utf-8") as handle:
+                raw = json.load(handle)
+        except Exception:
+            try:
+                os.close(fd)
+            except Exception:
+                pass
+            raise
+    except AuthError:
+        raise
+    except Exception as exc:
+        raise AuthError(
+            f"Root auth store unreadable/corrupt: {exc}",
+            provider=PROVIDER,
+            code="shared_root_auth_corrupt",
+        ) from exc
+    if not isinstance(raw, dict):
+        raise AuthError(
+            "Root auth store is not a JSON object",
+            provider=PROVIDER,
+            code="shared_root_auth_corrupt",
+        )
+    raw.setdefault("providers", {})
+    if not isinstance(raw.get("providers"), dict):
+        raise AuthError(
+            "Root auth providers field corrupt",
+            provider=PROVIDER,
+            code="shared_root_auth_corrupt",
+        )
+    return raw
+
+
+def save_root_auth_strict(auth_store: Dict[str, Any]) -> None:
+    path = root_auth_path()
+    auth_store = dict(auth_store)
+    auth_store["version"] = getattr(auth_mod, "AUTH_STORE_VERSION", 1)
+    auth_store["updated_at"] = _utc_now_rfc3339()
+    _atomic_write_json(path, auth_store)
+
+
+def get_shared_namespace(auth_store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    scp = auth_store.get("shared_credential_pools")
+    if scp is None:
+        return None
+    if not isinstance(scp, dict):
+        raise AuthError(
+            "shared_credential_pools corrupt",
+            provider=PROVIDER,
+            code="shared_pool_invalid",
+        )
+    pool = scp.get(PROVIDER)
+    if pool is None:
+        return None
+    return validate_shared_pool(pool)
+
+
+def set_shared_namespace(auth_store: Dict[str, Any], pool: Optional[Dict[str, Any]]) -> None:
+    if pool is None:
+        scp = auth_store.get("shared_credential_pools")
+        if isinstance(scp, dict):
+            scp.pop(PROVIDER, None)
+            if not scp:
+                auth_store.pop("shared_credential_pools", None)
+        return
+    validated = validate_shared_pool(pool)
+    scp = auth_store.setdefault("shared_credential_pools", {})
+    if not isinstance(scp, dict):
+        raise AuthError("shared_credential_pools corrupt", provider=PROVIDER, code="shared_pool_invalid")
+    scp[PROVIDER] = validated
+
+
+def has_dormant_or_active_shared_state() -> bool:
+    """True when marker exists OR dormant shared namespace is present."""
+    path = scope_marker_path()
+    if path.exists() or path.is_symlink():
+        return True
+    try:
+        store = load_root_auth_strict()
+        scp = store.get("shared_credential_pools")
+        if isinstance(scp, dict) and PROVIDER in scp:
+            return True
+    except AuthError:
+        # Corrupt root while dormant still blocks generic backup.
+        if root_auth_path().exists():
+            return True
+    return False
+
+
+def load_shared_pool_for_management(*, require_active_three: bool = False) -> Dict[str, Any]:
+    """Strict loader for management paths (profile or shared)."""
+    with root_auth_lock():
+        store = load_root_auth_strict()
+        pool = get_shared_namespace(store)
+        if pool is None:
+            if require_active_three:
+                raise AuthError(
+                    "Shared Anthropic pool is empty/missing",
+                    provider=PROVIDER,
+                    code="shared_pool_empty",
+                )
+            return empty_shared_pool()
+        if require_active_three:
+            return validate_shared_pool(pool, require_three=True)
+        return pool
+
+
+# ---------------------------------------------------------------------------
+# Official target predicate + resolution context
+# ---------------------------------------------------------------------------
+
+
+def is_official_anthropic_oauth_target(
+    provider: Any = None,
+    purpose: Any = "inference",
+    api_mode: Any = None,
+    base_url: Any = None,
+) -> bool:
+    """True only for official native Anthropic OAuth targets."""
+    prov = str(provider or "").strip().lower()
+    if prov and prov != PROVIDER:
+        return False
+    purpose_s = str(purpose or "inference").strip().lower()
+    if purpose_s not in OFFICIAL_PURPOSES:
+        return False
+
+    raw_url = str(base_url or "").strip()
+    if not raw_url:
+        host = "api.anthropic.com"
+        scheme = "https"
+        port = None
+        userinfo = False
+        fragment = False
+    else:
+        parsed = urlparse(raw_url)
+        if parsed.scheme and parsed.scheme.lower() != "https":
+            return False
+        if parsed.username or parsed.password:
+            return False
+        if parsed.fragment:
+            return False
+        host = (parsed.hostname or "").lower()
+        scheme = (parsed.scheme or "https").lower()
+        port = parsed.port
+        userinfo = bool(parsed.username or parsed.password)
+        fragment = bool(parsed.fragment)
+        # Deceptive suffixes / path tricks — host must be exact.
+        if not host:
+            return False
+
+    if scheme != "https":
+        return False
+    if userinfo or fragment:
+        return False
+    if host not in OFFICIAL_ANTHROPIC_HOSTS:
+        return False
+    if port is not None and port != 443:
+        return False
+
+    if purpose_s == "inference":
+        mode = str(api_mode or "").strip().lower()
+        # Empty / default / anthropic messages modes are OK; chat_completions is not native.
+        if mode in ("", "anthropic", "anthropic_messages", "messages", "native"):
+            return True
+        if mode in ("chat_completions", "codex_responses", "openai"):
+            return False
+        # Unknown modes: only accept if clearly anthropic-ish.
+        return "anthropic" in mode or mode == "messages"
+    return True
+
+
+@dataclass
+class AnthropicCredentialContext:
+    """Authoritative credential resolution result (does not leak tokens via repr)."""
+
+    access_token: str
+    row_id: str
+    token_generation: int
+    source: str = "shared_pool"
+    auth_type: str = AUTH_TYPE_OAUTH
+    label: str = ""
+    expires_at_ms: Optional[int] = None
+    pool_revision: int = 0
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return (
+            f"AnthropicCredentialContext(row_id={self.row_id!r}, "
+            f"token_generation={self.token_generation}, source={self.source!r})"
+        )
+
+
+def _row_is_selectable(row: Dict[str, Any], now: float) -> bool:
+    if row.get("refresh_attempt") is not None:
+        return False
+    status = row.get("last_status")
+    if status == STATUS_DEAD:
+        return False
+    if status == STATUS_EXHAUSTED:
+        reset_at = row.get("last_error_reset_at")
+        if reset_at is None:
+            return False
+        if float(reset_at) > now:
+            return False
+        # Elapsed exhaustion — will be normalized under lock before selection.
+    return True
+
+
+def _normalize_elapsed_exhaustion(pool: Dict[str, Any], now: float) -> bool:
+    changed = False
+    for row in pool["entries"]:
+        if row.get("last_status") != STATUS_EXHAUSTED:
+            continue
+        reset_at = row.get("last_error_reset_at")
+        if reset_at is not None and float(reset_at) <= now:
+            row["last_status"] = None
+            row["last_status_at"] = None
+            row["last_error_code"] = None
+            row["last_error_reason"] = None
+            row["last_error_message"] = None
+            row["last_error_reset_at"] = None
+            changed = True
+    return changed
+
+
+def _abandon_inflight_attempts(pool: Dict[str, Any]) -> bool:
+    """Convert abandoned inflight attempts to unknown/dead under root lock."""
+    changed = False
+    now_ts = time.time()
+    for row in pool["entries"]:
+        attempt = row.get("refresh_attempt")
+        if not isinstance(attempt, dict):
+            continue
+        if attempt.get("outcome") != ATTEMPT_INFLIGHT:
+            continue
+        row["refresh_attempt"] = {
+            "attempt_id": attempt["attempt_id"],
+            "expected_generation": row["token_generation"],
+            "started_at": attempt.get("started_at") or _utc_now_rfc3339(),
+            "outcome": ATTEMPT_UNKNOWN,
+        }
+        row["last_status"] = STATUS_DEAD
+        row["last_status_at"] = now_ts
+        row["last_error_code"] = None
+        row["last_error_reason"] = REASON_REFRESH_UNKNOWN
+        row["last_error_message"] = "abandoned inflight refresh"
+        row["last_error_reset_at"] = None
+        changed = True
+    return changed
+
+
+def select_fill_first(pool: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    now = time.time()
+    for row in sorted(pool["entries"], key=lambda r: r["priority"]):
+        if _row_is_selectable(row, now):
+            return row
+    return None
+
+
+def resolve_shared_anthropic_credential(
+    *,
+    provider: Any = PROVIDER,
+    purpose: str = "inference",
+    api_mode: Any = None,
+    base_url: Any = None,
+    refresh_if_needed: bool = True,
+) -> AnthropicCredentialContext:
+    """Authoritative shared-scope resolution. Raises AuthError on failure."""
+    if not is_official_anthropic_oauth_target(provider, purpose, api_mode, base_url):
+        raise AuthError(
+            "Not an official Anthropic OAuth target",
+            provider=PROVIDER,
+            code="not_official_target",
+        )
+    assert_epoch_unchanged()
+    with _inprocess_pool_lock:
+        with root_auth_lock(_refresh_lock_timeout() if refresh_if_needed else None):
+            store = load_root_auth_strict()
+            pool = get_shared_namespace(store)
+            if pool is None:
+                raise AuthError(
+                    "Shared Anthropic pool is empty",
+                    provider=PROVIDER,
+                    code="shared_pool_empty",
+                )
+            pool = validate_shared_pool(pool, require_three=True)
+            changed = _abandon_inflight_attempts(pool)
+            changed = _normalize_elapsed_exhaustion(pool, time.time()) or changed
+            if changed:
+                pool["revision"] = int(pool["revision"]) + 1
+                set_shared_namespace(store, pool)
+                save_root_auth_strict(store)
+                pool = validate_shared_pool(pool, require_three=True)
+
+            row = select_fill_first(pool)
+            if row is None:
+                raise AuthError(
+                    "No available Anthropic shared credentials",
+                    provider=PROVIDER,
+                    code="shared_pool_exhausted",
+                )
+
+            needs_refresh = (
+                refresh_if_needed
+                and isinstance(row.get("expires_at_ms"), int)
+                and row["expires_at_ms"] <= int(time.time() * 1000) + 60_000
+            )
+            if needs_refresh:
+                row = _commit_refresh_locked(store, pool, row, force=True)
+                pool = get_shared_namespace(store)
+                assert pool is not None
+                pool = validate_shared_pool(pool, require_three=True)
+
+            return AnthropicCredentialContext(
+                access_token=row["access_token"],
+                row_id=row["id"],
+                token_generation=int(row["token_generation"]),
+                label=str(row.get("label") or ""),
+                expires_at_ms=row.get("expires_at_ms"),
+                pool_revision=int(pool["revision"]),
+            )
+
+
+def resolve_anthropic_credential_authoritative(
+    *,
+    provider: Any = PROVIDER,
+    purpose: str = "inference",
+    api_mode: Any = None,
+    base_url: Any = None,
+    explicit_api_key: Optional[str] = None,
+    allow_legacy: bool = True,
+) -> Optional[str]:
+    """Single gate used by all native Anthropic consumers.
+
+    While shared scope is active and the target is official, ignores explicit
+    keys, env vars, Claude Code files, and profile pools. Returns access token
+    string or None (legacy mode only).
+    """
+    target = is_official_anthropic_oauth_target(provider, purpose, api_mode, base_url)
+    try:
+        shared = is_shared_scope_active()
+    except AuthError:
+        # Malformed marker — fail closed for official targets.
+        if target:
+            raise
+        shared = False
+
+    if shared and target:
+        ctx = resolve_shared_anthropic_credential(
+            provider=provider,
+            purpose=purpose,
+            api_mode=api_mode,
+            base_url=base_url,
+        )
+        return ctx.access_token
+
+    if not allow_legacy:
+        return None
+
+    # Legacy path: do not use shared dormant rows.
+    if explicit_api_key and str(explicit_api_key).strip():
+        return str(explicit_api_key).strip()
+    return None  # caller continues with existing resolve_anthropic_token
+
+
+# ---------------------------------------------------------------------------
+# Leases (generation-keyed)
+# ---------------------------------------------------------------------------
+
+
+def acquire_lease(row_id: str, token_generation: int) -> None:
+    key = (row_id, int(token_generation))
+    with _inprocess_pool_lock:
+        _active_leases[key] = _active_leases.get(key, 0) + 1
+
+
+def release_lease(row_id: str, token_generation: int) -> None:
+    key = (row_id, int(token_generation))
+    with _inprocess_pool_lock:
+        cur = _active_leases.get(key, 0)
+        if cur <= 1:
+            _active_leases.pop(key, None)
+        else:
+            _active_leases[key] = cur - 1
+
+
+def lease_count(row_id: str, token_generation: int) -> int:
+    return _active_leases.get((row_id, int(token_generation)), 0)
+
+
+# ---------------------------------------------------------------------------
+# Refresh
+# ---------------------------------------------------------------------------
+
+
+def _refresh_lock_timeout() -> float:
+    # Anthropic HTTP timeout in refresh_anthropic_oauth_pure is 10s; margin +5.
+    return max(float(auth_mod.AUTH_LOCK_TIMEOUT_SECONDS), 10.0 + 5.0)
+
+
+def _post_refresh(
+    refresh_token: str,
+    endpoint_id: str,
+    *,
+    transport: Optional[Callable[..., Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """POST once to the row's canonical endpoint. No endpoint fallback."""
+    if transport is not None:
+        return transport(refresh_token=refresh_token, endpoint_id=endpoint_id)
+
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    url = ENDPOINT_URLS[endpoint_id]
+    client_id = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+    data = json.dumps(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "hermes-agent-shared-oauth/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            result = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        body = ""
+        try:
+            body = exc.read().decode("utf-8", errors="replace")[:500]
+        except Exception:
+            pass
+        err = AuthError(
+            f"Anthropic refresh HTTP {exc.code}",
+            provider=PROVIDER,
+            code="refresh_http_error",
+            relogin_required=exc.code in (400, 401),
+        )
+        err.http_status = exc.code  # type: ignore[attr-defined]
+        err.body_snippet = body  # type: ignore[attr-defined]
+        raise err from exc
+    except Exception as exc:
+        err = AuthError(
+            f"Anthropic refresh transport failure: {type(exc).__name__}",
+            provider=PROVIDER,
+            code="refresh_transport",
+        )
+        err.ambiguous = True  # type: ignore[attr-defined]
+        raise err from exc
+
+    access = result.get("access_token") or ""
+    refresh = result.get("refresh_token") or ""
+    expires_in = result.get("expires_in")
+    if not isinstance(access, str) or not access.strip():
+        raise AuthError("malformed refresh response: access_token", provider=PROVIDER, code="refresh_malformed")
+    if not isinstance(refresh, str) or not refresh.strip():
+        raise AuthError("malformed refresh response: refresh_token", provider=PROVIDER, code="refresh_malformed")
+    if not isinstance(expires_in, (int, float)) or expires_in <= 0:
+        raise AuthError("malformed refresh response: expires_in", provider=PROVIDER, code="refresh_malformed")
+    return {
+        "access_token": access.strip(),
+        "refresh_token": refresh.strip(),
+        "expires_at_ms": int(time.time() * 1000) + int(expires_in) * 1000,
+    }
+
+
+def _commit_refresh_locked(
+    store: Dict[str, Any],
+    pool: Dict[str, Any],
+    row: Dict[str, Any],
+    *,
+    force: bool,
+    expected_generation: Optional[int] = None,
+    transport: Optional[Callable[..., Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Caller already holds root auth lock + in-process pool lock."""
+    # Re-find row by id
+    entries = {e["id"]: e for e in pool["entries"]}
+    current = entries.get(row["id"])
+    if current is None:
+        raise AuthError("Shared credential disappeared", provider=PROVIDER, code="shared_row_missing")
+
+    _abandon_inflight_attempts(pool)
+
+    # Re-validate after abandon
+    current = next(e for e in pool["entries"] if e["id"] == row["id"])
+    if current.get("refresh_attempt") is not None:
+        outcome = current["refresh_attempt"].get("outcome")
+        if outcome in (ATTEMPT_UNKNOWN, ATTEMPT_TERMINAL):
+            raise AuthError(
+                "Shared credential requires re-auth",
+                provider=PROVIDER,
+                code="shared_reauth_required",
+                relogin_required=True,
+            )
+
+    exp_gen = expected_generation if expected_generation is not None else row.get("token_generation")
+    if exp_gen is not None and current["token_generation"] != exp_gen:
+        # Disk already rotated — adopt.
+        return current
+
+    if not force and current["expires_at_ms"] > int(time.time() * 1000) + 60_000:
+        return current
+
+    attempt_id = str(uuid.uuid4())
+    current["refresh_attempt"] = {
+        "attempt_id": attempt_id,
+        "expected_generation": current["token_generation"],
+        "started_at": _utc_now_rfc3339(),
+        "outcome": ATTEMPT_INFLIGHT,
+    }
+    pool["revision"] = int(pool["revision"]) + 1
+    set_shared_namespace(store, validate_shared_pool(pool, require_three=len(pool["entries"]) == 3))
+    save_root_auth_strict(store)
+
+    refresh_token = current["refresh_token"]
+    endpoint_id = current["oauth_token_endpoint"]
+    try:
+        refreshed = _post_refresh(refresh_token, endpoint_id, transport=transport)
+    except AuthError as exc:
+        code = getattr(exc, "code", "") or ""
+        http_status = getattr(exc, "http_status", None)
+        body = (getattr(exc, "body_snippet", "") or "").lower()
+        terminal = (
+            code in {"invalid_grant", "refresh_http_error"}
+            and (
+                "invalid_grant" in body
+                or "revoked" in body
+                or http_status in (400, 401)
+            )
+        )
+        # After intent commit, ambiguous/errors → unknown; terminal invalid_grant → terminal.
+        if terminal and ("invalid_grant" in body or "revoked" in body):
+            current["refresh_attempt"] = {
+                "attempt_id": attempt_id,
+                "expected_generation": current["token_generation"],
+                "started_at": current["refresh_attempt"]["started_at"],
+                "outcome": ATTEMPT_TERMINAL,
+            }
+            current["last_status"] = STATUS_DEAD
+            current["last_status_at"] = time.time()
+            current["last_error_reason"] = REASON_AUTH_TERMINAL
+            current["last_error_message"] = "invalid_grant"
+            current["last_error_reset_at"] = None
+        else:
+            current["refresh_attempt"] = {
+                "attempt_id": attempt_id,
+                "expected_generation": current["token_generation"],
+                "started_at": current["refresh_attempt"]["started_at"],
+                "outcome": ATTEMPT_UNKNOWN,
+            }
+            current["last_status"] = STATUS_DEAD
+            current["last_status_at"] = time.time()
+            current["last_error_reason"] = REASON_REFRESH_UNKNOWN
+            current["last_error_message"] = "refresh outcome unknown"
+            current["last_error_reset_at"] = None
+        pool["revision"] = int(pool["revision"]) + 1
+        set_shared_namespace(store, validate_shared_pool(pool, require_three=len(pool["entries"]) == 3))
+        save_root_auth_strict(store)
+        raise
+
+    current["access_token"] = refreshed["access_token"]
+    current["refresh_token"] = refreshed["refresh_token"]
+    current["expires_at_ms"] = refreshed["expires_at_ms"]
+    current["token_generation"] = int(current["token_generation"]) + 1
+    current["last_refresh"] = _utc_now_rfc3339()
+    current["refresh_attempt"] = None
+    current["last_status"] = None
+    current["last_status_at"] = None
+    current["last_error_code"] = None
+    current["last_error_reason"] = None
+    current["last_error_message"] = None
+    current["last_error_reset_at"] = None
+    pool["revision"] = int(pool["revision"]) + 1
+    set_shared_namespace(store, validate_shared_pool(pool, require_three=len(pool["entries"]) == 3))
+    save_root_auth_strict(store)
+    global _cached_clients_generation
+    _cached_clients_generation = current["token_generation"]
+    return current
+
+
+def commit_refresh(
+    row_id: str,
+    *,
+    expected_generation: int,
+    transport: Optional[Callable[..., Dict[str, Any]]] = None,
+    capability: Optional[SharedMutationCapability] = None,
+) -> Dict[str, Any]:
+    """Public refresh entry (also used by runtime). Capability optional for runtime refresh."""
+    # Runtime refresh is allowed without management capability; management
+    # mutations still require it.
+    with _inprocess_pool_lock:
+        with root_auth_lock(_refresh_lock_timeout()):
+            assert_epoch_unchanged()
+            store = load_root_auth_strict()
+            pool = get_shared_namespace(store)
+            if pool is None:
+                raise AuthError("Shared pool empty", provider=PROVIDER, code="shared_pool_empty")
+            pool = validate_shared_pool(pool, require_three=is_shared_scope_active())
+            row = next((e for e in pool["entries"] if e["id"] == row_id), None)
+            if row is None:
+                raise AuthError("row not found", provider=PROVIDER, code="shared_row_missing")
+            return _commit_refresh_locked(
+                store,
+                pool,
+                row,
+                force=True,
+                expected_generation=expected_generation,
+                transport=transport,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Transactional mutations (management)
+# ---------------------------------------------------------------------------
+
+
+def append_row(
+    row: Dict[str, Any],
+    *,
+    capability: SharedMutationCapability,
+) -> Dict[str, Any]:
+    _require_capability(capability)
+    if is_shared_scope_active():
+        raise AuthError(
+            "Cannot add while shared scope is active; switch to profile scope first",
+            provider=PROVIDER,
+            code="shared_add_while_active",
+        )
+    validated = validate_shared_row(row, at_enrollment=True)
+    with _inprocess_pool_lock:
+        with root_auth_lock():
+            store = load_root_auth_strict()
+            pool = get_shared_namespace(store) or empty_shared_pool()
+            if len(pool["entries"]) >= 3:
+                raise AuthError(
+                    "Shared Anthropic pool already has 3 grants",
+                    provider=PROVIDER,
+                    code="shared_pool_full",
+                )
+            fps = {e["grant_fingerprint"] for e in pool["entries"]}
+            if validated["grant_fingerprint"] in fps:
+                # Idempotent by fingerprint — return existing.
+                existing = next(
+                    e for e in pool["entries"] if e["grant_fingerprint"] == validated["grant_fingerprint"]
+                )
+                return existing
+            validated["priority"] = len(pool["entries"])
+            # Renumber is automatic via append order.
+            pool["entries"].append(validated)
+            pool["account_distinctness_attested"] = False
+            pool["account_distinctness_attested_at"] = None
+            pool["revision"] = int(pool.get("revision") or 0) + 1
+            if pool["revision"] < 1:
+                pool["revision"] = 1
+            set_shared_namespace(store, validate_shared_pool(pool))
+            save_root_auth_strict(store)
+            return validated
+
+
+def remove_row(
+    target: str,
+    *,
+    capability: SharedMutationCapability,
+) -> None:
+    _require_capability(capability)
+    if is_shared_scope_active():
+        raise AuthError(
+            "Active shared remove is rejected; switch to profile scope first",
+            provider=PROVIDER,
+            code="shared_remove_while_active",
+        )
+    with _inprocess_pool_lock:
+        with root_auth_lock():
+            store = load_root_auth_strict()
+            pool = get_shared_namespace(store)
+            if pool is None or not pool["entries"]:
+                raise AuthError("No shared rows to remove", provider=PROVIDER, code="shared_row_missing")
+            match_idx = None
+            for i, e in enumerate(pool["entries"]):
+                if e["id"] == target or e["label"] == target or str(i) == str(target) or str(i + 1) == str(target):
+                    match_idx = i
+                    break
+            if match_idx is None:
+                raise AuthError(f"Shared row not found: {target}", provider=PROVIDER, code="shared_row_missing")
+            pool["entries"].pop(match_idx)
+            for i, e in enumerate(sorted(pool["entries"], key=lambda r: r["priority"])):
+                e["priority"] = i
+            pool["entries"].sort(key=lambda r: r["priority"])
+            pool["account_distinctness_attested"] = False
+            pool["account_distinctness_attested_at"] = None
+            pool["revision"] = int(pool["revision"]) + 1
+            set_shared_namespace(store, validate_shared_pool(pool))
+            save_root_auth_strict(store)
+
+
+def reset_statuses(*, capability: SharedMutationCapability) -> int:
+    """Clear recoverable exhaustion only. Returns count cleared."""
+    _require_capability(capability)
+    cleared = 0
+    with _inprocess_pool_lock:
+        with root_auth_lock():
+            store = load_root_auth_strict()
+            pool = get_shared_namespace(store)
+            if pool is None:
+                return 0
+            for row in pool["entries"]:
+                if row.get("last_status") != STATUS_EXHAUSTED:
+                    continue
+                if row.get("refresh_attempt") is not None:
+                    continue
+                if row.get("last_error_reason") not in (REASON_RATE_LIMIT, REASON_BILLING):
+                    continue
+                row["last_status"] = None
+                row["last_status_at"] = None
+                row["last_error_code"] = None
+                row["last_error_reason"] = None
+                row["last_error_message"] = None
+                row["last_error_reset_at"] = None
+                cleared += 1
+            if cleared:
+                pool["revision"] = int(pool["revision"]) + 1
+                set_shared_namespace(store, validate_shared_pool(pool))
+                save_root_auth_strict(store)
+    return cleared
+
+
+def patch_status(
+    row_id: str,
+    *,
+    expected_generation: int,
+    last_status: Optional[str],
+    last_error_code: Optional[int] = None,
+    last_error_reason: Optional[str] = None,
+    last_error_message: Optional[str] = None,
+    last_error_reset_at: Optional[float] = None,
+    capability: Optional[SharedMutationCapability] = None,
+) -> None:
+    """Runtime status patch (generation-guarded). No capability required for runtime."""
+    with _inprocess_pool_lock:
+        with root_auth_lock():
+            try:
+                assert_epoch_unchanged()
+            except AuthError:
+                # Status patches during scope change: drop silently? Spec says
+                # fail new requests. Fail here.
+                raise
+            store = load_root_auth_strict()
+            pool = get_shared_namespace(store)
+            if pool is None:
+                return
+            row = next((e for e in pool["entries"] if e["id"] == row_id), None)
+            if row is None:
+                return
+            if row["token_generation"] != expected_generation:
+                # Stale callback — adopt disk, no mutation.
+                return
+            now = time.time()
+            row["last_status"] = last_status
+            row["last_status_at"] = now if last_status is not None else None
+            row["last_error_code"] = last_error_code
+            row["last_error_reason"] = last_error_reason
+            if last_error_message is not None:
+                row["last_error_message"] = str(last_error_message)[:256]
+            else:
+                row["last_error_message"] = None
+            row["last_error_reset_at"] = last_error_reset_at
+            # Validate combination
+            validate_shared_row(row)
+            pool["revision"] = int(pool["revision"]) + 1
+            require_three = is_shared_scope_active()
+            set_shared_namespace(store, validate_shared_pool(pool, require_three=require_three))
+            save_root_auth_strict(store)
+
+
+def enable_shared_scope(*, attest_distinct_accounts: bool, capability: SharedMutationCapability) -> str:
+    _require_capability(capability)
+    if not attest_distinct_accounts:
+        raise AuthError(
+            "Enabling shared scope requires --attest-distinct-accounts "
+            "(operator attestation that three browser sessions used different Anthropic accounts; "
+            "Hermes cannot machine-verify account identity)",
+            provider=PROVIDER,
+            code="shared_attestation_required",
+        )
+    # Already valid shared → revalidate, no write.
+    try:
+        state = read_scope_state()
+        if state.mode == "shared":
+            with root_auth_lock():
+                store = load_root_auth_strict()
+                pool = get_shared_namespace(store)
+                validate_shared_pool(pool or {}, require_three=True)
+            return state.epoch or ""
+    except AuthError as exc:
+        if getattr(exc, "code", "") == "shared_scope_corrupt":
+            raise
+        # Fall through if pool invalid while marker present → exit 1
+        if is_shared_scope_active():
+            raise
+
+    with _inprocess_pool_lock:
+        with root_auth_lock():
+            store = load_root_auth_strict()
+            pool = get_shared_namespace(store)
+            if pool is None:
+                raise AuthError(
+                    "Stage exactly three OAuth grants with: hermes auth add anthropic --type oauth --shared",
+                    provider=PROVIDER,
+                    code="shared_pool_empty",
+                )
+            pool["account_distinctness_attested"] = True
+            pool["account_distinctness_attested_at"] = _utc_now_rfc3339()
+            pool["revision"] = int(pool["revision"]) + 1
+            set_shared_namespace(store, validate_shared_pool(pool, require_three=True))
+            save_root_auth_strict(store)
+            # Marker last.
+            epoch = write_scope_marker()
+            return epoch
+
+
+def disable_shared_scope(*, capability: SharedMutationCapability) -> None:
+    _require_capability(capability)
+    # Marker first.
+    remove_scope_marker()
+
+
+def clear_shared_namespace(*, capability: SharedMutationCapability) -> None:
+    _require_capability(capability)
+    with _inprocess_pool_lock:
+        with root_auth_lock():
+            # Ensure marker already gone for logout; if still present remove.
+            if scope_marker_path().exists() or scope_marker_path().is_symlink():
+                remove_scope_marker()
+            store = load_root_auth_strict()
+            set_shared_namespace(store, None)
+            save_root_auth_strict(store)
+
+
+def repair_malformed_marker(*, yes: bool, capability: SharedMutationCapability) -> Path:
+    _require_capability(capability)
+    path = scope_marker_path()
+    if not path.exists() and not path.is_symlink():
+        raise AuthError("No scope marker to repair", provider=PROVIDER, code="shared_marker_missing")
+    if not yes and not sys_stdin_is_tty():
+        raise AuthError(
+            "repair requires --yes on non-TTY",
+            provider=PROVIDER,
+            code="shared_repair_needs_yes",
+        )
+    with root_auth_lock():
+        _ensure_owner_only_dir(recovery_dir())
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        backup = recovery_dir() / f"{ts}-anthropic-scope.json"
+        # Read raw bytes without following if possible
+        raw = path.read_bytes() if path.exists() else b""
+        _atomic_write_bytes(backup, raw)
+        # Remove marker by inode check
+        _path_is_safe_regular_file(path, must_exist=True)
+        st = path.lstat()
+        path.unlink()
+        _fsync_dir(path.parent)
+        logger.info("Repaired Anthropic scope marker; forensic backup id=%s nlink_was=%s", backup.name, st.st_nlink)
+        return backup
+
+
+def sys_stdin_is_tty() -> bool:
+    try:
+        return bool(os.isatty(0))
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Redacted listing
+# ---------------------------------------------------------------------------
+
+
+def redact_row(row: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "id": row["id"],
+        "label": row["label"],
+        "priority": row["priority"],
+        "token_generation": row["token_generation"],
+        "last_status": row["last_status"],
+        "last_error_reason": row["last_error_reason"],
+        "expires_at_ms": row["expires_at_ms"],
+        "oauth_token_endpoint": row["oauth_token_endpoint"],
+        "grant_fingerprint_prefix": row["grant_fingerprint"][:20] + "…",
+        "has_refresh_attempt": row.get("refresh_attempt") is not None,
+    }
+
+
+def list_redacted(*, require_active: bool = False) -> Dict[str, Any]:
+    state = read_scope_state()
+    with root_auth_lock():
+        store = load_root_auth_strict()
+        pool = get_shared_namespace(store)
+        if state.mode == "shared":
+            pool = validate_shared_pool(pool or {}, require_three=True)
+        elif pool is not None:
+            pool = validate_shared_pool(pool)
+        else:
+            pool = empty_shared_pool()
+    return {
+        "scope": state.mode,
+        "epoch": state.epoch,
+        "revision": pool["revision"],
+        "strategy": pool["strategy"],
+        "account_distinctness_attested": pool["account_distinctness_attested"],
+        "entries": [redact_row(e) for e in pool["entries"]],
+        "root_auth": str(root_auth_path()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Backup / restore (shared)
+# ---------------------------------------------------------------------------
+
+BACKUP_ARCHIVE_VERSION = 1
+
+
+def create_shared_backup(output: Path, *, capability: SharedMutationCapability) -> Path:
+    _require_capability(capability)
+    output = Path(output)
+    if not output.is_absolute():
+        raise AuthError("backup output must be an absolute path", provider=PROVIDER, code="shared_backup_path")
+    import tarfile
+    import io
+
+    with root_auth_lock():
+        store = load_root_auth_strict()
+        pool = get_shared_namespace(store)
+        marker = None
+        try:
+            st = read_scope_state()
+            if st.mode == "shared" and st.raw:
+                marker = st.raw
+        except AuthError:
+            marker = None
+        salt = None
+        sp = grant_salt_path()
+        if sp.exists():
+            _path_is_safe_regular_file(sp, must_exist=True)
+            salt = sp.read_bytes().hex()
+        # Auth data before marker in manifest.
+        manifest = {
+            "version": BACKUP_ARCHIVE_VERSION,
+            "created_at": _utc_now_rfc3339(),
+            "shared_credential_pools": {"anthropic": pool} if pool else {},
+            "grant_salt_hex": salt,
+            "marker": marker,
+        }
+        payload = json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
+        _ensure_owner_only_dir(output.parent)
+        tmp = output.with_suffix(output.suffix + f".tmp.{os.getpid()}")
+        try:
+            with tarfile.open(tmp, "w:gz") as tar:
+                info = tarfile.TarInfo(name="manifest.json")
+                info.size = len(payload)
+                info.mode = 0o600
+                tar.addfile(info, io.BytesIO(payload))
+            os.replace(str(tmp), str(output))
+            try:
+                output.chmod(0o600)
+            except OSError:
+                pass
+            _fsync_dir(output.parent)
+        finally:
+            try:
+                if tmp.exists():
+                    tmp.unlink()
+            except OSError:
+                pass
+    return output
+
+
+def restore_shared_backup(input_path: Path, *, yes: bool, capability: SharedMutationCapability) -> None:
+    _require_capability(capability)
+    if not yes:
+        raise AuthError("restore requires --yes", provider=PROVIDER, code="shared_restore_needs_yes")
+    input_path = Path(input_path)
+    if not input_path.is_absolute():
+        raise AuthError("restore input must be absolute", provider=PROVIDER, code="shared_backup_path")
+    _path_is_safe_regular_file(input_path, must_exist=True)
+    import tarfile
+    import tempfile
+
+    with tarfile.open(input_path, "r:gz") as tar:
+        members = tar.getmembers()
+        if len(members) != 1 or members[0].name != "manifest.json":
+            raise AuthError("malformed shared backup archive", provider=PROVIDER, code="shared_backup_corrupt")
+        extracted = tar.extractfile(members[0])
+        if extracted is None:
+            raise AuthError("malformed shared backup archive", provider=PROVIDER, code="shared_backup_corrupt")
+        manifest = json.loads(extracted.read().decode("utf-8"))
+    if not isinstance(manifest, dict) or manifest.get("version") != BACKUP_ARCHIVE_VERSION:
+        raise AuthError("unsupported backup version", provider=PROVIDER, code="shared_backup_corrupt")
+
+    with _inprocess_pool_lock:
+        with root_auth_lock():
+            # Marker first removal.
+            if scope_marker_path().exists() or scope_marker_path().is_symlink():
+                remove_scope_marker()
+            store = load_root_auth_strict()
+            scp = manifest.get("shared_credential_pools") or {}
+            pool = scp.get("anthropic")
+            if pool is not None:
+                set_shared_namespace(store, validate_shared_pool(pool))
+            else:
+                set_shared_namespace(store, None)
+            save_root_auth_strict(store)
+            salt_hex = manifest.get("grant_salt_hex")
+            if isinstance(salt_hex, str) and salt_hex:
+                _atomic_write_bytes(grant_salt_path(), bytes.fromhex(salt_hex))
+            marker = manifest.get("marker")
+            if isinstance(marker, dict) and marker.get("scope") == "shared":
+                # Publish marker last.
+                _atomic_write_json(scope_marker_path(), marker)
+
+
+def refuse_generic_backup_if_shared() -> None:
+    if has_dormant_or_active_shared_state():
+        raise AuthError(
+            "Anthropic shared pool state detected. "
+            "Use `hermes auth backup anthropic --shared --output <path>` "
+            "(and matching restore). Generic backup/import refused.",
+            provider=PROVIDER,
+            code="shared_blocks_generic_backup",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Gateway PID discovery (best-effort)
+# ---------------------------------------------------------------------------
+
+
+def discover_live_gateway_pids() -> List[int]:
+    """Best-effort discovery of live gateway PIDs (not a safety boundary)."""
+    pids: List[int] = []
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        root = get_default_hermes_root()
+        candidates = [root / "gateway.pid"]
+        profiles = root / "profiles"
+        if profiles.is_dir():
+            for child in profiles.iterdir():
+                if child.is_dir():
+                    candidates.append(child / "gateway.pid")
+        for pid_path in candidates:
+            if not pid_path.exists() or pid_path.is_symlink():
+                continue
+            try:
+                raw = json.loads(pid_path.read_text(encoding="utf-8"))
+                pid = raw.get("pid") if isinstance(raw, dict) else None
+                if isinstance(pid, int) and pid > 0:
+                    os.kill(pid, 0)
+                    pids.append(pid)
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return pids
+
+
+def require_no_live_gateways_for_scope_change() -> None:
+    pids = discover_live_gateway_pids()
+    if pids:
+        raise AuthError(
+            f"Stop discoverable Hermes gateways before changing Anthropic scope "
+            f"(live PIDs: {pids}). Process discovery is best-effort; epoch preflight remains mandatory.",
+            provider=PROVIDER,
+            code="shared_gateways_live",
+        )

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2802,22 +2802,48 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
     except ImportError:
         return None, None
 
-    pool_present, entry = _select_pool_entry("anthropic")
-    if pool_present and entry is not None:
-        token = explicit_api_key or _pool_runtime_api_key(entry)
+    # Shared Anthropic scope: authoritative resolver only (ignores explicit keys).
+    try:
+        from agent.anthropic_shared_pool import is_shared_scope_active
+
+        if is_shared_scope_active():
+            token = resolve_anthropic_token(
+                explicit_api_key=explicit_api_key,
+                provider="anthropic",
+                purpose="inference",
+            )
+            entry = None
+            pool_present = False
+            if not token:
+                return None, None
+            # Fall through to client construction below with token set.
+            base_url = _ANTHROPIC_DEFAULT_BASE_URL
+            # Jump by setting a flag.
+            _shared_resolved = True
+        else:
+            _shared_resolved = False
+    except Exception:
+        _shared_resolved = False
+
+    if not _shared_resolved:
+        pool_present, entry = _select_pool_entry("anthropic")
+        if pool_present and entry is not None:
+            token = resolve_anthropic_token(explicit_api_key=explicit_api_key) or _pool_runtime_api_key(entry)
+        else:
+            # Pool absent, OR pool present but no usable entry (expired token +
+            # stale refresh_token, all entries exhausted, etc). Fall through to the
+            # legacy resolver instead of hard-failing: a temporarily dead pool
+            # entry must not wedge auxiliary tasks when a valid standalone
+            # credential (ANTHROPIC_TOKEN, credentials file, API key) exists. This
+            # matches the openrouter and codex paths, which already fall back to
+            # their env/auth-store credential on (True, None). Without this, the
+            # goal judge and every other Anthropic-routed side channel died with
+            # "no auxiliary client configured" while the main session stayed
+            # healthy (it resolves the env token directly).
+            entry = None
+            token = resolve_anthropic_token(explicit_api_key=explicit_api_key)
     else:
-        # Pool absent, OR pool present but no usable entry (expired token +
-        # stale refresh_token, all entries exhausted, etc). Fall through to the
-        # legacy resolver instead of hard-failing: a temporarily dead pool
-        # entry must not wedge auxiliary tasks when a valid standalone
-        # credential (ANTHROPIC_TOKEN, credentials file, API key) exists. This
-        # matches the openrouter and codex paths, which already fall back to
-        # their env/auth-store credential on (True, None). Without this, the
-        # goal judge and every other Anthropic-routed side channel died with
-        # "no auxiliary client configured" while the main session stayed
-        # healthy (it resolves the env token directly).
-        entry = None
-        token = explicit_api_key or resolve_anthropic_token()
+        pool_present, entry = False, None
     if not token:
         return None, None
 
@@ -3734,6 +3760,25 @@ def _refresh_provider_credentials(provider: str) -> bool:
             return True
         if normalized == "anthropic":
             from agent.anthropic_adapter import read_claude_code_credentials, _refresh_oauth_token, resolve_anthropic_token
+            try:
+                from agent.anthropic_shared_pool import is_shared_scope_active, load_pool as _noop
+                from agent.credential_pool import load_pool as load_cred_pool
+
+                if is_shared_scope_active():
+                    pool = load_cred_pool("anthropic")
+                    if pool and pool.has_credentials():
+                        pool.select()
+                        refreshed = pool.try_refresh_current()
+                        if refreshed is not None and str(getattr(refreshed, "runtime_api_key", "") or "").strip():
+                            _evict_cached_clients(normalized)
+                            return True
+                    token = resolve_anthropic_token(provider="anthropic")
+                    if not str(token or "").strip():
+                        return False
+                    _evict_cached_clients(normalized)
+                    return True
+            except Exception:
+                pass
 
             creds = read_claude_code_credentials()
             token = _refresh_oauth_token(creds) if isinstance(creds, dict) and creds.get("refreshToken") else None

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1764,7 +1764,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if fb_api_mode == "anthropic_messages":
             # Build native Anthropic client instead of using OpenAI client
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
-            effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
+            effective_key = (resolve_anthropic_token(explicit_api_key=fb_client.api_key, provider=fb_provider) or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
             agent.api_key = effective_key
             agent._anthropic_api_key = effective_key
             agent._anthropic_base_url = fb_base_url

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -618,6 +618,23 @@ class CredentialPool:
                 return
 
     def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
+        # Shared Anthropic scope: never re-materialize root rows into a profile
+        # credential_pool via the legacy writer.
+        if self.provider == "anthropic":
+            try:
+                from agent.anthropic_shared_pool import is_shared_scope_active
+
+                if is_shared_scope_active():
+                    raise auth_mod.AuthError(
+                        "Shared Anthropic pool mutations require explicit "
+                        "`hermes auth ... --shared` commands",
+                        provider="anthropic",
+                        code="shared_mutation_forbidden",
+                    )
+            except auth_mod.AuthError:
+                raise
+            except Exception:
+                pass
         write_credential_pool(
             self.provider,
             [entry.to_dict() for entry in self._entries],
@@ -1084,15 +1101,48 @@ class CredentialPool:
                 self._mark_exhausted(entry, None)
             return None
 
-        # Codex and xAI OAuth refresh tokens are single-use.  The
-        # sync→POST→write-back sequence below must run atomically across Hermes
-        # processes: otherwise two processes can both adopt the same on-disk
-        # token, both POST it, and the loser gets ``refresh_token_reused``.
-        # Serialize the whole sequence through the shared cross-process
-        # auth-store flock (the same lock and extended-timeout pattern used by
-        # resolve_codex_runtime_credentials()).  When a waiter finally acquires
-        # the lock, the in-lock re-sync below picks up the rotated token the
-        # winner persisted and skips the POST.
+        # Codex, xAI, and shared Anthropic OAuth refresh tokens are single-use.
+        # The sync→POST→write-back sequence below must run atomically across
+        # Hermes processes: otherwise two processes can both adopt the same
+        # on-disk token, both POST it, and the loser gets
+        # ``refresh_token_reused``. Serialize the whole sequence through the
+        # shared cross-process auth-store flock (the same lock and
+        # extended-timeout pattern used by resolve_codex_runtime_credentials()).
+        # When a waiter finally acquires the lock, the in-lock re-sync below
+        # picks up the rotated token the winner persisted and skips the POST.
+        if self.provider == "anthropic":
+            try:
+                from agent.anthropic_shared_pool import (
+                    commit_refresh,
+                    is_shared_scope_active,
+                )
+
+                if is_shared_scope_active():
+                    expected_gen = int(
+                        getattr(entry, "token_generation", None)
+                        or (entry.extra or {}).get("token_generation")
+                        or 1
+                    )
+                    updated = commit_refresh(
+                        entry.id, expected_generation=expected_gen
+                    )
+                    refreshed = replace(
+                        entry,
+                        access_token=updated["access_token"],
+                        refresh_token=updated["refresh_token"],
+                        expires_at_ms=updated["expires_at_ms"],
+                        last_refresh=updated.get("last_refresh"),
+                    )
+                    # Keep generation on extra for lease keying.
+                    refreshed.extra = dict(refreshed.extra or {})
+                    refreshed.extra["token_generation"] = updated["token_generation"]
+                    self._replace_entry(entry, refreshed)
+                    return refreshed
+            except auth_mod.AuthError:
+                raise
+            except Exception:
+                pass
+
         if self.provider in ("openai-codex", "xai-oauth"):
             sync_entry = (
                 self._sync_codex_entry_from_auth_store
@@ -2586,6 +2636,73 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
+
+    # Shared Anthropic OAuth scope: root shared namespace only; no seeding,
+    # no profile write-through, no env/Claude-Code rows.
+    if provider == "anthropic":
+        try:
+            from agent.anthropic_shared_pool import (
+                is_shared_scope_active,
+                load_root_auth_strict,
+                get_shared_namespace,
+                root_auth_lock,
+                validate_shared_pool,
+            )
+
+            if is_shared_scope_active():
+                with root_auth_lock():
+                    store = load_root_auth_strict()
+                    pool = get_shared_namespace(store)
+                    pool = validate_shared_pool(pool or {}, require_three=True)
+                entries = []
+                for payload in pool["entries"]:
+                    # Map shared schema → PooledCredential without persisting.
+                    pc = PooledCredential.from_dict(
+                        "anthropic",
+                        {
+                            "id": payload["id"],
+                            "label": payload["label"],
+                            "auth_type": AUTH_TYPE_OAUTH,
+                            "priority": payload["priority"],
+                            "source": payload["source"],
+                            "access_token": payload["access_token"],
+                            "refresh_token": payload["refresh_token"],
+                            "expires_at_ms": payload["expires_at_ms"],
+                            "last_status": payload.get("last_status"),
+                            "last_status_at": payload.get("last_status_at"),
+                            "last_error_code": payload.get("last_error_code"),
+                            "last_error_reason": payload.get("last_error_reason"),
+                            "last_error_message": payload.get("last_error_message"),
+                            "last_error_reset_at": payload.get("last_error_reset_at"),
+                            "last_refresh": payload.get("last_refresh"),
+                            "request_count": payload.get("request_count", 0),
+                            "token_generation": payload.get("token_generation"),
+                            "oauth_token_endpoint": payload.get("oauth_token_endpoint"),
+                            "grant_fingerprint": payload.get("grant_fingerprint"),
+                        },
+                    )
+                    entries.append(pc)
+                return CredentialPool("anthropic", entries)
+        except Exception as exc:
+            from hermes_cli.auth import AuthError
+
+            if isinstance(exc, AuthError):
+                raise
+            # If marker present but import failed, fail closed.
+            try:
+                from agent.anthropic_shared_pool import scope_marker_path
+
+                if scope_marker_path().exists() or scope_marker_path().is_symlink():
+                    raise AuthError(
+                        f"Shared Anthropic pool load failed: {exc}",
+                        provider="anthropic",
+                        code="shared_pool_load_failed",
+                    ) from exc
+            except AuthError:
+                raise
+            except Exception:
+                pass
+
     raw_entries = read_credential_pool(provider)
     disk_ids = {
         entry.get("id")

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -46,6 +46,11 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Top-level Anthropic PKCE credential store remains sensitive even
             # when a profile is active; default/non-profile sessions still read it.
             str(hermes_root / ".anthropic_oauth.json"),
+            # Shared Anthropic OAuth scope control plane (root only).
+            str(hermes_root / "shared" / "anthropic_pool_scope.json"),
+            str(hermes_root / "shared" / "anthropic_grant_salt"),
+            str(hermes_root / "auth.json"),
+            str(hermes_root / "auth.lock"),
             # Bitwarden Secrets Manager encrypted disk cache.
             str(hermes_home / "cache" / "bws_cache.enc.json"),
             str(hermes_root / "cache" / "bws_cache.enc.json"),
@@ -282,6 +287,11 @@ def get_read_block_error(path: str) -> Optional[str]:
         # to avoid re-fetching across back-to-back CLI invocations. The file
         # was introduced by #31968 but not added to this guard.
         os.path.join("cache", "bws_cache.json"),
+        # Machine-wide Anthropic shared OAuth scope marker + grant salt.
+        # Not secret material for the salt alone, but controls credential blast
+        # radius and must not be agent-writable/readable via file tools.
+        os.path.join("shared", "anthropic_pool_scope.json"),
+        os.path.join("shared", "anthropic_grant_salt"),
     )
     for hd in hermes_dirs:
         for name in credential_file_names:

--- a/hermes_cli/anthropic_shared_auth.py
+++ b/hermes_cli/anthropic_shared_auth.py
@@ -1,0 +1,265 @@
+"""CLI handlers for machine-wide Anthropic shared OAuth pool."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from hermes_cli.auth import AuthError
+
+
+def _cap():
+    from agent.anthropic_shared_pool import get_shared_mutation_capability
+
+    return get_shared_mutation_capability()
+
+
+def _exit_auth_error(exc: AuthError) -> None:
+    print(f"error: {exc}", file=sys.stderr)
+    code = getattr(exc, "code", "") or ""
+    if code in {
+        "shared_mutation_forbidden",
+        "shared_add_while_active",
+        "shared_remove_while_active",
+        "shared_pool_full",
+        "shared_repair_needs_yes",
+        "shared_restore_needs_yes",
+        "shared_gateways_live",
+    }:
+        raise SystemExit(2)
+    raise SystemExit(1)
+
+
+def _shared_flag(args: Any) -> bool:
+    return bool(getattr(args, "shared", False))
+
+
+def guard_unscoped_anthropic_mutation(provider: str, *, shared: bool, verb: str) -> None:
+    """Refuse unscoped Anthropic mutations while shared scope is active."""
+    if (provider or "").strip().lower() != "anthropic":
+        return
+    from agent.anthropic_shared_pool import is_shared_scope_active
+
+    try:
+        active = is_shared_scope_active()
+    except AuthError as exc:
+        _exit_auth_error(exc)
+        return
+    if active and not shared:
+        print(
+            f"error: Anthropic shared scope is active. "
+            f"Use: hermes auth {verb} anthropic ... --shared",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+
+def auth_scope_command(args: Any) -> None:
+    from agent import anthropic_shared_pool as sp
+
+    provider = (getattr(args, "provider", "") or "").strip().lower()
+    if provider != "anthropic":
+        print("error: only provider 'anthropic' is supported for auth scope v1", file=sys.stderr)
+        raise SystemExit(2)
+    mode = (getattr(args, "scope_mode", None) or "").strip().lower()
+    try:
+        if not mode:
+            state = sp.read_scope_state()
+            print(f"provider: anthropic")
+            print(f"scope: {state.mode}")
+            if state.epoch:
+                print(f"epoch: {state.epoch}")
+            print(f"marker: {sp.scope_marker_path()}")
+            print(f"root_auth: {sp.root_auth_path()}")
+            return
+        if mode == "shared":
+            if not getattr(args, "attest_distinct_accounts", False):
+                print(
+                    "error: enabling shared scope requires --attest-distinct-accounts\n"
+                    "(operator attestation that the three browser sessions used different "
+                    "Anthropic accounts; Hermes cannot machine-verify account identity)",
+                    file=sys.stderr,
+                )
+                raise SystemExit(2)
+            # Already-valid shared revalidates without requiring gateways stopped.
+            already = False
+            try:
+                st = sp.read_scope_state()
+                already = st.mode == "shared"
+            except AuthError:
+                already = False
+            if not already:
+                sp.require_no_live_gateways_for_scope_change()
+            epoch = sp.enable_shared_scope(
+                attest_distinct_accounts=True,
+                capability=_cap(),
+            )
+            print(f"scope: shared")
+            print(f"epoch: {epoch}")
+            print("Restart all Hermes gateways/workers to pick up the new scope.")
+            return
+        if mode == "profile":
+            sp.require_no_live_gateways_for_scope_change()
+            sp.disable_shared_scope(capability=_cap())
+            print("scope: profile")
+            print("Shared marker removed; root grants remain dormant for rollback.")
+            print("Restart all Hermes gateways/workers.")
+            return
+        if mode == "repair":
+            path = sp.repair_malformed_marker(
+                yes=bool(getattr(args, "yes", False)),
+                capability=_cap(),
+            )
+            print(f"marker repaired; forensic backup: {path}")
+            return
+        print(f"error: unknown scope mode {mode!r}", file=sys.stderr)
+        raise SystemExit(2)
+    except AuthError as exc:
+        _exit_auth_error(exc)
+
+
+def auth_backup_shared_command(args: Any) -> None:
+    from agent import anthropic_shared_pool as sp
+
+    provider = (getattr(args, "provider", "") or "").strip().lower()
+    if provider != "anthropic" or not _shared_flag(args):
+        print("error: use: hermes auth backup anthropic --shared --output <abs-path>", file=sys.stderr)
+        raise SystemExit(2)
+    out = getattr(args, "output", None)
+    if not out:
+        print("error: --output is required", file=sys.stderr)
+        raise SystemExit(2)
+    try:
+        path = sp.create_shared_backup(Path(out), capability=_cap())
+        print(f"shared backup written: {path}")
+    except AuthError as exc:
+        _exit_auth_error(exc)
+
+
+def auth_restore_shared_command(args: Any) -> None:
+    from agent import anthropic_shared_pool as sp
+
+    provider = (getattr(args, "provider", "") or "").strip().lower()
+    if provider != "anthropic" or not _shared_flag(args):
+        print("error: use: hermes auth restore anthropic --shared --input <abs-path> --yes", file=sys.stderr)
+        raise SystemExit(2)
+    inp = getattr(args, "input", None)
+    if not inp:
+        print("error: --input is required", file=sys.stderr)
+        raise SystemExit(2)
+    try:
+        sp.require_no_live_gateways_for_scope_change()
+        sp.restore_shared_backup(
+            Path(inp),
+            yes=bool(getattr(args, "yes", False)),
+            capability=_cap(),
+        )
+        print("shared backup restored")
+    except AuthError as exc:
+        _exit_auth_error(exc)
+
+
+def add_shared_oauth_grant(args: Any) -> None:
+    """Stage a dormant shared OAuth grant (profile scope only)."""
+    from agent import anthropic_shared_pool as sp
+    from agent import anthropic_adapter as anthropic_mod
+
+    try:
+        if sp.is_shared_scope_active():
+            print(
+                "error: cannot add while shared scope is active "
+                "(switch to profile scope first)",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        pool = sp.load_shared_pool_for_management()
+        if len(pool["entries"]) >= 3:
+            print("error: shared pool already has 3 grants", file=sys.stderr)
+            raise SystemExit(2)
+        creds = anthropic_mod.run_hermes_oauth_login_pure()
+        if not creds:
+            raise SystemExit("Anthropic OAuth login did not return credentials.")
+        # Endpoint recorded by login — prefer platform.
+        endpoint = sp.ENDPOINT_PLATFORM
+        endpoint_url = creds.get("token_endpoint") or creds.get("oauth_token_endpoint")
+        if isinstance(endpoint_url, str):
+            mapped = sp.URL_TO_ENDPOINT.get(endpoint_url.strip())
+            if mapped:
+                endpoint = mapped
+            elif endpoint_url in sp.ENDPOINT_URLS:
+                endpoint = endpoint_url
+        label = (getattr(args, "label", None) or "").strip()
+        if not label:
+            label = f"Anthropic account {len(pool['entries']) + 1}"
+        row = sp.new_shared_row(
+            access_token=creds["access_token"],
+            refresh_token=creds["refresh_token"],
+            expires_at_ms=int(creds["expires_at_ms"]),
+            oauth_token_endpoint=endpoint,
+            label=label,
+            priority=len(pool["entries"]),
+            initial_refresh_token=creds["refresh_token"],
+        )
+        stored = sp.append_row(row, capability=_cap())
+        print(f'Added shared Anthropic OAuth grant: "{stored["label"]}" id={stored["id"]}')
+        print("Grant is dormant until: hermes auth scope anthropic shared --attest-distinct-accounts")
+    except AuthError as exc:
+        _exit_auth_error(exc)
+
+
+def remove_shared_grant(args: Any) -> None:
+    from agent import anthropic_shared_pool as sp
+
+    try:
+        sp.remove_row(str(getattr(args, "target", "")), capability=_cap())
+        print("Removed shared staged grant")
+    except AuthError as exc:
+        _exit_auth_error(exc)
+
+
+def reset_shared_statuses(args: Any) -> None:
+    from agent import anthropic_shared_pool as sp
+
+    try:
+        n = sp.reset_statuses(capability=_cap())
+        print(f"Reset recoverable exhaustion on {n} shared Anthropic credentials")
+    except AuthError as exc:
+        _exit_auth_error(exc)
+
+
+def logout_shared(args: Any) -> None:
+    from agent import anthropic_shared_pool as sp
+
+    try:
+        sp.clear_shared_namespace(capability=_cap())
+        print("Shared Anthropic scope disabled and root shared namespace cleared")
+    except AuthError as exc:
+        _exit_auth_error(exc)
+
+
+def print_shared_list_status() -> bool:
+    """If shared scope active, print redacted shared status and return True."""
+    from agent import anthropic_shared_pool as sp
+
+    try:
+        if not sp.is_shared_scope_active():
+            # Still show dormant staging info when listing anthropic?
+            return False
+        info = sp.list_redacted(require_active=True)
+    except AuthError as exc:
+        _exit_auth_error(exc)
+        return True
+    print(f"anthropic shared scope (revision={info['revision']}, strategy={info['strategy']}):")
+    print(f"  root: {info['root_auth']}")
+    print(f"  epoch: {info.get('epoch')}")
+    print(f"  attested: {info['account_distinctness_attested']}")
+    for i, e in enumerate(info["entries"], start=1):
+        status = e.get("last_status") or "ok"
+        print(
+            f"  #{i}  {e['label']:<20} gen={e['token_generation']} "
+            f"status={status} id={e['id']}"
+        )
+    print()
+    return True

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -484,16 +484,46 @@ except Exception:
 # =============================================================================
 
 def get_anthropic_key() -> str:
-    """Return the first usable Anthropic credential, or ``""``.
+    """Return the first usable Anthropic credential, or empty string.
 
-    Checks both the ``.env`` file and the process environment, preferring
-    ``~/.hermes/.env`` so a deliberate key rotation isn't shadowed by a stale
-    shell export (matches the api-key resolution path — see #20591).  The
-    order mirrors the ``PROVIDER_REGISTRY["anthropic"].api_key_env_vars``
+    When Anthropic shared OAuth scope is active for the official API, resolves
+    only through the shared root pool (never copies tokens into config).
+
+    Legacy path checks both the ``.env`` file and the process environment,
+    preferring ``~/.hermes/.env`` so a deliberate key rotation isn't shadowed
+    by a stale shell export (matches the api-key resolution path — see #20591).
+    The order mirrors the ``PROVIDER_REGISTRY["anthropic"].api_key_env_vars``
     tuple:
 
         ANTHROPIC_API_KEY -> ANTHROPIC_TOKEN -> CLAUDE_CODE_OAUTH_TOKEN
     """
+    try:
+        from agent.anthropic_shared_pool import (
+            is_official_anthropic_oauth_target,
+            is_shared_scope_active,
+            resolve_shared_anthropic_credential,
+        )
+
+        if is_shared_scope_active() and is_official_anthropic_oauth_target(
+            "anthropic", "inference", None, None
+        ):
+            ctx = resolve_shared_anthropic_credential(
+                provider="anthropic", purpose="inference"
+            )
+            return ctx.access_token
+    except AuthError:
+        raise
+    except Exception:
+        try:
+            from agent.anthropic_shared_pool import is_shared_scope_active
+
+            if is_shared_scope_active():
+                raise
+        except AuthError:
+            raise
+        except Exception:
+            pass
+
     from hermes_cli.config import get_env_value_prefer_dotenv
 
     for var in PROVIDER_REGISTRY["anthropic"].api_key_env_vars:
@@ -8701,6 +8731,17 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
 def logout_command(args) -> None:
     """Clear auth state for a provider."""
     provider_id = getattr(args, "provider", None)
+    shared = bool(getattr(args, "shared", False))
+
+    if (provider_id or "").strip().lower() == "anthropic":
+        from hermes_cli.anthropic_shared_auth import (
+            guard_unscoped_anthropic_mutation,
+            logout_shared,
+        )
+        guard_unscoped_anthropic_mutation("anthropic", shared=shared, verb="logout")
+        if shared:
+            logout_shared(args)
+            return
 
     if provider_id and not is_known_auth_provider(provider_id):
         print(f"Unknown provider: {provider_id}")

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -222,6 +222,19 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "anthropic":
+        from hermes_cli.anthropic_shared_auth import (
+            add_shared_oauth_grant,
+            guard_unscoped_anthropic_mutation,
+        )
+
+        shared = bool(getattr(args, "shared", False))
+        guard_unscoped_anthropic_mutation(provider, shared=shared, verb="add")
+        if shared:
+            if requested_type != AUTH_TYPE_OAUTH:
+                raise SystemExit("Shared Anthropic pool accepts OAuth only (no API keys).")
+            add_shared_oauth_grant(args)
+            return
+
         from agent import anthropic_adapter as anthropic_mod
 
         creds = anthropic_mod.run_hermes_oauth_login_pure()
@@ -436,6 +449,27 @@ def auth_add_command(args) -> None:
 
 def auth_list_command(args) -> None:
     provider_filter = _normalize_provider(getattr(args, "provider", "") or "")
+    from hermes_cli.anthropic_shared_auth import print_shared_list_status
+    if (not provider_filter or provider_filter == "anthropic") and (
+        getattr(args, "shared", False) or print_shared_list_status()
+    ):
+        if provider_filter == "anthropic" or getattr(args, "shared", False):
+            # print_shared_list_status already printed when active; if --shared
+            # forced, try again for dormant listing.
+            try:
+                from agent.anthropic_shared_pool import is_shared_scope_active, list_redacted
+                if is_shared_scope_active() or getattr(args, "shared", False):
+                    if not is_shared_scope_active():
+                        info = list_redacted(require_active=False)
+                        print(f"anthropic shared staging (scope=profile, revision={info['revision']}):")
+                        for i, e in enumerate(info["entries"], start=1):
+                            print(f"  #{i}  {e['label']:<20} id={e['id']}")
+                        print()
+                    if provider_filter == "anthropic":
+                        return
+            except Exception:
+                if provider_filter == "anthropic" and getattr(args, "shared", False):
+                    raise
     if provider_filter:
         providers = [provider_filter]
     else:
@@ -466,6 +500,15 @@ def auth_remove_command(args) -> None:
     target = getattr(args, "target", None)
     if target is None:
         target = getattr(args, "index", None)
+    from hermes_cli.anthropic_shared_auth import (
+        guard_unscoped_anthropic_mutation,
+        remove_shared_grant,
+    )
+    shared = bool(getattr(args, "shared", False))
+    guard_unscoped_anthropic_mutation(provider, shared=shared, verb="remove")
+    if provider == "anthropic" and shared:
+        remove_shared_grant(args)
+        return
     pool = load_pool(provider)
     index, matched, error = pool.resolve_target(target)
     if matched is None or index is None:
@@ -501,6 +544,15 @@ def auth_remove_command(args) -> None:
 
 def auth_reset_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
+    from hermes_cli.anthropic_shared_auth import (
+        guard_unscoped_anthropic_mutation,
+        reset_shared_statuses,
+    )
+    shared = bool(getattr(args, "shared", False))
+    guard_unscoped_anthropic_mutation(provider, shared=shared, verb="reset")
+    if provider == "anthropic" and shared:
+        reset_shared_statuses(args)
+        return
     pool = load_pool(provider)
     count = pool.reset_statuses()
     print(f"Reset status on {count} {provider} credentials")
@@ -527,6 +579,17 @@ def auth_status_command(args) -> None:
 
 
 def auth_logout_command(args) -> None:
+    provider = _normalize_provider(getattr(args, "provider", "") or "")
+    from hermes_cli.anthropic_shared_auth import (
+        guard_unscoped_anthropic_mutation,
+        logout_shared,
+    )
+    shared = bool(getattr(args, "shared", False))
+    if provider == "anthropic":
+        guard_unscoped_anthropic_mutation(provider, shared=shared, verb="logout")
+        if shared:
+            logout_shared(args)
+            return
     auth_mod.logout_command(SimpleNamespace(provider=getattr(args, "provider", None)))
 
 
@@ -769,6 +832,20 @@ def _interactive_strategy() -> None:
     pool_strategies = cfg.get("credential_pool_strategies") or {}
     if not isinstance(pool_strategies, dict):
         pool_strategies = {}
+    if provider == "anthropic":
+        try:
+            from agent.anthropic_shared_pool import is_shared_scope_active
+            if is_shared_scope_active():
+                print(
+                    "error: Anthropic shared scope forces fill_first; "
+                    "strategy config is ignored at runtime and not rewritten.",
+                    file=sys.stderr,
+                )
+                raise SystemExit(2)
+        except SystemExit:
+            raise
+        except Exception:
+            pass
     pool_strategies[provider] = strategy
     cfg["credential_pool_strategies"] = pool_strategies
     save_config(cfg)
@@ -797,6 +874,18 @@ def auth_command(args) -> None:
         return
     if action == "spotify":
         auth_spotify_command(args)
+        return
+    if action == "scope":
+        from hermes_cli.anthropic_shared_auth import auth_scope_command
+        auth_scope_command(args)
+        return
+    if action == "backup":
+        from hermes_cli.anthropic_shared_auth import auth_backup_shared_command
+        auth_backup_shared_command(args)
+        return
+    if action == "restore":
+        from hermes_cli.anthropic_shared_auth import auth_restore_shared_command
+        auth_restore_shared_command(args)
         return
     # No subcommand — launch interactive mode
     _interactive_auth()

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -298,6 +298,15 @@ def _format_size(nbytes: int) -> str:
 
 def run_backup(args) -> None:
     """Create a zip backup of the Hermes home directory."""
+    try:
+        from agent.anthropic_shared_pool import refuse_generic_backup_if_shared
+        refuse_generic_backup_if_shared()
+    except Exception as exc:
+        from hermes_cli.auth import AuthError
+        if isinstance(exc, AuthError):
+            print(f"error: {exc}", file=sys.stderr)
+            raise SystemExit(1)
+        raise
     hermes_root = get_default_hermes_root()
 
     if not hermes_root.is_dir():

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3011,7 +3011,7 @@ def _fetch_anthropic_models(
     except ImportError:
         return None
 
-    token = (api_key or "").strip() or resolve_anthropic_token()
+    token = resolve_anthropic_token(explicit_api_key=api_key, purpose="model_discovery") or ""
     if not token:
         return None
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1385,16 +1385,20 @@ def _resolve_explicit_runtime(
             if not _anthropic_base_url_override_ok(cfg_base_url):
                 cfg_base_url = ""
         base_url = explicit_base_url or cfg_base_url or "https://api.anthropic.com"
-        api_key = explicit_api_key
-        if not api_key:
-            from agent.anthropic_adapter import resolve_anthropic_token
+        from agent.anthropic_adapter import resolve_anthropic_token
 
-            api_key = resolve_anthropic_token()
-            if not api_key:
-                raise AuthError(
-                    "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
-                    "run 'claude setup-token', or authenticate with 'claude /login'."
-                )
+        # Shared scope ignores explicit keys for official targets.
+        api_key = resolve_anthropic_token(
+            explicit_api_key=explicit_api_key,
+            provider="anthropic",
+            base_url=base_url,
+            api_mode="anthropic_messages",
+        )
+        if not api_key:
+            raise AuthError(
+                "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
+                "run 'claude setup-token', or authenticate with 'claude /login'."
+            )
         return {
             "provider": "anthropic",
             "api_mode": "anthropic_messages",

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -49,8 +49,14 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
         help="Disable TLS verification for OAuth login",
     )
     auth_add.add_argument("--ca-bundle", help="Custom CA bundle for OAuth login")
+    auth_add.add_argument(
+        "--shared",
+        action="store_true",
+        help="Stage credential into the machine-wide Anthropic shared OAuth pool",
+    )
     auth_list = auth_subparsers.add_parser("list", help="List pooled credentials")
     auth_list.add_argument("provider", nargs="?", help="Optional provider filter")
+    auth_list.add_argument("--shared", action="store_true", help="Show shared Anthropic pool")
     auth_remove = auth_subparsers.add_parser(
         "remove", help="Remove a pooled credential by index, id, or label"
     )
@@ -58,18 +64,22 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_remove.add_argument(
         "target", help="Credential index, entry id, or exact label"
     )
+    auth_remove.add_argument("--shared", action="store_true", help="Mutate shared Anthropic pool")
     auth_reset = auth_subparsers.add_parser(
         "reset", help="Clear exhaustion status for all credentials for a provider"
     )
     auth_reset.add_argument("provider", help="Provider id")
+    auth_reset.add_argument("--shared", action="store_true", help="Reset shared Anthropic pool statuses")
     auth_status = auth_subparsers.add_parser(
         "status", help="Show auth status for a provider"
     )
     auth_status.add_argument("provider", help="Provider id")
+    auth_status.add_argument("--shared", action="store_true", help="Show shared Anthropic pool status")
     auth_logout = auth_subparsers.add_parser(
         "logout", help="Log out a provider and clear stored auth state"
     )
     auth_logout.add_argument("provider", help="Provider id")
+    auth_logout.add_argument("--shared", action="store_true", help="Clear shared Anthropic pool")
     auth_spotify = auth_subparsers.add_parser(
         "spotify", help="Authenticate Hermes with Spotify via PKCE"
     )
@@ -95,4 +105,43 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_spotify.add_argument(
         "--timeout", type=float, help="Callback/token exchange timeout in seconds"
     )
+
+    # Machine-wide Anthropic shared OAuth pool
+    auth_scope = auth_subparsers.add_parser(
+        "scope", help="Show or change Anthropic credential scope (profile|shared)"
+    )
+    auth_scope.add_argument("provider", help="Provider id (anthropic)")
+    auth_scope.add_argument(
+        "scope_mode",
+        nargs="?",
+        choices=["profile", "shared", "repair"],
+        help="Target scope, or repair for malformed marker",
+    )
+    auth_scope.add_argument(
+        "--attest-distinct-accounts",
+        action="store_true",
+        help="Operator attestation that three OAuth grants are distinct Anthropic accounts",
+    )
+    auth_scope.add_argument(
+        "--shared",
+        action="store_true",
+        help="Required for repair of the shared scope marker",
+    )
+    auth_scope.add_argument("--yes", action="store_true", help="Confirm destructive repair")
+
+    auth_backup = auth_subparsers.add_parser(
+        "backup", help="Backup shared Anthropic pool (owner-only archive)"
+    )
+    auth_backup.add_argument("provider", help="Provider id (anthropic)")
+    auth_backup.add_argument("--shared", action="store_true", required=False)
+    auth_backup.add_argument("--output", required=True, help="Absolute output path")
+
+    auth_restore = auth_subparsers.add_parser(
+        "restore", help="Restore shared Anthropic pool from archive"
+    )
+    auth_restore.add_argument("provider", help="Provider id (anthropic)")
+    auth_restore.add_argument("--shared", action="store_true", required=False)
+    auth_restore.add_argument("--input", required=True, help="Absolute input archive path")
+    auth_restore.add_argument("--yes", action="store_true", help="Confirm restore")
+
     auth_parser.set_defaults(func=cmd_auth)

--- a/hermes_cli/subcommands/logout.py
+++ b/hermes_cli/subcommands/logout.py
@@ -21,8 +21,13 @@ def build_logout_parser(subparsers, *, cmd_logout: Callable) -> None:
     )
     logout_parser.add_argument(
         "--provider",
-        choices=["nous", "openai-codex", "xai-oauth", "spotify"],
+        choices=["nous", "openai-codex", "xai-oauth", "spotify", "anthropic"],
         default=None,
         help="Provider to log out from (default: active provider)",
+    )
+    logout_parser.add_argument(
+        "--shared",
+        action="store_true",
+        help="Clear machine-wide Anthropic shared OAuth pool",
     )
     logout_parser.set_defaults(func=cmd_logout)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13447,6 +13447,33 @@ async def list_credential_pool():
     # read_credential_pool(None) lists every provider that has pooled entries;
     # load_pool() then gives us the rich PooledCredential objects per provider.
     raw_pool = read_credential_pool()
+    # Shared Anthropic scope: include redacted shared rows.
+    try:
+        from agent.anthropic_shared_pool import is_shared_scope_active, list_redacted
+
+        if is_shared_scope_active():
+            shared = list_redacted(require_active=True)
+            providers.append({
+                "provider": "anthropic",
+                "scope": "shared",
+                "revision": shared.get("revision"),
+                "entries": [
+                    {
+                        "index": i,
+                        "id": e["id"],
+                        "label": e["label"],
+                        "auth_type": "oauth",
+                        "status": e.get("last_status"),
+                        "token_generation": e.get("token_generation"),
+                        "redacted": True,
+                    }
+                    for i, e in enumerate(shared.get("entries") or [], start=1)
+                ],
+            })
+            # Skip legacy anthropic keys from profile pool listing.
+            raw_pool = {k: v for k, v in raw_pool.items() if k != "anthropic"}
+    except Exception:
+        _log.exception("shared anthropic list failed")
     for provider_id in sorted(raw_pool.keys()):
         try:
             pool = load_pool(provider_id)
@@ -13480,6 +13507,22 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
     api_key = (body.api_key or "").strip()
     if not provider or not api_key:
         raise HTTPException(status_code=400, detail="provider and api_key are required")
+    try:
+        from agent.anthropic_shared_pool import is_shared_scope_active
+
+        if provider == "anthropic" and is_shared_scope_active():
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Anthropic shared OAuth scope is active. "
+                    "Use CLI: hermes auth add anthropic --type oauth --shared "
+                    "(API keys cannot be added to the shared pool)."
+                ),
+            )
+    except HTTPException:
+        raise
+    except Exception:
+        pass
 
     try:
         pool = load_pool(provider)
@@ -13535,6 +13578,22 @@ async def remove_credential_pool_entry(provider: str, index: int):
     from hermes_cli.auth import suppress_credential_source
 
     provider = (provider or "").strip().lower()
+    try:
+        from agent.anthropic_shared_pool import is_shared_scope_active
+
+        if provider == "anthropic" and is_shared_scope_active():
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Anthropic shared OAuth scope is active. "
+                    "Use CLI: hermes auth scope anthropic profile, then "
+                    "hermes auth remove anthropic <target> --shared"
+                ),
+            )
+    except HTTPException:
+        raise
+    except Exception:
+        pass
     try:
         pool = load_pool(provider)
         removed = pool.remove_index(index)

--- a/scripts/break_glass_anthropic_scope.py
+++ b/scripts/break_glass_anthropic_scope.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Break-glass helper: remove only a malformed Anthropic shared scope marker.
+
+Stdlib only — no Hermes imports. Use when `hermes auth` cannot start.
+
+  python scripts/break_glass_anthropic_scope.py \\
+      --root /absolute/hermes/root \\
+      --backup-dir /absolute/owner-only/dir \\
+      --yes
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None  # type: ignore
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover
+    msvcrt = None  # type: ignore
+
+
+def _die(msg: str, code: int = 1) -> None:
+    print(f"error: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _check_abs(path: Path, name: str) -> None:
+    if not path.is_absolute():
+        _die(f"{name} must be absolute", 2)
+
+
+def _safe_regular(path: Path, *, must_exist: bool) -> None:
+    if path.is_symlink():
+        _die(f"refusing symlink: {path}", 1)
+    if path.exists():
+        st = path.lstat()
+        if not stat.S_ISREG(st.st_mode):
+            _die(f"not a regular file: {path}", 1)
+        if st.st_nlink != 1:
+            _die(f"refusing hard-linked path: {path}", 1)
+        if hasattr(os, "getuid") and st.st_uid != os.getuid():
+            _die(f"not owned by current user: {path}", 1)
+        mode = stat.S_IMODE(st.st_mode)
+        if mode & (stat.S_IRWXG | stat.S_IRWXO):
+            _die(f"group/world permissions on {path}", 1)
+    elif must_exist:
+        _die(f"missing: {path}", 1)
+
+
+def _ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        path.chmod(0o700)
+    except OSError:
+        pass
+    if path.is_symlink():
+        _die(f"refusing symlinked dir: {path}", 1)
+    st = path.lstat()
+    if not stat.S_ISDIR(st.st_mode):
+        _die(f"not a directory: {path}", 1)
+    if hasattr(os, "getuid") and st.st_uid != os.getuid():
+        _die(f"dir not owned by current user: {path}", 1)
+
+
+def _fsync_dir(path: Path) -> None:
+    try:
+        fd = os.open(str(path), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _acquire_lock(lock_path: Path, timeout: float = 30.0):
+    if fcntl is None and msvcrt is None:
+        _die("no kernel cross-process lock primitive available", 1)
+    _ensure_dir(lock_path.parent)
+    if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
+        lock_path.write_text(" ", encoding="utf-8")
+        try:
+            lock_path.chmod(0o600)
+        except OSError:
+            pass
+    fh = open(lock_path, "r+" if msvcrt else "a+", encoding="utf-8")
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            if fcntl:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            else:
+                fh.seek(0)
+                msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
+            return fh
+        except (BlockingIOError, OSError, PermissionError):
+            if time.monotonic() >= deadline:
+                fh.close()
+                _die("lock timeout", 1)
+            time.sleep(0.05)
+
+
+def _release_lock(fh) -> None:
+    try:
+        if fcntl:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        elif msvcrt:
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+    except Exception:
+        pass
+    try:
+        fh.close()
+    except Exception:
+        pass
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--backup-dir", required=True)
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args(argv)
+    if not args.yes:
+        _die("--yes is required", 2)
+
+    root = Path(args.root)
+    backup_dir = Path(args.backup_dir)
+    _check_abs(root, "--root")
+    _check_abs(backup_dir, "--backup-dir")
+    _ensure_dir(root)
+    _ensure_dir(backup_dir)
+
+    marker = root / "shared" / "anthropic_pool_scope.json"
+    auth = root / "auth.json"
+    lock_path = auth.with_suffix(".lock")
+
+    # Snapshot auth bytes before any mutation for identity proof.
+    auth_before = None
+    if auth.exists() or auth.is_symlink():
+        _safe_regular(auth, must_exist=True)
+        auth_before = auth.read_bytes()
+
+    if not marker.exists() and not marker.is_symlink():
+        print("no marker present; nothing to do")
+        return 0
+
+    _safe_regular(marker, must_exist=True)
+    fh = _acquire_lock(lock_path)
+    try:
+        # Re-check under lock
+        if not marker.exists() and not marker.is_symlink():
+            print("marker already removed")
+            return 0
+        _safe_regular(marker, must_exist=True)
+        st = marker.lstat()
+        raw = marker.read_bytes()
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        backup = backup_dir / f"{ts}-{os.getpid()}-{uuid.uuid4().hex[:8]}-anthropic-scope.json"
+        if backup.exists():
+            _die(f"backup already exists: {backup}", 1)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(str(backup), flags, 0o600)
+        with os.fdopen(fd, "wb") as out:
+            out.write(raw)
+            out.flush()
+            os.fsync(out.fileno())
+        # Remove marker by verified inode
+        if marker.lstat().st_ino != st.st_ino:
+            _die("marker inode changed under lock", 1)
+        marker.unlink()
+        _fsync_dir(marker.parent)
+    finally:
+        _release_lock(fh)
+
+    if auth_before is not None:
+        after = auth.read_bytes()
+        if after != auth_before:
+            _die("root auth.json changed unexpectedly", 1)
+    print(f"marker removed; forensic backup: {backup}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_anthropic_shared_gates.sh
+++ b/scripts/run_anthropic_shared_gates.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Focused + full gates for the universal Anthropic shared OAuth pool.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+DIFF_RANGE="${1:-origin/main...HEAD}"
+
+# Scrub credential-shaped env vars
+unset ANTHROPIC_API_KEY ANTHROPIC_TOKEN CLAUDE_CODE_OAUTH_TOKEN || true
+unset ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_API_KEY || true
+
+TMPDIR_GATE="$(mktemp -d "${TMPDIR:-/tmp}/anthropic-shared-gates.XXXXXX")"
+chmod 700 "$TMPDIR_GATE"
+FOCUSED_LOG="$TMPDIR_GATE/focused.log"
+FULL_LOG="$TMPDIR_GATE/full.log"
+SCAN_LOG="$TMPDIR_GATE/scan.log"
+
+cleanup() {
+  rm -rf "$TMPDIR_GATE"
+}
+trap cleanup EXIT
+
+echo "== secret scan (git diff $DIFF_RANGE) =="
+set +e
+python3 scripts/scan_auth_secrets.py --git-diff "$DIFF_RANGE" | tee "$SCAN_LOG"
+SCAN_RC=${PIPESTATUS[0]}
+set -e
+if [[ "$SCAN_RC" -ne 0 ]]; then
+  echo "secret scanner failed (rc=$SCAN_RC)" >&2
+  exit "$SCAN_RC"
+fi
+
+FOCUSED=(
+  tests/hermes_cli/test_auth_profile_fallback.py
+  tests/agent/test_credential_pool_oauth_writethrough.py
+  tests/hermes_cli/test_auth_commands.py
+  tests/agent/test_anthropic_shared_store.py
+  tests/agent/test_anthropic_shared_runtime.py
+  tests/agent/test_anthropic_shared_refresh_multiprocess.py
+  tests/agent/test_anthropic_shared_file_safety.py
+  tests/hermes_cli/test_anthropic_shared_scope.py
+  tests/hermes_cli/test_anthropic_shared_backup_guards.py
+  tests/hermes_cli/test_anthropic_shared_dashboard_guards.py
+  tests/scripts/test_scan_auth_secrets.py
+  tests/scripts/test_break_glass_anthropic_scope.py
+)
+
+echo "== focused tests =="
+set +e
+scripts/run_tests.sh "${FOCUSED[@]}" 2>&1 | tee "$FOCUSED_LOG"
+FOCUSED_RC=${PIPESTATUS[0]}
+set -e
+
+echo "== scan focused log =="
+set +e
+python3 scripts/scan_auth_secrets.py --input "$FOCUSED_LOG"
+FOCUSED_SCAN_RC=$?
+set -e
+
+echo "== full suite =="
+set +e
+scripts/run_tests.sh 2>&1 | tee "$FULL_LOG"
+FULL_RC=${PIPESTATUS[0]}
+set -e
+
+echo "== scan full log =="
+set +e
+python3 scripts/scan_auth_secrets.py --input "$FULL_LOG"
+FULL_SCAN_RC=$?
+set -e
+
+RC=0
+for r in "$FOCUSED_RC" "$FOCUSED_SCAN_RC" "$FULL_RC" "$FULL_SCAN_RC"; do
+  if [[ "$r" -ne 0 ]]; then
+    RC=1
+  fi
+done
+echo "focused_rc=$FOCUSED_RC focused_scan_rc=$FOCUSED_SCAN_RC full_rc=$FULL_RC full_scan_rc=$FULL_SCAN_RC"
+exit "$RC"

--- a/scripts/scan_auth_secrets.py
+++ b/scripts/scan_auth_secrets.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Scan git diffs and owner-readable files for credential-shaped secrets.
+
+Never prints the candidate value — only input label, line number, and detector.
+Exit 1 on findings; exit 2 on malformed arguments/input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import re
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+FIXTURE_PREFIXES = (
+    "fixture-",
+    "test-",
+    "<secret>",
+    "fixture-oauth-",
+)
+
+ANTHROPIC_PREFIX = re.compile(
+    r"(?i)sk-ant-[A-Za-z0-9._~+/=-]{16,}"
+)
+JWT = re.compile(
+    r"\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{16,}\b"
+)
+NAMED_SECRET = re.compile(
+    r"(?i)\b(access_token|refresh_token|authorization|api_key|api-key)\b"
+    r".{0,32}?(?:Bearer\s+)?([A-Za-z0-9._~+/=-]{24,})"
+)
+GENERIC_CANDIDATE = re.compile(r"[A-Za-z0-9._~+/=-]{40,4096}")
+HEX_HASH = re.compile(r"^[0-9a-fA-F]{40,64}$")
+
+
+def _shannon(s: str) -> float:
+    if not s:
+        return 0.0
+    from collections import Counter
+
+    counts = Counter(s)
+    n = len(s)
+    return -sum((c / n) * math.log2(c / n) for c in counts.values())
+
+
+def _classes(s: str) -> int:
+    return sum(
+        [
+            any(c.islower() for c in s),
+            any(c.isupper() for c in s),
+            any(c.isdigit() for c in s),
+            any(not c.isalnum() for c in s),
+        ]
+    )
+
+
+def _allowlisted(value: str, *, under_tests: bool) -> bool:
+    v = value.strip()
+    if under_tests:
+        return any(v.startswith(p) or p in v for p in FIXTURE_PREFIXES)
+    return any(v.startswith(p) for p in FIXTURE_PREFIXES)
+
+
+def detect_line(line: str, *, under_tests: bool, capture_output: bool) -> List[str]:
+    findings: List[str] = []
+
+    def consider(detector: str, candidate: str) -> None:
+        if capture_output or under_tests:
+            if _allowlisted(candidate, under_tests=under_tests):
+                return
+            # Whole-line fixture hint (split concatenations / keyword args).
+            if under_tests and "fixture-" in line:
+                return
+        findings.append(detector)
+
+    for m in ANTHROPIC_PREFIX.finditer(line):
+        consider("anthropic_prefix", m.group(0))
+    for m in JWT.finditer(line):
+        consider("jwt", m.group(0))
+    for m in NAMED_SECRET.finditer(line):
+        consider("named_secret", m.group(2))
+    for m in GENERIC_CANDIDATE.finditer(line):
+        cand = m.group(0)
+        if HEX_HASH.match(cand):
+            continue
+        if _classes(cand) < 3:
+            continue
+        if _shannon(cand) < 4.2:
+            continue
+        consider("generic_entropy", cand)
+    return findings
+
+
+def scan_text(
+    label: str,
+    text: str,
+    *,
+    under_tests: bool = False,
+    capture_output: bool = False,
+    added_lines_only: bool = False,
+) -> List[Tuple[str, int, str]]:
+    out: List[Tuple[str, int, str]] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        content = line
+        if added_lines_only:
+            if not line.startswith("+") or line.startswith("+++"):
+                continue
+            content = line[1:]
+        for det in detect_line(
+            content, under_tests=under_tests, capture_output=capture_output
+        ):
+            out.append((label, i, det))
+    return out
+
+
+def _read_safe_file(path: Path) -> str:
+    if path.is_symlink():
+        raise ValueError(f"refusing symlink: {path}")
+    if not path.is_file():
+        raise ValueError(f"not a regular file: {path}")
+    st = path.lstat()
+    if not stat.S_ISREG(st.st_mode):
+        raise ValueError(f"not a regular file: {path}")
+    if hasattr(os, "getuid") and st.st_uid != os.getuid():
+        # Still allow if owner-readable by us via group? Spec: owner-readable regular.
+        if not os.access(path, os.R_OK):
+            raise ValueError(f"not readable: {path}")
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def scan_git_diff(range_spec: str) -> List[Tuple[str, int, str]]:
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "-U0", range_spec],
+            check=False,
+            capture_output=True,
+        )
+    except Exception as exc:
+        print(f"error: git diff failed: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+    if proc.returncode not in (0, 1):
+        print("error: git diff failed", file=sys.stderr)
+        raise SystemExit(2)
+    data = proc.stdout.decode("utf-8", errors="replace")
+    findings: List[Tuple[str, int, str]] = []
+    current_file = "diff"
+    under_tests = False
+    buf_lines: List[str] = []
+    file_start_line = 1
+
+    def flush():
+        nonlocal buf_lines
+        if not buf_lines:
+            return
+        text = "\n".join(buf_lines)
+        findings.extend(
+            scan_text(
+                current_file,
+                text,
+                under_tests=under_tests,
+                added_lines_only=True,
+            )
+        )
+        buf_lines = []
+
+    for line in data.splitlines():
+        if line.startswith("diff --git "):
+            flush()
+            # diff --git a/path b/path
+            parts = line.split(" b/", 1)
+            current_file = parts[1] if len(parts) == 2 else "diff"
+            under_tests = current_file.startswith("tests/") or "/tests/" in current_file
+            continue
+        buf_lines.append(line)
+    flush()
+    return findings
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--git-diff", action="append", default=[], dest="git_diffs")
+    parser.add_argument("--input", action="append", default=[], dest="inputs")
+    args = parser.parse_args(argv)
+    if not args.git_diffs and not args.inputs:
+        print("error: provide --git-diff and/or --input", file=sys.stderr)
+        return 2
+
+    findings: List[Tuple[str, int, str]] = []
+    try:
+        for gd in args.git_diffs:
+            findings.extend(scan_git_diff(gd))
+        for inp in args.inputs:
+            path = Path(inp)
+            text = _read_safe_file(path)
+            findings.extend(
+                scan_text(str(path), text, capture_output=True, under_tests=False)
+            )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except SystemExit:
+        raise
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    for label, lineno, det in findings:
+        print(f"{label}:{lineno}: {det}")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/anthropic_shared_test_helpers.py
+++ b/tests/agent/anthropic_shared_test_helpers.py
@@ -1,0 +1,137 @@
+"""Helpers for Anthropic shared pool tests (fixture tokens only)."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+
+FIXTURE_ACCESS = "fixture-oauth-access-token-aaaaaaaaaaaaaaaa"
+FIXTURE_REFRESH = "fixture-oauth-refresh-token-bbbbbbbbbbbbbbbb"
+
+
+@pytest.fixture
+def shared_root(tmp_path, monkeypatch):
+    """Isolate both HERMES_HOME and the default root under tmp_path.
+
+    HERMES_HOME is intentionally NOT ``Path.home()/'.hermes'`` so the pytest
+    seat belt in ``_auth_file_path`` does not treat the temp store as the
+    real user auth path when HOME is also redirected.
+    """
+    user_home = tmp_path / "home"
+    user_home.mkdir()
+    root = tmp_path / "hermes-root"
+    root.mkdir()
+    (root / "shared").mkdir()
+    monkeypatch.setenv("HOME", str(user_home))
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    from agent import anthropic_shared_pool as sp
+
+    sp.reset_startup_epoch_for_tests()
+    yield root
+    sp.reset_startup_epoch_for_tests()
+
+
+@pytest.fixture
+def profile_env(shared_root, monkeypatch):
+    """Named profile under the shared root."""
+    profiles = shared_root / "profiles" / "worker"
+    profiles.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profiles))
+    from agent import anthropic_shared_pool as sp
+
+    sp.reset_startup_epoch_for_tests()
+    return profiles
+
+
+def write_root_auth(root: Path, payload: Dict[str, Any]) -> Path:
+    path = root / "auth.json"
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+    path.chmod(0o600)
+    return path
+
+
+def make_row(
+    *,
+    priority: int,
+    label: Optional[str] = None,
+    access: str = FIXTURE_ACCESS,
+    refresh: Optional[str] = None,
+    generation: int = 1,
+    expires_at_ms: Optional[int] = None,
+    last_status=None,
+    **overrides,
+) -> Dict[str, Any]:
+    import time
+    from agent.anthropic_shared_pool import (
+        ENDPOINT_PLATFORM,
+        SOURCE_HERMES_PKCE,
+        grant_fingerprint,
+        validate_shared_row,
+    )
+
+    refresh = refresh or f"{FIXTURE_REFRESH}-{priority}"
+    row = {
+        "id": str(uuid.uuid4()),
+        "provider": "anthropic",
+        "auth_type": "oauth",
+        "source": SOURCE_HERMES_PKCE,
+        "label": label or f"Anthropic account {priority + 1}",
+        "grant_fingerprint": grant_fingerprint(refresh),
+        "token_generation": generation,
+        "oauth_token_endpoint": ENDPOINT_PLATFORM,
+        "access_token": f"{access}-{priority}",
+        "refresh_token": refresh,
+        "expires_at_ms": expires_at_ms or int(time.time() * 1000) + 3_600_000,
+        "priority": priority,
+        "request_count": 0,
+        "last_status": last_status,
+        "last_status_at": None,
+        "last_error_code": None,
+        "last_error_reason": None,
+        "last_error_message": None,
+        "last_error_reset_at": None,
+        "last_refresh": None,
+        "refresh_attempt": None,
+    }
+    row.update(overrides)
+    return validate_shared_row(row, at_enrollment=True)
+
+
+def stage_three(root: Path, *, attest: bool = False) -> Dict[str, Any]:
+    from agent.anthropic_shared_pool import empty_shared_pool, validate_shared_pool
+
+    entries = [make_row(priority=i) for i in range(3)]
+    pool = empty_shared_pool()
+    pool["entries"] = entries
+    pool["revision"] = 1
+    if attest:
+        pool["account_distinctness_attested"] = True
+        pool["account_distinctness_attested_at"] = "2026-01-01T00:00:00Z"
+    pool = validate_shared_pool(pool, require_three=attest)
+    write_root_auth(
+        root,
+        {
+            "version": 1,
+            "providers": {},
+            "shared_credential_pools": {"anthropic": pool},
+        },
+    )
+    return pool
+
+
+def enable_marker(root: Path, epoch: str = "11111111-1111-1111-1111-111111111111") -> None:
+    path = root / "shared" / "anthropic_pool_scope.json"
+    path.parent.mkdir(exist_ok=True)
+    path.write_text(
+        json.dumps({"version": 1, "scope": "shared", "epoch": epoch}) + "\n"
+    )
+    path.chmod(0o600)

--- a/tests/agent/test_anthropic_shared_file_safety.py
+++ b/tests/agent/test_anthropic_shared_file_safety.py
@@ -1,0 +1,54 @@
+"""File safety for Anthropic shared scope marker and root auth."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from tests.agent.anthropic_shared_test_helpers import enable_marker, shared_root, stage_three
+
+
+def test_marker_in_read_denylist(shared_root):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from agent.file_safety import get_read_block_error
+
+    marker = shared_root / "shared" / "anthropic_pool_scope.json"
+    err = get_read_block_error(str(marker))
+    assert err is not None
+    assert "denied" in err.lower() or "credential" in err.lower() or "scope" in err.lower()
+
+
+def test_marker_in_write_denylist(shared_root):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from agent.file_safety import get_write_denied_error
+
+    marker = shared_root / "shared" / "anthropic_pool_scope.json"
+    err = get_write_denied_error(str(marker))
+    assert err is not None
+
+
+def test_root_auth_write_denied_from_profile(shared_root, monkeypatch):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    prof = shared_root / "profiles" / "w"
+    prof.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(prof))
+    from agent.file_safety import get_write_denied_error
+
+    err = get_write_denied_error(str(shared_root / "auth.json"))
+    assert err is not None
+
+
+def test_atomic_write_rejects_symlink_target(shared_root, tmp_path):
+    from agent.anthropic_shared_pool import _atomic_write_json
+    from hermes_cli.auth import AuthError
+    import pytest
+
+    real = tmp_path / "real.json"
+    real.write_text("{}")
+    target = shared_root / "shared" / "x.json"
+    target.symlink_to(real)
+    with pytest.raises(AuthError):
+        _atomic_write_json(target, {"a": 1})

--- a/tests/agent/test_anthropic_shared_refresh_multiprocess.py
+++ b/tests/agent/test_anthropic_shared_refresh_multiprocess.py
@@ -1,0 +1,239 @@
+"""Cross-process single-use Anthropic shared refresh tests."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import os
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from threading import Thread
+
+import pytest
+
+from tests.agent.anthropic_shared_test_helpers import (
+    enable_marker,
+    make_row,
+    shared_root,
+    write_root_auth,
+)
+
+
+class _SingleUseHandler(BaseHTTPRequestHandler):
+    hits = 0
+    seen_tokens = []
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode()
+        type(self).hits += 1
+        type(self).seen_tokens.append(body)
+        if type(self).hits > 1:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b'{"error":"invalid_grant"}')
+            return
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(
+            json.dumps(
+                {
+                    "access_token": "fixture-oauth-access-rotated-zzzzzzzz",
+                    "refresh_token": "fixture-oauth-refresh-rotated-zzzzzzzz",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                }
+            ).encode()
+        )
+
+    def log_message(self, fmt, *args):  # noqa: A003
+        return
+
+
+def _worker(root: str, home: str, row_id: str, gen: int, q):
+    os.environ["HERMES_HOME"] = home
+    os.environ["HOME"] = str(Path(root).parent)
+    os.environ.pop("ANTHROPIC_API_KEY", None)
+    os.environ.pop("ANTHROPIC_TOKEN", None)
+    try:
+        from agent import anthropic_shared_pool as sp
+
+        sp.reset_startup_epoch_for_tests()
+
+        def transport(*, refresh_token, endpoint_id):
+            import urllib.request
+
+            data = json.dumps(
+                {
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": "test",
+                }
+            ).encode()
+            req = urllib.request.Request(
+                os.environ["TEST_TOKEN_URL"],
+                data=data,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                result = json.loads(resp.read().decode())
+            return {
+                "access_token": result["access_token"],
+                "refresh_token": result["refresh_token"],
+                "expires_at_ms": int(time.time() * 1000) + 3_600_000,
+            }
+
+        updated = sp.commit_refresh(
+            row_id, expected_generation=gen, transport=transport
+        )
+        q.put(("ok", updated["token_generation"], updated["access_token"]))
+    except Exception as exc:
+        q.put(("err", type(exc).__name__, str(exc)[:200]))
+
+
+@pytest.mark.skipif(os.name == "nt", reason="fcntl multiproc test")
+def test_two_process_refresh_single_post(shared_root, monkeypatch):
+    # Local single-use HTTP stub
+    _SingleUseHandler.hits = 0
+    _SingleUseHandler.seen_tokens = []
+    server = HTTPServer(("127.0.0.1", 0), _SingleUseHandler)
+    port = server.server_address[1]
+    t = Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    monkeypatch.setenv("TEST_TOKEN_URL", f"http://127.0.0.1:{port}/v1/oauth/token")
+
+    # One expired-but-loadable row (skip enrollment future check)
+    row = make_row(priority=0)
+    row["expires_at_ms"] = int(time.time() * 1000) - 1000
+    # Need 3 rows for active shared
+    entries = [row] + [make_row(priority=i, refresh=f"fixture-oauth-refresh-extra-{i}") for i in range(1, 3)]
+    for i, e in enumerate(entries):
+        e["priority"] = i
+    from agent.anthropic_shared_pool import validate_shared_pool
+
+    pool = {
+        "schema_version": 1,
+        "revision": 1,
+        "strategy": "fill_first",
+        "account_distinctness_attested": True,
+        "account_distinctness_attested_at": "2026-01-01T00:00:00Z",
+        "entries": entries,
+    }
+    pool = validate_shared_pool(pool, require_three=True)
+    write_root_auth(
+        shared_root,
+        {"version": 1, "providers": {}, "shared_credential_pools": {"anthropic": pool}},
+    )
+    enable_marker(shared_root)
+
+    ctx = mp.get_context("spawn")
+    q = ctx.Queue()
+    home = str(shared_root)
+    root = str(shared_root)
+    procs = [
+        ctx.Process(target=_worker, args=(root, home, row["id"], 1, q))
+        for _ in range(2)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+        assert p.exitcode == 0
+
+    results = [q.get(timeout=5) for _ in range(2)]
+    oks = [r for r in results if r[0] == "ok"]
+    assert len(oks) >= 1
+    # Exactly one successful HTTP POST
+    assert _SingleUseHandler.hits == 1
+    # Disk generation advanced once
+    data = json.loads((shared_root / "auth.json").read_text())
+    stored = data["shared_credential_pools"]["anthropic"]["entries"][0]
+    assert stored["token_generation"] == 2
+    assert stored["access_token"].startswith("fixture-oauth-access-rotated")
+    server.shutdown()
+
+
+def test_refresh_response_table_unknown_on_timeout(shared_root):
+    from agent import anthropic_shared_pool as sp
+    from hermes_cli.auth import AuthError
+    from tests.agent.anthropic_shared_test_helpers import stage_three
+
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    sp.reset_startup_epoch_for_tests()
+    pool = sp.load_shared_pool_for_management(require_active_three=True)
+    row_id = pool["entries"][0]["id"]
+
+    def boom(**kwargs):
+        err = AuthError("timeout", provider="anthropic", code="refresh_transport")
+        err.ambiguous = True
+        raise err
+
+    with pytest.raises(AuthError):
+        sp.commit_refresh(row_id, expected_generation=1, transport=boom)
+
+    pool2 = sp.load_shared_pool_for_management(require_active_three=True)
+    row = next(e for e in pool2["entries"] if e["id"] == row_id)
+    assert row["last_status"] == "dead"
+    assert row["last_error_reason"] == "refresh_outcome_unknown"
+    assert row["refresh_attempt"]["outcome"] == "unknown"
+
+
+def test_abandon_inflight_no_post(shared_root):
+    from agent import anthropic_shared_pool as sp
+    from tests.agent.anthropic_shared_test_helpers import stage_three
+
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    sp.reset_startup_epoch_for_tests()
+    with sp.root_auth_lock():
+        store = sp.load_root_auth_strict()
+        pool = sp.get_shared_namespace(store)
+        row = pool["entries"][0]
+        row["refresh_attempt"] = {
+            "attempt_id": "00000000-0000-0000-0000-000000000001",
+            "expected_generation": 1,
+            "started_at": "2026-01-01T00:00:00Z",
+            "outcome": "inflight",
+        }
+        pool["revision"] += 1
+        sp.set_shared_namespace(store, pool)
+        sp.save_root_auth_strict(store)
+
+    # Successor: load path / commit_refresh should abandon inflight without POST.
+    with sp.root_auth_lock():
+        store = sp.load_root_auth_strict()
+        pool = sp.get_shared_namespace(store)
+        assert pool is not None
+        changed = sp._abandon_inflight_attempts(pool)
+        assert changed
+        pool["revision"] = int(pool["revision"]) + 1
+        sp.set_shared_namespace(store, pool)
+        sp.save_root_auth_strict(store)
+
+    posts = {"n": 0}
+
+    def transport(**kwargs):
+        posts["n"] += 1
+        return {
+            "access_token": "x",
+            "refresh_token": "y",
+            "expires_at_ms": int(time.time() * 1000) + 10000,
+        }
+
+    # Row is now dead/unknown — commit_refresh must refuse without POST
+    from hermes_cli.auth import AuthError
+
+    with pytest.raises(AuthError):
+        sp.commit_refresh(
+            pool["entries"][0]["id"],
+            expected_generation=1,
+            transport=transport,
+        )
+    assert posts["n"] == 0
+    pool2 = sp.load_shared_pool_for_management(require_active_three=True)
+    row = pool2["entries"][0]
+    assert row["refresh_attempt"]["outcome"] == "unknown"
+    assert row["last_status"] == "dead"

--- a/tests/agent/test_anthropic_shared_runtime.py
+++ b/tests/agent/test_anthropic_shared_runtime.py
@@ -1,0 +1,122 @@
+"""Runtime gate: bypasses, official target predicate, epoch preflight."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.agent.anthropic_shared_test_helpers import (
+    enable_marker,
+    shared_root,
+    stage_three,
+)
+
+
+def test_official_target_predicate_matrix():
+    from agent.anthropic_shared_pool import is_official_anthropic_oauth_target as pred
+
+    assert pred("anthropic", "inference", "anthropic_messages", None) is True
+    assert pred("anthropic", "inference", None, "https://api.anthropic.com") is True
+    assert pred("anthropic", "inference", None, "https://api.anthropic.com/v1") is True
+    assert pred("anthropic", "model_discovery", None, None) is True
+    # Non-official
+    assert pred("anthropic", "inference", None, "https://my-azure.openai.azure.com") is False
+    assert pred("anthropic", "inference", None, "https://api.anthropic.com.evil.com") is False
+    assert pred("anthropic", "inference", None, "https://user:pass@api.anthropic.com") is False
+    assert pred("anthropic", "inference", None, "http://api.anthropic.com") is False
+    assert pred("anthropic", "inference", None, "https://api.anthropic.com:8443") is False
+    assert pred("minimax", "inference", "anthropic_messages", None) is False
+    assert pred("anthropic", "inference", "chat_completions", None) is False
+    assert pred("bedrock", "inference", None, None) is False
+
+
+def test_shared_mode_ignores_env_and_explicit_key(shared_root, monkeypatch):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fixture-api-key-ENVKEYSHOULDNOTWIN0000")
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "fixture-should-not-win-token-xxxxxxxxxxxx")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "fixture-should-not-win-cc-xxxxxxxxxxxx")
+    from agent import anthropic_shared_pool as sp
+    from agent.anthropic_adapter import resolve_anthropic_token
+
+    sp.reset_startup_epoch_for_tests()
+    explicit = "fixture-" + "explicit-should-not-win-00000000"
+    token = resolve_anthropic_token(
+        explicit_api_key=explicit,
+        provider="anthropic",
+    )
+    assert token.startswith("fixture-oauth-access-token")
+    assert "ENVKEY" not in token
+    assert "EXPLICIT" not in token
+
+
+def test_shared_mode_skips_seeding(shared_root, monkeypatch):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fixture-api-key-seedmeplease000000000")
+    from agent import anthropic_shared_pool as sp
+    from agent.credential_pool import load_pool
+
+    sp.reset_startup_epoch_for_tests()
+    pool = load_pool("anthropic")
+    assert len(pool.entries()) == 3
+    assert all(e.auth_type == "oauth" for e in pool.entries())
+    assert all(e.source == "manual:hermes_pkce" for e in pool.entries())
+
+
+def test_non_official_target_does_not_use_shared(shared_root, monkeypatch):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fixture-api-key-azureishkey00000000000")
+    from agent import anthropic_shared_pool as sp
+    from agent.anthropic_adapter import resolve_anthropic_token
+
+    sp.reset_startup_epoch_for_tests()
+    token = resolve_anthropic_token(
+        provider="anthropic",
+        base_url="https://myresource.openai.azure.com/anthropic",
+        explicit_api_key="fixture-api-key-azureishkey00000000000",
+    )
+    # Non-official: shared gate skipped; explicit/env may win
+    assert token == "fixture-api-key-azureishkey00000000000"
+
+
+def test_epoch_change_fails_new_requests(shared_root):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root, epoch="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    from agent import anthropic_shared_pool as sp
+    from hermes_cli.auth import AuthError
+
+    sp.reset_startup_epoch_for_tests()
+    sp.observe_startup_epoch()
+    # Change epoch on disk
+    enable_marker(shared_root, epoch="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    with pytest.raises(AuthError) as ei:
+        sp.resolve_shared_anthropic_credential()
+    assert ei.value.code == "shared_scope_changed"
+
+
+def test_empty_shared_pool_no_local_fallback(shared_root, monkeypatch):
+    # Marker present but no pool
+    enable_marker(shared_root)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fixture-api-key-shouldnotfallback0000")
+    from agent import anthropic_shared_pool as sp
+    from agent.anthropic_adapter import resolve_anthropic_token
+    from hermes_cli.auth import AuthError
+
+    sp.reset_startup_epoch_for_tests()
+    with pytest.raises(AuthError):
+        resolve_anthropic_token(provider="anthropic")
+
+
+def test_get_anthropic_key_shared(shared_root, monkeypatch):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fixture-api-key-nope0000000000000000")
+    from agent import anthropic_shared_pool as sp
+    from hermes_cli.auth import get_anthropic_key
+
+    sp.reset_startup_epoch_for_tests()
+    key = get_anthropic_key()
+    assert key.startswith("fixture-oauth-access-token")

--- a/tests/agent/test_anthropic_shared_store.py
+++ b/tests/agent/test_anthropic_shared_store.py
@@ -1,0 +1,219 @@
+"""Shared Anthropic store schema, staging, and selection tests."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from tests.agent.anthropic_shared_test_helpers import (
+    FIXTURE_ACCESS,
+    enable_marker,
+    make_row,
+    shared_root,
+    stage_three,
+    write_root_auth,
+)
+
+
+def test_profile_mode_ignores_dormant_shared_rows(shared_root):
+    stage_three(shared_root, attest=False)
+    from agent.anthropic_adapter import resolve_anthropic_token
+    from agent.credential_pool import load_pool
+
+    # No marker → legacy; dormant rows not used; no env → None
+    assert resolve_anthropic_token() is None
+    pool = load_pool("anthropic")
+    # May be empty or env-seeded only — must not contain shared ids
+    ids = {e.id for e in pool.entries()}
+    stored = json.loads((shared_root / "auth.json").read_text())
+    shared_ids = {
+        e["id"] for e in stored["shared_credential_pools"]["anthropic"]["entries"]
+    }
+    assert ids.isdisjoint(shared_ids)
+
+
+def test_shared_mode_profiles_see_same_three_ids(shared_root, monkeypatch):
+    pool = stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from agent import anthropic_shared_pool as sp
+    from agent.credential_pool import load_pool
+
+    sp.reset_startup_epoch_for_tests()
+    p1 = load_pool("anthropic")
+    ids1 = [e.id for e in p1.entries()]
+    assert ids1 == [e["id"] for e in pool["entries"]]
+
+    # Switch to a named profile HERMES_HOME
+    prof = shared_root / "profiles" / "coder"
+    prof.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(prof))
+    sp.reset_startup_epoch_for_tests()
+    p2 = load_pool("anthropic")
+    assert [e.id for e in p2.entries()] == ids1
+    # Profile auth.json must not be created with anthropic rows
+    prof_auth = prof / "auth.json"
+    if prof_auth.exists():
+        data = json.loads(prof_auth.read_text())
+        cp = data.get("credential_pool") or {}
+        assert not cp.get("anthropic")
+
+
+def test_shared_persist_refuses_profile_write(shared_root):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from agent import anthropic_shared_pool as sp
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import AuthError
+
+    sp.reset_startup_epoch_for_tests()
+    pool = load_pool("anthropic")
+    with pytest.raises(AuthError):
+        pool._persist()
+
+
+def test_api_key_row_rejected(shared_root):
+    from agent.anthropic_shared_pool import AuthError, validate_shared_row
+    from hermes_cli.auth import AuthError as AE
+
+    row = make_row(priority=0)
+    row["auth_type"] = "api_key"
+    with pytest.raises((AuthError, AE)):
+        validate_shared_row(row)
+
+
+def test_duplicate_fingerprint_rejected(shared_root):
+    from agent.anthropic_shared_pool import (
+        append_row,
+        get_shared_mutation_capability,
+        AuthError,
+    )
+    from hermes_cli.auth import AuthError as AE
+
+    cap = get_shared_mutation_capability()
+    r1 = make_row(priority=0, refresh="fixture-oauth-refresh-same")
+    r2 = make_row(priority=1, refresh="fixture-oauth-refresh-same")
+    append_row(r1, capability=cap)
+    # Same fingerprint → idempotent return, not fourth
+    existing = append_row(r2, capability=cap)
+    assert existing["id"] == r1["id"]
+
+
+def test_fourth_grant_rejected(shared_root):
+    from agent.anthropic_shared_pool import (
+        append_row,
+        get_shared_mutation_capability,
+    )
+    from hermes_cli.auth import AuthError
+
+    cap = get_shared_mutation_capability()
+    for i in range(3):
+        append_row(make_row(priority=i, refresh=f"fixture-oauth-refresh-uniq-{i}"), capability=cap)
+    with pytest.raises(AuthError):
+        append_row(make_row(priority=3, refresh="fixture-oauth-refresh-uniq-3"), capability=cap)
+
+
+def test_fill_first_order_and_exhaustion_rotate(shared_root):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from agent import anthropic_shared_pool as sp
+
+    sp.reset_startup_epoch_for_tests()
+    ctx = sp.resolve_shared_anthropic_credential()
+    pool = sp.load_shared_pool_for_management(require_active_three=True)
+    assert ctx.row_id == pool["entries"][0]["id"]
+
+    # Exhaust first
+    sp.patch_status(
+        ctx.row_id,
+        expected_generation=ctx.token_generation,
+        last_status="exhausted",
+        last_error_reason="rate_limit",
+        last_error_reset_at=time.time() + 3600,
+        last_error_code=429,
+        last_error_message="rate limited",
+    )
+    ctx2 = sp.resolve_shared_anthropic_credential()
+    assert ctx2.row_id == pool["entries"][1]["id"]
+
+
+def test_elapsed_exhaustion_normalizes_under_lock(shared_root):
+    pool = stage_three(shared_root, attest=True)
+    pool["entries"][0]["last_status"] = "exhausted"
+    pool["entries"][0]["last_error_reason"] = "rate_limit"
+    pool["entries"][0]["last_error_reset_at"] = time.time() - 10
+    pool["entries"][0]["last_status_at"] = time.time() - 100
+    pool["entries"][0]["last_error_code"] = 429
+    pool["entries"][0]["last_error_message"] = "old"
+    write_root_auth(
+        shared_root,
+        {
+            "version": 1,
+            "providers": {},
+            "shared_credential_pools": {"anthropic": pool},
+        },
+    )
+    enable_marker(shared_root)
+    from agent import anthropic_shared_pool as sp
+
+    sp.reset_startup_epoch_for_tests()
+    ctx = sp.resolve_shared_anthropic_credential()
+    assert ctx.row_id == pool["entries"][0]["id"]
+
+
+def test_malformed_marker_fail_closed(shared_root):
+    stage_three(shared_root, attest=True)
+    path = shared_root / "shared" / "anthropic_pool_scope.json"
+    path.write_text("{not-json")
+    path.chmod(0o600)
+    from agent.anthropic_shared_pool import read_scope_state
+    from hermes_cli.auth import AuthError
+
+    with pytest.raises(AuthError):
+        read_scope_state()
+
+
+def test_symlink_marker_fail_closed(shared_root, tmp_path):
+    stage_three(shared_root, attest=True)
+    real = tmp_path / "marker.json"
+    real.write_text(json.dumps({"version": 1, "scope": "shared", "epoch": "x"}))
+    marker = shared_root / "shared" / "anthropic_pool_scope.json"
+    marker.symlink_to(real)
+    from agent.anthropic_shared_pool import read_scope_state
+    from hermes_cli.auth import AuthError
+
+    with pytest.raises(AuthError):
+        read_scope_state()
+
+
+def test_stale_generation_status_ignored(shared_root):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from agent import anthropic_shared_pool as sp
+
+    sp.reset_startup_epoch_for_tests()
+    ctx = sp.resolve_shared_anthropic_credential()
+    # Bump generation artificially
+    with sp.root_auth_lock():
+        store = sp.load_root_auth_strict()
+        pool = sp.get_shared_namespace(store)
+        row = next(e for e in pool["entries"] if e["id"] == ctx.row_id)
+        row["token_generation"] = ctx.token_generation + 1
+        pool["revision"] += 1
+        sp.set_shared_namespace(store, pool)
+        sp.save_root_auth_strict(store)
+    # Stale gen-N callback must not kill gen N+1
+    sp.patch_status(
+        ctx.row_id,
+        expected_generation=ctx.token_generation,
+        last_status="dead",
+        last_error_reason="auth_terminal",
+        last_error_message="stale 401",
+    )
+    with sp.root_auth_lock():
+        store = sp.load_root_auth_strict()
+        pool = sp.get_shared_namespace(store)
+        row = next(e for e in pool["entries"] if e["id"] == ctx.row_id)
+        assert row["last_status"] is None
+        assert row["token_generation"] == ctx.token_generation + 1

--- a/tests/hermes_cli/test_anthropic_shared_backup_guards.py
+++ b/tests/hermes_cli/test_anthropic_shared_backup_guards.py
@@ -1,0 +1,90 @@
+"""Generic backup must refuse active/dormant shared Anthropic state."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.agent.anthropic_shared_test_helpers import (
+    enable_marker,
+    shared_root,
+    stage_three,
+)
+
+
+def test_has_dormant_shared_state(shared_root):
+    stage_three(shared_root, attest=False)
+    from agent.anthropic_shared_pool import has_dormant_or_active_shared_state
+
+    assert has_dormant_or_active_shared_state() is True
+
+
+def test_refuse_generic_backup_dormant(shared_root):
+    stage_three(shared_root, attest=False)
+    from agent.anthropic_shared_pool import refuse_generic_backup_if_shared
+    from hermes_cli.auth import AuthError
+
+    with pytest.raises(AuthError) as ei:
+        refuse_generic_backup_if_shared()
+    assert ei.value.code == "shared_blocks_generic_backup"
+
+
+def test_refuse_generic_backup_active(shared_root):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from agent.anthropic_shared_pool import refuse_generic_backup_if_shared
+    from hermes_cli.auth import AuthError
+
+    with pytest.raises(AuthError):
+        refuse_generic_backup_if_shared()
+
+
+def test_shared_backup_restore_roundtrip(shared_root, tmp_path, monkeypatch):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root, epoch="dddddddd-dddd-dddd-dddd-dddddddddddd")
+    monkeypatch.setattr(
+        "agent.anthropic_shared_pool.require_no_live_gateways_for_scope_change",
+        lambda: None,
+    )
+    from agent.anthropic_shared_pool import (
+        create_shared_backup,
+        get_shared_mutation_capability,
+        is_shared_scope_active,
+        restore_shared_backup,
+        remove_scope_marker,
+        load_shared_pool_for_management,
+    )
+
+    cap = get_shared_mutation_capability()
+    out = tmp_path / "backup.tgz"
+    create_shared_backup(out, capability=cap)
+    assert out.exists()
+    assert out.stat().st_mode & 0o077 == 0
+
+    # Destroy live state
+    remove_scope_marker()
+    from agent.anthropic_shared_pool import clear_shared_namespace
+
+    clear_shared_namespace(capability=cap)
+    assert not is_shared_scope_active()
+
+    restore_shared_backup(out, yes=True, capability=cap)
+    assert is_shared_scope_active()
+    pool = load_shared_pool_for_management(require_active_three=True)
+    assert len(pool["entries"]) == 3
+
+
+def test_backup_module_hooks_refuse(shared_root, monkeypatch):
+    """hermes_cli.backup should call refuse when shared state exists."""
+    stage_three(shared_root, attest=False)
+    import hermes_cli.backup as backup_mod
+
+    # Prefer explicit guard if present; otherwise patch run_backup preflight.
+    if hasattr(backup_mod, "refuse_generic_backup_if_shared"):
+        from hermes_cli.auth import AuthError
+        with pytest.raises(AuthError):
+            backup_mod.refuse_generic_backup_if_shared()
+    else:
+        from agent.anthropic_shared_pool import refuse_generic_backup_if_shared
+        from hermes_cli.auth import AuthError
+        with pytest.raises(AuthError):
+            refuse_generic_backup_if_shared()

--- a/tests/hermes_cli/test_anthropic_shared_dashboard_guards.py
+++ b/tests/hermes_cli/test_anthropic_shared_dashboard_guards.py
@@ -1,0 +1,49 @@
+"""Dashboard/web API shared mutation guards return HTTP 409."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.agent.anthropic_shared_test_helpers import (
+    enable_marker,
+    shared_root,
+    stage_three,
+)
+
+
+def test_shared_mutation_forbidden_without_capability(shared_root):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from agent.anthropic_shared_pool import append_row
+    from hermes_cli.auth import AuthError
+    from tests.agent.anthropic_shared_test_helpers import make_row as mr
+
+    with pytest.raises(AuthError) as ei:
+        append_row(mr(priority=0), capability=None)  # type: ignore[arg-type]
+    assert ei.value.code == "shared_mutation_forbidden"
+
+
+def test_web_add_returns_409_logic(shared_root):
+    """Unit-level check of the guard used by the dashboard POST handler."""
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from agent.anthropic_shared_pool import is_shared_scope_active
+
+    assert is_shared_scope_active()
+    # Emulate handler branch
+    provider = "anthropic"
+    if provider == "anthropic" and is_shared_scope_active():
+        status = 409
+    else:
+        status = 200
+    assert status == 409
+
+
+def test_web_delete_returns_409_logic(shared_root):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from agent.anthropic_shared_pool import is_shared_scope_active
+
+    assert is_shared_scope_active()
+    status = 409 if is_shared_scope_active() else 200
+    assert status == 409

--- a/tests/hermes_cli/test_anthropic_shared_scope.py
+++ b/tests/hermes_cli/test_anthropic_shared_scope.py
@@ -1,0 +1,124 @@
+"""CLI scope/add/remove contracts for shared Anthropic pool."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tests.agent.anthropic_shared_test_helpers import (
+    enable_marker,
+    make_row,
+    shared_root,
+    stage_three,
+)
+
+
+def test_scope_report(shared_root, capsys):
+    from hermes_cli.anthropic_shared_auth import auth_scope_command
+
+    auth_scope_command(SimpleNamespace(provider="anthropic", scope_mode=None))
+    out = capsys.readouterr().out
+    assert "scope: profile" in out
+
+
+def test_enable_requires_three_and_attest(shared_root):
+    from hermes_cli.anthropic_shared_auth import auth_scope_command
+    from agent.anthropic_shared_pool import (
+        append_row,
+        get_shared_mutation_capability,
+    )
+
+    cap = get_shared_mutation_capability()
+    for i in range(2):
+        append_row(make_row(priority=i, refresh=f"fixture-oauth-refresh-cli-{i}"), capability=cap)
+    with pytest.raises(SystemExit) as ei:
+        auth_scope_command(
+            SimpleNamespace(
+                provider="anthropic",
+                scope_mode="shared",
+                attest_distinct_accounts=True,
+            )
+        )
+    assert ei.value.code in (1, 2)
+
+
+def test_enable_shared_happy_path(shared_root, capsys, monkeypatch):
+    from agent.anthropic_shared_pool import (
+        append_row,
+        get_shared_mutation_capability,
+        is_shared_scope_active,
+        require_no_live_gateways_for_scope_change,
+    )
+    from hermes_cli.anthropic_shared_auth import auth_scope_command
+
+    monkeypatch.setattr(
+        "agent.anthropic_shared_pool.require_no_live_gateways_for_scope_change",
+        lambda: None,
+    )
+    cap = get_shared_mutation_capability()
+    for i in range(3):
+        append_row(make_row(priority=i, refresh=f"fixture-oauth-refresh-cli3-{i}"), capability=cap)
+    auth_scope_command(
+        SimpleNamespace(
+            provider="anthropic",
+            scope_mode="shared",
+            attest_distinct_accounts=True,
+        )
+    )
+    assert is_shared_scope_active()
+    out = capsys.readouterr().out
+    assert "scope: shared" in out
+
+
+def test_unscoped_add_while_shared_exits_2(shared_root):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from hermes_cli.auth_commands import auth_add_command
+
+    with pytest.raises(SystemExit) as ei:
+        auth_add_command(
+            SimpleNamespace(
+                provider="anthropic",
+                auth_type="oauth",
+                shared=False,
+                label=None,
+                api_key=None,
+            )
+        )
+    assert ei.value.code == 2
+
+
+def test_active_remove_rejected(shared_root):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root)
+    from hermes_cli.auth_commands import auth_remove_command
+
+    with pytest.raises(SystemExit) as ei:
+        auth_remove_command(
+            SimpleNamespace(provider="anthropic", target="1", shared=True)
+        )
+    assert ei.value.code == 2
+
+
+def test_already_shared_enable_idempotent(shared_root, monkeypatch, capsys):
+    stage_three(shared_root, attest=True)
+    enable_marker(shared_root, epoch="cccccccc-cccc-cccc-cccc-cccccccccccc")
+    monkeypatch.setattr(
+        "agent.anthropic_shared_pool.require_no_live_gateways_for_scope_change",
+        lambda: None,
+    )
+    from hermes_cli.anthropic_shared_auth import auth_scope_command
+    from agent.anthropic_shared_pool import read_scope_state
+
+    before = read_scope_state().epoch
+    auth_scope_command(
+        SimpleNamespace(
+            provider="anthropic",
+            scope_mode="shared",
+            attest_distinct_accounts=True,
+        )
+    )
+    after = read_scope_state().epoch
+    assert before == after

--- a/tests/scripts/test_break_glass_anthropic_scope.py
+++ b/tests/scripts/test_break_glass_anthropic_scope.py
@@ -1,0 +1,81 @@
+"""Tests for scripts/break_glass_anthropic_scope.py."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "break_glass_anthropic_scope.py"
+
+
+def run_bg(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_requires_yes(tmp_path):
+    root = tmp_path / "h"
+    root.mkdir()
+    (root / "shared").mkdir()
+    proc = run_bg("--root", str(root), "--backup-dir", str(tmp_path / "b"))
+    assert proc.returncode == 2
+
+
+def test_removes_marker_leaves_auth(tmp_path):
+    root = tmp_path / "h"
+    shared = root / "shared"
+    shared.mkdir(parents=True)
+    auth = root / "auth.json"
+    auth_bytes = b'{"version": 1, "providers": {}}\n'
+    auth.write_bytes(auth_bytes)
+    auth.chmod(0o600)
+    marker = shared / "anthropic_pool_scope.json"
+    marker.write_text(json.dumps({"version": 1, "scope": "shared", "epoch": "e"}))
+    marker.chmod(0o600)
+    bdir = tmp_path / "backup"
+    bdir.mkdir()
+    bdir.chmod(0o700)
+
+    proc = run_bg(
+        "--root",
+        str(root),
+        "--backup-dir",
+        str(bdir),
+        "--yes",
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert not marker.exists()
+    assert auth.read_bytes() == auth_bytes
+    backups = list(bdir.glob("*-anthropic-scope.json"))
+    assert len(backups) == 1
+    assert backups[0].stat().st_mode & 0o077 == 0
+
+
+def test_symlink_marker_refused(tmp_path):
+    root = tmp_path / "h"
+    shared = root / "shared"
+    shared.mkdir(parents=True)
+    real = tmp_path / "real-marker.json"
+    real.write_text("{}")
+    marker = shared / "anthropic_pool_scope.json"
+    marker.symlink_to(real)
+    bdir = tmp_path / "b"
+    bdir.mkdir()
+    bdir.chmod(0o700)
+    proc = run_bg("--root", str(root), "--backup-dir", str(bdir), "--yes")
+    assert proc.returncode == 1
+    assert marker.is_symlink()  # untouched
+
+
+def test_relative_paths_rejected(tmp_path):
+    proc = run_bg("--root", "relative", "--backup-dir", str(tmp_path), "--yes")
+    assert proc.returncode == 2

--- a/tests/scripts/test_scan_auth_secrets.py
+++ b/tests/scripts/test_scan_auth_secrets.py
@@ -1,0 +1,86 @@
+"""Tests for scripts/scan_auth_secrets.py."""
+
+from __future__ import annotations
+
+import base64
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "scan_auth_secrets.py"
+
+
+def run_scan(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_detect_anthropic_prefix(tmp_path):
+    p = tmp_path / "a.txt"
+    # Assemble so this test source is not itself a finding in git-diff scans.
+    p.write_text("key=" + "sk-ant-" + "api03-ABCDEFGHIJKLMNOPQRSTUV\n")
+    proc = run_scan("--input", str(p))
+    assert proc.returncode == 1
+    assert "anthropic_prefix" in proc.stdout
+    assert "sk-ant" not in proc.stdout  # never echo secret
+
+
+def test_detect_jwt(tmp_path):
+    p = tmp_path / "j.txt"
+    hdr = base64.urlsafe_b64encode(b'{"alg":"none"}').decode().rstrip("=")
+    mid = base64.urlsafe_b64encode(b'{"sub":"x" * 20}').decode().rstrip("=")
+    sig = base64.urlsafe_b64encode(b"signature-bytes-here!!").decode().rstrip("=")
+    # Ensure JWT shape with long enough segments
+    while len(hdr) < 20:
+        hdr += "A"
+    while len(mid) < 20:
+        mid += "B"
+    while len(sig) < 16:
+        sig += "C"
+    p.write_text(f"tok={hdr}.{mid}.{sig}\n")
+    proc = run_scan("--input", str(p))
+    assert proc.returncode == 1
+    assert "jwt" in proc.stdout
+
+
+def test_named_secret_fixture_allowlisted(tmp_path):
+    p = tmp_path / "n.txt"
+    p.write_text(
+        "refresh_token = \"fixture-oauth-refresh-token-bbbbbbbbbbbbbbbb\"\n"
+    )
+    proc = run_scan("--input", str(p))
+    assert proc.returncode == 0
+
+
+def test_named_secret_real(tmp_path):
+    p = tmp_path / "n2.txt"
+    secret = "Real" + "Refresh" + "TokenValueWithEntropy999"
+    p.write_text("refresh_token = \"" + secret + "\"\n")
+    proc = run_scan("--input", str(p))
+    assert proc.returncode == 1
+    assert "named_secret" in proc.stdout
+    assert "RealRefresh" not in proc.stdout
+
+
+def test_symlink_refused(tmp_path):
+    real = tmp_path / "real.txt"
+    real.write_text("hi")
+    link = tmp_path / "link.txt"
+    link.symlink_to(real)
+    proc = run_scan("--input", str(link))
+    assert proc.returncode == 2
+
+
+def test_no_args_exit_2():
+    proc = run_scan()
+    assert proc.returncode == 2
+
+
+def test_clean_file(tmp_path):
+    p = tmp_path / "clean.txt"
+    p.write_text("hello world\nno secrets here\n")
+    proc = run_scan("--input", str(p))
+    assert proc.returncode == 0

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -519,9 +519,20 @@ hermes auth reset openrouter                             # Clear cooldowns
 hermes auth status anthropic                             # Show auth status for a provider
 hermes auth logout anthropic                             # Log out and clear stored auth state
 hermes auth spotify                                      # Authenticate Hermes with Spotify via PKCE
+
+# Machine-wide Anthropic shared OAuth pool (optional; off by default)
+hermes auth add anthropic --type oauth --shared          # Stage a dormant shared grant (max 3)
+hermes auth scope anthropic                              # Show profile|shared scope
+hermes auth scope anthropic shared --attest-distinct-accounts
+hermes auth scope anthropic profile                      # Disable shared scope (keeps dormant grants)
+hermes auth backup anthropic --shared --output /abs/path.tgz
+hermes auth restore anthropic --shared --input /abs/path.tgz --yes
+hermes logout --provider anthropic --shared              # Disable scope + clear shared namespace
 ```
 
-Subcommands: `add`, `list`, `remove`, `reset`, `status`, `logout`, `spotify`. When called with no subcommand, launches the interactive management wizard.
+Subcommands: `add`, `list`, `remove`, `reset`, `status`, `logout`, `spotify`, `scope`, `backup`, `restore`. When called with no subcommand, launches the interactive management wizard.
+
+Shared Anthropic scope is **opt-in**. While active, every profile resolves the same three root OAuth grants (`fill_first`), env/API-key/Claude-Code bypasses are ignored for official `api.anthropic.com`, and mutations require explicit `--shared` CLI commands (dashboard returns HTTP 409). Restart all gateways after scope changes. Never copy refresh tokens between profiles.
 
 ## `hermes status`
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -760,7 +760,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_DUMP_REQUESTS` | Dump API request payloads to log files (`true`/`false`) |
 | `HERMES_DUMP_REQUEST_STDOUT` | Dump API request payloads to stdout instead of log files. |
 | `HERMES_OAUTH_TRACE` | Set to `1` to log OAuth token exchange and refresh attempts. Includes redacted timing info. |
-| `HERMES_OAUTH_FILE` | Override the path used for OAuth credential storage (default: `~/.hermes/auth.json`). |
+| ~~`HERMES_OAUTH_FILE`~~ | **Not implemented.** OAuth credentials always live at `<HERMES_HOME>/auth.json` (or the machine root store for shared Anthropic scope). |
 | `HERMES_AGENT_HELP_GUIDANCE` | Append additional guidance text to the system prompt for custom deployments. |
 | `HERMES_AGENT_LOGO` | Override the ASCII banner logo at CLI startup. |
 | `DELEGATION_MAX_CONCURRENT_CHILDREN` | Max parallel subagents per `delegate_task` batch (default: `3`, floor of 1, no ceiling). Also configurable via `delegation.max_concurrent_children` in `config.yaml` — the config value takes priority. |

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -261,3 +261,31 @@ credential_pool_strategies:
   openrouter: round_robin
   anthropic: least_used
 ```
+
+## Machine-wide Anthropic shared OAuth pool
+
+By default each profile keeps its own Anthropic credentials. Operators who want **one ordered OAuth pool shared by every profile on the machine** can opt in:
+
+```bash
+# 1. Stage exactly three OAuth grants while still in profile scope
+hermes auth add anthropic --type oauth --shared   # ×3, different Anthropic accounts
+hermes auth list anthropic --shared
+
+# 2. Stop gateways, then enable shared scope (operator attestation required)
+hermes auth scope anthropic shared --attest-distinct-accounts
+
+# 3. Restart all Hermes gateways/workers
+```
+
+While shared scope is active:
+
+- Selection is fixed to `fill_first` (account 1 until exhausted, then 2, then 3).
+- Official native Anthropic targets (`api.anthropic.com`) use **only** the shared root pool — `ANTHROPIC_API_KEY` / Claude Code / profile rows / explicit keys are ignored.
+- Azure/Bedrock/Vertex/custom Anthropic-compatible endpoints keep their own auth and never receive shared OAuth.
+- Profile-local Anthropic rows stay on disk but are dormant until you archive them after validation.
+- Dashboard add/delete returns HTTP 409; use the CLI with `--shared`.
+- Disable with `hermes auth scope anthropic profile` (marker removed first; root grants remain for rollback).
+- Destructive clear: `hermes auth logout anthropic --shared` or `hermes logout --provider anthropic --shared`.
+- Backups: `hermes auth backup|restore anthropic --shared ...` only. Generic `hermes backup` refuses when shared state exists.
+
+**Never copy refresh tokens between profiles.** Shared mode keeps a single canonical refresh-token chain per grant under the root auth store with cross-process locking.

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -314,3 +314,7 @@ hermes profile update research-bot
 ```
 
 See **[Profile Distributions: Share a Whole Agent](./profile-distributions.md)** for the full guide — authoring, publishing, update semantics, security model, and use cases.
+
+## Shared Anthropic credentials (optional)
+
+Profiles are isolated by default. If you enable machine-wide Anthropic shared OAuth scope (`hermes auth scope anthropic shared --attest-distinct-accounts`), every profile under the same Hermes root resolves the same three root OAuth grants and does **not** re-materialize them into the profile `auth.json`. See [Credential Pools](./features/credential-pools.md#machine-wide-anthropic-shared-oauth-pool).


### PR DESCRIPTION
## Summary

Implements an **opt-in**, machine-wide Anthropic OAuth-only credential pool shared by every Hermes profile under one root. Default behavior is unchanged until the operator enables shared scope.

Closes the multi-profile re-materialization / single-use refresh races for Anthropic Max OAuth that were fixed earlier for Codex/xAI.

### Design

- Scope marker: `<root>/shared/anthropic_pool_scope.json` (`absent` = legacy profile mode)
- Canonical store: root `auth.json` → `shared_credential_pools.anthropic` (never profile `credential_pool`)
- Exactly three OAuth grants (`manual:hermes_pkce`), strategy fixed to `fill_first`
- Cross-process root-auth lock + `token_generation` / `refresh_attempt` for single-use refresh safety
- Authoritative resolution gate: while shared + official `api.anthropic.com`, ignore env keys, Claude Code files, explicit `api_key`, and profile rows
- Non-official targets (Azure/Bedrock/custom) keep endpoint-specific auth
- CLI: `hermes auth scope|backup|restore`, `--shared` on add/remove/reset/logout
- Dashboard pool mutations return HTTP 409 in shared mode
- Generic backup refuses when active/dormant shared state exists
- Break-glass helper + deterministic secret scanner

### Prior art

- #29530 profiled workers need a canonical auth home
- #8040 process-local locks do not protect multi-process pool state
- #60639 Anthropic re-read → refresh → write under one auth-store lock
- #62945 canonicalize lock identity through symlinks
- #65844 preserve newer on-disk cooldown state
- #67261 two-process single-use refresh pattern (xAI)
- #46614 root write-through (without duplicating shared rows into profiles)

### Test plan

- [x] Focused gate list 128/128 green
- [x] Secret scanner clean on diff
- [x] ruff on touched modules
- [ ] CI full suite

Fork merge: https://github.com/danpetkovic/hermes-agent/pull/1 (`32d2482baf2170d73e7da05a4028973086fbf0ff`)