### PR TITLE
fix: profile-isolation env fallback, doctor credential reconciliation, cron dispatcher sync + kanban close_as_obsolete verb

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3750,6 +3750,79 @@ def run_job(
                 )
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)
+            # Drain any straggler subagents registered on this agent's
+            # `_active_children` list before closing the SessionDB. Under
+            # the Hunk D sync-dispatch contract, subagents stay attached
+            # to the parent's active-children list until they complete
+            # (delegate_tool.py:2298-2305 removes them on successful
+            # completion; the async branch's detach at lines 2824-2834
+            # is skipped entirely on the sync path). A cron worker that
+            # finishes its LLM turn while a child is still in its
+            # `run_conversation` would otherwise leak the connection:
+            # the child's finalize_turn → _persist_session calls would
+            # race the close and either crash on `self._conn is None`
+            # (Hunk A's lazy-reopen net catches that) or, worse, write
+            # after the WAL checkpoint truncated.
+            #
+            # Drain mechanism: copy the current `_active_children`
+            # snapshot under the agent's `_active_children_lock`,
+            # release the lock, sleep, repeat. Children remove
+            # themselves under the same lock when they complete; on
+            # the happy path the snapshot is empty on the first poll
+            # and we exit immediately. Bounded at 30 seconds total —
+            # a stuck child must not freeze the scheduler. On timeout,
+            # log a structured warning that names Hunk A's lazy-reopen
+            # safety net (so a future engineer reading the log knows
+            # the children *will* still produce their writes, just
+            # through a fresh connection).
+            #
+            # Bounded loop also runs in O(snapshot_count) memory; worst
+            # case is one extra list copy per poll which is bounded by
+            # delegation.max_concurrent_children (default 3).
+            try:
+                if agent is not None:
+                    _drain_budget_s = 30.0
+                    _drain_start = time.monotonic()
+                    _drain_lock = getattr(agent, "_active_children_lock", None)
+                    _drain_remaining = _drain_budget_s
+                    _snapshot: list = []
+                    while _drain_remaining > 0:
+                        if _drain_lock is not None:
+                            with _drain_lock:
+                                _snapshot = list(agent._active_children)
+                        else:
+                            _snapshot = list(agent._active_children)
+                        if not _snapshot:
+                            break
+                        # Snapshot shows live children — sleep, then re-poll.
+                        # 0.5s cadence matches the executor.wait timeout in
+                        # delegate_tool's _execute_and_aggregate, so we're
+                        # not slower than the children themselves.
+                        time.sleep(0.5)
+                        _drain_remaining = _drain_budget_s - (
+                            time.monotonic() - _drain_start
+                        )
+                    if _snapshot:
+                        # Still children registered after the budget — the
+                        # lazy-reopen net in hermes_state.SessionDB._ensure_conn
+                        # will re-establish a connection on their next write,
+                        # but log the situation so it's visible in
+                        # agent.log/cron.log for future debugging.
+                        logger.warning(
+                            "Job '%s': %d subagent(s) still registered on "
+                            "agent._active_children after %.1fs drain; "
+                            "their late writes will be served by "
+                            "SessionDB._ensure_conn's lazy-reopen net "
+                            "(interim close path, not permanent)",
+                            job_id,
+                            len(_snapshot),
+                            _drain_budget_s,
+                        )
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug(
+                    "Job '%s': subagent drain raised (continuing to close): %s",
+                    job_id, e,
+                )
             try:
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9417,13 +9417,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the new gateway tries to open the same file.
             # ``self`` holds the DB at ``_session_db`` (an AsyncSessionDB facade);
             # unwrap to the sync handle. ``session_store`` holds it at ``_db``.
+            # On shutdown we hand each handle ``permanent=True`` so that
+            # any later ``_execute_write`` call (e.g. a completion-event
+            # echo or notification flush that races interpreter exit)
+            # fails loudly via the lazy-reopen net in
+            # hermes_state.SessionDB._ensure_conn instead of silently
+            # resurrecting a connection in a process that's already
+            # tearing down WAL locks. The Hunk A lazy-reopen path is
+            # for *interim* closes (cron between-job teardown), not
+            # process-shutdown closes.
             _self_db = getattr(self, "_session_db", None)
             _self_db = getattr(_self_db, "_db", _self_db)
             for _db in (_self_db, getattr(getattr(self, "session_store", None), "_db", None)):
                 if _db is None or not hasattr(_db, "close"):
                     continue
                 try:
-                    _db.close()
+                    _db.close(permanent=True)
+                except TypeError:
+                    # Defensive: if a stub adapter's close() doesn't accept
+                    # the keyword (pre-Hunk-A class on disk), fall back to
+                    # plain close. New code paths always accept the kwarg.
+                    try:
+                        _db.close()
+                    except Exception as _e:
+                        logger.debug("SessionDB close error: %s", _e)
                 except Exception as _e:
                     logger.debug("SessionDB close error: %s", _e)
             GatewayRunner._shutdown_executor(self)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -679,6 +679,7 @@ def get_container_exec_info() -> Optional[dict]:
 
 # Re-export from hermes_constants — canonical definition lives there.
 from hermes_constants import get_hermes_home, get_process_hermes_home  # noqa: F811,E402
+from hermes_constants import get_default_hermes_root  # noqa: F811,E402
 from utils import atomic_replace, fast_safe_load
 
 def get_config_path() -> Path:
@@ -7844,6 +7845,52 @@ def invalidate_env_cache() -> None:
     _env_cache = None
 
 
+def _is_in_profile_scope(home: Path, root: Path) -> bool:
+    """True when ``home`` is a profile directory under ``<root>/profiles/``.
+
+    Determined via ``Path.relative_to`` arithmetic — no env reads, no
+    substring matches, platform-agnostic (POSIX + Windows native).  Validated
+    under interactive env AND ``env -i`` (launchd-stripped) in the test
+    matrix: handles default root, missing-profile paths, Docker profile
+    paths (``/opt/data/profiles/<x>``), and Docker-root paths.
+    """
+    try:
+        profiles_root = (root / "profiles").resolve()
+        home.resolve().relative_to(profiles_root)
+        return True
+    except ValueError:
+        return False
+    except Exception:
+        # Truly pathological (path-resolve failure between the two calls).
+        # Fail-closed: caller treats this as "skip root fallback", which is
+        # the pre-fix behavior.  Never a wrong-path guess.
+        return False
+
+
+def _load_env_from_path(path: Path) -> Dict[str, str]:
+    """Parse a single .env file into a dict.  Single-file variant of load_env().
+
+    No caching (the caller controls re-read frequency); no sanitization
+    pass (callers only invoke this on files we trust — currently only the
+    global root ``.env`` in the profile-fallback path).
+    """
+    out: Dict[str, str] = {}
+    if not path.exists():
+        return out
+    try:
+        with open(path, encoding="utf-8-sig", errors="replace") as f:
+            for raw in f:
+                line = raw.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    if line.startswith("export "):
+                        line = line[7:]
+                    k, _, v = line.partition("=")
+                    out[k.strip()] = v.strip().strip('"').strip("'")
+    except Exception:
+        return out
+    return out
+
+
 _STRUCTURED_VALUE_MARKERS = ("://", "?", "&")
 
 
@@ -8313,11 +8360,50 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
     that, under an active profile scope (multiplexed gateway turn), this read
     is scope-checked rather than leaking another profile's raw ``os.environ``
     value — matching the credential-pool seeding path's behaviour.
+
+    In profile mode (``HERMES_HOME`` is a profile directory), after the
+    profile .env misses, falls back to the **global root** ``~/.hermes/.env``
+    so cron/launchd resolution can resolve keys seeded at global scope
+    without requiring per-profile duplication.  Profile always wins when
+    it has a value — root is a fallback, not an override.  Addresses the
+    issue #18594 profile-isolation trap: an empty profile-pool return used
+    to surface as ``Bearer None`` over the wire because the credential-pool
+    shadowing (``read_credential_pool`` profile-wins) blocked the global
+    pool entry without any profile key taking its place.
+
+    The global root path comes from ``get_default_hermes_root()`` which is
+    platform-aware (POSIX + Windows native) and Docker-aware
+    (``/opt/data`` layouts); no hardcoded path.  Skipped silently when
+    ``HERMES_HOME`` is already the root (avoids redundant re-read of the
+    same file).
     """
     env_vars = load_env()
     val = env_vars.get(key)
     if val:
         return val
+    # Profile-root fallback: only when we're actually in a profile scope.
+    # Calling get_default_hermes_root() (rather than hardcoding ~/.hermes)
+    # keeps this correct for Docker/custom-root deployments and for
+    # Windows installs where the native root is %LOCALAPPDATA%\hermes.
+    try:
+        home = get_hermes_home()
+        root = get_default_hermes_root()
+    except Exception:
+        # get_default_hermes_root is import-safe (no Hermes-logging
+        # bootstrap); anything that throws here means the env is too broken
+        # to safely consult a fallback path.  Skip silently — caller
+        # proceeds to the secret_scope / os.environ tiers below.
+        home = root = None
+    if (
+        home is not None
+        and root is not None
+        and _is_in_profile_scope(home, root)
+        and root != home
+    ):
+        root_vars = _load_env_from_path(root / ".env")
+        root_val = root_vars.get(key)
+        if root_val:
+            return root_val
     try:
         from agent.secret_scope import (
             UnscopedSecretError,

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -10,7 +10,7 @@ import subprocess
 import shutil
 from pathlib import Path
 
-from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
+from hermes_cli.config import get_project_root, get_hermes_home, get_env_path, get_env_value_prefer_dotenv
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
 from hermes_constants import agent_browser_runnable
@@ -2058,7 +2058,7 @@ def run_doctor(args):
                                supports_health_check) -> _ConnectivityResult:
         key = ""
         for ev in env_vars:
-            key = os.getenv(ev, "")
+            key = (get_env_value_prefer_dotenv(ev) or "").strip()
             if key:
                 break
         if not key:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5535,6 +5535,263 @@ def block_task(
     return True
 
 
+# ---------------------------------------------------------------------------
+# close_as_obsolete (Issue: dispatcher race on unblock → ready → claim)
+# ---------------------------------------------------------------------------
+# Background: an unblock of a blocked card transitions ``blocked → ready``,
+# which makes the card immediately claimable by the next dispatcher tick.
+# If an orchestrator then tries to complete/close the same card a moment
+# later, the dispatcher's claim lock can race in and bounce the
+# complete/close call. This verb eliminates that window by going
+# ``blocked → done`` in a single atomic transition: the card never visits
+# ``ready``, so the dispatcher has no state to claim.
+#
+# Refusal rules (per spec):
+#   * Active ``claim_lock`` — there is a live worker; this is not obsolete.
+#   * Open children — unresolved dependencies would silently drop on a
+#     terminal transition.
+#   * ``reason`` is mandatory (validated by the tool layer, not here).
+
+class CardHasActiveClaimError(RuntimeError):
+    """Raised by ``close_as_obsolete`` when the card holds an active claim_lock.
+
+    A card in ``blocked`` state with a non-NULL ``claim_lock`` has a live
+    worker attached (rare but possible — a worker set the lock then the
+    task was force-blocked by some non-block_tool path, or a future
+    feature path leaves a stale lock). Closing it as obsolete would
+    yank the task out from under that worker. Subclass ``RuntimeError``
+    so the tool layer treats it as an operational refusal, not a user
+    input error.
+    """
+
+    def __init__(self, task_id: str, claim_lock: str):
+        self.task_id = task_id
+        self.claim_lock = claim_lock
+        super().__init__(
+            f"task {task_id} has active claim_lock={claim_lock!r}; "
+            f"refusing to close as obsolete while a worker holds the lock"
+        )
+
+
+class CardHasOpenChildrenError(RuntimeError):
+    """Raised by ``close_as_obsolete`` when the card has unresolved child deps.
+
+    Closing a parent as ``done`` while children are still in flight
+    would silently drop the dependency edge — a child that should
+    block waiting for the parent instead transitions through ``ready``
+    on the next ``recompute_ready``. Refused at the kernel so the
+    orchestrator has to address the children first.
+    """
+
+    def __init__(self, task_id: str, open_children: list[str]):
+        self.task_id = task_id
+        self.open_children = list(open_children)
+        super().__init__(
+            f"task {task_id} has open children that must reach a "
+            f"terminal state before close-as-obsolete: "
+            f"{', '.join(open_children)}"
+        )
+
+
+# Terminal statuses for the open-children check. Mirrors the set used by
+# ``_cleanup_workspace`` (``done`` / ``archived`` / ``failed`` /
+# ``cancelled``). Any status outside this set is treated as still in
+# flight and blocks the obsolete close.
+_OBSOLETE_CLOSE_TERMINAL_STATUSES = frozenset(
+    {"done", "archived", "failed", "cancelled"}
+)
+
+
+def close_as_obsolete(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: str,
+    closed_by: str,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Atomically transition ``blocked → done`` without passing through ``ready``.
+
+    Used by the ``kanban_close_as_obsolete`` tool (and the operator CLI
+    equivalent) to retire a blocked card whose work is no longer
+    relevant — superseded by another task, removed from scope, or
+    otherwise moot. The transition is a single ``UPDATE … WHERE
+    id=? AND status='blocked'`` inside :func:`write_txn` so the
+    dispatcher cannot observe a claimable state between the read and the
+    write.
+
+    Refusals (raise before any write):
+
+    * :class:`CardHasActiveClaimError` — ``tasks.claim_lock`` is non-NULL.
+      A live worker holds the card; this is not obsolete.
+    * :class:`CardHasOpenChildrenError` — at least one child in
+      ``task_links`` is still in a non-terminal status.
+
+    The verb accepts ``reason`` and ``closed_by`` and writes them onto
+    the ``completed`` event payload (alongside ``obsolete: True``) so
+    downstream notifiers and audit consumers can distinguish a normal
+    completion from an obsolete close. The task row's
+    ``completed_at`` is stamped; ``claim_lock`` / ``claim_expires`` /
+    ``worker_pid`` are cleared (defensive — should already be NULL on a
+    blocked card that wasn't actively claimed).
+    """
+    now = int(time.time())
+
+    # Pre-flight refusal checks (read-only). Done outside the write_txn
+    # so the refusal message can name the offending claim_lock / open
+    # children ids; doing it inside the txn would require holding the
+    # SQLite write lock for the duration of a possibly-expensive
+    # children scan. SQLite WAL serialises writers anyway, so the
+    # subsequent UPDATE inside write_txn is still atomic.
+    row = conn.execute(
+        "SELECT status, claim_lock FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    if row is None:
+        return False
+    if row["status"] != "blocked":
+        return False
+    if row["claim_lock"]:
+        raise CardHasActiveClaimError(task_id, row["claim_lock"])
+    open_children = [
+        r["child_id"]
+        for r in conn.execute(
+            "SELECT child_id FROM tasks t "
+            "JOIN task_links l ON l.child_id = t.id "
+            "WHERE l.parent_id = ? "
+            "AND t.status NOT IN ("
+            + ",".join("?" for _ in _OBSOLETE_CLOSE_TERMINAL_STATUSES)
+            + ")",
+            (task_id, *_OBSOLETE_CLOSE_TERMINAL_STATUSES),
+        ).fetchall()
+    ]
+    if open_children:
+        raise CardHasOpenChildrenError(task_id, open_children)
+
+    with write_txn(conn):
+        # Atomic single-statement transition: only succeeds when the
+        # row is still ``blocked``. The ``status='blocked'`` guard is
+        # the load-bearing constraint — without it a concurrent
+        # ``unblock → claim → running`` would silently succeed because
+        # the WHERE on `id` alone matches any status. The ``claim_lock
+        # IS NULL`` mirror is belt-and-suspenders: a stale lock that
+        # slipped past the pre-flight check (race window) is caught
+        # here too.
+        if expected_run_id is None:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'done',
+                       result       = ?,
+                       completed_at = ?,
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL,
+                       block_kind   = NULL,
+                       block_recurrences = 0
+                 WHERE id = ?
+                   AND status = 'blocked'
+                   AND claim_lock IS NULL
+                """,
+                (f"obsolete: {reason}", now, task_id),
+            )
+        else:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'done',
+                       result       = ?,
+                       completed_at = ?,
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL,
+                       block_kind   = NULL,
+                       block_recurrences = 0
+                 WHERE id = ?
+                   AND status = 'blocked'
+                   AND claim_lock IS NULL
+                   AND current_run_id = ?
+                """,
+                (f"obsolete: {reason}", now, task_id, int(expected_run_id)),
+            )
+        if cur.rowcount != 1:
+            # Lost the race: someone unblocked/claimed between the
+            # pre-flight read and the write. The dispatcher now holds
+            # the card and ``close_as_obsolete`` must refuse cleanly.
+            # Re-read inside the txn so the error message names the
+            # current state.
+            current = conn.execute(
+                "SELECT status, claim_lock FROM tasks WHERE id = ?",
+                (task_id,),
+            ).fetchone()
+            if current is None:
+                return False
+            if current["claim_lock"]:
+                raise CardHasActiveClaimError(task_id, current["claim_lock"])
+            return False
+
+        # Persist the close in attempt history so the dashboard shows
+        # why the card is done. ``close_as_obsolete`` may run on a
+        # blocked card that was never claimed (the common case — a
+        # worker-initiated ``kanban_block`` cleared claim_lock), in
+        # which case there's no run to end and we synthesise one.
+        run_id = _end_run(
+            conn, task_id,
+            outcome="completed", status="done",
+            summary=reason,
+            metadata={
+                "obsolete": True,
+                "closed_by": closed_by,
+            },
+        )
+        if run_id is None:
+            run_id = _synthesize_ended_run(
+                conn, task_id,
+                outcome="completed",
+                summary=reason,
+                metadata={
+                    "obsolete": True,
+                    "closed_by": closed_by,
+                },
+            )
+
+        # Emit ``completed`` (matches existing notifier wiring in
+        # gateway/run.py — a fresh event kind would silently bypass
+        # dashboard renderers and attachment uploads) with the
+        # ``obsolete: True`` flag as the discriminator. The verb name
+        # in the payload makes the audit trail unambiguous without
+        # inventing a new event kind.
+        _append_event(
+            conn, task_id, "completed",
+            {
+                "obsolete": True,
+                "verb": "close_as_obsolete",
+                "reason": reason,
+                "closed_by": closed_by,
+                "summary_preview": (
+                    reason.strip().splitlines()[0][:200] if reason else None
+                ),
+            },
+            run_id=run_id,
+        )
+
+    # Post-commit side effects, mirroring complete_task so behaviour
+    # stays consistent for downstream consumers (children gating,
+    # failure counter, workspace cleanup, lifecycle hooks).
+    _clear_failure_counter(conn, task_id)
+    recompute_ready(conn)
+    _cleanup_workspace(conn, task_id)
+    _done_task = get_task(conn, task_id)
+    _fire_kanban_lifecycle_hook(
+        "kanban_task_completed",
+        task_id,
+        board=get_current_board(),
+        assignee=_done_task.assignee if _done_task else None,
+        run_id=run_id,
+        summary=reason,
+    )
+    return True
+
+
 
 def promote_task(
     conn: sqlite3.Connection,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1569,6 +1569,15 @@ class SessionDB:
         self._fts_cjk_loaded = False
         self._fts_cjk_available = False
         self._fts_unavailable_warned = False
+        # Permanent-close latch: set by close(permanent=True) when the owning
+        # process is exiting for good (gateway shutdown, process terminate).
+        # Distinguishes "this conn closed itself and can be lazy-reopened for
+        # a stray background write" (interim close — e.g. cron's between-job
+        # teardown) from "we're done, never reconnect — let write attempts
+        # fail loudly instead of resurrecting a connection in a dying
+        # process". Read-only SessionDBs are never reconnected (no write
+        # path means no lazy-reopen path), so the flag is inert there.
+        self._closed_permanently = False
         self._conn = None
         try:
             if read_only:
@@ -2011,11 +2020,24 @@ class SessionDB:
         SQLite's built-in deterministic backoff creates.
 
         Returns whatever *fn* returns.
+
+        Lazy-reopen net: if the connection was closed by a prior
+        ``close(permanent=False)`` (e.g. cron's between-job teardown) and
+        a backgrounded writer still calls in, we transparently re-open
+        a fresh connection via ``_ensure_conn()`` and proceed. The
+        net only triggers for interim closes — a permanent close
+        (gateway shutdown path) raises ``OperationalError`` cleanly
+        from ``_ensure_conn`` instead of letting ``self._conn`` access
+        blow up with ``AttributeError: NoneType``.
         """
         last_err: Optional[Exception] = None
         for attempt in range(self._WRITE_MAX_RETRIES):
             try:
                 with self._lock:
+                    if self._conn is None:
+                        # Re-open or fail loudly, per _ensure_conn's
+                        # permanent-vs-interim rules.
+                        self._ensure_conn()
                     self._conn.execute("BEGIN IMMEDIATE")
                     try:
                         result = fn(self._conn)
@@ -2175,13 +2197,25 @@ class SessionDB:
         except Exception:
             pass  # Best effort — never fatal.
 
-    def close(self):
+    def close(self, permanent: bool = False):
         """Close the database connection.
 
         Attempts a TRUNCATE WAL checkpoint first so that exiting processes
         help shrink the WAL file.
+
+        ``permanent`` (default False): when True, marks the SessionDB as
+        permanently closed — subsequent write attempts will raise
+        ``sqlite3.OperationalError`` immediately instead of lazily
+        reconnecting. Use on process-shutdown paths (gateway teardown,
+        process termination) where resurrecting a connection in a dying
+        process would create more problems than it solves. Interim closes
+        (cron's between-job teardown, any place where we expect a later
+        write to happen) leave ``permanent`` False so the lazy-reopen net
+        in ``_execute_write`` can still save late stragglers.
         """
         with self._lock:
+            if permanent:
+                self._closed_permanently = True
             if self._conn:
                 try:
                     self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
@@ -2765,6 +2799,54 @@ class SessionDB:
             "FTS storage optimization complete (layout v%d).", FTS_STORAGE_VERSION
         )
         return {"ok": True, "vacuumed": vacuum_ok}
+
+    def _ensure_conn(self) -> None:
+        """Re-open a closed connection if it's safe to do so.
+
+        Called by ``_execute_write`` when a write encounters
+        ``self._conn is None`` after an interim close. Mirrors the
+        write-path portion of ``__init__`` without re-running schema
+        init (DB is already initialised — closing and reopening
+        preserves the on-disk schema; FTS triggers are SQL-level and
+        survive a fresh connection). On permanent close, raises
+        ``sqlite3.OperationalError`` immediately so the caller hears the
+        truth instead of seeing a phantom reconnection in a dying
+        process.
+
+        Must be called with ``self._lock`` already held, since
+        ``_execute_write`` invokes us from inside its `with self._lock:`
+        block on the retry path. Holding the lock prevents two writers
+        racing to reopen the same connection.
+        """
+        if self.read_only:
+            # Read-only opens never auto-reconnect: callers that want a
+            # fresh handle call the constructor; the startup probe
+            # path is a separate code path.
+            raise sqlite3.OperationalError(
+                "SessionDB is closed and was opened read-only; "
+                "construct a fresh handle"
+            )
+        if self._closed_permanently:
+            raise sqlite3.OperationalError(
+                "SessionDB was closed with permanent=True; "
+                "no writes permitted after process-shutdown close"
+            )
+        try:
+            new_conn = sqlite3.connect(
+                str(self.db_path),
+                check_same_thread=False,
+                timeout=1.0,
+                isolation_level=None,
+            )
+            new_conn.row_factory = sqlite3.Row
+            apply_wal_with_fallback(new_conn, db_label="state.db")
+            new_conn.execute("PRAGMA foreign_keys=ON")
+            self._conn = new_conn
+        except Exception:
+            # Re-raise so the caller surfaces a clear OperationalError
+            # instead of letting a NoneType AttributeError propagate
+            # from the next statement.
+            raise
 
     @staticmethod
     def _parse_schema_columns(schema_sql: str) -> Dict[str, Dict[str, str]]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -6462,14 +6462,34 @@ class AIAgent:
         #     its own turn to compose a summary, and a subagent doesn't own the
         #     gateway session the async result would route back to.
         # The schema-level `background` param is intentionally ignored here.
+        #
+        # Cron-path exception: HERMES_CRON_SESSION=1 means we are running under
+        # cron/scheduler.py (a fire-and-exit CLI invocation, not a long-lived
+        # gateway process). Async background dispatch relies on
+        # gateway/run.py:15390's main loop to drain
+        # ``process_registry.completion_queue`` and surface results back into
+        # the conversation. Cron has no such consumer — when the worker's
+        # delegate_task returns "dispatched" and the worker's turn ends, the
+        # subagent completion event has no path back to the worker. The
+        # research prompts (research-scan, research-sweep) already assume
+        # synchronous semantics ("merge subagent findings into draft" / "wait
+        # for the skeptic result") — we force sync on the cron path here so
+        # the worker actually receives the consolidated findings in its
+        # tool-result block within its own turn. The per-child timeout floor
+        # in ``delegate_tool._get_child_timeout`` keeps the sync wait bounded.
         _is_subagent = getattr(self, "_delegate_depth", 0) > 0
+        _is_cron_session = os.environ.get("HERMES_CRON_SESSION") == "1"
+        if _is_cron_session and not _is_subagent:
+            _background = False
+        else:
+            _background = (not _is_subagent)
         return _delegate_task(
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
-            background=(not _is_subagent),
+            background=_background,
             parent_agent=self,
         )
 

--- a/tests/hermes_cli/test_kanban_close_as_obsolete.py
+++ b/tests/hermes_cli/test_kanban_close_as_obsolete.py
@@ -1,0 +1,145 @@
+"""Regression tests for the ``close_as_obsolete`` admin verb.
+
+Contract: kanban_db.close_as_obsolete docstring (blocked → done atomic
+transition, refusal guards) — cherry-picked from origin/main 1f378065a,
+Dre-approved 2026-07-19 ref t_21cc0e2a. These tests fail on pre-verb
+code (AttributeError on import) and pin the three refusal paths plus the
+happy path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _make_blocked_task(conn, title="obsolete-me"):
+    task_id = kb.create_task(conn, title=title)
+    assert kb.block_task(conn, task_id, reason="superseded")
+    return task_id
+
+
+def test_blocked_card_closes_as_done(kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = _make_blocked_task(conn)
+        assert kb.close_as_obsolete(
+            conn, task_id, reason="superseded by t_new", closed_by="test-admin"
+        ) is True
+        row = conn.execute(
+            "SELECT status, result, claim_lock, block_kind FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        assert row["status"] == "done"
+        assert row["result"] == "obsolete: superseded by t_new"
+        assert row["claim_lock"] is None
+        assert row["block_kind"] is None
+    finally:
+        conn.close()
+
+
+def test_non_blocked_card_returns_false(kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="still-ready")
+        assert kb.close_as_obsolete(
+            conn, task_id, reason="nope", closed_by="test-admin"
+        ) is False
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        assert row["status"] != "done"
+    finally:
+        conn.close()
+
+
+def test_missing_card_returns_false(kanban_home):
+    conn = kb.connect()
+    try:
+        assert kb.close_as_obsolete(
+            conn, "t_does_not_exist", reason="nope", closed_by="test-admin"
+        ) is False
+    finally:
+        conn.close()
+
+
+def test_stale_claim_lock_refused(kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = _make_blocked_task(conn)
+        # Simulate the stale-lock scenario from the docstring: a blocked
+        # card that still carries a claim_lock from a non-block_tool path.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET claim_lock = ? WHERE id = ?",
+                ("host:stale-worker", task_id),
+            )
+        with pytest.raises(kb.CardHasActiveClaimError) as exc:
+            kb.close_as_obsolete(
+                conn, task_id, reason="nope", closed_by="test-admin"
+            )
+        assert exc.value.claim_lock == "host:stale-worker"
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        assert row["status"] == "blocked"
+    finally:
+        conn.close()
+
+
+def test_open_children_refused_until_terminal(kanban_home):
+    conn = kb.connect()
+    try:
+        parent_id = _make_blocked_task(conn, title="parent")
+        child_id = kb.create_task(conn, title="child")
+        kb.link_tasks(conn, parent_id, child_id)
+
+        with pytest.raises(kb.CardHasOpenChildrenError) as exc:
+            kb.close_as_obsolete(
+                conn, parent_id, reason="nope", closed_by="test-admin"
+            )
+        assert child_id in exc.value.open_children
+
+        # Any terminal child status unblocks the close.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'cancelled' WHERE id = ?",
+                (child_id,),
+            )
+        assert kb.close_as_obsolete(
+            conn, parent_id, reason="children resolved", closed_by="test-admin"
+        ) is True
+    finally:
+        conn.close()
+
+
+def test_completed_event_carries_obsolete_marker(kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = _make_blocked_task(conn)
+        assert kb.close_as_obsolete(
+            conn, task_id, reason="moot", closed_by="test-admin"
+        )
+        run = conn.execute(
+            "SELECT metadata, outcome FROM task_runs WHERE task_id = ? "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert run is not None
+        assert run["outcome"] == "completed"
+        assert '"obsolete": true' in (run["metadata"] or "").lower()
+    finally:
+        conn.close()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -439,7 +439,38 @@ def _get_child_timeout() -> Optional[float]:
 
     Set ``delegation.child_timeout_seconds`` to a positive number to opt back
     in to a hard cap (floor 30 s); ``0`` or a negative value means disabled.
+
+    Cron-path floor: when ``HERMES_CRON_SESSION=1`` (set by the cron scheduler
+    for every job in cron/scheduler.py:2686), this returns a hard cap default
+    of 600 s, env-overridable via ``HERMES_CRON_CHILD_TIMEOUT_SECONDS``. This
+    is a code-level safety net rather than a config dependency — a stuck
+    subagent must not be able to hang cron indefinitely on the direct-CLI
+    path, which lacks the gateway's inactivity_timeout that would otherwise
+    fire the heartbeat staleness monitor. The interactive path (cron env var
+    unset) keeps the original ``None`` default so heavy legitimate work isn't
+    capped. Set ``HERMES_CRON_CHILD_TIMEOUT_SECONDS=0`` (or any negative
+    value) to explicitly opt out per-run; the value is still floored at 30 s
+    when positive so a too-small override can't kill in-progress children.
     """
+    if os.environ.get("HERMES_CRON_SESSION") == "1":
+        cron_val = os.getenv("HERMES_CRON_CHILD_TIMEOUT_SECONDS", "600")
+        try:
+            parsed = float(cron_val)
+        except (TypeError, ValueError):
+            logger.warning(
+                "HERMES_CRON_CHILD_TIMEOUT_SECONDS=%r is not a valid number; "
+                "using 600s cron default for this run",
+                cron_val,
+            )
+            return 600.0
+        if parsed <= 0:
+            # Explicit opt-out (0/negative) — fall through to the
+            # existing config-driven behavior below. This keeps
+            # HERMES_CRON_CHILD_TIMEOUT_SECONDS=0 as an escape hatch
+            # for an operator who really does want unbounded children.
+            pass
+        else:
+            return max(30.0, parsed)
     cfg = _load_config()
     val = cfg.get("child_timeout_seconds")
     if val is not None:
@@ -3616,8 +3647,28 @@ def _model_background_value(args: dict, parent_agent=None) -> bool:
     ``run_agent._dispatch_delegate_task``; this lambda mirrors it for the rare
     case the intercept is bypassed. Direct Python callers of ``delegate_task``
     keep the historical synchronous default.
+
+    Cron-path exception: the cron scheduler is a fire-and-exit CLI invocation,
+    not a long-lived gateway process. Async background dispatch relies on the
+    gateway's main loop (gateway/run.py:15390) draining
+    ``process_registry.completion_queue`` to surface results back into the
+    conversation. Cron has no such consumer — when the worker's
+    ``delegate_task`` returns ``"dispatched"`` and the worker's turn ends, the
+    subagent completion event has no path back to the cron worker. The research
+    prompts (research-scan, research-sweep) already assume synchronous
+    semantics — "merge subagent findings into draft" / "wait for the skeptic
+    result" — so we force sync on the cron path here. The per-child timeout
+    floor (see ``_get_child_timeout``) keeps the sync wait bounded.
     """
     is_subagent = getattr(parent_agent, "_delegate_depth", 0) > 0
+    is_cron_session = os.environ.get("HERMES_CRON_SESSION") == "1"
+    if is_cron_session and not is_subagent:
+        # Top-level agent on the cron path — sync dispatch. Children stay
+        # attached to the parent's _active_children (the detach block in
+        # delegate_task's async branch is skipped), the worker blocks on them
+        # via _execute_and_aggregate's executor.wait loop, and the consolidated
+        # results land in the worker's tool-result block in this turn.
+        return False
     return not is_subagent
 
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -796,6 +796,127 @@ def _handle_block(args: dict, **kw) -> str:
         return tool_error(f"kanban_block: {e}")
 
 
+def _handle_close_as_obsolete(args: dict, **kw) -> str:
+    """Atomically transition a BLOCKED card directly to done.
+
+    Closes a blocked card as obsolete (superseded / removed from scope /
+    otherwise moot) in a single atomic transaction: ``blocked → done``
+    with no intermediate ``ready`` state, so the dispatcher can never
+    race in and claim the card mid-close. Emits a ``completed`` event
+    carrying ``obsolete: True``, ``reason``, and ``closed_by`` so
+    downstream notifiers and audit consumers can distinguish this from
+    a normal completion.
+
+    Refuses (returns tool_error, no state change) when:
+
+    * ``reason`` is missing or blank.
+    * The card has an active ``claim_lock`` (live worker attached).
+    * The card has open children (unresolved dependencies).
+    * The card is not currently in ``blocked`` status (callers should
+      use ``kanban_complete`` for running/ready tasks).
+
+    Worker-scope semantics: ``_enforce_worker_task_ownership`` is
+    enforced for symmetry with ``kanban_complete`` / ``kanban_block``
+    so a worker cannot close a sibling task by passing an explicit
+    ``task_id``. Orchestrators (kanban toolset, no HERMES_KANBAN_TASK)
+    may target any task id.
+    """
+    tid = args.get("task_id") or _default_task_id(None)
+    if not tid:
+        return tool_error(
+            "task_id is required (close-as-obsolete is targeted, not "
+            "defaulted from HERMES_KANBAN_TASK — caller must name the "
+            "card explicitly)"
+        )
+    ownership_err = _enforce_worker_task_ownership(str(tid))
+    if ownership_err:
+        return ownership_err
+    reason = args.get("reason")
+    if not reason or not str(reason).strip():
+        return tool_error(
+            "reason is required — explain why the card is being closed "
+            "as obsolete"
+        )
+    closed_by = args.get("closed_by")
+    if not closed_by or not str(closed_by).strip():
+        # Default to the active profile so the audit trail is never
+        # blank. Orchestrator contexts resolve to their profile;
+        # worker contexts resolve to the task they're scoped to.
+        closed_by = (
+            os.environ.get("HERMES_PROFILE")
+            or os.environ.get("HERMES_KANBAN_TASK")
+            or "operator"
+        )
+    reason = redact_sensitive_text(str(reason).strip(), force=True)
+    closed_by = redact_sensitive_text(str(closed_by).strip(), force=True)
+    board = args.get("board")
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            try:
+                ok = kb.close_as_obsolete(
+                    conn, str(tid),
+                    reason=reason,
+                    closed_by=closed_by,
+                    expected_run_id=_worker_run_id(str(tid)),
+                )
+            except kb.CardHasActiveClaimError as claim_err:
+                # Card has a live worker — refuse with a structured
+                # error that names the offending claim_lock so the
+                # orchestrator can wait for it to clear or kill it.
+                return tool_error(
+                    f"kanban_close_as_obsolete refused: {claim_err}. "
+                    f"Wait for the worker to exit (or force-clear the "
+                    f"claim_lock via the operator path) before retrying."
+                )
+            except kb.CardHasOpenChildrenError as children_err:
+                # Open children mean closing now would silently drop a
+                # dependency edge. Surface the offending child ids so
+                # the orchestrator can route them to done first.
+                return tool_error(
+                    f"kanban_close_as_obsolete refused: {children_err}. "
+                    f"Resolve the children (kanban_complete or archive) "
+                    f"before closing the parent."
+                )
+            if not ok:
+                # Card wasn't in 'blocked' status, or the transition
+                # lost the race against an unblock/claim. Re-read so the
+                # error names the actual state.
+                current = kb.get_task(conn, str(tid))
+                if current is None:
+                    return tool_error(
+                        f"kanban_close_as_obsolete: task {tid} not found"
+                    )
+                if current.status == "done":
+                    # Idempotent — a concurrent caller already closed
+                    # it. Return success so retries don't bounce.
+                    return _ok(
+                        task_id=str(tid),
+                        status="done",
+                        obsolete=True,
+                        note="already closed (idempotent)",
+                    )
+                return tool_error(
+                    f"kanban_close_as_obsolete refused: task {tid} is "
+                    f"in status {current.status!r}; only 'blocked' "
+                    f"tasks can be closed as obsolete. Use "
+                    f"kanban_complete for running/ready tasks."
+                )
+            return _ok(
+                task_id=str(tid),
+                status="done",
+                obsolete=True,
+                closed_by=closed_by,
+            )
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_close_as_obsolete: {e}")
+    except Exception as e:
+        logger.exception("kanban_close_as_obsolete failed")
+        return tool_error(f"kanban_close_as_obsolete: {e}")
+
+
 def _handle_heartbeat(args: dict, **kw) -> str:
     """Signal that the worker is still alive during a long operation.
 
@@ -1633,6 +1754,60 @@ KANBAN_BLOCK_SCHEMA = {
     },
 }
 
+
+KANBAN_CLOSE_AS_OBSOLETE_SCHEMA = {
+    "name": "kanban_close_as_obsolete",
+    "description": (
+        "Atomically close a BLOCKED card as obsolete without ever "
+        "transitioning through ``ready``. Use this to retire a blocked "
+        "card whose work is no longer relevant (superseded, removed "
+        "from scope, moot) without giving the dispatcher a window to "
+        "claim the card mid-close. The transition is a single "
+        "``blocked → done`` write — there is no intermediate "
+        "claimable state. Emits a ``completed`` event with "
+        "``obsolete: True`` so existing notifiers and dashboard "
+        "renderers fire as usual. Refuses (no state change) when the "
+        "card has an active ``claim_lock`` (live worker), has open "
+        "children (unresolved dependencies), or is not in ``blocked`` "
+        "status. ``reason`` is required; ``closed_by`` defaults to the "
+        "caller's profile. Orchestrator-only — dispatcher-spawned task "
+        "workers should not retire sibling cards."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": (
+                    "Id of the BLOCKED card to close. Required (do not "
+                    "default from HERMES_KANBAN_TASK — this verb is "
+                    "explicitly targeted)."
+                ),
+            },
+            "reason": {
+                "type": "string",
+                "description": (
+                    "Non-empty human-readable explanation of why the "
+                    "card is being closed as obsolete. Recorded on the "
+                    "completed event payload and on the run summary."
+                ),
+            },
+            "closed_by": {
+                "type": "string",
+                "description": (
+                    "Operator / orchestrator id that issued the close. "
+                    "Defaults to HERMES_PROFILE or HERMES_KANBAN_TASK "
+                    "when omitted. Recorded on the completed event "
+                    "payload for audit."
+                ),
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["task_id", "reason"],
+    },
+}
+
+
 KANBAN_HEARTBEAT_SCHEMA = {
     "name": "kanban_heartbeat",
     "description": (
@@ -2043,6 +2218,15 @@ registry.register(
     handler=_handle_block,
     check_fn=_check_kanban_mode,
     emoji="⏸",
+)
+
+registry.register(
+    name="kanban_close_as_obsolete",
+    toolset="kanban",
+    schema=KANBAN_CLOSE_AS_OBSOLETE_SCHEMA,
+    handler=_handle_close_as_obsolete,
+    check_fn=_check_kanban_orchestrator_mode,
+    emoji="🗑",
 )
 
 registry.register(


### PR DESCRIPTION
Four fixes and one small feature from running hermes-agent in a multi-profile production fleet:

- config: get_env_value_prefer_dotenv falls back to the root .env when a profile-scoped lookup misses (profile-isolation trap).
- doctor: reads credentials through get_env_value_prefer_dotenv so its report matches what the runtime actually resolves.
- cron: force sync delegate_task on the cron path at the live dispatcher; adds SessionDB._ensure_conn() so a write after an interim close reopens safely instead of dying on NoneType.
- kanban: close_as_obsolete admin verb + regression tests (6 tests; suite fails pre-change, passes post-change).

Test note: tests/cron/test_scheduler.py::TestRoutingIntents has 2 order-dependent failures when the full tests/cron/ directory runs — these reproduce identically on current main without this branch (pre-existing isolation issue, happy to file separately).