### PR TITLE
fix(desktop): stop resurrecting completed stream bubbles

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -432,6 +432,13 @@ describe('preserveLocalPendingTurnMessages', () => {
     expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
   })
 
+  it('does not resurrect a completed stream bubble after persisted history catches up', () => {
+    const next = [msg('1-user-stored', 'user', 'question'), msg('2-assistant-stored', 'assistant', 'answer')]
+    const completedLocalStream = msg('assistant-stream-runtime-1', 'assistant', 'answer', { pending: false })
+
+    expect(preserveLocalPendingTurnMessages(next, [...next, completedLocalStream])).toBe(next)
+  })
+
   it('drops stale optimistic history after compression and keeps only the live tail', () => {
     const compressedAuthority = [
       msg('stored-user', 'user', 'first turn that survived compression'),

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -389,8 +389,7 @@ export function preserveLocalPendingTurnMessages(
 
     const isOptimisticUser = message.role === 'user' && message.id.startsWith('user-')
 
-    const isPendingAssistant =
-      message.role === 'assistant' && (message.pending === true || message.id.startsWith('assistant-stream-'))
+    const isPendingAssistant = message.role === 'assistant' && message.pending === true
 
     if ((!isOptimisticUser && !isPendingAssistant) || nextIds.has(message.id)) {
       continue


### PR DESCRIPTION
## Summary

- treat the explicit `pending` flag as the authority when reconciling local assistant projections
- stop a completed `assistant-stream-*` bubble from being re-appended after authoritative history has caught up
- add a focused regression test for the completed-stream case

## Why

`preserveLocalPendingTurnMessages` currently considers any assistant message whose ID starts with `assistant-stream-` to be pending, even after terminal stream paths have explicitly set `pending: false`.

If such a completed local bubble has no same-ordinal assistant in the refreshed authoritative transcript, the reconciliation step appends it again. This can resurrect an already completed assistant bubble alongside the persisted response.

All live stream constructors set `pending: true`, while completion, interim sealing, interruption, and error paths set `pending: false`; the explicit state is therefore the correct authority. This is a separate reconciliation invariant from the upstream stream/final merge work in #70173.

Related: #70108

## Verification

- focused regression fails on current `origin/main` and passes with this patch
- `npm exec vitest run -- --project ui src/app/session/hooks/use-session-actions/utils.test.ts` — 33 passed
- `npm exec vitest run -- --project ui src/app/session/hooks/use-session-actions.test.tsx` — 33 passed
- `npm run typecheck` — passed
- `npm exec eslint -- src/app/session/hooks/use-session-actions/utils.ts src/app/session/hooks/use-session-actions/utils.test.ts` — passed
- `npm exec prettier -- --check src/app/session/hooks/use-session-actions/utils.ts src/app/session/hooks/use-session-actions/utils.test.ts` — passed
