### PR TITLE
fix(moa): thread custom-provider context metadata into aggregator context-length resolution (salvage #67071)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2201,11 +2201,18 @@ def get_model_context_length(
     # acting context, so they're ignored here.
     if (provider or "").strip().lower() == "moa":
         try:
-            from hermes_cli.config import load_config
+            from hermes_cli.config import (
+                get_compatible_custom_providers,
+                load_config,
+            )
             from hermes_cli.moa_config import resolve_moa_preset
             from hermes_cli.runtime_provider import resolve_runtime_provider
 
-            preset = resolve_moa_preset(load_config().get("moa") or {}, model)
+            config = load_config()
+            effective_custom_providers = custom_providers
+            if effective_custom_providers is None:
+                effective_custom_providers = get_compatible_custom_providers(config)
+            preset = resolve_moa_preset(config.get("moa") or {}, model)
             agg = preset.get("aggregator") or {}
             agg_provider = str(agg.get("provider") or "").strip()
             agg_model = str(agg.get("model") or "").strip()
@@ -2215,7 +2222,8 @@ def get_model_context_length(
                     agg_model,
                     base_url=rt.get("base_url", "") or "",
                     api_key=rt.get("api_key", "") or "",
-                    provider=agg_provider,
+                    provider=rt.get("provider") or agg_provider,
+                    custom_providers=effective_custom_providers,
                 )
         except Exception:
             logger.debug("MoA aggregator context-length resolution failed", exc_info=True)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1800,27 +1800,31 @@ class TestGrok43StaleCacheGuard:
 class TestMoAContextLength:
     """MoA virtual provider resolves context from the aggregator slot, not 256K default."""
 
-    def _write_moa_config(self, home, aggregator):
+    def _write_moa_config(
+        self, home, aggregator, custom_providers=None, providers=None
+    ):
         import os
         os.makedirs(home, exist_ok=True)
-        with open(os.path.join(home, "config.yaml"), "w") as f:
-            yaml.safe_dump(
-                {
-                    "moa": {
-                        "default_preset": "p",
-                        "presets": {
-                            "p": {
-                                "enabled": True,
-                                "reference_models": [
-                                    {"provider": "openrouter", "model": "openai/gpt-5.5"}
-                                ],
-                                "aggregator": aggregator,
-                            }
-                        },
+        payload = {
+            "moa": {
+                "default_preset": "p",
+                "presets": {
+                    "p": {
+                        "enabled": True,
+                        "reference_models": [
+                            {"provider": "openrouter", "model": "openai/gpt-5.5"}
+                        ],
+                        "aggregator": aggregator,
                     }
                 },
-                f,
-            )
+            }
+        }
+        if custom_providers is not None:
+            payload["custom_providers"] = custom_providers
+        if providers is not None:
+            payload["providers"] = providers
+        with open(os.path.join(home, "config.yaml"), "w") as f:
+            yaml.safe_dump(payload, f)
 
     def test_moa_resolves_from_aggregator(self, tmp_path, monkeypatch):
         home = str(tmp_path / ".hermes")
@@ -1843,3 +1847,138 @@ class TestMoAContextLength:
             "p", base_url="http://127.0.0.1/v1", provider="moa", config_context_length=500_000
         )
         assert ctx == 500_000
+
+    def test_moa_resolves_custom_provider_per_model_context(self, tmp_path, monkeypatch):
+        home = str(tmp_path / ".hermes")
+        monkeypatch.setenv("HERMES_HOME", home)
+        self._write_moa_config(
+            home,
+            {"provider": "custom:example", "model": "example-model"},
+            custom_providers=[
+                {
+                    "name": "example",
+                    "base_url": "http://127.0.0.1:1/v1",
+                    "model": "example-model",
+                    "models": {
+                        "example-model": {"context_length": 777_777},
+                    },
+                }
+            ],
+        )
+
+        ctx = get_model_context_length(
+            "p", base_url="http://127.0.0.1/v1", provider="moa"
+        )
+
+        assert ctx == 777_777
+
+    def test_moa_resolves_canonical_provider_per_model_context(
+        self, tmp_path, monkeypatch
+    ):
+        home = str(tmp_path / ".hermes")
+        monkeypatch.setenv("HERMES_HOME", home)
+        self._write_moa_config(
+            home,
+            {"provider": "custom:example", "model": "example-model"},
+            providers={
+                "example": {
+                    "api": "http://127.0.0.1:1/v1",
+                    "default_model": "example-model",
+                    "models": {
+                        "example-model": {"context_length": 888_888},
+                    },
+                }
+            },
+        )
+
+        with patch(
+            "agent.model_metadata._resolve_endpoint_context_length",
+            return_value=None,
+        ) as endpoint_probe:
+            ctx = get_model_context_length(
+                "p", base_url="http://127.0.0.1/v1", provider="moa"
+            )
+
+        assert ctx == 888_888
+        endpoint_probe.assert_not_called()
+
+    def test_moa_custom_context_configures_compressor_threshold(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.context_compressor import ContextCompressor
+
+        configured_context = 600_000
+        home = str(tmp_path / ".hermes")
+        monkeypatch.setenv("HERMES_HOME", home)
+        self._write_moa_config(
+            home,
+            {"provider": "custom:example", "model": "example-model"},
+            providers={
+                "example": {
+                    "api": "http://127.0.0.1:1/v1",
+                    "default_model": "example-model",
+                    "models": {
+                        "example-model": {
+                            "context_length": configured_context,
+                        },
+                    },
+                }
+            },
+        )
+
+        with patch(
+            "agent.model_metadata._resolve_endpoint_context_length",
+            return_value=None,
+        ) as endpoint_probe:
+            compressor = ContextCompressor(
+                model="p",
+                base_url="http://127.0.0.1/v1",
+                provider="moa",
+                threshold_percent=0.50,
+                quiet_mode=True,
+            )
+
+        assert compressor.context_length == configured_context
+        assert compressor.threshold_tokens == configured_context // 2
+        endpoint_probe.assert_not_called()
+
+    def test_moa_preserves_caller_supplied_custom_provider_context(
+        self, tmp_path, monkeypatch
+    ):
+        home = str(tmp_path / ".hermes")
+        monkeypatch.setenv("HERMES_HOME", home)
+        self._write_moa_config(
+            home,
+            {"provider": "custom:example", "model": "example-model"},
+            providers={
+                "example": {
+                    "api": "http://127.0.0.1:1/v1",
+                    "default_model": "example-model",
+                    "models": {"example-model": {}},
+                }
+            },
+        )
+        supplied = [
+            {
+                "name": "example",
+                "base_url": "http://127.0.0.1:1/v1",
+                "model": "example-model",
+                "models": {
+                    "example-model": {"context_length": 999_999},
+                },
+            }
+        ]
+
+        with patch(
+            "agent.model_metadata._resolve_endpoint_context_length",
+            return_value=None,
+        ) as endpoint_probe:
+            ctx = get_model_context_length(
+                "p",
+                base_url="http://127.0.0.1/v1",
+                provider="moa",
+                custom_providers=supplied,
+            )
+
+        assert ctx == 999_999
+        endpoint_probe.assert_not_called()


### PR DESCRIPTION
## Summary

A MoA preset whose aggregator lives on a custom provider now honors the user's per-model `context_length` declaration — the compression threshold and context-window gating derive from the real window instead of a catalog guess or the 256K default. Salvages #67071 (@wjq990112, authorship preserved via cherry-pick). Fixes #56749.

Root cause: `get_model_context_length()`'s MoA branch recurses on the aggregator slot's real provider+model but dropped the `custom_providers` parameter, so the custom-provider override step (0b) could never match for the aggregator. Users had to set an unsafe global `model.context_length` that leaks across provider switches.

## Changes

- `agent/model_metadata.py` (+11/−3): the MoA recursion now threads `custom_providers` (caller-supplied wins, else `get_compatible_custom_providers()` — covering both the legacy `custom_providers:` list and the keyed v12 `providers:` schema) plus the resolved runtime provider name into the recursive lookup.
- `tests/agent/test_model_metadata.py` (+156/−17): 4 regression tests — legacy schema, keyed v12 schema (asserting no endpoint probe), caller-supplied metadata precedence, and a real ContextCompressor deriving its 50% threshold from the declared window.

Supersedes #60373 (@royzhrxy-glitch, same site, legacy-key-only) — will be closed with credit after merge; @kyssta-exe's earlier #56758 (closed stale) credited as the first submitter of this fix class.

## Validation

| Check | Result |
|---|---|
| tests/agent/test_model_metadata.py | 132 pass (incl. 4 new) |
| Premise on main | verified: model_metadata.py L2213-2218 recursion omits custom_providers |

## Infographic

![moa-context-metadata](https://v3b.fal.media/files/b/0aa36c02/WKaKFaDJNP8A8Y2cD15WC_fdyiNDJg.png)
