### PR TITLE
fix(gateway): bridge top-level port/host/secret into extra for webhook and api_server (#57320 salvage)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1497,6 +1497,24 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
                 if "typing_status_text" in platform_cfg:
                     bridged["typing_status_text"] = platform_cfg["typing_status_text"]
+                # Bridge top-level port/host/secret into extra for platforms
+                # whose adapters read these from config.extra (webhook,
+                # msgraph_webhook, api_server).  Without this, YAML like:
+                #   platforms:
+                #     webhook:
+                #       enabled: true
+                #       port: 8649
+                # silently falls back to the hardcoded DEFAULT_PORT because
+                # PlatformConfig.from_dict only extracts ``extra`` from the
+                # ``extra:`` sub-key, not from the top level.
+                if plat in {Platform.WEBHOOK, Platform.MSGRAPH_WEBHOOK}:
+                    for _bridge_key in ("port", "host", "secret"):
+                        if _bridge_key in platform_cfg and _bridge_key not in platform_cfg.get("extra", {}):
+                            bridged[_bridge_key] = platform_cfg[_bridge_key]
+                if plat == Platform.API_SERVER:
+                    for _bridge_key in ("port", "host"):
+                        if _bridge_key in platform_cfg and _bridge_key not in platform_cfg.get("extra", {}):
+                            bridged[_bridge_key] = platform_cfg[_bridge_key]
                 has_channel_overrides = "channel_overrides" in platform_cfg
                 if has_channel_overrides:
                     raw_overrides = platform_cfg.get("channel_overrides")

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1962,6 +1962,40 @@ class TestWebhookPortBridging:
         wh = config.platforms[Platform.WEBHOOK]
         assert "port" not in wh.extra or wh.extra.get("port") is None
 
+    def test_msgraph_webhook_port_host_secret_bridged_from_toplevel(self, tmp_path, monkeypatch):
+        """msgraph_webhook top-level port/host/secret must be bridged into extra,
+        with an explicit extra: value still winning over the top-level one."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  msgraph_webhook:\n"
+            "    enabled: true\n"
+            "    host: 0.0.0.0\n"
+            "    port: 8651\n"
+            "    secret: toplevel-secret\n"
+            "    extra:\n"
+            "      client_state: my-client-state\n"
+            "      secret: extra-secret\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("MSGRAPH_WEBHOOK_ENABLED", raising=False)
+        monkeypatch.delenv("MSGRAPH_WEBHOOK_PORT", raising=False)
+        monkeypatch.delenv("MSGRAPH_WEBHOOK_CLIENT_STATE", raising=False)
+
+        config = load_gateway_config()
+
+        assert Platform.MSGRAPH_WEBHOOK in config.platforms
+        ms = config.platforms[Platform.MSGRAPH_WEBHOOK]
+        assert ms.enabled is True
+        assert ms.extra.get("port") == 8651
+        assert ms.extra.get("host") == "0.0.0.0"
+        # explicit extra: wins over top-level
+        assert ms.extra.get("secret") == "extra-secret"
+        assert ms.extra.get("client_state") == "my-client-state"
+
 
 class TestHomeChannelEnvOverrides:
     """Home channel env vars should apply even when the platform was already

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1855,6 +1855,114 @@ class TestLoadGatewayConfig:
         assert Platform.API_SERVER not in config.platforms
 
 
+class TestWebhookPortBridging:
+    """Top-level port/host in the YAML platform section must be bridged into
+    PlatformConfig.extra so the webhook/api_server adapters can read them.
+
+    The adapters (WebhookAdapter, ApiServerAdapter) read port/host from
+    ``config.extra``, but users naturally write them at the top level of the
+    platform section in config.yaml:
+
+        platforms:
+          webhook:
+            enabled: true
+            host: 0.0.0.0
+            port: 8649
+
+    Without bridging, the port silently falls back to DEFAULT_PORT (8644),
+    causing port conflicts between profiles that configure different ports."""
+
+    def test_webhook_port_bridged_from_toplevel(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  webhook:\n"
+            "    enabled: true\n"
+            "    host: 0.0.0.0\n"
+            "    port: 8649\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("WEBHOOK_ENABLED", raising=False)
+        monkeypatch.delenv("WEBHOOK_PORT", raising=False)
+
+        config = load_gateway_config()
+
+        assert Platform.WEBHOOK in config.platforms
+        wh = config.platforms[Platform.WEBHOOK]
+        assert wh.enabled is True
+        assert wh.extra.get("port") == 8649
+        assert wh.extra.get("host") == "0.0.0.0"
+
+    def test_webhook_port_in_extra_not_overwritten_by_toplevel(self, tmp_path, monkeypatch):
+        """If port is already under extra, the top-level value must not clobber it."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  webhook:\n"
+            "    enabled: true\n"
+            "    extra:\n"
+            "      port: 8650\n"
+            "    port: 8649\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("WEBHOOK_ENABLED", raising=False)
+        monkeypatch.delenv("WEBHOOK_PORT", raising=False)
+
+        config = load_gateway_config()
+
+        wh = config.platforms[Platform.WEBHOOK]
+        assert wh.extra.get("port") == 8650
+
+    def test_api_server_port_bridged_from_toplevel(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  api_server:\n"
+            "    enabled: true\n"
+            "    host: 127.0.0.1\n"
+            "    port: 8648\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("API_SERVER_ENABLED", raising=False)
+        monkeypatch.delenv("API_SERVER_PORT", raising=False)
+
+        config = load_gateway_config()
+
+        assert Platform.API_SERVER in config.platforms
+        api = config.platforms[Platform.API_SERVER]
+        assert api.extra.get("port") == 8648
+        assert api.extra.get("host") == "127.0.0.1"
+
+    def test_webhook_port_defaults_when_not_configured(self, tmp_path, monkeypatch):
+        """No port anywhere -> adapter uses its hardcoded DEFAULT_PORT."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  webhook:\n"
+            "    enabled: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("WEBHOOK_ENABLED", raising=False)
+        monkeypatch.delenv("WEBHOOK_PORT", raising=False)
+
+        config = load_gateway_config()
+
+        wh = config.platforms[Platform.WEBHOOK]
+        assert "port" not in wh.extra or wh.extra.get("port") is None
+
+
 class TestHomeChannelEnvOverrides:
     """Home channel env vars should apply even when the platform was already
     configured via config.yaml (not just when credential env vars create it)."""


### PR DESCRIPTION
## Summary

Salvage of #57320 by @kjames2001 — top-level YAML `port`/`host`/`secret` keys on webhook, api_server, and msgraph_webhook platform sections now reach the adapters instead of being silently dropped.

Adapters read these from `config.extra`, but the shared-key bridge loop covered ~25 keys and not these three — `platforms.webhook.port: 8649` silently fell back to the default port.

## Changes
- `gateway/config.py`: bridge loop lifts top-level `port`/`host`/`secret` into `extra` (webhook, msgraph_webhook; `port`/`host` for api_server); explicit `extra:` always wins
- `tests/gateway/test_config.py`: contributor's 4 `TestWebhookPortBridging` tests + follow-up msgraph_webhook coverage (previously untested branch)

## Validation
| Scenario | Result |
|---|---|
| top-level webhook port/host/secret | bridged into extra |
| explicit `extra:` present | wins over top-level (no clobber) |
| msgraph_webhook branch | covered incl. secret precedence |
| `tests/gateway/test_config.py` | 140/140 pass |

Authorship preserved via cherry-pick; msgraph test added as follow-up commit. Adjacent-not-duplicate: #66633 lane handles the nested `gateway.api_server` section (different root cause); #10208/#20506/#20528 are competing generic approaches, left open. Closes #57320.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa36bd7/Am0aTThkNzlzxKnqVTrwh_lacahovH.png)
