### PR TITLE
fix(desktop): 修复间歇性重复渲染 assistant 回复的问题

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -507,16 +507,21 @@ export function useMessageStream({
               )
             } else if (
               interimBoundaryPending &&
-              responsePreviewed &&
               finalText &&
               existingText &&
               finalText.startsWith(existingText)
             ) {
-              // The verification candidate was published provisionally as an
-              // interim message and then reused as the terminal response
-              // (continuation-budget fallback). Settle the interim in place
-              // instead of creating a duplicate — the DB has one row, so the
-              // live UI must agree. (#65919 review: duplicate-message blocker)
+              // An interim message was just sealed (message.interim) and the
+              // terminal response (message.complete) either reuses it exactly
+              // or extends it. The DB will persist one row, so the live UI
+              // must settle onto the existing interim instead of appending a
+              // duplicate bubble. (#70108: Desktop intermittently renders
+              // duplicate assistant replies)
+              //
+              // This covers both the response_previewed path (continuation-
+              // budget fallback, #65919) and the common case where the
+              // gateway doesn't set response_previewed but the final text
+              // is the same as (or a superset of) the interim text.
               //
               // Prefix match (not exact equality): the final response may be
               // the streamed text plus a trailing delta.  mergeFinalAssistantText

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -186,18 +186,19 @@ describe('useMessageStream interim text sealing', () => {
     expect(getState().interimBoundaryPending).toBe(true)
   })
 
-  it('keeps an identical final completion distinct from an interim reply without response_previewed', async () => {
+  it('settles an identical final completion onto the interim even without response_previewed', async () => {
     await mountStream()
     await start()
 
     await interim('same reply')
     await complete('same reply')
 
-    // Without response_previewed, the interim and terminal replies are
-    // distinct messages — the gateway didn't signal that the final reuses
-    // the provisional candidate.
+    // The interim and final are byte-identical — the DB will have one row,
+    // so the live UI must collapse them into one bubble instead of
+    // rendering a duplicate. (#70108: Desktop intermittently renders
+    // duplicate assistant replies)
     const texts = assistantMessages()
-    expect(texts.filter(t => t === 'same reply')).toHaveLength(2)
+    expect(texts.filter(t => t === 'same reply')).toHaveLength(1)
   })
 
   it('settles an identical final completion onto the interim when response_previewed', async () => {
@@ -226,6 +227,22 @@ describe('useMessageStream interim text sealing', () => {
 
     // Prefix match: the final starts with the interim text, so settle
     // onto the interim instead of creating a duplicate bubble.
+    const texts = assistantMessages()
+    expect(texts.filter(t => t.includes('partial answer'))).toHaveLength(1)
+    expect(texts[0]).toBe('partial answer with more detail')
+  })
+
+  it('settles a prefix-matched final onto the interim even without response_previewed', async () => {
+    await mountStream()
+    await start()
+
+    // The interim seals a partial answer, then the final response
+    // extends it — even without response_previewed, the DB will have
+    // one row, so the live UI must settle onto the interim.
+    await interim('partial answer')
+    await complete('partial answer with more detail')
+
+    // One bubble, containing the full final text — not two. (#70108)
     const texts = assistantMessages()
     expect(texts.filter(t => t.includes('partial answer'))).toHaveLength(1)
     expect(texts[0]).toBe('partial answer with more detail')


### PR DESCRIPTION
## 背景

修复 #70108: Desktop 间歇性地将同一个 assistant 回复渲染为两个独立的消息气泡。

## 根因分析

当 gateway 发送 `message.interim` 将正在流式传输的 assistant 气泡密封（sealed）后，紧接着的 `message.complete` 在落地时会尝试找到已有的 assistant 消息进行合并。

原有的去重逻辑要求 `response_previewed=true` 才能将最终回复合并到已密封的 interim 气泡上。当 gateway 未设置 `response_previewed` 标志时（这是常见情况），即使最终回复文本与 interim 文本完全相同或是其前缀扩展，代码也会创建一个新的 assistant 消息气泡，导致同一回复在界面上出现两次。

数据库只持久化了一行 assistant 消息，所以重新加载（rehydration）后重复气泡消失——这证实了问题出在实时渲染路径上。

## 修复方式

在 `use-message-stream/index.ts` 的 `completeAssistantMessage` 中：

- **移除 `response_previewed` 的前置要求**：当 `interimBoundaryPending=true` 时，只要最终文本与已密封的 interim 文本相同或是其前缀扩展（`finalText.startsWith(existingText)`），就将最终回复合并到现有的 interim 气泡上。
- 这覆盖了两种场景：
  1. 有 `response_previewed` 的场景（continuation-budget 回退路径，#65919）
  2. 没有 `response_previewed` 但最终文本与 interim 相同或扩展了 interim 的常见场景

## 测试变更

- 更新 `interim-sealing.test.tsx` 中的同名文本测试：期望 1 个气泡（原期望 2 个）
- 新增 `settles a prefix-matched final onto the interim even without response_previewed` 测试用例
- 所有 40 个 use-message-stream 测试通过

## 验证

- [x] 代码变更已在本地验证（40/40 tests passed）
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更

Closes #70108