### PR TITLE
fix(tools): send CR for Enter on PTY stdin submissions

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -470,6 +470,34 @@ class TestStdinHelpers:
         pty.sendeof.assert_called_once()
         assert result["status"] == "ok"
 
+    def test_submit_stdin_pty_mode_sends_cr(self, registry, monkeypatch):
+        """PTY Enter is \\r — what a real keyboard sends. Raw-mode TUIs bind
+        Enter to \\r and ignore \\n; canonical-mode children still see \\n via
+        the tty driver's ICRNL mapping.
+        """
+        monkeypatch.setattr("tools.process_registry._IS_WINDOWS", False)
+        pty = MagicMock()
+        s = _make_session()
+        s._pty = pty
+        registry._running[s.id] = s
+
+        result = registry.submit_stdin(s.id, "hello")
+
+        pty.write.assert_called_once_with(b"hello\r")
+        assert result["status"] == "ok"
+
+    def test_submit_stdin_pipe_mode_sends_newline(self, registry):
+        proc = MagicMock()
+        proc.stdin = MagicMock()
+        s = _make_session()
+        s.process = proc
+        registry._running[s.id] = s
+
+        result = registry.submit_stdin(s.id, "hello")
+
+        proc.stdin.write.assert_called_once_with("hello\n")
+        assert result["status"] == "ok"
+
     def test_close_stdin_allows_eof_driven_process_to_finish(self, registry, tmp_path):
         """PTY mode: writing data + sending EOF lets an EOF-driven child finish.
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1631,7 +1631,15 @@ class ProcessRegistry:
             return {"status": "error", "error": str(e)}
 
     def submit_stdin(self, session_id: str, data: str = "") -> dict:
-        """Send data + newline to a running process's stdin (like pressing Enter)."""
+        """Send data + Enter to a running process's stdin (like pressing Enter).
+
+        Uses \\r (carriage return) for PTY sessions — this is what a real
+        keyboard produces, and TUIs (claude, vim, htop, etc.) read in raw
+        mode expecting CR. For non-PTY (Popen) sessions, \\n works fine.
+        """
+        session = self.get(session_id)
+        if session is not None and hasattr(session, '_pty') and session._pty:
+            return self.write_stdin(session_id, data + "\r")
         return self.write_stdin(session_id, data + "\n")
 
     def request_close_terminal(self, session_id: str) -> dict:


### PR DESCRIPTION
## What does this PR do?

`submit_stdin` appends `\n` unconditionally. In a PTY session running a raw-mode TUI (claude, vim, htop), the submitted input is typed into the program but never registers as Enter: raw-mode programs bind Enter to `\r` — the byte a real keyboard produces — and do not treat `\n` as a submit.

Fix: send `\r` for PTY sessions, keep `\n` for pipe (Popen) sessions. `\r` is strictly safer on a PTY: canonical-mode children are unaffected because the tty driver's ICRNL flag (on by default) maps `\r` to `\n` before the child reads it. This is the same reason `tmux send-keys Enter` transmits `\r`. Since non-PTY stdin was detached to DEVNULL (#17959), the PTY branch is the only interactive stdin path — the bug affects essentially all interactive use of `submit_stdin`.

Callers that need a literal `\n` delivered to a raw-mode child can still use `write_stdin` directly.

## Related Issue

No existing issue — searched issues and PRs for `submit_stdin` / PTY carriage return. Closest is #31697 (Windows pywinpty write types), which is unrelated.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py` — `submit_stdin` sends `data + "\r"` when the session has a PTY handle, `data + "\n"` otherwise
- `tests/tools/test_process_registry.py` — asserts `\r` for PTY mode and `\n` for pipe mode

## How to Test

1. `pytest tests/tools/test_process_registry.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` — 45310 passed, 97 failed; a control run of the failing files on unmodified `main` in the same environment fails identically (93 pre-existing env-specific failures, 4 load flakes that pass on rerun). Zero regressions from this change; `tests/tools/test_process_registry.py` is fully green (117 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5, Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `submit_stdin` docstring; no other docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — `\r` is also the Enter byte for ConPTY/pywinpty on Windows; pipe mode unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (behavior now matches the existing "like pressing Enter" description)

## Screenshots / Logs

Canonical-mode child driven through the real registry after the fix (ICRNL maps the CR):

```
>>> reg.submit_stdin(session.id, "hello")
{'status': 'ok', 'bytes_written': 6}
exit_code: 0
output: GOT:hello
```

https://claude.ai/code/session_013LH6C3g6wjMjhSXRauyVCW
