### PR TITLE
fix(codex): adopt refresh_token from auth.json even without access_token (#70097)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -763,19 +763,43 @@ class CredentialPool:
             # Adopt auth.json tokens when either side differs.  Codex refresh
             # tokens are single-use too, so a fresh refresh_token from
             # another process means our entry's pair is consumed/stale.
+            #
+            # Also adopt when the store has a refresh_token but no
+            # access_token — another process may have rotated the pair
+            # and the store entry's access_token was already consumed;
+            # the important signal is the refresh_token difference.
             entry_access = entry.access_token or ""
             entry_refresh = entry.refresh_token or ""
+            should_adopt = False
             if store_access and (
                 store_access != entry_access
                 or (store_refresh and store_refresh != entry_refresh)
             ):
+                should_adopt = True
+            elif (
+                store_refresh
+                and store_refresh != entry_refresh
+                and not store_access
+            ):
+                # Store has only a refresh_token (no access_token) —
+                # another process rotated the pair.  Adopt the
+                # refresh_token so we don't replay the consumed one.
+                logger.info(
+                    "Pool entry %s: auth.json has newer refresh_token "
+                    "but no access_token; adopting refresh_token to "
+                    "avoid replaying consumed token",
+                    entry.id,
+                )
+                should_adopt = True
+
+            if should_adopt:
                 logger.debug(
                     "Pool entry %s: syncing Codex tokens from auth.json "
                     "(refreshed by another process)",
                     entry.id,
                 )
                 field_updates: Dict[str, Any] = {
-                    "access_token": store_access,
+                    "access_token": store_access or entry.access_token,
                     "refresh_token": store_refresh or entry.refresh_token,
                     "last_status": None,
                     "last_status_at": None,

--- a/run_agent.py
+++ b/run_agent.py
@@ -4628,10 +4628,12 @@ class AIAgent:
             if self.provider == "openai-codex":
                 from hermes_cli.auth import resolve_codex_runtime_credentials
 
+                old_key = str(self.api_key or "").strip()
                 creds = resolve_codex_runtime_credentials(force_refresh=force)
             else:
                 from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
 
+                old_key = str(self.api_key or "").strip()
                 creds = resolve_xai_oauth_runtime_credentials(force_refresh=force)
         except Exception as exc:
             logger.debug("%s credential refresh failed: %s", self.provider, exc)
@@ -4642,6 +4644,19 @@ class AIAgent:
         if not isinstance(api_key, str) or not api_key.strip():
             return False
         if not isinstance(base_url, str) or not base_url.strip():
+            return False
+
+        # Defect 2 fix: return False when no NEW token was actually minted.
+        # resolve_codex_runtime_credentials returns the same stale token
+        # when the underlying refresh fails (failure is debug-only).
+        # Comparing the access token (api_key) before/after detects this.
+        new_key = api_key.strip()
+        if old_key and new_key == old_key:
+            logger.debug(
+                "%s credential refresh returned the same token; "
+                "refresh likely failed silently",
+                self.provider,
+            )
             return False
 
         self.api_key = api_key.strip()


### PR DESCRIPTION
## Summary

Fixes two defects in the openai-codex credential pool recovery path that cause profiles to go terminally DEAD when a sibling profile rotates the shared token pair.

## Defect 1 — adoption path silently no-ops

**Root cause**: `_sync_codex_entry_from_auth_store()` (credential_pool.py:768) skips adoption when `store_access` is empty. When another process rotated the token pair and the auth store only has `last_refresh` + a new `refresh_token` (no `access_token`), the stale profile's entry keeps the consumed `refresh_token` and replays it, getting `refresh_token_reused` → terminally DEAD.

**Fix**: Also adopt when `store_refresh` differs from `entry_refresh`, even when `store_access` is empty. Preserve the entry's existing `access_token` via `store_access or entry.access_token`.

## Defect 2 — false "auth refreshed" success log

**Root cause**: `_try_refresh_codex_client_credentials()` (run_agent.py:4583) returns `True` whenever `resolve_codex_runtime_credentials()` returns any non-empty credentials — including the same stale token when the underlying refresh failed (failure is `logger.debug`-only). The conversation loop then logs "auth refreshed after 401" right before the retry fails with the identical `token_expired`.

**Fix**: Compare the access token before/after the refresh. If unchanged, return `False` so the 401-retry path doesn't claim success.

## Changes

| File | Lines | Change |
|------|-------|--------|
| `agent/credential_pool.py` | +25 | Adopt refresh_token even without access_token |
| `run_agent.py` | +15 | Return False when refresh produced no new token |

Fixes #70097