### PR TITLE
feat(slack): add static channel-join message

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -917,6 +917,11 @@ platform_toolsets:
 #       # Route scripts default to a 30 second timeout. Scripts must live under
 #       # the active profile's scripts directory and receive webhook JSON on stdin.
 #       script_timeout_seconds: 30
+#   slack:
+#     extra:
+#       # Static text posted when the bot itself joins a channel. Requires the
+#       # Slack app to subscribe to the member_joined_channel bot event.
+#       channel_join_message: ""
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1708,6 +1708,10 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_app_mention(event, say, body):
                 await self._handle_slack_message(event, body)
 
+            @self._app.event("member_joined_channel")
+            async def handle_member_joined_channel(event, say, body):
+                await self._handle_member_joined_channel(event, body)
+
             @self._app.event("app_home_opened")
             async def handle_app_home_opened(event, say, body):
                 await self._handle_app_home_opened(event, body)
@@ -3618,6 +3622,69 @@ class SlackAdapter(BasePlatformAdapter):
             if isinstance(authorization, dict) and authorization.get("team_id"):
                 return str(authorization["team_id"])
         return ""
+
+    async def _handle_member_joined_channel(
+        self, event: dict, body: Optional[dict] = None
+    ) -> None:
+        """Post the configured static message when this workspace's bot joins."""
+        message = self.config.extra.get("channel_join_message")
+        if not isinstance(message, str) or not message.strip():
+            return
+        if not isinstance(event, dict):
+            return
+
+        body = body if isinstance(body, dict) else {}
+        user_id = event.get("user")
+        channel_id = event.get("channel")
+        team_id = self._event_team_id(event, body)
+        event_id = body.get("event_id") or event.get("event_ts")
+        if not all(
+            isinstance(value, str) and value
+            for value in (user_id, channel_id, team_id, event_id)
+        ):
+            return
+
+        bot_user_id = self._team_bot_user_ids.get(team_id)
+        client = self._team_clients.get(team_id)
+        if not bot_user_id or user_id != bot_user_id or client is None:
+            return
+
+        allowed_channels = self._slack_allowed_channels()
+        if allowed_channels and channel_id not in allowed_channels:
+            return
+
+        try:
+            response = await client.conversations_info(channel=channel_id)
+        except Exception as exc:
+            logger.debug(
+                "[Slack] Could not verify channel-join conversation type (%s)",
+                type(exc).__name__,
+            )
+            return
+
+        response_get = getattr(response, "get", None)
+        conversation = response_get("channel") if callable(response_get) else None
+        if not isinstance(conversation, dict):
+            return
+        if (
+            not (conversation.get("is_channel") or conversation.get("is_group"))
+            or conversation.get("is_im")
+            or conversation.get("is_mpim")
+        ):
+            return
+
+        dedup_key = f"member_joined_channel:{team_id}:{event_id}"
+        if self._dedup.is_duplicate(dedup_key):
+            return
+
+        self._remember_channel_team(channel_id, team_id)
+        try:
+            await client.chat_postMessage(channel=channel_id, text=message)
+        except Exception as exc:
+            logger.warning(
+                "[Slack] Failed to post configured channel-join message (%s)",
+                type(exc).__name__,
+            )
 
     @staticmethod
     def _context_channel_id(context: Any) -> str:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -217,6 +217,50 @@ class TestSlashCommandSessionIsolation:
 class TestAppMentionHandler:
     """Verify that the app_mention event handler is registered."""
 
+    @pytest.mark.asyncio
+    async def test_channel_join_message_posts_once_only_for_the_bot(self, adapter):
+        message = "Welcome to the channel."
+        adapter.config.extra["channel_join_message"] = message
+        adapter._team_bot_user_ids = {"T123": "U_BOT"}
+        client = AsyncMock()
+        client.conversations_info.return_value = {
+            "ok": True,
+            "channel": {
+                "is_channel": True,
+                "is_im": False,
+                "is_mpim": False,
+                "is_member": True,
+            },
+        }
+        adapter._team_clients = {"T123": client}
+
+        self_join = {
+            "type": "member_joined_channel",
+            "user": "U_BOT",
+            "channel": "C123",
+            "channel_type": "C",
+            "team": "T123",
+            "event_ts": "1700000000.123456",
+        }
+        self_join_body = {"team_id": "T123", "event_id": "Ev-self-join"}
+
+        await adapter._handle_member_joined_channel(
+            {**self_join, "user": "U_OTHER", "event_ts": "1700000001.123456"},
+            {"team_id": "T123", "event_id": "Ev-other-join"},
+        )
+        client.conversations_info.assert_not_awaited()
+        client.chat_postMessage.assert_not_awaited()
+
+        await adapter._handle_member_joined_channel(self_join, self_join_body)
+        await adapter._handle_member_joined_channel(self_join, self_join_body)
+
+        assert client.conversations_info.await_count == 2
+        client.chat_postMessage.assert_awaited_once_with(
+            channel="C123",
+            text=message,
+        )
+        adapter.handle_message.assert_not_awaited()
+
     def test_app_mention_registered_on_connect(self):
         """connect() should register message + assistant lifecycle handlers."""
         config = PlatformConfig(enabled=True, token="xoxb-fake")
@@ -280,6 +324,7 @@ class TestAppMentionHandler:
 
         assert "message" in registered_events
         assert "app_mention" in registered_events
+        assert "member_joined_channel" in registered_events
         assert "app_home_opened" in registered_events
         assert "app_context_changed" in registered_events
         assert "reaction_added" in registered_events


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `platforms.slack.extra.channel_join_message` setting. When Slack
delivers `member_joined_channel` for the authenticated bot user, the existing
Slack adapter posts that exact static text without starting a Hermes session or
invoking a model. Missing or empty configuration remains disabled.

The handler keeps workspace identity and clients isolated, respects
`allowed_channels`, verifies that the destination is a channel rather than a DM
or MPDM, and uses the existing deduplicator for Slack retries.

## Related Issue

No issue. Related proposals: #61635 combines a hard-coded onboarding message
with skill-binding hot reload, while #23971 routes join events through the
model. This PR intentionally keeps the capability generic, static, and narrow.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Register `member_joined_channel` through the existing Slack Bolt adapter.
- Match the event user against the workspace-specific authenticated bot user.
- Post configured static text once for supported channel types.
- Document the optional setting and add one focused regression test.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_slack.py -q`
2. `scripts/run_tests.sh tests/gateway/test_slack_dedup_ttl.py -q`
3. `.venv/bin/ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.
