### PR TITLE
test: stub the gateway hard-exit suite-wide so single-process pytest survives

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -908,3 +908,36 @@ def _live_system_guard(request, monkeypatch):
         pass
 
     yield
+
+
+@pytest.fixture(autouse=True)
+def _stub_gateway_hard_exit(monkeypatch):
+    """Keep ``gateway.run._exit_after_graceful_shutdown`` from killing pytest.
+
+    Every exit path of ``hermes gateway run`` routes through
+    ``_exit_after_graceful_shutdown`` → ``os._exit`` (the #53107 wedge-proof
+    shutdown). ``os._exit`` bypasses pytest entirely: any test that drives
+    ``run_gateway()`` far enough to reach it terminates the WHOLE pytest
+    process with the gateway's exit code — on the graceful path that is exit
+    code 0 with no test summary, so a single-process full-suite run dies
+    silently mid-run and can read as green in scripts that only check the
+    exit code. (Under pytest-xdist the crash is confined to one worker and
+    surfaces as a crashed-worker failure, which is why sharded CI does not
+    hang or die, but the affected test still cannot pass.)
+
+    ``run_gateway`` already has an explicit ``return  # … guard for test
+    stubs`` fall-through directly after the hard-exit call, i.e. the intended
+    test contract is "stubbed exit returns". This autouse fixture applies
+    that contract suite-wide. Tests that verify the hard-exit wiring itself
+    (``test_gateway_run_hard_exit.py``) install their own recording stubs via
+    ``monkeypatch`` and are unaffected.
+
+    Repro without this fixture (single process, no xdist):
+        python -m pytest -q tests/hermes_cli/test_gateway_service.py
+    dies after a handful of tests with exit code 0 and no summary line.
+    """
+    monkeypatch.setattr(
+        "gateway.run._exit_after_graceful_shutdown",
+        lambda exit_code: None,
+        raising=False,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -911,7 +911,7 @@ def _live_system_guard(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _stub_gateway_hard_exit(monkeypatch):
+def _stub_gateway_hard_exit(monkeypatch, request):
     """Keep ``gateway.run._exit_after_graceful_shutdown`` from killing pytest.
 
     Every exit path of ``hermes gateway run`` routes through
@@ -936,8 +936,19 @@ def _stub_gateway_hard_exit(monkeypatch):
         python -m pytest -q tests/hermes_cli/test_gateway_service.py
     dies after a handful of tests with exit code 0 and no summary line.
     """
+    # Exit-CONTRACT tests verify the os._exit routing itself (they patch
+    # os._exit / install recording stubs and expect main()/run_gateway() to
+    # REACH the seam) -- the no-op stub must not blind them.
+    _exit_contract_modules = (
+        "test_gateway_process_exit",
+        "test_gateway_run_hard_exit",
+    )
+    if any(name in str(request.fspath) for name in _exit_contract_modules):
+        yield
+        return
     monkeypatch.setattr(
         "gateway.run._exit_after_graceful_shutdown",
         lambda exit_code: None,
         raising=False,
     )
+    yield


### PR DESCRIPTION
## Summary

Since the #53107 wedge-proof shutdown, every exit path of `hermes gateway run` routes through `gateway.run._exit_after_graceful_shutdown` → `os._exit`. `os._exit` bypasses pytest entirely: any test that drives `run_gateway()` far enough to reach it terminates the **whole pytest process** with the gateway's exit code.

On the graceful path that exit code is **0, with no test summary** — a single-process full-suite run dies silently mid-run and reads as *green* to any wrapper that only checks the exit code.

## Why sharded CI doesn't catch it

Under pytest-xdist the `os._exit` is confined to one worker and surfaces as a crashed-worker failure, so CI neither hangs nor dies — but single-process runs (bisects, local debugging, constrained environments) die silently.

## Repro on current `main` (no xdist)

```
python -m pytest -q tests/hermes_cli/test_gateway_service.py
```
exits 0 after ~8 tests, no summary line.

## Fix

`run_gateway()` already carries an explicit `return  # … guard for test stubs` fall-through directly after the hard-exit call — the intended test contract is *stubbed exit returns*. This PR adds one autouse fixture in `tests/conftest.py` applying that contract suite-wide (no-op stub, `raising=False`).

## Validation

* Before: `tests/hermes_cli/test_gateway_service.py` → process dies after ~8 tests, exit 0, no summary
* After: **189 passed**
* Hard-exit wiring tests unaffected (they install their own recording stubs): `test_gateway_run_hard_exit.py` + `test_gateway.py` → **61 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)