### PR TITLE
fix(dashboard): let plugins override the home page (tab.override: "/")

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -284,6 +284,7 @@ function partitionSidebarNav(
 function buildRoutes(
   builtinRoutes: Record<string, ComponentType>,
   manifests: PluginManifest[],
+  pluginsLoading: boolean,
 ): Array<{
   key: string;
   path: string;
@@ -314,6 +315,11 @@ function buildRoutes(
         path,
         element: <PluginPage name={om.name} />,
       });
+    } else if (path === "/" && pluginsLoading) {
+      // Don't redirect home until plugin manifests load — a plugin may
+      // override "/" (custom home). Redirecting now would pre-empt the
+      // override, exactly as UnknownRouteFallback guards the catch-all.
+      routes.push({ key: "builtin:/:loading", path, element: <></> });
     } else {
       routes.push({ key: `builtin:${path}`, path, element: <Component /> });
     }
@@ -440,8 +446,8 @@ export default function App() {
     [builtinNav, manifests],
   );
   const routes = useMemo(
-    () => buildRoutes(builtinRoutes, manifests),
-    [builtinRoutes, manifests],
+    () => buildRoutes(builtinRoutes, manifests, pluginsLoading),
+    [builtinRoutes, manifests, pluginsLoading],
   );
   const pluginTabMeta = useMemo(
     () =>


### PR DESCRIPTION
### Problem

A dashboard plugin that sets `tab.override: "/"` — documented in *Extending the Dashboard → Replacing built-in pages* as the way to ship a custom home page — never renders. Opening `/` redirects to `/sessions` instead.

**Root cause:** `usePlugins()` fetches manifests asynchronously, so on first paint `manifests` is `[]`. `buildRoutes` therefore builds the built-in `"/": RootRedirect` (`<Navigate to="/sessions" replace />`), whose navigation fires immediately and replaces the URL. By the time the manifests arrive and `buildRoutes` re-runs mapping `/` → `<PluginPage>`, the app is already at `/sessions` (history replaced), so the override never gets a turn.

The codebase already guards this exact race everywhere else it matters:
- `UnknownRouteFallback` renders `null` while `pluginsLoading` (the `*` catch-all), and
- the `/chat` override is gated on `pluginsLoading` via `chatOverriddenByPlugin` (with a load-bearing comment).

`RootRedirect` for `/` was the one spot left unguarded.

### Fix

Thread `pluginsLoading` into `buildRoutes`; while it's `true`, render nothing at `/` instead of redirecting, so an override can win once manifests load. If no plugin overrides `/`, the redirect fires exactly as before once loading completes. Three-line change, mirroring the existing pattern — no behavior change for dashboards without a home-override plugin.

### Verify

Drop a plugin with `tab: { "path": "/home", "override": "/" }` into `~/.hermes/plugins/<name>/dashboard/`, add it to `plugins.enabled`, restart.

- **Before:** opening `/` redirects to `/sessions`; the plugin never renders.
- **After:** `/` renders the plugin page; `/sessions` and all other routes are unaffected; with no home-override plugin installed, `/` still redirects to `/sessions`.

Verified live on v0.18.2 with a custom home-page plugin.
