### PR TITLE
feat(desktop): reorder pinned sessions by dragging within the sidebar

### DIFF
--- a/apps/desktop/e2e/pinned-reorder.spec.ts
+++ b/apps/desktop/e2e/pinned-reorder.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * E2E: reorder pinned sessions by dragging within the sidebar.
+ *
+ * Regression for the two-drag-systems conflict (#47728 follow-up): the row body
+ * is a session-drag source (drag onto chat → link), and reorder used to live on
+ * a separate, near-invisible dnd-kit grab handle that the session-drag stole
+ * from. Now one pointer drag routes by DROP LOCATION — released within the
+ * pinned list it reorders, released on a chat surface it links. This test drives
+ * a REAL pointer drag (mouse.move/down/up in steps, like tile-unread-bug.spec)
+ * and asserts the pinned order actually changes.
+ *
+ * Prerequisite: `npm run build` must have been run so dist/ exists.
+ */
+
+import { expect, test, type Page } from '@playwright/test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { restartMockServer } from './mock-server'
+
+/** A pinned row's durable order is read from the DOM: the tagged reorder rows
+ *  in document order carry the session id in data-reorder-row. */
+async function pinnedOrder(page: Page): Promise<string[]> {
+  return page.locator('[data-reorder-row]').evaluateAll(nodes =>
+    nodes.map(n => (n as HTMLElement).dataset.reorderRow ?? '')
+  )
+}
+
+/** Create a fresh session with a distinct first message so its row is findable. */
+async function createSession(page: Page, marker: string): Promise<void> {
+  await page.locator('button:has-text("New session")').first().click()
+  await page.waitForTimeout(500)
+
+  const composer = page.locator('[contenteditable="true"]').first()
+  await composer.waitFor({ state: 'visible', timeout: 10_000 })
+  await composer.click()
+  await composer.type(marker, { delay: 15 })
+  await page.keyboard.press('Enter')
+
+  await page.waitForFunction(
+    text => (document.body.textContent ?? '').includes(text),
+    marker,
+    { timeout: 20_000 }
+  )
+}
+
+/** Shift-click a session row to pin it (the row's onClick pin shortcut). */
+async function shiftClickPin(page: Page, marker: string): Promise<void> {
+  const row = page.locator('[data-slot="sidebar"] button').filter({ hasText: marker }).first()
+  await row.click({ modifiers: ['Shift'] })
+  await page.waitForTimeout(300)
+}
+
+test.describe('sidebar — pinned reorder via pointer drag', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let fixture: MockBackendFixture
+
+  test.beforeAll(async () => {
+    restartMockServer()
+    fixture = await setupMockBackend()
+    await waitForAppReady(fixture, 120_000)
+  })
+
+  test.afterAll(async () => {
+    await fixture?.cleanup()
+  })
+
+  test('dragging a pinned row within the sidebar reorders it', async () => {
+    const page = fixture.page
+
+    // Two pinned sessions, distinct markers so their rows are addressable.
+    await createSession(page, 'E2E_PIN_ALPHA')
+    await shiftClickPin(page, 'E2E_PIN_ALPHA')
+    await createSession(page, 'E2E_PIN_BETA')
+    await shiftClickPin(page, 'E2E_PIN_BETA')
+
+    // Both rows now carry data-reorder-row (the pinned list is a reorder zone).
+    await expect
+      .poll(() => pinnedOrder(page).then(o => o.length), { timeout: 10_000 })
+      .toBe(2)
+
+    const before = await pinnedOrder(page)
+    expect(before).toHaveLength(2)
+
+    const topId = before[0]!
+    const topRow = page.locator(`[data-reorder-row="${topId}"]`)
+    const box = await topRow.boundingBox()
+    expect(box, 'top pinned row must be visible').not.toBeNull()
+
+    // Drag the top row down past the second row's midpoint, in steps so the
+    // pointer session engages (threshold) and resolveMove tracks the slot.
+    const startX = box!.x + box!.width / 2
+    const startY = box!.y + box!.height / 2
+    const targetY = box!.y + box!.height * 1.6
+
+    await page.mouse.move(startX, startY)
+    await page.mouse.down()
+    for (let i = 1; i <= 10; i++) {
+      await page.mouse.move(startX, startY + (targetY - startY) * (i / 10))
+      await page.waitForTimeout(25)
+    }
+    await page.mouse.up()
+    await page.waitForTimeout(500)
+
+    // The order flipped — the dragged row is no longer first.
+    const after = await pinnedOrder(page)
+    expect(after, 'pinned order should have the same two ids').toHaveLength(2)
+    expect(after[0], 'the dragged top row should now be second').not.toBe(topId)
+    expect(after).toContain(topId)
+  })
+})

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -50,6 +50,13 @@ import { openSessionTile, type TileDock } from '@/store/session-states'
 
 import { requestComposerInsertRefs } from './composer/focus'
 import { type SessionDragPayload, sessionInlineRef, sessionLabel } from './composer/inline-refs'
+import {
+  $sidebarReorderHint,
+  reorderIds,
+  type ReorderZoneSnapshot,
+  resolveReorderTarget,
+  snapshotReorderZones
+} from './sidebar/reorder-zones'
 
 /** A chat surface's drag-start geometry: the anchor pane id it advertises
  *  (`data-session-anchor`) and the composer a link drop routes to
@@ -101,11 +108,16 @@ export function startSessionDrag(
   let surfaces: SurfaceSnapshot[] = []
   let composers: ZoneRect[] = []
   let zoneHost = new Map<string, null | string>()
+  let reorderZones: ReorderZoneSnapshot[] = []
 
   // Commit intent, updated per resolved move (the machinery flushes the final
   // move before commit, so these always match the released-at position).
   let split: { anchor: string; before?: null | string; pos: TileDock } | null = null
   let link: null | string = null
+  // A sidebar reorder target — set when the pointer is over a registered
+  // reorder zone (e.g. Pinned) that owns this session. Mutually exclusive with
+  // split/link: dropping within the bar reorders, dropping on chat links.
+  let reorder: { before: null | string; ids: string[]; onReorder: (ids: string[]) => void } | null = null
 
   // The drag SOURCE (sidebar row or tile tab). Captured synchronously — React
   // clears `currentTarget` after the pointerdown handler returns, but this runs
@@ -125,6 +137,7 @@ export function startSessionDrag(
       surfaces = snapshotSurfaces()
       composers = [...document.querySelectorAll<HTMLElement>('[data-slot="composer-root"]')].map(snapRect)
       zoneHost = new Map(zones.map(zone => [zone.id, chatZonePane(zone.id)]))
+      reorderZones = snapshotReorderZones()
       source?.style.setProperty('opacity', '0.45')
       // The same sentinel the zone overlay + chat surfaces key off — the
       // whole drop language (sheets, pills, caret, link overlay) lights up.
@@ -135,9 +148,30 @@ export function startSessionDrag(
       if (source) {
         source.style.opacity = restoreOpacity
       }
+
+      $sidebarReorderHint.set(null)
     },
 
     resolveMove(x, y): DropHint | null {
+      // Sidebar reorder wins inside its own bounds: dropping a row within the
+      // bar reorders, only a drop over a chat surface links/splits. Checked
+      // first so the two never fight over the same pixels.
+      const reorderTarget = resolveReorderTarget(reorderZones, payload.id, x, y)
+
+      if (reorderTarget) {
+        reorder = reorderTarget
+        split = null
+        link = null
+        $sidebarReorderHint.set({ before: reorderTarget.before, draggedId: payload.id })
+
+        // Not a pane/zone drop — the tree overlay stands down. The pinned list
+        // paints its own insertion line off $sidebarReorderHint.
+        return null
+      }
+
+      reorder = null
+      $sidebarReorderHint.set(null)
+
       const zone = zones.find(z => rectContains(z.rect, x, y))
       const host = zone ? zoneHost.get(zone.id) : null
 
@@ -178,7 +212,14 @@ export function startSessionDrag(
     },
 
     onCommit() {
-      if (split) {
+      if (reorder) {
+        // Drop within the sidebar: reorder the list in place. No tile, no link.
+        const next = reorderIds(reorder.ids, payload.id, reorder.before)
+
+        if (next !== reorder.ids) {
+          reorder.onReorder(next)
+        }
+      } else if (split) {
         openSessionTile(payload.id, split.pos, split.anchor, split.before)
         // A tile for this session may already exist (openSessionTile is
         // idempotent — e.g. persisted from an earlier run): a drop must never

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1239,7 +1239,7 @@ export function ChatSidebar({
             {!trimmedQuery && (
               <SidebarSessionsSection
                 activeSessionId={activeSidebarSessionId}
-                contentClassName={cn('flex max-h-44 flex-col gap-px rounded-lg pb-2 pt-1', GROUP_BODY)}
+                contentClassName={cn('flex max-h-[40vh] flex-col gap-px rounded-lg pb-2 pt-1', GROUP_BODY)}
                 dndSensors={dndSensors}
                 emptyState={<SidebarPinnedEmptyState />}
                 label={s.pinned}
@@ -1252,10 +1252,10 @@ export function ChatSidebar({
                 onTogglePin={unpinSession}
                 open={pinsOpen}
                 pinned
+                reorderViaDrag={pinnedSessions.length > 1}
                 rootClassName="shrink-0 p-0 pb-1"
                 sessions={pinnedSessions}
                 showProfileTags={showAllProfiles}
-                sortable={pinnedSessions.length > 1}
                 workingSessionIdSet={workingSessionIdSet}
               />
             )}

--- a/apps/desktop/src/app/chat/sidebar/reorder-zone-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/reorder-zone-list.test.tsx
@@ -1,0 +1,58 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ReorderZoneList } from './reorder-zone-list'
+import { $sidebarReorderHint, snapshotReorderZones } from './reorder-zones'
+
+afterEach(() => {
+  cleanup()
+  $sidebarReorderHint.set(null)
+})
+
+function items(ids: string[]) {
+  return ids.map(id => ({ id, node: <div data-testid={`row-${id}`}>{id}</div> }))
+}
+
+describe('ReorderZoneList', () => {
+  it('registers a reorder zone while mounted and unregisters on unmount', () => {
+    const { unmount } = render(<ReorderZoneList items={items(['a', 'b', 'c'])} onReorder={() => undefined} />)
+
+    // The drag resolver discovers the zone via snapshotReorderZones().
+    const snaps = snapshotReorderZones()
+    expect(snaps).toHaveLength(1)
+    expect(snaps[0]!.ids).toEqual(['a', 'b', 'c'])
+
+    unmount()
+    expect(snapshotReorderZones()).toHaveLength(0)
+  })
+
+  it('tags each row so the resolver can find it by id', () => {
+    render(<ReorderZoneList items={items(['a', 'b'])} onReorder={() => undefined} />)
+
+    expect(document.querySelector('[data-reorder-row="a"]')).toBeTruthy()
+    expect(document.querySelector('[data-reorder-row="b"]')).toBeTruthy()
+  })
+
+  it('exposes live ids to the registration (a reorder reads current order at engage)', () => {
+    const onReorder = vi.fn()
+    const { rerender } = render(<ReorderZoneList items={items(['a', 'b', 'c'])} onReorder={onReorder} />)
+
+    // Re-render with a new order (as a commit would produce) — the zone's
+    // getIds must report the latest, not the mount-time snapshot.
+    rerender(<ReorderZoneList items={items(['c', 'a', 'b'])} onReorder={onReorder} />)
+
+    expect(snapshotReorderZones()[0]!.ids).toEqual(['c', 'a', 'b'])
+  })
+
+  it('paints the insertion line only for a drag of one of its own rows', () => {
+    render(<ReorderZoneList items={items(['a', 'b', 'c'])} onReorder={() => undefined} />)
+
+    // A foreign drag (id not in this list) shows no line.
+    act(() => $sidebarReorderHint.set({ before: 'b', draggedId: 'foreign' }))
+    expect(document.querySelector('[data-reorder-line]')).toBeNull()
+
+    // A drag of one of ours renders exactly one insertion line.
+    act(() => $sidebarReorderHint.set({ before: 'b', draggedId: 'a' }))
+    expect(document.querySelectorAll('[data-reorder-line]')).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/reorder-zone-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/reorder-zone-list.tsx
@@ -1,0 +1,73 @@
+import { useStore } from '@nanostores/react'
+import { Fragment, useEffect, useRef } from 'react'
+
+import { $sidebarReorderHint, registerReorderZone } from './reorder-zones'
+
+/**
+ * A pointer-drag reorderable list for a flat sidebar section (Pinned).
+ *
+ * Unlike the dnd-kit `ReorderableList` (which owns its own DndContext and a
+ * grab handle), this list has NO handle and NO second drag system: the rows are
+ * already session-drag sources (session-drag.ts), and that shared pointer drag
+ * now resolves a reorder when the drop lands inside a registered zone. This
+ * component is only the registration + the insertion-line UI — dropping a row
+ * within the bar reorders, dropping it on the chat links, one gesture routed by
+ * where it's released.
+ *
+ * Items are passed as `{ id, node }` so the list can tag each row for the
+ * resolver's geometry snapshot (`data-reorder-row`) and interleave the
+ * insertion line at the live hint without reaching into row markup. The zone
+ * container is `display: contents` so the row wrappers remain the direct flex
+ * children of the section body (unchanged gap/scroll); each wrapper is a real
+ * box so its rect reflects the row for slot math.
+ */
+export function ReorderZoneList({
+  items,
+  onReorder
+}: {
+  items: { id: string; node: React.ReactNode }[]
+  onReorder: (ids: string[]) => void
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const hint = useStore($sidebarReorderHint)
+
+  // Keep the latest ids/onReorder readable by the (stable) registration without
+  // re-registering on every order change — the drag reads them live at engage.
+  const idsRef = useRef<string[]>([])
+  idsRef.current = items.map(item => item.id)
+  const onReorderRef = useRef(onReorder)
+  onReorderRef.current = onReorder
+
+  useEffect(() => {
+    const el = containerRef.current
+
+    if (!el) {
+      return
+    }
+
+    return registerReorderZone({
+      el,
+      getIds: () => idsRef.current,
+      onReorder: ids => onReorderRef.current(ids)
+    })
+  }, [])
+
+  // Only paint the insertion line for a drag that started in THIS list (its id
+  // is one of ours) — a chat/tile drag never shows a reorder caret here.
+  const showHint = hint !== null && idsRef.current.includes(hint.draggedId)
+  const lineBefore = showHint ? hint.before : undefined
+
+  const line = <div aria-hidden className="mx-1 my-px h-0.5 rounded-full bg-primary/70" data-reorder-line />
+
+  return (
+    <div className="contents" ref={containerRef}>
+      {items.map(item => (
+        <Fragment key={item.id}>
+          {showHint && lineBefore === item.id ? line : null}
+          <div data-reorder-row={item.id}>{item.node}</div>
+        </Fragment>
+      ))}
+      {showHint && lineBefore === null ? line : null}
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/reorder-zones.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/reorder-zones.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  reorderIds,
+  type ReorderZoneSnapshot,
+  resolveReorderTarget
+} from './reorder-zones'
+
+// A zone spanning x[0,100] y[0,100] with three rows at mid-Y 20/50/80.
+function zone(ids: string[], mids: number[]): ReorderZoneSnapshot {
+  return {
+    bottom: 100,
+    ids,
+    left: 0,
+    onReorder: () => undefined,
+    right: 100,
+    rows: ids.map((id, i) => ({ id, mid: mids[i]! })),
+    top: 0
+  }
+}
+
+describe('resolveReorderTarget', () => {
+  const snap = [zone(['a', 'b', 'c'], [20, 50, 80])]
+
+  it('returns null when the pointer is outside every zone', () => {
+    expect(resolveReorderTarget(snap, 'a', 200, 50)).toBeNull()
+    expect(resolveReorderTarget(snap, 'a', 50, -10)).toBeNull()
+  })
+
+  it('inserts before the first row whose mid-Y is below the pointer', () => {
+    // y=10 is above row a's mid (20) → insert before a.
+    expect(resolveReorderTarget(snap, 'c', 50, 10)).toEqual({
+      before: 'a',
+      ids: ['a', 'b', 'c'],
+      onReorder: expect.any(Function)
+    })
+    // y=60 is below a(20) and b(50), above c(80) → insert before c.
+    expect(resolveReorderTarget(snap, 'a', 50, 60)?.before).toBe('c')
+  })
+
+  it('resolves to end (before:null) below the last row', () => {
+    expect(resolveReorderTarget(snap, 'a', 50, 95)?.before).toBeNull()
+  })
+
+  it('skips the dragged row when choosing the boundary', () => {
+    // Dragging b, pointer at y=45 (just above b's own mid): b is skipped, so the
+    // first OTHER row below the pointer is c → before c, not before b.
+    expect(resolveReorderTarget(snap, 'b', 50, 45)?.before).toBe('c')
+  })
+
+  it('returns null when the zone does not own the dragged id (foreign drop)', () => {
+    // A non-pinned row dragged over the pinned zone is not a reorder.
+    expect(resolveReorderTarget(snap, 'x', 50, 50)).toBeNull()
+  })
+
+  it('picks the zone the pointer is actually inside among several', () => {
+    const two: ReorderZoneSnapshot[] = [
+      { ...zone(['a', 'b'], [20, 60]), top: 0, bottom: 80 },
+      { ...zone(['p', 'q'], [120, 160]), top: 100, bottom: 180 }
+    ]
+
+    // Pointer in zone 2, dragging p: q is the first other row below → before q.
+    expect(resolveReorderTarget(two, 'p', 50, 130)?.before).toBe('q')
+    // Pointer near the top of zone 2, dragging q: p is below the pointer → before p.
+    expect(resolveReorderTarget(two, 'q', 50, 110)?.before).toBe('p')
+    // Pointer in zone 1, dragging b: a is below the pointer → before a.
+    expect(resolveReorderTarget(two, 'b', 50, 10)?.before).toBe('a')
+  })
+})
+
+describe('reorderIds', () => {
+  it('moves an id to sit before the target', () => {
+    expect(reorderIds(['a', 'b', 'c'], 'c', 'a')).toEqual(['c', 'a', 'b'])
+    expect(reorderIds(['a', 'b', 'c'], 'a', 'c')).toEqual(['b', 'a', 'c'])
+  })
+
+  it('moves an id to the end when before is null', () => {
+    expect(reorderIds(['a', 'b', 'c'], 'a', null)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('returns the SAME reference on a no-op move (skip the commit)', () => {
+    const ids = ['a', 'b', 'c']
+    // Moving a before b is where a already is → unchanged.
+    expect(reorderIds(ids, 'a', 'b')).toBe(ids)
+    // Moving c to the end where it already is → unchanged.
+    expect(reorderIds(ids, 'c', null)).toBe(ids)
+  })
+
+  it('returns the same reference when the id is not in the list', () => {
+    const ids = ['a', 'b']
+    expect(reorderIds(ids, 'z', 'a')).toBe(ids)
+  })
+
+  it('treats an unknown before-target as end insertion', () => {
+    expect(reorderIds(['a', 'b', 'c'], 'a', 'zzz')).toEqual(['b', 'c', 'a'])
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/reorder-zones.ts
+++ b/apps/desktop/src/app/chat/sidebar/reorder-zones.ts
@@ -1,0 +1,152 @@
+import { atom } from 'nanostores'
+
+/**
+ * Sidebar reorder drop-zones — the seam that lets the shared pointer session
+ * drag (session-drag.ts) reorder a flat sidebar list by DROP LOCATION, the
+ * same way it links/splits by dropping over a chat surface.
+ *
+ * A list (currently just Pinned) registers itself while mounted: its container
+ * element, a live getter for its ordered ids, and the commit callback. The drag
+ * resolver snapshots the registered zones at engage, hit-tests the pointer
+ * against a zone and its rows, and on release calls `onReorder` with the moved
+ * order. One drag system, no dnd-kit handle to hunt for — dragging a row within
+ * the bar reorders; dragging it onto the chat links (session-drag's other
+ * targets are unchanged).
+ */
+export interface ReorderZone {
+  el: HTMLElement
+  /** Live ordered ids — read at engage so a mid-session refresh can't stale it. */
+  getIds: () => string[]
+  onReorder: (ids: string[]) => void
+}
+
+const zones = new Set<ReorderZone>()
+
+/** Register a reorder zone for the drag resolver. Returns an unregister fn. */
+export function registerReorderZone(zone: ReorderZone): () => void {
+  zones.add(zone)
+
+  return () => {
+    zones.delete(zone)
+  }
+}
+
+/** A resolver-time snapshot of one zone: its rect, its rows' vertical spans in
+ *  order, and the commit callback. Rows are captured from the live DOM so the
+ *  slot math never depends on the virtualizer or render timing. */
+export interface ReorderZoneSnapshot {
+  bottom: number
+  ids: string[]
+  left: number
+  onReorder: (ids: string[]) => void
+  right: number
+  /** Row mid-Y per id, in DOM order — the insertion boundaries. */
+  rows: { id: string; mid: number }[]
+  top: number
+}
+
+/** Snapshot every registered zone. Called once at drag engage. */
+export function snapshotReorderZones(): ReorderZoneSnapshot[] {
+  const snaps: ReorderZoneSnapshot[] = []
+
+  for (const zone of zones) {
+    const zoneRect = zone.el.getBoundingClientRect()
+    const ids = zone.getIds()
+    const rows: { id: string; mid: number }[] = []
+
+    for (const id of ids) {
+      // Rows tag themselves with data-reorder-row so the snapshot can find the
+      // element that owns each id without coupling to row markup. Match by
+      // scanning tagged rows (not a CSS attribute selector) so an id with
+      // selector-special characters — or a context without CSS.escape — can't
+      // break the lookup.
+      const rowEl = [...zone.el.querySelectorAll<HTMLElement>('[data-reorder-row]')].find(
+        el => el.dataset.reorderRow === id
+      )
+
+      if (rowEl) {
+        const r = rowEl.getBoundingClientRect()
+        rows.push({ id, mid: r.top + r.height / 2 })
+      }
+    }
+
+    snaps.push({
+      bottom: zoneRect.bottom,
+      ids,
+      left: zoneRect.left,
+      onReorder: zone.onReorder,
+      right: zoneRect.right,
+      rows,
+      top: zoneRect.top
+    })
+  }
+
+  return snaps
+}
+
+export interface ReorderTarget {
+  /** Insert the dragged id before this id, or at the end when null. */
+  before: null | string
+  onReorder: (ids: string[]) => void
+  /** The zone's ordered ids at snapshot time. */
+  ids: string[]
+}
+
+/**
+ * Resolve the reorder target for a pointer position, or null when it isn't over
+ * a zone that contains the dragged id. Pure given the snapshots — unit-tested.
+ *
+ * The insertion boundary is the first row whose mid-Y is below the pointer; ties
+ * and below-the-last-row resolve to end (`before: null`). A zone only accepts a
+ * drag whose id it already owns, so dropping a non-pinned row onto Pinned is a
+ * miss (falls back to the drag's other targets / deny), never a spurious move.
+ */
+export function resolveReorderTarget(
+  snapshots: ReorderZoneSnapshot[],
+  draggedId: string,
+  x: number,
+  y: number
+): null | ReorderTarget {
+  for (const snap of snapshots) {
+    if (x < snap.left || x > snap.right || y < snap.top || y > snap.bottom) {
+      continue
+    }
+
+    if (!snap.ids.includes(draggedId)) {
+      // Over the zone, but this row doesn't belong to it — not a reorder.
+      return null
+    }
+
+    const beforeRow = snap.rows.find(row => row.id !== draggedId && y < row.mid)
+
+    return { before: beforeRow ? beforeRow.id : null, ids: snap.ids, onReorder: snap.onReorder }
+  }
+
+  return null
+}
+
+/**
+ * Apply a resolved reorder to an id list: move `draggedId` to sit immediately
+ * before `before` (or to the end when null). Returns the same reference when the
+ * order is unchanged so callers can skip a no-op commit. Pure — unit-tested.
+ */
+export function reorderIds(ids: string[], draggedId: string, before: null | string): string[] {
+  const from = ids.indexOf(draggedId)
+
+  if (from < 0) {
+    return ids
+  }
+
+  const without = ids.filter(id => id !== draggedId)
+  const insertAt = before === null ? without.length : without.indexOf(before)
+  const target = insertAt < 0 ? without.length : insertAt
+  const next = [...without.slice(0, target), draggedId, ...without.slice(target)]
+
+  // No-op guard: same order in, same reference out.
+  return next.every((id, i) => id === ids[i]) ? ids : next
+}
+
+/** Live reorder hint for the insertion-line UI: which zone, insert before which
+ *  id. A dedicated atom (not the heavy `$dropHint`) so only the pinned list
+ *  re-renders on hint churn, never the chat surfaces. */
+export const $sidebarReorderHint = atom<null | { before: null | string; draggedId: string }>(null)

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -20,6 +20,7 @@ import {
   SidebarWorkspaceGroup,
   type SidebarWorkspaceTree
 } from './projects'
+import { ReorderZoneList } from './reorder-zone-list'
 import { ReorderableList, useSortableBindings } from './reorderable-list'
 import { SidebarSessionSkeletons } from './section-states'
 import { SidebarSessionRow } from './session-row'
@@ -130,6 +131,10 @@ interface SidebarSessionsSectionProps {
   // The flat session list is the only hand-reorderable surface (grouped/project
   // views sort deterministically), so it owns the one ReorderableList.
   onReorderSessions?: (ids: string[]) => void
+  // When true, reorder via the shared pointer session-drag (drop within the
+  // bar reorders; drop on chat links) instead of the dnd-kit grab handle. Set
+  // for the Pinned list. Pairs with `onReorderSessions` for the commit.
+  reorderViaDrag?: boolean
   // Drag-to-reorder for the project overview list (top-level projects).
   onReorderProjects?: (ids: string[]) => void
   // Rendered atop the entered-project body (a "back to overview" row).
@@ -176,6 +181,7 @@ export function SidebarSessionsSection({
   collapsible = true,
   sortable = false,
   onReorderSessions,
+  reorderViaDrag = false,
   onReorderProjects,
   projectBackRow,
   dndSensors,
@@ -331,6 +337,20 @@ export function SidebarSessionsSection({
       ) : (
         virtual
       )
+  } else if (reorderViaDrag && onReorderSessions) {
+    // Pointer-drag reorder (Pinned): no dnd-kit handle — the row body is already
+    // a session-drag source, and that drag reorders when dropped within the bar.
+    // Rows render as plain (non-sortable) rows; ReorderZoneList registers the
+    // drop zone and paints the insertion line.
+    inner = (
+      <ReorderZoneList
+        items={displayEntries.map(({ branchStem, session }) => ({
+          id: session.id,
+          node: renderRow(session, false, branchStem)
+        }))}
+        onReorder={onReorderSessions}
+      />
+    )
   } else if (sessionsDraggable && onReorderSessions) {
     inner = (
       <ReorderableList ids={sessions.map(s => s.id)} onReorder={onReorderSessions} sensors={dndSensors}>


### PR DESCRIPTION
## What does this PR do?

Two related asks for the pinned-sessions sidebar: **reorder pinned chats**, and **let the pinned section grow past ~6 rows**.

### Reorder (the substantive half)

Reordering pinned rows was effectively broken. The pinned list had a reorder affordance on a near-invisible dnd-kit grab handle (the leading status dot), but commit `ac4f596ca2` made the **whole row body** a pointer session-drag source (drag a row onto the chat to link it as an `@session` ref, or onto a zone edge to split). The two drag systems fought on the same row and session-drag won: grabbing a pin started a link-into-chat drag, and even when you found the handle its dotted focus ring appeared but the reorder never committed.

Fixed by resolving the conflict the way the session-drag engine already works — **by drop location, not by which pixel you grab.** The engine is a resolver: it snapshots targets at drag engage, hit-tests the pointer each move, and acts on release. This adds sidebar reorder as one more resolved target:

- **`reorder-zones.ts`** — a small registry a flat list joins while mounted (container element + live id getter + `onReorder`). The drag snapshots registered zones at engage; `resolveReorderTarget` picks the insertion slot by pointer-Y (skipping the dragged row); `reorderIds` applies it with a no-op-identity guard. Both are pure functions, unit-tested.
- **`session-drag.ts`** — `resolveMove` checks reorder **first** (inside the bar's bounds it wins), otherwise falls through to the existing stack/split/link zone logic unchanged; `onCommit` reorders in place instead of opening a tile or link. A dedicated `$sidebarReorderHint` atom drives the insertion line so the chat surfaces never re-render on reorder churn (they subscribe to the heavy `$dropHint` only for real link/split hints).
- **`reorder-zone-list.tsx`** — registers the zone, tags rows (`data-reorder-row`) for the geometry snapshot, and paints the insertion line. No dnd-kit handle. The pinned section renders through it (`reorderViaDrag`) instead of `ReorderableList`.

**Net behavior:** drag a pin **within the sidebar** → reorder; drag it **onto the chat** → link (unchanged). Recents/Sessions rows keep session-drag exactly as before. This is the model the reporter asked for and it matches how the engine was built to route.

### Height

The pinned body was hard-capped at `max-h-44` (~6 rows) then scrolled. Relaxed to `max-h-[40vh]` so more pins show on a tall window. Still bounded, so the Sessions section below can never be buried — preserving the `#43147` anti-overlap invariant — and `GROUP_BODY` still flattens the cap in compact mode.

## Related Issue

Fixes the reorder half of **#47728** (closed `implemented-on-main`, but reorder never actually worked once row-body session-drag landed — the handle was shadowed by the link drag). The height cap is the other half of the reporter's ask.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (the height relaxation + drop-location routing)

## How was this tested?

- **Unit** (`reorder-zones.test.ts`, 11 cases): slot-boundary math, dragged-row skip, foreign-drop rejection (a non-pinned row over the zone is not a reorder), multi-zone hit-testing, and `reorderIds` no-op identity + end-insertion.
- **Component** (`reorder-zone-list.test.tsx`, 4 cases): zone register/unregister lifecycle, live-id reporting across re-render, per-row tagging, and insertion-line rendering only for a drag of the list's own row.
- **Real pointer-drag e2e** (`pinned-reorder.spec.ts`): creates two pinned sessions, drags the top row down within the sidebar via actual `mouse.down`/`move`/`up` (stepped, like `tile-unread-bug.spec`), asserts the pinned order flips. **Ran locally against the packaged macOS app — passes** (`1 passed (7.7s)`).
- `npx tsc -p .` / `tsconfig.electron.json` / `tsconfig.e2e.json` all clean; full renderer suite `2050 passed`; eslint clean on touched files (test-file `document` warnings match existing test conventions).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the desktop renderer suite (`npx vitest run --project ui`) and all tests pass; `pytest` N/A (no Python changes)
- [x] I've added tests for my changes (unit + component + real-drag e2e)
- [x] I've tested on my platform: macOS 26.5 (arm64), packaged app

### Documentation & Housekeeping

- [x] Docs — N/A (no user-facing doc describes the pinned drag/height behavior)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — renderer + shared drag engine; the `max-h-[40vh]` and pointer-drag path are platform-agnostic. The e2e was exercised on macOS.
- [x] Tool descriptions/schemas — N/A
