### PR TITLE
Make SSH environment timeouts configurable (env overrides, defaults unchanged)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -235,6 +235,13 @@ TERMINAL_LIFETIME_SECONDS=300
 # TERMINAL_SSH_USER=agent
 # TERMINAL_SSH_PORT=22
 # TERMINAL_SSH_KEY=~/.ssh/id_rsa
+#
+# Optional timeout overrides (integer seconds; invalid values fall back to
+# defaults). Raise these on slow or congested links so a reachable host is
+# not misclassified as unreachable.
+# TERMINAL_SSH_CONNECT_TIMEOUT=10      # OpenSSH ConnectTimeout option
+# TERMINAL_SSH_ESTABLISH_TIMEOUT=15    # initial connection handshake deadline
+# TERMINAL_SSH_FILE_SYNC_TIMEOUT=120   # tar-over-SSH bulk file sync deadline
 
 # =============================================================================
 # SUDO SUPPORT (works with ALL terminal backends)

--- a/tests/tools/test_ssh_timeouts.py
+++ b/tests/tools/test_ssh_timeouts.py
@@ -1,0 +1,81 @@
+"""Tests for configurable SSH environment timeouts (TERMINAL_SSH_*_TIMEOUT)."""
+
+import pytest
+
+from tools.environments import ssh as ssh_env
+from tools.environments.ssh import SSHEnvironment, _timeout_env
+
+
+@pytest.fixture
+def make_env(monkeypatch):
+    """Factory building an SSHEnvironment with mocked connection/sync."""
+    monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/testuser")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+    monkeypatch.setattr(
+        ssh_env, "FileSyncManager",
+        lambda **kw: type("M", (), {"sync": lambda self, **k: None})(),
+    )
+
+    def _make():
+        return SSHEnvironment(host="example.com", user="testuser")
+
+    return _make
+
+
+class TestTimeoutEnvHelper:
+    """Unit tests for the _timeout_env parser."""
+
+    def test_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv("TERMINAL_SSH_CONNECT_TIMEOUT", raising=False)
+        assert _timeout_env("TERMINAL_SSH_CONNECT_TIMEOUT", 10) == 10
+
+    def test_valid_override(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_SSH_CONNECT_TIMEOUT", "45")
+        assert _timeout_env("TERMINAL_SSH_CONNECT_TIMEOUT", 10) == 45
+
+    @pytest.mark.parametrize("raw", ["abc", "", "12.5", "10s"])
+    def test_non_integer_falls_back(self, monkeypatch, raw):
+        monkeypatch.setenv("TERMINAL_SSH_CONNECT_TIMEOUT", raw)
+        assert _timeout_env("TERMINAL_SSH_CONNECT_TIMEOUT", 10) == 10
+
+    @pytest.mark.parametrize("raw", ["0", "-5"])
+    def test_non_positive_falls_back(self, monkeypatch, raw):
+        monkeypatch.setenv("TERMINAL_SSH_CONNECT_TIMEOUT", raw)
+        assert _timeout_env("TERMINAL_SSH_CONNECT_TIMEOUT", 10) == 10
+
+
+class TestSSHEnvironmentTimeouts:
+    """Timeout wiring on SSHEnvironment instances."""
+
+    def test_defaults_match_previous_hardcoded_values(self, monkeypatch, make_env):
+        for name in ("TERMINAL_SSH_CONNECT_TIMEOUT",
+                     "TERMINAL_SSH_ESTABLISH_TIMEOUT",
+                     "TERMINAL_SSH_FILE_SYNC_TIMEOUT"):
+            monkeypatch.delenv(name, raising=False)
+        env = make_env()
+        assert env.connect_timeout == 10
+        assert env.establish_timeout == 15
+        assert env.file_sync_timeout == 120
+        assert "ConnectTimeout=10" in " ".join(env._build_ssh_command())
+
+    def test_env_overrides_applied(self, monkeypatch, make_env):
+        monkeypatch.setenv("TERMINAL_SSH_CONNECT_TIMEOUT", "60")
+        monkeypatch.setenv("TERMINAL_SSH_ESTABLISH_TIMEOUT", "90")
+        monkeypatch.setenv("TERMINAL_SSH_FILE_SYNC_TIMEOUT", "600")
+        env = make_env()
+        assert env.connect_timeout == 60
+        assert env.establish_timeout == 90
+        assert env.file_sync_timeout == 600
+        assert "ConnectTimeout=60" in " ".join(env._build_ssh_command())
+
+    def test_invalid_overrides_fall_back_to_defaults(self, monkeypatch, make_env):
+        monkeypatch.setenv("TERMINAL_SSH_CONNECT_TIMEOUT", "not-a-number")
+        monkeypatch.setenv("TERMINAL_SSH_ESTABLISH_TIMEOUT", "-1")
+        monkeypatch.setenv("TERMINAL_SSH_FILE_SYNC_TIMEOUT", "0")
+        env = make_env()
+        assert env.connect_timeout == 10
+        assert env.establish_timeout == 15
+        assert env.file_sync_timeout == 120

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -21,6 +21,26 @@ from tools.environments.file_sync import (
 logger = logging.getLogger(__name__)
 
 
+def _timeout_env(name: str, default: int) -> int:
+    """Read a positive integer timeout (seconds) from the environment.
+
+    Invalid or non-positive values fall back to ``default`` so a bad
+    override can never make the backend less usable than stock behavior.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid %s=%r; using default %ss", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Ignoring non-positive %s=%r; using default %ss", name, raw, default)
+        return default
+    return value
+
+
 def _ensure_ssh_available() -> None:
     """Fail fast with a clear error when the SSH client is unavailable."""
     if not shutil.which("ssh"):
@@ -40,6 +60,19 @@ class SSHEnvironment(BaseEnvironment):
     Session snapshot preserves env vars across calls.
     CWD persists via in-band stdout markers.
     Uses SSH ControlMaster for connection reuse.
+
+    Timeouts are tunable via environment variables (integer seconds;
+    invalid or non-positive values fall back to the defaults):
+
+    - ``TERMINAL_SSH_CONNECT_TIMEOUT`` — OpenSSH ``ConnectTimeout`` option
+      passed on every ssh/scp invocation (default: 10).
+    - ``TERMINAL_SSH_ESTABLISH_TIMEOUT`` — overall deadline for the initial
+      connection handshake in ``_establish_connection`` (default: 15).
+    - ``TERMINAL_SSH_FILE_SYNC_TIMEOUT`` — deadline for the tar-over-SSH
+      bulk file sync streams (default: 120).
+
+    Raising these helps on congested-but-alive links, where the stock
+    short timeouts can misclassify a reachable host as unreachable.
     """
 
     def __init__(self, host: str, user: str, cwd: str = "~",
@@ -49,6 +82,10 @@ class SSHEnvironment(BaseEnvironment):
         self.user = user
         self.port = port
         self.key_path = key_path
+
+        self.connect_timeout = _timeout_env("TERMINAL_SSH_CONNECT_TIMEOUT", 10)
+        self.establish_timeout = _timeout_env("TERMINAL_SSH_ESTABLISH_TIMEOUT", 15)
+        self.file_sync_timeout = _timeout_env("TERMINAL_SSH_FILE_SYNC_TIMEOUT", 120)
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
@@ -87,7 +124,7 @@ class SSHEnvironment(BaseEnvironment):
         cmd.extend(["-o", "ControlPersist=300"])
         cmd.extend(["-o", "BatchMode=yes"])
         cmd.extend(["-o", "StrictHostKeyChecking=accept-new"])
-        cmd.extend(["-o", "ConnectTimeout=10"])
+        cmd.extend(["-o", f"ConnectTimeout={self.connect_timeout}"])
         if self.port != 22:
             cmd.extend(["-p", str(self.port)])
         if self.key_path:
@@ -105,7 +142,7 @@ class SSHEnvironment(BaseEnvironment):
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=15,
+                timeout=self.establish_timeout,
                 stdin=subprocess.DEVNULL,
             )
             if result.returncode != 0:
@@ -272,7 +309,7 @@ class SSHEnvironment(BaseEnvironment):
             tar_proc.stdout.close()
 
             try:
-                _, ssh_stderr = ssh_proc.communicate(timeout=120)
+                _, ssh_stderr = ssh_proc.communicate(timeout=self.file_sync_timeout)
                 # Use communicate() instead of wait() to drain stderr and
                 # avoid deadlock if tar produces more than PIPE_BUF of errors.
                 tar_stderr_raw = b""
@@ -313,7 +350,7 @@ class SSHEnvironment(BaseEnvironment):
                 stdin=subprocess.DEVNULL,
                 stdout=f,
                 stderr=subprocess.PIPE,
-                timeout=120,
+                timeout=self.file_sync_timeout,
             )
         if result.returncode != 0:
             raise RuntimeError(f"SSH bulk download failed: {result.stderr.decode(errors='replace').strip()}")


### PR DESCRIPTION
## Problem

The SSH environment backend (`tools/environments/ssh.py`) hard-codes three timeouts:

- `ConnectTimeout=10` passed to every ssh/scp invocation (`_build_ssh_command`)
- a 15-second `subprocess.run` deadline on the initial handshake (`_establish_connection`)
- a 120-second deadline on the tar-over-SSH bulk file sync streams (`_ssh_bulk_upload` / `_ssh_bulk_download`)

On a congested-but-alive network link (saturated uplink, high-latency WAN, flaky cellular), these fixed short deadlines can make a perfectly reachable host look unreachable: the handshake or file sync times out, `SSHEnvironment` construction raises, and the agent concludes the environment is down and stops trying — even though a slightly longer wait would have succeeded.

## Change

Add three optional environment overrides, following the existing `TERMINAL_SSH_*` naming used by this backend (`TERMINAL_SSH_HOST`, `TERMINAL_SSH_PORT`, ...) and the timeout-env parsing pattern already used by the managed Modal backend (`_request_timeout_env` in `tools/environments/managed_modal.py`):

| Variable | Controls | Default |
|---|---|---|
| `TERMINAL_SSH_CONNECT_TIMEOUT` | OpenSSH `ConnectTimeout` option | `10` |
| `TERMINAL_SSH_ESTABLISH_TIMEOUT` | initial connection handshake deadline | `15` |
| `TERMINAL_SSH_FILE_SYNC_TIMEOUT` | tar-over-SSH bulk upload/download deadline | `120` |

Values are integer seconds. Invalid or non-positive values are ignored with a warning and fall back to the defaults, so a bad override can never make the backend less usable than stock. **With the variables unset, behavior is byte-for-byte identical to today** — same defaults, same command lines.

Also documents the new knobs in the class docstring and the SSH section of `.env.example`.

## Tests

New `tests/tools/test_ssh_timeouts.py` (mirrors the mocked-connection style of `tests/tools/test_ssh_bulk_upload.py`):

- `_timeout_env` parsing: unset → default, valid override, non-integer / empty / non-positive → fallback
- instance wiring: defaults match the previous hard-coded values (including `ConnectTimeout=10` in the built command line), env overrides applied, invalid overrides fall back

`python3 -m pytest tests/tools/test_ssh_timeouts.py tests/tools/test_ssh_bulk_upload.py` — 32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
