### PR TITLE
fix(gateway): stop authz env fallthrough under multiplex profiles

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -20,6 +20,11 @@ from __future__ import annotations
 import os
 from typing import Optional
 
+from agent.secret_scope import (
+    UnscopedSecretError,
+    get_secret,
+    is_multiplex_active,
+)
 from gateway.config import Platform
 from gateway.session import SessionSource
 from gateway.whatsapp_identity import (
@@ -29,17 +34,25 @@ from gateway.whatsapp_identity import (
 
 
 def _auth_env(name: str, default: str = "") -> str:
-    """Read allowlist/auth env; prefer profile secret_scope under multiplex."""
+    """Read allowlist/auth env; prefer profile secret_scope under multiplex.
+
+    Under multiplexing the active profile scope is authoritative: a missing or
+    empty key must NOT fall through to ``os.environ``, which may still hold
+    another profile's allowlist / allow-all flags. Non-multiplex deployments
+    keep the legacy getenv fallback for process-injected credentials.
+    """
     if not name:
         return default
+    default_s = (default or "").strip()
     try:
-        from agent.secret_scope import get_secret
-
         val = get_secret(name)
-        if val is not None and str(val).strip():
-            return str(val).strip()
-    except Exception:
-        pass
+    except UnscopedSecretError:
+        return default_s
+
+    if val is not None and str(val).strip():
+        return str(val).strip()
+    if is_multiplex_active():
+        return default_s
     return (os.getenv(name) or default).strip()
 
 
@@ -417,7 +430,7 @@ class GatewayAuthorizationMixin:
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
             if chat_allowlist_env:
-                raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
+                raw_chat_allowlist = _auth_env(chat_allowlist_env)
                 if raw_chat_allowlist:
                     allowed_group_ids = {
                         cid.strip()
@@ -459,7 +472,7 @@ class GatewayAuthorizationMixin:
         }
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
-            if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+            if allow_bots_var and _auth_env(allow_bots_var, "none").lower() in {"mentions", "all"}:
                 return True
 
         if not user_id:
@@ -816,13 +829,13 @@ class GatewayAuthorizationMixin:
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
-            if os.getenv(platform_env_map.get(platform, ""), "").strip():
+            if _auth_env(platform_env_map.get(platform, "")):
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):
-                if os.getenv(env_key, "").strip():
+                if _auth_env(env_key):
                     return "ignore"
 
-        if os.getenv("GATEWAY_ALLOWED_USERS", "").strip():
+        if _auth_env("GATEWAY_ALLOWED_USERS"):
             return "ignore"
 
         return "pair"

--- a/tests/gateway/test_authz_env_multiplex_isolation.py
+++ b/tests/gateway/test_authz_env_multiplex_isolation.py
@@ -1,0 +1,209 @@
+"""Regression: _auth_env must not inherit process env under multiplex.
+
+When gateway.multiplex_profiles is on, each turn's secret_scope is authoritative.
+A profile that omits allowlist / allow-all keys must not pick up those values
+from os.environ (which may belong to another profile in the same process).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import agent.secret_scope as secret_scope
+from gateway.authz_mixin import _auth_env
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _reset_multiplex():
+    secret_scope.set_multiplex_active(False)
+    yield
+    secret_scope.set_multiplex_active(False)
+
+
+@pytest.fixture
+def clear_auth_env(monkeypatch):
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_ALLOW_BOTS",
+        "DISCORD_ALLOW_BOTS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.config = None
+    return runner
+
+
+def _dm_source(user_id: str) -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="dm-1",
+        chat_type="dm",
+        user_id=user_id,
+    )
+
+
+def test_auth_env_ignores_process_allowlist_under_multiplex(clear_auth_env, monkeypatch):
+    """Scope omits TELEGRAM_ALLOWED_USERS; process env must not leak through."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "env-allowed")
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"TELEGRAM_BOT_TOKEN": "x"})
+    try:
+        assert _auth_env("TELEGRAM_ALLOWED_USERS") == ""
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+
+def test_auth_env_ignores_process_allow_all_under_multiplex(clear_auth_env, monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"TELEGRAM_BOT_TOKEN": "x"})
+    try:
+        assert _auth_env("GATEWAY_ALLOW_ALL_USERS") == ""
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+
+def test_is_user_authorized_denies_foreign_process_allowlist(clear_auth_env, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "env-allowed")
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"TELEGRAM_BOT_TOKEN": "x"})
+    try:
+        runner = _make_runner()
+        assert runner._is_user_authorized(_dm_source("env-allowed")) is False
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+
+def test_is_user_authorized_denies_foreign_process_allow_all(clear_auth_env, monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"TELEGRAM_BOT_TOKEN": "x"})
+    try:
+        runner = _make_runner()
+        assert runner._is_user_authorized(_dm_source("stranger")) is False
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+
+def test_auth_env_honors_scoped_allowlist_under_multiplex(clear_auth_env):
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"TELEGRAM_ALLOWED_USERS": "scoped-user"})
+    try:
+        assert _auth_env("TELEGRAM_ALLOWED_USERS") == "scoped-user"
+        runner = _make_runner()
+        assert runner._is_user_authorized(_dm_source("scoped-user")) is True
+        assert runner._is_user_authorized(_dm_source("other")) is False
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+
+def test_auth_env_still_reads_process_env_when_multiplex_off(clear_auth_env, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "env-allowed")
+    secret_scope.set_multiplex_active(False)
+    assert _auth_env("TELEGRAM_ALLOWED_USERS") == "env-allowed"
+
+
+def test_auth_env_returns_default_when_multiplex_unscoped(clear_auth_env, monkeypatch):
+    """No secret scope under multiplex must not fall through to os.environ."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "env-allowed")
+    secret_scope.set_multiplex_active(True)
+    assert _auth_env("TELEGRAM_ALLOWED_USERS") == ""
+
+
+def test_auth_env_empty_scoped_value_does_not_fall_through(clear_auth_env, monkeypatch):
+    """Explicit empty string in scope must not inherit process env under multiplex."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "env-allowed")
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"TELEGRAM_ALLOWED_USERS": ""})
+    try:
+        assert _auth_env("TELEGRAM_ALLOWED_USERS") == ""
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+
+def test_group_chat_allowlist_ignores_process_env_under_multiplex(clear_auth_env, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", "-100A")
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"TELEGRAM_BOT_TOKEN": "x"})
+    try:
+        runner = _make_runner()
+        src = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100A",
+            chat_type="channel",
+            user_id=None,
+        )
+        assert runner._is_user_authorized(src) is False
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+
+def test_group_chat_allowlist_honors_profile_scope(clear_auth_env):
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"TELEGRAM_GROUP_ALLOWED_CHATS": "-100B"})
+    try:
+        runner = _make_runner()
+        src = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100B",
+            chat_type="channel",
+            user_id=None,
+        )
+        assert runner._is_user_authorized(src) is True
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+
+def test_allow_bots_ignores_process_env_under_multiplex(clear_auth_env, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"DISCORD_BOT_TOKEN": "x"})
+    try:
+        runner = _make_runner()
+        src = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="dm-1",
+            chat_type="dm",
+            user_id="bot-1",
+            is_bot=True,
+        )
+        assert runner._is_user_authorized(src) is False
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+
+def test_unauthorized_dm_behavior_ignores_process_allowlist_under_multiplex(
+    clear_auth_env, monkeypatch
+):
+    monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "env-owner")
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"TELEGRAM_BOT_TOKEN": "x"})
+    try:
+        runner = _make_runner()
+        assert runner._get_unauthorized_dm_behavior(Platform.TELEGRAM) == "pair"
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+
+def test_unauthorized_dm_behavior_honors_scoped_allowlist(clear_auth_env):
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"GATEWAY_ALLOWED_USERS": "owner1"})
+    try:
+        runner = _make_runner()
+        assert runner._get_unauthorized_dm_behavior(Platform.TELEGRAM) == "ignore"
+    finally:
+        secret_scope.reset_secret_scope(token)


### PR DESCRIPTION
## What does this PR do?

Stops cross-profile allowlist / allow-all leakage in the multiplex gateway by making `_auth_env` and remaining authz getenv call sites honor the active profile `secret_scope` instead of falling through to process `os.environ`.

### Bug Cause

`_auth_env` preferred `get_secret` but always fell back to `os.getenv` on miss/empty/error. Under `gateway.multiplex_profiles`, a profile that omits allowlist keys inherited another profile's `TELEGRAM_ALLOWED_USERS` / `GATEWAY_ALLOW_ALL_USERS` (and sibling raw `os.getenv` sites had the same class of leak).

### Reproduction Steps

1. Enable multiplex; leave process env with `TELEGRAM_ALLOWED_USERS=env-allowed` and/or `GATEWAY_ALLOW_ALL_USERS=true`.
2. Handle a turn for a profile whose secret_scope omits those keys (`set_multiplex_active(True)` + `set_secret_scope({"TELEGRAM_BOT_TOKEN": "x"})`).
3. Call `_is_user_authorized` for `env-allowed` / an arbitrary stranger.

Expected: denied (active profile never allowlisted them).
Before fix: authorized via process env fallthrough.

### Fix

- `_auth_env`: under multiplex, miss/empty/`UnscopedSecretError` return default; never `os.getenv`. Top-level `agent.secret_scope` import.
- Route remaining authz allowlist reads through `_auth_env` (early group/channel chats, `{PLATFORM}_ALLOW_BOTS`, `_get_unauthorized_dm_behavior`).
- Regression tests in `tests/gateway/test_authz_env_multiplex_isolation.py`.

Note: open PR #68581 routes some of the sibling sites through `_auth_env` but does not fix `_auth_env`'s own fallthrough; this PR closes both.

## Related Issue

No issue — found via adversarial scan of `gateway/authz_mixin.py`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/authz_mixin.py` — multiplex-safe `_auth_env`; sibling getenv → `_auth_env`
- `tests/gateway/test_authz_env_multiplex_isolation.py` — new regressions

## How to Test

1. Manual: follow Reproduction Steps; after fix, `_is_user_authorized` must deny foreign process-env identities.
2. Automated (already run locally, 61 passed on the focused set):

```bash
scripts/run_tests.sh \
  tests/gateway/test_authz_env_multiplex_isolation.py \
  tests/gateway/test_multiplex_profile_authz.py \
  tests/gateway/test_unauthorized_dm_behavior.py \
  -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure env resolution)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
