### PR TITLE
fix(desktop): handle session-not-found in checkpoint restore (#70077)

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -251,7 +251,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
   // the primary chat so the two can't diverge.
   const submitRewind = useCallback(
     (text: string, truncateOrdinal: number | undefined, interruptFirst: boolean) =>
-      runRewindSubmit(requestGateway, runtimeIdRef.current, text, truncateOrdinal, interruptFirst),
+      runRewindSubmit(requestGateway, runtimeIdRef.current, text, truncateOrdinal, interruptFirst, storedIdRef.current),
     [requestGateway]
   )
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -782,7 +782,7 @@ export function usePromptActions({
   // response interrupts + retries through the shared busy gate.
   const submitRewindPrompt = useCallback(
     (sessionId: string, text: string, truncateOrdinal: number | undefined, interruptFirst: boolean) =>
-      runRewindSubmit(requestGateway, sessionId, text, truncateOrdinal, interruptFirst),
+      runRewindSubmit(requestGateway, sessionId, text, truncateOrdinal, interruptFirst, selectedStoredSessionIdRef.current),
     [requestGateway]
   )
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -18,6 +18,7 @@ import { branchGroupForUser, type ChatMessage, chatMessageText, textPart } from 
 import {
   appendText,
   isSessionBusyError,
+  isSessionNotFoundError,
   visibleUserIndexAtOrdinal,
   visibleUserOrdinal,
   withSessionBusyRetry
@@ -37,7 +38,8 @@ export async function runRewindSubmit(
   sessionId: string,
   text: string,
   truncateOrdinal: number | undefined,
-  interruptFirst: boolean
+  interruptFirst: boolean,
+  storedSessionId?: string | null
 ): Promise<void> {
   const interrupt = async () => {
     try {
@@ -65,6 +67,29 @@ export async function runRewindSubmit(
   try {
     await submit()
   } catch (err) {
+    // Session-not-found recovery: after cancelRun + edit, the gateway may
+    // have dropped the in-memory session. Resume the stored session and
+    // retry, mirroring the pattern in submitPromptText (#70077).
+    if (isSessionNotFoundError(err) && storedSessionId) {
+      const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+        session_id: storedSessionId,
+        source: 'desktop'
+      })
+
+      if (resumed?.session_id) {
+        await requestGateway(
+          'prompt.submit',
+          {
+            session_id: resumed.session_id,
+            text,
+            ...(truncateOrdinal !== undefined && { truncate_before_user_ordinal: truncateOrdinal })
+          },
+          PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+        )
+        return
+      }
+    }
+
     if (!isSessionBusyError(err)) {
       throw err
     }


### PR DESCRIPTION
## Summary

After stopping a generation, editing the prompt, and using "Restore checkpoint — rerun from this prompt," the restore fails with "session not found" because `runRewindSubmit` only handled `isSessionBusyError` — it had no `isSessionNotFoundError` recovery path.

## Root cause

After `cancelRun` calls `session.interrupt`, the gateway can drop the in-memory (volatile) session. The normal submit path (`submitPromptText`) detects this and recovers by calling `session.resume` + retry. But `runRewindSubmit` (used by restore/edit) had no such recovery.

## Fix

Add session-not-found recovery to `runRewindSubmit`, mirroring the resume+retry pattern in `submitPromptText`:

1. Accept optional `storedSessionId` parameter
2. On `isSessionNotFoundError`, call `session.resume` with the stored session ID
3. Retry `prompt.submit` with the recovered session ID

Update both callers to pass the stored session ID:
- `index.ts`: `selectedStoredSessionIdRef.current`
- `session-tile-actions.ts`: `storedIdRef.current`

## Changes

| File | Lines | Change |
|------|-------|--------|
| `rewind.ts` | +25 | Session-not-found recovery in `runRewindSubmit` |
| `index.ts` | +1 | Pass storedSessionId to submitRewindPrompt |
| `session-tile-actions.ts` | +1 | Pass storedSessionId to submitRewind |

Fixes #70077