### PR TITLE
fix(test): patch _launch_configured_cwd in completion tests for hermeticity (#70041)

### DIFF
--- a/tests/gateway/test_complete_path_at_filter.py
+++ b/tests/gateway/test_complete_path_at_filter.py
@@ -44,6 +44,14 @@ def _reset_fuzzy_cache(monkeypatch):
     # Each test walks a fresh tmp dir; clear the cached listing so prior
     # roots can't leak through the TTL window.
     server._fuzzy_cache.clear()
+    # #70041: _launch_configured_cwd() reads the launch profile's config.yaml
+    # via _load_cfg(), which resolves through _hermes_home captured at module
+    # import time — before the per-test HERMES_HOME redirect applies. When the
+    # developer's real config sets terminal.cwd, _completion_cwd() returns that
+    # directory instead of the test's tmp_path (from monkeypatch.chdir). Patch
+    # it to None so _completion_cwd falls through to os.getcwd(), which
+    # monkeypatch.chdir controls.
+    monkeypatch.setattr(server, "_launch_configured_cwd", lambda: None)
     yield
     server._fuzzy_cache.clear()
 
@@ -415,3 +423,25 @@ def test_leading_slash_falls_back_only_when_absolute_is_missing(tmp_path, monkey
     assert "@folder:nonexistent-at-root/" in [
         t for t, _, _ in _items("@/nonexistent-at-root")
     ]
+
+
+def test_completion_ignores_real_terminal_cwd(tmp_path, monkeypatch):
+    """#70041: _completion_cwd must not read the developer's real config.yaml
+    terminal.cwd when running under hermetic tests.
+
+    The autouse _reset_fuzzy_cache fixture patches _launch_configured_cwd
+    to None so _completion_cwd falls through to os.getcwd() (controlled
+    by monkeypatch.chdir). This test verifies that even if someone
+    re-patches _launch_configured_cwd to return a real path, the autouse
+    fixture's monkeypatch takes precedence (restored after each test).
+    """
+    _fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # _completion_cwd should resolve to tmp_path (via os.getcwd),
+    # not to any configured terminal.cwd from the real config.
+    resolved = server._completion_cwd({})
+    assert resolved == str(tmp_path), (
+        f"_completion_cwd resolved to {resolved} instead of {tmp_path} — "
+        f"the autouse fixture may not be patching _launch_configured_cwd"
+    )


### PR DESCRIPTION
## Summary

`tests/gateway/test_complete_path_at_filter.py` fails 7 of 15 tests on a pristine checkout whenever the developer's real `~/.hermes/config.yaml` sets `terminal.cwd` to an absolute path. CI stays green because CI machines have no real Hermes config.

The tests are not hermetic: `_completion_cwd()` calls `_launch_configured_cwd()` before `os.getcwd()`, and `_launch_configured_cwd()` reads `config.yaml` via `_hermes_home` captured at module import time — before the per-test `HERMES_HOME` redirect applies. When the real config sets `terminal.cwd` to an absolute path, the handler lists that directory instead of the test's `tmp_path`.

Same bug class as #69283 (kanban tests) and #69385 (kanban write guard): test isolation relies on env vars that are not yet set when module-level state is captured.

## Fix

Add `monkeypatch.setattr(server, "_launch_configured_cwd", lambda: None)` to the existing autouse `_reset_fuzzy_cache` fixture, so `_completion_cwd()` falls through to `os.getcwd()` (controlled by `monkeypatch.chdir`).

This is the narrower of the two approaches proposed in the issue — it fixes this file without changing the test runner. The broader approach (setting a neutral `HERMES_HOME` at interpreter start in `scripts/run_tests_parallel.py`) would close the class but is a larger change.

## Test Plan

- [x] All 15 existing tests pass with the fix
- [x] New `test_completion_ignores_real_terminal_cwd` verifies `_completion_cwd({})` resolves to the test's `tmp_path`, not to any configured `terminal.cwd`
- [x] Verified the bug reproduces without the fix when `_launch_configured_cwd` returns an absolute path (confirmed via manual probe: `_completion_cwd` returns the configured path instead of `os.getcwd()`)

```
tests/gateway/test_complete_path_at_filter.py: 16 passed in 9.18s
```

Closes #70041