### PR TITLE
fix(credential-pool): exhaust all entries sharing a failed API key (#68565 salvage)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -652,6 +652,8 @@ class CredentialPool:
         entry: PooledCredential,
         status_code: Optional[int],
         error_context: Optional[Dict[str, Any]] = None,
+        *,
+        persist: bool = True,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
         # Permanent OAuth failures (token_invalidated, token_revoked, etc.)
@@ -675,7 +677,8 @@ class CredentialPool:
             last_error_reset_at=normalized_error.get("reset_at"),
         )
         self._replace_entry(entry, updated)
-        self._persist()
+        if persist:
+            self._persist()
         return updated
 
     def _sync_anthropic_entry_from_credentials_file(self, entry: PooledCredential) -> PooledCredential:
@@ -1775,11 +1778,17 @@ class CredentialPool:
             # Mark every entry sharing the failed key so the pool can reach the
             # "no available entries" state and let the error propagate.
             if api_key_hint:
+                siblings_marked = False
                 for sibling in self._entries:
                     if sibling.id == entry.id:
                         continue
                     if sibling.runtime_api_key == api_key_hint:
-                        self._mark_exhausted(sibling, status_code, error_context)
+                        self._mark_exhausted(
+                            sibling, status_code, error_context, persist=False
+                        )
+                        siblings_marked = True
+                if siblings_marked:
+                    self._persist()
             # Re-read the updated entry to log the correct terminal state.
             updated_entry = next(
                 (e for e in self._entries if e.id == entry.id), entry,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1763,6 +1763,23 @@ class CredentialPool:
                 return None
             _label = entry.label or entry.id[:8]
             self._mark_exhausted(entry, status_code, error_context)
+            # A 402/429/401 is an API-key–level failure: the account is out of
+            # balance, rate-limited, or its key is rejected.  The same key can
+            # back more than one pool entry (e.g. an explicit pool entry plus a
+            # ``model_config`` entry auto-seeded from ``model.api_key`` — both
+            # carry the identical ``runtime_api_key``).  Marking only the first
+            # match leaves the sibling entries OK, so ``_select_unlocked()``
+            # keeps handing back the same depleted key and rotation never
+            # converges — the caller ``continue``s forever until the client
+            # disconnects (a ~2.5min hang with no error surfaced to the user).
+            # Mark every entry sharing the failed key so the pool can reach the
+            # "no available entries" state and let the error propagate.
+            if api_key_hint:
+                for sibling in self._entries:
+                    if sibling.id == entry.id:
+                        continue
+                    if sibling.runtime_api_key == api_key_hint:
+                        self._mark_exhausted(sibling, status_code, error_context)
             # Re-read the updated entry to log the correct terminal state.
             updated_entry = next(
                 (e for e in self._entries if e.id == entry.id), entry,

--- a/contributors/emails/hang.li@tcredit.com
+++ b/contributors/emails/hang.li@tcredit.com
@@ -1,0 +1,1 @@
+airclear

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -379,6 +379,70 @@ def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
     assert persisted["last_error_code"] == 402
 
 
+def test_billing_rotation_marks_all_entries_sharing_failed_key(tmp_path, monkeypatch):
+    """A 402 must exhaust every pool entry backed by the same API key.
+
+    Regression: the same key can back more than one pool entry — e.g. an
+    explicit pool entry plus a ``model_config`` entry auto-seeded from
+    ``model.api_key`` (both carry the identical ``runtime_api_key``).  When
+    ``mark_exhausted_and_rotate`` is called with ``api_key_hint`` it matched
+    only the *first* such entry, leaving the sibling OK.  ``_select_unlocked()``
+    then kept handing back the same depleted key, so the billing-recovery
+    ``continue`` loop in the conversation retry path never converged — the
+    request hung ~2.5min until the client disconnected, with no 402 ever
+    surfaced to the user.  All entries sharing the failed key must be
+    exhausted so the pool reaches "no available entries" and the error
+    propagates immediately.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    shared_key = "sk-deepseek-shared"
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "custom": [
+                    {
+                        "id": "cred-explicit",
+                        "label": "520555",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": shared_key,
+                        "base_url": "https://api.deepseek.com",
+                    },
+                    {
+                        "id": "cred-model-config",
+                        "label": "model_config",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": shared_key,
+                        "base_url": "https://api.deepseek.com",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+
+    pool = load_pool("custom")
+
+    # First 402 on the shared key: rotation must NOT hand back a sibling
+    # entry that wraps the same depleted key — it must converge to None.
+    next_entry = pool.mark_exhausted_and_rotate(
+        status_code=402,
+        api_key_hint=shared_key,
+    )
+    assert next_entry is None
+
+    # Both entries are now exhausted (not just the first match).
+    statuses = {entry.id: entry.last_status for entry in pool.entries()}
+    assert statuses["cred-explicit"] == STATUS_EXHAUSTED
+    assert statuses["cred-model-config"] == STATUS_EXHAUSTED
+
+
 def test_token_invalidated_marks_credential_dead(tmp_path, monkeypatch):
     """OpenAI Codex token_invalidated must mark the credential DEAD, not exhausted.
 


### PR DESCRIPTION
## Summary

Salvage of #68565 by @airclear: `mark_exhausted_and_rotate(api_key_hint=...)` now exhausts **every** pool entry sharing the failed API key, not just the first match. A 402/429/401 is a key-level failure — when the same key backs multiple entries (e.g. an explicit pool entry plus the `model_config` entry auto-seeded from `model.api_key`), marking only one left `_select_unlocked()` handing back the identical depleted key forever: the billing-recovery loop never converged and the request hung ~2.5 min with no error surfaced.

Premise verified empirically: the PR's regression test fails on unpatched main (rotation returns the same-key sibling) and passes with the fix.

## Changes

- `agent/credential_pool.py` (contributor commit, cherry-picked): after marking the hinted entry, sweep siblings with the same `runtime_api_key` and exhaust them too. Per-entry `_mark_exhausted` preserves DEAD-vs-EXHAUSTED classification; guarded by `if api_key_hint`, so hint-less callers are unchanged.
- `agent/credential_pool.py` (follow-up): `_mark_exhausted(persist=False)` + one batched `_persist()` for the sibling sweep — one auth.json write instead of one per sibling.
- `tests/agent/test_credential_pool.py` (contributor): regression test with two entries backed by one key.

## Validation

| | Before | After |
|---|---|---|
| 402 on a key backing 2 entries | Sibling stays OK → same key re-selected → ~2.5 min hang, no error | Both exhausted, rotation moves to the next distinct key |
| All keys exhausted | Loop never converges | `mark_exhausted_and_rotate` returns None, error propagates |

- 109 targeted tests green (`test_credential_pool.py`, `test_credential_pool_routing.py`, `test_credential_pool_interrupt.py`).
- Live E2E with a real 3-entry pool (two sharing a key) in a temp `HERMES_HOME`: both same-key entries exhausted + persisted in one write, rotation lands on the distinct key, and exhausting that converges to None.

Closes #68565's scope. Complements #69553/#69843 (attribution) — this covers the key-to-many-entries direction.

## Credit

Core fix and regression test by @airclear (#68565), cherry-picked with authorship preserved. Persistence batching added on top.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa36b05/AMltgY08cfsxcqIenNkrr_powrK72n.png)
