### PR TITLE
fix(anthropic): non-whitespace placeholder for synthetic leading user turn

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2427,7 +2427,10 @@ def _ensure_leading_user_turn(result: List[Dict[str, Any]]) -> None:
     (convert_messages_to_converse).
     """
     if result and result[0].get("role") != "user":
-        result.insert(0, {"role": "user", "content": [{"type": "text", "text": " "}]})
+        # ponytail: some Anthropic-compatible endpoints (e.g. zenmux) reject a
+        # whitespace-only text block with HTTP 400 "text content blocks must
+        # contain non-whitespace text"; use a minimal non-blank placeholder.
+        result.insert(0, {"role": "user", "content": [{"type": "text", "text": "."}]})
 
 
 def convert_messages_to_anthropic(

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1394,7 +1394,9 @@ class TestConvertMessages:
 
         assert system == "You are helpful."
         assert result[0]["role"] == "user"
-        assert result[0]["content"] == [{"type": "text", "text": " "}]
+        # Placeholder text must be non-whitespace: strict Anthropic-compatible
+        # endpoints (zenmux) 400 on whitespace-only text blocks.
+        assert result[0]["content"][0]["text"].strip()
         assert result[1]["role"] == "assistant"
         assert any(
             m["role"] == "assistant" and "Context compaction summary" in str(m["content"])
@@ -1418,7 +1420,7 @@ class TestConvertMessages:
 
         assert system is None
         assert result[0]["role"] == "user"
-        assert result[0]["content"] == [{"type": "text", "text": " "}]
+        assert result[0]["content"][0]["text"].strip()
         assert result[1]["role"] == "assistant"
         assert "Context compaction summary" in str(result[1]["content"])
 


### PR DESCRIPTION
## Summary

`_ensure_leading_user_turn` (in `agent/anthropic_adapter.py`) prepends a synthetic user message when `messages[0]` is not `role=user`. This happens after a **second context compaction on the auto path**, where the summary is emitted as `role=assistant` with nothing in front of it (the system prompt lives outside `messages[]`), so `messages[0]` ends up assistant and the Messages API would 400.

The synthetic placeholder used a single space `" "` as its text.

## The bug

Anthropic's own API tolerates a whitespace-only text block, but **stricter Anthropic-compatible endpoints reject it**. Observed against `zenmux.ai` (`/api/anthropic`):

```
HTTP 400 invalid_params: messages: text content blocks must contain non-whitespace text
```

This error is **non-retryable**, so once a conversation has compacted twice, every subsequent turn fails permanently. In our case a Feishu DM session silently stopped replying after auto-compaction — each inbound message hit the 400 and never recovered.

## Fix

Use a minimal **non-blank** placeholder `"."` instead of `" "`. One-line change in the shared helper, so every caller (all provider paths that route through `convert_messages_to_anthropic`) is fixed at once.

## Tests

The two existing tests froze the exact placeholder byte (`== [{"type": "text", "text": " "}]`) — change-detector shape. Updated them to assert the **behavior contract** instead: the prepended leading turn is `role=user` with non-whitespace text. This keeps them meaningful regardless of the exact placeholder character.

```
tests/agent/test_anthropic_adapter.py … 179 passed
```

(3 unrelated `TestRunOauthSetupToken` failures are pre-existing on `main`, verified by stashing this change.)
