### PR TITLE
test(gateway): fix hygiene-timeout timing flake — loosen wall-clock bound per policy

### DIFF
--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -811,7 +811,11 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     elapsed = time.monotonic() - started
 
     assert result == "ok"
-    assert elapsed < 0.15
+    # Loose wall-clock bound per flake policy: this asserts the handler did
+    # NOT block on the hygiene-compression timeout path (which would take
+    # multiple seconds), not a precise latency. 0.15s missed by ~1-8ms on
+    # busy CI shards twice on 2026-07-23.
+    assert elapsed < 2.0
     assert worker_started.is_set()
     assert runner._run_agent.await_count == 1
     assert runner._hygiene_compression_failure_cooldowns["sess-timeout"] > time.time()


### PR DESCRIPTION
## Summary
Fixes a timing flake: `test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown` failed twice today on busy CI shards with `0.1508 < 0.15` and `0.1584 < 0.15` — the wall-clock bound was too tight for a loaded runner.

The assertion's purpose is "the handler did not BLOCK on the hygiene-compression timeout path" (blocking would take seconds); 2.0s preserves that contract with margin per the flake policy (loose wall-clock bounds ≥ 2s).

Failing runs: PR #70193 run 30025889952 shard 7, PR #70189 run 30026770278 shard 7 — both on branches that don't touch this file.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/gateway/test_session_hygiene.py` | 28 passed |

## Infographic

![flake-fix](https://v3b.fal.media/files/b/0aa36d01/h-Hr1fj9W2NwVZSNFC3M__jwRhN59I.png)
