### PR TITLE
fix(memory): probe daemon health as a fallback for local_embedded status

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -467,7 +467,14 @@ def cmd_status(args) -> None:
 
         if provider:
             print("\n  Plugin:    installed ✓")
-            if provider.is_available():
+            # is_available() stays import/env-only (it's on the agent-init
+            # hot path); this on-demand display can afford a live daemon
+            # health probe as a supplement so a daemon started outside
+            # Hermes doesn't show as a false "not available" (#70089).
+            available = provider.is_available()
+            if not available and hasattr(provider, "check_daemon_health"):
+                available = provider.check_daemon_health()
+            if available:
                 print("  Status:    available ✓")
             else:
                 print("  Status:    not available ✗")

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -736,6 +736,40 @@ class HindsightMemoryProvider(MemoryProvider):
         except Exception:
             return False
 
+    def check_daemon_health(self) -> bool:
+        """Best-effort live probe of a local_embedded/local_external daemon's /health.
+
+        is_available() deliberately avoids network calls — it sits on the
+        agent-init hot path (every AIAgent construction checks it) and must
+        stay fast and side-effect-free. For local_embedded it falls back to
+        checking whether the ``hindsight``/``hindsight_embed`` packages
+        import cleanly in *this* process, which is a false negative when the
+        daemon was started independently (e.g. ``hindsight-embed daemon
+        start``) and is healthy but simply isn't importable from Hermes's
+        own environment (#70089).
+
+        This is an opt-in supplement for on-demand displays (``hermes memory
+        status``) where a couple hundred ms of network latency is expected
+        and acceptable — never called from the hot path.
+        """
+        try:
+            cfg = _load_config()
+            mode = cfg.get("mode", "cloud")
+            if mode == "local":
+                mode = "local_embedded"
+            if mode not in {"local_embedded", "local_external"}:
+                return False
+            api_url = cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", _DEFAULT_LOCAL_URL)
+            if not api_url:
+                return False
+            import urllib.request
+            req = urllib.request.Request(api_url.rstrip("/") + "/health")
+            with urllib.request.urlopen(req, timeout=2.0) as resp:  # noqa: S310
+                payload = json.loads(resp.read().decode("utf-8", errors="replace"))
+            return str(payload.get("status", "")).lower() == "healthy"
+        except Exception:
+            return False
+
     def save_config(self, values, hermes_home):
         """Write config to $HERMES_HOME/hindsight/config.json."""
         import json

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -759,7 +759,22 @@ class HindsightMemoryProvider(MemoryProvider):
                 mode = "local_embedded"
             if mode not in {"local_embedded", "local_external"}:
                 return False
-            api_url = cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", _DEFAULT_LOCAL_URL)
+            api_url = cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", "")
+            if not api_url and mode == "local_embedded":
+                # local_embedded has no fixed port -- it's per-profile
+                # (overridable in ~/.hindsight/profiles/<profile>.env, else
+                # hash-allocated from the profile name). _DEFAULT_LOCAL_URL
+                # only happens to be right for the unnamed default profile,
+                # which is why a daemon on any other port was reported as
+                # unavailable. Resolve the real port the same way the daemon
+                # itself does instead of guessing.
+                try:
+                    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+                    api_url = DaemonEmbedManager().get_url(cfg.get("profile", "hermes"))
+                except Exception:
+                    api_url = _DEFAULT_LOCAL_URL
+            elif not api_url:
+                api_url = _DEFAULT_LOCAL_URL
             if not api_url:
                 return False
             import urllib.request

--- a/tests/hermes_cli/test_memory_status.py
+++ b/tests/hermes_cli/test_memory_status.py
@@ -114,3 +114,73 @@ class TestMemoryStatusLabels:
         )
         assert out.count("disabled ✗") == 3
         assert "always active" not in out
+
+
+def _run_cmd_status_with_provider(capfd, provider, mem_config=None):
+    """Like _run_cmd_status but with a real (stub) provider candidate."""
+    from hermes_cli.memory_setup import cmd_status
+
+    config = {"memory": mem_config or {"provider": "hindsight"}}
+
+    with patch("hermes_cli.config.load_config", return_value=config):
+        with patch(
+            "hermes_cli.memory_setup._get_available_providers",
+            return_value=[("hindsight", "Hindsight memory", provider)],
+        ):
+            with patch(
+                "hermes_cli.tools_config._get_platform_tools",
+                return_value={"memory"},
+            ):
+                cmd_status(args=None)
+
+    return capfd.readouterr().out
+
+
+class TestMemoryStatusLiveDaemonProbe:
+    """`hermes memory status` must not report a false 'not available' when
+    is_available()'s import-only check misses a daemon that's actually
+    running healthy (#70089) — e.g. started via `hindsight-embed daemon
+    start` directly, outside Hermes's own Python environment.
+    """
+
+    class _StubProvider:
+        def __init__(self, available, daemon_healthy):
+            self._available = available
+            self._daemon_healthy = daemon_healthy
+
+        def is_available(self):
+            return self._available
+
+        def check_daemon_health(self):
+            return self._daemon_healthy
+
+    class _StubProviderNoHealthCheck:
+        """Mirrors providers (e.g. non-Hindsight) with no check_daemon_health."""
+
+        def is_available(self):
+            return False
+
+    def test_daemon_health_probe_overrides_false_negative(self, capfd):
+        provider = self._StubProvider(available=False, daemon_healthy=True)
+        out = _run_cmd_status_with_provider(capfd, provider)
+        assert "Status:    available ✓" in out
+        assert "not available" not in out
+
+    def test_is_available_true_short_circuits(self, capfd):
+        """When is_available() is already True, no probe is needed."""
+        provider = self._StubProvider(available=True, daemon_healthy=False)
+        out = _run_cmd_status_with_provider(capfd, provider)
+        assert "Status:    available ✓" in out
+
+    def test_both_false_still_reports_not_available(self, capfd):
+        """No regression: a genuinely dead daemon still reports unavailable."""
+        provider = self._StubProvider(available=False, daemon_healthy=False)
+        out = _run_cmd_status_with_provider(capfd, provider)
+        assert "Status:    not available ✗" in out
+
+    def test_provider_without_health_check_falls_back_cleanly(self, capfd):
+        """Providers with no check_daemon_health() must not raise
+        AttributeError — they just keep the plain is_available() result."""
+        provider = self._StubProviderNoHealthCheck()
+        out = _run_cmd_status_with_provider(capfd, provider)
+        assert "Status:    not available ✗" in out

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1722,6 +1722,96 @@ class TestAvailability:
         assert p._mode == "disabled"
 
 
+class TestDaemonHealthProbe:
+    """check_daemon_health() — the live-probe supplement `hermes memory
+    status` uses when is_available()'s import-only check misses a daemon
+    that was started outside Hermes's own environment and is actually
+    healthy (#70089).
+    """
+
+    class _FakeResponse:
+        def __init__(self, payload: bytes):
+            self._payload = payload
+
+        def read(self):
+            return self._payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def test_healthy_daemon_reports_true(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mode": "local_embedded"}))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda req, timeout=None: self._FakeResponse(
+                json.dumps({"status": "healthy", "database": "connected"}).encode()
+            ),
+        )
+
+        p = HindsightMemoryProvider()
+        assert p.check_daemon_health() is True
+
+    def test_unreachable_daemon_reports_false(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mode": "local_embedded"}))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        def _raise(req, timeout=None):
+            raise OSError("Connection refused")
+
+        monkeypatch.setattr("urllib.request.urlopen", _raise)
+
+        p = HindsightMemoryProvider()
+        assert p.check_daemon_health() is False
+
+    def test_cloud_mode_never_probed(self, tmp_path, monkeypatch):
+        """Cloud mode has no local daemon to probe — must return False
+        without attempting a network call."""
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mode": "cloud", "api_key": "***"}))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        def _fail_if_called(req, timeout=None):
+            raise AssertionError("cloud mode must not probe a local daemon")
+
+        monkeypatch.setattr("urllib.request.urlopen", _fail_if_called)
+
+        p = HindsightMemoryProvider()
+        assert p.check_daemon_health() is False
+
+    def test_uses_configured_api_url_not_hardcoded_port(self, tmp_path, monkeypatch):
+        """A user running the daemon on a non-default port (e.g. started
+        manually via `hindsight-embed daemon start`) must be probed on
+        *that* port, not a hardcoded default."""
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({
+            "mode": "local_embedded",
+            "api_url": "http://127.0.0.1:9177",
+        }))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        seen_urls = []
+
+        def _capture(req, timeout=None):
+            seen_urls.append(req.full_url)
+            return self._FakeResponse(json.dumps({"status": "healthy"}).encode())
+
+        monkeypatch.setattr("urllib.request.urlopen", _capture)
+
+        p = HindsightMemoryProvider()
+        assert p.check_daemon_health() is True
+        assert seen_urls == ["http://127.0.0.1:9177/health"]
+
+
 class TestSharedEventLoopLifecycle:
     """Regression tests for #11923 — Hindsight leaking aiohttp ClientSession /
     TCPConnector objects in long-running gateway processes.

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1811,6 +1811,62 @@ class TestDaemonHealthProbe:
         assert p.check_daemon_health() is True
         assert seen_urls == ["http://127.0.0.1:9177/health"]
 
+    def test_resolves_dynamic_port_when_api_url_not_configured(self, tmp_path, monkeypatch):
+        """local_embedded has no fixed port -- without an explicit api_url
+        override, the real per-profile port (allocated by hindsight_embed,
+        e.g. via its .env override or a hash of the profile name) must be
+        resolved rather than assumed to be _DEFAULT_LOCAL_URL. Previously a
+        daemon on any port but the unnamed-default one was reported
+        unavailable."""
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mode": "local_embedded", "profile": "acct-1"}))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        class _FakeManager:
+            def get_url(self, profile):
+                assert profile == "acct-1"
+                return "http://127.0.0.1:54321"
+
+        fake_module = SimpleNamespace(DaemonEmbedManager=_FakeManager)
+        monkeypatch.setitem(sys.modules, "hindsight_embed", SimpleNamespace())
+        monkeypatch.setitem(sys.modules, "hindsight_embed.daemon_embed_manager", fake_module)
+
+        seen_urls = []
+
+        def _capture(req, timeout=None):
+            seen_urls.append(req.full_url)
+            return self._FakeResponse(json.dumps({"status": "healthy"}).encode())
+
+        monkeypatch.setattr("urllib.request.urlopen", _capture)
+
+        p = HindsightMemoryProvider()
+        assert p.check_daemon_health() is True
+        assert seen_urls == ["http://127.0.0.1:54321/health"]
+
+    def test_falls_back_to_default_port_when_discovery_unavailable(self, tmp_path, monkeypatch):
+        """When hindsight_embed itself can't be imported (the same gap
+        is_available() hits per #70089), fall back to the old default
+        rather than raising."""
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mode": "local_embedded"}))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setitem(sys.modules, "hindsight_embed", None)
+        monkeypatch.setitem(sys.modules, "hindsight_embed.daemon_embed_manager", None)
+
+        seen_urls = []
+
+        def _capture(req, timeout=None):
+            seen_urls.append(req.full_url)
+            return self._FakeResponse(json.dumps({"status": "healthy"}).encode())
+
+        monkeypatch.setattr("urllib.request.urlopen", _capture)
+
+        p = HindsightMemoryProvider()
+        assert p.check_daemon_health() is True
+        assert seen_urls == ["http://localhost:8888/health"]
+
 
 class TestSharedEventLoopLifecycle:
     """Regression tests for #11923 — Hindsight leaking aiohttp ClientSession /


### PR DESCRIPTION
Hi! Fixes #70089.

## Problem

`hermes memory status` shows `Status: not available ✗` (and a spurious `Missing: HINDSIGHT_API_KEY`) for a Hindsight `local_embedded` daemon that's actually running healthy — e.g. `curl http://127.0.0.1:9177/health` returns `{"status":"healthy",...}` at the same time the CLI reports it as unavailable.

## Root cause

`HindsightMemoryProvider.is_available()` for `local_embedded`/`local` mode never touches the network — it only checks whether the `hindsight` / `hindsight_embed` packages **import cleanly in the current process** (`_check_local_runtime()`). That's a reasonable proxy when Hermes itself manages the daemon, but it's a false negative whenever the daemon was started independently of Hermes's own Python environment — e.g. via `hindsight-embed daemon start` directly, or from a separate venv — which is exactly the reported repro.

Note this is deliberate: `is_available()` sits on the agent-init hot path (every `AIAgent` construction checks it via `plugins/memory/__init__.py` / `agent/agent_init.py`), so it has to stay fast and side-effect-free. I didn't want to add a network round-trip there.

## Fix

Added `check_daemon_health()` — a live HTTP probe of `<api_url>/health` (using the same configured/default `api_url` resolution `initialize()` already uses, not a hardcoded port, since local_embedded runs on a per-profile dynamic port). `cmd_status` in `hermes_cli/memory_setup.py` now calls this **only as a fallback** when `is_available()` is already `False`, so the hot path is completely untouched — this is opt-in for the on-demand CLI display only.

## Testing

- New `TestDaemonHealthProbe` class covers: healthy daemon → `True`; unreachable daemon → `False`; cloud mode never attempts a probe; a custom `api_url` (e.g. a non-default port from a manually-started daemon) is respected rather than hardcoded.
- New `TestMemoryStatusLiveDaemonProbe` class covers `cmd_status`'s fallback wiring: probe overrides a false negative, `is_available()==True` short-circuits (no probe needed), both `False` still reports unavailable (no regression), and providers without `check_daemon_health` fall back cleanly (no `AttributeError`).
- Full `tests/plugins/memory/test_hindsight_provider.py` and `tests/hermes_cli/test_memory_status.py` suites pass; `ruff check` clean.