### PR TITLE
fix(ui-tui): pluralize the spawn-tree "N subagents" count label

### DIFF
--- a/ui-tui/src/__tests__/spawnHistoryStore.test.ts
+++ b/ui-tui/src/__tests__/spawnHistoryStore.test.ts
@@ -43,4 +43,35 @@ describe('spawnHistoryStore status normalization', () => {
 
     expect(status).toBe('completed')
   })
+
+  it('pluralizes the fallback label as singular for exactly one subagent', () => {
+    pushDiskSnapshot(
+      {
+        finished_at: 1_700_000_021,
+        session_id: 'sess-3',
+        started_at: 1_700_000_020,
+        subagents: [{ goal: 'lone child', id: 'sa-solo', index: 0, status: 'completed' }]
+      },
+      '/tmp/snap-one.json'
+    )
+
+    expect(getSpawnHistory()[0]?.label).toBe('1 subagent')
+  })
+
+  it('pluralizes the fallback label for multiple subagents', () => {
+    pushDiskSnapshot(
+      {
+        finished_at: 1_700_000_031,
+        session_id: 'sess-4',
+        started_at: 1_700_000_030,
+        subagents: [
+          { goal: 'first child', id: 'sa-a', index: 0, status: 'completed' },
+          { goal: 'second child', id: 'sa-b', index: 1, status: 'completed' }
+        ]
+      },
+      '/tmp/snap-two.json'
+    )
+
+    expect(getSpawnHistory()[0]?.label).toBe('2 subagents')
+  })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -439,7 +439,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         .filter(Boolean)
         .slice(0, 2)
 
-      const label = top.length ? top.join(' · ') : `${subagents.length} subagents`
+      const label = top.length ? top.join(' · ') : `${subagents.length} subagent${subagents.length === 1 ? '' : 's'}`
 
       await rpc('spawn_tree.save', {
         finished_at: Date.now() / 1000,

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -360,7 +360,7 @@ export const opsCommands: SlashCommand[] = [
 
               const rows: [string, string][] = entries.map(e => {
                 const ts = e.finished_at ? new Date(e.finished_at * 1000).toLocaleString() : '?'
-                const label = e.label || `${e.count} subagents`
+                const label = e.label || `${e.count} subagent${e.count === 1 ? '' : 's'}`
 
                 return [`${ts} · ${e.count}×`, `${label}\n  ${e.path}`]
               })

--- a/ui-tui/src/app/spawnHistoryStore.ts
+++ b/ui-tui/src/app/spawnHistoryStore.ts
@@ -112,7 +112,7 @@ export const pushDiskSnapshot = (r: SpawnTreeLoadResponse, path: string) => {
     finishedAt: (r.finished_at ?? Date.now() / 1000) * 1000,
     fromDisk: true,
     id: `disk-${path}`,
-    label: r.label || `${normalised.length} subagents`,
+    label: r.label || `${normalised.length} subagent${normalised.length === 1 ? '' : 's'}`,
     path,
     sessionId: r.session_id ?? null,
     startedAt: (r.started_at ?? r.finished_at ?? Date.now() / 1000) * 1000,


### PR DESCRIPTION
## What does this PR do?

Fixes an ungrammatical **"1 subagents"** in the TUI spawn-tree label. Three
spots build the spawn-tree fallback label by hard-coding the plural noun on a
dynamic count, so the common single-delegation case renders "1 subagents":

1. `ui-tui/src/app/createGatewayEventHandler.ts` — the `spawn_tree.save`
   fallback label (`${subagents.length} subagents`), which is then persisted.
2. `ui-tui/src/app/spawnHistoryStore.ts` — the `pushDiskSnapshot` fallback
   (`${normalised.length} subagents`) used when a disk snapshot has no label.
3. `ui-tui/src/app/slash/commands/ops.ts` — the `/replay list` panel render
   (`${e.count} subagents`).

Each site now pluralizes its existing `subagent` noun against the count. This
is exactly the convention the in-file sibling `summarizeLabel`
(`ui-tui/src/app/spawnHistoryStore.ts`, ~20 lines above the fixed
`pushDiskSnapshot` line) already uses:

```ts
return top || `${subagents.length} agent${subagents.length === 1 ? '' : 's'}`
```

The noun is deliberately left as `subagent` at each site (not unified to
`summarizeLabel`'s `agent`) — that wording is a pre-existing per-site choice and
out of scope here.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/app/createGatewayEventHandler.ts`: `${subagents.length} subagents` → `${subagents.length} subagent${subagents.length === 1 ? '' : 's'}`
- `ui-tui/src/app/spawnHistoryStore.ts`: `${normalised.length} subagents` → `${normalised.length} subagent${normalised.length === 1 ? '' : 's'}`
- `ui-tui/src/app/slash/commands/ops.ts`: `${e.count} subagents` → `${e.count} subagent${e.count === 1 ? '' : 's'}`
- `ui-tui/src/__tests__/spawnHistoryStore.test.ts`: regression coverage on the `pushDiskSnapshot` fallback seam.

## How to Test

1. `cd ui-tui && npm run build:ink && npx vitest run src/__tests__/spawnHistoryStore.test.ts`
2. New cases assert the fallback label is `1 subagent` for a one-subagent
   snapshot (fails before this change with `1 subagents`) and `2 subagents`
   for two.
3. `npm run typecheck` and `npm run lint` are clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suite (`ui-tui` vitest) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A