### PR TITLE
fix(vision): stop prompting duplicate native image loads

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 
 from tools.vision_tools import (
+    VISION_ANALYZE_SCHEMA,
     _build_native_vision_tool_result,
     _handle_vision_analyze,
     _supports_media_in_tool_results,
@@ -26,6 +27,18 @@ from tools.vision_tools import (
 _TINY_PNG = base64.b64decode(
     b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
 )
+
+
+# ─── Tool guidance ────────────────────────────────────────────────────────────
+
+
+def test_schema_does_not_prompt_duplicate_native_attachment_load():
+    """A native attachment path is a tool handle, not a reload instruction."""
+    description = VISION_ANALYZE_SCHEMA["description"].lower()
+
+    assert "already attached" in description
+    assert "answer directly" in description
+    assert "call this any time the user references an image" not in description
 
 
 # ─── _supports_media_in_tool_results ─────────────────────────────────────────

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1444,14 +1444,14 @@ from tools.registry import registry, tool_error
 VISION_ANALYZE_SCHEMA = {
     "name": "vision_analyze",
     "description": (
-        "Load an image into the conversation so you can see it. Accepts a "
-        "URL, local file path, or data URL. When your active model has "
-        "native vision, the image is attached to your context directly "
-        "and you read the pixels yourself on the next turn — call this "
-        "any time the user references an image (filepath in their message, "
-        "URL in tool output, screenshot from the browser, etc.). For "
-        "non-vision models, falls back to an auxiliary vision model that "
-        "returns a text description."
+        "Load an image that is not already visible in the conversation. "
+        "Accepts a URL, local file path, or data URL. If the image is already "
+        "attached natively in the current user turn, answer directly; its local "
+        "path is only a tool handle, not a reason to reload it. Use this for "
+        "path/URL-only references in prose or tool output, browser screenshots "
+        "not yet attached, or deliberate reinspection. Native-vision models "
+        "receive the pixels directly; other models get an auxiliary text "
+        "description."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## Summary

Prevent `vision_analyze` from prompting the model to reload an image that is already attached natively in the current user turn.

The native attachment path intentionally adds `[Image attached at: <path>]` as a tool handle (#18960). The current `vision_analyze` schema also says to call the tool any time the user references an image path. Together, those instructions make a vision-capable main model likely to call `vision_analyze` on pixels it already received, adding a redundant tool turn and visible progress noise.

This change keeps both valid capabilities:

- native user attachments remain directly visible to vision-capable models;
- path/URL-only and tool-discovered images can still be loaded with `vision_analyze`.

It only clarifies that a local path accompanying an already-native attachment is a tool handle, not a reload instruction. Deliberate reinspection remains supported.

## Regression coverage

Adds a model-facing schema contract test that requires the description to:

- tell the model to answer directly for an already attached native image;
- retain the distinction between a tool handle and a reload instruction;
- reject the previous blanket “call this any time” wording.

## Verification

```text
scripts/run_tests.sh tests/tools/test_vision_native_fast_path.py tests/agent/test_image_routing.py -q
128 passed

.venv/bin/ruff check tools/vision_tools.py tests/tools/test_vision_native_fast_path.py
All checks passed!

git diff --check
passed
```

## Context

- #16506 originally introduced native inbound image routing and explicitly described avoiding redundant `vision_analyze` calls for images already visible in the conversation.
- #22955 later made `vision_analyze` useful for path/URL and tool-discovered images.
- #18960 added native attachment path hints so MCP/skill tools can reuse the file path.

The updated description preserves all three intents without removing the path hint or disabling the vision tool.