### PR TITLE
fix(auth): scope Codex quota cooldown clearing by token

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -707,7 +707,7 @@ def redeem_codex_reset_credit(
         try:
             from hermes_cli.auth import clear_codex_pool_quota_cooldowns
 
-            clear_codex_pool_quota_cooldowns()
+            clear_codex_pool_quota_cooldowns(api_key)
         except Exception:
             logger.debug(
                 "Failed to clear Codex pool cooldowns after reset redemption",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3870,7 +3870,7 @@ def resolve_codex_runtime_credentials(
                 logger.info(
                     "Codex quota restored upstream — clearing stale pool cooldown(s)."
                 )
-                clear_codex_pool_quota_cooldowns()
+                clear_codex_pool_quota_cooldowns(stale_token)
                 pool_token = _pool_codex_access_token()
                 if pool_token:
                     base_url = (
@@ -4091,10 +4091,10 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
     ``exhausted`` entries whose error metadata is 429/quota-shaped — DEAD
     (terminal auth) entries and non-rate-limit failures are untouched.
 
-    When *access_token* is given, only the matching entry is cleared;
-    otherwise every rate-limited entry clears (a redeemed banked reset
-    restores the whole account, and any entry that is genuinely still
-    exhausted just re-freezes with fresh metadata on its next 429).
+    When *access_token* is given, only the matching entry is cleared. Callers
+    handling an account-specific live probe or reset redemption must pass it
+    so one recovered account cannot reactivate unrelated exhausted accounts.
+    Omitting it is reserved for an explicit whole-pool administrative reset.
 
     Returns the number of entries cleared.
     """

--- a/tests/hermes_cli/test_auth_codex_quota_probe.py
+++ b/tests/hermes_cli/test_auth_codex_quota_probe.py
@@ -326,9 +326,26 @@ def _pool_only_rate_limited_store(now=None):
 def test_resolver_recovers_when_probe_confirms_reset(tmp_path, monkeypatch):
     """The screenshot bug: pool-only cooldown raises `quota exhausted (429);
     retry after Ns` even though the upstream window already reset.  A positive
-    probe must clear the cooldown and return the pool credential."""
+    probe must clear only that credential's cooldown and return it."""
     hermes_home = tmp_path / "hermes"
-    _write_auth_store(hermes_home, _pool_only_rate_limited_store())
+    store = _pool_only_rate_limited_store()
+    store["credential_pool"]["openai-codex"].append(
+        {
+            "id": "cred-still-exhausted",
+            "label": "other-account",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-other",
+            "last_status": "exhausted",
+            "last_status_at": time.time(),
+            "last_error_code": 429,
+            "last_error_reason": "usage_limit_reached",
+            "last_error_message": "The usage limit has been reached",
+            "last_error_reset_at": time.time() + 4 * 24 * 3600,
+        }
+    )
+    _write_auth_store(hermes_home, store)
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     monkeypatch.setattr(
@@ -340,9 +357,11 @@ def test_resolver_recovers_when_probe_confirms_reset(tmp_path, monkeypatch):
     assert resolved["source"] == "credential_pool"
 
     store = json.loads((hermes_home / "auth.json").read_text())
-    entry = store["credential_pool"]["openai-codex"][0]
-    assert entry["last_status"] is None
-    assert entry["last_error_reset_at"] is None
+    entries = {e["id"]: e for e in store["credential_pool"]["openai-codex"]}
+    assert entries["cred-quota"]["last_status"] is None
+    assert entries["cred-quota"]["last_error_reset_at"] is None
+    assert entries["cred-still-exhausted"]["last_status"] == "exhausted"
+    assert entries["cred-still-exhausted"]["last_error_reset_at"] is not None
 
 
 def test_resolver_keeps_cooldown_when_probe_negative(tmp_path, monkeypatch):
@@ -462,7 +481,24 @@ def test_pool_readonly_enumeration_does_not_probe(tmp_path, monkeypatch):
 
 def test_redeem_reset_clears_pool_cooldowns(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
-    _write_auth_store(hermes_home, _pool_only_rate_limited_store())
+    store = _pool_only_rate_limited_store()
+    store["credential_pool"]["openai-codex"].append(
+        {
+            "id": "cred-still-exhausted",
+            "label": "other-account",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-other",
+            "last_status": "exhausted",
+            "last_status_at": time.time(),
+            "last_error_code": 429,
+            "last_error_reason": "usage_limit_reached",
+            "last_error_message": "The usage limit has been reached",
+            "last_error_reset_at": time.time() + 4 * 24 * 3600,
+        }
+    )
+    _write_auth_store(hermes_home, store)
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     from agent import account_usage
@@ -498,11 +534,13 @@ def test_redeem_reset_clears_pool_cooldowns(tmp_path, monkeypatch):
 
     result = account_usage.redeem_codex_reset_credit(
         base_url="https://chatgpt.com/backend-api/codex",
-        api_key="live-agent-token",
+        api_key="tok-quota",
     )
     assert result.redeemed
 
     store = json.loads((hermes_home / "auth.json").read_text())
-    entry = store["credential_pool"]["openai-codex"][0]
-    assert entry["last_status"] is None
-    assert entry["last_error_reset_at"] is None
+    entries = {e["id"]: e for e in store["credential_pool"]["openai-codex"]}
+    assert entries["cred-quota"]["last_status"] is None
+    assert entries["cred-quota"]["last_error_reset_at"] is None
+    assert entries["cred-still-exhausted"]["last_status"] == "exhausted"
+    assert entries["cred-still-exhausted"]["last_error_reset_at"] is not None


### PR DESCRIPTION
## What does this PR do?

Keeps Codex quota recovery scoped to the credential whose quota was actually
confirmed restored.

The early-reset recovery added in #69494 already accepts an optional
`access_token` in `clear_codex_pool_quota_cooldowns()`, but its two runtime
callers omitted that argument. In a multi-account credential pool, a positive
usage probe or successful reset redemption for account A therefore cleared
the persisted 429 cooldown for unrelated account B as well. If account B was
still at 100% usage, it re-entered rotation only to fail and be quarantined
again.

## Related Issue

Follow-up to #69494 and the multi-account behavior reported in #43747.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`: pass the positively probed `stale_token` when clearing
  a stale Codex pool cooldown.
- `agent/account_usage.py`: pass the token used for a successful `/usage reset`
  redemption.
- `tests/hermes_cli/test_auth_codex_quota_probe.py`: cover a two-account pool
  containing a separate `manual:device_code` credential that must remain
  exhausted.
- Clarify that unscoped clearing is reserved for an explicit whole-pool
  administrative reset.

## How to Test

1. Create two exhausted `openai-codex` pool entries with different access
   tokens.
2. Confirm quota recovery or redeem a reset for only the first token.
3. Verify the first entry is unfrozen while the unrelated entry retains its
   429 status and future `last_error_reset_at`.

Before the fix, the two strengthened regressions failed because both entries
were cleared. After the fix:

```text
tests/hermes_cli/test_auth_codex_quota_probe.py: 21 passed
Adjacent auth, account-usage, and credential-pool suites: 230 passed
ruff: passed
git diff --check: passed
Windows footgun scan: passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the full `pytest tests/ -q` suite
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Relevant function documentation was updated
- [x] `cli-config.yaml.example` update is N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] Cross-platform impact was considered; the change is platform-neutral
- [x] Tool descriptions/schemas update is N/A

## Screenshots / Logs

N/A — credential state is covered by hermetic regression tests; no secrets or
live authentication data are included.
