### PR TITLE
fix(agent): drop tool_calls key when all tool_calls are deduplicated (#70126)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2872,7 +2872,7 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 if cid:
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
-            if len(kept_tcs) != len(msg.get("tool_calls") or []):
+            if kept_tcs:
                 msg = {**msg, "tool_calls": kept_tcs}
             deduped.append(msg)
         elif role == "tool":


### PR DESCRIPTION
Closes #70126

sanitize_api_messages() Step 3 deduplication creates tool_calls: []
when every tool_call in a turn has a duplicate id. This empty array
then passes through to strict OpenAI-compatible providers (Qwen-series)
which reject it with HTTP 400. Fix: when kept_tcs is empty after
dedup, drop the tool_calls key entirely instead of setting it to [].