### PR TITLE
fix(gateway): deny sibling-profile credentials in media delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1229,19 +1229,102 @@ _MEDIA_DELIVERY_CACHE_SUBDIRS = (
     "screenshots",
 )
 
+# Per-file credential / secret stores that live at a Hermes home root.
+# Mirrored from agent/file_safety.py (get_read_block_error / build_write_denied_*)
+# so delivery (read/exfil) can't trail the write side. Enumerated per-file
+# rather than denying the whole tree, so skills/, logs/, and ad-hoc agent
+# files under a Hermes home stay deliverable (see #32090, #34425).
+_MEDIA_DELIVERY_ROOT_CREDENTIAL_FILES = (
+    ".env",
+    "auth.json",
+    "auth.lock",
+    "credentials",
+    "config.yaml",
+    # Anthropic PKCE / OAuth refresh credential store.
+    ".anthropic_oauth.json",
+    # Google Workspace skill: auto-refreshing OAuth token (mtime bumps
+    # every turn, which defeated the strict-mode recency window) plus the
+    # pending-exchange session/verifier file.
+    "google_token.json",
+    "google_oauth_pending.json",
+    os.path.join("auth", "google_oauth.json"),
+    # Webhook subscription HMAC secrets.
+    "webhook_subscriptions.json",
+    # Bitwarden Secrets Manager plaintext and encrypted disk caches.
+    os.path.join("cache", "bws_cache.json"),
+    os.path.join("cache", "bws_cache.enc.json"),
+)
+
+# Directory trees whose every child is credential material.
+#
+# mcp-tokens/ holds live MCP OAuth access tokens (<server>.json) and
+# dynamically-registered client credentials (<server>.client.json); see
+# tools/mcp_oauth.py. Same credential class as auth.json/credentials/.
+# The write side already denies it (file_tools _check_sensitive_path);
+# this pairs the media-delivery (exfil) side so a prompt-injection MEDIA
+# tag can't deliver a live bearer token as a native attachment.
+# (session/kanban SQLite stores are handled by #41071 — kept out here.)
+_MEDIA_DELIVERY_ROOT_CREDENTIAL_DIRS = (
+    "pairing",
+    "mcp-tokens",
+)
+
 
 def _iter_hermes_profile_dirs() -> List[Path]:
     """Return ``<root>/profiles/<name>/`` directories that currently exist.
 
-    Shared by cache allowlisting and credential denylisting so both sides
-    see the same live profile set (including profiles created after process
-    start). Missing or unreadable ``profiles/`` yields an empty list.
+    Used by cache allowlisting so profiles created after process start are
+    covered. Missing or unreadable ``profiles/`` yields an empty list —
+    credential denial must NOT depend on this helper (see
+    ``_path_is_profile_tree_credential``).
     """
     profiles_dir = _HERMES_ROOT / "profiles"
     try:
         return [p for p in profiles_dir.iterdir() if p.is_dir()]
     except OSError:
         return []
+
+
+def _rel_matches_hermes_root_credential(rel: Path) -> bool:
+    """Return True if ``rel`` (relative to a Hermes home) is a credential path."""
+    if not rel.parts:
+        return False
+    for denied_rel in _MEDIA_DELIVERY_ROOT_CREDENTIAL_FILES:
+        denied = Path(denied_rel)
+        if rel == denied or _path_is_within(rel, denied):
+            return True
+    for denied_rel in _MEDIA_DELIVERY_ROOT_CREDENTIAL_DIRS:
+        denied = Path(denied_rel)
+        if rel == denied or _path_is_within(rel, denied):
+            return True
+    return False
+
+
+def _path_is_profile_tree_credential(resolved: Path) -> bool:
+    """Deny credentials under ``<root>/profiles/<name>/`` without listing profiles.
+
+    ``profiles/`` enumeration can fail while a known child path remains
+    openable (POSIX execute-only directory). Structural matching keeps the
+    credential policy intact under that error condition — denial must not
+    depend on ``_iter_hermes_profile_dirs()``.
+    """
+    profiles_root = _HERMES_ROOT / "profiles"
+    try:
+        profiles_root = profiles_root.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        # Fail closed: still match against the unresolved profiles path
+        # rather than skipping sibling credential denial entirely.
+        profiles_root = _HERMES_ROOT / "profiles"
+    try:
+        rel = resolved.relative_to(profiles_root)
+    except ValueError:
+        return False
+    # Need at least <profile_name>/<credential...> — a bare profiles/<name>
+    # path is not a deliverable file anyway (validate requires is_file).
+    parts = rel.parts
+    if len(parts) < 2:
+        return False
+    return _rel_matches_hermes_root_credential(Path(*parts[1:]))
 
 
 def _profile_cache_roots() -> List[Path]:
@@ -1342,73 +1425,32 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
-    # The active Hermes profile, the shared Hermes root, and every sibling
-    # profile under <root>/profiles/<name>/ contain control files and
-    # credentials. Only cache subdirectories under them are explicitly
+    # The active Hermes home and the shared Hermes root contain control files
+    # and credentials. Only cache subdirectories under them are explicitly
     # allowlisted above (matched BEFORE this denylist in
     # validate_media_delivery_path, so generated media still delivers).
     #
-    # These are the per-file credential / secret stores that live at each
-    # Hermes home root. The set mirrors the canonical read guard in
-    # agent/file_safety.py (get_read_block_error / build_write_denied_*) so the
-    # delivery (read/exfil) side can't trail the write side: a credential the
-    # agent is forbidden to write or read must also never be auto-attached to a
-    # chat reply. Enumerated explicitly per-file rather than denying the whole
-    # tree, so skills/, logs/, and ad-hoc agent-written files under ~/.hermes
-    # stay deliverable (see #32090, #34425).
-    #
-    # Sibling/inactive profiles must use the same policy: default mode would
-    # otherwise accept MEDIA:<root>/profiles/<other>/.env (and the rest of
-    # this list) because only (_HERMES_HOME, _HERMES_ROOT) were denied.
-    # Enumeration mirrors _profile_cache_roots() so profiles created after
-    # process start are covered.
-    _ROOT_CREDENTIAL_FILES = (
-        ".env",
-        "auth.json",
-        "auth.lock",
-        "credentials",
-        "config.yaml",
-        # Anthropic PKCE / OAuth refresh credential store.
-        ".anthropic_oauth.json",
-        # Google Workspace skill: auto-refreshing OAuth token (mtime bumps
-        # every turn, which defeated the strict-mode recency window) plus the
-        # pending-exchange session/verifier file.
-        "google_token.json",
-        "google_oauth_pending.json",
-        os.path.join("auth", "google_oauth.json"),
-        # Webhook subscription HMAC secrets.
-        "webhook_subscriptions.json",
-        # Bitwarden Secrets Manager plaintext and encrypted disk caches.
-        os.path.join("cache", "bws_cache.json"),
-        os.path.join("cache", "bws_cache.enc.json"),
-    )
-    # Directory trees whose every child is credential material.
-    #
-    # mcp-tokens/ holds live MCP OAuth access tokens (<server>.json) and
-    # dynamically-registered client credentials (<server>.client.json); see
-    # tools/mcp_oauth.py. Same credential class as auth.json/credentials/.
-    # The write side already denies it (file_tools _check_sensitive_path);
-    # this pairs the media-delivery (exfil) side so a prompt-injection MEDIA
-    # tag can't deliver a live bearer token as a native attachment.
-    # (session/kanban SQLite stores are handled by #41071 — kept out here.)
-    _ROOT_CREDENTIAL_DIRS = (
-        "pairing",
-        "mcp-tokens",
-    )
+    # Sibling/inactive profiles under <root>/profiles/<name>/ use the same
+    # credential file/dir policy, but denial is applied structurally in
+    # ``_path_is_profile_tree_credential`` — not by listing ``profiles/``.
+    # Directory enumeration can fail while a known child path remains
+    # openable (POSIX execute-only), so building this list from
+    # ``_iter_hermes_profile_dirs()`` would fail open at the exact boundary
+    # sibling denial is meant to close.
     hermes_dirs: List[Path] = []
-    for base in (_HERMES_HOME, _HERMES_ROOT, *_iter_hermes_profile_dirs()):
+    for base in (_HERMES_HOME, _HERMES_ROOT):
         try:
             real = base.expanduser().resolve(strict=False)
         except (OSError, RuntimeError, ValueError):
             # Fail closed: still deny under the unresolved path rather than
-            # skipping the home/profile entirely.
+            # skipping the home entirely.
             real = base
         if real not in hermes_dirs:
             hermes_dirs.append(real)
     for hermes_root in hermes_dirs:
-        for rel in _ROOT_CREDENTIAL_FILES:
+        for rel in _MEDIA_DELIVERY_ROOT_CREDENTIAL_FILES:
             denied.append(hermes_root / rel)
-        for rel in _ROOT_CREDENTIAL_DIRS:
+        for rel in _MEDIA_DELIVERY_ROOT_CREDENTIAL_DIRS:
             denied.append(hermes_root / rel)
     return denied
 
@@ -1427,6 +1469,10 @@ def _path_under_denied_prefix(resolved: Path) -> bool:
     only un-block a plain file sitting in the running user's home tree, never a
     credential location or another user's home.
     """
+    # Structural sibling-profile credential check first — independent of
+    # whether ``profiles/`` can be listed.
+    if _path_is_profile_tree_credential(resolved):
+        return True
     try:
         home = Path(os.path.expanduser("~")).resolve(strict=False)
     except (OSError, RuntimeError, ValueError):

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1309,6 +1309,27 @@ def _paths_equal_casefold(left: Path, right: Path) -> bool:
     return _path_parts_casefold(left) == _path_parts_casefold(right)
 
 
+def _paths_refer_to_same_home(left: Path, right: Path) -> bool:
+    """Return True when both paths identify the same filesystem home.
+
+    The running-home denylist exception must preserve filesystem identity.
+    Exact resolved equality is always enough. Casefold equality alone is
+    not: on a case-sensitive volume, ``/Etc`` and ``/etc`` are distinct
+    directories, and treating them as the same home would incorrectly exempt
+    a hard-denied system tree. When spellings differ only by case, require
+    ``Path.samefile`` so case-insensitive volumes still recognize aliases.
+    """
+    if left == right:
+        return True
+    if not _paths_equal_casefold(left, right):
+        return False
+    try:
+        return left.samefile(right)
+    except OSError:
+        # Cannot prove identity — do not exempt the deny entry.
+        return False
+
+
 def _path_is_within_casefold(path: Path, root: Path) -> bool:
     """Containment check that treats path components case-insensitively.
 
@@ -1591,7 +1612,9 @@ def _path_under_denied_prefix(resolved: Path, lexical: Optional[Path] = None) ->
             continue
         # Allow the running user's own home tree; its credential sub-dirs are
         # caught by their own (more-specific) denylist entries above.
-        if home is not None and _paths_equal_casefold(resolved_denied, home):
+        # Identity-preserving: never exempt a distinct hard-denied root that
+        # only casefolds to the configured home (case-sensitive volumes).
+        if home is not None and _paths_refer_to_same_home(resolved_denied, home):
             continue
         return True
     return False

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1328,6 +1328,32 @@ def _path_is_profile_tree_credential(resolved: Path) -> bool:
     return _rel_matches_hermes_root_credential(Path(*parts[1:]))
 
 
+def _path_is_lexical_profile_tree_credential(absolute: Path) -> bool:
+    """Deny profile credentials using lexical ancestry (no symlink resolve).
+
+    ``validate_media_delivery_path`` canonicalizes candidates before the
+    denylist runs. A ``profiles/<name>`` directory symlink therefore loses
+    its profile-tree prefix on the resolved path, and when
+    ``_iter_hermes_profile_dirs`` also returns empty the discovered-home
+    denylist cannot recover the target. Matching the normalized absolute
+    input against ``<root>/profiles/<name>/<credential...>`` closes that
+    conjunction without depending on directory enumeration.
+    """
+    try:
+        profiles_root = Path(os.path.normpath(str(_HERMES_ROOT.expanduser() / "profiles")))
+        candidate = Path(os.path.normpath(str(absolute)))
+    except (OSError, RuntimeError, ValueError):
+        return False
+    try:
+        rel = candidate.relative_to(profiles_root)
+    except ValueError:
+        return False
+    parts = rel.parts
+    if len(parts) < 2:
+        return False
+    return _rel_matches_hermes_root_credential(Path(*parts[1:]))
+
+
 def _profile_cache_roots() -> List[Path]:
     """Return per-profile canonical cache roots under the shared Hermes root.
 
@@ -1433,13 +1459,15 @@ def _media_delivery_denied_paths() -> List[Path]:
     #
     # Sibling/inactive profiles under <root>/profiles/<name>/ use the same
     # credential file/dir policy. Denial is layered:
-    #   1. Structural match in ``_path_is_profile_tree_credential`` — works
-    #      without listing ``profiles/`` (POSIX execute-only dirs).
-    #   2. Discovered profile homes below — covers directory-symlink siblings
+    #   1. Lexical match in ``_path_is_lexical_profile_tree_credential`` —
+    #      preserves ``profiles/<name>/`` ancestry from the submitted path
+    #      even when resolve() collapses a directory symlink and listing fails.
+    #   2. Structural match in ``_path_is_profile_tree_credential`` — works
+    #      without listing ``profiles/`` (POSIX execute-only dirs) for
+    #      ordinary (non-symlink) sibling paths after resolve.
+    #   3. Discovered profile homes below — covers directory-symlink siblings
     #      (``profiles/bob -> /elsewhere``) whose resolved targets sit outside
-    #      the structural profiles root after ``validate_media_delivery_path``
-    #      canonicalizes the candidate. Enumeration alone would fail open on
-    #      unreadable ``profiles/``; the structural check covers that case.
+    #      the structural profiles root when enumeration succeeds.
     hermes_dirs: List[Path] = []
     for base in (_HERMES_HOME, _HERMES_ROOT):
         try:
@@ -1465,7 +1493,7 @@ def _media_delivery_denied_paths() -> List[Path]:
     return denied
 
 
-def _path_under_denied_prefix(resolved: Path) -> bool:
+def _path_under_denied_prefix(resolved: Path, lexical: Optional[Path] = None) -> bool:
     """Return True if ``resolved`` lives under a deny-listed system path.
 
     One narrow exception: when a denied prefix IS the running user's own home,
@@ -1478,9 +1506,18 @@ def _path_under_denied_prefix(resolved: Path) -> bool:
     denied paths, so they stay blocked regardless of this exception — it can
     only un-block a plain file sitting in the running user's home tree, never a
     credential location or another user's home.
+
+    ``lexical`` is the normalized absolute input before symlink resolution.
+    When present, sibling-profile credential policy is also applied to that
+    ancestry so a ``profiles/<name>`` directory symlink cannot drop the
+    profile-tree prefix before denial runs.
     """
-    # Structural sibling-profile credential check first — independent of
-    # whether ``profiles/`` can be listed.
+    # Lexical sibling-profile credential check — independent of resolve()
+    # and of whether ``profiles/`` can be listed.
+    if lexical is not None and _path_is_lexical_profile_tree_credential(lexical):
+        return True
+    # Structural sibling-profile credential check on the resolved path —
+    # independent of whether ``profiles/`` can be listed.
     if _path_is_profile_tree_credential(resolved):
         return True
     try:
@@ -1565,6 +1602,11 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     if not expanded.is_absolute():
         return None
 
+    # Keep a symlink-preserving lexical form for sibling-profile credential
+    # policy. resolve() below collapses directory-symlink profile homes and
+    # would otherwise erase ``profiles/<name>/`` ancestry before denial.
+    lexical = Path(os.path.normpath(str(expanded)))
+
     try:
         resolved = expanded.resolve(strict=True)
     except (OSError, RuntimeError, ValueError):
@@ -1591,7 +1633,7 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     # (``MEDIA:/etc/passwd``, ``MEDIA:~/.ssh/id_rsa``,
     # ``MEDIA:~/.hermes/google_token.json``) remain rejected.
     if not _media_delivery_strict_mode():
-        if _path_under_denied_prefix(resolved):
+        if _path_under_denied_prefix(resolved, lexical=lexical):
             return None
         return str(resolved)
 
@@ -1601,7 +1643,7 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     # credential locations remain blocked even when "recent" — see
     # ``_MEDIA_DELIVERY_DENIED_PREFIXES`` for the denylist.
     window = _media_delivery_recency_seconds()
-    if window > 0 and not _path_under_denied_prefix(resolved):
+    if window > 0 and not _path_under_denied_prefix(resolved, lexical=lexical):
         if _file_is_recently_produced(resolved, window):
             return str(resolved)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1187,9 +1187,11 @@ _MEDIA_DELIVERY_TRUST_RECENT_DEFAULT_SECONDS = 600
 # Hard denylist applied even when a path would otherwise pass recency trust.
 # These prefixes hold credentials, system state, or process introspection that
 # should never be uploaded as a gateway attachment, regardless of how new the
-# file looks. The cache-dir allowlist still beats this — an operator-configured
-# allowed root can intentionally live under one of these prefixes (rare, but
-# their choice).
+# file looks. The cache-dir allowlist still beats system-prefix denial for
+# ordinary artifacts — an operator-configured allowed root can intentionally
+# live under one of these prefixes (rare, but their choice). Credential-shaped
+# sibling-profile paths are checked before that allowlist so a ``.env``
+# symlink into ``cache/images`` cannot redeem via safe-root acceptance.
 _MEDIA_DELIVERY_DENIED_PREFIXES = (
     "/etc",
     "/proc",
@@ -1696,8 +1698,19 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     if not resolved.is_file():
         return None
 
-    # Cache / operator allowlist is always honored — these are unconditionally
-    # trusted regardless of mode.
+    # Credential-shaped sibling-profile paths must be denied before safe-root
+    # acceptance. Otherwise ``profiles/<name>/.env`` (or another credential
+    # relative path) that symlinks into ``cache/images`` resolves into an
+    # unconditional allowlisted root and returns before lexical/structural
+    # credential denial can run. Direct cache artifacts remain deliverable.
+    if (
+        _path_is_lexical_profile_tree_credential(lexical)
+        or _path_is_profile_tree_credential(resolved)
+    ):
+        return None
+
+    # Cache / operator allowlist is always honored for paths that are not
+    # credential-shaped — these remain trusted regardless of mode.
     for root in _media_delivery_allowed_roots():
         try:
             resolved_root = root.expanduser().resolve(strict=False)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1230,6 +1230,20 @@ _MEDIA_DELIVERY_CACHE_SUBDIRS = (
 )
 
 
+def _iter_hermes_profile_dirs() -> List[Path]:
+    """Return ``<root>/profiles/<name>/`` directories that currently exist.
+
+    Shared by cache allowlisting and credential denylisting so both sides
+    see the same live profile set (including profiles created after process
+    start). Missing or unreadable ``profiles/`` yields an empty list.
+    """
+    profiles_dir = _HERMES_ROOT / "profiles"
+    try:
+        return [p for p in profiles_dir.iterdir() if p.is_dir()]
+    except OSError:
+        return []
+
+
 def _profile_cache_roots() -> List[Path]:
     """Return per-profile canonical cache roots under the shared Hermes root.
 
@@ -1244,12 +1258,7 @@ def _profile_cache_roots() -> List[Path]:
     denied prefix and $HOME is not that prefix). See issue #31733.
     """
     roots: List[Path] = []
-    profiles_dir = _HERMES_ROOT / "profiles"
-    try:
-        profile_dirs = [p for p in profiles_dir.iterdir() if p.is_dir()]
-    except OSError:
-        return roots
-    for profile_dir in profile_dirs:
+    for profile_dir in _iter_hermes_profile_dirs():
         for subdir in _MEDIA_DELIVERY_CACHE_SUBDIRS:
             roots.append(profile_dir / "cache" / subdir)
     return roots
@@ -1333,19 +1342,26 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
-    # The active Hermes profile and shared Hermes root both contain control
-    # files and credentials. Only cache subdirectories under them are
-    # explicitly allowlisted above (matched BEFORE this denylist in
+    # The active Hermes profile, the shared Hermes root, and every sibling
+    # profile under <root>/profiles/<name>/ contain control files and
+    # credentials. Only cache subdirectories under them are explicitly
+    # allowlisted above (matched BEFORE this denylist in
     # validate_media_delivery_path, so generated media still delivers).
     #
-    # These are the per-file credential / secret stores that live at the
-    # HERMES_HOME root. The set mirrors the canonical read guard in
+    # These are the per-file credential / secret stores that live at each
+    # Hermes home root. The set mirrors the canonical read guard in
     # agent/file_safety.py (get_read_block_error / build_write_denied_*) so the
     # delivery (read/exfil) side can't trail the write side: a credential the
     # agent is forbidden to write or read must also never be auto-attached to a
     # chat reply. Enumerated explicitly per-file rather than denying the whole
     # tree, so skills/, logs/, and ad-hoc agent-written files under ~/.hermes
     # stay deliverable (see #32090, #34425).
+    #
+    # Sibling/inactive profiles must use the same policy: default mode would
+    # otherwise accept MEDIA:<root>/profiles/<other>/.env (and the rest of
+    # this list) because only (_HERMES_HOME, _HERMES_ROOT) were denied.
+    # Enumeration mirrors _profile_cache_roots() so profiles created after
+    # process start are covered.
     _ROOT_CREDENTIAL_FILES = (
         ".env",
         "auth.json",
@@ -1379,7 +1395,17 @@ def _media_delivery_denied_paths() -> List[Path]:
         "pairing",
         "mcp-tokens",
     )
-    for hermes_root in (_HERMES_HOME, _HERMES_ROOT):
+    hermes_dirs: List[Path] = []
+    for base in (_HERMES_HOME, _HERMES_ROOT, *_iter_hermes_profile_dirs()):
+        try:
+            real = base.expanduser().resolve(strict=False)
+        except (OSError, RuntimeError, ValueError):
+            # Fail closed: still deny under the unresolved path rather than
+            # skipping the home/profile entirely.
+            real = base
+        if real not in hermes_dirs:
+            hermes_dirs.append(real)
+    for hermes_root in hermes_dirs:
         for rel in _ROOT_CREDENTIAL_FILES:
             denied.append(hermes_root / rel)
         for rel in _ROOT_CREDENTIAL_DIRS:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1286,17 +1286,65 @@ def _iter_hermes_profile_dirs() -> List[Path]:
         return []
 
 
+def _path_parts_casefold(path: Path) -> Tuple[str, ...]:
+    """Return path parts casefolded for case-insensitive deny matching."""
+    return tuple(part.casefold() for part in Path(path).parts)
+
+
+def _parts_is_within_casefold(
+    path_parts: Tuple[str, ...],
+    root_parts: Tuple[str, ...],
+) -> bool:
+    """Return True if ``path_parts`` is ``root_parts`` or a descendant."""
+    if not root_parts:
+        return False
+    return (
+        len(path_parts) >= len(root_parts)
+        and path_parts[: len(root_parts)] == root_parts
+    )
+
+
+def _paths_equal_casefold(left: Path, right: Path) -> bool:
+    """Return True if both paths match under casefold semantics."""
+    return _path_parts_casefold(left) == _path_parts_casefold(right)
+
+
+def _path_is_within_casefold(path: Path, root: Path) -> bool:
+    """Containment check that treats path components case-insensitively.
+
+    Used only on the media-delivery denylist side. Case-insensitive volumes
+    (default macOS / Windows) preserve mixed-case spellings through
+    ``Path.resolve()`` for non-symlink components, so case-sensitive
+    ``relative_to`` would miss real credential files opened via alias
+    casing. Fail closed: deny when the casefolded ancestry matches.
+    """
+    return _parts_is_within_casefold(
+        _path_parts_casefold(path),
+        _path_parts_casefold(root),
+    )
+
+
+def _relative_parts_casefold(path: Path, root: Path) -> Optional[Tuple[str, ...]]:
+    """Return casefolded parts of ``path`` relative to ``root``, or None."""
+    path_parts = _path_parts_casefold(path)
+    root_parts = _path_parts_casefold(root)
+    if not _parts_is_within_casefold(path_parts, root_parts):
+        return None
+    return path_parts[len(root_parts) :]
+
+
 def _rel_matches_hermes_root_credential(rel: Path) -> bool:
     """Return True if ``rel`` (relative to a Hermes home) is a credential path."""
     if not rel.parts:
         return False
+    rel_parts = _path_parts_casefold(rel)
     for denied_rel in _MEDIA_DELIVERY_ROOT_CREDENTIAL_FILES:
-        denied = Path(denied_rel)
-        if rel == denied or _path_is_within(rel, denied):
+        denied_parts = _path_parts_casefold(Path(denied_rel))
+        if rel_parts == denied_parts or _parts_is_within_casefold(rel_parts, denied_parts):
             return True
     for denied_rel in _MEDIA_DELIVERY_ROOT_CREDENTIAL_DIRS:
-        denied = Path(denied_rel)
-        if rel == denied or _path_is_within(rel, denied):
+        denied_parts = _path_parts_casefold(Path(denied_rel))
+        if rel_parts == denied_parts or _parts_is_within_casefold(rel_parts, denied_parts):
             return True
     return False
 
@@ -1308,6 +1356,10 @@ def _path_is_profile_tree_credential(resolved: Path) -> bool:
     openable (POSIX execute-only directory). Structural matching keeps the
     credential policy intact under that error condition — denial must not
     depend on ``_iter_hermes_profile_dirs()``.
+
+    Comparisons are casefolded so mixed-case aliases on case-insensitive
+    filesystems (``PROFILES/bob/.ENV``) cannot miss the deny check while
+    still opening the real credential file.
     """
     profiles_root = _HERMES_ROOT / "profiles"
     try:
@@ -1316,16 +1368,14 @@ def _path_is_profile_tree_credential(resolved: Path) -> bool:
         # Fail closed: still match against the unresolved profiles path
         # rather than skipping sibling credential denial entirely.
         profiles_root = _HERMES_ROOT / "profiles"
-    try:
-        rel = resolved.relative_to(profiles_root)
-    except ValueError:
+    rel_parts = _relative_parts_casefold(resolved, profiles_root)
+    if rel_parts is None:
         return False
     # Need at least <profile_name>/<credential...> — a bare profiles/<name>
     # path is not a deliverable file anyway (validate requires is_file).
-    parts = rel.parts
-    if len(parts) < 2:
+    if len(rel_parts) < 2:
         return False
-    return _rel_matches_hermes_root_credential(Path(*parts[1:]))
+    return _rel_matches_hermes_root_credential(Path(*rel_parts[1:]))
 
 
 def _path_is_lexical_profile_tree_credential(absolute: Path) -> bool:
@@ -1338,20 +1388,22 @@ def _path_is_lexical_profile_tree_credential(absolute: Path) -> bool:
     denylist cannot recover the target. Matching the normalized absolute
     input against ``<root>/profiles/<name>/<credential...>`` closes that
     conjunction without depending on directory enumeration.
+
+    Path components are compared casefolded so case-insensitive volumes
+    cannot bypass denial via mixed-case spelling of ``profiles/`` or
+    credential basenames.
     """
     try:
         profiles_root = Path(os.path.normpath(str(_HERMES_ROOT.expanduser() / "profiles")))
         candidate = Path(os.path.normpath(str(absolute)))
     except (OSError, RuntimeError, ValueError):
         return False
-    try:
-        rel = candidate.relative_to(profiles_root)
-    except ValueError:
+    rel_parts = _relative_parts_casefold(candidate, profiles_root)
+    if rel_parts is None:
         return False
-    parts = rel.parts
-    if len(parts) < 2:
+    if len(rel_parts) < 2:
         return False
-    return _rel_matches_hermes_root_credential(Path(*parts[1:]))
+    return _rel_matches_hermes_root_credential(Path(*rel_parts[1:]))
 
 
 def _profile_cache_roots() -> List[Path]:
@@ -1529,11 +1581,17 @@ def _path_under_denied_prefix(resolved: Path, lexical: Optional[Path] = None) ->
             resolved_denied = denied.expanduser().resolve(strict=False)
         except (OSError, RuntimeError, ValueError):
             continue
-        if not (_path_is_within(resolved, resolved_denied) or resolved == resolved_denied):
+        # Casefold deny matching: on case-insensitive volumes, resolve() may
+        # preserve mixed-case input spelling while discovered denied paths use
+        # the on-disk casing from iterdir()/Path construction.
+        if not (
+            _path_is_within_casefold(resolved, resolved_denied)
+            or _paths_equal_casefold(resolved, resolved_denied)
+        ):
             continue
         # Allow the running user's own home tree; its credential sub-dirs are
         # caught by their own (more-specific) denylist entries above.
-        if home is not None and resolved_denied == home:
+        if home is not None and _paths_equal_casefold(resolved_denied, home):
             continue
         return True
     return False

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1273,9 +1273,10 @@ _MEDIA_DELIVERY_ROOT_CREDENTIAL_DIRS = (
 def _iter_hermes_profile_dirs() -> List[Path]:
     """Return ``<root>/profiles/<name>/`` directories that currently exist.
 
-    Used by cache allowlisting so profiles created after process start are
-    covered. Missing or unreadable ``profiles/`` yields an empty list —
-    credential denial must NOT depend on this helper (see
+    Used by cache allowlisting and by media-delivery credential denial for
+    discovered profile homes (including directory-symlink targets). Missing
+    or unreadable ``profiles/`` yields an empty list — ordinary sibling
+    credential denial must NOT depend solely on this helper (see
     ``_path_is_profile_tree_credential``).
     """
     profiles_dir = _HERMES_ROOT / "profiles"
@@ -1431,12 +1432,14 @@ def _media_delivery_denied_paths() -> List[Path]:
     # validate_media_delivery_path, so generated media still delivers).
     #
     # Sibling/inactive profiles under <root>/profiles/<name>/ use the same
-    # credential file/dir policy, but denial is applied structurally in
-    # ``_path_is_profile_tree_credential`` — not by listing ``profiles/``.
-    # Directory enumeration can fail while a known child path remains
-    # openable (POSIX execute-only), so building this list from
-    # ``_iter_hermes_profile_dirs()`` would fail open at the exact boundary
-    # sibling denial is meant to close.
+    # credential file/dir policy. Denial is layered:
+    #   1. Structural match in ``_path_is_profile_tree_credential`` — works
+    #      without listing ``profiles/`` (POSIX execute-only dirs).
+    #   2. Discovered profile homes below — covers directory-symlink siblings
+    #      (``profiles/bob -> /elsewhere``) whose resolved targets sit outside
+    #      the structural profiles root after ``validate_media_delivery_path``
+    #      canonicalizes the candidate. Enumeration alone would fail open on
+    #      unreadable ``profiles/``; the structural check covers that case.
     hermes_dirs: List[Path] = []
     for base in (_HERMES_HOME, _HERMES_ROOT):
         try:
@@ -1445,6 +1448,13 @@ def _media_delivery_denied_paths() -> List[Path]:
             # Fail closed: still deny under the unresolved path rather than
             # skipping the home entirely.
             real = base
+        if real not in hermes_dirs:
+            hermes_dirs.append(real)
+    for profile_dir in _iter_hermes_profile_dirs():
+        try:
+            real = profile_dir.expanduser().resolve(strict=False)
+        except (OSError, RuntimeError, ValueError):
+            real = profile_dir
         if real not in hermes_dirs:
             hermes_dirs.append(real)
     for hermes_root in hermes_dirs:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1032,6 +1032,41 @@ class TestMediaDeliveryDefaultMode:
         else:
             assert BasePlatformAdapter.validate_media_delivery_path(mixed_notes) is None
 
+    def test_sibling_credential_symlink_into_cache_denied(
+        self, tmp_path, monkeypatch,
+    ):
+        """Credential-shaped paths must not redeem via safe-root after resolve.
+
+        ``profiles/bob/.env`` symlinked to ``bob/cache/images/...`` resolves
+        into an unconditional profile-cache allowlist root. Lexical sibling
+        credential policy must reject that submission before safe-root
+        acceptance, while the cache target addressed directly still delivers.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_root = fake_home / ".hermes"
+        alice = hermes_root / "profiles" / "alice"
+        bob = hermes_root / "profiles" / "bob"
+        alice.mkdir(parents=True)
+        cache_file = bob / "cache" / "images" / "credential.txt"
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_text("leaked-secret\n")
+        secret_link = bob / ".env"
+        try:
+            secret_link.symlink_to(cache_file)
+        except OSError:
+            pytest.skip("symlink creation is unavailable")
+
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", alice)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_root)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(secret_link)) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(str(cache_file)) == str(
+            cache_file.resolve()
+        )
+
     def test_case_sensitive_home_exception_preserves_denied_root_identity(
         self, tmp_path, monkeypatch,
     ):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -730,6 +730,51 @@ class TestMediaDeliveryDefaultMode:
             notes.resolve()
         )
 
+    def test_sibling_credential_denied_when_profiles_enumeration_fails(
+        self, tmp_path, monkeypatch,
+    ):
+        """Fail closed on known sibling credentials when profiles/ can't be listed.
+
+        POSIX execute-only (0111) profiles/ lets open(bob/.env) succeed while
+        iterdir() raises. Denial must be structural under profiles/<name>/,
+        not derived from enumeration (which returns [] on OSError).
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_root = fake_home / ".hermes"
+        profiles_dir = hermes_root / "profiles"
+        alice = profiles_dir / "alice"
+        bob = profiles_dir / "bob"
+        alice.mkdir(parents=True)
+        secret = bob / ".env"
+        secret.parent.mkdir(parents=True)
+        secret.write_text("SECRET=1")
+        notes = bob / "notes.md"
+        notes.write_text("# ok\n")
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", alice)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_root)
+
+        # Simulate execute-only / unreadable profiles/: listing fails, but
+        # the known child paths remain openable (already created above).
+        real_iterdir = type(profiles_dir).iterdir
+
+        def _iterdir_raises(self):
+            if self.resolve() == profiles_dir.resolve():
+                raise PermissionError("profiles dir not readable")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(type(profiles_dir), "iterdir", _iterdir_raises)
+
+        import gateway.platforms.base as base
+
+        assert base._iter_hermes_profile_dirs() == []
+        assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(str(notes)) == str(
+            notes.resolve()
+        )
+
     def test_denylist_blocks_google_token_default_mode(self, tmp_path, monkeypatch):
         """Integration credentials at the HERMES_HOME root (google_token.json)
         must never be deliverable, even though they aren't the historically

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -635,6 +635,101 @@ class TestMediaDeliveryDefaultMode:
         assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
 
 
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            ".env",
+            "auth.json",
+            "auth.lock",
+            "config.yaml",
+            ".anthropic_oauth.json",
+            "google_token.json",
+            "google_oauth_pending.json",
+            "auth/google_oauth.json",
+            "webhook_subscriptions.json",
+            "credentials/x",
+            "cache/bws_cache.json",
+            "cache/bws_cache.enc.json",
+            "mcp-tokens/t.json",
+            "pairing/x.json",
+        ],
+    )
+    def test_denylist_blocks_sibling_profile_credentials(
+        self, tmp_path, monkeypatch, rel,
+    ):
+        """Active profile alice must not deliver bob's credential stores.
+
+        Default mode accepts any non-denied regular file. The denylist must
+        therefore cover every <root>/profiles/<name>/ entry with the same
+        credential file/dir policy as the active home and shared root —
+        otherwise MEDIA:<root>/profiles/bob/.env (etc.) exfiltrates as a
+        chat attachment. Supersedes the incomplete four-file list in #47220.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_root = fake_home / ".hermes"
+        alice = hermes_root / "profiles" / "alice"
+        bob = hermes_root / "profiles" / "bob"
+        alice.mkdir(parents=True)
+        secret = bob / rel
+        secret.parent.mkdir(parents=True, exist_ok=True)
+        secret.write_text("SECRET=1")
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", alice)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_root)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
+
+    def test_denylist_blocks_sibling_profile_when_home_is_root(
+        self, tmp_path, monkeypatch,
+    ):
+        """Default (non-profile) HERMES_HOME==root must still deny profiles/*.
+
+        The hole also exists for a root-home gateway that coexists with
+        profile directories on disk — not only when the active home is itself
+        under profiles/<name>/.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_root = fake_home / ".hermes"
+        bob = hermes_root / "profiles" / "bob"
+        secret = bob / ".env"
+        secret.parent.mkdir(parents=True)
+        secret.write_text("SECRET=1")
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_root)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_root)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
+
+    def test_sibling_profile_non_credential_still_delivers(
+        self, tmp_path, monkeypatch,
+    ):
+        """Non-credential files under a sibling profile remain deliverable.
+
+        The denylist is per-credential-store, not a whole-tree deny of
+        profiles/<other>/ (same #32090/#34425 posture as the active home).
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_root = fake_home / ".hermes"
+        alice = hermes_root / "profiles" / "alice"
+        bob = hermes_root / "profiles" / "bob"
+        alice.mkdir(parents=True)
+        notes = bob / "notes.md"
+        notes.parent.mkdir(parents=True)
+        notes.write_text("# shared notes\n")
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", alice)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_root)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(notes)) == str(
+            notes.resolve()
+        )
+
     def test_denylist_blocks_google_token_default_mode(self, tmp_path, monkeypatch):
         """Integration credentials at the HERMES_HOME root (google_token.json)
         must never be deliverable, even though they aren't the historically

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -895,6 +895,18 @@ class TestMediaDeliveryDefaultMode:
             text = text.replace(old, new)
         return text
 
+    def _mixed_case_opens_same_file(self, alias: str, real: Path) -> bool:
+        """True when the mixed-case spelling opens the same on-disk file.
+
+        Case-sensitive volumes (Linux CI) do not resolve ``PROFILES/...`` to
+        ``profiles/...``; the alias simply does not exist. Case-insensitive
+        volumes (default macOS / Windows) open the real credential/file.
+        """
+        try:
+            return Path(alias).resolve(strict=True).samefile(real.resolve(strict=True))
+        except OSError:
+            return False
+
     def test_mixed_case_sibling_credential_helpers(self, tmp_path, monkeypatch):
         """Casefolded profile/credential matching must catch mixed-case aliases.
 
@@ -961,11 +973,18 @@ class TestMediaDeliveryDefaultMode:
         )
         mixed_notes = self._mixed_case_alias(notes, ("profiles", "PROFILES"))
 
+        # Credential aliases must never deliver. On case-sensitive volumes the
+        # mixed spelling does not open the file (also None); on case-insensitive
+        # volumes the deny helpers reject the opened secret.
         assert BasePlatformAdapter.validate_media_delivery_path(mixed_secret) is None
         assert BasePlatformAdapter.validate_media_delivery_path(mixed_token) is None
-        assert BasePlatformAdapter.validate_media_delivery_path(mixed_notes) == str(
-            notes.resolve()
-        )
+        if self._mixed_case_opens_same_file(mixed_notes, notes):
+            assert BasePlatformAdapter.validate_media_delivery_path(mixed_notes) == str(
+                notes.resolve()
+            )
+        else:
+            # Case-sensitive FS: alias path does not exist, so delivery is None.
+            assert BasePlatformAdapter.validate_media_delivery_path(mixed_notes) is None
 
     def test_mixed_case_sibling_credential_denied_when_enumeration_fails(
         self, tmp_path, monkeypatch,
@@ -1006,7 +1025,99 @@ class TestMediaDeliveryDefaultMode:
 
         assert base._iter_hermes_profile_dirs() == []
         assert BasePlatformAdapter.validate_media_delivery_path(mixed_secret) is None
-        assert BasePlatformAdapter.validate_media_delivery_path(mixed_notes) == str(
+        if self._mixed_case_opens_same_file(mixed_notes, notes):
+            assert BasePlatformAdapter.validate_media_delivery_path(mixed_notes) == str(
+                notes.resolve()
+            )
+        else:
+            assert BasePlatformAdapter.validate_media_delivery_path(mixed_notes) is None
+
+    def test_case_sensitive_home_exception_preserves_denied_root_identity(
+        self, tmp_path, monkeypatch,
+    ):
+        """Casefold-equal but distinct homes must not exempt a hard-denied tree.
+
+        On case-sensitive filesystems, ``/Etc`` and ``/etc`` can both exist.
+        The running-home exception must require filesystem identity so a
+        configured home that only casefolds to a denied system root cannot
+        unlock files under the real denied tree.
+        """
+        self._patch_roots(monkeypatch)
+
+        denied_root = tmp_path / "etc"
+        home_alias = tmp_path / "Etc"
+        denied_root.mkdir()
+        try:
+            home_alias.mkdir()
+        except FileExistsError:
+            pytest.skip("filesystem is case-insensitive")
+        try:
+            if denied_root.samefile(home_alias):
+                pytest.skip("filesystem is case-insensitive")
+        except OSError:
+            pytest.skip("cannot compare directory identity")
+
+        secret = denied_root / "shadow"
+        secret.write_text("root:*:0:0\n")
+
+        monkeypatch.setenv("HOME", str(home_alias))
+        monkeypatch.setenv("USERPROFILE", str(home_alias))
+        monkeypatch.setattr(
+            "gateway.platforms.base._MEDIA_DELIVERY_DENIED_PREFIXES",
+            (str(denied_root),),
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base._MEDIA_DELIVERY_DENIED_HOME_SUBPATHS",
+            (),
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base._HERMES_HOME",
+            tmp_path / "unused-hermes",
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base._HERMES_ROOT",
+            tmp_path / "unused-hermes",
+        )
+
+        import gateway.platforms.base as base
+
+        assert base._paths_equal_casefold(denied_root, home_alias) is True
+        assert base._paths_refer_to_same_home(
+            denied_root.resolve(), home_alias.resolve(),
+        ) is False
+        assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
+
+    def test_running_home_exception_allows_exact_home_identity(
+        self, tmp_path, monkeypatch,
+    ):
+        """When the denied prefix IS the running home, non-credential files deliver."""
+        self._patch_roots(monkeypatch)
+
+        home = tmp_path / "rootish"
+        home.mkdir()
+        notes = home / "notes.md"
+        notes.write_text("# ok\n")
+
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        monkeypatch.setattr(
+            "gateway.platforms.base._MEDIA_DELIVERY_DENIED_PREFIXES",
+            (str(home),),
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base._MEDIA_DELIVERY_DENIED_HOME_SUBPATHS",
+            (),
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base._HERMES_HOME",
+            tmp_path / "unused-hermes",
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base._HERMES_ROOT",
+            tmp_path / "unused-hermes",
+        )
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(notes)) == str(
             notes.resolve()
         )
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -775,6 +775,58 @@ class TestMediaDeliveryDefaultMode:
             notes.resolve()
         )
 
+    def test_symlinked_sibling_profile_credentials_denied(
+        self, tmp_path, monkeypatch,
+    ):
+        """Directory-symlink siblings must still deny credentials after resolve.
+
+        Profile discovery accepts directory symlinks (``profiles/bob`` ->
+        external home). ``validate_media_delivery_path`` resolves the
+        candidate first, so a structural ``<root>/profiles/<name>/`` match
+        misses the external target. Discovered profile homes must apply the
+        same credential-relative policy to their resolved targets, while
+        ordinary sibling files remain deliverable.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_root = fake_home / ".hermes"
+        alice = hermes_root / "profiles" / "alice"
+        bob_link = hermes_root / "profiles" / "bob"
+        alice.mkdir(parents=True)
+        external_bob = tmp_path / "external_bob"
+        external_bob.mkdir()
+        secret = external_bob / ".env"
+        secret.write_text("SECRET=1")
+        token = external_bob / "mcp-tokens" / "t.json"
+        token.parent.mkdir()
+        token.write_text("{}")
+        notes = external_bob / "notes.md"
+        notes.write_text("# ok\n")
+        try:
+            bob_link.symlink_to(external_bob, target_is_directory=True)
+        except OSError:
+            pytest.skip("directory symlink creation is unavailable")
+
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", alice)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_root)
+
+        # Access via the profiles/ symlink entry (the MEDIA-tag shape).
+        linked_secret = bob_link / ".env"
+        linked_token = bob_link / "mcp-tokens" / "t.json"
+        linked_notes = bob_link / "notes.md"
+
+        import gateway.platforms.base as base
+
+        # Structural check alone misses the resolved external target.
+        assert base._path_is_profile_tree_credential(linked_secret.resolve()) is False
+        assert BasePlatformAdapter.validate_media_delivery_path(str(linked_secret)) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(str(linked_token)) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(str(linked_notes)) == str(
+            linked_notes.resolve()
+        )
+
     def test_denylist_blocks_google_token_default_mode(self, tmp_path, monkeypatch):
         """Integration credentials at the HERMES_HOME root (google_token.json)
         must never be deliverable, even though they aren't the historically

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -885,6 +886,128 @@ class TestMediaDeliveryDefaultMode:
         assert BasePlatformAdapter.validate_media_delivery_path(str(linked_token)) is None
         assert BasePlatformAdapter.validate_media_delivery_path(str(linked_notes)) == str(
             linked_notes.resolve()
+        )
+
+    def _mixed_case_alias(self, path: Path, *replacements: tuple[str, str]) -> str:
+        """Rewrite path components' spelling without touching the real file."""
+        text = str(path)
+        for old, new in replacements:
+            text = text.replace(old, new)
+        return text
+
+    def test_mixed_case_sibling_credential_helpers(self, tmp_path, monkeypatch):
+        """Casefolded profile/credential matching must catch mixed-case aliases.
+
+        On case-insensitive volumes, ``Path.resolve()`` can preserve the
+        supplied spelling of non-symlink components. Helpers must therefore
+        deny ``PROFILES/bob/.ENV`` even when on-disk names are lowercase.
+        """
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir()
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_root)
+
+        import gateway.platforms.base as base
+
+        mixed = Path(self._mixed_case_alias(
+            hermes_root / "profiles" / "bob" / ".env",
+            ("profiles", "PROFILES"),
+            (".env", ".ENV"),
+        ))
+        mixed_token = Path(self._mixed_case_alias(
+            hermes_root / "profiles" / "bob" / "mcp-tokens" / "t.json",
+            ("profiles", "PROFILES"),
+            ("mcp-tokens", "MCP-TOKENS"),
+        ))
+        mixed_notes = Path(self._mixed_case_alias(
+            hermes_root / "profiles" / "bob" / "notes.md",
+            ("profiles", "PROFILES"),
+        ))
+
+        assert base._rel_matches_hermes_root_credential(Path(".ENV")) is True
+        assert base._rel_matches_hermes_root_credential(Path("MCP-TOKENS") / "t.json") is True
+        assert base._path_is_profile_tree_credential(mixed) is True
+        assert base._path_is_lexical_profile_tree_credential(mixed) is True
+        assert base._path_is_profile_tree_credential(mixed_token) is True
+        assert base._path_is_lexical_profile_tree_credential(mixed_token) is True
+        assert base._path_is_profile_tree_credential(mixed_notes) is False
+        assert base._path_is_lexical_profile_tree_credential(mixed_notes) is False
+
+    def test_mixed_case_sibling_credential_denied(self, tmp_path, monkeypatch):
+        """Mixed-case MEDIA paths must not deliver sibling credentials."""
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_root = fake_home / ".hermes"
+        alice = hermes_root / "profiles" / "alice"
+        bob = hermes_root / "profiles" / "bob"
+        alice.mkdir(parents=True)
+        secret = bob / ".env"
+        secret.parent.mkdir(parents=True)
+        secret.write_text("SECRET=1")
+        token = bob / "mcp-tokens" / "t.json"
+        token.parent.mkdir()
+        token.write_text("{}")
+        notes = bob / "notes.md"
+        notes.write_text("# ok\n")
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", alice)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_root)
+
+        mixed_secret = self._mixed_case_alias(
+            secret, ("profiles", "PROFILES"), (".env", ".ENV"),
+        )
+        mixed_token = self._mixed_case_alias(
+            token, ("profiles", "PROFILES"), ("mcp-tokens", "MCP-TOKENS"),
+        )
+        mixed_notes = self._mixed_case_alias(notes, ("profiles", "PROFILES"))
+
+        assert BasePlatformAdapter.validate_media_delivery_path(mixed_secret) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(mixed_token) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(mixed_notes) == str(
+            notes.resolve()
+        )
+
+    def test_mixed_case_sibling_credential_denied_when_enumeration_fails(
+        self, tmp_path, monkeypatch,
+    ):
+        """Mixed-case aliases stay denied when profiles/ listing raises."""
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_root = fake_home / ".hermes"
+        profiles_dir = hermes_root / "profiles"
+        alice = profiles_dir / "alice"
+        bob = profiles_dir / "bob"
+        alice.mkdir(parents=True)
+        secret = bob / ".env"
+        secret.parent.mkdir(parents=True)
+        secret.write_text("SECRET=1")
+        notes = bob / "notes.md"
+        notes.write_text("# ok\n")
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", alice)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_root)
+
+        real_iterdir = type(profiles_dir).iterdir
+
+        def _iterdir_raises(self):
+            if self.resolve() == profiles_dir.resolve():
+                raise PermissionError("profiles dir not readable")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(type(profiles_dir), "iterdir", _iterdir_raises)
+
+        import gateway.platforms.base as base
+
+        mixed_secret = self._mixed_case_alias(
+            secret, ("profiles", "PROFILES"), (".env", ".ENV"),
+        )
+        mixed_notes = self._mixed_case_alias(notes, ("profiles", "PROFILES"))
+
+        assert base._iter_hermes_profile_dirs() == []
+        assert BasePlatformAdapter.validate_media_delivery_path(mixed_secret) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(mixed_notes) == str(
+            notes.resolve()
         )
 
     def test_denylist_blocks_google_token_default_mode(self, tmp_path, monkeypatch):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -827,6 +827,66 @@ class TestMediaDeliveryDefaultMode:
             linked_notes.resolve()
         )
 
+    def test_symlinked_sibling_credential_denied_when_enumeration_fails(
+        self, tmp_path, monkeypatch,
+    ):
+        """Symlink sibling + unreadable profiles/ must still deny credentials.
+
+        resolve() drops ``profiles/<name>/`` ancestry for directory-symlink
+        homes, and ``_iter_hermes_profile_dirs`` returns [] when listing fails.
+        Lexical ancestry on the submitted absolute path must close that
+        conjunction while non-credential sibling files remain deliverable.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_root = fake_home / ".hermes"
+        profiles_dir = hermes_root / "profiles"
+        alice = profiles_dir / "alice"
+        bob_link = profiles_dir / "bob"
+        alice.mkdir(parents=True)
+        external_bob = tmp_path / "external_bob"
+        external_bob.mkdir()
+        secret = external_bob / ".env"
+        secret.write_text("SECRET=1")
+        token = external_bob / "mcp-tokens" / "t.json"
+        token.parent.mkdir()
+        token.write_text("{}")
+        notes = external_bob / "notes.md"
+        notes.write_text("# ok\n")
+        try:
+            bob_link.symlink_to(external_bob, target_is_directory=True)
+        except OSError:
+            pytest.skip("directory symlink creation is unavailable")
+
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", alice)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_root)
+
+        real_iterdir = type(profiles_dir).iterdir
+
+        def _iterdir_raises(self):
+            if self.resolve() == profiles_dir.resolve():
+                raise PermissionError("profiles dir not readable")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(type(profiles_dir), "iterdir", _iterdir_raises)
+
+        import gateway.platforms.base as base
+
+        linked_secret = bob_link / ".env"
+        linked_token = bob_link / "mcp-tokens" / "t.json"
+        linked_notes = bob_link / "notes.md"
+
+        assert base._iter_hermes_profile_dirs() == []
+        assert base._path_is_profile_tree_credential(linked_secret.resolve()) is False
+        assert base._path_is_lexical_profile_tree_credential(linked_secret) is True
+        assert BasePlatformAdapter.validate_media_delivery_path(str(linked_secret)) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(str(linked_token)) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(str(linked_notes)) == str(
+            linked_notes.resolve()
+        )
+
     def test_denylist_blocks_google_token_default_mode(self, tmp_path, monkeypatch):
         """Integration credentials at the HERMES_HOME root (google_token.json)
         must never be deliverable, even though they aren't the historically


### PR DESCRIPTION
## What does this PR do?

Default (non-strict) media delivery only denied credential stores under the active HERMES_HOME and the shared Hermes root. Sibling profile paths under `<root>/profiles/<other>/` were accepted, so a prompt-injected `MEDIA:` tag could attach another profile's secrets as a chat document. This applies the full current credential file/dir policy to every live profile directory (same enumeration pattern as cache allowlisting).

### Bug Cause

`_media_delivery_denied_paths()` in `gateway/platforms/base.py` only appended `_ROOT_CREDENTIAL_FILES` / `_ROOT_CREDENTIAL_DIRS` for `(_HERMES_HOME, _HERMES_ROOT)`. In non-strict mode, `validate_media_delivery_path` accepts any existing regular file not on that denylist, so `MEDIA:<root>/profiles/bob/.env` (and auth/OAuth/mcp-tokens/pairing/etc.) delivered while `alice/.env` and root `.env` stayed blocked.

### Reproduction Steps

1. Create a temp Hermes root with `profiles/alice` and `profiles/bob`; write credential files under bob (`.env`, `auth.json`, `.anthropic_oauth.json`, `mcp-tokens/`, `pairing/`, `google_token.json`, `webhook_subscriptions.json`, `credentials/`, `cache/bws_cache.json`).
2. Patch `_HERMES_HOME` to alice and `_HERMES_ROOT` to the temp root; leave `HERMES_MEDIA_DELIVERY_STRICT` unset/off.
3. Call `validate_media_delivery_path` on each bob credential path and on alice/root `.env`.

Expected: sibling credential paths return `None` (same as active/root).
Before fix: bob credential paths returned an allowed absolute path; alice/root `.env` correctly returned `None`.

### Fix

- Extract `_iter_hermes_profile_dirs()` and reuse it from `_profile_cache_roots()` and `_media_delivery_denied_paths()`.
- Resolve each home/root/profile path before dedup (fail closed to the unresolved path on resolve error), then apply the full credential file/dir list to every profile.
- Tests: parametrized sibling credential denial, home-is-root sibling case, and a non-credential sibling `notes.md` still delivers.

Supersedes #47220 (that PR only denied four control files and lagged the expanded credential set on current main).

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

- `gateway/platforms/base.py` - enumerate sibling profiles into the media-delivery credential denylist; share profile-dir iteration with cache allowlisting
- `tests/gateway/test_platform_base.py` - non-strict sibling credential / home-is-root / non-credential control tests

## How to Test

1. Manual: with `HERMES_HOME=<root>/profiles/alice`, assert `validate_media_delivery_path(<root>/profiles/bob/.env)` (and other credential rels) is `None`, while `<root>/profiles/bob/notes.md` still resolves.
2. Automated (already run locally, 211 passed):

```bash
scripts/run_tests.sh tests/gateway/test_platform_base.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (supersedes #47220)
- [x] My PR contains only changes related to this fix
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - path resolve + profiles/*/ enumeration
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
