### PR TITLE
fix(cli): show 'grew by' when optimize-storage DB size increases (#70146)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -16084,10 +16084,11 @@ def main():
                 os.path.getsize(db_path) / (1024 * 1024) if db_path.exists() else 0.0
             )
             saved = before_mb - after_mb
+            saved_label = f"reclaimed {saved:.1f} MB" if saved >= 0 else f"grew by {-saved:.1f} MB"
             print(f"\n✓ Search index optimized.")
             print(
                 f"  Database size: {before_mb:.1f} MB -> {after_mb:.1f} MB "
-                f"(reclaimed {saved:.1f} MB)"
+                f"({saved_label})"
             )
             if result.get("vacuumed") is False:
                 print("  (VACUUM was skipped or failed — run "


### PR DESCRIPTION
Closes #70146

When `hermes sessions optimize-storage` runs and the database grows
(rather than shrinks), the old code always printed `(reclaimed X MB)`
with a negative value. Fix by using a conditional label:
- positive delta → `reclaimed X MB`
- negative delta → `grew by X MB`