### PR TITLE
feat(doctor): probe exact configured runtime routes

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -337,19 +337,87 @@ def _enabled_cli_toolsets_for_doctor() -> set[str] | None:
         return None
 
 
-def _missing_api_key_toolsets_for_summary(unavailable: list[dict]) -> list[dict]:
-    """Filter unavailable API-key toolsets to those enabled for the CLI."""
-    api_key_unavailable = [
-        item for item in unavailable
-        if item.get("missing_vars") or item.get("env_vars")
-    ]
+def _enabled_unavailable_toolsets_for_summary(unavailable: list[dict]) -> list[dict]:
+    """Return unavailable toolsets that are enabled on the CLI surface."""
     enabled_toolsets = _enabled_cli_toolsets_for_doctor()
     if enabled_toolsets is None:
-        return api_key_unavailable
+        return list(unavailable)
     return [
-        item for item in api_key_unavailable
+        item for item in unavailable
         if str(item.get("name") or "") in enabled_toolsets
     ]
+
+
+def _missing_api_key_toolsets_for_summary(unavailable: list[dict]) -> list[dict]:
+    """Filter unavailable API-key toolsets to those enabled for the CLI."""
+    return [
+        item for item in _enabled_unavailable_toolsets_for_summary(unavailable)
+        if item.get("missing_vars") or item.get("env_vars")
+    ]
+
+
+def _check_configured_runtime_routes(issues: list[str], *, probe_routes: bool) -> None:
+    """Validate and optionally execute the exact configured inference routes."""
+    from hermes_cli.config import load_config, read_raw_config
+    from hermes_cli.doctor_routes import (
+        collect_configured_routes,
+        probe_route,
+        validate_route_config,
+    )
+
+    _section("Configured Runtime Routes")
+    raw_config = read_raw_config()
+    route_config_issues = validate_route_config(raw_config)
+    if route_config_issues:
+        for route_issue in route_config_issues:
+            check_fail(route_issue.path, f"({route_issue.message})")
+            check_info(route_issue.fix)
+            issues.append(f"{route_issue.path}: {route_issue.message}. {route_issue.fix}")
+    else:
+        check_ok("Route configuration structure")
+
+    routes = collect_configured_routes(load_config())
+    if routes:
+        check_ok(f"Resolved {len(routes)} configured inference route(s)")
+    else:
+        check_warn("No explicit inference routes found")
+
+    if not probe_routes:
+        check_warn(
+            "Live inference routes were not probed",
+            "(run 'hermes doctor --probe-routes' to test provider + endpoint + model)",
+        )
+        return
+
+    if not routes:
+        return
+
+    check_info("Sending one minimal prompt per configured route; provider charges may apply.")
+    import concurrent.futures as _futures
+
+    max_workers = min(4, len(routes))
+    with _futures.ThreadPoolExecutor(
+        max_workers=max_workers,
+        thread_name_prefix="doctor-route-probe",
+    ) as executor:
+        futures = [executor.submit(probe_route, route) for route in routes]
+        results = [future.result() for future in futures]
+
+    for result in results:
+        route = result.route
+        route_detail = f"({route.provider}/{route.model})"
+        if result.ok:
+            check_ok(route.label, route_detail)
+        elif result.skipped:
+            check_warn(route.label, f"({result.detail})")
+            issues.append(
+                f"Configured route {route.label} could not be live-probed: {result.detail}"
+            )
+        else:
+            check_fail(route.label, f"({result.detail})")
+            issues.append(
+                f"Configured route {route.label} failed live inference: {result.detail}"
+            )
 
 
 def _read_pyproject_version() -> str | None:
@@ -1367,6 +1435,15 @@ def run_doctor(args):
             )
     except Exception as _xai_check_err:
         check_warn("xAI retirement check skipped", f"({_xai_check_err})")
+
+    try:
+        _check_configured_runtime_routes(
+            issues,
+            probe_routes=bool(getattr(args, "probe_routes", False)),
+        )
+    except Exception as route_check_err:
+        check_warn("Configured runtime route check skipped", f"({route_check_err})")
+        issues.append("Configured runtime routes could not be validated")
 
     _section("Auth Providers")
 
@@ -2552,12 +2629,23 @@ def run_doctor(args):
             else:
                 check_warn(item["name"], "(system dependency not met)")
 
-        # Count missing API-key requirements only for toolsets enabled in the
-        # current CLI platform. Default-off or explicitly disabled toolsets may
-        # still show warnings above, but should not pollute the final summary.
+        # Only enabled toolsets may affect the final summary. Missing API keys
+        # retain the existing setup guidance; unavailable local/runtime
+        # dependencies get their own actionable blocking item instead of a
+        # yellow row followed by the misleading "All checks passed" banner.
+        enabled_unavailable = _enabled_unavailable_toolsets_for_summary(unavailable)
         api_disabled = _missing_api_key_toolsets_for_summary(unavailable)
         if api_disabled:
             issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
+        dependency_disabled = [
+            item for item in enabled_unavailable
+            if not (item.get("missing_vars") or item.get("env_vars"))
+        ]
+        if dependency_disabled:
+            names = ", ".join(str(item.get("name") or "unknown") for item in dependency_disabled)
+            issues.append(
+                f"Enabled toolsets unavailable because runtime dependencies are not met: {names}"
+            )
     except Exception as e:
         check_warn("Could not check tool availability", f"({e})")
     
@@ -2780,6 +2868,14 @@ def run_doctor(args):
             print(color("  Tip: run 'hermes doctor --fix' to auto-fix what's possible.", Colors.DIM))
     else:
         print(color("─" * 60, Colors.GREEN))
-        print(color("  All checks passed! 🎉", Colors.GREEN, Colors.BOLD))
+        if bool(getattr(args, "probe_routes", False)):
+            print(color("  All checks passed, including live inference routes! 🎉", Colors.GREEN, Colors.BOLD))
+        else:
+            print(color("  Configuration checks passed.", Colors.GREEN, Colors.BOLD))
+            print(color(
+                "  Live provider/model routes were not tested; run "
+                "'hermes doctor --probe-routes' for end-to-end verification.",
+                Colors.YELLOW,
+            ))
     
     print()

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -681,19 +681,87 @@ def _enabled_cli_toolsets_for_doctor() -> set[str] | None:
         return None
 
 
-def _missing_api_key_toolsets_for_summary(unavailable: list[dict]) -> list[dict]:
-    """Filter unavailable API-key toolsets to those enabled for the CLI."""
-    api_key_unavailable = [
-        item for item in unavailable
-        if item.get("missing_vars") or item.get("env_vars")
-    ]
+def _enabled_unavailable_toolsets_for_summary(unavailable: list[dict]) -> list[dict]:
+    """Return unavailable toolsets that are enabled on the CLI surface."""
     enabled_toolsets = _enabled_cli_toolsets_for_doctor()
     if enabled_toolsets is None:
-        return api_key_unavailable
+        return list(unavailable)
     return [
-        item for item in api_key_unavailable
+        item for item in unavailable
         if str(item.get("name") or "") in enabled_toolsets
     ]
+
+
+def _missing_api_key_toolsets_for_summary(unavailable: list[dict]) -> list[dict]:
+    """Filter unavailable API-key toolsets to those enabled for the CLI."""
+    return [
+        item for item in _enabled_unavailable_toolsets_for_summary(unavailable)
+        if item.get("missing_vars") or item.get("env_vars")
+    ]
+
+
+def _check_configured_runtime_routes(issues: list[str], *, probe_routes: bool) -> None:
+    """Validate and optionally execute the exact configured inference routes."""
+    from hermes_cli.config import load_config, read_raw_config
+    from hermes_cli.doctor_routes import (
+        collect_configured_routes,
+        probe_route,
+        validate_route_config,
+    )
+
+    _section("Configured Runtime Routes")
+    raw_config = read_raw_config()
+    route_config_issues = validate_route_config(raw_config)
+    if route_config_issues:
+        for route_issue in route_config_issues:
+            check_fail(route_issue.path, f"({route_issue.message})")
+            check_info(route_issue.fix)
+            issues.append(f"{route_issue.path}: {route_issue.message}. {route_issue.fix}")
+    else:
+        check_ok("Route configuration structure")
+
+    routes = collect_configured_routes(load_config())
+    if routes:
+        check_ok(f"Resolved {len(routes)} configured inference route(s)")
+    else:
+        check_warn("No explicit inference routes found")
+
+    if not probe_routes:
+        check_warn(
+            "Live inference routes were not probed",
+            "(run 'hermes doctor --probe-routes' to test provider + endpoint + model)",
+        )
+        return
+
+    if not routes:
+        return
+
+    check_info("Sending one minimal prompt per configured route; provider charges may apply.")
+    import concurrent.futures as _futures
+
+    max_workers = min(4, len(routes))
+    with _futures.ThreadPoolExecutor(
+        max_workers=max_workers,
+        thread_name_prefix="doctor-route-probe",
+    ) as executor:
+        futures = [executor.submit(probe_route, route) for route in routes]
+        results = [future.result() for future in futures]
+
+    for result in results:
+        route = result.route
+        route_detail = f"({route.provider}/{route.model})"
+        if result.ok:
+            check_ok(route.label, route_detail)
+        elif result.skipped:
+            check_warn(route.label, f"({result.detail})")
+            issues.append(
+                f"Configured route {route.label} could not be live-probed: {result.detail}"
+            )
+        else:
+            check_fail(route.label, f"({result.detail})")
+            issues.append(
+                f"Configured route {route.label} failed live inference: {result.detail}"
+            )
 
 
 def _read_pyproject_version() -> str | None:
@@ -1909,6 +1977,15 @@ def run_doctor(args):
             )
     except Exception as _xai_check_err:
         check_warn("xAI retirement check skipped", f"({_xai_check_err})")
+
+    try:
+        _check_configured_runtime_routes(
+            issues,
+            probe_routes=bool(getattr(args, "probe_routes", False)),
+        )
+    except Exception as route_check_err:
+        check_warn("Configured runtime route check skipped", f"({route_check_err})")
+        issues.append("Configured runtime routes could not be validated")
 
     _section("Auth Providers")
 
@@ -3160,13 +3237,24 @@ def run_doctor(args):
             else:
                 check_warn(item["name"], "(system dependency not met)")
 
-        # Count missing API-key requirements only for toolsets enabled in the
-        # current CLI platform. Default-off or explicitly disabled toolsets may
-        # still show warnings above, but should not pollute the final summary.
+        # Only enabled toolsets may affect the final summary. Missing API keys
+        # retain the existing setup guidance; unavailable local/runtime
+        # dependencies get their own actionable blocking item instead of a
+        # yellow row followed by the misleading "All checks passed" banner.
+        enabled_unavailable = _enabled_unavailable_toolsets_for_summary(unavailable)
         api_disabled = _missing_api_key_toolsets_for_summary(unavailable)
         web_not_ready = any(status != "ok" for status, _, _ in web_rows)
         if api_disabled or web_not_ready:
             issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
+        dependency_disabled = [
+            item for item in enabled_unavailable
+            if not (item.get("missing_vars") or item.get("env_vars"))
+        ]
+        if dependency_disabled:
+            names = ", ".join(str(item.get("name") or "unknown") for item in dependency_disabled)
+            issues.append(
+                f"Enabled toolsets unavailable because runtime dependencies are not met: {names}"
+            )
     except Exception as e:
         check_warn("Could not check tool availability", f"({e})")
     
@@ -3389,6 +3477,14 @@ def run_doctor(args):
             print(color("  Tip: run 'hermes doctor --fix' to auto-fix what's possible.", Colors.DIM))
     else:
         print(color("─" * 60, Colors.GREEN))
-        print(color("  All checks passed! 🎉", Colors.GREEN, Colors.BOLD))
+        if bool(getattr(args, "probe_routes", False)):
+            print(color("  All checks passed, including live inference routes! 🎉", Colors.GREEN, Colors.BOLD))
+        else:
+            print(color("  Configuration checks passed.", Colors.GREEN, Colors.BOLD))
+            print(color(
+                "  Live provider/model routes were not tested; run "
+                "'hermes doctor --probe-routes' for end-to-end verification.",
+                Colors.YELLOW,
+            ))
     
     print()

--- a/hermes_cli/doctor_routes.py
+++ b/hermes_cli/doctor_routes.py
@@ -1,0 +1,397 @@
+"""Exact configured-route diagnostics for :mod:`hermes_cli.doctor`.
+
+The regular doctor connectivity table proves that a credential can reach a
+provider-level endpoint (usually ``/models``).  It does not prove that the
+configured provider/model/API-mode tuple can execute inference.  This module
+keeps the structural validation and opt-in live probes isolated from the
+already-large doctor command.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from agent.auxiliary_client import (
+    _build_call_kwargs,
+    _get_task_extra_body,
+    resolve_provider_client,
+)
+from agent.redact import redact_sensitive_text
+from hermes_cli.fallback_config import get_fallback_chain
+
+
+@dataclass(frozen=True)
+class ConfigIssue:
+    path: str
+    message: str
+    fix: str
+
+
+@dataclass(frozen=True)
+class RouteSpec:
+    label: str
+    provider: str
+    model: str
+    base_url: str = ""
+    api_key: str = field(default="", repr=False, compare=False)
+    api_mode: str = ""
+    task: str = ""
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    route: RouteSpec
+    ok: bool
+    detail: str = ""
+    skipped: bool = False
+
+
+def _nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _validate_fallback_entries(
+    raw: Any,
+    *,
+    path: str,
+    require_list: bool,
+) -> list[ConfigIssue]:
+    issues: list[ConfigIssue] = []
+    if raw is None or raw == {} or raw == []:
+        return issues
+    if require_list and not isinstance(raw, list):
+        return [
+            ConfigIssue(
+                path,
+                f"{path} must be a YAML list of provider/model mappings; got {type(raw).__name__}",
+                f"Rewrite {path} as a YAML list, for example: "
+                "[{provider: openrouter, model: openai/gpt-4.1-mini}]",
+            )
+        ]
+    if not isinstance(raw, (dict, list)):
+        return [
+            ConfigIssue(
+                path,
+                f"{path} must be a provider/model mapping or list of mappings; got {type(raw).__name__}",
+                f"Remove the malformed {path} value or replace it with valid YAML mappings",
+            )
+        ]
+
+    entries = raw if isinstance(raw, list) else [raw]
+    for index, entry in enumerate(entries):
+        entry_path = f"{path}[{index}]"
+        if not isinstance(entry, dict):
+            issues.append(
+                ConfigIssue(
+                    entry_path,
+                    "fallback entry must be a YAML mapping",
+                    f"Set {entry_path} to a mapping with string provider and model fields",
+                )
+            )
+            continue
+        provider = entry.get("provider")
+        model = entry.get("model")
+        if not _nonempty_string(provider):
+            issues.append(
+                ConfigIssue(
+                    f"{entry_path}.provider",
+                    "fallback provider must be a non-empty string",
+                    f"Set {entry_path}.provider to a valid provider ID",
+                )
+            )
+        if not _nonempty_string(model):
+            issues.append(
+                ConfigIssue(
+                    f"{entry_path}.model",
+                    "fallback model must be a non-empty string",
+                    f"Set {entry_path}.model to a model available on that provider",
+                )
+            )
+    return issues
+
+
+def validate_route_config(raw_config: dict[str, Any] | None) -> list[ConfigIssue]:
+    """Return route/config defects that runtime loaders would otherwise ignore.
+
+    This deliberately validates only routing fields with clear runtime
+    contracts.  It is not a speculative whole-config schema and therefore does
+    not reject plugin-owned or future keys.
+    """
+
+    config = raw_config if isinstance(raw_config, dict) else {}
+    issues: list[ConfigIssue] = []
+
+    model = config.get("model")
+    if isinstance(model, dict):
+        for key in ("fallback_providers", "fallback_model"):
+            if key in model:
+                issues.append(
+                    ConfigIssue(
+                        f"model.{key}",
+                        f"model.{key} is ignored by the runtime because fallback chains are top-level",
+                        f"Move model.{key} to top-level {key}",
+                    )
+                )
+
+    issues.extend(
+        _validate_fallback_entries(
+            config.get("fallback_providers"),
+            path="fallback_providers",
+            require_list=True,
+        )
+    )
+    issues.extend(
+        _validate_fallback_entries(
+            config.get("fallback_model"),
+            path="fallback_model",
+            require_list=False,
+        )
+    )
+
+    auxiliary = config.get("auxiliary")
+    if auxiliary is not None and not isinstance(auxiliary, dict):
+        issues.append(
+            ConfigIssue(
+                "auxiliary",
+                "auxiliary must be a YAML mapping of task names to route settings",
+                "Replace auxiliary with a YAML mapping or remove the malformed value",
+            )
+        )
+    elif isinstance(auxiliary, dict):
+        for task, task_config in auxiliary.items():
+            if not isinstance(task_config, dict):
+                issues.append(
+                    ConfigIssue(
+                        f"auxiliary.{task}",
+                        "auxiliary task configuration must be a YAML mapping",
+                        f"Replace auxiliary.{task} with a mapping or remove it",
+                    )
+                )
+
+    delegation = config.get("delegation")
+    if delegation is not None and not isinstance(delegation, dict):
+        issues.append(
+            ConfigIssue(
+                "delegation",
+                "delegation must be a YAML mapping",
+                "Replace delegation with a YAML mapping or remove the malformed value",
+            )
+        )
+    elif isinstance(delegation, dict):
+        limit_rules = {
+            "child_timeout_seconds": 0,
+            "max_spawn_depth": 1,
+            "max_concurrent_children": 1,
+        }
+        for key, minimum in limit_rules.items():
+            if key not in delegation:
+                continue
+            value = delegation.get(key)
+            # bool is an int subclass but is never a useful numeric limit here.
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                issues.append(
+                    ConfigIssue(
+                        f"delegation.{key}",
+                        f"delegation.{key} must be numeric, not {type(value).__name__}",
+                        f"Set delegation.{key} to a number greater than or equal to {minimum}",
+                    )
+                )
+            elif value < minimum:
+                issues.append(
+                    ConfigIssue(
+                        f"delegation.{key}",
+                        f"delegation.{key} must be greater than or equal to {minimum}",
+                        f"Set delegation.{key} to {minimum} or higher",
+                    )
+                )
+
+    return issues
+
+
+def _route_api_key(route_config: dict[str, Any]) -> str:
+    inline = route_config.get("api_key")
+    if _nonempty_string(inline):
+        return inline.strip()
+    key_env = route_config.get("key_env") or route_config.get("api_key_env")
+    if _nonempty_string(key_env):
+        return os.getenv(key_env.strip(), "").strip()
+    return ""
+
+
+def _route_from_mapping(
+    label: str,
+    mapping: dict[str, Any],
+    *,
+    inherited_provider: str = "auto",
+    inherited_model: str = "",
+    task: str = "",
+) -> RouteSpec | None:
+    provider = mapping.get("provider")
+    model = mapping.get("model")
+    if not _nonempty_string(model) and label == "model.primary":
+        model = mapping.get("default")
+    explicit_model = _nonempty_string(model)
+    provider_text = (
+        str(provider).strip() if _nonempty_string(provider) else inherited_provider
+    )
+    model_text = str(model).strip() if explicit_model else inherited_model
+    base_url = mapping.get("base_url")
+    api_mode = mapping.get("api_mode")
+    base_url_text = str(base_url).strip() if _nonempty_string(base_url) else ""
+    api_mode_text = str(api_mode).strip() if _nonempty_string(api_mode) else ""
+
+    # Inherited/auto auxiliary defaults do not create a distinct route. Their
+    # actual backend is already covered by the primary route.
+    if (
+        task
+        and provider_text in {"", "auto"}
+        and not any((
+            explicit_model,
+            base_url_text,
+            api_mode_text,
+            _route_api_key(mapping),
+        ))
+    ):
+        return None
+    if not model_text:
+        return None
+    return RouteSpec(
+        label=label,
+        provider=provider_text or "auto",
+        model=model_text,
+        base_url=base_url_text,
+        api_key=_route_api_key(mapping),
+        api_mode=api_mode_text,
+        task=task,
+    )
+
+
+def collect_configured_routes(raw_config: dict[str, Any] | None) -> list[RouteSpec]:
+    """Enumerate every explicit inference route selected by the configuration."""
+
+    config = raw_config if isinstance(raw_config, dict) else {}
+    routes: list[RouteSpec] = []
+    model = config.get("model")
+    if isinstance(model, str):
+        model = {"default": model}
+    if not isinstance(model, dict):
+        model = {}
+
+    primary_provider = (
+        model.get("provider").strip()
+        if _nonempty_string(model.get("provider"))
+        else "auto"
+    )
+    primary_model = ""
+    for key in ("default", "model"):
+        if _nonempty_string(model.get(key)):
+            primary_model = model[key].strip()
+            break
+    primary = _route_from_mapping(
+        "model.primary",
+        model,
+        inherited_provider=primary_provider,
+        inherited_model=primary_model,
+    )
+    if primary is not None:
+        routes.append(primary)
+
+    for index, entry in enumerate(get_fallback_chain(config)):
+        route = _route_from_mapping(f"fallback[{index}]", entry)
+        if route is not None:
+            routes.append(route)
+
+    delegation = config.get("delegation")
+    if isinstance(delegation, dict) and any(
+        _nonempty_string(delegation.get(key))
+        for key in ("provider", "model", "base_url", "api_mode", "api_key")
+    ):
+        route = _route_from_mapping(
+            "delegation",
+            delegation,
+            inherited_provider=primary_provider,
+            inherited_model=primary_model,
+        )
+        if route is not None:
+            routes.append(route)
+
+    auxiliary = config.get("auxiliary")
+    if isinstance(auxiliary, dict):
+        for task, task_config in sorted(auxiliary.items()):
+            if not isinstance(task_config, dict):
+                continue
+            if not any(
+                _nonempty_string(task_config.get(key))
+                for key in ("provider", "model", "base_url", "api_mode", "api_key")
+            ):
+                continue
+            route = _route_from_mapping(
+                f"auxiliary.{task}",
+                task_config,
+                inherited_provider=primary_provider,
+                inherited_model=primary_model,
+                task=str(task),
+            )
+            if route is not None:
+                routes.append(route)
+
+    return routes
+
+
+def _safe_error_text(exc: BaseException, *, api_key: str = "") -> str:
+    text = redact_sensitive_text(str(exc), force=True)
+    if api_key:
+        text = text.replace(api_key, "[REDACTED]")
+    # Avoid producing multi-page SDK payloads in the doctor summary.
+    text = " ".join(text.split())
+    return text[:500] + ("…" if len(text) > 500 else "")
+
+
+def probe_route(route: RouteSpec, *, timeout: float = 15.0) -> ProbeResult:
+    """Execute one minimal, exact inference call without provider fallback."""
+
+    try:
+        client, resolved_model = resolve_provider_client(
+            route.provider,
+            model=route.model,
+            explicit_base_url=route.base_url or None,
+            explicit_api_key=route.api_key or None,
+            api_mode=route.api_mode or None,
+        )
+        if client is None:
+            return ProbeResult(route, False, "runtime could not resolve a client")
+        if not hasattr(getattr(client, "chat", None), "completions"):
+            return ProbeResult(
+                route,
+                False,
+                "resolved transport does not expose a probeable chat-completions interface",
+                skipped=True,
+            )
+
+        final_model = resolved_model or route.model
+        client_base_url = str(getattr(client, "base_url", route.base_url) or "")
+        kwargs = _build_call_kwargs(
+            route.provider,
+            final_model,
+            [{"role": "user", "content": "Reply with exactly: OK"}],
+            temperature=0,
+            max_tokens=8,
+            timeout=timeout,
+            extra_body=_get_task_extra_body(route.task) if route.task else None,
+            base_url=client_base_url or route.base_url,
+        )
+        response = client.chat.completions.create(**kwargs)
+        choices = getattr(response, "choices", None)
+        if not choices or not hasattr(choices[0], "message"):
+            return ProbeResult(
+                route, False, "provider returned an invalid response shape"
+            )
+        return ProbeResult(route, True, f"{route.provider}/{final_model}")
+    except Exception as exc:  # noqa: BLE001 - doctor must report, never crash
+        return ProbeResult(
+            route,
+            False,
+            _safe_error_text(exc, api_key=route.api_key),
+        )

--- a/hermes_cli/subcommands/doctor.py
+++ b/hermes_cli/subcommands/doctor.py
@@ -32,6 +32,14 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
         ),
     )
     doctor_parser.add_argument(
+        "--probe-routes",
+        action="store_true",
+        help=(
+            "Run minimal live inference probes for configured primary, fallback, "
+            "delegation, and explicit auxiliary routes"
+        ),
+    )
+    doctor_parser.add_argument(
         "--ack",
         metavar="ADVISORY_ID",
         default=None,

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -63,6 +63,33 @@ class TestDoctorToolAvailabilitySummary:
 
         assert [item["name"] for item in filtered] == ["web"]
 
+    def test_missing_api_key_summary_falls_back_when_config_unavailable(self, monkeypatch):
+        unavailable = [
+            {"name": "rl", "missing_vars": ["TINKER_API_KEY"]},
+            {"name": "web", "missing_vars": ["EXA_API_KEY"]},
+        ]
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: None)
+
+        filtered = doctor._missing_api_key_toolsets_for_summary(unavailable)
+
+        assert [item["name"] for item in filtered] == ["rl", "web"]
+
+    def test_enabled_unavailable_summary_includes_system_dependency_failures(self, monkeypatch):
+        unavailable = [
+            {"name": "image", "env_vars": [], "tools": ["image_generate"]},
+            {"name": "video", "env_vars": [], "tools": ["video_generate"]},
+            {"name": "tts", "env_vars": [], "tools": ["text_to_speech"]},
+            {"name": "browser", "env_vars": [], "tools": ["browser_navigate"]},
+        ]
+        monkeypatch.setattr(
+            doctor,
+            "_enabled_cli_toolsets_for_doctor",
+            lambda: {"image", "video", "tts"},
+        )
+
+        filtered = doctor._enabled_unavailable_toolsets_for_summary(unavailable)
+
+        assert [item["name"] for item in filtered] == ["image", "video", "tts"]
 
 class TestDoctorEnvFileEncoding:
     """Regression for #18637 (bug 3): `hermes doctor` crashed on Windows

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -124,6 +124,33 @@ class TestDoctorToolAvailabilitySummary:
             ("ok", "web extract", "(ddgs)"),
         ]
 
+    def test_missing_api_key_summary_falls_back_when_config_unavailable(self, monkeypatch):
+        unavailable = [
+            {"name": "rl", "missing_vars": ["TINKER_API_KEY"]},
+            {"name": "web", "missing_vars": ["EXA_API_KEY"]},
+        ]
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: None)
+
+        filtered = doctor._missing_api_key_toolsets_for_summary(unavailable)
+
+        assert [item["name"] for item in filtered] == ["rl", "web"]
+
+    def test_enabled_unavailable_summary_includes_system_dependency_failures(self, monkeypatch):
+        unavailable = [
+            {"name": "image", "env_vars": [], "tools": ["image_generate"]},
+            {"name": "video", "env_vars": [], "tools": ["video_generate"]},
+            {"name": "tts", "env_vars": [], "tools": ["text_to_speech"]},
+            {"name": "browser", "env_vars": [], "tools": ["browser_navigate"]},
+        ]
+        monkeypatch.setattr(
+            doctor,
+            "_enabled_cli_toolsets_for_doctor",
+            lambda: {"image", "video", "tts"},
+        )
+
+        filtered = doctor._enabled_unavailable_toolsets_for_summary(unavailable)
+
+        assert [item["name"] for item in filtered] == ["image", "video", "tts"]
 
 class TestDoctorEnvFileEncoding:
     """Regression for #18637 (bug 3): `hermes doctor` crashed on Windows

--- a/tests/hermes_cli/test_doctor_routes.py
+++ b/tests/hermes_cli/test_doctor_routes.py
@@ -1,0 +1,278 @@
+"""Regression coverage for exact runtime-route diagnostics in ``hermes doctor``."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import config as config_module
+from hermes_cli import doctor, doctor_routes
+
+
+def test_validate_route_config_rejects_misplaced_model_fallback_chain():
+    issues = doctor_routes.validate_route_config({
+        "model": {
+            "provider": "openrouter",
+            "default": "openai/gpt-4.1-mini",
+            "fallback_providers": [{"provider": "deepseek", "model": "deepseek-chat"}],
+        }
+    })
+
+    assert any(issue.path == "model.fallback_providers" for issue in issues)
+    assert any("top-level fallback_providers" in issue.fix for issue in issues)
+
+
+def test_validate_route_config_rejects_stringified_fallback_chain():
+    issues = doctor_routes.validate_route_config({
+        "fallback_providers": ("[{'provider': 'deepseek', 'model': 'deepseek-chat'}]")
+    })
+
+    assert any(issue.path == "fallback_providers" for issue in issues)
+    assert any("YAML list" in issue.message for issue in issues)
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "deepseek/deepseek-chat",
+        {"provider": "deepseek"},
+        {"model": "deepseek-chat"},
+        {"provider": 123, "model": "deepseek-chat"},
+    ],
+)
+def test_validate_route_config_rejects_invalid_fallback_entries(entry):
+    issues = doctor_routes.validate_route_config({"fallback_providers": [entry]})
+
+    assert any(issue.path.startswith("fallback_providers[0]") for issue in issues)
+
+
+def test_validate_route_config_accepts_well_formed_routes():
+    issues = doctor_routes.validate_route_config({
+        "model": {"provider": "openrouter", "default": "openai/gpt-4.1-mini"},
+        "fallback_providers": [{"provider": "deepseek", "model": "deepseek-chat"}],
+        "delegation": {
+            "provider": "nvidia",
+            "model": "qwen/qwen3.5-122b-a10b",
+            "child_timeout_seconds": 0,
+            "max_spawn_depth": 2,
+            "max_concurrent_children": 3,
+        },
+        "auxiliary": {
+            "compression": {
+                "provider": "deepseek",
+                "model": "deepseek-chat",
+            }
+        },
+    })
+
+    assert issues == []
+
+
+def test_validate_route_config_accepts_disabled_empty_fallback():
+    assert doctor_routes.validate_route_config({"fallback_model": {}}) == []
+    assert doctor_routes.validate_route_config({"fallback_providers": []}) == []
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("child_timeout_seconds", -1),
+        ("child_timeout_seconds", "600"),
+        ("max_spawn_depth", 0),
+        ("max_spawn_depth", "2"),
+        ("max_concurrent_children", 0),
+    ],
+)
+def test_validate_route_config_rejects_malformed_delegation_limits(key, value):
+    issues = doctor_routes.validate_route_config({"delegation": {key: value}})
+
+    assert any(issue.path == f"delegation.{key}" for issue in issues)
+
+
+def test_collect_configured_routes_covers_every_explicit_runtime_surface():
+    routes = doctor_routes.collect_configured_routes({
+        "model": {"provider": "openrouter", "default": "openai/gpt-4.1-mini"},
+        "fallback_providers": [{"provider": "deepseek", "model": "deepseek-chat"}],
+        "delegation": {
+            "provider": "nvidia",
+            "model": "qwen/qwen3.5-122b-a10b",
+        },
+        "auxiliary": {
+            "compression": {
+                "provider": "xiaomi",
+                "model": "mimo-v2-flash",
+            },
+            "title_generation": {"provider": "auto", "model": ""},
+        },
+    })
+
+    by_label = {route.label: route for route in routes}
+    assert set(by_label) == {
+        "model.primary",
+        "fallback[0]",
+        "delegation",
+        "auxiliary.compression",
+    }
+    assert by_label["auxiliary.compression"].task == "compression"
+    assert by_label["auxiliary.compression"].provider == "xiaomi"
+
+
+def test_collect_configured_routes_uses_neutral_label_for_legacy_fallback():
+    routes = doctor_routes.collect_configured_routes({
+        "model": {"provider": "openrouter", "default": "openai/gpt-4.1-mini"},
+        "fallback_model": {"provider": "deepseek", "model": "deepseek-chat"},
+    })
+
+    assert [route.label for route in routes] == ["model.primary", "fallback[0]"]
+
+
+def test_probe_route_executes_exact_route_without_fallback(monkeypatch):
+    calls = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            calls["kwargs"] = kwargs
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="OK"))]
+            )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions()),
+        base_url="https://api.example.test/v1",
+    )
+
+    def fake_resolve(provider, model=None, **kwargs):
+        calls["resolve"] = (provider, model, kwargs)
+        return fake_client, model
+
+    monkeypatch.setattr(doctor_routes, "resolve_provider_client", fake_resolve)
+    monkeypatch.setattr(
+        doctor_routes,
+        "_get_task_extra_body",
+        lambda task: {"diagnostic_task": task},
+    )
+
+    def fake_build(provider, model, messages, **kwargs):
+        calls["build"] = (provider, model, kwargs)
+        return {
+            "model": model,
+            "messages": messages,
+            "timeout": kwargs["timeout"],
+        }
+
+    monkeypatch.setattr(doctor_routes, "_build_call_kwargs", fake_build)
+
+    result = doctor_routes.probe_route(
+        doctor_routes.RouteSpec(
+            label="auxiliary.compression",
+            provider="xiaomi",
+            model="mimo-v2-flash",
+            base_url="https://api.example.test/v1",
+            api_key="secret",
+            task="compression",
+        ),
+        timeout=7,
+    )
+
+    assert result.ok is True
+    assert calls["resolve"] == (
+        "xiaomi",
+        "mimo-v2-flash",
+        {
+            "explicit_base_url": "https://api.example.test/v1",
+            "explicit_api_key": "secret",
+            "api_mode": None,
+        },
+    )
+    assert calls["kwargs"]["timeout"] == 7
+    assert calls["build"][2]["extra_body"] == {"diagnostic_task": "compression"}
+
+
+def test_probe_route_reports_auth_failure_and_redacts_secret(monkeypatch):
+    class FakeCompletions:
+        def create(self, **kwargs):
+            raise RuntimeError("HTTP 401 api_key=not-a-real-key")
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions()),
+        base_url="https://api.example.test/v1",
+    )
+    monkeypatch.setattr(
+        doctor_routes,
+        "resolve_provider_client",
+        lambda *args, **kwargs: (fake_client, "broken-model"),
+    )
+    monkeypatch.setattr(
+        doctor_routes,
+        "_build_call_kwargs",
+        lambda *args, **kwargs: {"model": "broken-model", "messages": []},
+    )
+
+    result = doctor_routes.probe_route(
+        doctor_routes.RouteSpec(
+            label="delegation",
+            provider="openrouter",
+            model="broken-model",
+            api_key="not-a-real-key",
+        )
+    )
+
+    assert result.ok is False
+    assert "401" in result.detail
+    assert "not-a-real-key" not in result.detail
+
+
+def _install_doctor_route_config(monkeypatch):
+    config = {"model": {"provider": "openrouter", "default": "openai/gpt-4.1-mini"}}
+    monkeypatch.setattr(config_module, "read_raw_config", lambda: config)
+    monkeypatch.setattr(config_module, "load_config", lambda: config)
+
+
+def test_doctor_default_discloses_unprobed_routes_without_blocking(monkeypatch, capsys):
+    _install_doctor_route_config(monkeypatch)
+    issues = []
+
+    doctor._check_configured_runtime_routes(issues, probe_routes=False)
+
+    output = capsys.readouterr().out
+    assert issues == []
+    assert "Live inference routes were not probed" in output
+    assert "--probe-routes" in output
+
+
+def test_doctor_live_route_failure_is_blocking(monkeypatch, capsys):
+    _install_doctor_route_config(monkeypatch)
+    monkeypatch.setattr(
+        doctor_routes,
+        "probe_route",
+        lambda route: doctor_routes.ProbeResult(route, False, "HTTP 401 invalid key"),
+    )
+    issues = []
+
+    doctor._check_configured_runtime_routes(issues, probe_routes=True)
+
+    output = capsys.readouterr().out
+    assert any("failed live inference" in issue for issue in issues)
+    assert "HTTP 401 invalid key" in output
+
+
+def test_doctor_unprobeable_route_is_blocking(monkeypatch, capsys):
+    _install_doctor_route_config(monkeypatch)
+    monkeypatch.setattr(
+        doctor_routes,
+        "probe_route",
+        lambda route: doctor_routes.ProbeResult(
+            route,
+            False,
+            "transport has no chat-completions interface",
+            skipped=True,
+        ),
+    )
+    issues = []
+
+    doctor._check_configured_runtime_routes(issues, probe_routes=True)
+
+    output = capsys.readouterr().out
+    assert any("could not be live-probed" in issue for issue in issues)
+    assert "transport has no chat-completions interface" in output

--- a/tests/hermes_cli/test_subcommands_batch.py
+++ b/tests/hermes_cli/test_subcommands_batch.py
@@ -78,6 +78,18 @@ SINGLE_HANDLER_CASES = [
 
 
 
+def test_doctor_probe_routes_flag_parses():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    handler = _h("doctor")
+    build_doctor_parser(sub, cmd_doctor=handler)
+
+    ns = parser.parse_args(["doctor", "--probe-routes"])
+
+    assert ns.func is handler
+    assert ns.probe_routes is True
+
+
 def test_config_get_unset_subcommands_parse():
     """`hermes config get/unset` parse key args (and --json for get)."""
     parser = argparse.ArgumentParser(prog="hermes")

--- a/tests/hermes_cli/test_subcommands_batch.py
+++ b/tests/hermes_cli/test_subcommands_batch.py
@@ -76,6 +76,18 @@ SINGLE_HANDLER_CASES = [
 
 
 
+def test_doctor_probe_routes_flag_parses():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    handler = _h("doctor")
+    build_doctor_parser(sub, cmd_doctor=handler)
+
+    ns = parser.parse_args(["doctor", "--probe-routes"])
+
+    assert ns.func is handler
+    assert ns.probe_routes is True
+
+
 def test_config_get_unset_subcommands_parse():
     """`hermes config get/unset` parse key args (and --json for get)."""
     parser = argparse.ArgumentParser(prog="hermes")

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -769,12 +769,15 @@ Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-relo
 ## `hermes doctor`
 
 ```bash
-hermes doctor [--fix]
+hermes doctor [--fix] [--probe-routes]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--fix` | Attempt automatic repairs where possible. |
+| `--probe-routes` | Send a minimal live inference request through each configured primary, fallback, delegation, and explicit auxiliary route. This verifies the exact provider, endpoint, and model without silently falling back; provider charges may apply. |
+
+Without `--probe-routes`, `doctor` validates configuration, credentials, provider-level connectivity, dependencies, and enabled toolsets, but does not claim that live model routes passed. Use the probe when diagnosing 401/404 responses, unavailable configured models, or auxiliary/delegation failures that a provider `/models` health check cannot detect.
 
 ## `hermes dump`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -813,12 +813,15 @@ Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-relo
 ## `hermes doctor`
 
 ```bash
-hermes doctor [--fix]
+hermes doctor [--fix] [--probe-routes]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--fix` | Attempt automatic repairs where possible. |
+| `--probe-routes` | Send a minimal live inference request through each configured primary, fallback, delegation, and explicit auxiliary route. This verifies the exact provider, endpoint, and model without silently falling back; provider charges may apply. |
+
+Without `--probe-routes`, `doctor` validates configuration, credentials, provider-level connectivity, dependencies, and enabled toolsets, but does not claim that live model routes passed. Use the probe when diagnosing 401/404 responses, unavailable configured models, or auxiliary/delegation failures that a provider `/models` health check cannot detect.
 
 ## `hermes dump`
 


### PR DESCRIPTION
## Summary

`hermes doctor` currently verifies provider-level connectivity (usually a `/models` request) and credential presence, but that can still produce a green result when the exact configured provider + endpoint + model route fails at inference time.

This PR adds an explicit end-to-end diagnostic mode:

```bash
hermes doctor --probe-routes
```

It sends one minimal inference request through each configured primary, fallback, delegation, and explicit auxiliary route, without silently falling back to another provider.

## What changed

- Add `--probe-routes` to test exact configured inference routes.
- Enumerate primary, effective fallback, delegation, and explicit auxiliary routes using the runtime provider resolver.
- Reuse the runtime request builder so API mode and auxiliary task request settings are exercised.
- Report 401/400/404/model/endpoint failures against the route that actually failed.
- Validate route configuration that the runtime would otherwise ignore or coerce silently, including:
  - fallback chains incorrectly nested under `model`;
  - stringified or malformed `fallback_providers` entries;
  - malformed auxiliary/delegation mappings;
  - invalid delegation numeric limits.
- Treat configured routes that cannot be live-probed as unresolved instead of claiming all live checks passed.
- Make enabled-but-unavailable toolsets block the final green summary, including local/runtime dependency failures (not only missing API keys).
- Replace the unconditional `All checks passed` message in normal mode with an explicit statement that live model routes were not tested.
- Document the new flag, its scope, and the fact that provider charges may apply.

## Safety and compatibility

- Live inference is opt-in because it can incur provider charges.
- Each request uses a minimal prompt and a bounded timeout.
- Probes are concurrent but capped at four workers.
- The probe invokes the resolved client directly; it does not use the fallback execution path.
- Error output is passed through Hermes secret redaction, explicit route credentials are additionally removed, and long SDK payloads are bounded.
- Plugin-owned and future configuration keys remain accepted; validation only covers routing fields with established runtime contracts.
- Legacy `fallback_model` configurations remain supported and receive neutral `fallback[n]` labels.

## Real-world validation

Against a live Hermes profile, the existing provider-level connectivity table accepted Xiaomi as configured/reachable, while `--probe-routes` correctly found:

```text
auxiliary.mcp: 400 Unsupported model mimo-v2.5-flash
```

The primary, fallback, delegation, compression, title-generation, vision, and web-extract routes were independently exercised. This is the exact class of false positive that a generic `/models` check cannot detect.

## Tests

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_doctor_routes.py \
  tests/hermes_cli/test_doctor.py \
  tests/hermes_cli/test_subcommands_batch.py \
  -q --tb=short

126 passed
```

```text
18 auxiliary resolver/client regression files via scripts/run_tests.sh

517 passed
```

Also passed:

- `ruff check` on all changed Python files;
- Python bytecode compilation for the changed CLI modules;
- `git diff --check`;
- live default and `--probe-routes` doctor runs;
- independent read-only code review with no blocking findings.

A broader `tests/hermes_cli` run reached 91% before the 600-second harness limit. Its three unrelated failures were reproduced unchanged on a clean `origin/main` worktree: two SQLite WAL tests while the bundled SQLite 3.50.4 safety gate forces `journal_mode=DELETE`, and one unreadable-file test executed as `root`.

## Related work

This is complementary to #38823, which adds JSON/verbose route observability but explicitly defers live route testing. This PR focuses on exact end-to-end route health and truthful final status semantics.