### PR TITLE
fix: kanban notifier ownership

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -131,30 +131,9 @@ class GatewayKanbanWatchersMixin:
         cross boards, so delivery semantics are unchanged — this is
         purely a fan-out of the single-DB poll.
         """
-        # Gate: only the dispatch-owning gateway opens kanban DBs for notifier polling.
-        # Non-dispatch gateways have no subscriptions to deliver — all kanban state lives
-        # in the dispatch owner's per-board DBs. This prevents N-gateway -shm contention.
-        # TODO: gate per-board when per-board dispatcher_owner tracking lands.
-        try:
-            from hermes_cli.config import load_config as _load_config
-        except Exception:
-            logger.warning("kanban notifier: config loader unavailable; disabled")
-            return
-        env_override = os.environ.get("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "").strip().lower()
-        if env_override in {"0", "false", "no", "off"}:
-            logger.info("kanban notifier: disabled via HERMES_KANBAN_DISPATCH_IN_GATEWAY env")
-            return
-        try:
-            cfg = _load_config()
-        except Exception as exc:
-            logger.warning("kanban notifier: cannot load config (%s); disabled", exc)
-            return
-        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-        if not kanban_cfg.get("dispatch_in_gateway", True):
-            logger.info(
-                "kanban notifier: disabled via config kanban.dispatch_in_gateway=false"
-            )
-            return
+        # Every profile gateway polls the shared board, but only claims rows
+        # stamped for that profile. The default profile additionally handles
+        # ownerless rows created before notifier ownership was persisted.
         from gateway.config import Platform as _Platform
         try:
             from hermes_cli import kanban_db as _kb
@@ -198,6 +177,7 @@ class GatewayKanbanWatchersMixin:
             try:
                 def _collect():
                     deliveries: list[dict] = []
+                    include_ownerless = (notifier_profile == "default")
                     active_platforms = {
                         getattr(platform, "value", str(platform)).lower()
                         for platform in self.adapters.keys()
@@ -248,19 +228,14 @@ class GatewayKanbanWatchersMixin:
                             # a legacy DB. `_add_column_if_missing` now
                             # tolerates that race, but we still skip the
                             # redundant call to avoid the wasted work.
-                            subs = _kb.list_notify_subs(conn)
+                            subs = _kb.list_notify_subs(
+                                conn,
+                                notifier_profile=notifier_profile,
+                                include_ownerless=include_ownerless,
+                            )
                             if not subs:
                                 logger.debug("kanban notifier: board %s has no subscriptions", slug)
                             for sub in subs:
-                                owner_profile = sub.get("notifier_profile") or None
-                                if owner_profile and owner_profile != notifier_profile:
-                                    _owner_adapters = getattr(self, "_profile_adapters", {}).get(owner_profile)
-                                    if not _owner_adapters:
-                                        logger.debug(
-                                            "kanban notifier: subscription for %s owned by profile %s; current profile %s has no adapter for it, skipping",
-                                            sub.get("task_id"), owner_profile, notifier_profile,
-                                        )
-                                        continue
                                 platform = (sub.get("platform") or "").lower()
                                 if platform not in active_platforms:
                                     logger.debug(
@@ -275,6 +250,8 @@ class GatewayKanbanWatchersMixin:
                                     chat_id=sub["chat_id"],
                                     thread_id=sub.get("thread_id") or "",
                                     kinds=TERMINAL_KINDS,
+                                    notifier_profile=notifier_profile,
+                                    include_ownerless=include_ownerless,
                                 )
                                 if not events:
                                     continue
@@ -311,16 +288,7 @@ class GatewayKanbanWatchersMixin:
                         )
                         continue
                     sub_profile = sub.get("notifier_profile") or ""
-                    # Route via the SAME chokepoint the authorization path uses
-                    # (gateway/authz_mixin.py::_authorization_adapter): a stamped
-                    # profile with its own adapter-registry entry must be served
-                    # by THAT profile's same-platform adapter and must NOT silently
-                    # fall back to the default profile's adapter — otherwise a
-                    # secondary profile's task notification is delivered by the
-                    # wrong bot (the cross-profile mis-delivery this whole change
-                    # exists to fix). The helper returns None only when the profile
-                    # (or default) genuinely has no adapter for the platform.
-                    adapter = self._authorization_adapter(plat, sub_profile or None)
+                    adapter = getattr(self, "adapters", {}).get(plat)
                     if adapter is None:
                         logger.debug(
                             "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -131,9 +131,10 @@ class GatewayKanbanWatchersMixin:
         cross boards, so delivery semantics are unchanged — this is
         purely a fan-out of the single-DB poll.
         """
-        # Every profile gateway polls the shared board, but only claims rows
-        # stamped for that profile. The default profile additionally handles
-        # ownerless rows created before notifier ownership was persisted.
+        # A standalone gateway claims only its active profile. A multiplex
+        # gateway also claims rows for registered secondary profiles and routes
+        # them through those profiles' adapters. Only the active default
+        # profile handles legacy ownerless rows.
         from gateway.config import Platform as _Platform
         try:
             from hermes_cli import kanban_db as _kb
@@ -178,11 +179,17 @@ class GatewayKanbanWatchersMixin:
                 def _collect():
                     deliveries: list[dict] = []
                     include_ownerless = (notifier_profile == "default")
-                    active_platforms = {
-                        getattr(platform, "value", str(platform)).lower()
-                        for platform in self.adapters.keys()
+                    owned_adapter_maps = {
+                        notifier_profile: getattr(self, "adapters", {})
                     }
-                    if not active_platforms:
+                    owned_adapter_maps.update({
+                        profile: adapters
+                        for profile, adapters in getattr(
+                            self, "_profile_adapters", {}
+                        ).items()
+                        if profile != notifier_profile
+                    })
+                    if not any(owned_adapter_maps.values()):
                         logger.debug("kanban notifier: no connected adapters; skipping tick")
                         return deliveries
 
@@ -228,15 +235,25 @@ class GatewayKanbanWatchersMixin:
                             # a legacy DB. `_add_column_if_missing` now
                             # tolerates that race, but we still skip the
                             # redundant call to avoid the wasted work.
-                            subs = _kb.list_notify_subs(
-                                conn,
-                                notifier_profile=notifier_profile,
-                                include_ownerless=include_ownerless,
-                            )
+                            subs = []
+                            for owner in owned_adapter_maps:
+                                subs.extend(_kb.list_notify_subs(
+                                    conn,
+                                    notifier_profile=owner,
+                                    include_ownerless=(
+                                        include_ownerless
+                                        and owner == notifier_profile
+                                    ),
+                                ))
                             if not subs:
                                 logger.debug("kanban notifier: board %s has no subscriptions", slug)
                             for sub in subs:
                                 platform = (sub.get("platform") or "").lower()
+                                sub_profile = sub.get("notifier_profile") or notifier_profile
+                                active_platforms = {
+                                    getattr(p, "value", str(p)).lower()
+                                    for p in owned_adapter_maps[sub_profile].keys()
+                                }
                                 if platform not in active_platforms:
                                     logger.debug(
                                         "kanban notifier: subscription for %s on %s skipped; adapter not connected",
@@ -250,8 +267,11 @@ class GatewayKanbanWatchersMixin:
                                     chat_id=sub["chat_id"],
                                     thread_id=sub.get("thread_id") or "",
                                     kinds=TERMINAL_KINDS,
-                                    notifier_profile=notifier_profile,
-                                    include_ownerless=include_ownerless,
+                                    notifier_profile=sub_profile,
+                                    include_ownerless=(
+                                        include_ownerless
+                                        and not sub.get("notifier_profile")
+                                    ),
                                 )
                                 if not events:
                                     continue
@@ -288,11 +308,14 @@ class GatewayKanbanWatchersMixin:
                         )
                         continue
                     sub_profile = sub.get("notifier_profile") or ""
-                    adapter = getattr(self, "adapters", {}).get(plat)
-                    if adapter is None and sub_profile and sub_profile != notifier_profile:
-                        adapter_resolver = getattr(self, "_authorization_adapter", None)
-                        if callable(adapter_resolver):
-                            adapter = adapter_resolver(plat, sub_profile)
+                    if not sub_profile or sub_profile == notifier_profile:
+                        adapter = getattr(self, "adapters", {}).get(plat)
+                    else:
+                        adapter = (
+                            getattr(self, "_profile_adapters", {})
+                            .get(sub_profile, {})
+                            .get(plat)
+                        )
                     if adapter is None:
                         logger.debug(
                             "kanban notifier: adapter %s disconnected before delivery for %s profile=%s; rewinding claim",

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -289,10 +289,14 @@ class GatewayKanbanWatchersMixin:
                         continue
                     sub_profile = sub.get("notifier_profile") or ""
                     adapter = getattr(self, "adapters", {}).get(plat)
+                    if adapter is None and sub_profile and sub_profile != notifier_profile:
+                        adapter_resolver = getattr(self, "_authorization_adapter", None)
+                        if callable(adapter_resolver):
+                            adapter = adapter_resolver(plat, sub_profile)
                     if adapter is None:
                         logger.debug(
-                            "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",
-                            platform_str, sub["task_id"],
+                            "kanban notifier: adapter %s disconnected before delivery for %s profile=%s; rewinding claim",
+                            platform_str, sub["task_id"], sub_profile or notifier_profile,
                         )
                         await asyncio.to_thread(
                             self._kanban_rewind,
@@ -482,27 +486,14 @@ class GatewayKanbanWatchersMixin:
                                     )
                                     from gateway.session import SessionSource
                                     from gateway.platforms.base import MessageEvent, MessageType
-                                    # KNOWN LIMITATION (tracked follow-up): the
-                                    # subscription row does not persist the
-                                    # creator's chat_type, and it is not carried
-                                    # on the session-context bridge, so we cannot
-                                    # faithfully reconstruct the creator's real
-                                    # session key here. build_session_key() keys
-                                    # DMs (":dm:<chat_id>") on a wholly different
-                                    # shape from group/thread, so any hardcoded
-                                    # value mis-routes some creators. "group" is
-                                    # the least-surprising default for the
-                                    # dashboard/group flows this wake primarily
-                                    # serves; DM-originated creators are handled
-                                    # by the follow-up that stamps + persists
-                                    # chat_type end-to-end. handle_message()
-                                    # get_or_create_session's the target, so a
-                                    # mismatch degrades to "wake lands in a fresh
-                                    # group session" — never an exception.
+                                    _chat_type = sub.get("chat_type") or "group"
+                                    # Legacy rows predate chat_type persistence.
+                                    # Default them to group so existing non-DM
+                                    # subscriptions keep their old wake shape.
                                     _source = SessionSource(
                                         platform=plat,
                                         chat_id=sub["chat_id"],
-                                        chat_type="group",
+                                        chat_type=_chat_type,
                                         thread_id=sub.get("thread_id") or None,
                                         user_id=sub.get("user_id"),
                                         profile=sub_profile or None,
@@ -783,7 +774,6 @@ class GatewayKanbanWatchersMixin:
                 "kanban dispatcher: advisory lock unavailable at %s; proceeding "
                 "on config control alone.", _lock_path,
             )
-
         try:
             interval = float(kanban_cfg.get("dispatch_interval_seconds", 60) or 60)
         except (ValueError, TypeError):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16746,12 +16746,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
             chat_name=context.source.chat_name or "",
+            chat_type=context.source.chat_type or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
-            profile=getattr(context.source, "profile", "") or "",
+            profile=(getattr(context.source, "profile", "") or self._active_profile_name()),
             async_delivery=_async_delivery,
         )
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -74,6 +74,7 @@ _SESSION_PLATFORM: ContextVar = ContextVar("HERMES_SESSION_PLATFORM", default=_U
 _SESSION_SOURCE: ContextVar = ContextVar("HERMES_SESSION_SOURCE", default=_UNSET)
 _SESSION_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNSET)
 _SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
+_SESSION_CHAT_TYPE: ContextVar = ContextVar("HERMES_SESSION_CHAT_TYPE", default=_UNSET)
 _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
@@ -125,6 +126,7 @@ _VAR_MAP = {
     "HERMES_SESSION_SOURCE": _SESSION_SOURCE,
     "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
+    "HERMES_SESSION_CHAT_TYPE": _SESSION_CHAT_TYPE,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
@@ -159,6 +161,7 @@ def set_session_vars(
     source: str = "",
     chat_id: str = "",
     chat_name: str = "",
+    chat_type: str = "",
     thread_id: str = "",
     user_id: str = "",
     user_name: str = "",
@@ -195,6 +198,7 @@ def set_session_vars(
         _SESSION_SOURCE.set(source),
         _SESSION_CHAT_ID.set(chat_id),
         _SESSION_CHAT_NAME.set(chat_name),
+        _SESSION_CHAT_TYPE.set(chat_type),
         _SESSION_THREAD_ID.set(thread_id),
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
@@ -230,6 +234,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_SOURCE,
         _SESSION_CHAT_ID,
         _SESSION_CHAT_NAME,
+        _SESSION_CHAT_TYPE,
         _SESSION_THREAD_ID,
         _SESSION_USER_ID,
         _SESSION_USER_NAME,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -479,6 +479,7 @@ class GatewaySlashCommandsMixin:
                     ).lower()
                     chat_id = str(getattr(source, "chat_id", "") or "")
                     thread_id = str(getattr(source, "thread_id", "") or "")
+                    chat_type = str(getattr(source, "chat_type", "") or "")
                     user_id = str(getattr(source, "user_id", "") or "") or None
                     if platform_str and chat_id:
                         def _sub():
@@ -490,6 +491,7 @@ class GatewaySlashCommandsMixin:
                                     platform=platform_str, chat_id=chat_id,
                                     thread_id=thread_id or None,
                                     user_id=user_id,
+                                    chat_type=chat_type or None,
                                     notifier_profile=getattr(self, "_kanban_notifier_profile", None) or self._active_profile_name(),
                                 )
                             finally:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2687,8 +2687,9 @@ def _cmd_notify_list(args: argparse.Namespace) -> int:
         return 0
     for s in subs:
         thr = f":{s['thread_id']}" if s.get("thread_id") else ""
+        ctype = f":{s['chat_type']}" if s.get("chat_type") else ""
         owner = f"  owner={s['notifier_profile']}" if s.get("notifier_profile") else ""
-        print(f"  {s['task_id']:10s}  {s['platform']}:{s['chat_id']}{thr}"
+        print(f"  {s['task_id']:10s}  {s['platform']}:{s['chat_id']}{ctype}{thr}"
               f"  (since event {s['last_event_id']}){owner}")
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9222,14 +9222,28 @@ def add_notify_sub(
 
 
 def list_notify_subs(
-    conn: sqlite3.Connection, task_id: Optional[str] = None,
+    conn: sqlite3.Connection,
+    task_id: Optional[str] = None,
+    *,
+    notifier_profile: Optional[str] = None,
+    include_ownerless: bool = False,
 ) -> list[dict]:
+    """List subscriptions, optionally restricted to one notifier owner."""
+    clauses: list[str] = []
+    params: list[Any] = []
     if task_id is not None:
-        rows = conn.execute(
-            "SELECT * FROM kanban_notify_subs WHERE task_id = ?", (task_id,),
-        ).fetchall()
-    else:
-        rows = conn.execute("SELECT * FROM kanban_notify_subs").fetchall()
+        clauses.append("task_id = ?")
+        params.append(task_id)
+    if notifier_profile is not None:
+        owner_clause = "notifier_profile = ?"
+        params.append(notifier_profile)
+        if include_ownerless:
+            owner_clause = f"({owner_clause} OR notifier_profile IS NULL OR notifier_profile = '')"
+        clauses.append(owner_clause)
+    query = "SELECT * FROM kanban_notify_subs"
+    if clauses:
+        query += " WHERE " + " AND ".join(clauses)
+    rows = conn.execute(query, params).fetchall()
     return [dict(r) for r in rows]
 
 
@@ -9307,6 +9321,8 @@ def claim_unseen_events_for_sub(
     chat_id: str,
     thread_id: Optional[str] = None,
     kinds: Optional[Iterable[str]] = None,
+    notifier_profile: Optional[str] = None,
+    include_ownerless: bool = False,
 ) -> tuple[int, int, list[Event]]:
     """Atomically claim unseen notification events for one subscription.
 
@@ -9321,12 +9337,25 @@ def claim_unseen_events_for_sub(
     Callers should send the claimed events, then either leave the cursor at
     ``new_cursor`` on success or call :func:`rewind_notify_cursor` if delivery
     failed before any terminal unsubscribe removed the row.
+
+    When ``notifier_profile`` is set, both the read and cursor CAS are scoped
+    to that owner. ``include_ownerless`` lets one explicit legacy owner claim
+    unstamped rows without exposing them to every profile gateway.
     """
     with write_txn(conn):
+        owner_clause = ""
+        owner_params: list[Any] = []
+        if notifier_profile is not None:
+            owner_clause = " AND (notifier_profile = ?"
+            owner_params.append(notifier_profile)
+            if include_ownerless:
+                owner_clause += " OR notifier_profile IS NULL OR notifier_profile = ''"
+            owner_clause += ")"
         row = conn.execute(
             "SELECT last_event_id FROM kanban_notify_subs "
-            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
-            (task_id, platform, chat_id, thread_id or ""),
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?"
+            + owner_clause,
+            (task_id, platform, chat_id, thread_id or "", *owner_params),
         ).fetchone()
         if row is None:
             return 0, 0, []
@@ -9341,12 +9370,17 @@ def claim_unseen_events_for_sub(
         )
         if not events:
             return old_cursor, old_cursor, []
-        conn.execute(
+        cur = conn.execute(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
-            "AND last_event_id = ?",
-            (int(new_cursor), task_id, platform, chat_id, thread_id or "", int(old_cursor)),
+            "AND last_event_id = ?" + owner_clause,
+            (
+                int(new_cursor), task_id, platform, chat_id, thread_id or "",
+                int(old_cursor), *owner_params,
+            ),
         )
+        if cur.rowcount != 1:
+            return old_cursor, old_cursor, []
         return old_cursor, new_cursor, events
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1273,6 +1273,7 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     task_id       TEXT NOT NULL,
     platform      TEXT NOT NULL,
     chat_id       TEXT NOT NULL,
+    chat_type     TEXT,
     thread_id     TEXT NOT NULL DEFAULT '',
     user_id       TEXT,
     notifier_profile TEXT,
@@ -2381,6 +2382,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         notify_cols = {
             row["name"] for row in conn.execute("PRAGMA table_info(kanban_notify_subs)")
         }
+        if "chat_type" not in notify_cols:
+            _add_column_if_missing(
+                conn, "kanban_notify_subs", "chat_type", "chat_type TEXT"
+            )
         if "notifier_profile" not in notify_cols:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
@@ -2507,7 +2512,7 @@ _REBUILD_SPECS = {
     "kanban_notify_subs": (
         "CREATE TABLE kanban_notify_subs ("
         " task_id TEXT NOT NULL, platform TEXT NOT NULL, chat_id TEXT NOT NULL,"
-        " thread_id TEXT NOT NULL DEFAULT '', user_id TEXT,"
+        " chat_type TEXT, thread_id TEXT NOT NULL DEFAULT '', user_id TEXT,"
         " notifier_profile TEXT, created_at INTEGER NOT NULL,"
         " last_event_id INTEGER NOT NULL DEFAULT 0,"
         " PRIMARY KEY (task_id, platform, chat_id, thread_id))",
@@ -9191,6 +9196,7 @@ def add_notify_sub(
     task_id: str,
     platform: str,
     chat_id: str,
+    chat_type: Optional[str] = None,
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
     notifier_profile: Optional[str] = None,
@@ -9202,11 +9208,23 @@ def add_notify_sub(
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
-                (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (task_id, platform, chat_id, chat_type, thread_id, user_id, notifier_profile, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
+            (task_id, platform, chat_id, chat_type, thread_id or "", user_id, notifier_profile, now),
         )
+        if chat_type:
+            # Self-heal legacy rows that predate chat-type persistence by
+            # backfilling only when the existing value is unset.
+            conn.execute(
+                """
+                UPDATE kanban_notify_subs
+                   SET chat_type = ?
+                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                   AND (chat_type IS NULL OR chat_type = '')
+                """,
+                (chat_type, task_id, platform, chat_id, thread_id or ""),
+            )
         if notifier_profile:
             # Self-heal legacy rows that predate notifier ownership by
             # backfilling only when the existing value is unset.

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1794,6 +1794,7 @@ def _configured_home_channels() -> list[dict]:
         result.append({
             "platform": platform.value,
             "chat_id": hc.chat_id,
+            "chat_type": getattr(hc, "chat_type", "") or "",
             "thread_id": hc.thread_id or "",
             "name": hc.name or "Home",
         })
@@ -1813,11 +1814,16 @@ def _active_profile_name() -> str:
 
 def _home_sub_matches(sub: dict, home: dict) -> bool:
     """True if a notify_subs row corresponds to the given home channel."""
-    return (
-        sub.get("platform") == home["platform"]
-        and str(sub.get("chat_id", "")) == str(home["chat_id"])
-        and str(sub.get("thread_id") or "") == str(home["thread_id"] or "")
-    )
+    if (
+        sub.get("platform") != home["platform"]
+        or str(sub.get("chat_id", "")) != str(home["chat_id"])
+        or str(sub.get("thread_id") or "") != str(home["thread_id"] or "")
+    ):
+        return False
+    home_chat_type = str(home.get("chat_type") or "")
+    if home_chat_type:
+        return str(sub.get("chat_type") or "") == home_chat_type
+    return True
 
 
 @router.get("/home-channels")
@@ -1882,6 +1888,7 @@ def subscribe_home(task_id: str, platform: str, board: Optional[str] = Query(Non
             platform=platform,
             chat_id=home["chat_id"],
             thread_id=home["thread_id"] or None,
+            chat_type=home.get("chat_type") or None,
             notifier_profile=_active_profile_name(),
         )
         return {"ok": True, "task_id": task_id, "home_channel": home}

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -16,6 +16,15 @@ class RecordingAdapter:
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
 
 
+class WakeRecordingAdapter(RecordingAdapter):
+    def __init__(self):
+        super().__init__()
+        self.handled = []
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
 class DisconnectedAdapters(dict):
     """Expose a platform during collection, then simulate disconnect on get()."""
 
@@ -47,7 +56,12 @@ def _make_runner(adapter):
 def _create_completed_subscription(summary="done once"):
     conn = kb.connect()
     try:
-        tid = kb.create_task(conn, title="notify once", assignee="worker")
+        tid = kb.create_task(
+            conn,
+            title="notify once",
+            assignee="worker",
+            session_id="session-1",
+        )
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
         kb.complete_task(conn, tid, summary=summary)
         return tid
@@ -55,17 +69,107 @@ def _create_completed_subscription(summary="done once"):
         conn.close()
 
 
-def _unseen_terminal_events(tid):
+def test_profile_notifier_uses_owned_profile_adapter_and_legacy_default(tmp_path, monkeypatch):
+    db_path = tmp_path / "profile-owned-plus-legacy.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
     conn = kb.connect()
     try:
-        _, events = kb.unseen_events_for_sub(
+        ownerless_tid = kb.create_task(
             conn,
-            task_id=tid,
-            platform="telegram",
-            chat_id="chat-1",
-            kinds=["completed", "blocked", "gave_up", "crashed", "timed_out"],
+            title="legacy ownerless",
+            assignee="worker",
+            session_id="session-default",
         )
-        return events
+        kb.add_notify_sub(
+            conn,
+            task_id=ownerless_tid,
+            platform="telegram",
+            chat_id="chat-default",
+        )
+        kb.complete_task(conn, ownerless_tid, summary="done default")
+
+        owned_tid = kb.create_task(
+            conn,
+            title="orchestrator owned",
+            assignee="worker",
+            session_id="session-orchestrator",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=owned_tid,
+            platform="telegram",
+            chat_id="chat-orchestrator",
+            notifier_profile="orchestrator",
+        )
+        kb.complete_task(conn, owned_tid, summary="done orchestrator")
+    finally:
+        conn.close()
+
+    lock_path = tmp_path / ".dispatcher.lock"
+    lock_handle, lock_state = _acquire_singleton_lock(lock_path)
+    contender_handle, contender_state = _acquire_singleton_lock(lock_path)
+    assert lock_state == "held"
+    assert contender_state == "contended"
+
+    default_adapter = ProfileWakeRecordingAdapter()
+    owned_adapter = ProfileWakeRecordingAdapter()
+    default_cursors = []
+    owned_cursors = []
+
+    async def _recording_send(adapter, task_id, cursors, chat_id, text, metadata=None):
+        conn = kb.connect()
+        try:
+            cursors.append(kb.list_notify_subs(conn, task_id)[0]["last_event_id"])
+        finally:
+            conn.close()
+        await RecordingAdapter.send(adapter, chat_id, text, metadata)
+
+    default_adapter.send = lambda chat_id, text, metadata=None: _recording_send(
+        default_adapter, ownerless_tid, default_cursors, chat_id, text, metadata
+    )
+    owned_adapter.send = lambda chat_id, text, metadata=None: _recording_send(
+        owned_adapter, owned_tid, owned_cursors, chat_id, text, metadata
+    )
+
+    default_runner = _make_runner(default_adapter)
+    default_runner._kanban_notifier_profile = "default"
+    setattr(default_runner, "_kanban_dispatcher_owner", True)
+
+    orchestrator_runner = _make_runner(owned_adapter)
+    orchestrator_runner._kanban_notifier_profile = "orchestrator"
+    setattr(orchestrator_runner, "_kanban_dispatcher_owner", False)
+    orchestrator_runner._profile_adapters = {}
+
+    try:
+        asyncio.run(_run_one_notifier_tick(monkeypatch, default_runner))
+        asyncio.run(_run_one_notifier_tick(monkeypatch, orchestrator_runner))
+        asyncio.run(_run_one_notifier_tick(monkeypatch, default_runner))
+        asyncio.run(_run_one_notifier_tick(monkeypatch, orchestrator_runner))
+    finally:
+        _release_singleton_lock(contender_handle)
+        _release_singleton_lock(lock_handle)
+
+    assert len(default_adapter.sent) == 1
+    assert len(default_adapter.handled) == 1
+    assert default_cursors == [default_cursors[0]]
+    assert default_cursors[0] > 0
+    assert ownerless_tid in default_adapter.sent[0]["text"]
+    assert default_adapter.handled[0].source.profile is None
+
+    assert len(owned_adapter.sent) == 1
+    assert len(owned_adapter.handled) == 1
+    assert owned_cursors == [owned_cursors[0]]
+    assert owned_cursors[0] > 0
+    assert owned_tid in owned_adapter.sent[0]["text"]
+    assert owned_adapter.handled[0].source.profile == "orchestrator"
+    assert orchestrator_runner._profile_adapters == {}
+
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, ownerless_tid) == []
+        assert kb.list_notify_subs(conn, owned_tid) == []
     finally:
         conn.close()
 
@@ -166,7 +270,9 @@ def test_profile_notifier_claims_only_owned_subscription(tmp_path, monkeypatch):
     orchestrator_runner = _make_runner(orchestrator_adapter)
     orchestrator_runner._kanban_notifier_profile = "orchestrator"
     setattr(orchestrator_runner, "_kanban_dispatcher_owner", False)
-    orchestrator_runner._profile_adapters = {}
+    orchestrator_runner._profile_adapters = {
+        "orchestrator": {Platform.TELEGRAM: orchestrator_adapter},
+    }
 
     lock_path = tmp_path / ".dispatcher.lock"
     lock_handle, lock_state = _acquire_singleton_lock(lock_path)
@@ -249,6 +355,7 @@ def test_profile_notifier_runs_when_embedded_dispatch_disabled(tmp_path, monkeyp
     adapter = ProfileWakeRecordingAdapter()
     runner = _make_runner(adapter)
     runner._kanban_notifier_profile = "orchestrator"
+    runner._profile_adapters = {"orchestrator": {Platform.TELEGRAM: adapter}}
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
     assert len(adapter.sent) == 1
@@ -285,6 +392,75 @@ def test_kanban_db_path_is_test_isolated_from_real_home():
 
     assert kb.kanban_db_path().resolve().is_relative_to(hermes_home.resolve())
     assert kb.kanban_db_path().resolve() != production_db.resolve()
+
+
+def test_kanban_notifier_uses_subscribed_chat_type(tmp_path, monkeypatch):
+    db_path = tmp_path / "chat-type.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    cases = [
+        ("dm", None),
+        ("group", "42"),
+    ]
+
+    for chat_type, thread_id in cases:
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(
+                conn,
+                title=f"notify-{chat_type}",
+                assignee="worker",
+                session_id="session-1",
+            )
+            kb.add_notify_sub(
+                conn,
+                task_id=tid,
+                platform="telegram",
+                chat_id=f"chat-{chat_type}",
+                chat_type=chat_type,
+                thread_id=thread_id,
+            )
+            kb.complete_task(conn, tid, summary="done once")
+        finally:
+            conn.close()
+
+        adapter = WakeRecordingAdapter()
+        runner = _make_runner(adapter)
+        asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+        assert len(adapter.sent) == 1
+        assert len(adapter.handled) == 1
+        assert adapter.handled[0].source.chat_type == chat_type
+        assert adapter.handled[0].source.chat_id == f"chat-{chat_type}"
+        assert adapter.handled[0].source.thread_id == thread_id
+
+
+def test_kanban_notifier_legacy_subscription_defaults_to_group(tmp_path, monkeypatch):
+    db_path = tmp_path / "legacy-chat-type.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="legacy notify", assignee="worker", session_id="session-1")
+        conn.execute(
+            "INSERT INTO kanban_notify_subs (task_id, platform, chat_id, thread_id, user_id, created_at, last_event_id) "
+            "VALUES (?, 'telegram', 'chat-legacy', '', NULL, 0, 0)",
+            (tid,),
+        )
+        kb.complete_task(conn, tid, summary="done once")
+    finally:
+        conn.close()
+
+    adapter = WakeRecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert len(adapter.handled) == 1
+    assert adapter.handled[0].source.chat_type == "group"
+    assert adapter.handled[0].source.chat_id == "chat-legacy"
 
 
 class FailingAdapter:
@@ -442,6 +618,26 @@ def test_notifier_owning_profile_adapter_no_default_fallback(tmp_path, monkeypat
     # The claim is rewound (adapter resolved to None → treated as disconnected),
     # so the event is still unseen and will deliver once beta's adapter connects.
     assert [ev.kind for ev in _unseen_terminal_events_for(tid, "chat-beta")] == ["completed"]
+
+
+def _unseen_terminal_events(tid):
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+        if not subs:
+            return []
+        sub = subs[0]
+        _, events = kb.unseen_events_for_sub(
+            conn,
+            task_id=tid,
+            platform=sub["platform"],
+            chat_id=sub["chat_id"],
+            thread_id=sub.get("thread_id") or None,
+            kinds=["completed", "blocked", "gave_up", "crashed", "timed_out"],
+        )
+        return events
+    finally:
+        conn.close()
 
 
 def _unseen_terminal_events_for(tid, chat_id):

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 
 from gateway.config import Platform
+from gateway.kanban_watchers import _acquire_singleton_lock, _release_singleton_lock
 from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
 
@@ -103,6 +104,155 @@ def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatc
 
     assert len(adapter1.sent) == 1
     assert adapter2.sent == []
+
+
+class ProfileWakeRecordingAdapter(RecordingAdapter):
+    def __init__(self):
+        super().__init__()
+        self.handled = []
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
+def _create_profile_test_subscription(*, notifier_profile=None):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="owned notification",
+            assignee="worker",
+            session_id="session-1",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-orchestrator",
+            notifier_profile=notifier_profile,
+        )
+        kb.complete_task(conn, tid, summary="done")
+        return tid
+    finally:
+        conn.close()
+
+
+def test_profile_notifier_claims_only_owned_subscription(tmp_path, monkeypatch):
+    db_path = tmp_path / "profile-owner.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    tid = _create_profile_test_subscription(notifier_profile="orchestrator")
+
+    default_adapter = ProfileWakeRecordingAdapter()
+    orchestrator_adapter = ProfileWakeRecordingAdapter()
+    claimed_cursors = []
+
+    async def record_claimed_cursor(chat_id, text, metadata=None):
+        conn = kb.connect()
+        try:
+            claimed_cursors.append(kb.list_notify_subs(conn, tid)[0]["last_event_id"])
+        finally:
+            conn.close()
+        await RecordingAdapter.send(orchestrator_adapter, chat_id, text, metadata)
+
+    orchestrator_adapter.send = record_claimed_cursor
+    default_runner = _make_runner(default_adapter)
+    default_runner._kanban_notifier_profile = "default"
+    setattr(default_runner, "_kanban_dispatcher_owner", True)
+    default_runner._profile_adapters = {
+        "orchestrator": {Platform.TELEGRAM: orchestrator_adapter},
+    }
+    orchestrator_runner = _make_runner(orchestrator_adapter)
+    orchestrator_runner._kanban_notifier_profile = "orchestrator"
+    setattr(orchestrator_runner, "_kanban_dispatcher_owner", False)
+    orchestrator_runner._profile_adapters = {}
+
+    lock_path = tmp_path / ".dispatcher.lock"
+    lock_handle, lock_state = _acquire_singleton_lock(lock_path)
+    contender_handle, contender_state = _acquire_singleton_lock(lock_path)
+    assert lock_state == "held"
+    assert contender_state == "contended"
+
+    try:
+        asyncio.run(_run_one_notifier_tick(monkeypatch, default_runner))
+
+        conn = kb.connect()
+        try:
+            sub = kb.list_notify_subs(conn, tid)[0]
+        finally:
+            conn.close()
+        assert sub["last_event_id"] == 0
+        assert default_adapter.sent == []
+        assert default_adapter.handled == []
+        assert orchestrator_adapter.sent == []
+        assert orchestrator_adapter.handled == []
+
+        asyncio.run(_run_one_notifier_tick(monkeypatch, orchestrator_runner))
+    finally:
+        _release_singleton_lock(contender_handle)
+        _release_singleton_lock(lock_handle)
+
+    assert len(orchestrator_adapter.sent) == 1
+    assert len(orchestrator_adapter.handled) == 1
+    assert claimed_cursors[0] > 0
+    assert orchestrator_adapter.handled[0].source.profile == "orchestrator"
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_only_default_profile_claims_ownerless_subscription(tmp_path, monkeypatch):
+    db_path = tmp_path / "ownerless.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_profile_test_subscription()
+
+    nonowner_adapter = ProfileWakeRecordingAdapter()
+    nonowner_runner = _make_runner(nonowner_adapter)
+    nonowner_runner._kanban_notifier_profile = "orchestrator"
+    setattr(nonowner_runner, "_kanban_dispatcher_owner", True)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, nonowner_runner))
+
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, tid)[0]["last_event_id"] == 0
+    finally:
+        conn.close()
+    assert nonowner_adapter.sent == []
+    assert nonowner_adapter.handled == []
+
+    owner_adapter = ProfileWakeRecordingAdapter()
+    owner_runner = _make_runner(owner_adapter)
+    owner_runner._kanban_notifier_profile = "default"
+    setattr(owner_runner, "_kanban_dispatcher_owner", False)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, owner_runner))
+
+    assert len(owner_adapter.sent) == 1
+    assert len(owner_adapter.handled) == 1
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_profile_notifier_runs_when_embedded_dispatch_disabled(tmp_path, monkeypatch):
+    db_path = tmp_path / "dispatch-disabled.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "false")
+    kb.init_db()
+    _create_profile_test_subscription(notifier_profile="orchestrator")
+
+    adapter = ProfileWakeRecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._kanban_notifier_profile = "orchestrator"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert len(adapter.handled) == 1
 
 
 def test_kanban_notifier_rewinds_claim_if_adapter_disconnects(tmp_path, monkeypatch):

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -264,15 +264,11 @@ def test_profile_notifier_claims_only_owned_subscription(tmp_path, monkeypatch):
     default_runner = _make_runner(default_adapter)
     default_runner._kanban_notifier_profile = "default"
     setattr(default_runner, "_kanban_dispatcher_owner", True)
-    default_runner._profile_adapters = {
-        "orchestrator": {Platform.TELEGRAM: orchestrator_adapter},
-    }
+    default_runner._profile_adapters = {}
     orchestrator_runner = _make_runner(orchestrator_adapter)
     orchestrator_runner._kanban_notifier_profile = "orchestrator"
     setattr(orchestrator_runner, "_kanban_dispatcher_owner", False)
-    orchestrator_runner._profile_adapters = {
-        "orchestrator": {Platform.TELEGRAM: orchestrator_adapter},
-    }
+    orchestrator_runner._profile_adapters = {}
 
     lock_path = tmp_path / ".dispatcher.lock"
     lock_handle, lock_state = _acquire_singleton_lock(lock_path)
@@ -306,6 +302,63 @@ def test_profile_notifier_claims_only_owned_subscription(tmp_path, monkeypatch):
     conn = kb.connect()
     try:
         assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_multiplex_notifier_routes_active_and_secondary_owners(tmp_path, monkeypatch):
+    db_path = tmp_path / "multiplex-owners.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    primary_tid = _create_profile_test_subscription(notifier_profile="primary")
+    secondary_tid = _create_profile_test_subscription(notifier_profile="default")
+
+    primary_adapter = ProfileWakeRecordingAdapter()
+    secondary_adapter = ProfileWakeRecordingAdapter()
+    runner = _make_runner(primary_adapter)
+    runner._kanban_notifier_profile = "primary"
+    setattr(runner, "_profile_adapters", {
+        "default": {Platform.TELEGRAM: secondary_adapter},
+    })
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert primary_tid in primary_adapter.sent[0]["text"]
+    assert primary_adapter.handled[0].source.profile == "primary"
+    assert secondary_tid in secondary_adapter.sent[0]["text"]
+    assert secondary_adapter.handled[0].source.profile == "default"
+
+
+def test_multiplex_notifier_rewinds_disconnected_secondary_owner(tmp_path, monkeypatch):
+    db_path = tmp_path / "multiplex-disconnected.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_profile_test_subscription(notifier_profile="secondary")
+
+    primary_adapter = ProfileWakeRecordingAdapter()
+    runner = _make_runner(primary_adapter)
+    runner._kanban_notifier_profile = "primary"
+    setattr(runner, "_profile_adapters", {
+        "secondary": DisconnectedAdapters(
+            {Platform.TELEGRAM: ProfileWakeRecordingAdapter()}
+        ),
+    })
+    rewound = []
+    real_rewind = runner._kanban_rewind
+
+    def record_rewind(sub, claimed_cursor, old_cursor, board=None):
+        rewound.append((sub["task_id"], claimed_cursor, old_cursor))
+        real_rewind(sub, claimed_cursor, old_cursor, board)
+
+    runner._kanban_rewind = record_rewind
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert rewound and rewound[0][0] == tid
+    assert primary_adapter.sent == []
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, tid)[0]["last_event_id"] == 0
     finally:
         conn.close()
 

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -169,6 +169,33 @@ def test_set_session_env_handles_missing_optional_fields():
     runner._clear_session_env(tokens)
 
 
+@pytest.mark.parametrize("active_profile", ["default", "researcher", "orchestrator"])
+def test_set_session_env_falls_back_to_active_profile_when_source_profile_missing(
+    monkeypatch, active_profile
+):
+    """A profile-scoped gateway turn must stamp HERMES_SESSION_PROFILE even when
+    the SessionSource has no explicit profile.
+    """
+    runner = object.__new__(GatewayRunner)
+    monkeypatch.setattr(GatewayRunner, "_active_profile_name", lambda self: active_profile)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_name="Group",
+        chat_type="dm",
+        thread_id=None,
+        profile=None,
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    tokens = runner._set_session_env(context)
+    try:
+        assert get_session_env("HERMES_SESSION_PROFILE") == active_profile
+    finally:
+        runner._clear_session_env(tokens)
+
+
 # ---------------------------------------------------------------------------
 # SESSION_KEY contextvars tests
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -520,12 +520,13 @@ def test_notify_sub_crud(kanban_home):
     try:
         tid = kb.create_task(conn, title="x")
         kb.add_notify_sub(
-            conn, task_id=tid, platform="telegram", chat_id="123", user_id="u1",
+            conn, task_id=tid, platform="telegram", chat_id="123", chat_type="dm", user_id="u1",
             notifier_profile="default",
         )
         subs = kb.list_notify_subs(conn, tid)
         assert len(subs) == 1
         assert subs[0]["platform"] == "telegram"
+        assert subs[0]["chat_type"] == "dm"
         assert subs[0]["notifier_profile"] == "default"
         # Duplicate add is a no-op.
         kb.add_notify_sub(

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -115,13 +115,16 @@ def test_legacy_text_pk_tables_rebuilt_to_integer_autoincrement(tmp_path, monkey
 
         lei = {r["name"]: r for r in conn.execute("PRAGMA table_info(kanban_notify_subs)")}
         assert lei["last_event_id"]["type"].upper() == "INTEGER"
+        assert lei["chat_type"]["type"].upper() == "TEXT"
 
         # Data preserved across the rebuild.
         assert len(conn.execute("SELECT * FROM task_events").fetchall()) == 2
         assert conn.execute("SELECT body FROM task_comments").fetchone()["body"] == "hi"
         assert len(conn.execute("SELECT * FROM task_runs").fetchall()) == 1
         # Non-numeric legacy cursor ("e-1") casts to 0.
-        assert conn.execute("SELECT last_event_id FROM kanban_notify_subs").fetchone()["last_event_id"] == 0
+        row = conn.execute("SELECT last_event_id, chat_type FROM kanban_notify_subs").fetchone()
+        assert row["last_event_id"] == 0
+        assert row["chat_type"] is None
 
         # Indexes restored, including idx_events_run (added by the additive pass).
         indexes = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")}

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -458,6 +458,7 @@ async def test_gateway_create_autosubscribes_on_explicit_board(kanban_home):
     source = SimpleNamespace(
         platform=Platform.TELEGRAM,
         chat_id="chat1",
+        chat_type="group",
         thread_id="th1",
         user_id="u1",
     )

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -26,20 +26,25 @@ from hermes_cli import kanban_db as kb
 # ---------------------------------------------------------------------------
 
 
-def _load_plugin_router():
-    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+def _load_plugin_module():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return the module."""
     repo_root = Path(__file__).resolve().parents[2]
     plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
     assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
 
     spec = importlib.util.spec_from_file_location(
-        "hermes_dashboard_plugin_kanban_test", plugin_file,
+        "hermes_dashboard_plugin_kanban_test",
+        plugin_file,
     )
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
-    return mod.router
+    return mod
+
+
+def _load_plugin_router():
+    return _load_plugin_module().router
 
 
 @pytest.fixture
@@ -54,9 +59,14 @@ def kanban_home(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def client(kanban_home):
+def plugin_module(kanban_home):
+    return _load_plugin_module()
+
+
+@pytest.fixture
+def client(plugin_module):
     app = FastAPI()
-    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    app.include_router(plugin_module.router, prefix="/api/plugins/kanban")
     return TestClient(app)
 
 
@@ -113,6 +123,41 @@ def test_create_task_appears_on_board(client):
     assert ready["tasks"][0]["id"] == task_id
     assert "acme" in data["tenants"]
     assert "researcher" in data["assignees"]
+
+
+def test_home_subscribe_persists_chat_type(client, plugin_module, monkeypatch):
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Chat type", "assignee": "worker"},
+    )
+    assert r.status_code == 200, r.text
+    task_id = r.json()["task"]["id"]
+
+    monkeypatch.setattr(
+        plugin_module,
+        "_configured_home_channels",
+        lambda: [
+            {
+                "platform": "telegram",
+                "chat_id": "dm-123",
+                "chat_type": "dm",
+                "thread_id": "",
+                "name": "DM",
+            }
+        ],
+    )
+
+    r = client.post(f"/api/plugins/kanban/tasks/{task_id}/home-subscribe/telegram")
+    assert r.status_code == 200, r.text
+    assert r.json()["home_channel"]["chat_type"] == "dm"
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, task_id)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["chat_type"] == "dm"
 
 
 def test_board_list_recommends_persistent_workspace_for_configured_workdir(

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -227,6 +227,38 @@ def test_maybe_auto_subscribe_persists_session_chat_type(monkeypatch, tmp_path):
         conn.close()
 
 
+@pytest.mark.parametrize(
+    ("active_profile", "expected_owner"),
+    [("spanorama", "spanorama"), (None, "default")],
+)
+def test_maybe_auto_subscribe_defaults_to_canonical_active_profile(
+    monkeypatch, tmp_path, active_profile, expected_owner
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-dm")
+    monkeypatch.delenv("HERMES_SESSION_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: active_profile
+    )
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="canonical owner", assignee="worker")
+        assert kt._maybe_auto_subscribe(conn, tid) is True
+        assert kb.list_notify_subs(conn, tid)[0]["notifier_profile"] == expected_owner
+    finally:
+        conn.close()
+
+
 @pytest.mark.parametrize("active_profile", ["default", "researcher", "orchestrator"])
 def test_maybe_auto_subscribe_persists_active_profile_when_session_profile_missing(
     monkeypatch, tmp_path, active_profile

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 
 import pytest
 
@@ -196,6 +197,74 @@ def test_show_explicit_task_id(worker_env):
     out = kt._handle_show({"task_id": other})
     d = json.loads(out)
     assert d["task"]["id"] == other
+
+
+def test_maybe_auto_subscribe_persists_session_chat_type(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    kb.init_db()
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-dm")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_TYPE", "dm")
+    monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "u1")
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="auto-subscribe", assignee="worker")
+        assert kt._maybe_auto_subscribe(conn, tid) is True
+        sub = kb.list_notify_subs(conn, tid)[0]
+        assert sub["chat_type"] == "dm"
+        assert sub["platform"] == "telegram"
+        assert sub["chat_id"] == "chat-dm"
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("active_profile", ["default", "researcher", "orchestrator"])
+def test_maybe_auto_subscribe_persists_active_profile_when_session_profile_missing(
+    monkeypatch, tmp_path, active_profile
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionContext, SessionSource
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    kb.init_db()
+    runner = object.__new__(GatewayRunner)
+    monkeypatch.setattr(GatewayRunner, "_active_profile_name", lambda self: active_profile)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-dm",
+        chat_type="dm",
+        user_id="u1",
+        profile=None,
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+    tokens = runner._set_session_env(context)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title=f"auto-subscribe-{active_profile}", assignee="worker")
+        assert kt._maybe_auto_subscribe(conn, tid) is True
+        sub = kb.list_notify_subs(conn, tid)[0]
+        assert sub["notifier_profile"] == active_profile
+    finally:
+        conn.close()
+        runner._clear_session_env(tokens)
 
 
 def test_list_filters_tasks(monkeypatch, worker_env):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -265,6 +265,10 @@ def test_maybe_auto_subscribe_persists_active_profile_when_session_profile_missi
     finally:
         conn.close()
         runner._clear_session_env(tokens)
+        # Restore the thread-local session vars to their unset state so
+        # later tests in this file still exercise the env fallback path.
+        from gateway.session_context import reset_session_vars
+        reset_session_vars()
 
 
 def test_list_filters_tasks(monkeypatch, worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1266,6 +1266,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             chat_id = session_key
         thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "") or None
         user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
+        chat_type = get_session_env("HERMES_SESSION_CHAT_TYPE", "") or None
         notifier_profile = (
             get_session_env("HERMES_SESSION_PROFILE", "")
             or os.environ.get("HERMES_PROFILE")
@@ -1277,6 +1278,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             conn, task_id=task_id,
             platform=platform, chat_id=chat_id,
             thread_id=thread_id, user_id=user_id,
+            chat_type=chat_type,
             notifier_profile=notifier_profile,
         )
         return True

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1271,6 +1271,12 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             get_session_env("HERMES_SESSION_PROFILE", "")
             or os.environ.get("HERMES_PROFILE")
         )
+        if not notifier_profile:
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+                notifier_profile = get_active_profile_name() or "default"
+            except Exception:
+                notifier_profile = "default"
 
         # Lazy-import to keep the module-level dependency light
         from hermes_cli import kanban_db as _kb


### PR DESCRIPTION
## Summary
Fix Kanban notifier ownership so claims and delivery follow the subscription owner, not the task assignee, with deterministic legacy handling.

## Owner / adapter contract
1. `assignee` is display-only; it never selects the notifier owner.
2. Exact `notifier_profile` rows claim atomically only for that owner.
3. Standalone gateways serve active-profile rows through `self.adapters[platform]`.
4. Multiplex gateways serve active-profile rows through `self.adapters` and secondary owners through the exact `_profile_adapters` entry for that profile.
5. Missing secondary adapters fail closed and rewind; no foreign-owner fallback to the active/default bot.
6. Legacy `notifier_profile IS NULL/''` rows are claimable only by active `default`, through the default adapter.
7. New auto-subscriptions resolve owner as session profile → `HERMES_PROFILE` → canonical active profile → `default`, so new rows are never ownerless.
8. New rows persist `chat_type`; legacy missing values keep the documented `group` wake fallback, and `task.session_id` remains the synthetic-wake target.

## Related work disposition
- #57993 / #57995 stamping and credit are incorporated here and credited in commit `32a9225b4` with a co-author trailer.
- #62380's active-vs-secondary adapter split remains compatible here; its unrelated blocked-message truncation change is not taken.
- #67673's notifier/dispatcher decoupling is superseded on this branch; its scheduled-event and truncation scope is not taken.

## Tests
- `scripts/run_tests.sh tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_core_functionality.py` — 200 passed
- `scripts/run_tests.sh tests/gateway/test_kanban_notifier.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py tests/hermes_cli/test_kanban_db_init.py` — 255 passed
- `git diff --check` passed
- Ruff on the four amended files passed
- Added-line secret/privacy scan passed

## Compatibility / rollback
Legacy ownerless rows remain default-owned. Roll back by reverting the four commits on this branch.
