### PR TITLE
fix: respect HTTP proxy env vars in Mattermost adapter

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -292,6 +292,7 @@ class MattermostAdapter(BasePlatformAdapter):
             return False
 
         self._session = aiohttp.ClientSession(
+            trust_env=True,
             timeout=aiohttp.ClientTimeout(total=30)
         )
         self._closing = False
@@ -751,7 +752,8 @@ class MattermostAdapter(BasePlatformAdapter):
         ws_url = re.sub(r"^http", "ws", self._base_url) + "/api/v4/websocket"
         logger.info("Mattermost: connecting to %s", ws_url)
 
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30.0)
+        ws_proxy = os.environ.get("https_proxy") or os.environ.get("HTTPS_PROXY")
+        self._ws = await self._session.ws_connect(ws_url, heartbeat=30.0, proxy=ws_proxy)
 
         # Authenticate via the WebSocket.
         auth_msg = {

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -752,8 +752,7 @@ class MattermostAdapter(BasePlatformAdapter):
         ws_url = re.sub(r"^http", "ws", self._base_url) + "/api/v4/websocket"
         logger.info("Mattermost: connecting to %s", ws_url)
 
-        ws_proxy = os.environ.get("https_proxy") or os.environ.get("HTTPS_PROXY")
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30.0, proxy=ws_proxy)
+        self._ws = await self._session.ws_connect(ws_url, heartbeat=30.0)
 
         # Authenticate via the WebSocket.
         auth_msg = {

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -1122,3 +1122,27 @@ async def test_mattermost_dm_post_does_not_seed_thread_root():
     msg_event = adapter.handle_message.call_args[0][0]
     assert msg_event.source.thread_id is None
     assert msg_event.source.message_id == "dm_post_123"
+
+
+# ---------------------------------------------------------------------------
+# Proxy / trust_env
+# ---------------------------------------------------------------------------
+
+class TestMattermostProxySupport:
+    @pytest.mark.asyncio
+    async def test_connect_creates_session_with_trust_env(self):
+        """ClientSession must use trust_env=True so proxy env vars are honored."""
+        adapter = _make_adapter()
+        adapter._api_get = AsyncMock(return_value={"id": "bot123", "username": "hermes-bot"})
+        adapter._ws_task = None
+
+        with patch("aiohttp.ClientSession") as mock_cls:
+            mock_session = AsyncMock()
+            mock_session.closed = False
+            mock_cls.return_value = mock_session
+
+            await adapter.connect()
+
+            mock_cls.assert_called_once()
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs.get("trust_env") is True


### PR DESCRIPTION
Fixes #70116

The Mattermost adapter creates its `aiohttp.ClientSession` without `trust_env=True`, causing it to ignore standard proxy environment variables (`https_proxy`, `HTTPS_PROXY`, etc.). This breaks in environments that route outbound traffic through an HTTP proxy (e.g. OpenShell sandboxes on OpenShift, corporate proxies).

## Change

One line in the adapter, one test:

- **`trust_env=True` on `ClientSession`** (line 294) - makes aiohttp honor proxy env vars for both REST API calls and WebSocket connections. In aiohttp 3.14.1, `ws_connect()` delegates to `_request()`, which calls `get_env_proxy_for_url(url)` when `trust_env` is set. So this single flag covers HTTP, HTTPS, and WebSocket traffic, and properly respects `NO_PROXY`.

- **Test** - verifies the session is created with `trust_env=True`.

The flag is a no-op when no proxy env vars are present.

## Tested

Verified on Hermes 0.17.0 running inside an OpenShell sandbox on OpenShift, where all outbound traffic goes through an HTTP CONNECT proxy. Before the fix, the gateway logged continuous `Name or service not known` connection failures. After the fix, both REST auth and WebSocket listener connect successfully through the proxy.