### PR TITLE
feat(cli): remind users what they were doing last session

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7173,6 +7173,34 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _cli_visible_print()
         return True
 
+    def _show_previous_session_recap(self) -> None:
+        """Print a one-line reminder of the last CLI session on a fresh start.
+
+        Only for a genuinely new session — /resume already shows the full
+        prior transcript via _display_resumed_history, so this would be
+        redundant there. Best-effort: any failure is swallowed so it can
+        never block startup.
+        """
+        try:
+            from tools.ansi_strip import sanitize_display_text
+            from hermes_cli.main import _relative_time
+
+            prior = self._list_recent_sessions(limit=1)
+            if not prior:
+                return
+            session = prior[0]
+            label = sanitize_display_text((session.get("title") or "").strip())
+            if not label:
+                label = sanitize_display_text((session.get("preview") or "").strip())
+            if not label:
+                return
+            if len(label) > 80:
+                label = label[:79] + "…"
+            when = _relative_time(session.get("last_active"))
+            _cli_visible_print(f'  Last time: "{label}" — {when}')
+        except Exception:
+            pass
+
     def show_history(self):
         """Display conversation history."""
         if not self.conversation_history:
@@ -13410,9 +13438,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._show_security_advisories()
         # If resuming a session, load history and display it immediately
         # so the user has context before typing their first message.
+        # Otherwise, on a genuinely fresh session, remind the user what
+        # they were doing last time so they don't have to go dig for it.
         if self._resumed:
             if self._preload_resumed_session():
                 self._display_resumed_history()
+        else:
+            self._show_previous_session_recap()
 
         try:
             from hermes_cli.skin_engine import get_active_skin

--- a/tests/cli/test_cli_previous_session_recap.py
+++ b/tests/cli/test_cli_previous_session_recap.py
@@ -1,0 +1,127 @@
+"""Tests for _show_previous_session_recap() — the one-line "last time you
+were doing X, N ago" reminder shown on a fresh (non-resumed) CLI start.
+
+Distinct from _display_resumed_history() (tests/cli/test_resume_display.py),
+which shows a full multi-exchange recap when /resume reattaches to the SAME
+session. This is a one-liner about the PREVIOUS, already-ended session,
+shown when starting a brand new one.
+"""
+
+from unittest.mock import MagicMock
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.session_id = "current_session"
+    cli_obj._session_db = MagicMock()
+    return cli_obj
+
+
+class TestShowPreviousSessionRecap:
+    def test_shows_title_and_relative_time(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[
+            {"id": "sess_001", "title": "fixing the memory leak", "preview": "", "last_active": None},
+        ])
+
+        cli_obj._show_previous_session_recap()
+        output = capsys.readouterr().out
+
+        assert '"fixing the memory leak"' in output
+        assert "Last time:" in output
+
+    def test_falls_back_to_preview_when_untitled(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[
+            {"id": "sess_001", "title": "", "preview": "help me debug this crash", "last_active": None},
+        ])
+
+        cli_obj._show_previous_session_recap()
+        output = capsys.readouterr().out
+
+        assert '"help me debug this crash"' in output
+
+    def test_no_prior_sessions_prints_nothing(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[])
+
+        cli_obj._show_previous_session_recap()
+        output = capsys.readouterr().out
+
+        assert output == ""
+
+    def test_untitled_and_no_preview_prints_nothing(self, capsys):
+        """A session with neither a title nor a preview (e.g. never got a
+        user message) has nothing worth recapping."""
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[
+            {"id": "sess_001", "title": "", "preview": "", "last_active": None},
+        ])
+
+        cli_obj._show_previous_session_recap()
+        output = capsys.readouterr().out
+
+        assert output == ""
+
+    def test_long_label_is_truncated(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[
+            {"id": "sess_001", "title": "x" * 200, "preview": "", "last_active": None},
+        ])
+
+        cli_obj._show_previous_session_recap()
+        output = capsys.readouterr().out
+
+        assert "x" * 200 not in output
+        assert "…" in output
+
+    def test_escape_sequences_in_label_are_stripped(self, capsys):
+        """Stored session titles/previews are untrusted for display — a
+        title carrying terminal escape sequences must not reach the
+        terminal raw (mirrors the same threat model _display_resumed_history
+        and session_recap.py guard against)."""
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[
+            {"id": "sess_001", "title": "\x1b[2J\x1b]0;pwned\x07evil title", "preview": "", "last_active": None},
+        ])
+
+        cli_obj._show_previous_session_recap()
+        output = capsys.readouterr().out
+
+        assert "\x1b" not in output
+        assert "evil title" in output
+
+    def test_never_raises_when_list_recent_sessions_fails(self):
+        """Best-effort: this must never block CLI startup."""
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(side_effect=RuntimeError("db locked"))
+
+        cli_obj._show_previous_session_recap()  # must not raise
+
+    def test_only_looks_at_the_single_most_recent_session(self):
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[])
+
+        cli_obj._show_previous_session_recap()
+
+        cli_obj._list_recent_sessions.assert_called_once_with(limit=1)
+
+
+def test_run_calls_recap_only_on_the_non_resumed_branch():
+    """Source-level regression guard for the wiring in HermesCLI.run():
+    _show_previous_session_recap() must sit in the same if/else as
+    _display_resumed_history() (mutually exclusive), not run unconditionally
+    or alongside it — otherwise /resume would show both recaps at once.
+    """
+    import inspect
+
+    src = inspect.getsource(HermesCLI.run)
+    resumed_branch, _, rest = src.partition("if self._resumed:")
+    assert resumed_branch != src, "run() no longer branches on self._resumed"
+    else_branch = rest.split("else:", 1)[1]
+    # Only look at the immediate else: block, not the rest of run().
+    else_block = else_branch.split("\n\n", 1)[0]
+    assert "_show_previous_session_recap()" in else_block
+    assert "_display_resumed_history()" not in else_block

--- a/tests/cli/test_cli_previous_session_recap.py
+++ b/tests/cli/test_cli_previous_session_recap.py
@@ -9,6 +9,8 @@ shown when starting a brand new one.
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from cli import HermesCLI
 
 
@@ -109,19 +111,62 @@ class TestShowPreviousSessionRecap:
         cli_obj._list_recent_sessions.assert_called_once_with(limit=1)
 
 
-def test_run_calls_recap_only_on_the_non_resumed_branch():
-    """Source-level regression guard for the wiring in HermesCLI.run():
-    _show_previous_session_recap() must sit in the same if/else as
-    _display_resumed_history() (mutually exclusive), not run unconditionally
-    or alongside it — otherwise /resume would show both recaps at once.
-    """
-    import inspect
+class _StopRun(Exception):
+    """Raised by the stubbed ``_console_print`` to abort ``run()`` right after
+    the startup dispatch branch, before it reaches the interactive input loop
+    (which would otherwise block forever in a test)."""
 
-    src = inspect.getsource(HermesCLI.run)
-    resumed_branch, _, rest = src.partition("if self._resumed:")
-    assert resumed_branch != src, "run() no longer branches on self._resumed"
-    else_branch = rest.split("else:", 1)[1]
-    # Only look at the immediate else: block, not the rest of run().
-    else_block = else_branch.split("\n\n", 1)[0]
-    assert "_show_previous_session_recap()" in else_block
-    assert "_display_resumed_history()" not in else_block
+
+def _make_run_ready_cli(*, resumed):
+    """A HermesCLI wired to run real dispatch logic in HermesCLI.run(), with
+    everything before and after the branch under test stubbed out."""
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj._resumed = resumed
+    cli_obj._claim_active_session = MagicMock(return_value=True)
+    cli_obj.show_banner = MagicMock()
+    cli_obj._show_security_advisories = MagicMock()
+    cli_obj._preload_resumed_session = MagicMock(return_value=True)
+    cli_obj._display_resumed_history = MagicMock()
+    cli_obj._show_previous_session_recap = MagicMock()
+    # First real print after the dispatch branch (the welcome banner) aborts
+    # the run — we only want to exercise the branch itself.
+    cli_obj._console_print = MagicMock(side_effect=_StopRun)
+    return cli_obj
+
+
+class TestRunStartupDispatch:
+    """Runtime coverage for the wiring in HermesCLI.run(): the previous-session
+    recap and the resumed-history recap are mutually exclusive, driven by
+    self._resumed. Executes the real run() dispatch rather than reading its
+    source (AGENTS.md bans source-inspection tests: they pass on broken wiring
+    and fail on harmless refactors)."""
+
+    def test_fresh_start_shows_recap_not_resumed_history(self):
+        cli_obj = _make_run_ready_cli(resumed=False)
+
+        with pytest.raises(_StopRun):
+            cli_obj.run()
+
+        cli_obj._show_previous_session_recap.assert_called_once()
+        cli_obj._display_resumed_history.assert_not_called()
+
+    def test_resumed_start_shows_history_not_recap(self):
+        cli_obj = _make_run_ready_cli(resumed=True)
+
+        with pytest.raises(_StopRun):
+            cli_obj.run()
+
+        cli_obj._display_resumed_history.assert_called_once()
+        cli_obj._show_previous_session_recap.assert_not_called()
+
+    def test_resumed_but_preload_failure_shows_neither(self):
+        """A resumed session whose history fails to preload shows no recap at
+        all rather than falling back to the fresh-start one."""
+        cli_obj = _make_run_ready_cli(resumed=True)
+        cli_obj._preload_resumed_session.return_value = False
+
+        with pytest.raises(_StopRun):
+            cli_obj.run()
+
+        cli_obj._display_resumed_history.assert_not_called()
+        cli_obj._show_previous_session_recap.assert_not_called()


### PR DESCRIPTION
Hi! Small quality-of-life addition.

## What

Starting `hermes` fresh (not `/resume`) gives no hint of what your last session was about — you'd have to run `/sessions` or `/resume` just to check. This adds a one-line reminder on a genuinely fresh session start:

```
  Last time: "fixing the flaky test" — 2h ago
```

Falls back to the first-message preview when the session was never titled, and shows nothing when there's no prior session (new install) or nothing worth showing (an untitled session with no messages).

## Why this isn't redundant with existing recap features

I checked before building this — hermes-agent already has two related-but-distinct features:
- `/recap` (`hermes_cli/session_recap.py`) summarizes recent activity **within the current, ongoing session** (for when you've stepped away from an active terminal).
- `/resume` (`_display_resumed_history`) re-displays the full prior transcript when reattaching to **the same session**.

This is neither — it's a one-liner about the **previous, already-ended** session, shown only when starting a **new, different** one. The three are mutually exclusive in practice (this only fires on the non-`/resume` branch of `run()`).

## Implementation

- Reuses the existing `_list_recent_sessions` → `query_session_listing` → `SessionDB.list_sessions_rich` lookup (already powers `/sessions` and the resume picker) and the existing `_relative_time` formatter — no new query logic.
- Session titles/previews are stored, untrusted content (they come from prior conversation text), so the label is run through `sanitize_display_text` before printing — the same guard `_display_resumed_history` and `session_recap.py` already use, so a title carrying terminal escape sequences can't do anything to your terminal.
- Best-effort: wrapped in a bare `except Exception: pass` so a DB hiccup can never block startup.
- Printed via `_cli_visible_print` (not `self._console_print`) since the content is untrusted and shouldn't go through Rich markup parsing — same choice already made for the `/sessions` table.

## Testing

New `tests/cli/test_cli_previous_session_recap.py` (9 tests): title shown, preview fallback, silent on no prior session, silent when nothing to show, long-label truncation, escape-sequence stripping (security regression case), never raises on a DB error, only queries `limit=1`, and a source-inspection test confirming the new call sits in the same `if/else` as `_display_resumed_history()` so `/resume` never shows both at once.

Also manually verified end-to-end against a real `SessionDB` (not just mocks) for: titled session, untitled-with-preview session, and a brand-new user with zero history.

Existing `test_cli_resume_command.py` / `test_resume_display.py` / `test_cli_new_session.py` suites (72 tests) still pass unchanged; `ruff check` clean.