### PR TITLE
fix: recover startup cwd when launch dir is deleted

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -405,6 +405,72 @@ def _parse_service_tier_config(raw: str) -> str | None:
     logger.warning("Unknown service_tier '%s', ignoring", raw)
     return None
 
+
+def _normalize_startup_cwd_candidate(path: str) -> str:
+    """Translate shell-provided cwd candidates into a host path Python can use.
+
+    When ``os.getcwd()`` fails during startup, the remaining breadcrumbs are
+    usually shell environment variables like ``PWD``. On Git Bash / MSYS these
+    can be POSIX-style drive paths (``/c/Users/...``), which Windows Python
+    cannot stat directly. Normalize those spellings before existence checks.
+    """
+    if sys.platform != "win32" or not path:
+        return path
+    import re as _re
+
+    m = _re.match(r"^/([a-zA-Z])/(.*)$", path)
+    if m:
+        drive, rest = m.group(1), m.group(2)
+        return f"{drive.upper()}:\\{rest.replace('/', chr(92))}"
+
+    m = _re.match(r"^/(?:cygdrive|mnt)/([a-zA-Z])/(.*)$", path)
+    if m:
+        drive, rest = m.group(1), m.group(2)
+        return f"{drive.upper()}:\\{rest.replace('/', chr(92))}"
+
+    return path
+
+
+def _startup_cwd_usable(path: str) -> bool:
+    """Return True when *path* exists as a directory this process can enter."""
+    return bool(path) and os.path.isdir(path) and os.access(path, os.X_OK)
+
+
+def _recover_startup_cwd() -> str:
+    """Return a safe cwd for CLI startup, even if the launch cwd was deleted.
+
+    The failure shape is a shell that remains attached to a deleted directory
+    (common after removing a git worktree from another checkout). In that state
+    ``os.getcwd()`` raises before the CLI can even load its config. Recover by
+    walking up the shell-reported path to the nearest usable ancestor, then fall
+    back to ``TERMINAL_CWD``, home, and finally the temp dir.
+    """
+    try:
+        return os.getcwd()
+    except OSError as exc:
+        logger.warning(
+            "Current working directory is unavailable (%s); recovering a safe startup cwd.",
+            exc,
+        )
+
+    for raw in (
+        os.environ.get("PWD", ""),
+        os.environ.get("TERMINAL_CWD", ""),
+        os.path.expanduser("~"),
+    ):
+        candidate = _normalize_startup_cwd_candidate(str(raw or "").strip())
+        if not candidate:
+            continue
+        if _startup_cwd_usable(candidate):
+            return candidate
+        parent = os.path.dirname(candidate)
+        while parent and parent != candidate:
+            if _startup_cwd_usable(parent):
+                return parent
+            candidate, parent = parent, os.path.dirname(parent)
+
+    return tempfile.gettempdir()
+
 def load_cli_config() -> Dict[str, Any]:
     """
     Load CLI configuration from config files.
@@ -649,7 +715,7 @@ def load_cli_config() -> Dict[str, Any]:
     effective_backend = terminal_config.get("env_type", "local")
 
     if effective_backend == "local":
-        terminal_config["cwd"] = os.getcwd()
+        terminal_config["cwd"] = _recover_startup_cwd()
         defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -822,3 +822,39 @@ class TestProviderResolution:
         cli = _make_cli()
         assert isinstance(cli.model, str)
         assert isinstance(cli.model, str) and '/' in cli.model
+
+
+class TestStartupCwdRecovery:
+    def test_recover_startup_cwd_climbs_to_nearest_existing_pwd_ancestor(self, monkeypatch, tmp_path):
+        import cli as cli_mod
+
+        missing = tmp_path / "gone" / "deeper"
+
+        def _boom():
+            raise FileNotFoundError("cwd deleted")
+
+        monkeypatch.setattr(cli_mod.os, "getcwd", _boom)
+        monkeypatch.setenv("PWD", str(missing))
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        assert cli_mod._recover_startup_cwd() == str(tmp_path)
+
+    def test_load_cli_config_uses_recovered_cwd_for_local_backend(self, monkeypatch, tmp_path):
+        import cli as cli_mod
+
+        missing = tmp_path / "gone" / "deeper"
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        def _boom():
+            raise FileNotFoundError("cwd deleted")
+
+        monkeypatch.setattr(cli_mod.os, "getcwd", _boom)
+        monkeypatch.setenv("PWD", str(missing))
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.setattr(cli_mod, "_hermes_home", hermes_home)
+
+        config = cli_mod.load_cli_config()
+
+        assert config["terminal"]["cwd"] == str(tmp_path)
+        assert os.environ["TERMINAL_CWD"] == str(tmp_path)


### PR DESCRIPTION
## Summary
- recover CLI startup when `os.getcwd()` fails because the launch directory was deleted
- walk `PWD` up to the nearest usable ancestor before falling back to `TERMINAL_CWD`, home, or tempdir
- add regression tests for both the helper and `load_cli_config()` local-backend wiring

## Problem
Running `hermes` from a shell whose current directory had been removed (for example after deleting a git worktree from another checkout) crashed during import-time config loading:

```text
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
FileNotFoundError: [Errno 2] No such file or directory
```

The immediate cause was `cli.py` calling `os.getcwd()` unguarded while resolving the local terminal cwd.

## Fix
- add `_recover_startup_cwd()` in `cli.py`
- prefer the real cwd when available
- when it is gone, recover from the nearest existing accessible ancestor of `PWD`
- if that fails too, try `TERMINAL_CWD`, then `~`, then `tempfile.gettempdir()`
- keep Windows Git Bash / MSYS path normalization for shell-provided cwd candidates

## Validation
- `python3 -m py_compile cli.py tests/cli/test_cli_init.py`
- `scripts/run_tests.sh tests/cli/test_cli_init.py -k StartupCwdRecovery -v`
- `scripts/run_tests.sh tests/cli/test_cli_init.py tests/tools/test_terminal_task_cwd.py -k 'StartupCwdRecovery or safe_getcwd' -v`
- real repro via forked child process: start `hermes --help` from a cwd that is deleted after `chdir()` but before exec; command now exits 0 and prints help instead of crashing
