### PR TITLE
fix(agent): detect emoji sign-offs by Unicode category, not codepoint range

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -19,6 +19,7 @@ import os
 import re
 import sys
 import time
+import unicodedata
 import threading
 import uuid
 import warnings
@@ -680,7 +681,26 @@ class AIAgent(
             return False
         last = stripped[-1]
         # Closing punctuation/brackets, a fenced-code close, or an emoji (Misc Symbols, Dingbats, Emoticons, ...).
-        return stripped.endswith("```") or last in '.!?:)"\']}。！？：）】」』》^' or ord(last) >= 0x1F300
+        if stripped.endswith("```") or last in '.!?:)"\']}。！？：）】」』》^':
+            return True
+
+        # Emoji sign-off. Enumerating codepoint ranges keeps missing cases —
+        # a `>= 0x1F300` cutoff starts above Misc Symbols (U+2600-26FF) and
+        # Dingbats (U+2700-27BF), so ✨ U+2728 and ✅ U+2705 still read as
+        # unfinished. Ask Unicode instead: emoji and pictographs carry general
+        # category So. Trailing modifiers are not the sign-off character, so
+        # peel them off first: variation selectors (U+FE0E/U+FE0F), ZWJ
+        # (U+200D) joining a sequence like 👨‍💻, and skin-tone modifiers
+        # (U+1F3FB-1F3FF) as in 👍🏽.
+        tail = stripped
+        while tail and (
+            ord(tail[-1]) in (0xFE0E, 0xFE0F, 0x200D)
+            or 0x1F3FB <= ord(tail[-1]) <= 0x1F3FF
+        ):
+            tail = tail[:-1]
+        if tail and unicodedata.category(tail[-1]) == "So":
+            return True
+        return False
 
     def _is_ollama_glm_backend(self) -> bool:
         """Ollama-hosted GLM models misreport finish_reason='stop'. Matches only explicit Ollama signatures

--- a/run_agent.py
+++ b/run_agent.py
@@ -43,6 +43,7 @@ import re
 import sys
 import tempfile
 import time
+import unicodedata
 import threading
 import uuid
 import warnings
@@ -1621,8 +1622,22 @@ class AIAgent:
         last = stripped[-1]
         if last in '.!?:)"\']}。！？：）】」』》^':
             return True
-        # Emoji ranges (Misc Symbols, Dingbats, Emoticons, Supplemental, etc.)
-        if ord(last) >= 0x1F300:
+
+        # Emoji sign-off. Enumerating codepoint ranges keeps missing cases —
+        # a `>= 0x1F300` cutoff starts above Misc Symbols (U+2600-26FF) and
+        # Dingbats (U+2700-27BF), so ✨ U+2728 and ✅ U+2705 still read as
+        # unfinished. Ask Unicode instead: emoji and pictographs carry general
+        # category So. Trailing modifiers are not the sign-off character, so
+        # peel them off first: variation selectors (U+FE0E/U+FE0F), ZWJ
+        # (U+200D) joining a sequence like 👨‍💻, and skin-tone modifiers
+        # (U+1F3FB-1F3FF) as in 👍🏽.
+        tail = stripped
+        while tail and (
+            ord(tail[-1]) in (0xFE0E, 0xFE0F, 0x200D)
+            or 0x1F3FB <= ord(tail[-1]) <= 0x1F3FF
+        ):
+            tail = tail[:-1]
+        if tail and unicodedata.category(tail[-1]) == "So":
             return True
         return False
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4425,7 +4425,6 @@ class TestRunConversation:
             result["final_response"]
             == "Based on the search results, the best next step is to update the config."
         )
-
         third_call_messages = agent.client.chat.completions.create.call_args_list[2].kwargs["messages"]
         assert third_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in third_call_messages[-1]["content"]
@@ -4442,6 +4441,47 @@ class TestRunConversation:
         agent.model = model
         unpunctuated = SimpleNamespace(content="Based on the results the best next step is to update the config", tool_calls=None)
         assert agent._should_treat_stop_as_truncated("stop", unpunctuated, [{"role": "tool", "content": "r"}]) is False
+
+    @pytest.mark.parametrize(
+        "sign_off",
+        ["✨", "✅"],
+        ids=["sparkles", "check"],
+    )
+    def test_ollama_glm_stop_with_emoji_sign_off_does_not_continue(self, agent, sign_off):
+        """Regression for #70131 — a complete Ollama/GLM post-tool `stop`
+        response ending in a Dingbats emoji (✨ U+2728 / ✅ U+2705) must not
+        be reclassified as truncated.  Before the Unicode-category fix,
+        ``_has_natural_response_ending`` returned False for these, so
+        ``_should_treat_stop_as_truncated`` injected a continuation prompt
+        and issued an extra API call for a response that was already whole.
+        """
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.1:cloud"
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
+        )
+        complete_stop = _mock_response(
+            content=f"Done — the config is updated {sign_off}",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [tool_turn, complete_stop]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert result["final_response"] == f"Done — the config is updated {sign_off}"
 
     def test_length_thinking_exhausted_skips_continuation(self, agent):
         """When finish_reason='length' but content is only thinking, skip retries."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -384,6 +384,60 @@ class TestHasContentAfterThinkBlock:
 
 
 
+class TestHasNaturalResponseEnding:
+    """Refs #14572 — an emoji sign-off must not read as an unfinished reply.
+
+    ``_should_treat_stop_as_truncated`` calls this on Ollama-hosted GLM
+    replies, so a false negative reclassifies a complete response as
+    truncated and burns the continuation budget.
+    """
+
+    @pytest.mark.parametrize(
+        "ending",
+        [
+            "✨",  # ✨ Dingbats
+            "✅",  # ✅ Dingbats
+            "⭐",  # ⭐ Misc Symbols & Pictographs Suppl.
+            "☀",  # ☀ Misc Symbols
+            "\U0001f389",  # 🎉 Misc Symbols & Pictographs
+            "\U0001f99e",  # 🦞
+        ],
+        ids=["sparkles", "check", "star", "sun", "party", "lobster"],
+    )
+    def test_emoji_sign_off_is_natural(self, agent, ending):
+        assert agent._has_natural_response_ending(f"All done {ending}") is True
+
+    @pytest.mark.parametrize(
+        "ending",
+        [
+            "❤️",  # ❤️ variation selector 16
+            "\U0001f44d\U0001f3fd",  # 👍🏽 skin-tone modifier
+            "\U0001f468‍\U0001f4bb",  # 👨‍💻 ZWJ sequence
+            "\U0001f1f0\U0001f1f7",  # 🇰🇷 regional indicators
+        ],
+        ids=["variation-selector", "skin-tone", "zwj", "regional-indicator"],
+    )
+    def test_composed_emoji_sign_off_is_natural(self, agent, ending):
+        """The final codepoint is a modifier, not the pictograph itself."""
+        assert agent._has_natural_response_ending(f"Thanks {ending}") is True
+
+    @pytest.mark.parametrize(
+        "text",
+        ["Finished.", "Done!", "Really?", "```\nx = 1\n```"],
+        ids=["period", "bang", "question", "code-fence"],
+    )
+    def test_existing_endings_still_natural(self, agent, text):
+        assert agent._has_natural_response_ending(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        ["and then we", "the value is 42", "", "   "],
+        ids=["mid-sentence", "trailing-digit", "empty", "whitespace"],
+    )
+    def test_unfinished_text_is_not_natural(self, agent, text):
+        assert agent._has_natural_response_ending(text) is False
+
+
 class TestStripThinkBlocks:
     def test_none_returns_empty(self, agent):
         assert agent._strip_think_blocks(None) == ""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3629,13 +3629,50 @@ class TestRunConversation:
             result["final_response"]
             == "Based on the search results, the best next step is to update the config."
         )
-
         third_call_messages = agent.client.chat.completions.create.call_args_list[2].kwargs["messages"]
         assert third_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in third_call_messages[-1]["content"]
 
+    @pytest.mark.parametrize(
+        "sign_off",
+        ["✨", "✅"],
+        ids=["sparkles", "check"],
+    )
+    def test_ollama_glm_stop_with_emoji_sign_off_does_not_continue(self, agent, sign_off):
+        """Regression for #70131 — a complete Ollama/GLM post-tool `stop`
+        response ending in a Dingbats emoji (✨ U+2728 / ✅ U+2705) must not
+        be reclassified as truncated.  Before the Unicode-category fix,
+        ``_has_natural_response_ending`` returned False for these, so
+        ``_should_treat_stop_as_truncated`` injected a continuation prompt
+        and issued an extra API call for a response that was already whole.
+        """
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.1:cloud"
 
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
+        )
+        complete_stop = _mock_response(
+            content=f"Done — the config is updated {sign_off}",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [tool_turn, complete_stop]
 
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert result["final_response"] == f"Done — the config is updated {sign_off}"
 
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -341,6 +341,60 @@ class TestHasContentAfterThinkBlock:
 
 
 
+class TestHasNaturalResponseEnding:
+    """Refs #14572 — an emoji sign-off must not read as an unfinished reply.
+
+    ``_should_treat_stop_as_truncated`` calls this on Ollama-hosted GLM
+    replies, so a false negative reclassifies a complete response as
+    truncated and burns the continuation budget.
+    """
+
+    @pytest.mark.parametrize(
+        "ending",
+        [
+            "✨",  # ✨ Dingbats
+            "✅",  # ✅ Dingbats
+            "⭐",  # ⭐ Misc Symbols & Pictographs Suppl.
+            "☀",  # ☀ Misc Symbols
+            "\U0001f389",  # 🎉 Misc Symbols & Pictographs
+            "\U0001f99e",  # 🦞
+        ],
+        ids=["sparkles", "check", "star", "sun", "party", "lobster"],
+    )
+    def test_emoji_sign_off_is_natural(self, agent, ending):
+        assert agent._has_natural_response_ending(f"All done {ending}") is True
+
+    @pytest.mark.parametrize(
+        "ending",
+        [
+            "❤️",  # ❤️ variation selector 16
+            "\U0001f44d\U0001f3fd",  # 👍🏽 skin-tone modifier
+            "\U0001f468‍\U0001f4bb",  # 👨‍💻 ZWJ sequence
+            "\U0001f1f0\U0001f1f7",  # 🇰🇷 regional indicators
+        ],
+        ids=["variation-selector", "skin-tone", "zwj", "regional-indicator"],
+    )
+    def test_composed_emoji_sign_off_is_natural(self, agent, ending):
+        """The final codepoint is a modifier, not the pictograph itself."""
+        assert agent._has_natural_response_ending(f"Thanks {ending}") is True
+
+    @pytest.mark.parametrize(
+        "text",
+        ["Finished.", "Done!", "Really?", "```\nx = 1\n```"],
+        ids=["period", "bang", "question", "code-fence"],
+    )
+    def test_existing_endings_still_natural(self, agent, text):
+        assert agent._has_natural_response_ending(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        ["and then we", "the value is 42", "", "   "],
+        ids=["mid-sentence", "trailing-digit", "empty", "whitespace"],
+    )
+    def test_unfinished_text_is_not_natural(self, agent, text):
+        assert agent._has_natural_response_ending(text) is False
+
+
 class TestStripThinkBlocks:
     def test_none_returns_empty(self, agent):
         assert agent._strip_think_blocks(None) == ""


### PR DESCRIPTION
## What does this PR do?

`_has_natural_response_ending()` gated emoji on a single lower bound:

```python
# Emoji ranges (Misc Symbols, Dingbats, Emoticons, Supplemental, etc.)
if ord(last) >= 0x1F300:
    return True
```

`0x1F300` is the start of Misc Symbols & Pictographs, which sits *above* three blocks the comment claims to cover:

| Block | Range | Example |
|---|---|---|
| Misc Symbols | U+2600–U+26FF | ☀ U+2600 |
| **Dingbats** | **U+2700–U+27BF** | **✨ U+2728, ✅ U+2705** |
| Misc Symbols & Pictographs Suppl. | U+2B00–U+2BFF | ⭐ U+2B50 |

So a reply ending in ✨ or ✅ still read as unfinished, `_should_treat_stop_as_truncated()` reclassified a complete Ollama/GLM response as truncated, and the continuation budget went on re-asking a model that had already answered — surfacing `Response remained truncated after N continuation attempts` for a response that was whole.

Those two emoji are the ones named in #14572 (✨ in the issue body, ✅ in the reproduction comment), so that report is still reproducible on v0.19.0 despite the range check added to close it.

Enumerating ranges keeps missing cases, so this asks Unicode instead — emoji and pictographs carry general category `So`. Trailing modifiers are peeled first, because the final codepoint of `❤️` (U+FE0F), `👍🏽` (U+1F3FD) and `👨‍💻` (a ZWJ sequence) is not the pictograph itself.

## Related Issue

Fixes #70131 — follows up #14572, whose fix was incomplete.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` — `_has_natural_response_ending()` now peels variation selectors (U+FE0E/U+FE0F), ZWJ (U+200D) and skin-tone modifiers (U+1F3FB–U+1F3FF), then tests `unicodedata.category(...) == "So"`. Replaces the codepoint comparison; adds the stdlib `unicodedata` import.
- `tests/run_agent/test_run_agent.py` — adds `TestHasNaturalResponseEnding` (18 cases).

## How to Test

1. Configure a GLM model on Ollama (`model.default: glm-5.2`, `provider: ollama-cloud`, `base_url: https://ollama.com/v1`) with a persona that signs off with ✨.
2. Send a message that calls a tool and then answers. Before this change the gateway logs `⚠️ Treating suspicious Ollama/GLM stop response as truncated`, retries, and fails the turn; after it, the reply is delivered.
3. Unit tests:
   ```bash
   pytest tests/run_agent/test_run_agent.py -k NaturalResponseEnding -q
   ```
   Six of the new cases (✨, ✅, ⭐, ☀, ❤️, 🇰🇷) fail against the previous implementation and pass with this one; the rest guard endings that already worked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass — `tests/run_agent/`: 2235 passed, 4 skipped
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64), Python 3.12, Hermes v0.19.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, the explanatory comment sits with the code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — `unicodedata` is stdlib and platform-independent; no file I/O, process or terminal handling touched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before, on every turn ending with ✨:

```
⚠️  Treating suspicious Ollama/GLM stop response as truncated
…
Response remained truncated after 4 continuation attempts
```

The model reported it had already finished on each continuation, so the loop added turns without adding output.
