### PR TITLE
fix(fallback): honor explicit api_mode on fallback_providers entries

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1665,43 +1665,57 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        # Determine api_mode from provider / base URL / model.
+        # An explicit api_mode on the fallback_providers config entry is
+        # authoritative — it's how the user tells us the wire protocol for
+        # a custom endpoint that the heuristics below can't infer from the
+        # base_url/provider name alone (e.g. a proxy whose host doesn't look
+        # like api.anthropic.com but only speaks the Anthropic Messages
+        # format). Without this, an explicitly configured
+        # `api_mode: anthropic_messages` was silently discarded and every
+        # such fallback defaulted to chat_completions, hitting the wrong
+        # path (/chat/completions instead of /v1/messages) with the wrong
+        # auth header (Bearer instead of x-api-key) and failing with a 404.
+        fb_explicit_api_mode = (fb.get("api_mode") or "").strip()
         fb_base_url = str(fb_client.base_url)
-        _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
-            fb_api_mode = "codex_responses"
-        elif (
-            fb_provider == "anthropic"
-            or fb_base_url.rstrip("/").lower().endswith("/anthropic")
-            or base_url_hostname(fb_base_url) == "api.anthropic.com"
-        ):
-            # Custom providers (e.g. cron-anthropic) point at the native
-            # api.anthropic.com host with no "/anthropic" path suffix, so the
-            # name/suffix checks above miss them and they default to
-            # chat_completions → POST /v1/chat/completions → 404. Match the
-            # host the same way determine_api_mode() and _detect_api_mode_for_url()
-            # do on the primary path. (#32243, #49247)
-            fb_api_mode = "anthropic_messages"
-        elif _fb_is_azure:
-            # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
-            # support the Responses API. Stay on chat_completions.
+        if fb_explicit_api_mode:
+            fb_api_mode = fb_explicit_api_mode
+        else:
             fb_api_mode = "chat_completions"
-        elif agent._is_direct_openai_url(fb_base_url):
-            fb_api_mode = "codex_responses"
-        elif agent._provider_model_requires_responses_api(
-            fb_model,
-            provider=fb_provider,
-        ):
-            # GPT-5.x models usually need Responses API, but keep
-            # provider-specific exceptions like Copilot gpt-5-mini on
-            # chat completions.
-            fb_api_mode = "codex_responses"
-        elif fb_provider == "bedrock" or (
-            base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
-            and base_url_host_matches(fb_base_url, "amazonaws.com")
-        ):
-            fb_api_mode = "bedrock_converse"
+            _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
+            if fb_provider == "openai-codex":
+                fb_api_mode = "codex_responses"
+            elif (
+                fb_provider == "anthropic"
+                or fb_base_url.rstrip("/").lower().endswith("/anthropic")
+                or base_url_hostname(fb_base_url) == "api.anthropic.com"
+            ):
+                # Custom providers (e.g. cron-anthropic) point at the native
+                # api.anthropic.com host with no "/anthropic" path suffix, so the
+                # name/suffix checks above miss them and they default to
+                # chat_completions → POST /v1/chat/completions → 404. Match the
+                # host the same way determine_api_mode() and _detect_api_mode_for_url()
+                # do on the primary path. (#32243, #49247)
+                fb_api_mode = "anthropic_messages"
+            elif _fb_is_azure:
+                # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
+                # support the Responses API. Stay on chat_completions.
+                fb_api_mode = "chat_completions"
+            elif agent._is_direct_openai_url(fb_base_url):
+                fb_api_mode = "codex_responses"
+            elif agent._provider_model_requires_responses_api(
+                fb_model,
+                provider=fb_provider,
+            ):
+                # GPT-5.x models usually need Responses API, but keep
+                # provider-specific exceptions like Copilot gpt-5-mini on
+                # chat completions.
+                fb_api_mode = "codex_responses"
+            elif fb_provider == "bedrock" or (
+                base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
+                and base_url_host_matches(fb_base_url, "amazonaws.com")
+            ):
+                fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
         old_provider = agent.provider


### PR DESCRIPTION
## Problem

`try_activate_fallback()` in `agent/chat_completion_helpers.py` re-derives `api_mode` for a fallback entry purely from provider name / base_url heuristics — it never reads the `api_mode` field the user explicitly set on that `fallback_providers` config entry.

For a custom proxy/endpoint whose host doesn't match any of the heuristics (not `api.anthropic.com`, not `api.openai.com`, not Azure, not Bedrock), the code silently discards an explicitly configured `api_mode: anthropic_messages` and falls through to the `chat_completions` default.

### Symptom

Observed in production with a custom Anthropic-compatible proxy configured as a fallback:

```yaml
fallback_providers:
- provider: custom:MyProxy
  model: claude-sonnet-4-6
  api_key: ${MY_API_KEY}
  base_url: https://my-proxy.example.com
  api_mode: anthropic_messages
```

When the primary provider hit a 429 and the agent switched to this fallback, the request went to `POST /chat/completions` with a `Bearer` auth header (chat_completions wire format) instead of `POST /v1/messages` with an `x-api-key` header (the configured anthropic_messages format). The proxy doesn't serve `/chat/completions` at all, so it returned its frontend's HTML 404 page instead of a JSON API error, and the whole fallback chain failed after 3 retries — even though the endpoint and credentials were both valid.

## Fix

Read `fb.get("api_mode")` first. If the config entry specifies one, use it as-is (it's authoritative — the user is telling us the wire protocol for an endpoint the heuristics can't classify from the URL alone). Only fall back to the existing provider/base_url heuristics when the entry didn't specify `api_mode`.

## Testing

- `python3 -m py_compile agent/chat_completion_helpers.py` — syntax OK
- Verified against my own multi-profile Hermes setup: reproduced the 404-on-fallback failure with an `api_mode: anthropic_messages` custom fallback provider, applied the fix, restarted the gateway, and confirmed the fallback path now correctly resolves to `anthropic_messages` instead of defaulting to `chat_completions`.
- No test suite changes — did not have time to write a unit test covering `try_activate_fallback`'s api_mode resolution path; happy to add one if requested.