### PR TITLE
fix(desktop): stop assistant reply rendering twice after a tool-call turn (#63679)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -501,27 +501,38 @@ export function useMessageStream({
             const existing = prev[index]
             const existingText = chatMessageText(existing).trim()
 
+            // The last assistant row is a sealed interim (a tool-call turn or a
+            // verify-on-stop candidate — `message.interim` fires for BOTH, see
+            // tui_gateway `_load_interim_assistant_messages`). When the final
+            // completion is the SAME turn's reply, settle it onto that interim
+            // instead of appending a second bubble. Continuity, not exact
+            // equality: streaming can drop characters and the final may add a
+            // trailing delta, so treat prefix-either-way as the same message.
+            // (mergeFinalAssistantText, via completeMessage, does the real
+            // text merge — replaces the interim's text with the full final.)
+            const finalContinuesInterim = Boolean(
+              existing.interim &&
+                finalText &&
+                existingText &&
+                (finalText === existingText ||
+                  finalText.startsWith(existingText) ||
+                  existingText.startsWith(finalText))
+            )
+
             if (existing.pending || (!interimBoundaryPending && finalText && existingText === finalText)) {
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )
-            } else if (
-              interimBoundaryPending &&
-              responsePreviewed &&
-              finalText &&
-              existingText &&
-              finalText.startsWith(existingText)
-            ) {
-              // The verification candidate was published provisionally as an
-              // interim message and then reused as the terminal response
-              // (continuation-budget fallback). Settle the interim in place
-              // instead of creating a duplicate — the DB has one row, so the
-              // live UI must agree. (#65919 review: duplicate-message blocker)
-              //
-              // Prefix match (not exact equality): the final response may be
-              // the streamed text plus a trailing delta.  mergeFinalAssistantText
-              // (called via completeMessage) handles the actual merge — it
-              // strips the old text parts and appends the full final text.
+            } else if (interimBoundaryPending && (responsePreviewed || finalContinuesInterim)) {
+              // Settle the interim in place instead of creating a duplicate —
+              // the DB has one row, so the live UI must agree. Previously this
+              // was gated on `responsePreviewed` alone, so a NON-previewed
+              // tool-call turn whose final matched its sealed interim appended a
+              // second bubble (the "renders twice: partial first copy + clean
+              // final" bug, #63679). `finalContinuesInterim` closes that gap
+              // for ordinary tool-call turns while `responsePreviewed` still
+              // covers the verify-on-stop continuation-budget case even when the
+              // final text was rewritten and no longer shares a prefix.
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -186,18 +186,51 @@ describe('useMessageStream interim text sealing', () => {
     expect(getState().interimBoundaryPending).toBe(true)
   })
 
-  it('keeps an identical final completion distinct from an interim reply without response_previewed', async () => {
+  it('settles an identical final onto a non-previewed interim (tool-call turn) instead of duplicating (#63679)', async () => {
     await mountStream()
     await start()
 
+    // A plain tool-call turn: the streamed text is sealed as an interim at the
+    // tool boundary (no response_previewed — that flag is only for verify-on-
+    // stop). The final completion is the SAME turn's reply. It must settle onto
+    // the interim, not append a second bubble — the DB has one row. This is the
+    // "renders twice" bug: partial streamed copy + clean final copy side by side.
     await interim('same reply')
     await complete('same reply')
 
-    // Without response_previewed, the interim and terminal replies are
-    // distinct messages — the gateway didn't signal that the final reuses
-    // the provisional candidate.
     const texts = assistantMessages()
-    expect(texts.filter(t => t === 'same reply')).toHaveLength(2)
+    expect(texts.filter(t => t === 'same reply')).toHaveLength(1)
+  })
+
+  it('settles a prefix-extended final onto a non-previewed interim (streamed + trailing delta)', async () => {
+    await mountStream()
+    await start()
+
+    // The stream dropped/settled early at the tool boundary; the final adds a
+    // trailing delta. Same turn — one bubble with the full final text.
+    await delta('partial')
+    await interim('partial')
+    await complete('partial answer continued')
+
+    const texts = assistantMessages()
+    expect(texts.filter(t => t.includes('partial'))).toHaveLength(1)
+    expect(texts[0]).toBe('partial answer continued')
+  })
+
+  it('appends a genuinely different final as its own bubble (two real assistant segments)', async () => {
+    await mountStream()
+    await start()
+
+    // The interim is one segment (pre-tool commentary); the final is different
+    // content, not a continuation of it. These are two real messages and must
+    // both render — the fix must not over-collapse distinct replies.
+    await interim('let me check the files')
+    await complete('the answer is 42')
+
+    const texts = assistantMessages()
+    expect(texts).toContain('let me check the files')
+    expect(texts).toContain('the answer is 42')
+    expect(texts).toHaveLength(2)
   })
 
   it('settles an identical final completion onto the interim when response_previewed', async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop "assistant message renders twice" bug (**#63679**): one turn shows two assistant bubbles — a partial streamed copy (dropped characters, half-rendered markdown) followed by the clean final copy. A window reload clears it, which tells you the persisted transcript is correct; this is a **live-reconciliation** bug in the renderer.

## Root cause (current `main`, verified)

In `completeAssistantMessage` (`use-message-stream/index.ts`):

- `message.interim` fires for **both** verify-on-stop candidates **and** ordinary tool-call turns — see `tui_gateway/server.py::_load_interim_assistant_messages` ("interim text from tool-call turns **and** verify-on-stop candidates").
- The interim seal (`finalizeInterimAssistantMessage`) marks the streamed bubble `interim: true`, **clears `streamId` to `null`**, and sets `interimBoundaryPending: true`.
- So when `message.complete` arrives, the `streamId && prev.some(...)` fast-path is skipped (streamId is null) and it enters the fallback branch.
- In the fallback, the settle-onto-the-interim branch was gated on **`responsePreviewed`**, which is true **only** for the verify-on-stop case. A normal tool-call turn whose final text matched its sealed interim satisfied neither settle condition and fell through to `[...prev, newAssistantFromCompletion()]` — appending a brand-new bubble next to the sealed interim.

Two rows, distinct ids. Dedup downstream is id-based (`syncRepositoryIncrementally` keys on `message.id`), so it can never collapse a streamed-interim id with a fresh completion id → the turn renders twice. The "partial first / clean second" pattern is exactly the sealed interim + the appended completion surviving side by side.

This also matches why non-DeepSeek providers (the reporter and I are both on Anthropic) hit it: nothing about it is provider-specific — any turn that emits text then calls a tool takes this path.

## The fix

Settle onto the sealed interim whenever the final **continues** it, instead of gating on `responsePreviewed`:

```ts
const finalContinuesInterim = Boolean(
  existing.interim && finalText && existingText &&
  (finalText === existingText ||
   finalText.startsWith(existingText) ||   // streamed + trailing delta
   existingText.startsWith(finalText))     // streaming dropped characters
)
// … else if (interimBoundaryPending && (responsePreviewed || finalContinuesInterim)) settle-in-place
```

- Gated on `existing.interim`, so it only ever collapses a genuine sealed interim.
- A genuinely **different** final (e.g. pre-tool commentary, then an unrelated answer) still appends as its own bubble — the fix does not over-collapse distinct segments.
- `responsePreviewed` is retained as an OR, so the verify-on-stop continuation-budget case (where the final text was rewritten and no longer shares a prefix) still settles exactly as before (#65919).

## Not the community patch

A comment on #63679 traced this to `seedSeenBubbleKeys` / a `!("kind" in m)` content-dedup guard. I checked `main`: **those symbols no longer exist** — that analysis was against a pre-refactor v0.7.0 minified bundle, and the reconciler is now id-based. This PR fixes the current code path (the interim/complete fallback), not the dead one.

## Tests

`interim-sealing.test.tsx`:

- **Rewrote** the test that asserted a non-previewed identical interim+final produced **two** bubbles — that was encoding the bug — to assert **one**.
- Added: prefix-extended non-previewed final (`'partial'` → `'partial answer continued'`) collapses to one bubble with the full text.
- Added: a genuinely different final still appends (two bubbles) — guards against over-collapse.
- The two existing `response_previewed` tests still pass unchanged.

`npx tsc -p .` clean; full renderer suite `2037 passed`; eslint clean on `index.ts`.

## Related Issue

Fixes #63679. Adjacent open reports of the same symptom that this likely also resolves: #59423 (TUI twin), #65666 (interrupted response), #64304.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

1. On any provider, send a prompt that makes the agent emit some text and then call a tool (most non-trivial turns).
2. Before: the reply appears twice — a partial/garbled copy above the clean final. After: one bubble.
3. Confirm a reload was previously the only fix and is no longer needed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched for existing PRs (this is the fix for the long-standing #63679; no open PR addresses the current-code path)
- [x] Only changes related to this fix
- [x] Ran the renderer suite (`npx vitest run --project ui`) — all pass; `pytest` N/A (no Python changes)
- [x] Added/updated tests
- [x] Tested on my platform: macOS 26.5 (arm64)

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — renderer-only, provider- and OS-agnostic
- [x] Tool descriptions/schemas — N/A
