### PR TITLE
fix(gateway): distinguish gateway auth 401 from provider API key errors (#39439 salvage, fixes #39365)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -413,6 +413,7 @@ _CONTENT_POLICY_BLOCKED_PATTERNS = [
 _AUTH_PATTERNS = [
     "invalid api key",
     "invalid_api_key",
+    "gateway_auth_failed",
     "authentication",
     "unauthorized",
     "forbidden",

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -132,6 +132,7 @@ export const en: Translations = {
     errors: {
       elevenLabsNeedsKey: 'ElevenLabs STT needs ELEVENLABS_API_KEY.',
       elevenLabsRejectedKey: 'ElevenLabs rejected the API key (401).',
+      gatewayAuthFailed: 'Gateway authentication failed — check your API_SERVER_KEY.',
       methodNotAllowed:
         'The desktop backend rejected that request (405 Method Not Allowed). Try restarting Hermes Desktop.',
       microphonePermission: 'Microphone permission was denied.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -133,6 +133,7 @@ export const ja = defineLocale({
     errors: {
       elevenLabsNeedsKey: 'ElevenLabs STT には ELEVENLABS_API_KEY が必要です。',
       elevenLabsRejectedKey: 'ElevenLabs が API キーを拒否しました (401)。',
+      gatewayAuthFailed: 'ゲートウェイ認証に失敗しました — API_SERVER_KEY を確認してください。',
       methodNotAllowed:
         'デスクトップバックエンドがそのリクエストを拒否しました (405 Method Not Allowed)。Hermes Desktop を再起動してください。',
       microphonePermission: 'マイクのアクセス許可が拒否されました。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -173,6 +173,7 @@ export interface Translations {
     errors: {
       elevenLabsNeedsKey: string
       elevenLabsRejectedKey: string
+      gatewayAuthFailed: string
       methodNotAllowed: string
       microphonePermission: string
       openaiRejectedApiKey: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -129,6 +129,7 @@ export const zhHant = defineLocale({
     errors: {
       elevenLabsNeedsKey: 'ElevenLabs STT 需要 ELEVENLABS_API_KEY。',
       elevenLabsRejectedKey: 'ElevenLabs 拒絕了該 API 金鑰 (401)。',
+      gatewayAuthFailed: '閘道認證失敗 — 請檢查你的 API_SERVER_KEY。',
       methodNotAllowed: '桌面後端拒絕了該請求 (405 Method Not Allowed)。請嘗試重新啟動 Hermes Desktop。',
       microphonePermission: '麥克風權限已被拒絕。',
       openaiRejectedApiKey: 'OpenAI 拒絕了該 API 金鑰。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -129,6 +129,7 @@ export const zh: Translations = {
     errors: {
       elevenLabsNeedsKey: 'ElevenLabs STT 需要 ELEVENLABS_API_KEY。',
       elevenLabsRejectedKey: 'ElevenLabs 拒绝了该 API key (401)。',
+      gatewayAuthFailed: '网关认证失败 — 请检查你的 API_SERVER_KEY。',
       methodNotAllowed: '桌面后端拒绝了该请求 (405 Method Not Allowed)。请尝试重启 Hermes Desktop。',
       microphonePermission: '麦克风权限已被拒绝。',
       openaiRejectedApiKey: 'OpenAI 拒绝了该 API key。',

--- a/apps/desktop/src/store/notifications.test.ts
+++ b/apps/desktop/src/store/notifications.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, expect, test } from 'vitest'
+
+import { $notifications, clearNotifications, notifyError } from './notifications'
+
+beforeEach(() => {
+  clearNotifications()
+})
+
+function lastMessage(): string {
+  return $notifications.get()[0]?.message ?? ''
+}
+
+// Regression for #39365: a gateway auth 401 (bad API_SERVER_KEY) must not be
+// summarized as a provider (OpenAI/OpenRouter) API key problem.
+test('gateway_auth_failed error is summarized as gateway auth, not provider key', () => {
+  notifyError(
+    new Error(
+      '401 {"error": {"message": "Invalid gateway API key (API_SERVER_KEY)", "type": "gateway_auth_error", "code": "gateway_auth_failed"}}'
+    ),
+    'Request failed'
+  )
+
+  expect(lastMessage()).toContain('API_SERVER_KEY')
+  expect(lastMessage()).not.toMatch(/OpenAI/i)
+})
+
+test('provider invalid_api_key error still maps to the OpenAI summary', () => {
+  notifyError(
+    new Error('401 {"error": {"message": "Incorrect API key provided", "code": "invalid_api_key"}}'),
+    'Request failed'
+  )
+
+  expect(lastMessage()).toMatch(/OpenAI rejected the API key/i)
+})

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -78,7 +78,11 @@ function cleanErrorText(value: string) {
 
 const ERROR_SUMMARIES: { test: (msg: string) => boolean; summarize: (msg: string) => string }[] = [
   {
-    test: msg => /incorrect api key provided/i.test(msg) || /['"]code['"]\s*:\s*['"]invalid_api_key['"]/i.test(msg),
+    test: msg => /['"']code['"']\s*:\s*['"']gateway_auth_failed['"']/i.test(msg),
+    summarize: () => 'Gateway authentication failed — check your API_SERVER_KEY.'
+  },
+  {
+    test: msg => /incorrect api key provided/i.test(msg) || /['"']code['"']\s*:\s*['"']invalid_api_key['"']/i.test(msg),
     summarize: msg => {
       const status = msg.match(/(?:error code|status(?:Code)?)[^\d]*(\d{3})/i)?.[1]
 

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -78,11 +78,11 @@ function cleanErrorText(value: string) {
 
 const ERROR_SUMMARIES: { test: (msg: string) => boolean; summarize: (msg: string) => string }[] = [
   {
-    test: msg => /['"']code['"']\s*:\s*['"']gateway_auth_failed['"']/i.test(msg),
-    summarize: () => 'Gateway authentication failed — check your API_SERVER_KEY.'
+    test: msg => /['"]code['"]\s*:\s*['"]gateway_auth_failed['"]/i.test(msg),
+    summarize: () => translateNow('notifications.errors.gatewayAuthFailed')
   },
   {
-    test: msg => /incorrect api key provided/i.test(msg) || /['"']code['"']\s*:\s*['"']invalid_api_key['"']/i.test(msg),
+    test: msg => /incorrect api key provided/i.test(msg) || /['"]code['"]\s*:\s*['"]invalid_api_key['"]/i.test(msg),
     summarize: msg => {
       const status = msg.match(/(?:error code|status(?:Code)?)[^\d]*(\d{3})/i)?.[1]
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1335,7 +1335,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._request_audit_log_suffix(request),
         )
         return web.json_response(
-            {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
+            {"error": {"message": "Invalid gateway API key (API_SERVER_KEY)", "type": "gateway_auth_error", "code": "gateway_auth_failed"}},
             status=401,
         )
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -416,7 +416,7 @@ async def test_session_endpoints_require_auth_when_key_configured(auth_adapter):
         resp = await cli.get("/api/sessions")
         assert resp.status == 401
         body = await resp.json()
-        assert body["error"]["code"] == "invalid_api_key"
+        assert body["error"]["code"] == "gateway_auth_failed"
 
         ok = await cli.get("/api/sessions", headers={"Authorization": "Bearer sk-test"})
         assert ok.status == 200


### PR DESCRIPTION
## Summary

Salvage of #39439 by @annguyenNous — a bad `API_SERVER_KEY` from a client no longer masquerades as a provider API-key failure, fixing #39365.

`_check_auth()` returned the OpenAI-standard code `invalid_api_key` on gateway auth failures; the Desktop app maps that code to "OpenAI rejected the API key", sending operators to debug the wrong credential. The 401 now carries a distinct `gateway_auth_failed` code and the Desktop maps it to a gateway-specific message.

**⚠ API-compat note:** the 401 body on the OpenAI-compatible endpoints no longer uses `invalid_api_key` for gateway auth. HTTP status stays 401 (SDK retry/error behavior unchanged), but third-party clients matching the code string will see the new value. Intentional — the ambiguity was the bug.

## Changes
- `gateway/platforms/api_server.py`, `agent/error_classifier.py`: distinct `gateway_auth_failed` 401 code + classifier mapping (contributor's fix)
- `apps/desktop/src/store/notifications.ts` + i18n `types/en/ja/zh/zh-hant`: summary via `translateNow()` with full locale parity (was a hardcoded English literal)
- `apps/desktop/src/store/notifications.test.ts` (new): gateway_auth_failed → gateway summary; invalid_api_key → still provider summary
- Regex nit fixed (`['\"']` duplicate-quote char class, both new and pre-existing occurrence)

## Validation
| Suite | Result |
|---|---|
| backend (`test_session_api.py`, `test_error_classifier.py`) | 211/211 pass |
| Desktop vitest (store + i18n parity) | 63/63 pass |

Authorship preserved via cherry-pick; i18n/regex follow-up separate. Closes #39439, fixes #39365.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa36c09/EjyXjdl12GgvcrYM0i7Jh_0PnUMLIb.png)
