### PR TITLE
fix(auxiliary): treat explicit model:auto as the inherit sentinel (salvage #56319)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6369,6 +6369,15 @@ def _resolve_task_provider_model(
     # which downstream consumers like ContextCompressor accept as the task output.
     # The provider-side 'auto' is handled in _resolve_auto() via main_runtime
     # fallback, so dropping cfg_model to None here lets that path do its job.
+    #
+    # The explicit `model` kwarg needs the identical normalization: MoA slots
+    # (agent/moa_loop.py's _slot_runtime) forward a preset's `model:` field as
+    # this explicit argument rather than through auxiliary.<task> config, so a
+    # user-configured `model: auto` on a MoA reference/aggregator slot reaches
+    # this function here, not as cfg_model. Only normalizing cfg_model let that
+    # literal "auto" slip through via `model or cfg_model` below.
+    if model and model.lower() == "auto":
+        model = None
     if cfg_model and cfg_model.lower() == "auto":
         cfg_model = None
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -394,6 +394,55 @@ class TestResolveTaskProviderModel:
         assert resolved_provider == "anthropic"
         assert model == "claude-haiku-4-5-20251001"
 
+    def test_explicit_model_auto_sentinel_is_normalized(self):
+        """MoA slots (agent/moa_loop.py's _slot_runtime) forward a preset's
+        `model:` field as the explicit `model` kwarg here, not through
+        auxiliary.<task> config. Only cfg_model was normalized before, so a
+        MoA reference/aggregator slot configured with `model: auto` sent the
+        literal string "auto" to the wire as a model id."""
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            provider="anthropic",
+            model="auto",
+        )
+
+        assert resolved_provider == "anthropic"
+        assert model is None
+
+    def test_explicit_model_auto_sentinel_case_insensitive(self):
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            provider="anthropic",
+            model="AUTO",
+        )
+
+        assert model is None
+
+    def test_explicit_model_auto_falls_back_to_cfg_model(self, monkeypatch):
+        """When the explicit model is the "auto" sentinel, it must not shadow
+        a real configured task model — the `model or cfg_model` fallback
+        chain should still reach cfg_model exactly as if model had been
+        omitted entirely."""
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda _task: {"provider": "openai", "model": "gpt-real-model"},
+        )
+
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="moa_reference",
+            model="auto",
+        )
+
+        assert model == "gpt-real-model"
+
+    def test_non_auto_model_is_unaffected(self):
+        """Regression guard: a real model name must not be touched by the
+        sentinel normalization."""
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            provider="openai",
+            model="gpt-4o-mini",
+        )
+
+        assert model == "gpt-4o-mini"
+
 
 class TestMoaAggregatorSharedResolution:
     """The shared MoA→aggregator helper and the layers that consume it.


### PR DESCRIPTION
## Summary

An explicit `model: "auto"` argument now resolves as the inherit sentinel instead of being sent to the wire as a literal model id. Salvages #56319 (@srojk34, authorship preserved via cherry-pick).

Root cause: `_resolve_task_provider_model()` normalized the `auto` sentinel only on the config-derived `cfg_model` path. MoA reference/aggregator slots (`agent/moa_loop.py::_slot_runtime`) forward the preset's `model:` field as the **explicit** `model` kwarg, which won at `resolved_model = model or cfg_model` — so a slot configured with `model: auto` sent the literal string `"auto"` to the provider, which returns `200 OK` with error text that downstream consumers (e.g. ContextCompressor) accept as valid task output.

## Changes

- `agent/auxiliary_client.py` (+9): normalize the explicit `model` kwarg's `auto` sentinel (case-insensitive) before the `model or cfg_model` resolution, mirroring the existing cfg_model normalization.
- `tests/agent/test_auxiliary_client.py` (+49): 4 regression tests — sentinel normalization, case-insensitivity, cfg_model fallback when explicit model is `auto`, non-auto passthrough guard.

Composes with #69878: a `provider: moa, model: auto` slot now correctly resolves the default MoA preset instead of trying to resolve a preset literally named "auto".

## Validation

| Check | Result |
|---|---|
| tests/agent/test_auxiliary_client.py | 337 pass |
| Premise on main | verified live pre-fix at auxiliary_client.py:6372-6375 |

## Infographic

![auto-sentinel](https://v3b.fal.media/files/b/0aa36bac/oFhlRDZ2T0LkiFPwVE5LV_BKDTPHmU.png)
