### PR TITLE
fix(agent): restore model.context_length pin when /model returns to the configured default

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2058,10 +2058,64 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     _snapshot["_credential_pool"] = getattr(agent, "_credential_pool", _MISSING)
 
     try:
-        # Clear the per-config context_length override so the new model's
-        # actual context window is resolved via get_model_context_length()
-        # instead of inheriting the stale value from the previous model.
+        # Re-resolve the global ``model.context_length`` pin from live config
+        # instead of unconditionally clearing it. The old behavior
+        # (``agent._config_context_length = None``) meant the pin worked at
+        # startup but silently disappeared after ANY /model switch — even when
+        # switching straight back to the configured default model (#40979).
+        #
+        # Scoping matches the design intent documented in agent_init.py
+        # ("model.context_length describes the configured default model"):
+        # the pin is restored ONLY when the switched-to model+route equals the
+        # configured default model+route. Switching to a *different* model
+        # still clears the pin, so the override cannot leak onto models it
+        # was never meant for (#62152). Mirrors the live-config re-read this
+        # function already does for custom_providers overrides (#15779).
         agent._config_context_length = None
+        try:
+            from hermes_cli.config import load_config_readonly as _sm_cfg_ro
+
+            _sm_model_cfg = (_sm_cfg_ro() or {}).get("model") or {}
+            if isinstance(_sm_model_cfg, dict):
+                _sm_raw_ctx = _sm_model_cfg.get("context_length")
+                _sm_pin = int(_sm_raw_ctx) if _sm_raw_ctx else None
+            else:
+                _sm_model_cfg = {}
+                _sm_pin = None
+            if _sm_pin is not None and _sm_pin > 0:
+                _sm_default = str(_sm_model_cfg.get("default") or "").strip()
+                _sm_default_rt = _sm_default
+                _sm_active_rt = new_model
+                try:
+                    from hermes_cli.model_normalize import (
+                        normalize_model_for_provider,
+                    )
+
+                    _sm_default_rt = normalize_model_for_provider(
+                        _sm_default, new_provider
+                    )
+                    _sm_active_rt = normalize_model_for_provider(
+                        new_model, new_provider
+                    )
+                except Exception:
+                    pass
+                if not _sm_default or _sm_default_rt != _sm_active_rt:
+                    _sm_pin = None
+                else:
+                    from agent.agent_init import _context_route_mismatch
+
+                    if _context_route_mismatch(
+                        _sm_model_cfg.get("base_url"),
+                        base_url or agent.base_url,
+                        _sm_model_cfg.get("provider"),
+                        new_provider,
+                    ):
+                        _sm_pin = None
+            agent._config_context_length = _sm_pin
+        except Exception:
+            # Config unreadable mid-switch — keep the old clearing behavior
+            # rather than carrying the previous model's stale value.
+            agent._config_context_length = None
 
         # ── Swap core runtime fields ──
         agent.model = new_model

--- a/tests/run_agent/test_switch_model_context_pin_40979.py
+++ b/tests/run_agent/test_switch_model_context_pin_40979.py
@@ -1,0 +1,180 @@
+"""Regression tests for #40979: the global ``model.context_length`` pin must
+survive a /model switch back to the configured default model+route.
+
+Before the fix, ``switch_model()`` unconditionally set
+``agent._config_context_length = None`` and never re-read config.yaml, so the
+global pin worked at startup but silently disappeared after ANY /model switch
+— even ``/model <other>`` followed by ``/model <configured-default>``. The
+compressor then sized itself from the full catalog window (e.g. 1M for
+long-context models the user deliberately capped).
+
+The fix re-resolves the pin from live config at switch time, scoped exactly
+like startup (agent_init.py): restored ONLY when the switched-to model+route
+equals the configured default model+route, so the pin still cannot leak onto
+other models (#62152) and the stale-inheritance behavior the original
+clearing protected against is preserved.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+from agent.context_compressor import ContextCompressor
+
+
+NOUS_URL = "https://inference-api.nousresearch.com/v1"
+
+
+def _make_agent(model, provider, base_url, config_context_length=None):
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = model
+    agent.provider = provider
+    agent.base_url = base_url
+    agent.api_key = "sk-test"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock()
+    agent.quiet_mode = True
+    agent._config_context_length = config_context_length
+    agent.context_compressor = ContextCompressor(
+        model=model,
+        threshold_percent=0.50,
+        base_url=base_url,
+        api_key="sk-test",
+        provider=provider,
+        quiet_mode=True,
+        config_context_length=config_context_length,
+    )
+    agent._primary_runtime = {}
+    return agent
+
+
+def _cfg(default, provider, context_length, base_url=None):
+    model_cfg = {
+        "default": default,
+        "provider": provider,
+        "context_length": context_length,
+    }
+    if base_url:
+        model_cfg["base_url"] = base_url
+    return {"model": model_cfg}
+
+
+def test_pin_restored_when_switching_back_to_configured_default():
+    """/model away and back must restore the configured default's pin."""
+    cfg = _cfg("poolside/laguna-s-2.1:free", "nous", 262_144)
+    agent = _make_agent(
+        "tencent/hy3:free", "nous", NOUS_URL, config_context_length=None
+    )
+
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+        patch(
+            "agent.model_metadata.get_model_context_length",
+            side_effect=lambda *a, **k: k.get("config_context_length")
+            or 1_048_576,
+        ) as mock_ctx,
+    ):
+        agent.switch_model(
+            "poolside/laguna-s-2.1:free", "nous",
+            api_key="sk-test", base_url=NOUS_URL,
+        )
+
+    assert agent._config_context_length == 262_144
+    assert (
+        mock_ctx.call_args.kwargs.get("config_context_length") == 262_144
+    )
+    assert agent.context_compressor.context_length == 262_144
+
+
+def test_pin_not_leaked_onto_other_models():
+    """Switching to a model other than the configured default clears the pin."""
+    cfg = _cfg("poolside/laguna-s-2.1:free", "nous", 262_144)
+    agent = _make_agent(
+        "poolside/laguna-s-2.1:free", "nous", NOUS_URL,
+        config_context_length=262_144,
+    )
+
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+        patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=131_072,
+        ) as mock_ctx,
+    ):
+        agent.switch_model(
+            "tencent/hy3:free", "nous", api_key="sk-test", base_url=NOUS_URL
+        )
+
+    assert agent._config_context_length is None
+    assert mock_ctx.call_args.kwargs.get("config_context_length") is None
+
+
+def test_pin_not_restored_across_route_change():
+    """Same model name on a different provider/route must not reuse the pin."""
+    cfg = _cfg("shared-model", "custom:big-route", 1_048_576,
+               base_url="https://big.example/v1")
+    agent = _make_agent(
+        "other-model", "openrouter", "https://openrouter.ai/api/v1"
+    )
+
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+        patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=131_072,
+        ),
+    ):
+        agent.switch_model(
+            "shared-model", "openrouter",
+            api_key="sk-test", base_url="https://openrouter.ai/api/v1",
+        )
+
+    assert agent._config_context_length is None
+
+
+def test_reselecting_same_default_model_keeps_pin():
+    """/model to the model the session already runs must keep the pin."""
+    cfg = _cfg("tencent/hy3:free", "nous", 200_000)
+    agent = _make_agent(
+        "tencent/hy3:free", "nous", NOUS_URL, config_context_length=200_000
+    )
+
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+        patch(
+            "agent.model_metadata.get_model_context_length",
+            side_effect=lambda *a, **k: k.get("config_context_length")
+            or 262_144,
+        ),
+    ):
+        agent.switch_model(
+            "tencent/hy3:free", "nous", api_key="sk-test", base_url=NOUS_URL
+        )
+
+    assert agent._config_context_length == 200_000
+    assert agent.context_compressor.context_length == 200_000
+
+
+def test_unreadable_config_falls_back_to_clearing():
+    """A config read failure mid-switch must clear, not inherit, the pin."""
+    agent = _make_agent(
+        "primary-model", "openrouter", "https://openrouter.ai/api/v1",
+        config_context_length=32_768,
+    )
+
+    with (
+        patch(
+            "hermes_cli.config.load_config_readonly",
+            side_effect=OSError("disk error"),
+        ),
+        patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=131_072,
+        ) as mock_ctx,
+    ):
+        agent.switch_model(
+            "new-model", "openrouter",
+            api_key="sk-test", base_url="https://openrouter.ai/api/v1",
+        )
+
+    assert agent._config_context_length is None
+    assert mock_ctx.call_args.kwargs.get("config_context_length") is None


### PR DESCRIPTION
## Summary

Fixes #40979 — the global `model.context_length` pin is read once at agent init and stored as `agent._config_context_length`, but `switch_model()` (agent/agent_runtime_helpers.py) unconditionally sets it to `None` and never re-reads config. The pin therefore works at startup but silently disappears after **any** `/model` switch — including `/model <other>` followed by `/model <configured-default>`.

### Real-world impact
Configure `model.context_length: 262144` to cap a 1M-context model (e.g. `poolside/laguna-s-2.1`, where community reports show quality degradation and KV-cache pressure beyond ~256K). Works at startup. The moment you `/model` in the gateway or CLI, the cap evaporates: `get_model_context_length()` receives `config_context_length=None`, resolves the full 1M catalog window, and the context compressor never fires before the degradation zone.

The asymmetry is confusing: the per-model `custom_providers.<p>.models.<m>.context_length` override IS re-read live at switch time (#15779), but the documented global pin is not.

## Fix

Re-resolve the pin from live config (`load_config_readonly()`) at switch time, **scoped exactly like startup**: `agent_init.py` documents that "`model.context_length` describes the configured default model" and route-scopes the pin via `normalize_model_for_provider` + `_context_route_mismatch`. This fix reuses those same helpers, so the pin is restored **only when the switched-to model+route equals the configured default model+route**:

- `/model other` → pin cleared (previous behavior, prevents stale inheritance — the original comment's intent is preserved)
- `/model <configured-default>` → pin restored (the #40979 gap)
- same model name on a different route/provider → pin cleared (no leak, consistent with #62152 concerns and with `test_direct_start_same_model_on_different_route_drops_context_override`)
- config unreadable mid-switch → falls back to clearing (never inherits stale value)

No new config keys, no signature changes, no cache impact (context_length is not part of the prompt prefix).

## Verification

- **5 new behavior-contract tests** in `tests/run_agent/test_switch_model_context_pin_40979.py`: restore-on-return, no-leak-to-other-models, no-restore-across-routes, reselect-same-default, unreadable-config-falls-back
- **All 78 existing switch_model tests pass unchanged**, including `test_switch_model_clears_previous_config_context_length` (switch to a different model still passes `config_context_length=None`) and the full rollback/reasoning/pool-reload/header suites
- Reproduced the original symptom on main before the fix: after `switch_model()` back to the configured default, `mock_ctx.call_args.kwargs['config_context_length']` was `None`; with the fix it equals the configured pin

## Related issues

- Closes #40979 (global override not re-read after /model switch — exact match)
- Related: #24072 (closed — fixed the *inheritance* direction; this fixes the *loss* direction), #62152 (leak onto other models — this PR deliberately keeps the pin default-model-scoped so it cannot regress that), #66168 / #54386 / #10157 (broader design discussion about the pin masking live limits — orthogonal; this PR only makes existing documented behavior consistent between init and switch)