### PR TITLE
fix(slack): trust adapter routing after stripping self mention

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3189,11 +3189,16 @@ class SlackAdapter(BasePlatformAdapter):
             return ""
         return (
             f"You are connected to this Slack workspace as the bot "
-            f'"@{name}". In messages, each line is prefixed with the sender\'s '
-            f"name, and mentions are shown as @DisplayName. Only treat a "
-            f'message as directed at you when it mentions "@{name}" '
-            f"specifically; a mention of any other participant is not a "
-            f"mention of you, even if their name is similar."
+            f'"@{name}". The Slack adapter already applied authorization, mention, '
+            f"and channel-routing rules before delivering this message. Treat every "
+            f"delivered turn as intentionally routed to you, including a message "
+            f"accepted from a free-response channel or active thread. Your own routing "
+            f'mention "@{name}" may have been removed from the model-visible text. '
+            f"Do not ask for another mention, reject the message, or stay silent solely "
+            f'because "@{name}" is absent. In messages, each line is prefixed with the '
+            f"sender's name, and visible mentions are shown as @DisplayName; a mention "
+            f"of any other participant is not a mention of you, even if their name is "
+            f"similar."
         )
 
     async def _resolve_user_is_bot(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2985,6 +2985,35 @@ class TestMessageRouting:
         assert "<@U_BOT>" not in msg_event.text
 
     @pytest.mark.asyncio
+    async def test_accepted_mention_prompt_trusts_adapter_routing(self, adapter):
+        """Cleaned text must not make the model revalidate an accepted mention."""
+        adapter.config.extra.update({"require_mention": True, "strict_mention": True})
+        adapter._bot_display_name = "TestBot"
+        adapter._team_bot_names = {"T123": "WorkspaceBot"}
+        event = {
+            "text": "<@U_BOT> Hi",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T123",
+            "ts": "1234567890.000001",
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_awaited_once()
+        msg_event = adapter.handle_message.await_args.args[0]
+        prompt = msg_event.channel_prompt
+        assert msg_event.text == "Hi"
+        assert "@WorkspaceBot" in prompt
+        assert "already applied" in prompt
+        assert "may have been removed" in prompt
+        assert "Do not ask for another mention" in prompt
+        assert "free-response channel or active thread" in prompt
+        assert "not a mention of you" in prompt
+        assert "Only treat a message as directed" not in prompt
+
+    @pytest.mark.asyncio
     async def test_bot_messages_ignored(self, adapter):
         """Messages from bots should be ignored."""
         event = {


### PR DESCRIPTION
## Summary

- Make the Slack adapter authoritative for routing after it accepts a message.
- Clarify that the bot's own routing mention may be stripped before model delivery.
- Prevent redundant mention requests or intentional silence on accepted turns.
- Preserve strict mention gating and human-mention disambiguation.

## Root cause

The Slack adapter determines that the bot was explicitly mentioned and intentionally strips the bot's routing token before constructing the model-visible message. The identity prompt added by commit `5d747a91c48b19b274e357cd840791ca62a60212` then instructs the model to require that removed mention to remain visible. This contradicts the adapter's routing decision.

## Behavior preserved

- Unmentioned messages remain blocked when strict mention gating applies.
- Free-response and active-thread routing remain adapter-controlled.
- Mentions of other users remain humanized.
- Direct-message behavior remains unchanged.
- Mention-prefixed slash and bang commands continue to work.
- No Slack permissions, scopes, allowlists, or credentials are changed.

## Tests

- `python -m pytest tests/gateway/test_slack.py::TestMessageRouting::test_accepted_mention_prompt_trusts_adapter_routing -o 'addopts=' -q` — 1 passed.
- `python -m pytest tests/gateway/test_slack_mention.py tests/gateway/test_slack_mention_humanization.py tests/gateway/test_slack.py -o 'addopts=' -q` — 428 passed.
- `python -m pytest tests/gateway/test_slack*.py -o 'addopts=' -q` — 672 passed.
- `python -m ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py` — passed.

Each pytest command ran with isolated temporary `HOME` and `HERMES_HOME` directories.

## Reproduction coverage

Tests cover:

- Strict unmentioned messages dropped before dispatch.
- Explicitly mentioned messages accepted.
- Self-mention removed from model-visible text.
- Identity prompt acknowledges prior adapter routing.
- No requirement for the removed token to remain visible.
- Other-user mention humanization preserved.
- Free-response and active-thread routing not contradicted.
- Command routing preserved.
