### PR TITLE
fix(agent): sanitize iteration-limit summary failures

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -32,6 +32,7 @@ from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import (
     FailoverReason,
     PROVIDER_STREAM_NON_JSON_ERROR_CODE,
+    classify_api_error,
 )
 from agent.errors import EmptyStreamError
 from agent.turn_context import substitute_api_content
@@ -2873,6 +2874,63 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         return agent._try_activate_fallback(reason)  # try next in chain
 
 
+def _iteration_limit_summary_failure(agent, error: Exception) -> tuple[str, str, int | None]:
+    """Build a safe, actionable response when the final summary call fails.
+
+    The exception may contain credentials and provider-internal metadata. Classify
+    it for user guidance, but never interpolate its raw string into the response
+    or warning log.
+    """
+    try:
+        classified = classify_api_error(
+            error,
+            provider=str(getattr(agent, "provider", "") or ""),
+            model=str(getattr(agent, "model", "") or ""),
+        )
+        reason = classified.reason
+        status_code = classified.status_code
+    except Exception:
+        reason = FailoverReason.unknown
+        raw_status_code = getattr(error, "status_code", None)
+        status_code = raw_status_code if isinstance(raw_status_code, int) else None
+
+    prefix = (
+        f"I reached the maximum number of tool-calling iterations "
+        f"({agent.max_iterations}), and "
+    )
+    preserved_work = " Work completed before the limit remains in the conversation."
+
+    if reason in {FailoverReason.rate_limit, FailoverReason.upstream_rate_limit}:
+        message = (
+            prefix
+            + "the model provider's usage limit prevented the final summary request."
+            + preserved_work
+            + " Retry after the provider limit resets, or switch to another model or provider."
+        )
+    elif reason == FailoverReason.billing:
+        message = (
+            prefix
+            + "the model provider's billing or credit limit prevented the final summary request."
+            + preserved_work
+            + " Check the provider account, or switch to another model or provider."
+        )
+    elif reason in {FailoverReason.auth, FailoverReason.auth_permanent}:
+        message = (
+            prefix
+            + "provider authentication failed during the final summary request."
+            + preserved_work
+            + " Check the configured credentials, or switch to another model or provider."
+        )
+    else:
+        message = (
+            prefix
+            + "an error prevented the final summary request."
+            + preserved_work
+            + " Retry the turn, or switch to another model or provider."
+        )
+
+    return message, reason.value, status_code
+
 
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
@@ -3219,8 +3277,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 final_response = "I reached the iteration limit and couldn't generate a summary."
 
     except Exception as e:
-        logger.warning("Failed to get summary response: %s", e)
-        final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
+        final_response, failure_reason, status_code = _iteration_limit_summary_failure(agent, e)
+        logger.warning(
+            "Failed to get iteration-limit summary "
+            "(error_type=%s, reason=%s, status=%s)",
+            type(e).__name__,
+            failure_reason,
+            status_code,
+        )
     finally:
         from agent import relay_llm
 
@@ -3230,8 +3294,6 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         )
 
     return final_response
-
-
 
 def cleanup_task_resources(agent, task_id: str) -> None:
     """Clean up VM and browser resources for a given task.

--- a/tests/agent/test_max_iterations_summary_failure.py
+++ b/tests/agent/test_max_iterations_summary_failure.py
@@ -1,0 +1,188 @@
+"""Regression tests for iteration-limit summary failures."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent import chat_completion_helpers
+from agent.chat_completion_helpers import handle_max_iterations
+
+
+class _UsageLimitError(Exception):
+    status_code = 429
+    body = {
+        "error": {
+            "type": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+            "plan_type": "plus",
+            "resets_at": 1_785_376_302,
+            "resets_in_seconds": 558_947,
+        }
+    }
+
+
+class _ProviderError(Exception):
+    def __init__(self, status_code: int, error_type: str, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = {"error": {"type": error_type, "message": message}}
+
+
+class _SummaryAgent:
+    max_iterations = 90
+    model = "test-model"
+    provider = "openai-codex"
+    base_url = "https://example.invalid/v1"
+    _base_url_lower = base_url
+    api_mode = "openai"
+    max_tokens = None
+    reasoning_config = None
+    ephemeral_system_prompt = None
+    prefill_messages = []
+    openrouter_min_coding_score = None
+    providers_allowed = []
+    providers_ignored = []
+    providers_order = []
+    provider_sort = None
+    provider_require_parameters = False
+    provider_data_collection = None
+    session_id = "test-session"
+
+    _safe_print = lambda self, *a, **kw: None
+
+    def __init__(self, error: Exception):
+        self._error = error
+        self._cached_system_prompt = ""
+
+    def _should_sanitize_tool_calls(self):
+        return False
+
+    def _copy_reasoning_content_for_api(self, source, target):
+        return None
+
+    def _sanitize_api_messages(self, messages):
+        return messages
+
+    def _drop_thinking_only_and_merge_users(self, messages):
+        return messages
+
+    def _supports_reasoning_extra_body(self):
+        return False
+
+    def _is_openrouter_url(self):
+        return False
+
+    def _ensure_primary_openai_client(self, *, reason):
+        assert reason == "iteration_limit_summary"
+        return SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=self._raise_summary_error),
+            )
+        )
+
+    def _raise_summary_error(self, **kwargs):
+        raise self._error
+
+
+def test_usage_limit_summary_failure_is_actionable_and_hides_provider_payload(caplog):
+    messages = [{"role": "user", "content": "do the work"}]
+
+    result = handle_max_iterations(
+        _SummaryAgent(_UsageLimitError("raw provider payload")), messages, 90
+    )
+
+    assert "maximum number of tool-calling iterations (90)" in result
+    assert "usage limit" in result.lower()
+    assert "retry" in result.lower()
+    assert "switch" in result.lower()
+    assert (
+        "work completed before the limit remains in the conversation" in result.lower()
+    )
+    assert "raw provider payload" not in result
+    assert "plan_type" not in result
+    assert "resets_at" not in result
+    assert "558947" not in result
+    assert "raw provider payload" not in caplog.text
+    assert "reason=rate_limit" in caplog.text
+
+
+def test_generic_summary_failure_does_not_echo_exception_or_secrets(caplog):
+    private_detail = "connection failed api_key=private-test-token"
+    messages = [{"role": "user", "content": "do the work"}]
+
+    result = handle_max_iterations(
+        _SummaryAgent(RuntimeError(private_detail)), messages, 90
+    )
+
+    assert "an error prevented the final summary request" in result.lower()
+    assert (
+        "work completed before the limit remains in the conversation" in result.lower()
+    )
+    assert private_detail not in result
+    assert "private-test-token" not in result
+    assert private_detail not in caplog.text
+    assert "private-test-token" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_cause", "expected_action"),
+    [
+        (
+            _ProviderError(
+                402, "insufficient_quota", "account has insufficient credits"
+            ),
+            "billing or credit limit",
+            "check the provider account",
+        ),
+        (
+            _ProviderError(401, "authentication_error", "invalid bearer token"),
+            "provider authentication failed",
+            "check the configured credentials",
+        ),
+    ],
+)
+def test_summary_failure_uses_classified_action_without_echoing_error(
+    error,
+    expected_cause,
+    expected_action,
+):
+    messages = [{"role": "user", "content": "do the work"}]
+
+    result = handle_max_iterations(_SummaryAgent(error), messages, 90)
+
+    assert expected_cause in result.lower()
+    assert expected_action in result.lower()
+    assert str(error) not in result
+
+
+def test_classifier_failure_does_not_log_untrusted_status_object(monkeypatch, caplog):
+    private_detail = "private-status-object"
+
+    class _UnsafeStatus:
+        def __str__(self):
+            return private_detail
+
+    class _UnsafeStatusError(RuntimeError):
+        def __init__(self):
+            super().__init__("summary failed")
+            self.status_code = _UnsafeStatus()
+
+    error = _UnsafeStatusError()
+
+    def fail_classifier(*args, **kwargs):
+        raise RuntimeError("classifier failed")
+
+    monkeypatch.setattr(chat_completion_helpers, "classify_api_error", fail_classifier)
+
+    result = handle_max_iterations(
+        _SummaryAgent(error),
+        [{"role": "user", "content": "do the work"}],
+        90,
+    )
+
+    assert "an error prevented the final summary request" in result.lower()
+    assert private_detail not in result
+    assert private_detail not in caplog.text
+    assert "status=None" in caplog.text

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2720,7 +2720,7 @@ class TestHandleMaxIterations:
         combined = "\n".join(printed) + capsys.readouterr().out
         assert "Reached maximum iterations" in combined
 
-    def test_api_failure_returns_error(self, agent):
+    def test_api_failure_returns_safe_error(self, agent):
         agent.client.chat.completions.create.side_effect = Exception("API down")
         agent._cached_system_prompt = "You are helpful."
         messages = [{"role": "user", "content": "do stuff"}]
@@ -2728,7 +2728,8 @@ class TestHandleMaxIterations:
             result = agent._handle_max_iterations(messages, 60)
         assert isinstance(result, str)
         assert "error" in result.lower()
-        assert "API down" in result
+        assert "work completed before the limit remains" in result.lower()
+        assert "API down" not in result
         complete_logical.assert_called_once()
         assert complete_logical.call_args.kwargs == {"outcome": "failed"}
 


### PR DESCRIPTION
## Summary

Sanitize failures from the final no-tools summary request when Hermes reaches `max_iterations`.

The old catch-all branch interpolated `str(error)` into both the user-facing response and warning log. Structured provider errors can contain quota-plan/reset metadata, while arbitrary transport exceptions can contain credentials or tokens.

This PR preserves the summary attempt and returns stable, actionable guidance without exposing the raw exception.

## Root cause

`handle_max_iterations()` treated the final summary failure as ordinary display text:

```python
f"... couldn't summarize. Error: {str(e)}"
```

That crossed an exception-safety boundary: provider/SDK internals became user-visible and log-visible.

## What changed

- Reuse the central `classify_api_error()` taxonomy.
- Return tailored guidance for rate/usage limits, billing/credit limits, authentication failures, and generic failures.
- State truthfully that work completed before the limit remains visible in the conversation.
- Never interpolate the raw exception into the response or warning log.
- Log only exception type, classified reason, and HTTP status.
- Preserve the successful summary path, retry behavior, Relay logical-call identity, and finalization outcome from current `main`.

## Security properties

Regression tests assert that responses and logs do not contain:

- raw provider payloads;
- plan/reset metadata;
- arbitrary exception text;
- API-key-shaped private values.

The generic response remains actionable without claiming that a summary was produced.

## Current-main port

The branch was rebuilt on current `main` (`12b1f0f83d`). The surrounding summary path had evolved since the original patch, so the port deliberately preserves the newer Relay lifecycle contract (`complete_logical_call` in `finally`) and its retry identity tests. No current-main tests were deleted.

## Verification

```text
python -m pytest -q \
  tests/run_agent/test_run_agent.py \
  tests/agent/test_max_iterations_summary_failure.py
# 263 passed

python -m pytest -q \
  tests/agent/test_error_classifier.py \
  tests/agent/test_chat_completion_helpers_provider_sort.py \
  tests/agent/test_turn_finalizer_iteration_limit_exit.py \
  tests/agent/test_turn_finalizer_final_response_persistence.py \
  tests/agent/test_turn_finalizer_cleanup_guard.py \
  tests/agent/test_turn_finalizer_interrupt_alternation.py
# 102 passed

python -m ruff check \
  agent/chat_completion_helpers.py \
  tests/agent/test_max_iterations_summary_failure.py \
  tests/run_agent/test_run_agent.py
# All checks passed

python -m py_compile agent/chat_completion_helpers.py \
  tests/agent/test_max_iterations_summary_failure.py \
  tests/run_agent/test_run_agent.py

git diff --check
```

The full `test_run_agent.py` run emits one existing unrelated thread-warning from `_BarrierDB.flush_token_counts`; all 263 tests pass.
