### PR TITLE
fix(gateway): derive the Slack capability note from the live tool surface

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18647,6 +18647,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "1" if src.message_id else "0",
             )
 
+        # Slack renders a capability-aware platform note gated on
+        # _slack_tools_loaded() — the gate state must appear in the key
+        # (same parity contract as the Discord gate above) so a config /
+        # MCP-registration flip re-renders once instead of serving a
+        # stale pinned note for the rest of the session.
+        slack_tools = ""
+        if src.platform == Platform.SLACK:
+            from gateway.session import _slack_tools_loaded
+
+            slack_tools = "1" if _slack_tools_loaded() else "0"
+
         try:
             from hermes_constants import display_hermes_home
 
@@ -18667,6 +18678,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             bool(context.shared_multi_user_session),
             discord_ids,
             discord_tools,
+            slack_tools,
             tuple(p.value for p in context.connected_platforms),
             tuple(
                 (

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -572,9 +572,11 @@ def build_session_context_prompt(
             lines.append("")
             lines.append(
                 "**Platform notes:** You are running inside Slack and have access "
-                "to Slack-specific tools. You CAN search channel history, post "
-                "messages, react to messages, and perform other Slack operations "
-                "via the available Slack toolset."
+                "to Slack-specific tools this session. Consult the available Slack "
+                "tool schemas for the exact operations supported (e.g. channel "
+                "history and thread lookups, posting, reactions) — use those tools "
+                "for Slack-specific requests, and do not promise Slack actions "
+                "beyond what the loaded tools actually expose."
             )
         else:
             lines.append("")

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -342,6 +342,52 @@ that requires raw IDs).  Discord is excluded because mentions use ``<@user_id>``
 and the LLM needs the real ID to tag users."""
 
 
+def _slack_tools_loaded() -> bool:
+    """True iff the agent will actually have Slack tools this session.
+
+    Two independent paths grant Slack capability:
+      1. Native `slack` toolset enabled via `hermes tools` (opt-in, default
+         OFF) AND `SLACK_BOT_TOKEN` set — the tool's `check_fn` gates on it
+         at registry time, so config alone isn't enough.
+      2. An MCP server that has ACTUALLY registered tools into the live
+         registry (tools/mcp_tool.get_registered_mcp_server_names()), whose
+         name suggests Slack. This is the real, availability-filtered
+         signal (post-connection, post include/exclude filtering) rather
+         than just what's listed in config.yaml -- a configured-but-
+         unconnected or zero-tool MCP server must not claim capability.
+         Named MCP servers are process-wide (one gateway connects each MCP
+         server once, not per-session), so this check is intentionally NOT
+         scoped further per-session -- unlike the earlier get_all_tool_names()
+         approach this replaces, which conflated ALL built-in tool names
+         process-wide, this only inspects the small, purpose-built MCP
+         server-name map.
+
+    Returns False (safe default — keeps the stale-API disclaimer) on any
+    error so a bad config can never silently promise tools the agent lacks.
+    """
+    try:
+        from tools.mcp_tool import get_registered_mcp_server_names
+        if any("slack" in name.lower() for name in get_registered_mcp_server_names()):
+            return True
+    except Exception:
+        pass
+
+    if not (os.environ.get("SLACK_BOT_TOKEN") or "").strip():
+        return False
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+        cfg = load_config()
+        # include_default_mcp_servers=True (the default) so a Slack MCP
+        # server that's enabled by default for this platform (not
+        # explicitly listed) is also counted, in addition to the native
+        # 'slack' toolset.
+        enabled = _get_platform_tools(cfg, "slack")
+        return "slack" in enabled
+    except Exception:
+        return False
+
+
 def _discord_tools_loaded() -> bool:
     """True iff the agent will actually have Discord tools this session.
 
@@ -517,15 +563,29 @@ def build_session_context_prompt(
 
     # Platform-specific behavioral notes
     if context.source.platform == Platform.SLACK:
-        lines.append("")
-        lines.append(
-            "**Platform notes:** You are running inside Slack. "
-            "You do NOT have access to Slack-specific APIs — you cannot search "
-            "channel history, pin/unpin messages, manage channels, or list users. "
-            "Do not promise to perform these actions. The gateway may inline the "
-            "current message's Slack block/attachment payload when available, but "
-            "you still cannot call Slack APIs yourself."
-        )
+        # Inject the Slack capability note only when the agent actually has
+        # Slack tools loaded this session — native `slack` toolset opt-in,
+        # or a connected MCP server that has registered Slack tools.
+        # Otherwise keep the stale-API disclaimer honest so we never
+        # promise tools the agent lacks. Mirrors the Discord pattern below.
+        if _slack_tools_loaded():
+            lines.append("")
+            lines.append(
+                "**Platform notes:** You are running inside Slack and have access "
+                "to Slack-specific tools. You CAN search channel history, post "
+                "messages, react to messages, and perform other Slack operations "
+                "via the available Slack toolset."
+            )
+        else:
+            lines.append("")
+            lines.append(
+                "**Platform notes:** You are running inside Slack. "
+                "You do NOT have access to Slack-specific APIs — you cannot search "
+                "channel history, pin/unpin messages, manage channels, or list users. "
+                "Do not promise to perform these actions. The gateway may inline the "
+                "current message's Slack block/attachment payload when available, but "
+                "you still cannot call Slack APIs yourself."
+            )
         if context.shared_multi_user_session:
             lines.append(
                 "In shared Slack threads, use the current turn's sender prefix "

--- a/tests/gateway/test_prompt_tail_freeze.py
+++ b/tests/gateway/test_prompt_tail_freeze.py
@@ -99,9 +99,10 @@ def _make_context(
 
 @pytest.fixture(autouse=True)
 def _stable_discord_tools(monkeypatch):
-    """Pin the config/env-dependent renderer gate so key<->render parity is
+    """Pin the config/env-dependent renderer gates so key<->render parity is
     evaluated on the same footing in every environment."""
     monkeypatch.setattr("gateway.session._discord_tools_loaded", lambda: True)
+    monkeypatch.setattr("gateway.session._slack_tools_loaded", lambda: False)
 
 
 def _key(runner, context, redact_pii=False):
@@ -191,6 +192,45 @@ class TestEphemeralChangeKeyParity:
         monkeypatch.setattr("gateway.session._discord_tools_loaded", lambda: False)
         assert _render(ctx) != render_on
         assert _key(runner, ctx) != key_on
+
+    def test_slack_tools_gate_flip_changes_key(self, monkeypatch):
+        """The Slack capability note is gated on _slack_tools_loaded(); the
+        gate state must be part of the change key (same parity contract as
+        the Discord gate) or a config/MCP flip would serve a stale pinned
+        note forever."""
+        runner = _make_runner()
+        ctx = _make_context(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            thread_id=None,
+            parent_chat_id=None,
+            guild_id=None,
+        )
+        render_off, key_off = _render(ctx), _key(runner, ctx)
+        monkeypatch.setattr("gateway.session._slack_tools_loaded", lambda: True)
+        assert _render(ctx) != render_off
+        assert _key(runner, ctx) != key_off
+
+    def test_slack_note_byte_stable_across_turns_in_one_session(self):
+        """Within one session (gate state constant), the Slack platform note
+        must be byte-stable turn over turn — the pin returns the identical
+        object, so the composed system prompt cannot drift mid-conversation."""
+        runner = _make_runner()
+
+        def _slack_ctx():
+            return _make_context(
+                platform=Platform.SLACK,
+                chat_id="C123",
+                thread_id=None,
+                parent_chat_id=None,
+                guild_id=None,
+            )
+
+        t1 = runner._pinned_session_context_prompt(_slack_ctx(), False, "sk-slack")  # noqa: SLF001
+        t2 = runner._pinned_session_context_prompt(_slack_ctx(), False, "sk-slack")  # noqa: SLF001
+        t3 = runner._pinned_session_context_prompt(_slack_ctx(), False, "sk-slack")  # noqa: SLF001
+        assert t2 is t1 and t3 is t1
+        assert hashlib.sha256(t1.encode()).hexdigest() == hashlib.sha256(t3.encode()).hexdigest()
 
     def test_message_id_value_change_is_not_a_bust(self):
         """Only message-id PRESENCE renders (the id itself rides the user

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -278,7 +278,9 @@ class TestBuildSessionContextPrompt:
         # Static pointer tells the agent where the volatile id actually lives.
         assert "provided per-turn in the incoming user message" in p1
 
-    def test_slack_prompt_includes_platform_notes(self):
+    def test_slack_prompt_no_tools_shows_disclaimer(self):
+        """Without slack toolset loaded, prompt must show the stale-API disclaimer."""
+        from unittest.mock import patch
         config = GatewayConfig(
             platforms={
                 Platform.SLACK: PlatformConfig(enabled=True, token="fake"),
@@ -292,7 +294,100 @@ class TestBuildSessionContextPrompt:
             user_name="bob",
         )
         ctx = build_session_context(source, config)
-        prompt = build_session_context_prompt(ctx)
+        with patch("gateway.session._slack_tools_loaded", return_value=False):
+            prompt = build_session_context_prompt(ctx)
+
+        assert "Slack" in prompt
+        assert "cannot search" in prompt.lower()
+        assert "pin" in prompt.lower()
+        assert "current message's slack block/attachment payload" in prompt.lower()
+        assert "you can" not in prompt.lower() or "you cannot" in prompt.lower()
+
+    def test_slack_prompt_with_tools_shows_capability(self):
+        """When slack toolset is loaded, prompt must advertise API access."""
+        from unittest.mock import patch
+        config = GatewayConfig(
+            platforms={
+                Platform.SLACK: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_name="general",
+            chat_type="group",
+            user_name="bob",
+        )
+        ctx = build_session_context(source, config)
+        with patch("gateway.session._slack_tools_loaded", return_value=True):
+            prompt = build_session_context_prompt(ctx)
+
+        assert "Slack" in prompt
+        assert "have access" in prompt.lower() or "you can" in prompt.lower()
+        assert "you do not have access" not in prompt.lower()
+
+    def test_slack_tools_loaded_detects_real_mcp_registration(self):
+        """Regression (review of #63234): a connected MCP server whose tools
+        are ACTUALLY registered in the live registry must be detected as
+        Slack capability, without mocking _slack_tools_loaded itself -- this
+        exercises the real tools.mcp_tool registration signal the earlier
+        (mocked-wholesale) tests didn't reach. Native SLACK_BOT_TOKEN/toolset
+        config is intentionally left unset so only the MCP path can pass."""
+        import os as _os
+        from unittest.mock import patch
+        from gateway.session import _slack_tools_loaded
+        import tools.mcp_tool as _mcp_tool_mod
+
+        # No native slack toolset / token configured.
+        with patch.dict(_os.environ, {}, clear=False):
+            _os.environ.pop("SLACK_BOT_TOKEN", None)
+
+            # Simulate a connected MCP server ("company-slack") that has
+            # registered a real tool, via the actual tracking function used
+            # by the live registration path (tools/mcp_tool.py:_track_mcp_tool_server),
+            # not a mock of the capability check.
+            _mcp_tool_mod._track_mcp_tool_server("mcp-company-slack_post_message", "company-slack")
+            try:
+                assert _slack_tools_loaded() is True, (
+                    "A connected MCP server with 'slack' in its name and "
+                    "registered tools must be detected as Slack capability"
+                )
+            finally:
+                _mcp_tool_mod._forget_mcp_tool_server("mcp-company-slack_post_message")
+
+    def test_slack_tools_loaded_false_when_no_matching_mcp_server(self):
+        """An MCP server unrelated to Slack must not grant Slack capability."""
+        import os as _os
+        from unittest.mock import patch
+        from gateway.session import _slack_tools_loaded
+        import tools.mcp_tool as _mcp_tool_mod
+
+        with patch.dict(_os.environ, {}, clear=False):
+            _os.environ.pop("SLACK_BOT_TOKEN", None)
+            _mcp_tool_mod._track_mcp_tool_server("mcp-github_create_issue", "github")
+            try:
+                assert _slack_tools_loaded() is False
+            finally:
+                _mcp_tool_mod._forget_mcp_tool_server("mcp-github_create_issue")
+
+    def test_slack_prompt_includes_platform_notes(self):
+        """Legacy: backward-compat alias -- no tools loaded shows disclaimer."""
+        from unittest.mock import patch
+        config = GatewayConfig(
+            platforms={
+                Platform.SLACK: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_name="general",
+            chat_type="group",
+            user_name="bob",
+        )
+        ctx = build_session_context(source, config)
+        with patch("gateway.session._slack_tools_loaded", return_value=False):
+            prompt = build_session_context_prompt(ctx)
 
         assert "Slack" in prompt
         assert "cannot search" in prompt.lower()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5969,6 +5969,21 @@ def has_registered_mcp_tools() -> bool:
         return bool(_mcp_tool_server_names)
 
 
+def get_registered_mcp_server_names() -> set:
+    """Return the set of MCP server names that have actually registered at
+    least one tool into the registry (post-connection, post check_fn/include-
+    exclude filtering) -- i.e. the real, availability-filtered signal, not
+    just what's present in config.yaml under ``mcp_servers``.
+
+    Used by capability-aware prompt building (e.g. gateway/session.py's
+    Slack platform note) to detect an MCP server that provides a given
+    platform's capability regardless of what its config key is named.
+    """
+    with _lock:
+        return set(_mcp_tool_server_names.values())
+
+
+
 def refresh_agent_mcp_tools(
     agent,
     *,


### PR DESCRIPTION
## Summary
The Slack platform note no longer lies to the agent: instead of unconditionally claiming "you do NOT have access to Slack-specific APIs", the note is derived from the live tool surface (MCP servers + native toolsets), mirroring the merged Discord pattern — so the agent stops refusing valid requests when Slack tools are present.

Fixes #6536.

## Changes
- `tools/mcp_tool.get_registered_mcp_server_names()` — post-connection, availability-filtered MCP registration map; capability gate in `build_session_context_prompt` derives from it + native slack toolset/config.
- Session-stable: computed at session construction, never mutates mid-conversation (prompt-cache safe).

## Credits
Base: #68627 (@ygd58) — the only one of five overlapping PRs deriving the gate from the live tool surface, cherry-picked with authorship.
Supersedes #6545 (@mecampbellsoup — EARLIEST diagnosis, credited as originator), #62135, #36676, #69094.

## Validation
| Check | Result |
|---|---|
| Note reflects toolset (with slack tools → mentions them; without → doesn't) | green |
| Byte-stable across turns in one session | green |
| `tests/gateway/ -q -k slack` | 767 passed, 0 failed (re-verified post-rebase) |

## Infographic

![slack-capability-note](https://v3b.fal.media/files/b/0aa36ce8/p5ctcIY6ho1c76R0uAJt8_4koErXS7.png)
