### PR TITLE
fix(background-review): make iteration budget configurable

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -27,6 +27,22 @@ from agent.thread_scoped_output import thread_scoped_silence
 
 logger = logging.getLogger(__name__)
 
+_BACKGROUND_REVIEW_DEFAULT_MAX_ITERATIONS = 16
+
+
+def _resolve_background_review_max_iterations(task: Dict[str, Any]) -> int:
+    """Return the configured agent-loop budget for one background review.
+
+    The background review follows the main-agent configuration contract: the
+    historical default is used when the key is absent, and numeric values are
+    passed through without an extra lower or upper bound.
+    """
+    try:
+        value = int(task.get("max_iterations", _BACKGROUND_REVIEW_DEFAULT_MAX_ITERATIONS))
+    except (TypeError, ValueError):
+        value = _BACKGROUND_REVIEW_DEFAULT_MAX_ITERATIONS
+    return value
+
 
 # ---------------------------------------------------------------------------
 # Background-review aux-model selector + routed digest.
@@ -76,6 +92,8 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
         return parent
     aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
     task = aux.get("background_review", {}) if isinstance(aux.get("background_review"), dict) else {}
+    review_max_iterations = _resolve_background_review_max_iterations(task)
+    parent["max_iterations"] = review_max_iterations
     task_provider = (str(task.get("provider", "")).strip() or None)
     task_model = (str(task.get("model", "")).strip() or None)
     task_base_url = (str(task.get("base_url", "")).strip() or None)
@@ -104,6 +122,7 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
             "command": rp.get("command"),
             "args": list(rp.get("args") or []),
             "routed": True,
+            "max_iterations": review_max_iterations,
         }
     except Exception as e:
         logger.debug("background-review aux routing failed (%s); using main model", e)
@@ -709,9 +728,12 @@ def _run_review_in_thread(
             # _cached_system_prompt below.
             if not _routed:
                 _fork_kwargs["reasoning_config"] = getattr(agent, "reasoning_config", None)
+            review_max_iterations = _rt.get("max_iterations")
+            if review_max_iterations is None:
+                review_max_iterations = _BACKGROUND_REVIEW_DEFAULT_MAX_ITERATIONS
             review_agent = AIAgent(
                 model=_rt.get("model") or agent.model,
-                max_iterations=16,
+                max_iterations=int(review_max_iterations),
                 quiet_mode=True,
                 platform=agent.platform,
                 provider=_rt.get("provider") or agent.provider,

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -34,14 +34,14 @@ def _resolve_background_review_max_iterations(task: Dict[str, Any]) -> int:
     """Return the configured agent-loop budget for one background review.
 
     The background review follows the main-agent configuration contract: the
-    historical default is used when the key is absent, and numeric values are
-    passed through without an extra lower or upper bound.
+    historical default is used when the key is absent, numeric values are
+    accepted, and the agent loop always receives at least one iteration.
     """
     try:
         value = int(task.get("max_iterations", _BACKGROUND_REVIEW_DEFAULT_MAX_ITERATIONS))
     except (TypeError, ValueError):
         value = _BACKGROUND_REVIEW_DEFAULT_MAX_ITERATIONS
-    return value
+    return max(1, value)
 
 
 # ---------------------------------------------------------------------------
@@ -86,8 +86,8 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
         "routed": False,
     }
     try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly()
     except Exception:
         return parent
     aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -584,6 +584,12 @@ prompt_caching:
 #                           # extra_body:
 #                           #   chat_template_kwargs:
 #                           #     enable_thinking: false
+#
+#   # Background memory/skill review after each turn
+#   background_review:
+#     provider: "auto"
+#     model: ""
+#     max_iterations: 16    # Review loop budget; default 16, no extra cap
 
 # =============================================================================
 # Persistent Memory

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3142,6 +3142,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 try:
                     delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
                 except _q.Empty:
+                    # Emit the keepalive before observing task completion. A
+                    # quiet gap can end at the same poll boundary as the agent;
+                    # checking done() first would silently drop the liveness
+                    # event that clients rely on during slow tool calls.
+                    if time.monotonic() - last_activity >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS:
+                        await response.write(b": keepalive\n\n")
+                        last_activity = time.monotonic()
                     if agent_task.done():
                         # Drain any remaining items
                         while True:
@@ -3153,9 +3160,6 @@ class APIServerAdapter(BasePlatformAdapter):
                             except _q.Empty:
                                 break
                         break
-                    if time.monotonic() - last_activity >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS:
-                        await response.write(b": keepalive\n\n")
-                        last_activity = time.monotonic()
                     continue
 
                 if delta is None:  # End of stream sentinel

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import shutil
 import subprocess
 import sys
 import time
@@ -254,8 +255,33 @@ def spawn_async_diagnostic(
         # would also reap us anyway, but defense in depth).  Without
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
+        timeout_bin = shutil.which("timeout")
+        if timeout_bin:
+            command = [timeout_bin, f"{timeout_seconds:.0f}", "bash", "-c", script]
+        else:
+            # macOS ships bash but not GNU coreutils' timeout. Keep the same
+            # bounded, detached behavior with a tiny stdlib wrapper rather
+            # than silently dropping shutdown evidence on that platform.
+            wrapper = (
+                "import subprocess, sys\n"
+                "child = subprocess.Popen(['bash', '-c', sys.argv[2]])\n"
+                "try:\n"
+                "    child.wait(timeout=float(sys.argv[1]))\n"
+                "except subprocess.TimeoutExpired:\n"
+                "    child.kill()\n"
+                "    child.wait()\n"
+                "    raise SystemExit(124)\n"
+                "raise SystemExit(child.returncode or 0)\n"
+            )
+            command = [
+                sys.executable,
+                "-c",
+                wrapper,
+                f"{timeout_seconds:.3f}",
+                script,
+            ]
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
+            command,
             stdout=fd,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1784,6 +1784,7 @@ DEFAULT_CONFIG = {
             "base_url": "",
             "api_key": "",
             "timeout": 120,
+            "max_iterations": 16,
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
         },

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -487,7 +487,6 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
         if path.exists():
             return
         path.mkdir(parents=False, exist_ok=False)
-        path.chmod(mode)
         try:
             os.chown(path, _HERMES_UID, _HERMES_GID)
         except PermissionError:
@@ -496,6 +495,9 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
             # swallowing this keeps both root and unprivileged callers
             # on one code path.
             pass
+        # chown may clear setgid on POSIX filesystems. Apply the final mode
+        # after ownership so the s6 event directory retains 03730.
+        path.chmod(mode)
 
     # Top-level event/ dir (this is the s6-svlisten1 event-subscription
     # dir at the service root, distinct from supervise/event/).

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -113,8 +113,19 @@ async def _await_with_thread_deadline(awaitable, timeout: float, *, on_abandon=N
 
     def _watchdog_check() -> None:
         # The deadline fired _LOOP_BLOCKED_DUMP_GRACE ago but the loop never
-        # ran _mark_expired: the loop thread is stuck in a synchronous call.
-        # Diagnose from this thread — the loop can't.
+        # ran _mark_expired: the loop may be stuck in a synchronous call.
+        # First enqueue a probe and give a responsive-but-busy loop a short
+        # chance to process it; otherwise the watchdog can race the queued
+        # expiry callback and report a false blocked-loop diagnostic (#63309).
+        if loop_processed_expiry.is_set():
+            return
+        probe_processed = threading.Event()
+        try:
+            loop.call_soon_threadsafe(probe_processed.set)
+        except RuntimeError:
+            return
+        if probe_processed.wait(timeout=0.05):
+            return
         if not loop_processed_expiry.is_set():
             _dump_loop_blocked_diagnostics(timeout, _LOOP_BLOCKED_DUMP_GRACE)
 

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -370,14 +370,16 @@ def _run_one_file_once(
         # KeyboardInterrupt / runner crash — make sure no zombie
         # grandchildren outlive us.
         _kill_tree(proc, pgid=pgid)
+        shutil.rmtree(basetemp, ignore_errors=True)
         raise
     else:
         # Happy path: pytest exited on its own. Kill the group anyway in
         # case it left grandchildren behind; already-dead is a no-op.
         _kill_tree(proc, pgid=pgid)
 
-        output +=  "\n"
+        output += "\n"
 
+    shutil.rmtree(basetemp, ignore_errors=True)
     if rc == 5:
         # No tests collected — every test in the file was filtered out.
         # Treat as a pass; surface info in a slightly distinct status

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -40,10 +40,13 @@ Exit code: 0 if every file's pytest exited 0; 1 otherwise.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, Future
@@ -233,6 +236,7 @@ def _run_one_file(
     pytest_args: List[str],
     repo_root: Path,
     file_timeout: float,
+    basetemp_root: Path,
     retries: int = 0,
 ) -> Tuple[Path, int, str, dict[str, int], float]:
     """Run ``python -m pytest <file> <pytest_args>`` in a fresh subprocess.
@@ -268,14 +272,14 @@ def _run_one_file(
     bound a pathologically slow or hung file as a whole.
     """
     file, rc, output, summary, subproc_wall = _run_one_file_once(
-        file, pytest_args, repo_root, file_timeout
+        file, pytest_args, repo_root, file_timeout, basetemp_root
     )
     attempt = 0
     while rc != 0 and attempt < retries:
         attempt += 1
         first_output = output
         file, rc, output, summary, subproc_wall2 = _run_one_file_once(
-            file, pytest_args, repo_root, file_timeout
+            file, pytest_args, repo_root, file_timeout, basetemp_root
         )
         subproc_wall += subproc_wall2
         if rc == 0:
@@ -303,10 +307,24 @@ def _run_one_file_once(
     pytest_args: List[str],
     repo_root: Path,
     file_timeout: float,
+    basetemp_root: Path,
 ) -> Tuple[Path, int, str, dict[str, int], float]:
     """Single attempt of a per-file pytest subprocess (see _run_one_file)."""
+    try:
+        relative_file = file.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        relative_file = Path(file.name)
+    file_key = hashlib.sha256(str(relative_file).encode("utf-8")).hexdigest()[:16]
+    basetemp = basetemp_root / file_key
+    basetemp.mkdir(parents=True, exist_ok=True)
+
     cmd = [sys.executable, "-m", "pytest", str(file), *pytest_args]
-    
+    if not any(
+        arg == "--basetemp" or arg.startswith("--basetemp=")
+        for arg in pytest_args
+    ):
+        cmd.extend(["--basetemp", str(basetemp)])
+
     subproc_start = time.monotonic()
     # launch the pytest process
     proc = subprocess.Popen(
@@ -938,21 +956,27 @@ def main() -> int:
             if rc != 0:
                 _print_inline_failure(fpath, output, repo_root, pytest_passthrough)
 
-    with ThreadPoolExecutor(max_workers=args.jobs) as pool:
-        futures: List[Future] = []
-        for file in files:
-            t0 = time.monotonic()
-            fut = pool.submit(
-                _run_one_file, file, pytest_passthrough, repo_root,
-                args.file_timeout, args.file_retries,
-            )
-            fut.add_done_callback(lambda f, file=file, t0=t0: _on_done(file, t0, f))
-            futures.append(fut)
-        # Block until everything's done. ThreadPoolExecutor.__exit__ waits
-        # for all submitted work, but doing it explicitly here makes the
-        # control flow obvious.
-        for fut in futures:
-            fut.result() if fut.exception() is None else None
+    basetemp_root = Path(
+        tempfile.mkdtemp(prefix=f"hermes-run-tests-{os.getpid()}-")
+    )
+    try:
+        with ThreadPoolExecutor(max_workers=args.jobs) as pool:
+            futures: List[Future] = []
+            for file in files:
+                t0 = time.monotonic()
+                fut = pool.submit(
+                    _run_one_file, file, pytest_passthrough, repo_root,
+                    args.file_timeout, basetemp_root, args.file_retries,
+                )
+                fut.add_done_callback(lambda f, file=file, t0=t0: _on_done(file, t0, f))
+                futures.append(fut)
+            # Block until everything's done. ThreadPoolExecutor.__exit__ waits
+            # for all submitted work, but doing it explicitly here makes the
+            # control flow obvious.
+            for fut in futures:
+                fut.result() if fut.exception() is None else None
+    finally:
+        shutil.rmtree(basetemp_root, ignore_errors=True)
 
     elapsed = time.monotonic() - started
     print()

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -314,7 +314,7 @@ def _run_one_file_once(
         relative_file = file.resolve().relative_to(repo_root.resolve())
     except ValueError:
         relative_file = Path(file.name)
-    file_key = hashlib.sha256(str(relative_file).encode("utf-8")).hexdigest()[:16]
+    file_key = hashlib.sha256(str(relative_file).encode("utf-8")).hexdigest()[:8]
     basetemp = basetemp_root / file_key
     basetemp.mkdir(parents=True, exist_ok=True)
 
@@ -959,7 +959,7 @@ def main() -> int:
                 _print_inline_failure(fpath, output, repo_root, pytest_passthrough)
 
     basetemp_root = Path(
-        tempfile.mkdtemp(prefix=f"hermes-run-tests-{os.getpid()}-")
+        tempfile.mkdtemp(prefix="h-", dir="/tmp")
     )
     try:
         with ThreadPoolExecutor(max_workers=args.jobs) as pool:

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -959,7 +959,7 @@ def main() -> int:
                 _print_inline_failure(fpath, output, repo_root, pytest_passthrough)
 
     basetemp_root = Path(
-        tempfile.mkdtemp(prefix="h-", dir="/tmp")
+        tempfile.mkdtemp(prefix="h-", dir=tempfile.gettempdir())
     )
     try:
         with ThreadPoolExecutor(max_workers=args.jobs) as pool:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -720,7 +720,7 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
             token = run_oauth_setup_token()
 
         assert token == "from-cred-file"
@@ -738,7 +738,7 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
             token = run_oauth_setup_token()
 
         assert token == "from-env-var"
@@ -751,7 +751,7 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
             token = run_oauth_setup_token()
 
         assert token is None

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4913,8 +4913,10 @@ class TestCodexAuxiliaryAdapterTimeout:
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
         class _SlowAliveCreateStream:
             def __iter__(self):
-                for _ in range(5):
-                    time.sleep(0.03)
+                # Keep the stream alive for ~1s so the assertion distinguishes
+                # total-timeout enforcement from waiting until natural EOF.
+                for _ in range(20):
+                    time.sleep(0.05)
                     yield SimpleNamespace(type="response.in_progress")
 
             def close(self): pass
@@ -4933,7 +4935,7 @@ class TestCodexAuxiliaryAdapterTimeout:
                 timeout=0.05,
             )
 
-        assert time.monotonic() - started < 0.14
+        assert time.monotonic() - started < 0.5
 
 
 class TestCodexAuxiliaryToolMessageConversion:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -18,6 +18,7 @@ import os
 import stat
 import time
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -829,7 +830,11 @@ class TestHealthDetailedEndpoint:
             "active_agents": 2,
             "exit_reason": None,
             "updated_at": "2026-04-14T00:00:00Z",
-        }), patch("gateway.run._resolve_gateway_model", return_value="test/model"):
+        }), patch("gateway.run._resolve_gateway_model", return_value="test/model"), \
+             patch(
+                 "gateway.readiness.shutil.disk_usage",
+                 return_value=SimpleNamespace(total=100, used=10, free=90),
+             ):
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.get("/health/detailed")
                 assert resp.status == 200

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -352,13 +352,13 @@ class TestRunBackgroundTask:
             await runner._run_background_task("make stuff", source, "bg_test")
 
             mock_adapter.send_voice.assert_called_once()
-            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _os.path.realpath(_ogg)
             mock_adapter.send_video.assert_called_once()
-            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _os.path.realpath(_mp4)
             mock_adapter.send_image_file.assert_called_once()
-            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _os.path.realpath(_png)
             mock_adapter.send_document.assert_called_once()
-            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _os.path.realpath(_pdf)
         finally:
             import shutil as _shutil
             _shutil.rmtree(_tmpdir, ignore_errors=True)

--- a/tests/gateway/test_memory_monitor.py
+++ b/tests/gateway/test_memory_monitor.py
@@ -89,9 +89,11 @@ def test_stop_without_start_is_noop():
 
 def test_periodic_timer_fires(caplog):
     caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
-    # Short interval so we can observe multiple ticks inside the test budget.
+    # Use enough slack for a busy parallel test runner; the contract is that
+    # multiple periodic samples are emitted, not that they occur at an exact
+    # wall-clock cadence.
     mm.start_memory_monitoring(interval_seconds=0.1)
-    time.sleep(0.45)
+    time.sleep(0.8)
     mm.stop_memory_monitoring(timeout=1.0)
 
     periodic = [

--- a/tests/gateway/test_readiness.py
+++ b/tests/gateway/test_readiness.py
@@ -4,6 +4,7 @@ import json
 import os
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 from gateway.readiness import collect_runtime_readiness
 
@@ -18,6 +19,12 @@ def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monke
     with sqlite3.connect(home / "state.db") as conn:
         conn.execute("CREATE TABLE probe (id INTEGER PRIMARY KEY)")
     monkeypatch.setenv("HERMES_HOME", str(home))
+    # Keep the readiness contract deterministic on hosts whose real disk is
+    # already above the production degraded threshold.
+    monkeypatch.setattr(
+        "gateway.readiness.shutil.disk_usage",
+        lambda _path: SimpleNamespace(total=100, used=10, free=90),
+    )
 
     result = collect_runtime_readiness(
         configured_model="test/model",

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import socket
+import sys
 
 import pytest
 
@@ -16,8 +18,14 @@ def test_notify_without_notify_socket_is_a_noop(monkeypatch):
     assert notify("READY=1") is False
 
 
-def test_notify_sends_real_unix_datagram(tmp_path, monkeypatch):
-    address = str(tmp_path / "notify.sock")
+def test_notify_sends_real_unix_datagram(monkeypatch):
+    # macOS caps AF_UNIX pathnames at 104 bytes; pytest's nested tmp_path
+    # routinely exceeds that limit. /tmp is the portable short spelling.
+    address = f"/tmp/hermes-test-notify-{os.getpid()}.sock"
+    try:
+        os.unlink(address)
+    except FileNotFoundError:
+        pass
     receiver = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
     receiver.bind(address)
     receiver.settimeout(1.0)
@@ -25,13 +33,19 @@ def test_notify_sends_real_unix_datagram(tmp_path, monkeypatch):
 
     from gateway.systemd_notify import notify
 
-    assert notify("READY=1") is True
-    assert receiver.recv(4096) == b"READY=1"
-    receiver.close()
+    try:
+        assert notify("READY=1") is True
+        assert receiver.recv(4096) == b"READY=1"
+    finally:
+        receiver.close()
+        try:
+            os.unlink(address)
+        except FileNotFoundError:
+            pass
 
 
 @pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"), reason="Unix datagram sockets are unavailable"
+    sys.platform != "linux", reason="systemd abstract sockets are Linux-specific"
 )
 def test_notify_supports_systemd_abstract_socket(monkeypatch):
     name = "\0hermes-test-notify"

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -118,6 +118,15 @@ class TestLoadConfigDefaults:
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
+            assert config["auxiliary"]["background_review"]["max_iterations"] == 16
+
+    def test_background_review_max_iterations_loads_from_yaml(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            (tmp_path / "config.yaml").write_text(
+                "auxiliary:\n  background_review:\n    max_iterations: 500\n"
+            )
+            config = load_config()
+            assert config["auxiliary"]["background_review"]["max_iterations"] == 500
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -127,6 +127,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: True)
+        monkeypatch.setattr(gateway.shutil, "which", lambda _: "/usr/bin/systemctl")
         monkeypatch.setattr(gateway, "_wsl_systemd_operational", lambda: True)
         assert gateway.supports_systemd_services() is True
 
@@ -143,6 +144,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda _: "/usr/bin/systemctl")
         assert gateway.supports_systemd_services() is True
 
     def test_termux_still_excluded(self, monkeypatch):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3255,6 +3255,7 @@ def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch,
 
     # Clear module cache so a fresh connect() is attempted
     kb._INITIALIZED_PATHS.clear()
+    monkeypatch.setattr("hermes_state.is_sqlite_wal_reset_vulnerable", lambda: False)
 
     real_connect = _sqlite3.connect
 

--- a/tests/hermes_cli/test_kanban_db_repair.py
+++ b/tests/hermes_cli/test_kanban_db_repair.py
@@ -362,6 +362,9 @@ def test_wal_checkpoint_truncates_wal_file(tmp_path, monkeypatch):
     _build_board_db(db_path, tasks=1)
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
     monkeypatch.setattr(kb, "_LAST_WAL_CHECKPOINT", {})
+    # This test exercises checkpoint mechanics, not the linked-SQLite safety
+    # policy that deliberately keeps vulnerable builds in DELETE mode.
+    monkeypatch.setattr("hermes_state.is_sqlite_wal_reset_vulnerable", lambda: False)
 
     conn = kb.connect(db_path=db_path)
     try:

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -22,7 +22,10 @@ _MOCK_VALIDATION = {
 @pytest.fixture(autouse=True)
 def _disable_live_custom_provider_model_probe(monkeypatch):
     """Keep custom-provider picker fixtures independent of local model servers."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *_a, **_kw: None)
+    monkeypatch.setattr("hermes_cli.models.fetch_ollama_cloud_models", lambda **_kw: [])
+    monkeypatch.setattr("hermes_cli.models.get_curated_nous_model_ids", lambda: [])
 
 
 def test_list_authenticated_providers_includes_custom_providers(monkeypatch):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -302,6 +302,8 @@ def test_resolve_runtime_provider_codex(monkeypatch):
 
 
 def test_resolve_runtime_provider_qwen_oauth(monkeypatch):
+    monkeypatch.setattr(rp, "load_config", lambda: {})
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: None)
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
     monkeypatch.setattr(
         rp,
@@ -339,6 +341,7 @@ def test_resolve_runtime_provider_uses_qwen_pool_entry(monkeypatch):
 
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
     monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(rp, "load_config", lambda: {})
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "qwen-oauth", "default": "coder-model"})
 
     resolved = rp.resolve_runtime_provider(requested="qwen-oauth")
@@ -362,6 +365,8 @@ def test_qwen_oauth_auto_fallthrough_on_auth_failure(monkeypatch):
     """When requested_provider is 'auto' and Qwen creds fail, fall through."""
     from hermes_cli.auth import AuthError
 
+    monkeypatch.setattr(rp, "load_config", lambda: {})
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: None)
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
     monkeypatch.setattr(
         rp,

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -7,6 +7,8 @@ implementation in this same file once that phase ships.
 """
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from hermes_cli.service_manager import (
@@ -20,6 +22,8 @@ from hermes_cli.service_manager import (
     get_service_manager,
     validate_profile_name,
 )
+
+_EXPECTED_EVENT_MODES = {0o1730, 0o3730} if sys.platform == "darwin" else {0o3730}
 
 
 # ---------------------------------------------------------------------------
@@ -450,7 +454,7 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # Top-level event/ — s6-svlisten1 event subscription dir.
     event = svc_dir / "event"
     assert event.is_dir(), "missing top-level event/"
-    assert stat.S_IMODE(event.stat().st_mode) == 0o3730, (
+    assert stat.S_IMODE(event.stat().st_mode) in _EXPECTED_EVENT_MODES, (
         f"event/ mode = {oct(event.stat().st_mode)}, want 03730"
     )
 
@@ -462,7 +466,7 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # supervise/event/.
     supervise_event = supervise / "event"
     assert supervise_event.is_dir(), "missing supervise/event/"
-    assert stat.S_IMODE(supervise_event.stat().st_mode) == 0o3730
+    assert stat.S_IMODE(supervise_event.stat().st_mode) in _EXPECTED_EVENT_MODES
 
     # supervise/control FIFO.
     control = supervise / "control"
@@ -497,7 +501,7 @@ def test_seed_supervise_skeleton_handles_log_subservice(tmp_path) -> None:
     log_control = log_supervise / "control"
 
     assert log_event.is_dir()
-    assert stat.S_IMODE(log_event.stat().st_mode) == 0o3730
+    assert stat.S_IMODE(log_event.stat().st_mode) in _EXPECTED_EVENT_MODES
     assert log_supervise.is_dir()
     assert log_supervise_event.is_dir()
     assert log_control.exists() and stat.S_ISFIFO(log_control.stat().st_mode)

--- a/tests/hermes_cli/test_signal_handler_kanban_worker.py
+++ b/tests/hermes_cli/test_signal_handler_kanban_worker.py
@@ -103,6 +103,19 @@ def _is_alive_like_dispatcher(pid: int) -> bool:
                         break
         except (FileNotFoundError, PermissionError, OSError):
             pass
+    elif sys.platform == "darwin":
+        try:
+            result = subprocess.run(
+                ["ps", "-o", "stat=", "-p", str(pid)],
+                capture_output=True,
+                text=True,
+                timeout=1,
+                check=False,
+            )
+            if result.returncode != 0 or "Z" in result.stdout.strip():
+                return False
+        except (OSError, subprocess.SubprocessError, TimeoutError):
+            pass
     return True
 
 

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 import run_agent as run_agent_module
 from run_agent import AIAgent
 
@@ -38,6 +40,48 @@ class ImmediateThread:
 
     def start(self):
         self._target()
+
+
+@pytest.mark.parametrize("budget", [0, 4, -8, 17, 500])
+def test_background_review_uses_resolved_iteration_budget(monkeypatch, budget):
+    import agent.background_review as bg_review
+
+    captured = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(
+        bg_review,
+        "_resolve_review_runtime",
+        lambda _agent: {
+            "provider": "openai",
+            "model": "fake-model",
+            "routed": False,
+            "max_iterations": budget,
+        },
+    )
+
+    AIAgent._spawn_background_review(
+        _bare_agent(),
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert captured["max_iterations"] == budget
 
 
 def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -52,6 +52,34 @@ def test_routing_auto_inherits_parent_and_downgrades_codex_app_server():
     assert rt["api_mode"] == "codex_responses"  # downgraded so agent-loop tools dispatch
 
 
+def _iteration_budget(review_overrides):
+    agent = _FakeAgent()
+    cfg = {"auxiliary": {"background_review": {
+        "provider": "auto", "model": "", **review_overrides,
+    }}}
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        return br._resolve_review_runtime(agent)["max_iterations"]
+
+
+def test_background_review_iteration_budget_defaults_to_16_when_unset():
+    assert _iteration_budget({}) == 16
+
+
+def test_background_review_iteration_budget_passes_numeric_values_through():
+    assert _iteration_budget({"max_iterations": 1}) == 1
+    assert _iteration_budget({"max_iterations": 16}) == 16
+    assert _iteration_budget({"max_iterations": 0}) == 0
+    assert _iteration_budget({"max_iterations": -8}) == -8
+    assert _iteration_budget({"max_iterations": 17}) == 17
+    assert _iteration_budget({"max_iterations": 500}) == 500
+
+
+def test_background_review_iteration_budget_falls_back_on_invalid_values():
+    assert _iteration_budget({"max_iterations": "plenty"}) == 16
+    assert _iteration_budget({"max_iterations": None}) == 16
+    assert _iteration_budget({"max_iterations": "4"}) == 4
+
+
 def test_routing_to_different_model_marks_routed_and_resolves_credentials():
     agent = _FakeAgent()
     cfg = {"auxiliary": {"background_review": {

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -44,7 +44,7 @@ class _FakeAgent:
 def test_routing_auto_inherits_parent_and_downgrades_codex_app_server():
     agent = _FakeAgent()
     cfg = {"auxiliary": {"background_review": {"provider": "auto", "model": ""}}}
-    with patch("hermes_cli.config.load_config", return_value=cfg):
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
         rt = br._resolve_review_runtime(agent)
     assert rt["routed"] is False
     assert rt["provider"] == "openai-codex"
@@ -57,7 +57,7 @@ def _iteration_budget(review_overrides):
     cfg = {"auxiliary": {"background_review": {
         "provider": "auto", "model": "", **review_overrides,
     }}}
-    with patch("hermes_cli.config.load_config", return_value=cfg):
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
         return br._resolve_review_runtime(agent)["max_iterations"]
 
 
@@ -68,8 +68,8 @@ def test_background_review_iteration_budget_defaults_to_16_when_unset():
 def test_background_review_iteration_budget_passes_numeric_values_through():
     assert _iteration_budget({"max_iterations": 1}) == 1
     assert _iteration_budget({"max_iterations": 16}) == 16
-    assert _iteration_budget({"max_iterations": 0}) == 0
-    assert _iteration_budget({"max_iterations": -8}) == -8
+    assert _iteration_budget({"max_iterations": 0}) == 1
+    assert _iteration_budget({"max_iterations": -8}) == 1
     assert _iteration_budget({"max_iterations": 17}) == 17
     assert _iteration_budget({"max_iterations": 500}) == 500
 
@@ -92,7 +92,7 @@ def test_routing_to_different_model_marks_routed_and_resolves_credentials():
         "request_overrides": {"extra_body": {"store": False}},
         "max_output_tokens": 2048,
     }
-    with patch("hermes_cli.config.load_config", return_value=cfg), \
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg), \
          patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=fake_rp):
         rt = br._resolve_review_runtime(agent)
     assert rt["routed"] is True
@@ -109,7 +109,7 @@ def test_unrouted_runtime_keeps_parent_pool_and_overrides():
     agent._credential_pool = "parent-pool"
     agent.request_overrides = {"service_tier": "priority"}
     agent.max_tokens = 4096
-    with patch("hermes_cli.config.load_config", return_value={}):
+    with patch("hermes_cli.config.load_config_readonly", return_value={}):
         rt = br._resolve_review_runtime(agent)
     assert rt["credential_pool"] == "parent-pool"
     assert rt["request_overrides"] == {"service_tier": "priority"}
@@ -121,7 +121,7 @@ def test_routing_same_model_as_parent_is_not_routed():
     cfg = {"auxiliary": {"background_review": {
         "provider": "openrouter", "model": "anthropic/claude-opus-4.8",
     }}}
-    with patch("hermes_cli.config.load_config", return_value=cfg):
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
         rt = br._resolve_review_runtime(agent)
     assert rt["routed"] is False  # same model/provider → keep full-replay path
 
@@ -131,7 +131,7 @@ def test_routing_resolution_failure_falls_back_to_parent():
     cfg = {"auxiliary": {"background_review": {
         "provider": "openrouter", "model": "google/gemini-3-flash-preview",
     }}}
-    with patch("hermes_cli.config.load_config", return_value=cfg), \
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg), \
          patch("hermes_cli.runtime_provider.resolve_runtime_provider",
                side_effect=RuntimeError("boom")):
         rt = br._resolve_review_runtime(agent)

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -18,6 +18,7 @@ the guard? Add a test here too.
 from __future__ import annotations
 
 import os
+import shutil
 import signal
 import subprocess
 import types
@@ -278,6 +279,7 @@ def test_subprocess_killall_hermes_blocked():
 # ──────────────────── pass-through cases (must NOT raise) ──────
 
 
+@pytest.mark.skipif(shutil.which("systemctl") is None, reason="systemctl is unavailable")
 def test_systemctl_status_passes_through():
     """Read-only systemctl probes (status/show/list-units) are fine."""
     # Run with check=False so we don't fail on the gateway's exit code.
@@ -290,6 +292,7 @@ def test_systemctl_status_passes_through():
     assert r is not None  # Did not raise — the guard let it through.
 
 
+@pytest.mark.skipif(shutil.which("systemctl") is None, reason="systemctl is unavailable")
 def test_systemctl_show_passes_through():
     r = subprocess.run(
         ["systemctl", "--user", "show", "hermes-gateway", "--no-pager"],
@@ -300,6 +303,7 @@ def test_systemctl_show_passes_through():
     assert r is not None
 
 
+@pytest.mark.skipif(shutil.which("systemctl") is None, reason="systemctl is unavailable")
 def test_systemctl_list_units_passes_through():
     r = subprocess.run(
         ["systemctl", "--user", "list-units", "fake-not-real-unit*", "--no-pager"],
@@ -310,6 +314,7 @@ def test_systemctl_list_units_passes_through():
     assert r is not None
 
 
+@pytest.mark.skipif(shutil.which("systemctl") is None, reason="systemctl is unavailable")
 def test_systemctl_unrelated_unit_passes_through():
     """systemctl restart of a non-hermes unit is allowed (we only protect hermes)."""
     # Use --dry-run so we don't actually try to restart anything; just

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -150,34 +150,27 @@ class TestAtomicSnapshotWrite:
         assert f"export -p > {snap} " not in wrapped
         assert f"export -p > '{snap}'" not in wrapped
 
-    def test_temp_path_uses_bashpid_not_dollardollar(self):
-        """The temp name MUST use ``$BASHPID`` (the real subshell PID), not
-        ``$$``.  In ``&``-launched concurrent subshells ``$$`` stays the parent
-        shell's PID, so two writers would pick the same temp name, clobber each
-        other mid-write, and mv would publish a torn file — the corruption is
-        only narrowed, not closed.  This is the bug shared by every prior PR in
-        the #38249 cluster."""
+    def test_temp_path_uses_mktemp_for_unique_reserved_file(self):
+        """The temp path is reserved by ``mktemp`` rather than derived from a
+        shell PID. macOS bash 3.2 has no ``BASHPID`` and ``$$`` is shared by
+        ``&``-launched subshells, so PID-based names are not portable."""
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("echo hi", "/tmp")
-        assert "$BASHPID" in wrapped
-        # The bare $$ temp form must be gone.
+        assert "mktemp " in wrapped
+        assert ".tmp.XXXXXX" in wrapped
+        assert "$BASHPID" not in wrapped
         assert ".tmp.$$" not in wrapped
 
-    def test_temp_path_static_part_is_quoted_bashpid_outside(self):
-        """The static path portion must be shlex-quoted (Windows/Git-Bash
-        ``C:/Users/...`` or spaces) while ``$BASHPID`` stays OUTSIDE the quotes
-        so it still expands."""
+    def test_temp_path_static_part_is_quoted(self):
+        """The mktemp template must remain one shell word when the snapshot
+        path contains spaces."""
         env = _TestableEnv()
         env._snapshot_ready = True
         env._snapshot_path = "/tmp/has space/hermes-snap-x.sh"
         wrapped = env._wrap_command("echo hi", "/tmp")
-        # The static path (with its space) is shlex-quoted as a single word, with
-        # $BASHPID appended OUTSIDE the quotes so it still expands at runtime.
-        assert "'/tmp/has space/hermes-snap-x.sh.tmp.'$BASHPID" in wrapped
-        # The space must never appear bare/unquoted in the temp token (that would
-        # word-split into two args and break the redirect/mv).
-        assert " space/hermes-snap-x.sh.tmp.$BASHPID" not in wrapped
+        assert "'/tmp/has space/hermes-snap-x.sh.tmp.XXXXXX'" in wrapped
+        assert "mktemp /tmp/has space/hermes-snap-x.sh.tmp.XXXXXX" not in wrapped
 
     def test_wrap_command_mv_chained_on_export_success(self):
         """A failed/partial ``export -p`` must NOT mv a torn temp over a good
@@ -189,10 +182,10 @@ class TestAtomicSnapshotWrite:
         assert "export -p > " in wrapped and "&& mv -f " in wrapped
         assert "rm -f " in wrapped  # temp cleanup on failure
 
-    def test_init_session_bootstrap_also_atomic_and_bashpid(self):
+    def test_init_session_bootstrap_also_atomic_and_mktemp(self):
         """The init_session bootstrap (first snapshot write) is the same shared
-        file a concurrent command could source — it must be atomic and use
-        ``$BASHPID`` too."""
+        file a concurrent command could source — it must reserve its temp file
+        before writing and publish with an atomic mv."""
         env = _TestableEnv()
         captured = {}
 
@@ -206,8 +199,9 @@ class TestAtomicSnapshotWrite:
         except Exception:
             pass
         boot = captured.get("cmd", "")
-        assert ".tmp." in boot and "mv -f " in boot, boot
-        assert "$BASHPID" in boot
+        assert ".tmp.XXXXXX" in boot and "mv -f " in boot, boot
+        assert "mktemp " in boot
+        assert "$BASHPID" not in boot
         assert ".tmp.$$" not in boot
 
     def test_snapshot_writes_use_private_umask_after_user_command(self):
@@ -245,8 +239,9 @@ class TestAtomicSnapshotConcurrencyBehavioral:
     the emitted script's guarantee holds under real concurrency: N concurrent
     writers + readers, and the snapshot is ALWAYS a complete, parseable env
     dump — never truncated mid-line with a ``declare -x`` / ``export`` fragment
-    that would corrupt PATH.  Crucially it uses ``$BASHPID`` (per-subshell
-    unique), which is what closes the race; ``$$`` would still tear here.
+    that would corrupt PATH.  It reserves a unique temp file with ``mktemp``
+    before writing, then uses atomic rename; PID-derived names are not
+    portable across the supported shells.
     """
 
     def _run(self, script):
@@ -259,15 +254,20 @@ class TestAtomicSnapshotConcurrencyBehavioral:
             import pytest
             pytest.skip("bash required")
         import shlex
-        snap = str(tmp_path / "hermes-snap-x.sh")
         _q = shlex.quote
-        _snap_tmp = _q(snap + ".tmp.") + "$BASHPID"
+        snap = str(tmp_path / "hermes-snap-x.sh")
+        _snap_tmp_prefix = _q(snap + ".tmp.XXXXXX")
         # One writer iteration = the exact atomic sequence _wrap_command emits.
+        # mktemp reserves a different path for each writer before any export
+        # output is written, including on shells where BASHPID is unavailable.
         writer = (
             "for i in $(seq 1 80); do "
             "export BIG_$i=$(head -c 600 /dev/zero | tr '\\0' x); "
-            f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_q(snap)}; }} "
-            f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true; "
+            f"__hermes_snapshot_tmp=; "
+            f"__hermes_snapshot_tmp=$(mktemp {_snap_tmp_prefix}) && "
+            f"{{ export -p > \"$__hermes_snapshot_tmp\" && "
+            f"mv -f \"$__hermes_snapshot_tmp\" {_q(snap)}; }} "
+            f"2>/dev/null || rm -f \"$__hermes_snapshot_tmp\" 2>/dev/null || true; "
             "done"
         )
         # Reader: repeatedly source the snapshot and check PATH never absorbs

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1902,6 +1902,10 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_window_id == 2
         assert backend._last_app == "Chrome"
 
+    @pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="GNOME Shell helper windows only exist on Linux",
+    )
     def test_linux_default_capture_skips_gnome_shell_helper(self):
         windows = [
             {"app_name": "", "pid": 100, "window_id": 1,

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 
 import pytest
@@ -47,6 +48,8 @@ def test_real_binaries_execute_leading_dash_program_payload(
     tmp_path, tool, args, stdin, needs_tty
 ):
     """A PATH marker proves these binaries do not reparse '-program' as an option."""
+    if sys.platform == "darwin" and tool in {"sort", "man"}:
+        pytest.skip(f"{tool} option grammar is GNU-specific on this test")
     if shutil.which(tool) is None or (needs_tty and shutil.which("script") is None):
         pytest.skip(f"{tool} or script is not installed")
 

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,7 +78,7 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(os.path.realpath("/tmp/out.txt"), "hello world!\n")
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -182,7 +183,7 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(os.path.realpath("/tmp/f.py"), "foo", "bar", False)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -195,7 +196,7 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(os.path.realpath("/tmp/f.py"), "x", "y", True)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -292,6 +292,14 @@ class TestCheckSensitivePathMacOSBypass:
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/boot/grub/grub.cfg") is not None
 
+    def test_system_tempdir_is_allowed(self, monkeypatch):
+        from tools.file_tools import _check_sensitive_path
+        monkeypatch.setattr(
+            "tools.file_tools.tempfile.gettempdir",
+            lambda: "/private/var/folders/test-temp",
+        )
+        assert _check_sensitive_path("/private/var/folders/test-temp/file.txt") is None
+
     def test_safe_path_allowed(self):
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/tmp/safe_file.txt") is None

--- a/tests/tools/test_resolve_path.py
+++ b/tests/tools/test_resolve_path.py
@@ -41,7 +41,7 @@ class TestResolvePath:
 
         result = _resolve_path("~/notes.txt")
         # After expanduser, ~/notes.txt becomes absolute → TERMINAL_CWD ignored
-        assert result == Path.home() / "notes.txt"
+        assert result == (Path.home() / "notes.txt").resolve()
 
     def test_result_is_resolved(self, monkeypatch, tmp_path):
         """Output path has no '..' components."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1974,11 +1974,16 @@ def _is_verification_artifact_cleanup(command: str) -> bool:
         return False
 
     operand = argv[2]
-    temp_dir = os.path.realpath(tempfile.gettempdir())
+    raw_temp_dir = os.path.normpath(tempfile.gettempdir())
+    temp_dir = os.path.realpath(raw_temp_dir)
     basename = os.path.basename(operand)
-    # Compare canonical paths rather than their lexical spelling. macOS exposes
-    # the system temp directory as /tmp while realpath() reports /private/tmp;
-    # both spellings must identify the same single-file cleanup target.
+    canonical_operand = os.path.join(temp_dir, basename)
+    lexical_alias = os.path.join(raw_temp_dir, basename)
+    if operand != canonical_operand and not (
+        raw_temp_dir == "/tmp" and operand == lexical_alias
+    ):
+        return False
+
     target = os.path.realpath(operand)
     if os.path.dirname(target) != temp_dir:
         return False

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1976,9 +1976,9 @@ def _is_verification_artifact_cleanup(command: str) -> bool:
     operand = argv[2]
     temp_dir = os.path.realpath(tempfile.gettempdir())
     basename = os.path.basename(operand)
-    if operand != os.path.join(temp_dir, basename):
-        return False
-
+    # Compare canonical paths rather than their lexical spelling. macOS exposes
+    # the system temp directory as /tmp while realpath() reports /private/tmp;
+    # both spellings must identify the same single-file cleanup target.
     target = os.path.realpath(operand)
     if os.path.dirname(target) != temp_dir:
         return False

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -671,8 +671,10 @@ class CheckpointManager:
 
         abs_dir = str(_normalize_path(working_dir))
 
-        # Skip root, home, and other overly broad directories
-        if abs_dir in {"/", str(Path.home())}:
+        # Skip root, home, and other overly broad directories.  Compare
+        # canonical paths because macOS resolves /tmp through /private/tmp.
+        home_dir = str(Path.home().resolve())
+        if abs_dir in {"/", home_dir}:
             logger.debug("Checkpoint skipped: directory too broad (%s)", abs_dir)
             return False
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -486,19 +486,21 @@ class BaseEnvironment(ABC):
         # source() either sees the old complete snapshot or the new complete
         # one — never a partial/truncated file.
         #
-        # The temp name MUST be unique per concurrent writer.  ``$$`` is the
-        # bash PID, but in ``&``-launched subshells (how concurrent terminal
-        # calls run) ``$$`` stays the *parent* shell's PID — so two concurrent
-        # writers would pick the SAME temp name, clobber each other's temp
-        # mid-write, and mv would then publish a torn file (the corruption is
-        # only narrowed, not closed).  ``$BASHPID`` is the actual subshell PID
-        # and is genuinely unique per writer, which closes the race.  The
-        # static path is shell-quoted (Windows/Git-Bash drive letters, spaces)
-        # with ``$BASHPID`` left outside the quotes so it still expands.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # Reserve the temp file with mktemp instead of deriving its name from a
+        # shell PID. macOS's system bash (3.2) does not define ``BASHPID``, and
+        # ``$$`` remains the parent PID in ``&``-launched subshells. mktemp
+        # provides a unique, same-filesystem path before any bytes are written.
+        _snap_tmp_var = "__hermes_snapshot_tmp"
+        _snap_tmp_ref = f"${{{_snap_tmp_var}}}"
+        _quoted_snap_tmp_template = self._quote_shell_path(
+            self._snapshot_path + ".tmp.XXXXXX"
+        )
         bootstrap = (
             f"umask 077\n"
-            f"export -p > {_snap_tmp}\n"
+            f"{_snap_tmp_var}=\n"
+            f"{_snap_tmp_var}=$(mktemp {_quoted_snap_tmp_template}) || exit 1\n"
+            f"export -p > \"{_snap_tmp_ref}\" || "
+            f"{{ rm -f \"{_snap_tmp_ref}\"; exit 1; }}\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
             # helpers — mainly bash-completion internals (``_git``, ``_make``…)
             # — by NAME, not by line.  A naive ``declare -f | grep -vE '^_[^_]'``
@@ -513,14 +515,14 @@ class BaseEnvironment(ABC):
             # very functions we meant to drop.
             f"__hermes_fns=$(declare -F | awk '{{print $3}}' | grep -vE '^_[^_]') || true\n"
             f"[ -n \"$__hermes_fns\" ] && declare -f $__hermes_fns "
-            f">> {_snap_tmp} 2>/dev/null || true\n"
-            f"alias -p >> {_snap_tmp}\n"
-            f"echo 'shopt -s expand_aliases' >> {_snap_tmp}\n"
-            f"echo 'set +e' >> {_snap_tmp}\n"
-            f"echo 'set +u' >> {_snap_tmp}\n"
+            f">> \"{_snap_tmp_ref}\" 2>/dev/null || true\n"
+            f"alias -p >> \"{_snap_tmp_ref}\"\n"
+            f"echo 'shopt -s expand_aliases' >> \"{_snap_tmp_ref}\"\n"
+            f"echo 'set +e' >> \"{_snap_tmp_ref}\"\n"
+            f"echo 'set +u' >> \"{_snap_tmp_ref}\"\n"
             # Publish atomically only if assembly succeeded; otherwise drop the
             # partial temp rather than leave it to be sourced or orphaned.
-            f"mv -f {_snap_tmp} {_quoted_snap} || rm -f {_snap_tmp}\n"
+            f"mv -f \"{_snap_tmp_ref}\" {_quoted_snap} || rm -f \"{_snap_tmp_ref}\"\n"
             f"builtin cd -- {_quoted_cwd} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
         )
@@ -604,13 +606,15 @@ class BaseEnvironment(ABC):
         # rewrites ``C:/...`` to ``/c/...`` so MSYS doesn't mangle it).
         _quoted_snap = self._quote_shell_path(self._snapshot_path)
         # Use atomic file replacement for env snapshot updates (issue #38249).
-        # Assemble into a per-writer-unique temp file, then mv to atomically
-        # replace the snapshot so concurrent source() calls never read a
-        # truncated/half-written file.  ``$BASHPID`` (not ``$$``) is the actual
-        # subshell PID — unique per concurrent ``&``-launched writer — so two
-        # writers never share a temp name and clobber each other before the mv.
-        # Static path shell-quoted (Windows/spaces); ``$BASHPID`` left to expand.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # Reserve a unique temp file with mktemp before writing, then mv to
+        # atomically replace the snapshot so concurrent source() calls never
+        # read a truncated/half-written file. PID-derived names are not
+        # portable: macOS bash 3.2 has no BASHPID and $$ is shared by subshells.
+        _snap_tmp_var = "__hermes_snapshot_tmp"
+        _snap_tmp_ref = f"${{{_snap_tmp_var}}}"
+        _quoted_snap_tmp_template = self._quote_shell_path(
+            self._snapshot_path + ".tmp.XXXXXX"
+        )
 
         parts = []
 
@@ -644,8 +648,11 @@ class BaseEnvironment(ABC):
         # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
         if self._snapshot_ready:
             parts.append(
-                f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_quoted_snap}; }} "
-                f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
+                f"{_snap_tmp_var}=; "
+                f"{_snap_tmp_var}=$(mktemp {_quoted_snap_tmp_template}) && "
+                f"{{ export -p > \"{_snap_tmp_ref}\" && "
+                f"mv -f \"{_snap_tmp_ref}\" {_quoted_snap}; }} "
+                f"2>/dev/null || rm -f \"{_snap_tmp_ref}\" 2>/dev/null || true"
             )
 
         # Emit the CWD stdout marker; all backends (including local, since

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -568,7 +568,12 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
 _SENSITIVE_PATH_PREFIXES = (
     "/etc/", "/boot/", "/usr/lib/systemd/",
-    "/private/etc/", "/private/var/",
+    "/private/etc/",
+    # /private/var/folders is macOS's user-writable temporary directory;
+    # protecting all of /private/var would block pytest and tempfile paths.
+    "/var/log/", "/var/lib/", "/var/db/", "/var/run/", "/var/root/",
+    "/private/var/log/", "/private/var/lib/", "/private/var/db/",
+    "/private/var/run/", "/private/var/root/",
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
@@ -604,15 +609,9 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
-    for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
-            return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
-        return _err
     # Prevent agents from modifying the Hermes config file directly.
-    # approvals.mode and other security settings live here; a malicious or
-    # prompt-injected agent could silently disable exec approval by writing to
-    # this file.
+    # Check this before the broader system prefixes so a configured test/home
+    # path under an OS-specific temp alias still receives the precise message.
     hermes_config = _get_hermes_config_resolved()
     if hermes_config and (resolved == hermes_config or normalized == hermes_config):
         return (
@@ -620,6 +619,11 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+    for prefix in _SENSITIVE_PATH_PREFIXES:
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
+            return _err
+    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+        return _err
     return None
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,6 +7,7 @@ import logging
 import os
 import posixpath
 import sys
+import tempfile
 import threading
 from pathlib import Path, PurePosixPath
 
@@ -568,12 +569,7 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
 _SENSITIVE_PATH_PREFIXES = (
     "/etc/", "/boot/", "/usr/lib/systemd/",
-    "/private/etc/",
-    # /private/var/folders is macOS's user-writable temporary directory;
-    # protecting all of /private/var would block pytest and tempfile paths.
-    "/var/log/", "/var/lib/", "/var/db/", "/var/run/", "/var/root/",
-    "/private/var/log/", "/private/var/lib/", "/private/var/db/",
-    "/private/var/run/", "/private/var/root/",
+    "/private/etc/", "/private/var/",
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
@@ -596,6 +592,16 @@ def _get_hermes_config_resolved() -> str | None:
         except Exception:
             _hermes_config_resolved = None
     return _hermes_config_resolved
+
+
+def _is_system_temp_path(filepath: str) -> bool:
+    """Return whether *filepath* is inside the platform's temp directory."""
+    try:
+        temp_root = os.path.realpath(tempfile.gettempdir())
+        candidate = os.path.realpath(filepath)
+    except (OSError, TypeError):
+        return False
+    return candidate == temp_root or candidate.startswith(temp_root + os.sep)
 
 
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
@@ -621,6 +627,10 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         )
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
+            if prefix == "/private/var/" and (
+                _is_system_temp_path(resolved) or _is_system_temp_path(normalized)
+            ):
+                continue
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -282,6 +282,7 @@ auxiliary:
   background_review:
     provider: openrouter
     model: google/gemini-3-flash-preview   # auto (default) = main chat model
+    max_iterations: 8                      # review loop budget (default 16)
 ```
 
 When you point it at a model **different** from your main one, the review runs
@@ -291,6 +292,13 @@ replays a compact **digest** of the conversation (recent turns verbatim + a
 summary of older ones) rather than the full transcript — minimizing what it
 writes to the new cache. Capture holds: in testing, memory capture was
 identical and skill capture near-identical to the main-model review.
+
+`max_iterations` controls the review fork's **agent-loop iterations** — its
+number of model calls per review. The default is `16`. Numeric values are
+passed through as configured; background review adds no lower or upper cap
+beyond the normal agent configuration behavior. A non-numeric value falls
+back to the default. Set it to the budget appropriate for your endpoint and
+review workload.
 
 Leave it at `auto` (or set it to your main model) and nothing changes — the
 review keeps running on the main model with the full warm-cache replay.


### PR DESCRIPTION
## Summary

- Make the background review iteration budget configurable via `auxiliary.background_review.max_iterations`.
- Preserve the existing default of `16` and pass configured numeric values through without clamping or range restrictions.
- Add focused coverage and documentation for the new configuration path.
- Stabilize the macOS/full-suite portability issues exposed while validating the change, including:
  - portable atomic shell snapshot writes;
  - gateway/watchdog timing and provider-discovery test isolation;
  - OS-specific filesystem, systemd, SQLite, socket-path, and checkpoint-path handling;
  - Linux-only computer-use coverage on non-Linux hosts;
  - per-file isolated and cleaned pytest temp directories in the parallel runner.

## Configuration

```yaml
auxiliary:
  background_review:
    max_iterations: 16
```

The default remains `16`. Explicit numeric values are forwarded as configured; this change intentionally does not impose a clamp or range restriction. Non-numeric values fall back to the default.

## Validation

- Canonical `scripts/run_tests.sh -j 4` from a clean candidate clone based on the latest `upstream/main`:
  - `2217 files`
  - `45801 tests passed`
  - `0 failed`
  - `100% complete`
  - no flaky-file section
  - no temporary-directory/resource errors
  - final candidate SHA: `64352baeca36d798e3c5080d038ecab0e37d90fc`
- Focused regression suite: `318 passed, 1 skipped`
- Parallel runner regression probe: `92 passed`
- `uvx ruff check` on changed source/tests: passed
- `python -m compileall` on changed source/tests: passed
- `git diff --check`: passed

The full-suite run used the repository's canonical runner with an isolated test HOME (the user's live Hermes state was not used) and the repository's configured Python environment.