### PR TITLE
fix(deps): stop trace refresh breaking Hindsight

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -293,6 +293,23 @@ class TestIsSatisfiedVersionAware:
         self._fake_version(monkeypatch, {"mautrix": "0.20.0"})
         assert ld._is_satisfied("mautrix[encryption]==0.21.0") is False
 
+    @pytest.mark.parametrize(
+        ("installed", "satisfied"),
+        [
+            ("1.2.3", False),
+            ("1.5.0", True),
+            ("1.24.0", True),
+            ("2.0.0", False),
+        ],
+    )
+    def test_trace_upload_preserves_hindsight_compatible_hub(
+        self, monkeypatch, installed, satisfied
+    ):
+        """Refreshing trace upload must not downgrade Hindsight's shared SDK."""
+        self._fake_version(monkeypatch, {"huggingface-hub": installed})
+        spec = ld.LAZY_DEPS["tool.trace_upload"][0]
+        assert ld._is_satisfied(spec) is satisfied
+
 
 # ---------------------------------------------------------------------------
 # active_features + refresh_active_features (Piece A — hermes update wiring)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -239,7 +239,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "starlette==1.0.1",  # CVE-2026-48710 — keep in sync with pyproject [computer-use]
     ),
     # HF Agent Trace Viewer upload (hermes trace upload / /upload-trace).
-    "tool.trace_upload": ("huggingface-hub==1.2.3",),
+    # Keep this as a compatible range: local Hindsight installs Transformers,
+    # which requires huggingface-hub>=1.5. An older exact pin here made
+    # `hermes update` downgrade the shared venv and break Hindsight startup.
+    "tool.trace_upload": ("huggingface-hub>=1.5.0,<2.0",),
 }
 
 


### PR DESCRIPTION
## Summary

- stop the active lazy-feature refresh from downgrading `huggingface-hub` to `1.2.3`
- allow the trace uploader to share the Hindsight-compatible `huggingface-hub>=1.5,<2` dependency
- add regression coverage for the compatible and incompatible version boundaries

## Reproduction

A local embedded Hindsight install currently brings in `transformers 5.12.1`, which requires `huggingface-hub>=1.5.0,<2.0`. When trace upload has also been activated, `hermes update` refreshes active lazy features and applies `tool.trace_upload`'s exact `huggingface-hub==1.2.3` pin. That downgrades the shared venv. `pip check` then reports the conflict, and Hindsight daemon startup fails while importing `sentence_transformers` / `transformers`.

Using a compatible range preserves trace upload's 1.x API while preventing it from downgrading another active backend. It also causes the next lazy refresh to repair existing `1.2.3` environments.

## Tests

- `scripts/run_tests.sh tests/tools/test_lazy_deps.py` (68 passed)
- `scripts/run_tests.sh tests/test_project_metadata.py` (9 passed)
- `scripts/run_tests.sh tests/agent/test_trace_upload.py` (20 passed)
- `git diff --check`