### PR TITLE
test(dashboard): isolate auth gate state between tests

### DIFF
--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -15,6 +15,17 @@ from fastapi.testclient import TestClient
 from hermes_cli import web_server
 
 
+@pytest.fixture(autouse=True)
+def restore_dashboard_state():
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    yield
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
 @pytest.fixture
 def client_loopback():
     # Pin the bound-host state for host_header_middleware so requests with


### PR DESCRIPTION
## What does this PR do?

Fixes an order-dependent failure between two dashboard auth test files.
`test_dashboard_auth_gate.py` left the shared dashboard host, port, and auth
state changed after some tests. Tests in `test_dashboard_auth_password_login.py`
then received `400 Bad Request` responses when they ran afterward.

The new fixture saves those three values before each auth gate test and restores
them afterward. Dashboard runtime behavior is unchanged.

## Related Issue

Fixes #70017

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added an autouse fixture in `tests/hermes_cli/test_dashboard_auth_gate.py`.
- Restored `bound_host`, `bound_port`, and `auth_required` after every test.

## How to Test

1. Before the fix, run the auth gate file before the password login file: `3 failed, 40 passed, 1 skipped`.
2. Run `python -m pytest tests/hermes_cli/test_dashboard_auth_gate.py tests/hermes_cli/test_dashboard_auth_password_login.py -q -p no:randomly`: `43 passed, 1 skipped`.
3. Run the same command with the file order reversed: `43 passed, 1 skipped`.
4. Run `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the focused pytest commands above and they pass
- [x] The affected two-file sequence provides regression coverage for this change
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] Documentation changes are N/A because runtime behavior is unchanged
- [x] `cli-config.yaml.example` changes are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A because no workflow or architecture changed
- [x] Cross-platform impact is limited to restoring shared Python test state
- [x] Tool description and schema changes are N/A
