### PR TITLE
feat(providers): add Alibaba Cloud Token Plan exclusive MaaS endpoint

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -476,6 +476,8 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.minimax": "minimax",
     "dashscope.aliyuncs.com": "alibaba",
     "dashscope-intl.aliyuncs.com": "alibaba",
+    "coding-intl.dashscope.aliyuncs.com": "alibaba-coding-plan",
+    "token-plan.ap-southeast-1.maas.aliyuncs.com": "alibaba-token-plan",
     "portal.qwen.ai": "qwen-oauth",
     "openrouter.ai": "openrouter",
     "generativelanguage.googleapis.com": "gemini",
@@ -550,12 +552,17 @@ def _is_known_provider_base_url(base_url: str) -> bool:
 
 
 def _endpoint_scoped_context_length(model: str, base_url: str) -> Optional[int]:
-    """Return metadata confirmed only for the Kimi Coding endpoint.
+    """Return context metadata confirmed only for a specific endpoint.
 
     Kimi Coding serves K3 under the bare slug ``k3``, but users may also
     configure or select the public-facing aliases ``kimi-k3`` and
     ``kimi-k3-cot``. Only canonical ``https://api.kimi.com/coding`` endpoints
     (legacy Moonshot keys do not serve K3) get the 1 Mi context window.
+
+    Alibaba Token Plan's preview Qwen slug is likewise endpoint-scoped. A
+    custom provider may reuse ``qwen3.8-max-preview`` with a different context
+    allocation, so the Token Plan value must not enter the global substring
+    catalog.
     """
     normalized = _normalize_base_url(base_url)
     try:
@@ -575,6 +582,19 @@ def _endpoint_scoped_context_length(model: str, base_url: str) -> Optional[int]:
         and model.strip().lower() in {"k3", "kimi-k3", "kimi-k3-cot"}
     ):
         return 1_048_576
+    if (
+        parsed.scheme.lower() == "https"
+        and (parsed.hostname or "").lower()
+        == "token-plan.ap-southeast-1.maas.aliyuncs.com"
+        and port in (None, 443)
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.path.rstrip("/") == "/compatible-mode/v1"
+        and not parsed.query
+        and not parsed.fragment
+        and model.strip().lower() == "qwen3.8-max-preview"
+    ):
+        return 983_616
     return None
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -333,6 +333,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY"),
         base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
     ),
+    "alibaba-token-plan": ProviderConfig(
+        id="alibaba-token-plan",
+        name="Alibaba Cloud (Token Plan)",
+        auth_type="api_key",
+        inference_base_url="https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+        api_key_env_vars=("ALIBABA_TOKEN_PLAN_API_KEY",),
+        base_url_env_var="ALIBABA_TOKEN_PLAN_BASE_URL",
+    ),
     "minimax-cn": ProviderConfig(
         id="minimax-cn",
         name="MiniMax (China)",
@@ -1851,6 +1859,8 @@ def resolve_provider(
         "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
         "alibaba_coding_plan": "alibaba-coding-plan",
+        "alibaba_token": "alibaba-token-plan", "alibaba-token": "alibaba-token-plan",
+        "alibaba_token_plan": "alibaba-token-plan", "token-plan": "alibaba-token-plan",
         "claude": "anthropic", "claude-code": "anthropic",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -528,6 +528,17 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.7",
         "MiniMax-M2.5",
     ],
+    # Alibaba Token Plan — separate prepaid endpoint and model roster.
+    # Only agent-compatible chat models belong here; Wan image models exposed
+    # by the same /models endpoint are handled by image-generation tooling.
+    "alibaba-token-plan": [
+        "qwen3.8-max-preview",
+        "qwen3.7-max",
+        "qwen3.7-plus",
+        "qwen3.6-flash",
+        "glm-5.2",
+        "deepseek-v4-pro",
+    ],
     # Curated HF model list — only agentic models that map to OpenRouter defaults.
     "huggingface": [
         "moonshotai/Kimi-K2.5",
@@ -1154,7 +1165,7 @@ PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
     "xai":      ("xAI Grok",        "Direct API or SuperGrok / Premium+ OAuth",        ["xai", "xai-oauth"]),
     "google":   ("Google Gemini",   "Google AI Studio (API key)",                     ["gemini"]),
     "openai":   ("OpenAI",          "Codex CLI or direct OpenAI API",                  ["openai-codex", "openai-api"]),
-    "qwen":     ("Qwen",            "Qwen Cloud / DashScope, Coding Plan & Qwen CLI OAuth", ["alibaba", "alibaba-coding-plan", "qwen-oauth"]),
+    "qwen":     ("Qwen",            "Qwen Cloud / DashScope, Coding Plan, Token Plan & Qwen CLI OAuth", ["alibaba", "alibaba-coding-plan", "alibaba-token-plan", "qwen-oauth"]),
     "opencode": ("OpenCode",        "Zen pay-as-you-go or Go subscription",            ["opencode-zen", "opencode-go"]),
     "copilot":  ("GitHub Copilot",  "GitHub token API or copilot --acp process",       ["copilot", "copilot-acp"]),
 }

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -142,6 +142,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
     ),
+    "alibaba-token-plan": HermesOverlay(
+        transport="openai_chat",
+        base_url_env_var="ALIBABA_TOKEN_PLAN_BASE_URL",
+    ),
     "opencode": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
@@ -320,6 +324,10 @@ ALIASES: Dict[str, str] = {
     "alibaba_coding": "alibaba-coding-plan",
     "alibaba-coding": "alibaba-coding-plan",
     "alibaba_coding_plan": "alibaba-coding-plan",
+    "alibaba_token": "alibaba-token-plan",
+    "alibaba-token": "alibaba-token-plan",
+    "alibaba_token_plan": "alibaba-token-plan",
+    "token-plan": "alibaba-token-plan",
 
     # huggingface
     "hf": "huggingface",

--- a/plugins/model-providers/alibaba-token-plan/__init__.py
+++ b/plugins/model-providers/alibaba-token-plan/__init__.py
@@ -1,0 +1,54 @@
+"""Alibaba Cloud Token Plan provider profile.
+
+Separate from the standard `alibaba` profile because it hits the Token Plan's
+exclusive MaaS endpoint (token-plan.ap-southeast-1.maas.aliyuncs.com) rather
+than the public DashScope endpoint. The Token Plan exposes newer models
+(qwen3.8-max-preview, qwen3.7-plus/max, qwen3.6-flash, glm-5.2, deepseek-v4-pro,
+wan2.7-image[-pro]) and an Anthropic-protocol-compatible path under /apps/anthropic.
+
+Auth: use ALIBABA_TOKEN_PLAN_API_KEY so regular DashScope and Coding Plan keys
+are never probed against an incompatible billing-plan endpoint.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class AlibabaTokenPlanProfile(ProviderProfile):
+    """Token Plan catalog restricted to agent-compatible chat models."""
+
+    def fetch_models(self, **kwargs):
+        models = super().fetch_models(**kwargs)
+        if models is None:
+            return None
+        # The endpoint also advertises Wan image-generation models. They are
+        # not valid agent chat models and must not enter the main model picker.
+        return [model for model in models if not model.startswith("wan")]
+
+
+alibaba_token_plan = AlibabaTokenPlanProfile(
+    name="alibaba-token-plan",
+    aliases=("alibaba-token", "token-plan", "alibaba-maas", "alibaba-tokenplan"),
+    display_name="Alibaba Cloud (Token Plan)",
+    description="Alibaba Cloud Token Plan — exclusive MaaS endpoint (Qwen 3.8/3.7, GLM 5.2, DeepSeek v4)",
+    signup_url="https://www.alibabacloud.com/en/campaign/ai-landing-page-token",
+    env_vars=(
+        "ALIBABA_TOKEN_PLAN_API_KEY",
+        "ALIBABA_TOKEN_PLAN_BASE_URL",
+    ),
+    base_url="https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+    auth_type="api_key",
+    supports_health_check=True,
+    supports_vision=False,
+    default_aux_model="qwen3.6-flash",
+    fallback_models=(
+        "qwen3.8-max-preview",
+        "qwen3.7-max",
+        "qwen3.7-plus",
+        "qwen3.6-flash",
+        "glm-5.2",
+        "deepseek-v4-pro",
+    ),
+)
+
+register_provider(alibaba_token_plan)

--- a/plugins/model-providers/alibaba-token-plan/plugin.yaml
+++ b/plugins/model-providers/alibaba-token-plan/plugin.yaml
@@ -1,0 +1,5 @@
+name: alibaba-token-plan-provider
+kind: model-provider
+version: 1.0.0
+description: Alibaba Cloud Token Plan (exclusive MaaS endpoint)
+author: Nous Research

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -224,6 +224,38 @@ class TestDefaultContextLengths:
                         model, provider="kimi-coding", base_url=base_url
                     ) == 1_048_576
 
+    def test_qwen38_preview_context_is_scoped_to_token_plan_endpoint(self):
+        """Token Plan preview metadata must not leak to custom Qwen routes."""
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=None):
+            accepted_urls = (
+                "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+                "https://TOKEN-PLAN.AP-SOUTHEAST-1.MAAS.ALIYUNCS.COM:443/compatible-mode/v1/",
+            )
+            rejected_urls = (
+                "http://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+                "https://token-plan.ap-southeast-1.maas.aliyuncs.com:8443/compatible-mode/v1",
+                "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/other",
+                "https://custom.example.com/compatible-mode/v1",
+            )
+
+            for base_url in accepted_urls:
+                assert get_model_context_length(
+                    "qwen3.8-max-preview",
+                    provider="alibaba-token-plan",
+                    base_url=base_url,
+                ) == 983_616
+
+            for base_url in rejected_urls:
+                assert get_model_context_length(
+                    "qwen3.8-max-preview",
+                    provider="qwen-token-plan",
+                    base_url=base_url,
+                ) != 983_616
+
     def test_grok_substring_matching(self):
         # Longest-first substring matching must resolve the real xAI model
         # IDs to the correct fallback entries without 128k probe-down.

--- a/tests/hermes_cli/test_alibaba_token_plan_provider.py
+++ b/tests/hermes_cli/test_alibaba_token_plan_provider.py
@@ -1,0 +1,92 @@
+"""Tests for the Alibaba Cloud Token Plan provider plugin."""
+
+import importlib.util
+import os
+import pathlib
+
+import pytest
+
+from providers import get_provider_profile
+from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.models import _PROVIDER_MODELS, provider_group_for_slug
+from hermes_cli.providers import HERMES_OVERLAYS, normalize_provider
+
+PLUGIN_DIR = (
+    pathlib.Path(__file__).resolve().parent.parent.parent
+    / "plugins"
+    / "model-providers"
+    / "alibaba-token-plan"
+)
+
+# Capture only an explicitly exported integration credential before the global
+# autouse fixture scrubs provider keys from each test for hermeticity.
+_LIVE_API_KEY = os.environ.get("ALIBABA_TOKEN_PLAN_API_KEY")
+
+
+def _load_plugin():
+    init_file = PLUGIN_DIR / "__init__.py"
+    spec = importlib.util.spec_from_file_location(
+        "plugins.model_providers.alibaba_token_plan_test",
+        init_file,
+        submodule_search_locations=[str(PLUGIN_DIR)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_plugin_registers_and_resolves_by_alias():
+    _load_plugin()
+    prof = get_provider_profile("alibaba-token-plan")
+    assert prof is not None
+    assert prof.name == "alibaba-token-plan"
+    # alias resolution
+    assert get_provider_profile("token-plan").name == "alibaba-token-plan"
+
+
+def test_plugin_endpoint_is_token_plan_exclusive():
+    _load_plugin()
+    prof = get_provider_profile("alibaba-token-plan")
+    assert prof is not None
+    assert prof.base_url == (
+        "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+    )
+    assert prof.env_vars[0] == "ALIBABA_TOKEN_PLAN_API_KEY"
+    assert "DASHSCOPE_API_KEY" not in prof.env_vars
+
+
+def test_provider_is_registered_across_core_surfaces():
+    provider = PROVIDER_REGISTRY["alibaba-token-plan"]
+    assert provider.api_key_env_vars == ("ALIBABA_TOKEN_PLAN_API_KEY",)
+    assert provider.base_url_env_var == "ALIBABA_TOKEN_PLAN_BASE_URL"
+    assert HERMES_OVERLAYS["alibaba-token-plan"].transport == "openai_chat"
+    assert normalize_provider("token-plan") == "alibaba-token-plan"
+    assert provider_group_for_slug("alibaba-token-plan") == "qwen"
+
+
+def test_static_catalog_contains_only_agent_chat_models():
+    models = _PROVIDER_MODELS["alibaba-token-plan"]
+    assert "qwen3.8-max-preview" in models
+    assert "deepseek-v4-pro" in models
+    assert not any(model.startswith("wan") for model in models)
+
+
+@pytest.mark.integration
+def test_fetch_models_against_live_endpoint():
+    """Live probe — requires a real ALIBABA_TOKEN_PLAN_API_KEY.
+
+    The integration test is opt-in and only reads explicit process
+    environment variables; unit tests never inspect a user's Hermes profile.
+    """
+    key = _LIVE_API_KEY
+    if not key:
+        pytest.skip("ALIBABA_TOKEN_PLAN_API_KEY not available")
+
+    _load_plugin()
+    prof = get_provider_profile("alibaba-token-plan")
+    assert prof is not None
+    models = prof.fetch_models(api_key=key, timeout=20)
+    assert models
+    expected = {"qwen3.8-max-preview", "qwen3.7-max", "qwen3.6-flash", "deepseek-v4-pro"}
+    assert expected.issubset(set(models))
+    assert not any(model.startswith("wan") for model in models)


### PR DESCRIPTION
## Summary

Add first-class support for Alibaba Cloud Model Studio **Token Plan** as a distinct Hermes provider.

Token Plan uses its own OpenAI-compatible endpoint and billing route:

```text
https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
```

It must not be treated as regular DashScope PAYG or Coding Plan: keys and endpoints are plan-scoped, and probing the wrong route creates misleading authentication failures.

## What changed

- Register `alibaba-token-plan` in the core provider registry, runtime overlay, aliases, Qwen picker group, and Desktop/API provider metadata.
- Use a dedicated `ALIBABA_TOKEN_PLAN_API_KEY` credential route, with optional `ALIBABA_TOKEN_PLAN_BASE_URL` override.
- Add static fallback metadata for the six agent-compatible chat models currently exposed by the plan:
  - `qwen3.8-max-preview`
  - `qwen3.7-max`
  - `qwen3.7-plus`
  - `qwen3.6-flash`
  - `glm-5.2`
  - `deepseek-v4-pro`
- Add URL-to-provider detection for the Token Plan endpoint and correct the existing Coding Plan host mapping.
- Add endpoint-scoped context metadata for `qwen3.8-max-preview`; the Token Plan allocation does not leak to custom providers that reuse the model slug.
- Filter `wan2.7-image` and `wan2.7-image-pro` from live model discovery because they are image-generation models, not valid agent chat models.

## Root causes addressed

The initial implementation exposed three integration gaps caught by hosted CI:

1. the provider plugin appeared in `hermes model` but was absent from Desktop/API configuration surfaces;
2. `/api/env` inferred the Token Plan endpoint as generic `alibaba`;
3. sharing `DASHSCOPE_API_KEY` made ordinary DashScope credentials get probed against Token Plan, producing false authentication errors in `hermes doctor`;
4. globally cataloging the preview model's context window contaminated custom endpoints with the same model slug, so the value is now scoped to the canonical Token Plan endpoint.

The branch was also rebuilt on current `main`; it no longer contains unrelated gateway changes.

## Verification

Hosted-failure reproduction set after the fix:

```text
tests/hermes_cli/test_alibaba_token_plan_provider.py
tests/hermes_cli/test_provider_parity.py
tests/hermes_cli/test_doctor.py
tests/hermes_cli/test_web_server.py
tests/agent/test_model_metadata.py
tests/hermes_cli/test_context_switch_guard.py

707 passed, 0 failed
```

Additional provider/model resolution set:

```text
12 passed, 0 failed
```

Live Token Plan catalog probe with an explicitly exported integration credential:

```text
1 passed, 4 deselected
```

The real endpoint returned HTTP 200 and the expected eight IDs; the provider correctly retained the six chat-capable models and excluded the two Wan image models.

Also passed:

- `ruff check` on all changed Python files;
- Python bytecode compilation;
- `git diff --check`.

## Related work

This overlaps with #69667, which was opened independently around the same time. This PR includes live endpoint regression coverage, dedicated route credential semantics, Desktop/API parity coverage, and filtering of image-only models from the agent picker. Maintainers can choose the preferred implementation or consolidate the two.
