### PR TITLE
fix: preserve one-shot resume context

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1295,7 +1295,10 @@ def compress_context(
                             session_id=agent.session_id,
                             source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                             model=agent.model,
-                            model_config=agent._session_init_model_config,
+                            model_config={
+                                **agent._session_init_model_config,
+                                "_compression_from": old_session_id,
+                            },
                             parent_session_id=old_session_id,
                         )
                     except Exception as _cs_err:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -143,17 +143,23 @@ def _run_and_exit_oneshot(
     provider: object = None,
     toolsets: object = None,
     usage_file: object = None,
+    resume: object = None,
+    pass_session_id: bool = False,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
 
-        rc = run_oneshot(
-            prompt,
-            model=model,
-            provider=provider,
-            toolsets=toolsets,
-            usage_file=usage_file,
-        )
+        options = {
+            "model": model,
+            "provider": provider,
+            "toolsets": toolsets,
+            "usage_file": usage_file,
+        }
+        if resume:
+            options["resume"] = resume
+        if pass_session_id:
+            options["pass_session_id"] = True
+        rc = run_oneshot(prompt, **options)
     except KeyboardInterrupt:
         rc = 130
     except SystemExit as exc:
@@ -13368,6 +13374,8 @@ def _try_termux_fast_cli_launch() -> bool:
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            resume=getattr(args, "resume", None),
+            pass_session_id=bool(getattr(args, "pass_session_id", False)),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -15526,6 +15534,8 @@ def main():
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            resume=getattr(args, "resume", None),
+            pass_session_id=bool(getattr(args, "pass_session_id", False)),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -173,6 +173,8 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    resume: Optional[str] = None,
+    pass_session_id: bool = False,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -187,6 +189,9 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        resume: Exact durable session identity to continue. Its canonical
+            transcript is loaded before the prompt is run.
+        pass_session_id: Include the durable session identity in agent context.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -248,6 +253,8 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    resume=resume,
+                    pass_session_id=pass_session_id,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -310,12 +317,31 @@ def _create_session_db_for_oneshot():
         return None
 
 
+def _load_resume_context(session_db, requested: Optional[str]) -> tuple[Optional[str], list[dict]]:
+    """Resolve a one-shot resume target and hydrate its canonical history."""
+    requested = (requested or "").strip()
+    if not requested:
+        return None, []
+    if session_db is None:
+        raise RuntimeError("Session database is unavailable; cannot resume safely")
+    resolved = session_db.resolve_session_id(requested)
+    if not resolved:
+        raise ValueError(f"Session not found: {requested}")
+    resolved = session_db.resolve_resume_session_id(resolved) or resolved
+    history = session_db.get_messages_as_conversation(resolved, repair_alternation=True) or []
+    history = [message for message in history if message.get("role") != "session_meta"]
+    session_db.reopen_session(resolved)
+    return resolved, history
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    resume: Optional[str] = None,
+    pass_session_id: bool = False,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -398,10 +424,13 @@ def _run_agent(
     session_db = _create_session_db_for_oneshot()
     # The try spans agent construction (not just ``chat``) so the SQLite store
     # opened above is always closed — including when ``AIAgent(...)`` itself
-    # raises on a provider/config error. The one-shot exit path hard-exits via
-    # os._exit and skips finalizers, so an un-closed connection here would leak.
+    # or resume hydration raises. The one-shot exit path hard-exits via os._exit
+    # and skips finalizers, so an un-closed connection here would leak.
     agent = None
     try:
+        resume_session_id, conversation_history = _load_resume_context(
+            session_db, resume
+        )
         # Read the effective fallback chain from profile config so oneshot
         # workers honour the same merge semantics as interactive CLI and
         # gateway sessions.
@@ -419,6 +448,8 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            session_id=resume_session_id,
+            pass_session_id=pass_session_id,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction
@@ -439,7 +470,7 @@ def _run_agent(
         agent.stream_delta_callback = None
         agent.tool_gen_callback = None
 
-        result = agent.run_conversation(prompt)
+        result = agent.run_conversation(prompt, conversation_history=conversation_history or None)
         return (result.get("final_response") or "", result)
     finally:
         # Ordering deliberately mirrors gateway/run.py:_cleanup_agent_resources,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3676,10 +3676,10 @@ class SessionDB:
         the user's latest messages look "lost" even though they are persisted in
         the real continuation chain.
 
-        Instead, only follow children of compression-ended parents, exclude
-        explicit branch/delegate/tool children, and prefer children that are
-        themselves continuing the compression chain (``end_reason='compression'``)
-        or still live over stale closed siblings such as ``ws_orphan_reap``.
+        New continuations carry ``model_config._compression_from``. Prefer that
+        explicit marker. For legacy rows, follow a child that itself continues
+        the compression chain, or an only eligible child. Ambiguous unmarked
+        siblings fail closed at the parent rather than guessing across sessions.
         Returns the latest continuation tip, or the input id when no
         continuation exists.
         """
@@ -3691,7 +3691,12 @@ class SessionDB:
             with self._lock:
                 cursor = self._conn.execute(
                     """
-                    SELECT child.id
+                    SELECT child.id, child.end_reason, child.ended_at,
+                           child.started_at,
+                           json_extract(
+                             COALESCE(child.model_config, '{}'),
+                             '$._compression_from'
+                           ) AS compression_from
                     FROM sessions parent
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.id = ?
@@ -3711,12 +3716,21 @@ class SessionDB:
                       ) DESC,
                       child.started_at DESC,
                       child.id DESC
-                    LIMIT 1
                     """,
                     (current,),
                 )
-                row = cursor.fetchone()
-            if row is None:
+                rows = cursor.fetchall()
+            if not rows:
+                return current
+            marked = [row for row in rows if row["compression_from"] == current]
+            chained = [row for row in rows if row["end_reason"] == "compression"]
+            if marked:
+                row = marked[0]
+            elif chained:
+                row = chained[0]
+            elif len(rows) == 1:
+                row = rows[0]
+            else:
                 return current
             child_id = row["id"]
             if not child_id or child_id in seen:
@@ -4856,19 +4870,18 @@ class SessionDB:
         ``message_count = 0`` rows unless messages had already been flushed to
         it before compression. See #15000.
 
-        This helper walks ``parent_session_id`` forward from ``session_id`` and
-        returns the descendant in the chain that has the **most recent** messages.
-        Unlike the original logic, it does NOT short-circuit when the starting
-        session already has messages — a descendant that was created by
-        compression may hold the continuation content and should be preferred
-        by the WebUI and gateway for ``--resume`` and session loading.
+        This helper follows only the canonical compression-continuation chain
+        from ``session_id`` and returns its deepest message-bearing node. Unlike
+        the original logic, it does NOT short-circuit when the starting session
+        already has messages — a continuation may hold newer content and should
+        be preferred by the WebUI and gateway for ``--resume`` and session
+        loading. Ordinary children, branches, delegates, and tool sessions are
+        never eligible resume targets.
 
         If no descendant (including the starting session) has any messages,
         the original ``session_id`` is returned unchanged.
 
-        The chain is always walked via the child whose ``started_at`` is
-        latest; that matches the single-chain shape that compression creates.
-        A depth cap (32) guards against accidental loops in malformed data.
+        A depth cap (100) guards against accidental loops in malformed data.
         """
         if not session_id:
             return session_id
@@ -4884,57 +4897,54 @@ class SessionDB:
         # (created after the parent was ended), so delegation / branch children
         # never hijack the resume. This is the fix for the desktop "I came back
         # and the reply isn't there" report on large sessions.
+        requested_id = session_id
         try:
-            tip = self.get_compression_tip(session_id)
+            tip = self.get_compression_tip(requested_id)
         except Exception:
-            tip = session_id
-        if tip and tip != session_id:
-            session_id = tip
+            tip = requested_id
+        if not tip or tip == requested_id:
+            return requested_id
 
         with self._lock:
-            current = session_id
+            # Walk backward from the validated compression tip so an empty tail
+            # resolves to the nearest continuation that actually holds messages.
+            # Starting from the requested node and following arbitrary children
+            # is unsafe: ordinary child sessions share parent_session_id and can
+            # otherwise hijack resume into another conversation.
+            current = tip
             seen = {current}
-            best = None  # tracks the last (deepest) node with messages
-
-            for _ in range(32):
-                # Check if the current node has messages.
+            for _ in range(100):
                 try:
                     row = self._conn.execute(
                         "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
                         (current,),
                     ).fetchone()
                 except Exception:
-                    return session_id
+                    return requested_id
                 if row is not None:
-                    best = current
-
-                # Walk to the most-recently-started child — but skip explicit
-                # branch (`_branched_from`), delegate/subagent (`_delegate_from`),
-                # and tool children. They also carry a ``parent_session_id`` yet
-                # are NOT compression continuations; following them would hijack
-                # the resume target to an unrelated session (e.g. a subagent
-                # run). This mirrors the child-exclusion in ``get_compression_tip``.
+                    return current
+                if current == requested_id:
+                    break
                 try:
-                    child_row = self._conn.execute(
-                        "SELECT id FROM sessions "
-                        "WHERE parent_session_id = ? "
-                        "  AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL "
-                        "  AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL "
-                        "  AND COALESCE(source, '') != 'tool' "
-                        "ORDER BY started_at DESC, id DESC LIMIT 1",
+                    parent_row = self._conn.execute(
+                        "SELECT parent_session_id FROM sessions WHERE id = ?",
                         (current,),
                     ).fetchone()
                 except Exception:
-                    return session_id
-                if child_row is None:
+                    return requested_id
+                if parent_row is None:
                     break
-                child_id = child_row["id"] if hasattr(child_row, "keys") else child_row[0]
-                if not child_id or child_id in seen:
+                parent_id = (
+                    parent_row["parent_session_id"]
+                    if hasattr(parent_row, "keys")
+                    else parent_row[0]
+                )
+                if not parent_id or parent_id in seen:
                     break
-                seen.add(child_id)
-                current = child_id
+                seen.add(parent_id)
+                current = parent_id
 
-            return best if best is not None else session_id
+            return requested_id
 
     def get_messages_as_conversation(
         self,

--- a/tests/hermes_cli/test_oneshot_resume.py
+++ b/tests/hermes_cli/test_oneshot_resume.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+
+def test_load_resume_context_hydrates_exact_canonical_session():
+    from hermes_cli.oneshot import _load_resume_context
+
+    calls = []
+
+    class SessionDB:
+        def resolve_session_id(self, requested):
+            calls.append(("resolve", requested))
+            return "session_exact"
+
+        def resolve_resume_session_id(self, resolved):
+            calls.append(("resume", resolved))
+            return "session_leaf"
+
+        def get_messages_as_conversation(self, resolved, repair_alternation=False):
+            calls.append(("history", resolved, repair_alternation))
+            return [
+                {"role": "session_meta", "content": "private metadata"},
+                {"role": "user", "content": "thread-specific request"},
+                {"role": "assistant", "content": "thread-specific response"},
+            ]
+
+        def reopen_session(self, resolved):
+            calls.append(("reopen", resolved))
+
+    session_id, history = _load_resume_context(SessionDB(), "session_requested")
+
+    assert session_id == "session_leaf"
+    assert history == [
+        {"role": "user", "content": "thread-specific request"},
+        {"role": "assistant", "content": "thread-specific response"},
+    ]
+    assert calls == [
+        ("resolve", "session_requested"),
+        ("resume", "session_exact"),
+        ("history", "session_leaf", True),
+        ("reopen", "session_leaf"),
+    ]
+
+
+def test_load_resume_context_rejects_unknown_session():
+    from hermes_cli.oneshot import _load_resume_context
+
+    class SessionDB:
+        def resolve_session_id(self, requested):
+            return None
+
+    with pytest.raises(ValueError, match="Session not found: missing"):
+        _load_resume_context(SessionDB(), "missing")
+
+
+def test_load_resume_context_fails_closed_without_session_db():
+    from hermes_cli.oneshot import _load_resume_context
+
+    with pytest.raises(RuntimeError, match="cannot resume safely"):
+        _load_resume_context(None, "session_exact")
+
+
+def test_run_agent_binds_resolved_session_and_history(monkeypatch):
+    import hermes_cli.oneshot as oneshot_mod
+
+    constructor = {}
+    conversation = {}
+    closed = []
+
+    class FakeSessionDB:
+        def resolve_session_id(self, requested):
+            assert requested == "session_requested"
+            return "session_exact"
+
+        def resolve_resume_session_id(self, resolved):
+            assert resolved == "session_exact"
+            return "session_leaf"
+
+        def get_messages_as_conversation(self, resolved, repair_alternation=False):
+            assert (resolved, repair_alternation) == ("session_leaf", True)
+            return [{"role": "user", "content": "thread-specific request"}]
+
+        def reopen_session(self, resolved):
+            assert resolved == "session_leaf"
+
+        def close(self):
+            closed.append(True)
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            constructor.update(kwargs)
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def run_conversation(self, prompt, **kwargs):
+            conversation.update({"prompt": prompt, **kwargs})
+            return {"final_response": "done"}
+
+        def shutdown_memory_provider(self, *_args):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setitem(
+        sys.modules, "run_agent", types.SimpleNamespace(AIAgent=FakeAgent)
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "gpt-test", "provider": "openai"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "key",
+            "base_url": "https://example.invalid",
+            "provider": "openai",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(
+        oneshot_mod, "_create_session_db_for_oneshot", lambda: FakeSessionDB()
+    )
+
+    result = oneshot_mod._run_agent(
+        "continue this thread",
+        model="gpt-test",
+        provider="openai",
+        use_config_toolsets=False,
+        resume="session_requested",
+        pass_session_id=True,
+    )
+
+    assert result == ("done", {"final_response": "done"})
+    assert constructor["session_id"] == "session_leaf"
+    assert constructor["pass_session_id"] is True
+    assert conversation == {
+        "prompt": "continue this thread",
+        "conversation_history": [
+            {"role": "user", "content": "thread-specific request"}
+        ],
+    }
+    assert closed == [True]
+
+
+def test_run_agent_closes_session_db_when_resume_is_unknown(monkeypatch):
+    import hermes_cli.oneshot as oneshot_mod
+
+    closed = []
+
+    class FakeSessionDB:
+        def resolve_session_id(self, requested):
+            assert requested == "missing"
+            return None
+
+        def close(self):
+            closed.append(True)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "run_agent",
+        types.SimpleNamespace(AIAgent=lambda **_kwargs: None),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "gpt-test", "provider": "openai"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "key",
+            "base_url": "https://example.invalid",
+            "provider": "openai",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(
+        oneshot_mod, "_create_session_db_for_oneshot", lambda: FakeSessionDB()
+    )
+
+    with pytest.raises(ValueError, match="Session not found: missing"):
+        oneshot_mod._run_agent(
+            "continue this thread",
+            model="gpt-test",
+            provider="openai",
+            use_config_toolsets=False,
+            resume="missing",
+        )
+
+    assert closed == [True]

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -660,6 +660,60 @@ def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
     }
 
 
+def test_main_top_level_oneshot_forwards_resume_identity(monkeypatch, main_mod):
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "-z",
+            "continue this thread",
+            "--resume",
+            "session_exact",
+            "--pass-session-id",
+        ],
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=lambda _cfg, accept_hooks=False: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 0
+        ),
+    )
+    monkeypatch.setattr(main_mod, "_exit_after_oneshot", _raise_exit)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 0
+    assert captured["resume"] == "session_exact"
+    assert captured["pass_session_id"] is True
+
+
 def test_exit_after_oneshot_flushes_stdio_and_calls_os_exit(
     monkeypatch, main_mod
 ):

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -23,13 +23,22 @@ def db(tmp_path):
 
 
 def _make_chain(db: SessionDB, ids_with_parent):
-    """Create sessions in order, forcing started_at so ordering is deterministic."""
+    """Create a compression chain, forcing deterministic session ordering."""
     base = int(time.time()) - 10_000
+    compression_parents = set()
     for i, (sid, parent) in enumerate(ids_with_parent):
         db.create_session(sid, source="cli", parent_session_id=parent)
+        if parent:
+            compression_parents.add(parent)
         db._conn.execute(
             "UPDATE sessions SET started_at = ? WHERE id = ?",
             (base + i * 100, sid),
+        )
+    for parent in compression_parents:
+        db._conn.execute(
+            "UPDATE sessions SET ended_at = started_at, end_reason = 'compression' "
+            "WHERE id = ?",
+            (parent,),
         )
     db._conn.commit()
 
@@ -135,17 +144,69 @@ def test_compression_tip_not_confused_with_delegation_child(db):
     assert db.resolve_resume_session_id("conv") == "conv"
 
 
-def test_prefers_most_recent_child_when_fork_exists(db):
-    # If a session was somehow forked (two children), pick the latest one.
-    # In practice, compression only produces single-chain shape, but the helper
-    # should degrade gracefully.
+def test_resume_does_not_follow_an_ordinary_child(db):
+    db.create_session("parent", source="cli")
+    db.append_message("parent", role="user", content="parent turn")
+    db.create_session("ordinary_child", source="cli", parent_session_id="parent")
+    db.append_message(
+        "ordinary_child", role="assistant", content="different conversation"
+    )
+
+    assert db.resolve_resume_session_id("parent") == "parent"
+
+
+def test_ambiguous_unmarked_compression_children_fail_closed(db):
+    # Legacy rows have no explicit compression marker. Two eligible live
+    # children are ambiguous, so resuming the parent must not guess.
     _make_chain(db, [
         ("parent", None),
         ("older_fork", "parent"),
         ("newer_fork", "parent"),
     ])
     db.append_message("newer_fork", role="user", content="x")
-    assert db.resolve_resume_session_id("parent") == "newer_fork"
+    assert db.resolve_resume_session_id("parent") == "parent"
+
+
+def test_explicit_compression_child_wins_over_ordinary_and_special_siblings(db):
+    base = int(time.time()) - 10_000
+    db.create_session("parent", source="cli")
+    db.append_message("parent", role="user", content="before compression")
+    db.end_session("parent", "compression")
+    db.create_session(
+        "continuation",
+        source="cli",
+        parent_session_id="parent",
+        model_config={"_compression_from": "parent"},
+    )
+    db.append_message("continuation", role="assistant", content="canonical")
+    db.create_session("ordinary", source="cli", parent_session_id="parent")
+    db.append_message("ordinary", role="assistant", content="unrelated")
+    db.create_session(
+        "delegate",
+        source="subagent",
+        parent_session_id="parent",
+        model_config={"_delegate_from": "parent"},
+    )
+    db.create_session(
+        "branch",
+        source="cli",
+        parent_session_id="parent",
+        model_config={"_branched_from": "parent"},
+    )
+    db.create_session("tool_child", source="tool", parent_session_id="parent")
+    conn = db._conn
+    assert conn is not None
+    for offset, sid in enumerate(
+        ["parent", "continuation", "delegate", "branch", "tool_child", "ordinary"]
+    ):
+        conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (base + offset * 100, sid),
+        )
+    conn.commit()
+
+    assert db.get_compression_tip("parent") == "continuation"
+    assert db.resolve_resume_session_id("parent") == "continuation"
 
 
 def test_redirects_from_message_bearing_parent_to_child(db):


### PR DESCRIPTION
## What does this PR do?

Prevents one-shot resume calls from silently creating or binding to the wrong durable session.

The top-level `--oneshot` shortcut previously dropped `--resume` and `--pass-session-id`; the one-shot runner therefore started a fresh agent without hydrating the requested transcript. Callers that tried to recover identity by selecting the newest same-directory session could then bind to a nested, delegated, tool, or otherwise unrelated session.

## Changes made

- Forward `--resume` and `--pass-session-id` through the top-level one-shot path.
- Resolve the exact canonical resume identity and hydrate only its transcript.
- Fail closed when an explicit resume cannot access its session database.
- Strip internal `session_meta` records before replay.
- Close the session database on resume-hydration failures.
- Mark compression children with `_compression_from`.
- Prefer explicit compression lineage and fail closed for ambiguous legacy siblings.
- Add regressions for CLI forwarding, exact history hydration, unknown/missing sessions, cleanup, compression lineage, and ordinary/delegate/tool child exclusion.

## How to test

```bash
uv run --with pytest python -m pytest \
  tests/hermes_state/test_resolve_resume_session_id.py \
  tests/hermes_cli/test_oneshot_resume.py \
  tests/hermes_cli/test_tui_resume_flow.py \
  tests/hermes_cli/test_oneshot_usage_file.py \
  -o addopts='' -q
```

Result: 97 passed.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Session durability / safety hardening
