### PR TITLE
fix(skills): update Grok Build config guidance

### DIFF
--- a/optional-skills/autonomous-ai-agents/grok/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/grok/SKILL.md
@@ -256,15 +256,14 @@ write tools except the session plan file).
 auto_update = false          # skip background update checks persistently
 
 [ui]
-permission_mode = "ask"      # or "always-approve" to skip tool prompts by default
-
-[models]
-default = "grok-build-0.1"
+permission_mode = "ask"      # or "auto" / "always-approve"
 ```
 
 Put global preferences in `~/.grok/config.toml` (not project-scoped
-`.grok/config.toml`). `permission_mode` supersedes the legacy `approval_mode` /
-`yolo = true` keys.
+`.grok/config.toml`). Avoid pinning the default model unless `grok models`
+confirms that model is available for the authenticated account. For autonomous
+headless runs, use the explicit `--always-approve` flag. `permission_mode`
+supersedes the legacy `approval_mode` / `yolo = true` keys.
 
 ## Pitfalls & Gotchas
 


### PR DESCRIPTION
## What does this PR do?

Updates the official Grok Build skill's configuration example to match the
current xAI documentation.

The skill pins the obsolete `grok-build-0.1` model and lists only `ask` and
`always-approve` permission modes. Current Grok supports `auto` as well, and
model availability can vary by authenticated account.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Remove the obsolete `grok-build-0.1` default model pin.
- Document the current `auto`, `ask`, and `always-approve` permission modes.
- Keep `[ui].permission_mode` and its precedence over the legacy
  `approval_mode` and `yolo` keys.
- Recommend checking `grok models` before pinning a default model.

The session corrections originally included in this PR were removed during
the rebase because they were independently implemented on `main` by
`9a894dae5f128195a5dc96985d620f9ca6ffb270`.

## How to Test

1. Compare the example with the current xAI Grok configuration and permissions
   documentation.
2. Run `git diff --check`.

Validated:

- Rebased onto the current `main` branch.
- `git diff --check` passes.
- The final diff contains only the Grok configuration documentation update.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run: documentation-only skill update)
- [ ] I've added tests for my changes (N/A: documentation-only skill update)
- [ ] I've tested on my platform (N/A: documentation-only update verified against official documentation)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — this PR is the documentation update
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no Hermes config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific behavior changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. This is a Markdown-only skill correction.
