### PR TITLE
feat(kanban): dashboard dependency edges in board payload + 'review' direct-set status

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -406,8 +406,11 @@ def get_board(
             workflow_template_id=workflow_template_id,
             current_step_key=current_step_key,
         )
-        # Pre-fetch link counts per task (cheap: one query).
+        # Pre-fetch link counts per task (cheap: one query). Also collect the
+        # raw parent->child edges so the dashboard can draw the dependency
+        # graph (the "Show dependencies" overlay) without N per-task fetches.
         link_counts: dict[str, dict[str, int]] = {}
+        edges: list[dict[str, str]] = []
         for row in conn.execute(
             "SELECT parent_id, child_id FROM task_links"
         ).fetchall():
@@ -417,6 +420,7 @@ def get_board(
             link_counts.setdefault(row["child_id"], {"parents": 0, "children": 0})[
                 "parents"
             ] += 1
+            edges.append({"parent": row["parent_id"], "child": row["child_id"]})
 
         # Comment + event counts (both cheap aggregates).
         comment_counts: dict[str, int] = {
@@ -503,6 +507,7 @@ def get_board(
             ],
             "tenants": tenants,
             "assignees": assignees,
+            "edges": edges,
             "latest_event_id": int(latest_event_id),
             "now": int(time.time()),
         }
@@ -878,7 +883,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     status_code=400,
                     detail="Cannot set status to 'running' directly; use the dispatcher/claim path",
                 )
-            elif s in ("todo", "triage", "scheduled"):
+            elif s in ("todo", "triage", "scheduled", "review"):
                 ok = _set_status_direct(conn, task_id, s)
             else:
                 raise HTTPException(status_code=400, detail=f"unknown status: {s}")
@@ -1242,7 +1247,7 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         continue
                     elif s == "scheduled":
                         ok = kanban_db.schedule_task(conn, tid)
-                    elif s in {"todo", "triage"}:
+                    elif s in {"todo", "triage", "review"}:
                         ok = _set_status_direct(conn, tid, s)
                     else:
                         entry.update(ok=False, error=f"unknown status {s!r}")


### PR DESCRIPTION
## Summary

Two small, self-contained Kanban dashboard improvements (source-only; rebuild the dashboard bundle to pick them up). Closes #70212.

1. **Dependency-graph edges in the board payload.** `get_board()` already scans `task_links` in one pass to compute parent/child link *counts*. This collects the raw parent→child **edges** in that same loop and returns them as `"edges"` in the board JSON, so the dashboard can render a "Show dependencies" overlay without N per-task link fetches. **Zero extra queries.**

2. **Allow `"review"` as a direct-set status.** `update_task` and `bulk_update` gate direct status writes behind a whitelist (`todo`, `triage`, `scheduled`). A task in the `review` column couldn't be moved via the direct-set path (`unknown status: review`). Adds `"review"` to both whitelists.

## Changes

`plugins/kanban/dashboard/plugin_api.py` (+8/-3):
- `get_board()`: build `edges: list[{"parent","child"}]` during the existing `task_links` loop; add `"edges": edges` to the payload.
- `update_task()`: `elif s in ("todo", "triage", "scheduled", "review")`.
- `bulk_update()`: `elif s in {"todo", "triage", "review"}`.

## Not included

The rebuilt `dist/` bundle (index.js/style.css + overlay fonts) is intentionally left out — dist is build output and should be regenerated from source in CI/by a maintainer rather than carried in the PR diff. The renderer side that consumes `edges` can land alongside a dashboard rebuild.

## Invariants preserved

- No schema change: `task_links` and the `review` status already exist.
- The `running` guard (must go through the dispatcher/claim path) and the `scheduled` special-case are untouched.
- The single-query cost of `get_board()`'s link pass is unchanged.

Running locally on an editable install.
