### PR TITLE
fix(installer): migrate managed Python to fixed SQLite builds

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -15,6 +15,7 @@ import os
 import platform
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import Optional
@@ -156,11 +157,20 @@ def ensure_uv():
 
 
 def update_managed_uv() -> Optional[str]:
-    """Run ``uv self update`` on the managed uv binary.
+    """Update managed uv and replace Python builds with vulnerable SQLite.
 
     Call this during ``hermes update`` so the managed copy stays current.
-    Returns the managed path on success, ``None`` if uv isn't available or
-    the self-update fails (non-fatal — the old version still works).
+    Returns the managed path when uv is available, or ``None`` when it is not.
+    Self-update and runtime-migration failures are non-fatal.
+
+    Updating uv matters independently of the Python patch version: uv freezes
+    its python-build-standalone download catalog per release.  CPython 3.11.15
+    appears in both the old and fixed catalogs, so ``uv python upgrade`` sees
+    no patch-version change and leaves SQLite 3.50.4 in place.  A reinstall
+    through current uv replaces that build with one linked against fixed
+    SQLite.  Keep this migration here (rather than only in ``main.py``) because
+    ``hermes update`` imports this module *after* pulling new code; installs
+    updating across the fix boundary therefore migrate on their first update.
     """
     existing = resolve_uv()
     if not existing:
@@ -184,7 +194,129 @@ def update_managed_uv() -> Optional[str]:
     else:
         # Non-fatal — old uv still works fine.
         logger.debug("uv self update failed (rc=%d): %s", result.returncode, result.stderr)
+
+    # Best-effort for the same reason as uv's self-update: the WAL safety gate
+    # in hermes_state keeps vulnerable installs usable in DELETE mode when the
+    # network is unavailable or a running Windows interpreter prevents an
+    # in-place runtime replacement.  A successful refresh takes effect for the
+    # next Python process; this already-running updater may retain its old
+    # sqlite3 module until it exits.
+    upgrade_vulnerable_sqlite_runtime(existing)
     return existing
+
+
+_SQLITE_WAL_RESET_VULNERABLE_EXIT = 42
+_SQLITE_WAL_RESET_PROBE = (
+    "import sqlite3\n"
+    "v = sqlite3.sqlite_version_info\n"
+    "vulnerable = (\n"
+    "    v >= (3, 7, 0)\n"
+    "    and v < (3, 51, 3)\n"
+    "    and not ((3, 50, 7) <= v < (3, 51, 0))\n"
+    "    and not ((3, 44, 6) <= v < (3, 45, 0))\n"
+    ")\n"
+    "print(sqlite3.sqlite_version)\n"
+    f"raise SystemExit({_SQLITE_WAL_RESET_VULNERABLE_EXIT} if vulnerable else 0)\n"
+)
+
+
+def _probe_sqlite_runtime(python_executable: str) -> tuple[Optional[bool], str]:
+    """Return ``(is_vulnerable, version)`` for an interpreter subprocess.
+
+    ``None`` means the interpreter could not be probed.  A subprocess is
+    required after a managed-Python reinstall because the current updater has
+    already loaded its old sqlite3 extension and cannot observe the replacement
+    in-process.
+    """
+    try:
+        result = subprocess.run(
+            [python_executable, "-c", _SQLITE_WAL_RESET_PROBE],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("SQLite runtime probe failed for %s: %s", python_executable, exc)
+        return None, ""
+
+    version = (result.stdout or "").strip().splitlines()
+    version_text = version[-1] if version else ""
+    if result.returncode == 0:
+        return False, version_text
+    if result.returncode == _SQLITE_WAL_RESET_VULNERABLE_EXIT:
+        return True, version_text
+
+    logger.debug(
+        "SQLite runtime probe failed for %s (rc=%d): %s",
+        python_executable,
+        result.returncode,
+        (result.stderr or "").strip(),
+    )
+    return None, version_text
+
+
+def upgrade_vulnerable_sqlite_runtime(
+    uv_bin: str,
+    *,
+    python_version: str = "3.11",
+    python_executable: Optional[str] = None,
+) -> bool:
+    """Reinstall managed Python when its linked SQLite has the WAL-reset bug.
+
+    Returns ``True`` when the active interpreter was already safe or a new
+    process through the same interpreter now sees a fixed SQLite build.
+    Returns ``False`` on a non-fatal migration failure.  On Windows a running
+    venv may lock the base runtime; in that case the normal installer retries
+    after stopping Hermes processes and rebuilding the venv.
+    """
+    active_python = python_executable or sys.executable
+    vulnerable, sqlite_version = _probe_sqlite_runtime(active_python)
+    if vulnerable is False:
+        return True
+    if vulnerable is None:
+        return False
+
+    version_label = sqlite_version or "unknown"
+    print(
+        f"  ⚠ SQLite {version_label} has the WAL-reset bug; "
+        "refreshing managed Python..."
+    )
+    try:
+        result = subprocess.run(
+            [str(uv_bin), "python", "install", python_version, "--reinstall"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        logger.debug("Managed Python refresh could not start: %s", exc)
+        print(
+            "  ⚠ Could not replace the vulnerable Python runtime automatically. "
+            "Close Hermes processes and re-run the installer."
+        )
+        return False
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip().splitlines()
+        if detail:
+            logger.debug("Managed Python refresh failed: %s", detail[-1])
+        print(
+            "  ⚠ Could not replace the vulnerable Python runtime automatically. "
+            "Close Hermes processes and re-run the installer."
+        )
+        return False
+
+    vulnerable_after, sqlite_after = _probe_sqlite_runtime(active_python)
+    if vulnerable_after is False:
+        print(f"  ✓ Managed Python now links fixed SQLite {sqlite_after}")
+        return True
+
+    after_label = sqlite_after or "unknown"
+    print(
+        f"  ⚠ This venv still links vulnerable SQLite {after_label}. "
+        "Close Hermes processes and re-run the installer to rebuild it."
+    )
+    return False
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -594,6 +594,85 @@ function Resolve-AvailablePythonVersion {
     return $null
 }
 
+function Test-SqliteWalResetVulnerable {
+    param([Parameter(Mandatory = $true)][string]$PythonPath)
+
+    # Keep this version matrix in sync with
+    # hermes_state.is_sqlite_wal_reset_vulnerable. Exit 42 is reserved for a
+    # successful probe that found the bug; any other non-zero result is an
+    # unknown probe failure and must not be mistaken for "vulnerable".
+    $probe = @'
+import sqlite3
+v = sqlite3.sqlite_version_info
+vulnerable = (
+    v >= (3, 7, 0)
+    and v < (3, 51, 3)
+    and not ((3, 50, 7) <= v < (3, 51, 0))
+    and not ((3, 44, 6) <= v < (3, 45, 0))
+)
+raise SystemExit(42 if vulnerable else 0)
+'@
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        & $PythonPath -c $probe 2>$null | Out-Null
+        $probeExitCode = $LASTEXITCODE
+    } catch {
+        $probeExitCode = -1
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    return $probeExitCode -eq 42
+}
+
+function Resolve-FixedSqlitePythonPath {
+    param([Parameter(Mandatory = $true)][string]$Version)
+
+    try {
+        $pythonPath = & $UvCmd python find $Version 2>$null
+    } catch {
+        return $null
+    }
+    if (-not $pythonPath) { return $null }
+    if (-not (Test-SqliteWalResetVulnerable -PythonPath $pythonPath)) {
+        return $pythonPath
+    }
+
+    $sqliteVersion = & $pythonPath -c "import sqlite3; print(sqlite3.sqlite_version)" 2>$null
+    if (-not $sqliteVersion) { $sqliteVersion = "unknown" }
+    Write-Warn "SQLite $sqliteVersion has the WAL-reset bug; refreshing managed Python..."
+
+    # uv freezes its python-build-standalone download catalog per uv release.
+    # CPython 3.11.15 exists in both the vulnerable and fixed catalogs, so a
+    # normal patch-version upgrade is a no-op. Refresh uv and force a reinstall.
+    Invoke-NativeWithRelaxedErrorAction { & $UvCmd self update } | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warn "Could not update managed uv; trying the available Python catalog"
+    }
+
+    Invoke-NativeWithRelaxedErrorAction { & $UvCmd python install $Version --reinstall } | Out-Host
+    $installExitCode = $LASTEXITCODE
+    if ($installExitCode -eq 0) {
+        try {
+            $candidatePath = & $UvCmd python find $Version --managed-python 2>$null
+        } catch {
+            $candidatePath = $null
+        }
+        if (
+            $candidatePath -and
+            -not (Test-SqliteWalResetVulnerable -PythonPath $candidatePath)
+        ) {
+            $candidateSqlite = & $candidatePath -c "import sqlite3; print(sqlite3.sqlite_version)" 2>$null
+            if (-not $candidateSqlite) { $candidateSqlite = "unknown" }
+            Write-Success "Managed Python now links fixed SQLite $candidateSqlite"
+            return $candidatePath
+        }
+    }
+
+    Write-Warn "Could not provision a fixed SQLite runtime; DELETE-mode protection remains active"
+    return $pythonPath
+}
+
 function Test-Python {
     Write-Info "Checking Python $PythonVersion..."
     
@@ -601,6 +680,7 @@ function Test-Python {
     try {
         $pythonPath = & $UvCmd python find $PythonVersion 2>$null
         if ($pythonPath) {
+            $pythonPath = Resolve-FixedSqlitePythonPath -Version $PythonVersion
             $ver = & $pythonPath --version 2>$null
             Write-Success "Python found: $ver"
             return $true
@@ -632,6 +712,7 @@ function Test-Python {
         # since uv may return non-zero due to "already installed" etc.)
         $pythonPath = & $UvCmd python find $PythonVersion 2>$null
         if ($pythonPath) {
+            $pythonPath = Resolve-FixedSqlitePythonPath -Version $PythonVersion
             $ver = & $pythonPath --version 2>$null
             Write-Success "Python installed: $ver"
             return $true
@@ -654,6 +735,7 @@ function Test-Python {
         try {
             $pythonPath = & $UvCmd python find $fallbackVer 2>$null
             if ($pythonPath) {
+                $pythonPath = Resolve-FixedSqlitePythonPath -Version $fallbackVer
                 $ver = & $pythonPath --version 2>$null
                 Write-Success "Found fallback: $ver"
                 $script:PythonVersion = $fallbackVer
@@ -1940,12 +2022,18 @@ function Install-Venv {
     Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue | ForEach-Object {
         Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
     }
-    
-    # uv creates the venv and pins the Python version in one step.  uv emits
+
+    # Retry the SQLite runtime refresh after the process sweep above. A running
+    # Windows gateway can lock the managed Python DLL during the earlier
+    # prerequisite stage; at this point those holders are stopped.
+    $venvPythonRequest = Resolve-FixedSqlitePythonPath -Version $PythonVersion
+    if (-not $venvPythonRequest) { $venvPythonRequest = $PythonVersion }
+
+    # uv creates the venv and pins the verified interpreter in one step. uv emits
     # normal progress such as "Using CPython ..." on stderr; under Windows
     # PowerShell 5.1 with EAP=Stop that stderr is a NativeCommandError unless
     # we temporarily relax EAP and trust $LASTEXITCODE for real failures.
-    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
+    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $venvPythonRequest }
     # Relaxing EAP above means a *genuine* uv-venv failure (exit != 0) no longer
     # aborts on its own. Capture $LASTEXITCODE immediately and fail fast, so the
     # `venv` stage can't falsely report success (and Invoke-Stage can't emit

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -602,6 +602,63 @@ install_uv() {
     fi
 }
 
+sqlite_wal_reset_vulnerable() {
+    local python_path="$1"
+    local probe_rc
+
+    if "$python_path" -c '
+import sqlite3
+v = sqlite3.sqlite_version_info
+vulnerable = (
+    v >= (3, 7, 0)
+    and v < (3, 51, 3)
+    and not ((3, 50, 7) <= v < (3, 51, 0))
+    and not ((3, 44, 6) <= v < (3, 45, 0))
+)
+raise SystemExit(42 if vulnerable else 0)
+' >/dev/null 2>&1; then
+        return 1
+    else
+        probe_rc=$?
+    fi
+
+    [ "$probe_rc" -eq 42 ]
+}
+
+ensure_fixed_sqlite_python() {
+    # uv freezes its python-build-standalone download catalog per uv release.
+    # CPython 3.11.15 exists in both the vulnerable and fixed catalogs, so a
+    # normal patch-version upgrade is a no-op.  Refresh uv, force a reinstall,
+    # and pin venv creation to the verified managed interpreter.
+    local original_path="$PYTHON_PATH"
+    local sqlite_version candidate_path candidate_sqlite
+
+    if ! sqlite_wal_reset_vulnerable "$PYTHON_PATH"; then
+        return 0
+    fi
+
+    sqlite_version="$("$PYTHON_PATH" -c 'import sqlite3; print(sqlite3.sqlite_version)' 2>/dev/null || echo unknown)"
+    log_warn "SQLite $sqlite_version has the WAL-reset bug; refreshing managed Python..."
+
+    if ! "$UV_CMD" self update; then
+        log_warn "Could not update managed uv; trying the available Python catalog"
+    fi
+
+    if "$UV_CMD" python install "$PYTHON_VERSION" --reinstall; then
+        candidate_path="$("$UV_CMD" python find "$PYTHON_VERSION" --managed-python 2>/dev/null || true)"
+        if [ -n "$candidate_path" ] && ! sqlite_wal_reset_vulnerable "$candidate_path"; then
+            PYTHON_PATH="$candidate_path"
+            candidate_sqlite="$("$PYTHON_PATH" -c 'import sqlite3; print(sqlite3.sqlite_version)' 2>/dev/null || echo unknown)"
+            log_success "Managed Python now links fixed SQLite $candidate_sqlite"
+            return 0
+        fi
+    fi
+
+    PYTHON_PATH="$original_path"
+    log_warn "Could not provision a fixed SQLite runtime; DELETE-mode protection remains active"
+    return 0
+}
+
 check_python() {
     if [ "$DISTRO" = "termux" ]; then
         log_info "Checking Termux Python..."
@@ -629,6 +686,7 @@ check_python() {
     if PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION" 2>/dev/null)"; then
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         log_success "Python found: $PYTHON_FOUND_VERSION"
+        ensure_fixed_sqlite_python
         return 0
     fi
 
@@ -638,6 +696,7 @@ check_python() {
         PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION")"
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         log_success "Python installed: $PYTHON_FOUND_VERSION"
+        ensure_fixed_sqlite_python
     else
         log_error "Failed to install Python $PYTHON_VERSION"
         log_info "Install Python $PYTHON_VERSION manually, then re-run this script"
@@ -1345,8 +1404,10 @@ setup_venv() {
         rm -rf venv
     fi
 
-    # uv creates the venv and pins the Python version in one step
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    # Pin to the exact interpreter check_python verified.  A bare "3.11"
+    # request can rediscover a vulnerable system Python even after uv installed
+    # a fixed managed build with the same CPython patch version.
+    "$UV_CMD" venv venv --python "$PYTHON_PATH"
 
     # Neutralize any inherited UV_PYTHON (e.g. UV_PYTHON=3.14 left in the
     # user's shell env). uv honours UV_PYTHON over an existing venv for the

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -209,7 +209,10 @@ class TestUpdateManagedUv:
     def test_self_update_success(self, tmp_path):
         _make_executable(tmp_path / "bin" / "uv")
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
-             patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+             patch("hermes_cli.managed_uv.subprocess.run") as mock_run, \
+             patch(
+                 "hermes_cli.managed_uv.upgrade_vulnerable_sqlite_runtime"
+             ) as mock_runtime_upgrade:
             # uv self update succeeds
             mock_run.return_value = MagicMock(returncode=0, stdout="uv 0.2.0")
             from hermes_cli.managed_uv import update_managed_uv
@@ -218,16 +221,103 @@ class TestUpdateManagedUv:
             # First call is self update, second is --version
             assert mock_run.call_count == 2
             assert mock_run.call_args_list[0][0][0] == [str(tmp_path / "bin" / "uv"), "self", "update"]
+            mock_runtime_upgrade.assert_called_once_with(str(tmp_path / "bin" / "uv"))
 
     def test_self_update_failure_non_fatal(self, tmp_path):
         _make_executable(tmp_path / "bin" / "uv")
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
-             patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+             patch("hermes_cli.managed_uv.subprocess.run") as mock_run, \
+             patch(
+                 "hermes_cli.managed_uv.upgrade_vulnerable_sqlite_runtime"
+             ) as mock_runtime_upgrade:
             mock_run.return_value = MagicMock(returncode=1, stderr="nope")
             from hermes_cli.managed_uv import update_managed_uv
             result = update_managed_uv()
             # Still returns the path — failure is non-fatal
             assert result == str(tmp_path / "bin" / "uv")
+            mock_runtime_upgrade.assert_called_once_with(str(tmp_path / "bin" / "uv"))
+
+
+# ---------------------------------------------------------------------------
+# SQLite runtime migration
+# ---------------------------------------------------------------------------
+
+class TestSqliteRuntimeMigration:
+    def test_probe_reports_safe_runtime(self):
+        completed = MagicMock(returncode=0, stdout="3.53.1\n", stderr="")
+        with patch("hermes_cli.managed_uv.subprocess.run", return_value=completed):
+            from hermes_cli.managed_uv import _probe_sqlite_runtime
+
+            assert _probe_sqlite_runtime("/python") == (False, "3.53.1")
+
+    def test_probe_reports_vulnerable_runtime(self):
+        completed = MagicMock(returncode=42, stdout="3.50.4\n", stderr="")
+        with patch("hermes_cli.managed_uv.subprocess.run", return_value=completed):
+            from hermes_cli.managed_uv import _probe_sqlite_runtime
+
+            assert _probe_sqlite_runtime("/python") == (True, "3.50.4")
+
+    def test_safe_runtime_does_not_reinstall_python(self):
+        with patch(
+            "hermes_cli.managed_uv._probe_sqlite_runtime",
+            return_value=(False, "3.53.1"),
+        ), patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+            from hermes_cli.managed_uv import upgrade_vulnerable_sqlite_runtime
+
+            assert upgrade_vulnerable_sqlite_runtime(
+                "/uv", python_executable="/venv/python"
+            )
+            mock_run.assert_not_called()
+
+    def test_vulnerable_runtime_is_force_reinstalled(self):
+        reinstall = MagicMock(returncode=0, stdout="", stderr="")
+        with patch(
+            "hermes_cli.managed_uv._probe_sqlite_runtime",
+            side_effect=[(True, "3.50.4"), (False, "3.53.1")],
+        ), patch(
+            "hermes_cli.managed_uv.subprocess.run", return_value=reinstall
+        ) as mock_run:
+            from hermes_cli.managed_uv import upgrade_vulnerable_sqlite_runtime
+
+            assert upgrade_vulnerable_sqlite_runtime(
+                "/uv", python_executable="/venv/python"
+            )
+            assert mock_run.call_args_list[0][0][0] == [
+                "/uv",
+                "python",
+                "install",
+                "3.11",
+                "--reinstall",
+            ]
+
+    def test_failed_reinstall_is_non_fatal(self):
+        reinstall = MagicMock(returncode=1, stdout="", stderr="file is locked")
+        with patch(
+            "hermes_cli.managed_uv._probe_sqlite_runtime",
+            return_value=(True, "3.50.4"),
+        ), patch("hermes_cli.managed_uv.subprocess.run", return_value=reinstall):
+            from hermes_cli.managed_uv import upgrade_vulnerable_sqlite_runtime
+
+            assert not upgrade_vulnerable_sqlite_runtime(
+                "/uv", python_executable="/venv/python"
+            )
+
+    def test_active_path_still_vulnerable_requires_venv_rebuild(self):
+        reinstall = MagicMock(returncode=0, stdout="", stderr="")
+        with patch(
+            "hermes_cli.managed_uv._probe_sqlite_runtime",
+            side_effect=[
+                (True, "3.50.4"),
+                (True, "3.50.4"),
+            ],
+        ), patch(
+            "hermes_cli.managed_uv.subprocess.run", return_value=reinstall
+        ):
+            from hermes_cli.managed_uv import upgrade_vulnerable_sqlite_runtime
+
+            assert not upgrade_vulnerable_sqlite_runtime(
+                "/uv", python_executable="/venv/python"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_install_ps1_native_stderr_eap.py
+++ b/tests/test_install_ps1_native_stderr_eap.py
@@ -49,7 +49,7 @@ def test_repository_stage_relieves_eap_for_ssh_and_https_git_clone() -> None:
 
 def test_uv_venv_and_dependency_installs_relax_eap() -> None:
     text = _install_ps1()
-    _assert_relaxed_call(text, r"& \$UvCmd venv venv --python \$PythonVersion")
+    _assert_relaxed_call(text, r"& \$UvCmd venv venv --python \$venvPythonRequest")
     _assert_relaxed_call(text, r"& \$UvCmd sync --extra all --locked")
     _assert_relaxed_call(text, r"& \$UvCmd pip install -e \$tier\.Spec")
 
@@ -67,7 +67,7 @@ def test_uv_venv_failure_is_not_swallowed_after_eap_relax() -> None:
     # The uv-venv invocation, then an exit-code capture, then a throw — all
     # within a small window after the relaxed call.
     guard = re.search(
-        r"& \$UvCmd venv venv --python \$PythonVersion[\s\S]{0,400}?"
+        r"& \$UvCmd venv venv --python \$venvPythonRequest[\s\S]{0,400}?"
         r"\$LASTEXITCODE[\s\S]{0,200}?"
         r"-ne 0[\s\S]{0,200}?throw",
         text,

--- a/tests/test_install_sqlite_runtime_upgrade.py
+++ b/tests/test_install_sqlite_runtime_upgrade.py
@@ -1,0 +1,154 @@
+"""Installer regression tests for the SQLite WAL-reset runtime migration."""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _function_body(source: str, declaration: str) -> str:
+    start = source.index(declaration)
+    brace = source.index("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unterminated function: {declaration}")
+
+
+def _make_executable(path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def test_posix_installer_reinstalls_vulnerable_runtime_from_refreshed_catalog(
+    tmp_path,
+):
+    """The shell helper must select the newly verified managed interpreter."""
+    install_source = INSTALL_SH.read_text(encoding="utf-8")
+    functions = "\n\n".join(
+        _function_body(install_source, f"{name}()")
+        for name in (
+            "sqlite_wal_reset_vulnerable",
+            "ensure_fixed_sqlite_python",
+        )
+    )
+
+    old_python = tmp_path / "old-python"
+    fixed_python = tmp_path / "fixed-python"
+    fake_uv = tmp_path / "uv"
+    state = tmp_path / "state"
+    calls = tmp_path / "calls"
+
+    _make_executable(
+        old_python,
+        """#!/bin/sh
+case "$*" in
+  *"raise SystemExit(42 if vulnerable else 0)"*) exit 42 ;;
+  *"sqlite3.sqlite_version"*) echo 3.50.4; exit 0 ;;
+  *"--version"*) echo "Python 3.11.15"; exit 0 ;;
+esac
+exit 1
+""",
+    )
+    _make_executable(
+        fixed_python,
+        """#!/bin/sh
+case "$*" in
+  *"raise SystemExit(42 if vulnerable else 0)"*) exit 0 ;;
+  *"sqlite3.sqlite_version"*) echo 3.53.1; exit 0 ;;
+  *"--version"*) echo "Python 3.11.15"; exit 0 ;;
+esac
+exit 1
+""",
+    )
+    _make_executable(
+        fake_uv,
+        f"""#!/bin/sh
+echo "$*" >> "{calls}"
+case "$1 $2" in
+  "self update") exit 0 ;;
+  "python install") printf fixed > "{state}"; exit 0 ;;
+  "python find")
+    if [ -f "{state}" ]; then
+      printf '%s\\n' "{fixed_python}"
+    else
+      printf '%s\\n' "{old_python}"
+    fi
+    exit 0
+    ;;
+esac
+exit 1
+""",
+    )
+
+    script = f"""set -e
+UV_CMD={fake_uv}
+PYTHON_VERSION=3.11
+PYTHON_PATH={old_python}
+log_warn() {{ :; }}
+log_success() {{ :; }}
+{functions}
+ensure_fixed_sqlite_python
+printf '%s\\n' "$PYTHON_PATH"
+"""
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={**os.environ, "PATH": os.environ.get("PATH", "")},
+    )
+
+    assert result.stdout.strip() == str(fixed_python)
+    call_lines = calls.read_text(encoding="utf-8").splitlines()
+    assert call_lines.index("self update") < call_lines.index(
+        "python install 3.11 --reinstall"
+    )
+    assert "python find 3.11 --managed-python" in call_lines
+
+
+def test_posix_venv_is_pinned_to_verified_python_path():
+    source = INSTALL_SH.read_text(encoding="utf-8")
+    setup_venv = _function_body(source, "setup_venv()")
+    assert 'venv venv --python "$PYTHON_PATH"' in setup_venv
+    assert "ensure_fixed_sqlite_python" in _function_body(source, "check_python()")
+
+
+def test_windows_installer_refreshes_uv_before_force_reinstall():
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    resolver = _function_body(source, "function Resolve-FixedSqlitePythonPath")
+    update_at = resolver.index("& $UvCmd self update")
+    reinstall_at = resolver.index("& $UvCmd python install $Version --reinstall")
+    verify_at = resolver.index(
+        "Test-SqliteWalResetVulnerable -PythonPath $candidatePath"
+    )
+
+    assert update_at < reinstall_at < verify_at
+    assert resolver.count("| Out-Host") >= 2
+    assert "python find $Version --managed-python" in resolver
+    assert re.search(r"\(3,\s*51,\s*3\)", source)
+    assert re.search(r"\(3,\s*50,\s*7\)", source)
+    assert re.search(r"\(3,\s*44,\s*6\)", source)
+
+
+def test_windows_venv_retries_after_process_sweep_and_pins_verified_path():
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    install_venv = _function_body(source, "function Install-Venv")
+    process_sweep_at = install_venv.index("Stop-Process")
+    retry_at = install_venv.index("Resolve-FixedSqlitePythonPath")
+    create_at = install_venv.index("& $UvCmd venv venv --python $venvPythonRequest")
+
+    assert process_sweep_at < retry_at < create_at


### PR DESCRIPTION
## Summary

- refresh Hermes' managed uv before replacing a Python build whose linked SQLite has the WAL-reset bug
- force-reinstall the requested Python minor even when the CPython patch version is unchanged, then verify the replacement from a new interpreter process
- pin POSIX and Windows venv creation to the verified interpreter; on Windows, retry after the existing process sweep releases runtime locks
- migrate existing uv-managed installs through `hermes update`, while keeping the #70055 DELETE-mode fallback when an offline/locked runtime cannot be replaced

## Why

#70055 mitigated #69784 by refusing to enable WAL on fresh databases when SQLite is vulnerable. It intentionally leaves already-WAL databases alone, and it does not replace the SQLite embedded in python-build-standalone.

uv freezes its Python download catalog per uv release. The CPython patch version is identical across the relevant catalogs, so a normal Python upgrade does nothing:

- uv 0.11.7: CPython 3.11.15+20260414, SQLite 3.50.4 (vulnerable)
- uv 0.11.31: CPython 3.11.15+20260718, SQLite 3.53.1 (fixed)

That makes an updated uv plus `uv python install 3.11 --reinstall` necessary. A subprocess probe is used after replacement because the updater process has already loaded its old sqlite3 module.

Termux continues to use its distro Python; this migration targets Hermes' uv-managed desktop/server installs.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_managed_uv.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_*.py tests/test_install_*.py tests/test_sqlite_wal_reset_gate.py -q`
  - 352 passed
- focused runtime/installer/WAL suite
  - 60 passed
- ruff check on changed Python files
- `bash -n scripts/install.sh`
- `git diff --check`
- live probes classify SQLite 3.50.4 as vulnerable and 3.53.1 as fixed
- manual POSIX migration: an existing uv-managed venv retained SQLite 3.50.4 in the already-running process and reported SQLite 3.53.1 from the next process through the same venv

Follow-up to #69784. The #70055 fallback remains in place for migration failures and older installations.
