### PR TITLE
fix(gateway): forward approval denial reason

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9594,6 +9594,51 @@ def test_respond_unpacks_sid_tuple_correctly():
         server._answers.pop("rid-x", None)
 
 
+def test_approval_respond_forwards_reason_and_optional_resolve_all():
+    server._sessions["sid"] = _session()
+    try:
+        with patch(
+            "tools.approval.resolve_gateway_approval", return_value=1
+        ) as mock_resolve:
+            response = server.handle_request(
+                {
+                    "id": "1",
+                    "method": "approval.respond",
+                    "params": {
+                        "session_id": "sid",
+                        "choice": "deny",
+                        "reason": "Denied for this exact reason.",
+                        "all": True,
+                    },
+                }
+            )
+
+            assert response["result"] == {"resolved": 1}
+            mock_resolve.assert_called_once_with(
+                "session-key",
+                "deny",
+                reason="Denied for this exact reason.",
+                resolve_all=True,
+            )
+
+            mock_resolve.reset_mock()
+            server.handle_request(
+                {
+                    "id": "2",
+                    "method": "approval.respond",
+                    "params": {"session_id": "sid", "choice": "deny"},
+                }
+            )
+            mock_resolve.assert_called_once_with(
+                "session-key",
+                "deny",
+                reason=None,
+                resolve_all=False,
+            )
+    finally:
+        server._sessions.pop("sid", None)
+
+
 # ---------------------------------------------------------------------------
 # /model switch and other agent-mutating commands must reject while the
 # session is running.  agent.switch_model() mutates self.model, self.provider,

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -875,6 +875,7 @@ def _(rid, params: dict) -> dict:
                 "resolved": resolve_gateway_approval(
                     session["session_key"],
                     params.get("choice", "deny"),
+                    reason=params.get("reason"),
                     resolve_all=params.get("all", False),
                 )
             },


### PR DESCRIPTION
## Problem

`approval.respond` accepted a denial `reason` at the desktop/gateway RPC boundary but silently dropped it before calling the existing approval resolver. Any UI that collected a denial explanation therefore appeared to work while the backend never received the text.

## Premise and root cause

The lower-level `resolve_gateway_approval()` contract already supports an optional `reason`. The live gateway handler forwarded `session_key`, `choice`, and `resolve_all`, but omitted `params["reason"]`. This is a boundary propagation bug, not a new approval feature.

During review, upstream commit `f67ca220ab` had moved the active `approval.respond` handler from `tui_gateway/server.py` to `tui_gateway/methods_prompt.py`. The branch is now rebased onto current `main` and the one-line fix is applied only at that live call site.

## Changes

- Forward the optional `reason` from `approval.respond` to `resolve_gateway_approval()` in `tui_gateway/methods_prompt.py`.
- Keep the boundary-level `server.handle_request` regression test, which proves `choice`, `reason`, and `resolve_all` arrive together through the registered split-module handler.
- Keep calls without a reason backward-compatible (`None`).

## Before / after

| Request | Before | After |
|---|---|---|
| deny without reason | resolves denial | unchanged |
| deny with reason | reason silently discarded | resolver receives exact reason |
| allow / resolve-all | forwarded | unchanged |

## Validation

### RED on current main

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/test_tui_gateway_server.py \
  -k test_approval_respond_forwards_reason_and_optional_resolve_all -q
# 1 failed: actual resolver call omitted reason
```

### GREEN

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/test_tui_gateway_server.py \
  -k test_approval_respond_forwards_reason_and_optional_resolve_all -q
# 1 passed

scripts/run_tests.sh \
  tests/test_tui_gateway_server.py \
  tests/tui_gateway/test_protocol.py \
  tests/tools/test_approval.py \
  tests/gateway/test_approve_deny_commands.py \
  -k 'not test_nonrecursive_verification_artifact_cleanup_is_not_dangerous' -q
# 636 passed

uvx ruff check tui_gateway/methods_prompt.py tests/test_tui_gateway_server.py
# All checks passed

git diff --check origin/main...HEAD
# clean
```

The excluded verification-artifact cleanup case is an unrelated existing macOS `/tmp` path assertion. It was rerun in a detached worktree at unchanged current base `c55159f18` and failed identically there.

### Scope receipt

- 2 files changed
- 46 insertions, 0 deletions
- 1 production line; the remaining additions are one focused behavior test
- branch rebased onto current `origin/main` (`c55159f18`)
- original author and author date preserved

## Non-goals

- No new approval semantics.
- No desktop/pet UI changes.
- No session, prompt-store, queue, or IPC changes.

Tracks s-a-s-k-i-a/hermes-agent#3
Part of s-a-s-k-i-a/hermes-agent#1
Replaces the first narrow prerequisite extracted from #70156.
