### PR TITLE
fix(moa): pass custom-provider extra_body to reference and aggregator slots (salvage #60168)

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -212,9 +212,28 @@ def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
             out["api_key"] = rt["api_key"]
         if rt.get("api_mode"):
             out["api_mode"] = rt["api_mode"]
+        request_overrides = rt.get("request_overrides")
+        if isinstance(request_overrides, dict):
+            extra_body = request_overrides.get("extra_body")
+            if isinstance(extra_body, dict) and extra_body:
+                out["extra_body"] = dict(extra_body)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("MoA slot runtime resolution failed for %s: %s", _slot_label(slot), exc)
     return out
+
+
+def _merge_slot_extra_body(
+    slot_extra_body: Any,
+    caller_extra_body: Any,
+) -> Any:
+    """Merge slot defaults with a caller override for ``call_llm``."""
+    if isinstance(slot_extra_body, dict) and slot_extra_body:
+        if isinstance(caller_extra_body, dict):
+            return {**slot_extra_body, **caller_extra_body}
+        if caller_extra_body:
+            return caller_extra_body
+        return dict(slot_extra_body)
+    return caller_extra_body
 
 
 def _maybe_apply_moa_cache_control(
@@ -976,18 +995,26 @@ class MoAChatCompletions:
             # actually governs the aggregator stream, not just call_llm's default.
             if api_kwargs.get("timeout") is not None:
                 stream_kwargs["timeout"] = api_kwargs["timeout"]
+        agg_runtime = _slot_runtime(aggregator)
+        # _slot_runtime may carry the provider's request_overrides.extra_body;
+        # pop it and merge with the caller's extra_body (caller wins) so the
+        # explicit kwarg below never collides with **agg_runtime.
+        agg_extra_body = _merge_slot_extra_body(
+            agg_runtime.pop("extra_body", None),
+            extra_body,
+        )
         _agg_response = call_llm(
             task="moa_aggregator",
             messages=agg_messages,
             temperature=aggregator_temperature,
             max_tokens=max_tokens,
             tools=tools,
-            extra_body=extra_body,
+            extra_body=agg_extra_body,
             # Prepared requests must retain the acting aggregator's reasoning
             # policy exactly as the direct create() path does (#64187).
             reasoning_config=_aggregator_reasoning_config(aggregator),
             **stream_kwargs,
-            **_slot_runtime(aggregator),
+            **agg_runtime,
         )
         # Non-streaming path (quiet mode / eval / subagents): the aggregator
         # output is available inline, so capture it into the pending trace now.

--- a/contributors/emails/panding99@outlook.com
+++ b/contributors/emails/panding99@outlook.com
@@ -1,0 +1,1 @@
+panDing19

--- a/tests/agent/test_moa_slot_api_mode.py
+++ b/tests/agent/test_moa_slot_api_mode.py
@@ -188,6 +188,48 @@ moa:
     }
 
 
+def test_one_shot_aggregate_moa_context_passes_slot_extra_body(monkeypatch):
+    """The one-shot `/moa <prompt>` synthesis call (aggregate_moa_context) is
+    the third independent MoA call path — its aggregator call receives the
+    slot runtime via **agg_runtime, so custom-provider extra_body must flow
+    through it too."""
+    from agent import moa_loop
+
+    captured_calls = []
+
+    def fake_call_llm(**kwargs):
+        captured_calls.append(kwargs)
+        return _response("synthesis")
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {
+            "provider": "custom",
+            "model": "qwen3.7-max",
+            "base_url": "https://dashscope.example/v1",
+            "api_key": "test-key",
+            "extra_body": {"enable_thinking": False},
+        },
+    )
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        moa_loop, "_maybe_apply_moa_cache_control", lambda messages, runtime: messages
+    )
+
+    result = moa_loop.aggregate_moa_context(
+        user_prompt="hello",
+        api_messages=[{"role": "user", "content": "hello"}],
+        reference_models=[{"provider": "dashscope", "model": "qwen3.7-max"}],
+        aggregator={"provider": "dashscope", "model": "qwen3.7-max"},
+    )
+
+    assert "synthesis" in result
+    agg_calls = [c for c in captured_calls if c.get("task") == "moa_aggregator"]
+    assert len(agg_calls) == 1
+    assert agg_calls[0]["extra_body"] == {"enable_thinking": False}
+
+
 class TestCallLlmApiMode:
     """call_llm should accept and forward api_mode parameter."""
 

--- a/tests/agent/test_moa_slot_api_mode.py
+++ b/tests/agent/test_moa_slot_api_mode.py
@@ -7,9 +7,16 @@ so reference slots using providers that require a specific API surface
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
+
+
+def _response(content="ok"):
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fake")
 
 
 class TestSlotRuntimeApiMode:
@@ -60,6 +67,125 @@ class TestSlotRuntimeApiMode:
 
         result = _slot_runtime({"provider": "copilot", "model": "gpt-5.5"})
         assert "api_mode" not in result
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_slot_runtime_includes_request_override_extra_body(self, mock_resolve):
+        """Custom-provider extra_body is forwarded in call_llm's shape."""
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "model": "qwen3.7-max",
+            "base_url": "https://dashscope.example/v1",
+            "api_key": "test-key",
+            "api_mode": "chat_completions",
+            "request_overrides": {
+                "extra_body": {
+                    "enable_thinking": False,
+                    "reasoning": {"effort": "none"},
+                }
+            },
+        }
+        from agent.moa_loop import _slot_runtime
+
+        result = _slot_runtime({"provider": "dashscope", "model": "qwen3.7-max"})
+        assert result["extra_body"] == {
+            "enable_thinking": False,
+            "reasoning": {"effort": "none"},
+        }
+
+
+def test_run_reference_passes_slot_extra_body(monkeypatch):
+    """Reference advisors should receive custom provider extra_body."""
+    from agent import moa_loop
+
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return _response("advisor")
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {
+            "provider": "custom",
+            "model": "qwen3.7-max",
+            "base_url": "https://dashscope.example/v1",
+            "api_key": "test-key",
+            "extra_body": {"enable_thinking": False},
+        },
+    )
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    monkeypatch.setattr(moa_loop, "_maybe_apply_moa_cache_control", lambda messages, runtime: messages)
+
+    label, text, _usage = moa_loop._run_reference(
+        {"provider": "dashscope", "model": "qwen3.7-max"},
+        [{"role": "user", "content": "hello"}],
+    )
+
+    assert label == "dashscope:qwen3.7-max"
+    assert text == "advisor"
+    assert captured["extra_body"] == {"enable_thinking": False}
+
+
+def test_moa_aggregator_merges_slot_extra_body_with_caller_override(tmp_path, monkeypatch):
+    """Aggregator calls should merge slot defaults without duplicate kwargs."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: closed
+  presets:
+    closed:
+      enabled: true
+      reference_models: []
+      aggregator:
+        provider: dashscope
+        model: qwen3.7-max
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent import moa_loop
+
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return _response("acted")
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {
+            "provider": "custom",
+            "model": "qwen3.7-max",
+            "base_url": "https://dashscope.example/v1",
+            "api_key": "test-key",
+            "extra_body": {
+                "enable_thinking": False,
+                "metadata": {"source": "slot"},
+            },
+        },
+    )
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+
+    facade = moa_loop.MoAChatCompletions("closed")
+    facade.create(
+        model="closed",
+        messages=[{"role": "user", "content": "hello"}],
+        extra_body={
+            "metadata": {"source": "caller"},
+            "reasoning": {"effort": "none"},
+        },
+    )
+
+    assert captured["extra_body"] == {
+        "enable_thinking": False,
+        "metadata": {"source": "caller"},
+        "reasoning": {"effort": "none"},
+    }
 
 
 class TestCallLlmApiMode:


### PR DESCRIPTION
## Summary

MoA reference and aggregator slots now receive the `request_overrides.extra_body` their provider declares — reasoning models that need body flags (e.g. Qwen/DashScope's `enable_thinking: false`) work as MoA advisors instead of erroring. Salvages #60168 (@panDing19, authorship preserved via cherry-pick). Fixes #60153.

Root cause: `_slot_runtime()` resolved a slot's provider/model/base_url/api_key/api_mode via `resolve_runtime_provider()` but dropped the `request_overrides.extra_body` that named custom providers expose — so none of the three MoA call paths (advisor fan-out, one-shot `/moa` synthesis, acting-aggregator) ever sent it.

## Changes

- **Cherry-picked @panDing19's fix**: `_slot_runtime()` extracts `request_overrides.extra_body` into the slot runtime; new `_merge_slot_extra_body()` helper merges slot defaults with caller overrides (caller wins) and pops the key before `**runtime` expansion so the explicit `extra_body=` kwarg never collides. Conflict resolved in favor of current main's prepared-aggregator path (post-#64187 `reasoning_config` line preserved).
- **Follow-up test** (ours): the one-shot `aggregate_moa_context()` synthesis path — the third independent MoA call path — asserted to carry slot extra_body, per the sweeper's review note on the original PR.
- Contributor mapping added (`contributors/emails/panding99@outlook.com`).

## Validation

| Check | Result |
|---|---|
| tests/agent/test_moa_slot_api_mode.py (8, incl. 3 new extra_body tests) | pass |
| 6 sibling MoA suites (32 tests) | pass |
| Premise on main | verified: moa_loop.py `_slot_runtime` drops request_overrides; runtime_provider.py exposes it at 3 sites |

Closes #60168 (salvaged). Fixes #60153.

## Infographic

![moa-slot-extra-body](https://v3b.fal.media/files/b/0aa36bf4/cjkluWtNdaJHrMDHnG3Q__x9uoKWbz.png)
