### PR TITLE
fix(tests): isolate tui_gateway completion tests from the real config.yaml

### DIFF
--- a/tests/gateway/test_complete_path_at_filter.py
+++ b/tests/gateway/test_complete_path_at_filter.py
@@ -48,6 +48,20 @@ def _reset_fuzzy_cache(monkeypatch):
     server._fuzzy_cache.clear()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_hermes_home(tmp_path, monkeypatch):
+    """`_load_cfg()` reads `<home>/config.yaml` from the module-level
+    `_hermes_home`, captured at import time — before the per-test
+    `HERMES_HOME` env-var redirect in conftest's `_hermetic_environment`
+    ever applies. On a machine with a real `~/.hermes/config.yaml` setting
+    `terminal.cwd`, that config leaks into every test here and
+    `_completion_cwd()` lists the configured directory instead of the
+    test's `tmp_path` (#70041). Point the module straight at tmp_path so
+    no developer config can be seen.
+    """
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+
 def test_at_folder_colon_only_dirs(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     _fixture(tmp_path)


### PR DESCRIPTION
Hi! Fixes #70041.

## Summary

`tests/gateway/test_complete_path_at_filter.py` isn't hermetic: it reads the developer's real `~/.hermes/config.yaml` on a pristine checkout, and fails 7-14 of 15 tests whenever that config sets `terminal.cwd`. CI stays green only because CI machines have no real Hermes config to leak.

## Root cause

1. `tui_gateway/server.py:42` captures the home once at module import: `_hermes_home = get_hermes_home()`.
2. Test modules import at pytest collection time — before conftest's autouse `_hermetic_environment` fixture (which redirects `HERMES_HOME` to a per-test tempdir) ever runs on a per-test basis. The already-bound `_hermes_home` global in `server.py` never sees that redirect.
3. `_completion_cwd()` → `_launch_configured_cwd()` → `_load_cfg()` reads `<_hermes_home>/config.yaml` — the developer's real config — instead of the test's `tmp_path`, so a configured `terminal.cwd` wins and every assertion about the fixture's `src/`/`docs/`/`readme.md` fails.

## Fix

Added an autouse fixture that points `server._hermes_home` directly at the test's `tmp_path`, mirroring the identical fix already used elsewhere in the suite for `gateway/run.py`'s equivalent module-level capture (see `tests/gateway/test_checkpoint_config.py`, `tests/gateway/test_choice_picker.py`).

## Testing

Reproduced by pointing `HERMES_HOME` at a scratch dir containing a `config.yaml` with `terminal.cwd` set before the interpreter starts (mirrors the real-world trigger): 14/15 tests failed before the fix, 15/15 pass after, and the suite is unaffected without that scratch config either way.