### PR TITLE
fix(credential_pool): lock the public pool query surface (#62614 salvage)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -596,7 +596,8 @@ class CredentialPool:
         self._last_no_entries_log_at: Optional[float] = None
 
     def has_credentials(self) -> bool:
-        return bool(self._entries)
+        with self._lock:
+            return bool(self._entries)
 
     def has_available(self) -> bool:
         """True if at least one entry is not currently in exhaustion cooldown."""
@@ -1922,76 +1923,80 @@ class CredentialPool:
         return refreshed
 
     def reset_statuses(self) -> int:
-        count = 0
-        new_entries = []
-        for entry in self._entries:
-            if entry.last_status or entry.last_status_at or entry.last_error_code:
-                new_entries.append(
-                    replace(
-                        entry,
-                        last_status=None,
-                        last_status_at=None,
-                        last_error_code=None,
-                        last_error_reason=None,
-                        last_error_message=None,
-                        last_error_reset_at=None,
+        with self._lock:
+            count = 0
+            new_entries = []
+            for entry in self._entries:
+                if entry.last_status or entry.last_status_at or entry.last_error_code:
+                    new_entries.append(
+                        replace(
+                            entry,
+                            last_status=None,
+                            last_status_at=None,
+                            last_error_code=None,
+                            last_error_reason=None,
+                            last_error_message=None,
+                            last_error_reset_at=None,
+                        )
                     )
-                )
-                count += 1
-            else:
-                new_entries.append(entry)
-        if count:
-            self._entries = new_entries
-            self._persist()
-        return count
+                    count += 1
+                else:
+                    new_entries.append(entry)
+            if count:
+                self._entries = new_entries
+                self._persist()
+            return count
 
     def remove_index(self, index: int) -> Optional[PooledCredential]:
-        if index < 1 or index > len(self._entries):
-            return None
-        removed = self._entries.pop(index - 1)
-        self._entries = [
-            replace(entry, priority=new_priority)
-            for new_priority, entry in enumerate(self._entries)
-        ]
-        write_credential_pool(
-            self.provider,
-            [entry.to_dict() for entry in self._entries],
-            removed_ids=[removed.id],
-        )
-        if self._current_id == removed.id:
-            self._current_id = None
-        return removed
+        with self._lock:
+            if index < 1 or index > len(self._entries):
+                return None
+            removed = self._entries.pop(index - 1)
+            self._entries = [
+                replace(entry, priority=new_priority)
+                for new_priority, entry in enumerate(self._entries)
+            ]
+            write_credential_pool(
+                self.provider,
+                [entry.to_dict() for entry in self._entries],
+                removed_ids=[removed.id],
+            )
+            if self._current_id == removed.id:
+                self._current_id = None
+            return removed
 
     def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
         raw = str(target or "").strip()
         if not raw:
             return None, None, "No credential target provided."
 
-        for idx, entry in enumerate(self._entries, start=1):
-            if entry.id == raw:
-                return idx, entry, None
+        with self._lock:
+            for idx, entry in enumerate(self._entries, start=1):
+                if entry.id == raw:
+                    return idx, entry, None
 
-        label_matches = [
-            (idx, entry)
-            for idx, entry in enumerate(self._entries, start=1)
-            if entry.label.strip().lower() == raw.lower()
-        ]
-        if len(label_matches) == 1:
-            return label_matches[0][0], label_matches[0][1], None
-        if len(label_matches) > 1:
-            return None, None, f'Ambiguous credential label "{raw}". Use the numeric index or entry id instead.'
-        if raw.isdigit():
-            index = int(raw)
-            if 1 <= index <= len(self._entries):
-                return index, self._entries[index - 1], None
-            return None, None, f"No credential #{index}."
-        return None, None, f'No credential matching "{raw}".'
+            label_matches = [
+                (idx, entry)
+                for idx, entry in enumerate(self._entries, start=1)
+                if entry.label.strip().lower() == raw.lower()
+            ]
+            if len(label_matches) == 1:
+                return label_matches[0][0], label_matches[0][1], None
+            if len(label_matches) > 1:
+                return None, None, f'Ambiguous credential label "{raw}". Use the numeric index or entry id instead.'
+            if raw.isdigit():
+                index = int(raw)
+                if 1 <= index <= len(self._entries):
+                    return index, self._entries[index - 1], None
+                return None, None, f"No credential #{index}."
+            return None, None, f'No credential matching "{raw}".'
 
     def add_entry(self, entry: PooledCredential) -> PooledCredential:
-        entry = replace(entry, priority=_next_priority(self._entries))
-        self._entries.append(entry)
-        self._persist()
-        return entry
+        with self._lock:
+            entry = replace(entry, priority=_next_priority(self._entries))
+            self._entries.append(entry)
+            self._persist()
+            return entry
 
 
 def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, payload: Dict[str, Any]) -> bool:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -600,15 +600,26 @@ class CredentialPool:
 
     def has_available(self) -> bool:
         """True if at least one entry is not currently in exhaustion cooldown."""
-        return bool(self._available_entries())
+        # ``_available_entries`` is not read-only: it prunes aged-out DEAD
+        # manual entries (rebinding ``self._entries``) and persists.  It must
+        # run under ``self._lock`` like every other caller (``select`` etc.),
+        # otherwise a status probe here can race a concurrent ``select`` /
+        # rotation and tear ``self._entries`` or double-write auth.json.
+        with self._lock:
+            return bool(self._available_entries())
 
     def entries(self) -> List[PooledCredential]:
-        return list(self._entries)
+        with self._lock:
+            return list(self._entries)
 
-    def current(self) -> Optional[PooledCredential]:
+    def _current_unlocked(self) -> Optional[PooledCredential]:
         if not self._current_id:
             return None
         return next((entry for entry in self._entries if entry.id == self._current_id), None)
+
+    def current(self) -> Optional[PooledCredential]:
+        with self._lock:
+            return self._current_unlocked()
 
     def _replace_entry(self, old: PooledCredential, new: PooledCredential) -> None:
         """Swap an entry in-place by id, preserving sort order."""
@@ -1729,18 +1740,21 @@ class CredentialPool:
             self._entries = [replace(candidate, priority=idx) for idx, candidate in enumerate(rotated)]
             self._persist()
             self._current_id = entry.id
-            return self.current() or entry
+            return self._current_unlocked() or entry
 
         entry = available[0]
         self._current_id = entry.id
         return entry
 
     def peek(self) -> Optional[PooledCredential]:
-        current = self.current()
-        if current is not None:
-            return current
-        available = self._available_entries()
-        return available[0] if available else None
+        # Single lock acquisition for the whole read; call the unlocked
+        # helpers so we don't re-enter the non-reentrant ``self._lock``.
+        with self._lock:
+            current = self._current_unlocked()
+            if current is not None:
+                return current
+            available = self._available_entries()
+            return available[0] if available else None
 
     def mark_exhausted_and_rotate(
         self,
@@ -1775,7 +1789,7 @@ class CredentialPool:
                     self._current_id = None
                     return self._select_unlocked()
             if entry is None:
-                entry = self.current() or self._select_unlocked()
+                entry = self._current_unlocked() or self._select_unlocked()
             if entry is None:
                 return None
             _label = entry.label or entry.id[:8]
@@ -1899,7 +1913,7 @@ class CredentialPool:
             return self._try_refresh_current_unlocked()
 
     def _try_refresh_current_unlocked(self) -> Optional[PooledCredential]:
-        entry = self.current()
+        entry = self._current_unlocked()
         if entry is None:
             return None
         refreshed = self._refresh_entry(entry, force=True)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1907,7 +1907,7 @@ class CredentialPool:
                     None,
                 )
             else:
-                entry = self.current() or self._select_unlocked(refresh=False)
+                entry = self._current_unlocked() or self._select_unlocked(refresh=False)
             if entry is None:
                 return None
             self._current_id = entry.id

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -3585,15 +3585,25 @@ def _load_two_ok_pool(tmp_path, monkeypatch):
     return load_pool("anthropic")
 
 
+def _fresh_entry(pool):
+    """A copy of the pool's first entry under a new id, for add_entry()."""
+    from dataclasses import replace as dc_replace
+
+    return dc_replace(pool.entries()[0], id="cred-new")
+
+
 class TestCredentialPoolQueryLocking:
-    """Read/status methods must run under ``self._lock``.
+    """Public pool-state methods must run under ``self._lock``.
 
     ``has_available``/``peek``/``current``/``entries`` all touch
     ``self._entries`` (and ``_available_entries`` even prunes + persists),
-    so they must hold the same lock every mutating entry point uses.  A
-    naive fix would deadlock because the lock is non-reentrant and ``peek``
-    calls ``current`` + ``_available_entries``; these tests guard both the
-    no-deadlock and the actually-locked properties.
+    and the management surface (``has_credentials``/``reset_statuses``/
+    ``remove_index``/``resolve_target``/``add_entry``) reads or rebinds
+    ``self._entries`` and persists auth.json, so they must all hold the
+    same lock every mutating entry point uses.  A naive fix would deadlock
+    because the lock is non-reentrant and ``peek`` calls ``current`` +
+    ``_available_entries``; these tests guard both the no-deadlock and the
+    actually-locked properties.
     """
 
     def test_query_methods_do_not_deadlock(self, tmp_path, monkeypatch):
@@ -3605,33 +3615,81 @@ class TestCredentialPoolQueryLocking:
         assert pool.current() is not None
         assert pool.peek() is not None
         assert pool.has_available() is True
+        assert pool.has_credentials() is True
+        assert pool.resolve_target("cred-1")[1] is not None
         # (env may seed extra singleton entries; just assert ours are present)
         assert {"cred-1", "cred-2"} <= {e.id for e in pool.entries()}
 
-    @pytest.mark.parametrize("method", ["has_available", "peek", "current", "entries"])
-    def test_query_method_acquires_lock(self, tmp_path, monkeypatch, method):
+    @pytest.mark.parametrize(
+        "method,get_args",
+        [
+            ("has_available", lambda pool: ()),
+            ("peek", lambda pool: ()),
+            ("current", lambda pool: ()),
+            ("entries", lambda pool: ()),
+            ("has_credentials", lambda pool: ()),
+            ("reset_statuses", lambda pool: ()),
+            ("resolve_target", lambda pool: ("cred-1",)),
+            ("remove_index", lambda pool: (1,)),
+            ("add_entry", lambda pool: (_fresh_entry(pool),)),
+        ],
+    )
+    def test_query_method_acquires_lock(self, tmp_path, monkeypatch, method, get_args):
         import threading
 
         pool = _load_two_ok_pool(tmp_path, monkeypatch)
         pool.select()
+        args = get_args(pool)
+
+        inner = pool._lock
+
+        class _InstrumentedLock:
+            """Probe that records acquire attempts, so the test can prove the
+            worker actually reached ``self._lock`` before asserting that it
+            blocks (a plain timed wait passes spuriously if the worker is
+            simply never scheduled)."""
+
+            def __init__(self):
+                self.attempted = threading.Event()
+
+            def acquire(self, *args, **kwargs):
+                self.attempted.set()
+                return inner.acquire(*args, **kwargs)
+
+            def release(self):
+                inner.release()
+
+            def __enter__(self):
+                self.acquire()
+                return self
+
+            def __exit__(self, *exc):
+                self.release()
+
+        probe = _InstrumentedLock()
+        pool._lock = probe
 
         done = threading.Event()
 
         def _call():
-            getattr(pool, method)()
+            getattr(pool, method)(*args)
             done.set()
 
-        # Hold the pool lock, then fire the query on another thread. If the
-        # method acquires self._lock (as it must), it blocks until we release.
-        pool._lock.acquire()
+        # Hold the real lock (without tripping the probe), then fire the query
+        # on another thread. If the method acquires self._lock (as it must),
+        # it blocks until we release.
+        inner.acquire()
         try:
             worker = threading.Thread(target=_call, daemon=True)
             worker.start()
+            assert probe.attempted.wait(timeout=2.0), (
+                f"{method}() never attempted to acquire self._lock"
+            )
             assert not done.wait(timeout=0.5), (
                 f"{method}() returned while the pool lock was held — it is not "
-                f"acquiring self._lock"
+                f"blocking on self._lock"
             )
         finally:
-            pool._lock.release()
+            inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -3555,3 +3555,83 @@ def test_sync_anthropic_entry_clears_all_error_fields(tmp_path, monkeypatch):
     assert synced.last_error_reason is None
     assert synced.last_error_message is None
     assert synced.last_error_reset_at is None
+
+
+def _load_two_ok_pool(tmp_path, monkeypatch):
+    """A pool with two OK anthropic entries, current = cred-1."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-1", "label": "primary", "auth_type": "api_key",
+                        "priority": 0, "source": "manual", "access_token": "***",
+                        "last_status": "ok", "last_status_at": None, "last_error_code": None,
+                    },
+                    {
+                        "id": "cred-2", "label": "secondary", "auth_type": "api_key",
+                        "priority": 1, "source": "manual", "access_token": "***",
+                        "last_status": "ok", "last_status_at": None, "last_error_code": None,
+                    },
+                ]
+            },
+        },
+    )
+    from agent.credential_pool import load_pool
+
+    return load_pool("anthropic")
+
+
+class TestCredentialPoolQueryLocking:
+    """Read/status methods must run under ``self._lock``.
+
+    ``has_available``/``peek``/``current``/``entries`` all touch
+    ``self._entries`` (and ``_available_entries`` even prunes + persists),
+    so they must hold the same lock every mutating entry point uses.  A
+    naive fix would deadlock because the lock is non-reentrant and ``peek``
+    calls ``current`` + ``_available_entries``; these tests guard both the
+    no-deadlock and the actually-locked properties.
+    """
+
+    def test_query_methods_do_not_deadlock(self, tmp_path, monkeypatch):
+        pool = _load_two_ok_pool(tmp_path, monkeypatch)
+        pool.select()  # set a current entry
+
+        # peek() internally calls current() + _available_entries(); if any of
+        # these re-acquired the non-reentrant lock we'd hang here forever.
+        assert pool.current() is not None
+        assert pool.peek() is not None
+        assert pool.has_available() is True
+        # (env may seed extra singleton entries; just assert ours are present)
+        assert {"cred-1", "cred-2"} <= {e.id for e in pool.entries()}
+
+    @pytest.mark.parametrize("method", ["has_available", "peek", "current", "entries"])
+    def test_query_method_acquires_lock(self, tmp_path, monkeypatch, method):
+        import threading
+
+        pool = _load_two_ok_pool(tmp_path, monkeypatch)
+        pool.select()
+
+        done = threading.Event()
+
+        def _call():
+            getattr(pool, method)()
+            done.set()
+
+        # Hold the pool lock, then fire the query on another thread. If the
+        # method acquires self._lock (as it must), it blocks until we release.
+        pool._lock.acquire()
+        try:
+            worker = threading.Thread(target=_call, daemon=True)
+            worker.start()
+            assert not done.wait(timeout=0.5), (
+                f"{method}() returned while the pool lock was held — it is not "
+                f"acquiring self._lock"
+            )
+        finally:
+            pool._lock.release()
+
+        assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -3619,6 +3619,11 @@ class TestCredentialPoolQueryLocking:
         assert pool.resolve_target("cred-1")[1] is not None
         # (env may seed extra singleton entries; just assert ours are present)
         assert {"cred-1", "cred-2"} <= {e.id for e in pool.entries()}
+        # try_refresh_matching's no-hint branch resolves the current entry
+        # while already holding the lock — must use _current_unlocked(), not
+        # current(), or it deadlocks on the non-reentrant lock (found when
+        # rebasing this fix over the #69843 salvage which added the method).
+        pool.try_refresh_matching()
 
     @pytest.mark.parametrize(
         "method,get_args",


### PR DESCRIPTION
## Summary

Salvage of #62614 by @solyanviktor-star: every public `CredentialPool` state method now runs under `self._lock`. Previously `has_available` / `peek` / `current` / `entries` / `has_credentials` (plus the management surface: `reset_statuses` / `remove_index` / `resolve_target` / `add_entry`) read — and in `has_available`'s case pruned and persisted — shared pool state with no lock, racing against `select` / `mark_exhausted_and_rotate` / refresh, which all mutate under the lock. Gateway and auxiliary threads call these queries concurrently with rotation on every turn.

The lock is a non-reentrant `threading.Lock`, so the fix introduces `_current_unlocked()` and reroutes every in-lock caller — one lock boundary, unlocked helpers inside.

## The merge hazard we caught (and fixed)

The PR predates our #69843 salvage, which added `try_refresh_matching()` — it calls `self.current()` **inside** `with self._lock:`. Git merges the two changes with zero textual conflict, but the merged tree deadlocks the moment `try_refresh_matching` runs with no/unmatched hint (live callers: the 401 recovery path and `tools/xai_http.py`). Fixed with `_current_unlocked()` and covered in the no-deadlock test so the class of bug can't silently return.

## Changes

- `agent/credential_pool.py` (contributor, 2 commits cherry-picked): lock acquisition in the 4 query methods + 5 management methods; `_current_unlocked()` helper; all in-lock `current()` callers rerouted.
- `agent/credential_pool.py` (follow-up): `try_refresh_matching` no-hint branch uses `_current_unlocked()` — the silent-merge deadlock.
- Tests (contributor): parametrized 9-method matrix with an instrumented-lock probe (proves the worker actually reaches `self._lock` before asserting it blocks — no spurious passes) + no-deadlock smoke test. Follow-up: `try_refresh_matching` added to the no-deadlock test.

## Validation

- 372 targeted tests green across 6 files (`test_credential_pool.py`, `test_credential_pool_routing.py`, `test_credential_pool_interrupt.py`, `test_codex_xai_oauth_recovery.py`, `test_anthropic_adapter.py`, `test_auth_codex_quota_probe.py`).
- Live E2E with a real 4-entry pool: (1) no-hint `try_refresh_matching` completes in <5s on a background thread (hangs forever pre-follow-up on the merged tree); (2) 4 reader threads + 1 rotator hammering the pool for 3s — no hang, no exceptions.

Closes #62614's scope.

## Credit

Locking design, both commits, and the instrumented test matrix by @solyanviktor-star (#62614), cherry-picked with authorship preserved. The `try_refresh_matching` deadlock fix (a post-PR merge hazard) added on top.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa36bc4/fH3KldJVN4eN5RvVfUhMy_zfQ5cgxE.png)
