### PR TITLE
fix(codex): preserve active Responses streams past stale timeout

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -205,19 +205,54 @@ def _codex_wait_notice_recovery(
     idle_enabled: bool,
     idle_timeout: float,
     elapsed: float,
+    hard_timeout: float = 0.0,
 ) -> str:
     """Describe the earliest enabled Codex watchdog on the call timeline."""
     deadlines: list[float] = []
-    if math.isfinite(stale_timeout):
-        deadlines.append(stale_timeout)
     if last_event_ts is None:
+        if math.isfinite(stale_timeout):
+            deadlines.append(stale_timeout)
         if ttfb_enabled and math.isfinite(ttfb_timeout):
             deadlines.append(ttfb_timeout)
-    elif idle_enabled and math.isfinite(idle_timeout):
-        deadlines.append(max(0.0, last_event_ts - call_start) + idle_timeout)
+        if hard_timeout > 0 and math.isfinite(hard_timeout):
+            deadlines.append(hard_timeout)
+    else:
+        if hard_timeout > 0 and math.isfinite(hard_timeout):
+            # Once SSE activity proves that a Codex Responses call is alive,
+            # the absolute ceiling replaces the shorter generic wall-clock
+            # stale timeout. Stream-idle remains a separate, earlier deadline.
+            deadlines.append(hard_timeout)
+        elif math.isfinite(stale_timeout):
+            deadlines.append(stale_timeout)
+        if idle_enabled and math.isfinite(idle_timeout):
+            deadlines.append(max(0.0, last_event_ts - call_start) + idle_timeout)
     if not deadlines or min(deadlines) <= elapsed:
         return ""
     return f"; auto-reconnect at {int(min(deadlines))}s"
+
+
+def _non_stream_total_timeout(
+    *,
+    stale_timeout: float,
+    codex_watchdog_enabled: bool,
+    codex_hard_timeout: float,
+    last_codex_event_ts: Optional[float],
+) -> tuple[float, bool]:
+    """Return the active wall-clock deadline and whether it is a Codex hard cap.
+
+    Generic non-streaming providers keep their configured stale timeout. A
+    Codex Responses request with no SSE activity also keeps the earlier of that
+    timeout and its absolute hard ceiling. Once an SSE event arrives, however,
+    the stream is demonstrably alive: the stream-idle watchdog owns liveness,
+    while the longer absolute ceiling remains the final bounded backstop.
+
+    A non-positive hard timeout preserves the legacy generic stale behavior.
+    """
+    if not codex_watchdog_enabled or codex_hard_timeout <= 0:
+        return stale_timeout, False
+    if last_codex_event_ts is not None:
+        return codex_hard_timeout, True
+    return min(stale_timeout, codex_hard_timeout), False
 
 
 # ── Cross-turn stale-call circuit breaker (#58962) ─────────────────────
@@ -669,21 +704,14 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # first byte, but a request that emits SOME bytes and then wedges (the
     # issue-64507 symptom: vision-inflated request, worker idle, no ended_at)
     # is only reclaimed at the (high) stale floor. Add a flat, finite hard
-    # ceiling on total request time that ALWAYS applies to openai-codex
-    # requests regardless of the TTFB/stale interaction, so a stalled request
-    # is recovered (retry loop / visible failure) instead of hanging
-    # indefinitely. The default sits ABOVE the maximum stale floor (1200s) so
-    # it never clamps an intentionally-raised timeout for healthy large
-    # requests — it is a backstop against unbounded growth, not a tighter
-    # limit. Tunable via HERMES_CODEX_HARD_TIMEOUT_SECONDS (set to 0 to
-    # disable the ceiling entirely; that restores the pre-fix behavior).
+    # ceiling on total request time for every Codex Responses transport so a
+    # stalled request is recovered (retry loop / visible failure) instead of
+    # hanging indefinitely. Before the first SSE event it caps the generic
+    # stale timeout. After SSE activity proves the stream is alive, it replaces
+    # that shorter generic timeout while the event-idle watchdog detects an
+    # actual stalled stream. Tunable via HERMES_CODEX_HARD_TIMEOUT_SECONDS (set
+    # to 0 to restore the generic stale-timeout behavior).
     _codex_hard_timeout = _env_float("HERMES_CODEX_HARD_TIMEOUT_SECONDS", 1500.0)
-    if (
-        _codex_watchdog_enabled
-        and _openai_codex_backend
-        and _codex_hard_timeout > 0
-    ):
-        _stale_timeout = min(_stale_timeout, _codex_hard_timeout)
 
     if _est_tokens_for_codex_watchdog > 100_000:
         _codex_idle_timeout_default = 180.0
@@ -781,6 +809,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     idle_enabled=_codex_idle_enabled,
                     idle_timeout=_codex_idle_timeout,
                     elapsed=_elapsed,
+                    hard_timeout=(
+                        _codex_hard_timeout if _codex_watchdog_enabled else 0.0
+                    ),
                 )
                 agent._emit_wait_notice(
                     f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
@@ -893,9 +924,17 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 )
             break
 
-        # Stale-call detector: kill the connection if no response
-        # arrives within the configured timeout.
-        if _elapsed > _stale_timeout:
+        # Total wall-clock detector. For an active Codex Responses stream, SSE
+        # activity delegates liveness to the event-idle detector above and the
+        # longer absolute hard ceiling becomes the bounded final deadline.
+        # Other requests retain the generic non-streaming stale timeout.
+        _total_timeout, _is_codex_hard_timeout = _non_stream_total_timeout(
+            stale_timeout=_stale_timeout,
+            codex_watchdog_enabled=_codex_watchdog_enabled,
+            codex_hard_timeout=_codex_hard_timeout,
+            last_codex_event_ts=_last_codex_event_ts,
+        )
+        if _elapsed > _total_timeout:
             _est_ctx = estimate_request_context_tokens(api_kwargs)
             _silent_hint: Optional[str] = None
             _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
@@ -904,50 +943,84 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     _silent_hint = _hint_fn(model=api_kwargs.get("model"))
                 except Exception:
                     _silent_hint = None
-            logger.warning(
-                "Non-streaming API call stale for %.0fs (threshold %.0fs). "
-                "model=%s context=~%s tokens. Killing connection.",
-                _elapsed, _stale_timeout,
-                api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
-            )
-            if _silent_hint:
-                agent._buffer_status(
-                    f"⚠️ No response from provider for {int(_elapsed)}s "
-                    f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"{_silent_hint}"
+            if _is_codex_hard_timeout:
+                logger.warning(
+                    "Codex Responses call exceeded absolute hard timeout for "
+                    "%.0fs (threshold %.0fs) despite SSE activity. model=%s "
+                    "context=~%s tokens. Killing connection.",
+                    _elapsed,
+                    _total_timeout,
+                    api_kwargs.get("model", "unknown"),
+                    f"{_est_ctx:,}",
                 )
-            else:
                 agent._buffer_status(
-                    f"⚠️ No response from provider for {int(_elapsed)}s "
-                    f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
+                    f"⚠️ Codex stream reached its absolute {int(_total_timeout)}s "
+                    f"limit (model: {api_kwargs.get('model', 'unknown')}). "
                     f"Aborting call."
                 )
+            else:
+                logger.warning(
+                    "Non-streaming API call stale for %.0fs (threshold %.0fs). "
+                    "model=%s context=~%s tokens. Killing connection.",
+                    _elapsed,
+                    _total_timeout,
+                    api_kwargs.get("model", "unknown"),
+                    f"{_est_ctx:,}",
+                )
+                if _silent_hint:
+                    agent._buffer_status(
+                        f"⚠️ No response from provider for {int(_elapsed)}s "
+                        f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
+                        f"{_silent_hint}"
+                    )
+                else:
+                    agent._buffer_status(
+                        f"⚠️ No response from provider for {int(_elapsed)}s "
+                        f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
+                        f"Aborting call."
+                    )
             try:
                 # #67142: routes by client kind — anthropic now aborts the
                 # request-local client's sockets from this poll (stranger)
                 # thread instead of closing the shared _anthropic_client.
-                _close_request_client_once("stale_call_kill")
+                _close_request_client_once(
+                    "codex_hard_timeout_kill"
+                    if _is_codex_hard_timeout
+                    else "stale_call_kill"
+                )
             except Exception:
                 pass
             # Circuit breaker (#58962): count the stale kill.  See the
             # canonical comment block above ``_stale_streak()``.
             _bump_stale_streak(agent)
-            agent._touch_activity(
-                f"stale non-streaming call killed after {int(_elapsed)}s"
-            )
+            if _is_codex_hard_timeout:
+                agent._touch_activity(
+                    f"codex stream killed at absolute hard timeout after "
+                    f"{int(_elapsed)}s"
+                )
+            else:
+                agent._touch_activity(
+                    f"stale non-streaming call killed after {int(_elapsed)}s"
+                )
             # Wait briefly for the thread to notice the closed connection.
             t.join(timeout=2.0)
             if result["error"] is None and result["response"] is None:
-                if _silent_hint:
+                if _is_codex_hard_timeout:
+                    result["error"] = TimeoutError(
+                        f"Codex Responses call exceeded its absolute hard timeout "
+                        f"after {int(_elapsed)}s despite ongoing SSE activity "
+                        f"(threshold: {int(_total_timeout)}s)"
+                    )
+                elif _silent_hint:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s). "
+                        f"with no response (threshold: {int(_total_timeout)}s). "
                         f"{_silent_hint}"
                     )
                 else:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s)"
+                        f"with no response (threshold: {int(_total_timeout)}s)"
                     )
             break
 

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -271,6 +271,111 @@ def test_ttfb_does_not_kill_when_events_flow(tmp_path, monkeypatch):
     assert "codex_ttfb_kill" not in closes
 
 
+def test_active_custom_codex_stream_outlives_generic_stale_timeout(
+    tmp_path, monkeypatch
+):
+    """A custom Responses endpoint that keeps emitting SSE events is alive.
+
+    The generic non-streaming timeout measures total wall-clock duration, so
+    applying it to an active Responses stream aborts legitimate long reasoning
+    at the provider timeout and triggers unnecessary fallback churn.
+    """
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    agent.provider = "custom"
+    agent._base_url_lower = "https://aigateway.example/v1"
+    agent._base_url_hostname = "aigateway.example"
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 1.0
+    )
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "5")
+
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    sentinel = SimpleNamespace(ok=True)
+
+    def fake_active_stream(api_kwargs, client=None, on_first_delta=None):
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            agent._codex_stream_last_event_ts = time.time()
+            time.sleep(0.05)
+        return sentinel
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_active_stream)
+
+    resp = h.interruptible_api_call(agent, {"model": "gpt-5.6-sol", "input": "hi"})
+
+    assert resp is sentinel
+    assert "stale_call_kill" not in closes
+    assert "codex_hard_timeout_kill" not in closes
+
+
+def test_active_custom_codex_stream_still_hits_absolute_hard_timeout(
+    tmp_path, monkeypatch
+):
+    """SSE activity suppresses only the generic timeout, never the hard cap."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    agent.provider = "custom"
+    agent._base_url_lower = "https://aigateway.example/v1"
+    agent._base_url_hostname = "aigateway.example"
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 1.0
+    )
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "2")
+
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    stop = {"flag": False}
+
+    def fake_active_hang(api_kwargs, client=None, on_first_delta=None):
+        while not stop["flag"] and not agent._interrupt_requested:
+            agent._codex_stream_last_event_ts = time.time()
+            time.sleep(0.05)
+        raise RuntimeError("connection closed")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_active_hang)
+
+    try:
+        with pytest.raises(TimeoutError) as excinfo:
+            h.interruptible_api_call(
+                agent, {"model": "gpt-5.6-sol", "input": "hi"}
+            )
+        assert "absolute hard timeout" in str(excinfo.value)
+        assert "codex_hard_timeout_kill" in closes
+        assert "stale_call_kill" not in closes
+    finally:
+        stop["flag"] = True
+
+
 def test_event_idle_kills_after_first_event_then_silence(tmp_path, monkeypatch):
     """If Codex emits an opening SSE event and then goes silent, kill it via
     the stream-idle watchdog instead of waiting for the long non-stream stale
@@ -351,6 +456,44 @@ def test_wait_notice_reports_ttfb_before_first_event():
     )
 
     assert recovery == "; auto-reconnect at 120s"
+
+
+def test_wait_notice_uses_hard_ceiling_after_stream_activity():
+    """An active Codex stream must not advertise the shorter generic timeout."""
+    from agent import chat_completion_helpers as h
+
+    recovery = h._codex_wait_notice_recovery(
+        stale_timeout=60.0,
+        ttfb_enabled=True,
+        ttfb_timeout=120.0,
+        last_event_ts=130.0,
+        call_start=100.0,
+        idle_enabled=False,
+        idle_timeout=60.0,
+        elapsed=30.0,
+        hard_timeout=1500.0,
+    )
+
+    assert recovery == "; auto-reconnect at 1500s"
+
+
+def test_wait_notice_keeps_generic_timeout_before_first_event():
+    """SSE activity is required before the longer hard ceiling takes over."""
+    from agent import chat_completion_helpers as h
+
+    recovery = h._codex_wait_notice_recovery(
+        stale_timeout=60.0,
+        ttfb_enabled=False,
+        ttfb_timeout=120.0,
+        last_event_ts=None,
+        call_start=100.0,
+        idle_enabled=False,
+        idle_timeout=60.0,
+        elapsed=30.0,
+        hard_timeout=1500.0,
+    )
+
+    assert recovery == "; auto-reconnect at 60s"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Severity

This is an urgent production-availability defect. Under concurrent long-context gateway workloads, Hermes can terminate healthy Codex Responses calls at generic 90/240/600-second wall-clock deadlines even while SSE events continue to arrive. The resulting reconnect and fallback cascades sharply reduce session availability and can end in empty model responses.

## Root cause

`interruptible_api_call` already tracks every Codex SSE event for first-byte and stream-idle recovery, but its final non-streaming stale detector ignores that activity and measures only total call duration. Active reasoning streams are therefore treated like silent provider hangs.

## Fix

- preserve the existing generic stale deadline before the first SSE event
- preserve the existing event-idle watchdog when a stream stops producing events
- allow an active Codex Responses stream to continue past the shorter generic stale deadline
- apply the existing 1500-second absolute hard ceiling to every Codex Responses transport as the bounded final backstop
- report the effective recovery deadline and a distinct hard-timeout close reason
- keep non-Codex provider behavior unchanged

```mermaid
flowchart LR
    A[Codex Responses call] --> B{SSE event received?}
    B -- No --> C[TTFB or generic stale recovery]
    B -- Yes --> D{Events still arriving?}
    D -- No --> E[Stream-idle recovery]
    D -- Yes --> F[Continue past generic stale deadline]
    F --> G[Absolute hard ceiling]
```

## Behavior matrix

| Stream state | Recovery behavior |
| --- | --- |
| No first event | Existing TTFB and generic stale deadlines |
| First event, then silence | Existing event-idle deadline |
| Events continue past generic stale timeout | Continue processing |
| Active stream exceeds absolute ceiling | Abort with `codex_hard_timeout_kill` |
| Non-Codex request | Existing generic stale behavior |

## Validation

- `scripts/run_tests.sh tests/agent/test_codex_ttfb_watchdog.py tests/run_agent/test_stream_stale_breaker_reset.py tests/run_agent/test_wait_state_visibility.py tests/agent/test_reasoning_stale_timeout_floor.py` — 96 passed
- post-rebase focused watchdog regression — 4 passed
- `python -m ruff check agent/chat_completion_helpers.py tests/agent/test_codex_ttfb_watchdog.py`
- `git diff upstream/main...HEAD --check`
