### PR TITLE
fix(agent): expose a discoverable safe temp dir under HERMES_WRITE_SAFE_ROOT

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -163,6 +163,45 @@ def is_write_denied(path: str) -> bool:
     return _classify_write_denial(path) is not None
 
 
+def get_safe_tmp_dir() -> Optional[str]:
+    """Return a writable, profile-scoped temp directory under HERMES_WRITE_SAFE_ROOT.
+
+    A model reaching for a conventional ``/tmp/helper.py`` path has nowhere
+    valid to put it once a safe root is configured -- it just gets denied,
+    with no indication of where temp files *do* belong (#69962). This gives
+    ``get_write_denied_error`` something concrete to point at.
+
+    Prefers ``<hermes_home>/tmp`` when the active (profile-aware) HERMES_HOME
+    is already nested inside a safe root -- the common durable-profile
+    layout (``HERMES_WRITE_SAFE_ROOT=/opt/data``,
+    ``HERMES_HOME=/opt/data/profiles/<profile>``) -- so temp files stay
+    scoped per-profile instead of colliding across profiles in a shared
+    container. Falls back to ``<first_safe_root>/tmp`` when the active home
+    isn't under any safe root. Returns ``None`` when no safe root is
+    configured. The directory is created on demand so it's immediately
+    writable.
+    """
+    safe_roots = get_safe_write_roots()
+    if not safe_roots:
+        return None
+    try:
+        hermes_home = os.path.realpath(str(_hermes_home_path()))
+    except Exception:
+        hermes_home = ""
+    tmp_dir = None
+    for root in safe_roots:
+        if hermes_home and (hermes_home == root or hermes_home.startswith(root + os.sep)):
+            tmp_dir = os.path.join(hermes_home, "tmp")
+            break
+    if tmp_dir is None:
+        tmp_dir = os.path.join(sorted(safe_roots)[0], "tmp")
+    try:
+        os.makedirs(tmp_dir, exist_ok=True)
+    except OSError:
+        return None
+    return tmp_dir
+
+
 def get_write_denied_error(path: str, *, verb: str = "Write") -> Optional[str]:
     """Return a user/model-facing error when writes to ``path`` are blocked."""
     denial = _classify_write_denial(path)
@@ -170,9 +209,11 @@ def get_write_denied_error(path: str, *, verb: str = "Write") -> Optional[str]:
         return None
     if denial == "safe_root":
         roots_display = os.pathsep.join(sorted(get_safe_write_roots()))
+        safe_tmp = get_safe_tmp_dir()
+        tmp_hint = f" Temporary files belong in '{safe_tmp}'." if safe_tmp else ""
         return (
             f"{verb} denied: '{path}' is outside HERMES_WRITE_SAFE_ROOT "
-            f"({roots_display}). Unset the variable or add this path's directory prefix."
+            f"({roots_display}). Unset the variable or add this path's directory prefix.{tmp_hint}"
         )
     return f"{verb} denied: '{path}' is a protected system/credential file."
 

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -209,8 +209,13 @@ def get_write_denied_error(path: str, *, verb: str = "Write") -> Optional[str]:
         return None
     if denial == "safe_root":
         roots_display = os.pathsep.join(sorted(get_safe_write_roots()))
-        safe_tmp = get_safe_tmp_dir()
-        tmp_hint = f" Temporary files belong in '{safe_tmp}'." if safe_tmp else ""
+        tmp_hint = ""
+        if verb == "Write":
+            # Only a write denial benefits from a "put it here instead" hint —
+            # a denied delete/move isn't about finding somewhere to write.
+            safe_tmp = get_safe_tmp_dir()
+            if safe_tmp:
+                tmp_hint = f" Temporary files belong in '{safe_tmp}'."
         return (
             f"{verb} denied: '{path}' is outside HERMES_WRITE_SAFE_ROOT "
             f"({roots_display}). Unset the variable or add this path's directory prefix.{tmp_hint}"

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -200,6 +200,67 @@ class TestGetWriteDeniedError:
         assert get_write_denied_error(str(target)) is None
 
 
+class TestGetSafeTmpDir:
+    """get_safe_tmp_dir() -- a discoverable, writable temp location under a
+    configured HERMES_WRITE_SAFE_ROOT (#69962), so a denied conventional
+    `/tmp/helper.py` write has somewhere valid to retry instead of the model
+    silently claiming success on a path that was never written.
+    """
+
+    def test_returns_none_without_a_safe_root(self, monkeypatch):
+        from agent.file_safety import get_safe_tmp_dir
+
+        monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+        assert get_safe_tmp_dir() is None
+
+    def test_scopes_to_hermes_home_when_nested_in_safe_root(self, tmp_path: Path, monkeypatch):
+        """The common durable-profile layout: HERMES_HOME already lives
+        under the safe root, so temp files should be scoped per-profile
+        (<hermes_home>/tmp) rather than shared across profiles."""
+        from agent.file_safety import get_safe_tmp_dir
+
+        safe_root = tmp_path / "data"
+        hermes_home = safe_root / "profiles" / "acct-1"
+        hermes_home.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+        monkeypatch.setattr("agent.file_safety._hermes_home_path", lambda: hermes_home)
+
+        result = get_safe_tmp_dir()
+        assert result == str(hermes_home / "tmp")
+        assert Path(result).is_dir()
+
+    def test_falls_back_to_safe_root_when_home_not_nested(self, tmp_path: Path, monkeypatch):
+        from agent.file_safety import get_safe_tmp_dir
+
+        safe_root = tmp_path / "data"
+        safe_root.mkdir()
+        unrelated_home = tmp_path / "elsewhere" / ".hermes"
+        unrelated_home.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+        monkeypatch.setattr("agent.file_safety._hermes_home_path", lambda: unrelated_home)
+
+        result = get_safe_tmp_dir()
+        assert result == str(safe_root / "tmp")
+        assert Path(result).is_dir()
+
+    def test_denial_message_points_at_the_safe_tmp_dir(self, tmp_path: Path, monkeypatch):
+        from agent.file_safety import get_write_denied_error
+
+        safe_root = tmp_path / "data"
+        hermes_home = safe_root / "profiles" / "acct-1"
+        hermes_home.mkdir(parents=True)
+        outside = tmp_path / "tmp" / "helper.py"
+
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+        monkeypatch.setattr("agent.file_safety._hermes_home_path", lambda: hermes_home)
+
+        err = get_write_denied_error(str(outside))
+        assert err is not None
+        assert f"Temporary files belong in '{hermes_home / 'tmp'}'" in err
+
+
 class TestSafeRootDenialMessageIntegration:
     """Regression tests verifying that file-tools surface the correct denial
     message when HERMES_WRITE_SAFE_ROOT blocks a path.

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -329,6 +329,67 @@ class TestSafeRootDenialMessageIntegration:
         assert res.error is None
         assert inside.read_text() == "content"
 
+    def test_write_file_denial_hint_path_is_writable_on_retry(
+        self, ops, tmp_path: Path, monkeypatch
+    ):
+        """The denial message's suggested temp path isn't just a string in an
+        error message -- writing there for real must actually succeed (#69962),
+        exercised through the real write_file() denial/retry path rather than
+        the get_write_denied_error() helper in isolation."""
+        from agent.file_safety import get_safe_tmp_dir
+
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        outside = tmp_path / "other" / "helper.py"
+        outside.parent.mkdir()
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+        monkeypatch.setattr("agent.file_safety._hermes_home_path", lambda: safe_root)
+
+        res = ops.write_file(str(outside), "content")
+        assert res.error is not None
+        safe_tmp = get_safe_tmp_dir()
+        assert safe_tmp is not None
+        assert f"Temporary files belong in '{safe_tmp}'" in res.error
+
+        retry_path = Path(safe_tmp) / "helper.py"
+        retry = ops.write_file(str(retry_path), "content")
+        assert retry.error is None
+        assert retry_path.read_text() == "content"
+
+    def test_delete_denial_has_no_temp_file_hint(
+        self, ops, tmp_path: Path, monkeypatch
+    ):
+        """A denied delete isn't about finding somewhere to write -- the
+        write-only 'Temporary files belong in ...' hint would be nonsensical
+        tacked onto a Delete-denied message."""
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        outside = tmp_path / "other" / "file.txt"
+        outside.parent.mkdir()
+        outside.write_text("content")
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        res = ops.delete_path(str(outside))
+        assert res.error is not None
+        assert res.error.startswith("Delete denied")
+        assert "Temporary files belong in" not in res.error
+
+    def test_move_denial_has_no_temp_file_hint(
+        self, ops, tmp_path: Path, monkeypatch
+    ):
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        outside = tmp_path / "other" / "file.txt"
+        outside.parent.mkdir()
+        outside.write_text("content")
+        dst = safe_root / "file.txt"
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        res = ops.move_file(str(outside), str(dst))
+        assert res.error is not None
+        assert res.error.startswith("Move denied")
+        assert "Temporary files belong in" not in res.error
+
 
 class TestCheckSensitivePathMacOSBypass:
     """Verify _check_sensitive_path blocks /private/etc paths (issue #8734)."""


### PR DESCRIPTION
Hi! Addresses part of #69962.

## Problem

With `HERMES_WRITE_SAFE_ROOT` set (e.g. `/opt/data` in a Docker/s6 deployment), an agent reaching for a conventional temp path like `/tmp/helper.py` gets correctly denied by `write_file` -- but the denial message gives no indication of where a temp/helper file *should* go. The agent has no discoverable, valid fallback location to retry against, so (per the issue) it sometimes continues and its response implies the write succeeded when it didn't.

## Scope

This PR only tackles improvement #1 from the issue ("expose a harness-owned safe temporary directory"). The rest of the issue (#2/#3 -- promoting a denied mutation into turn-level recovery state that blocks an unqualified success claim until resolved) is a genuine tool-loop/harness design question that needs a maintainer decision on approach, not something I want to guess at unilaterally in the same PR.

## Fix

Added `get_safe_tmp_dir()` in `agent/file_safety.py`:
- Prefers `<hermes_home>/tmp` when the active (profile-aware) `HERMES_HOME` is already nested inside a safe root -- the common durable-profile container layout described in the issue (`HERMES_WRITE_SAFE_ROOT=/opt/data`, `HERMES_HOME=/opt/data/profiles/<profile>`) -- so temp files stay scoped per-profile instead of colliding across profiles sharing one container.
- Falls back to `<first_safe_root>/tmp` when the active home isn't nested under any safe root.
- Returns `None` when no safe root is configured (no-op for the common case).
- Creates the directory on demand so it's immediately writable.

`get_write_denied_error()`'s safe-root denial message now appends `Temporary files belong in '<path>'` so the model has a concrete, valid location to retry against instead of guessing again.

## Testing

New `TestGetSafeTmpDir` class: no safe root → `None`; profile-nested home → scoped `<home>/tmp`; non-nested home → falls back to `<safe_root>/tmp`; denial message includes the resolved path. Existing `TestSafeWriteRoot` / `TestGetWriteDeniedError` suites still pass unchanged; `ruff check` clean.