### PR TITLE
feat(api-server): SSE resume for /v1/runs/{id}/events via Last-Event-ID

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -44,6 +44,7 @@ import errno
 import hashlib
 import hmac
 import json
+from collections import deque
 from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar
 from functools import wraps
@@ -55,7 +56,7 @@ import sys
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
@@ -1041,9 +1042,18 @@ class APIServerAdapter(BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
-        # Active run streams: run_id -> asyncio.Queue of SSE event dicts
-        self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
-        # Creation timestamps for orphaned-run TTL sweep
+        # Per-run replay log: run_id -> bounded deque of (seq, event) tuples.
+        # seq is a per-run monotonically increasing id emitted as the SSE
+        # `id:` field, so reconnecting clients can resume via Last-Event-ID.
+        self._run_event_logs: Dict[str, "deque[Tuple[int, Dict]]"] = {}
+        self._run_event_seqs: Dict[str, int] = {}
+        # Live subscriber queues: run_id -> set of asyncio.Queue, one per
+        # connected SSE consumer. Events fan out to all of them; the replay
+        # log above is the source of truth for resume.
+        self._run_subscriber_queues: Dict[str, "Set[asyncio.Queue]"] = {}
+        # Orphan-TTL basis timestamps. Set at run creation and refreshed when
+        # the last SSE subscriber disconnects, so a reconnecting client gets a
+        # full _RUN_STREAM_TTL window to resume before the log is swept.
         self._run_streams_created: Dict[str, float] = {}
         # Runs with a connected SSE consumer; their queue is actively draining.
         self._run_stream_subscribers: set[str] = set()
@@ -4838,6 +4848,38 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
+    _RUN_EVENT_LOG_CAP = 4096  # per-run replay buffer bound (events)
+    _TERMINAL_RUN_STATUSES = frozenset({"completed", "failed", "cancelled"})
+
+    def _publish_run_event(self, run_id: str, event: Optional[Dict]) -> int:
+        """Append a run event to the replay log and fan out to live subscribers.
+
+        Returns the assigned seq (monotonic per run), or -1 when the event was
+        dropped. `None` is the stream-close sentinel: delivered to live
+        subscribers but never stored — a late subscriber recovers the terminal
+        state from the replayed log / GET /v1/runs/{run_id} instead. Events
+        for a swept run (replay log gone) are dropped so an unconsumed run
+        cannot grow buffers without bound.
+        """
+        if event is None:
+            for q in list(self._run_subscriber_queues.get(run_id, ())):
+                try:
+                    q.put_nowait(None)
+                except Exception:
+                    pass
+            return -1
+        log = self._run_event_logs.get(run_id)
+        if log is None:
+            return -1
+        seq = self._run_event_seqs.get(run_id, 0)
+        self._run_event_seqs[run_id] = seq + 1
+        log.append((seq, event))
+        for q in list(self._run_subscriber_queues.get(run_id, ())):
+            try:
+                q.put_nowait((seq, event))
+            except Exception:
+                pass
+        return seq
 
     def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
@@ -4855,18 +4897,17 @@ class APIServerAdapter(BasePlatformAdapter):
         return current
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
-        """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
+        """Return a tool_progress_callback that pushes structured events to the run's SSE log."""
         def _push(event: Dict[str, Any]) -> None:
             self._set_run_status(
                 run_id,
                 self._run_statuses.get(run_id, {}).get("status", "running"),
                 last_event=event.get("event"),
             )
-            q = self._run_streams.get(run_id)
-            if q is None:
+            if run_id not in self._run_event_logs:
                 return
             try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
+                loop.call_soon_threadsafe(self._publish_run_event, run_id, event)
             except Exception:
                 pass
 
@@ -4984,24 +5025,23 @@ class APIServerAdapter(BasePlatformAdapter):
         approval_session_key = run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
-        q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
         created_at = time.time()
-        self._run_streams[run_id] = q
+        self._run_event_logs[run_id] = deque(maxlen=self._RUN_EVENT_LOG_CAP)
+        self._run_event_seqs[run_id] = 0
         self._run_streams_created[run_id] = created_at
         self._run_approval_sessions[run_id] = approval_session_key
 
         event_cb = self._make_run_event_callback(run_id, loop)
 
         def _put_event_if_active(event: Optional[Dict]) -> None:
-            """Enqueue only while this run still owns live transport state."""
-            if self._run_streams.get(run_id) is q:
-                q.put_nowait(event)
+            """Publish only while this run's replay log still exists (drops after sweep)."""
+            self._publish_run_event(run_id, event)
 
         # Also wire stream_delta_callback so message.delta events flow through.
         def _text_cb(delta: Optional[str]) -> None:
             if delta is None:
                 return
-            if run_id not in self._run_streams:
+            if run_id not in self._run_event_logs:
                 return
             try:
                 loop.call_soon_threadsafe(_put_event_if_active, {
@@ -5264,23 +5304,43 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response(status)
 
     async def _handle_run_events(self, request: "web.Request") -> "web.StreamResponse":
-        """GET /v1/runs/{run_id}/events — SSE stream of structured agent lifecycle events."""
+        """GET /v1/runs/{run_id}/events — SSE stream of structured agent lifecycle events.
+
+        Resume support: every event frame carries an SSE `id:` field (per-run
+        monotonic seq). A reconnecting client passes `Last-Event-ID` (or the
+        `?since=<seq>` query param) and first receives buffered events newer
+        than the cursor, then continues live. The replay buffer is bounded
+        (_RUN_EVENT_LOG_CAP) and swept with the orphan TTL; when the cursor is
+        older than the oldest buffered event, the stream resumes from what is
+        available — clients should treat that gap as a signal to re-sync via
+        GET /v1/runs/{run_id} (terminal status carries the final output) or
+        session history. Subscribing after a run finished replays the buffer
+        and closes immediately, so late/again consumers no longer hit 404.
+        """
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
 
         run_id = request.match_info["run_id"]
 
+        cursor = -1
+        raw_cursor = request.headers.get("Last-Event-ID") or request.query.get("since")
+        if raw_cursor:
+            try:
+                cursor = max(-1, int(str(raw_cursor).strip()))
+            except (TypeError, ValueError):
+                return web.json_response(
+                    _openai_error(f"Invalid resume cursor: {raw_cursor!r}", code="invalid_cursor"),
+                    status=400,
+                )
+
         # Allow subscribing slightly before the run is registered (race condition window)
         for _ in range(20):
-            if run_id in self._run_streams:
+            if run_id in self._run_event_logs:
                 break
             await asyncio.sleep(0.05)
         else:
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
-
-        q = self._run_streams[run_id]
-        self._run_stream_subscribers.add(run_id)
 
         response = web.StreamResponse(
             status=200,
@@ -5292,25 +5352,59 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         await response.prepare(request)
 
+        async def _write_event(seq: int, event: Dict) -> None:
+            payload = f"id: {seq}\ndata: {json.dumps(event)}\n\n"
+            await response.write(payload.encode())
+
+        q: "asyncio.Queue" = asyncio.Queue()
+        self._run_subscriber_queues.setdefault(run_id, set()).add(q)
+        self._run_stream_subscribers.add(run_id)
+        last_seq = cursor
         try:
+            # Replay buffered events newer than the cursor. Events published
+            # during the replay also land in q and are deduped by seq below.
+            for seq, event in list(self._run_event_logs.get(run_id, ())):
+                if seq > last_seq:
+                    await _write_event(seq, event)
+                    last_seq = seq
+
+            if self._run_statuses.get(run_id, {}).get("status") in self._TERMINAL_RUN_STATUSES:
+                # Late subscriber attaching after the run finished: the replay
+                # above is the whole story — close instead of waiting for a
+                # close sentinel that already went out.
+                await response.write(b": stream closed\n\n")
+                return response
+
+            # Live phase ends on the None sentinel published when the run
+            # settles (guaranteed to arrive after the terminal event, so no
+            # terminal-status polling here that could strand queued events).
             while True:
                 try:
-                    event = await asyncio.wait_for(q.get(), timeout=30.0)
+                    item = await asyncio.wait_for(q.get(), timeout=30.0)
                 except asyncio.TimeoutError:
                     await response.write(b": keepalive\n\n")
                     continue
-                if event is None:
-                    # Run finished — send final SSE comment and close
-                    await response.write(b": stream closed\n\n")
+                if item is None:
                     break
-                payload = f"data: {json.dumps(event)}\n\n"
-                await response.write(payload.encode())
+                seq, event = item
+                if seq <= last_seq:
+                    continue  # already sent during the replay phase
+                await _write_event(seq, event)
+                last_seq = seq
+            await response.write(b": stream closed\n\n")
         except Exception as exc:
             logger.debug("[api_server] SSE stream error for run %s: %s", run_id, exc)
         finally:
             self._run_stream_subscribers.discard(run_id)
-            self._run_streams.pop(run_id, None)
-            self._run_streams_created.pop(run_id, None)
+            queues = self._run_subscriber_queues.get(run_id)
+            if queues is not None:
+                queues.discard(q)
+                if not queues:
+                    # Last consumer gone: restart the orphan clock so a
+                    # reconnecting client gets a full TTL window to resume.
+                    self._run_subscriber_queues.pop(run_id, None)
+                    if run_id in self._run_streams_created:
+                        self._run_streams_created[run_id] = time.time()
 
         return response
 
@@ -5383,18 +5477,13 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         self._set_run_status(run_id, "running", last_event="approval.responded")
-        q = self._run_streams.get(run_id)
-        if q is not None:
-            try:
-                q.put_nowait({
-                    "event": "approval.responded",
-                    "run_id": run_id,
-                    "timestamp": time.time(),
-                    "choice": choice,
-                    "resolved": resolved,
-                })
-            except Exception:
-                pass
+        self._publish_run_event(run_id, {
+            "event": "approval.responded",
+            "run_id": run_id,
+            "timestamp": time.time(),
+            "choice": choice,
+            "resolved": resolved,
+        })
 
         return web.json_response({
             "object": "hermes.run.approval_response",
@@ -5434,7 +5523,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._sweep_orphaned_runs_once(time.time())
 
     def _sweep_orphaned_runs_once(self, now: Optional[float] = None) -> None:
-        """Expire old SSE buffers without treating transport age as run age."""
+        """Expire old replay logs without treating transport age as run age."""
         if now is None:
             now = time.time()
         stale = [
@@ -5458,7 +5547,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     pass
             # The transport TTL always bounds buffering. Live control state is
             # independent and survives until the executor-backed task returns.
-            self._run_streams.pop(run_id, None)
+            self._run_event_logs.pop(run_id, None)
+            self._run_event_seqs.pop(run_id, None)
+            self._run_subscriber_queues.pop(run_id, None)
             self._run_streams_created.pop(run_id, None)
             if task_done:
                 self._active_run_agents.pop(run_id, None)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -615,7 +615,7 @@ class TestConcurrencyCap:
 
             tasks = [asyncio.create_task(_live_run()) for _ in range(2)]
             adapter._active_run_tasks = {f"r{i}": task for i, task in enumerate(tasks)}
-            adapter._run_streams = {}
+            adapter._run_event_logs = {}
             try:
                 resp = adapter._concurrency_limited_response()
                 assert resp is not None
@@ -919,8 +919,8 @@ class TestHealthDetailedEndpoint:
             "done": {"status": "completed"},
             "failed": {"status": "failed"},
         }
-        # Completed streams may remain attached for replay; they are not work.
-        adapter._run_streams = {"done": object(), "failed": object()}
+        # Completed replay logs may remain attached for resume; they are not work.
+        adapter._run_event_logs = {"done": object(), "failed": object()}
 
         with patch("tools.process_registry.process_registry.completion_queue.qsize", return_value=4), \
              patch("tools.async_delegation.active_count", return_value=2):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,8 @@ Covers:
 """
 
 import asyncio
+from collections import deque
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -181,7 +183,7 @@ class TestStartRun:
                 json={"input": "hello", "conversation_history": {"role": "user"}},
             )
         assert resp.status == 400
-        assert adapter._run_streams == {}
+        assert adapter._run_event_logs == {}
         assert adapter._run_statuses == {}
 
     @pytest.mark.asyncio
@@ -463,6 +465,181 @@ class TestRunEvents:
 
 
 # ---------------------------------------------------------------------------
+# GET /v1/runs/{run_id}/events — replay / resume
+# ---------------------------------------------------------------------------
+
+
+def _seed_live_run(adapter, run_id: str) -> None:
+    """Register a running run's replay state without booting an agent."""
+    adapter._run_event_logs[run_id] = deque(maxlen=adapter._RUN_EVENT_LOG_CAP)
+    adapter._run_event_seqs[run_id] = 0
+    adapter._run_streams_created[run_id] = time.time()
+    adapter._set_run_status(run_id, "running")
+
+
+def _parse_sse_frames(body: str) -> list[tuple[str | None, dict]]:
+    """Parse SSE body into (id, data-json) frames; skips comment-only frames."""
+    frames = []
+    for chunk in body.split("\n\n"):
+        frame_id, data_lines = None, []
+        for line in chunk.split("\n"):
+            if line.startswith("id:"):
+                frame_id = line[3:].strip()
+            elif line.startswith("data:"):
+                data_lines.append(line[5:].strip())
+        if data_lines:
+            frames.append((frame_id, json.loads("\n".join(data_lines))))
+    return frames
+
+
+class TestRunEventsResume:
+    @pytest.mark.asyncio
+    async def test_event_frames_carry_sse_id(self, adapter):
+        """Every event frame carries an `id:` line for cursor-based resume."""
+        app = _create_runs_app(adapter)
+        _seed_live_run(adapter, "run_ids")
+        adapter._set_run_status("run_ids", "completed", last_event="run.completed")
+        adapter._publish_run_event("run_ids", {"event": "run.completed", "run_id": "run_ids", "output": "ok"})
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/runs/run_ids/events")
+            body = await resp.text()
+        frames = _parse_sse_frames(body)
+        assert frames and all(frame_id is not None for frame_id, _ in frames)
+        assert [frame_id for frame_id, _ in frames] == ["0"]
+        assert ": stream closed" in body
+
+    @pytest.mark.asyncio
+    async def test_subscribe_after_completion_replays_log(self, adapter):
+        """Late subscriber gets the full buffered history, not a 404."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "Hello!"}
+                mock_agent.session_prompt_tokens = 10
+                mock_agent.session_completion_tokens = 5
+                mock_agent.session_total_tokens = 15
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                # Let the run settle without any subscriber attached.
+                for _ in range(40):
+                    if adapter._run_statuses.get(run_id, {}).get("status") == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+                assert adapter._run_statuses[run_id]["status"] == "completed"
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+                assert "run.completed" in body
+                assert "Hello!" in body
+                assert ": stream closed" in body
+
+    @pytest.mark.asyncio
+    async def test_resume_with_since_replays_only_newer_events(self, adapter):
+        """?since=<seq> skips buffered events at/below the cursor, then goes live."""
+        app = _create_runs_app(adapter)
+        run_id = "run_resume"
+        _seed_live_run(adapter, run_id)
+        for i in range(3):
+            adapter._publish_run_event(run_id, {"event": "message.delta", "run_id": run_id, "delta": f"d{i}"})
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(f"/v1/runs/{run_id}/events?since=1")
+            assert resp.status == 200
+            # Replay delivers only seq 2; a live publish follows on the same stream.
+            adapter._publish_run_event(run_id, {"event": "message.delta", "run_id": run_id, "delta": "d3"})
+            adapter._set_run_status(run_id, "completed", last_event="run.completed")
+            adapter._publish_run_event(run_id, {"event": "run.completed", "run_id": run_id})
+            adapter._publish_run_event(run_id, None)
+            body = await asyncio.wait_for(resp.text(), 3)
+
+        frames = _parse_sse_frames(body)
+        deltas = [event["delta"] for _, event in frames if event.get("event") == "message.delta"]
+        assert deltas == ["d2", "d3"]
+        assert [frame_id for frame_id, _ in frames] == ["2", "3", "4"]
+
+    @pytest.mark.asyncio
+    async def test_resume_with_last_event_id_header(self, adapter):
+        """The standard Last-Event-ID header is honored like ?since=."""
+        app = _create_runs_app(adapter)
+        run_id = "run_header"
+        _seed_live_run(adapter, run_id)
+        for i in range(2):
+            adapter._publish_run_event(run_id, {"event": "message.delta", "run_id": run_id, "delta": f"d{i}"})
+        adapter._set_run_status(run_id, "completed", last_event="run.completed")
+        adapter._publish_run_event(run_id, {"event": "run.completed", "run_id": run_id})
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                f"/v1/runs/{run_id}/events",
+                headers={"Last-Event-ID": "0"},
+            )
+            body = await resp.text()
+        frames = _parse_sse_frames(body)
+        assert [event.get("event") for _, event in frames] == ["message.delta", "run.completed"]
+        assert [frame_id for frame_id, _ in frames] == ["1", "2"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_cursor_returns_400(self, adapter):
+        app = _create_runs_app(adapter)
+        _seed_live_run(adapter, "run_bad_cursor")
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/runs/run_bad_cursor/events?since=abc")
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_multiple_subscribers_each_receive_events(self, adapter):
+        """Fan-out: two concurrent consumers each receive every event."""
+        app = _create_runs_app(adapter)
+        run_id = "run_multi"
+        _seed_live_run(adapter, run_id)
+        async with TestClient(TestServer(app)) as cli:
+            resp1 = await cli.get(f"/v1/runs/{run_id}/events")
+            resp2 = await cli.get(f"/v1/runs/{run_id}/events")
+            assert resp1.status == 200 and resp2.status == 200
+
+            adapter._publish_run_event(run_id, {"event": "message.delta", "run_id": run_id, "delta": "hi"})
+            adapter._set_run_status(run_id, "completed", last_event="run.completed")
+            adapter._publish_run_event(run_id, {"event": "run.completed", "run_id": run_id})
+            adapter._publish_run_event(run_id, None)
+
+            for resp in (resp1, resp2):
+                body = await asyncio.wait_for(resp.text(), 3)
+                frames = _parse_sse_frames(body)
+                assert [event.get("event") for _, event in frames] == ["message.delta", "run.completed"]
+                assert ": stream closed" in body
+
+    @pytest.mark.asyncio
+    async def test_last_subscriber_disconnect_refreshes_orphan_ttl(self, adapter):
+        """After the last consumer detaches, the resume window restarts (full TTL)."""
+        app = _create_runs_app(adapter)
+        run_id = "run_ttl"
+        _seed_live_run(adapter, run_id)
+        adapter._set_run_status(run_id, "completed", last_event="run.completed")
+        adapter._publish_run_event(run_id, {"event": "run.completed", "run_id": run_id})
+        adapter._run_streams_created[run_id] -= 100  # pretend the run is old
+
+        before = adapter._run_streams_created[run_id]
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(f"/v1/runs/{run_id}/events")
+            await resp.text()
+        assert adapter._run_streams_created[run_id] > before
+
+    @pytest.mark.asyncio
+    async def test_publish_after_sweep_is_dropped(self, adapter):
+        """Once the log is swept, late events buffer nothing (memory bound)."""
+        run_id = "run_swept"
+        _seed_live_run(adapter, run_id)
+        adapter._run_streams_created[run_id] -= adapter._RUN_STREAM_TTL + 1
+        adapter._sweep_orphaned_runs_once(time.time())
+        assert adapter._publish_run_event(run_id, {"event": "message.delta", "delta": "x"}) == -1
+        assert run_id not in adapter._run_event_logs
+
+
+# ---------------------------------------------------------------------------
 # Run lifecycle TTL sweeping
 # ---------------------------------------------------------------------------
 
@@ -470,14 +647,13 @@ class TestRunEvents:
 class TestRunLifecycleSweep:
     def test_sweep_keeps_transport_with_active_subscriber(self, adapter):
         run_id = "run_subscribed"
-        queue = asyncio.Queue()
-        adapter._run_streams[run_id] = queue
+        adapter._run_event_logs[run_id] = deque(maxlen=adapter._RUN_EVENT_LOG_CAP)
         adapter._run_streams_created[run_id] = 0
         adapter._run_stream_subscribers.add(run_id)
 
         adapter._sweep_orphaned_runs_once(time.time())
 
-        assert adapter._run_streams[run_id] is queue
+        assert run_id in adapter._run_event_logs
         assert run_id in adapter._run_streams_created
 
     @pytest.mark.asyncio
@@ -519,7 +695,7 @@ class TestRunLifecycleSweep:
 
                 assert adapter._active_run_tasks[run_id] is task
                 assert adapter._active_run_agents[run_id] is mock_agent
-                assert run_id not in adapter._run_streams
+                assert run_id not in adapter._run_event_logs
                 assert run_id not in adapter._run_streams_created
                 assert adapter._run_approval_sessions[run_id] == run_id
 
@@ -541,7 +717,7 @@ class TestRunLifecycleSweep:
 
     @pytest.mark.asyncio
     async def test_expired_transport_stops_buffering_new_deltas(self, adapter):
-        """An unconsumed expired queue must not grow for the rest of a live run."""
+        """A swept replay log must not grow for the rest of a live run."""
         app = _create_runs_app(adapter)
 
         async with TestClient(TestServer(app)) as cli:
@@ -552,12 +728,12 @@ class TestRunLifecycleSweep:
                 start_resp = await cli.post("/v1/runs", json={"input": "hello"})
                 run_id = (await start_resp.json())["run_id"]
                 assert agent_ready.wait(timeout=3.0)
-                expired_queue = adapter._run_streams[run_id]
+                expired_log = adapter._run_event_logs[run_id]
                 stream_delta = mock_create.call_args.kwargs["stream_delta_callback"]
 
                 adapter._run_streams_created[run_id] -= adapter._RUN_STREAM_TTL + 1
                 adapter._sweep_orphaned_runs_once(time.time())
-                before = expired_queue.qsize()
+                before = len(expired_log)
                 stream_delta("must-not-buffer")
                 mock_agent.interrupt("finish test")
                 for _ in range(40):
@@ -565,12 +741,12 @@ class TestRunLifecycleSweep:
                         break
                     await asyncio.sleep(0.05)
 
-                assert expired_queue.qsize() == before
+                assert len(expired_log) == before
 
     @pytest.mark.asyncio
     async def test_expired_orphan_run_state_is_reaped(self, adapter):
         run_id = "run_expired_orphan"
-        adapter._run_streams[run_id] = asyncio.Queue()
+        adapter._run_event_logs[run_id] = deque(maxlen=adapter._RUN_EVENT_LOG_CAP)
         adapter._run_streams_created[run_id] = 0
         adapter._run_approval_sessions[run_id] = run_id
 
@@ -589,7 +765,7 @@ class TestRunLifecycleSweep:
             with pytest.raises(asyncio.CancelledError):
                 await adapter._sweep_orphaned_runs()
 
-        assert run_id not in adapter._run_streams
+        assert run_id not in adapter._run_event_logs
         assert run_id not in adapter._run_streams_created
         assert run_id not in adapter._run_approval_sessions
         assert pending.event.is_set()


### PR DESCRIPTION
## Problem

`GET /v1/runs/{run_id}/events` was a single shared live queue that was popped the moment a consumer disconnected: events emitted while disconnected were lost, and re-subscribing to a finished run returned 404. Mobile clients in particular (the OS routinely freezes background sockets) had no way to continue an in-flight run stream, and resorted to re-POSTing a duplicate run to recover — executing the same user message twice on the engine.

## Change

Rework the transport into a per-run replay log + per-subscriber fan-out:

- Events are appended to a bounded per-run log (`deque(maxlen=_RUN_EVENT_LOG_CAP=4096)`) with a monotonic seq, and fanned out to per-subscriber queues, so multiple concurrent consumers each receive every event.
- Every SSE frame now carries `id: <seq>`. Reconnecting clients pass `Last-Event-ID` (or `?since=<seq>`) and receive buffered events newer than the cursor before continuing live. Invalid cursors return 400.
- Subscribing after a run finished replays the buffer and closes cleanly (`: stream closed`) instead of 404ing; terminal state remains available via `GET /v1/runs/{id}` (status carries final output) beyond the buffer.
- Memory stays bounded: the log is swept with the existing orphan TTL, which now restarts when the last subscriber detaches, so a reconnecting client gets a full TTL window to resume. Publishing into a swept run is dropped as before.
- The live loop terminates on the existing `None` sentinel rather than terminal-status polling, so a terminal event already queued is never stranded.

## Compatibility

No behavior change for existing consumers: frames only gain an `id:` line (ignored by clients that don't track it), and requests without a cursor stream live runs exactly as before.

## Tests

8 new tests in `tests/gateway/test_api_server_runs.py` (`TestRunEventsResume`): frame ids, late-subscriber replay, `since` / `Last-Event-ID` cursor replay, invalid cursor 400, multi-subscriber fan-out, orphan-TTL refresh on last detach, publish-after-sweep dropped. Existing run-transport tests updated to the replay-log internals.

`tests/gateway/test_api_server_runs.py` + `tests/gateway/test_api_server.py`: 256 passed on this branch.