### PR TITLE
feat: add board-wide Kanban event timeline

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -18,9 +18,11 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import shlex
 import sys
 import time
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Optional
 
@@ -48,6 +50,27 @@ def _fmt_ts(ts: Optional[int]) -> str:
     if not ts:
         return ""
     return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
+
+
+def _parse_since_duration(since_str: str) -> Optional[datetime]:
+    """Parse a relative duration string like '1h', '30m', '2d' into a datetime.
+
+    Returns None if the string can't be parsed.
+    Compatible with the same format used by ``hermes logs --since``.
+    """
+    since_str = since_str.strip().lower()
+    match = re.match(r"^(\d+)\s*([smhd])$", since_str)
+    if not match:
+        return None
+    value = int(match.group(1))
+    unit = match.group(2)
+    delta = {
+        "s": timedelta(seconds=value),
+        "m": timedelta(minutes=value),
+        "h": timedelta(hours=value),
+        "d": timedelta(days=value),
+    }[unit]
+    return datetime.now() - delta
 
 
 def _fmt_task_line(t: kb.Task) -> str:
@@ -683,6 +706,51 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_tail.add_argument("task_id")
     p_tail.add_argument("--interval", type=float, default=1.0)
 
+    # --- timeline ---
+    p_timeline = sub.add_parser(
+        "timeline",
+        help="Board-level chronological event feed across all tasks",
+        description=(
+            "Show events from all tasks on the board in chronological order. "
+            "Each line includes the task id/title/status/assignee alongside "
+            "the event kind and timestamp. Use --json for machine-readable "
+            "output. Full task bodies are never embedded."
+        ),
+    )
+    p_timeline.add_argument(
+        "--json", action="store_true",
+        help="Output as a JSON array of event dicts",
+    )
+    p_timeline.add_argument(
+        "--since",
+        default=None,
+        metavar="DURATION",
+        help="Only show events from the last DURATION. Format: <N><unit> "
+             "where unit is s (seconds), m (minutes), h (hours), or d (days). "
+             "Examples: --since 1h, --since 30m, --since 2d",
+    )
+    p_timeline.add_argument(
+        "--status",
+        default=None,
+        choices=sorted(kb.VALID_STATUSES),
+        metavar="STATUS",
+        help="Filter to tasks currently in this status "
+             "(todo, ready, running, blocked, done, etc.)",
+    )
+    p_timeline.add_argument(
+        "--assignee",
+        default=None,
+        metavar="PROFILE",
+        help="Filter to tasks assigned to this profile",
+    )
+    p_timeline.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        metavar="N",
+        help="Show at most the newest N matching events, in chronological order (default: 100)",
+    )
+
     # --- dispatch ---
     p_disp = sub.add_parser(
         "dispatch",
@@ -1047,6 +1115,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "promote":  _cmd_promote,
             "archive":  _cmd_archive,
             "tail":     _cmd_tail,
+            "timeline": _cmd_timeline,
             "dispatch": _cmd_dispatch,
             "daemon":   _cmd_daemon,
             "watch":    _cmd_watch,
@@ -2411,6 +2480,84 @@ def _cmd_tail(args: argparse.Namespace) -> int:
         return 0
 
 
+def _cmd_timeline(args: argparse.Namespace) -> int:
+    """Board-level chronological event feed across all tasks."""
+    # Parse --since relative duration
+    since_cutoff: Optional[int] = None
+    if args.since:
+        since_dt = _parse_since_duration(args.since)
+        if since_dt is None:
+            print(
+                f"kanban timeline: invalid --since value {args.since!r}. "
+                f"Use format like '1h', '30m', '2d'.",
+                file=sys.stderr,
+            )
+            return 2
+        since_cutoff = int(since_dt.timestamp())
+
+    kw: dict[str, Any] = {}
+    if since_cutoff is not None:
+        kw["since"] = since_cutoff
+    if args.status:
+        kw["status"] = args.status
+    if args.assignee:
+        kw["assignee"] = args.assignee
+    if args.limit <= 0:
+        print("kanban timeline: --limit must be greater than zero", file=sys.stderr)
+        return 2
+    kw["limit"] = args.limit
+
+    # Board isolation: if --board was passed, it's already active via the
+    # scoped_current_board context manager in kanban_command; but
+    # get_board_timeline also accepts an explicit board= arg.  Pass
+    # through the board override so the DB layer opens the right DB when
+    # called outside of the kanban_command context (e.g. from tests using
+    # connect_closing directly).
+    board_override = getattr(args, "board", None)
+    if board_override:
+        try:
+            board_override = kb._normalize_board_slug(board_override)
+        except ValueError:
+            board_override = None
+    if board_override:
+        kw["board"] = board_override
+
+    timeline = kb.get_board_timeline(**kw)
+
+    if args.json:
+        print(json.dumps(timeline, ensure_ascii=False, default=str))
+        return 0
+
+    if not timeline:
+        print("No events found.")
+        return 0
+
+    for entry in timeline:
+        ts = _fmt_ts(entry["created_at"])
+        tid_short = entry["task_id"][:8]
+        icon = _STATUS_ICONS.get(entry["task_status"], "?")
+        assignee = entry["task_assignee"] or "(unassigned)"
+        title = str(entry["task_title"])
+        if len(title) > 100:
+            title = f"{title[:97]}..."
+        payload = ""
+        if entry["payload"] and isinstance(entry["payload"], dict):
+            # Show one compact payload field; JSON mode retains the full object.
+            items = list(entry["payload"].items())
+            if items:
+                k, v = items[0]
+                rendered = repr(v)
+                if len(rendered) > 120:
+                    rendered = f"{rendered[:117]}..."
+                payload = f" {k}={rendered}"
+        print(
+            f"[{ts}] {icon} {tid_short}  {entry['kind']:16s}  "
+            f"{assignee:20s}  {title}{payload}"
+        )
+
+    return 0
+
+
 def _cmd_dispatch(args: argparse.Namespace) -> int:
     # Honour kanban.default_assignee as the fallback for unassigned ready
     # tasks (#27145), kanban.max_in_progress as the global concurrency cap
@@ -3124,6 +3271,7 @@ Common subcommands:
   `complete <id>…`      Mark task(s) done
   `block <id> [reason]` Mark blocked; `schedule <id> [reason]` parks time-delay work; `unblock <id>` to revive
   `assign <id> <profile>`  Reassign
+  `timeline`            Board-level chronological event feed (--json, --since, --status, --assignee)
   `boards list`         Show all boards
   `assignees`           Known profiles + counts
   `context <id>`        Full worker-context dump

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1314,6 +1314,7 @@ CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
 CREATE INDEX IF NOT EXISTS idx_links_parent          ON task_links(parent_id);
 CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_events_created        ON task_events(created_at, id);
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
@@ -2507,6 +2508,7 @@ _REBUILD_SPECS = {
         " payload TEXT, created_at INTEGER NOT NULL)",
         (
             "CREATE INDEX idx_events_task ON task_events(task_id, created_at)",
+            "CREATE INDEX idx_events_created ON task_events(created_at, id)",
             "CREATE INDEX idx_events_run ON task_events(run_id, id)",
         ),
     ),
@@ -3711,6 +3713,103 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
                 run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
             )
         )
+    return out
+
+
+def get_board_timeline(
+    *,
+    since: Optional[int] = None,
+    status: Optional[str] = None,
+    assignee: Optional[str] = None,
+    board: Optional[str] = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Return a chronological feed of events across ALL tasks on the board.
+
+    Each entry is a dict with event fields AND denormalised task metadata
+    (task_id, task_title, task_status, task_assignee) so consumers don't
+    need to issue N+1 lookups.  Full task ``body`` is **never** embedded.
+
+    Parameters
+    ----------
+    since:
+        Unix-timestamp cutoff — only events at or after this time.
+    status:
+        Filter to tasks whose *current* status is this value.
+    assignee:
+        Filter to tasks assigned to this profile.
+    board:
+        Board slug (falls through to :func:`connect` resolution when None).
+    limit:
+        Maximum number of newest matching events to return. Results are still
+        presented in chronological order.
+
+    Returns
+    -------
+    List of dicts, ordered by ``created_at ASC, task_events.id ASC``
+    (deterministic even when timestamps are equal).
+    """
+    if limit <= 0:
+        raise ValueError("Timeline limit must be greater than zero")
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if since is not None:
+        clauses.append("e.created_at >= ?")
+        params.append(since)
+    if status is not None:
+        clauses.append("t.status = ?")
+        params.append(status)
+    if assignee is not None:
+        clauses.append("t.assignee = ?")
+        params.append(assignee)
+
+    where = ""
+    if clauses:
+        where = "WHERE " + " AND ".join(clauses)
+
+    sql = f"""\
+SELECT
+    e.id          AS event_id,
+    e.task_id     AS task_id,
+    e.run_id      AS run_id,
+    e.kind        AS kind,
+    e.payload     AS payload,
+    e.created_at  AS created_at,
+    t.title       AS task_title,
+    t.status      AS task_status,
+    t.assignee    AS task_assignee
+FROM task_events e
+JOIN tasks t ON t.id = e.task_id
+{where}
+ORDER BY e.created_at DESC, e.id DESC
+LIMIT ?
+"""
+    params.append(limit)
+
+    with connect_closing(board=board) as conn:
+        rows = conn.execute(sql, params).fetchall()
+    rows = list(reversed(rows))
+
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        payload = None
+        if r["payload"] is not None:
+            try:
+                payload = json.loads(r["payload"])
+            except Exception:
+                payload = None
+        out.append({
+            "event_id": r["event_id"],
+            "task_id": r["task_id"],
+            "run_id": r["run_id"],
+            "kind": r["kind"],
+            "payload": payload,
+            "created_at": r["created_at"],
+            "task_title": r["task_title"],
+            "task_status": r["task_status"],
+            "task_assignee": r["task_assignee"],
+        })
     return out
 
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -565,3 +566,130 @@ def test_run_slash_board_override_does_not_change_boards_show_current(kanban_hom
     out = kc.run_slash("--board beta boards show")
 
     assert "Current board: alpha" in out
+
+
+# ---------------------------------------------------------------------------
+# Board-level event timeline (CLI)
+# ---------------------------------------------------------------------------
+
+
+class TestTimelineCLI:
+    """CLI-level tests for ``hermes kanban --board <slug> timeline``."""
+
+    def test_timeline_basic_output(self, kanban_home):
+        """Default view shows chronological events with task metadata."""
+        with kb.connect() as conn:
+            kb.create_task(conn, title="one", assignee="alice")
+            kb.create_task(conn, title="two", assignee="bob")
+
+        out = kc.run_slash("timeline")
+        assert "one" in out
+        assert "two" in out
+
+    def test_timeline_json_output(self, kanban_home):
+        """--json returns valid JSON array of event dicts."""
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="json test", assignee="alice")
+            kb.complete_task(conn, t, result="ok")
+
+        out = kc.run_slash("timeline --json")
+        parsed = json.loads(out)
+        assert isinstance(parsed, list)
+        assert len(parsed) >= 2
+        for entry in parsed:
+            assert "task_id" in entry
+            assert "task_title" in entry
+            assert "kind" in entry
+            assert "created_at" in entry
+
+    def test_timeline_since_filter(self, kanban_home):
+        """--since 1h filters to recent events."""
+        now = int(time.time())
+        with kb.connect() as conn:
+            old = kb.create_task(conn, title="two hours ago")
+            recent = kb.create_task(conn, title="thirty minutes ago")
+            conn.execute(
+                "UPDATE task_events SET created_at = ? WHERE task_id = ?",
+                (now - 7200, old),
+            )
+            conn.execute(
+                "UPDATE task_events SET created_at = ? WHERE task_id = ?",
+                (now - 1800, recent),
+            )
+            conn.commit()
+
+        out = kc.run_slash("timeline --since 1h")
+
+        assert "thirty minutes ago" in out
+        assert "two hours ago" not in out
+
+    def test_timeline_empty_board(self, kanban_home):
+        """Timeline on an empty board returns 'No events' without error."""
+        out = kc.run_slash("timeline")
+        assert isinstance(out, str)
+        # Should not crash, should indicate emptiness
+        assert "No events" in out or "no events" in out.lower() or out == ""
+
+    def test_timeline_board_selection(self, kanban_home):
+        """--board flag scopes timeline to that board."""
+        kb.create_board("project-a")
+        with kb.connect_closing(board="project-a") as conn:
+            kb.create_task(conn, title="project a task")
+        with kb.connect() as conn:
+            kb.create_task(conn, title="default task")
+
+        out = kc.run_slash("--board project-a timeline")
+        assert "project a task" in out
+        assert "default task" not in out
+
+    def test_timeline_status_filter(self, kanban_home):
+        """--status filters timeline to tasks currently in that status."""
+        with kb.connect() as conn:
+            t1 = kb.create_task(conn, title="done task", assignee="alice")
+            kb.complete_task(conn, t1, result="ok")
+            kb.create_task(conn, title="todo task")
+
+        out = kc.run_slash("timeline --status done")
+        assert "done task" in out
+        assert "todo task" not in out
+
+    def test_timeline_assignee_filter(self, kanban_home):
+        """--assignee filters timeline to tasks assigned to that profile."""
+        with kb.connect() as conn:
+            kb.create_task(conn, title="alice task", assignee="alice")
+            kb.create_task(conn, title="bob task", assignee="bob")
+
+        out = kc.run_slash("timeline --assignee alice")
+        assert "alice task" in out
+        assert "bob task" not in out
+
+    def test_timeline_limit_and_validation(self, kanban_home):
+        with kb.connect() as conn:
+            for index in range(3):
+                kb.create_task(conn, title=f"limited {index}")
+
+        parsed = json.loads(kc.run_slash("timeline --limit 2 --json"))
+        assert len(parsed) == 2
+        assert [entry["task_title"] for entry in parsed] == [
+            "limited 1",
+            "limited 2",
+        ]
+
+        assert "must be greater than zero" in kc.run_slash("timeline --limit 0")
+
+    def test_timeline_human_output_bounds_long_titles(self, kanban_home):
+        long_title = "x" * 150
+        with kb.connect() as conn:
+            kb.create_task(conn, title=long_title)
+
+        output = kc.run_slash("timeline")
+
+        assert f"{'x' * 97}..." in output
+        assert long_title not in output
+
+    def test_timeline_no_args_no_board_uses_default(self, kanban_home):
+        """Timeline with no --board uses whichever board is current."""
+        with kb.connect() as conn:
+            kb.create_task(conn, title="default board event")
+        out = kc.run_slash("timeline")
+        assert "default board event" in out

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4959,3 +4959,123 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Board-level event timeline
+# ---------------------------------------------------------------------------
+
+
+class TestBoardTimeline:
+    """Tests for ``get_board_timeline`` — cross-task chronological event feed."""
+
+    def test_chronological_ordering_across_tasks(self, kanban_home):
+        """Events from different tasks interleave in creation-time order."""
+        with kb.connect() as conn:
+            t1 = kb.create_task(conn, title="task one", assignee="alice")
+            t2 = kb.create_task(conn, title="task two", assignee="bob")
+            t3 = kb.create_task(conn, title="task three", assignee="alice")
+
+        timeline = kb.get_board_timeline()
+        assert len(timeline) >= 3
+        kinds = [entry["kind"] for entry in timeline]
+        assert "created" in kinds
+        # Each created event should carry task metadata
+        for entry in timeline:
+            assert "task_id" in entry
+            assert "task_title" in entry
+            assert "task_status" in entry
+            assert "task_assignee" in entry
+            assert "kind" in entry
+            assert "created_at" in entry
+            assert "body" not in entry  # never embed full bodies
+
+    def test_timeline_respects_since_filter(self, kanban_home):
+        """Only events at or after the since cutoff appear."""
+        with kb.connect() as conn:
+            t_old = kb.create_task(conn, title="old task")
+            t_new = kb.create_task(conn, title="new task")
+            conn.execute(
+                "UPDATE task_events SET created_at = 100 WHERE task_id = ?",
+                (t_old,),
+            )
+            conn.execute(
+                "UPDATE task_events SET created_at = 200 WHERE task_id = ?",
+                (t_new,),
+            )
+            conn.commit()
+
+        timeline = kb.get_board_timeline(since=150)
+        task_ids_in_timeline = {e["task_id"] for e in timeline}
+        assert t_new in task_ids_in_timeline
+        assert t_old not in task_ids_in_timeline
+
+    def test_timeline_limit_keeps_newest_events_in_chronological_order(
+        self, kanban_home
+    ):
+        with kb.connect() as conn:
+            task_ids = [kb.create_task(conn, title=f"task {index}") for index in range(4)]
+            for index, task_id in enumerate(task_ids, start=1):
+                conn.execute(
+                    "UPDATE task_events SET created_at = ? WHERE task_id = ?",
+                    (index, task_id),
+                )
+            conn.commit()
+
+        timeline = kb.get_board_timeline(limit=2)
+
+        assert [entry["task_id"] for entry in timeline] == task_ids[-2:]
+        assert [entry["created_at"] for entry in timeline] == [3, 4]
+
+    def test_timeline_has_global_created_at_index(self, kanban_home):
+        with kb.connect() as conn:
+            indexes = {
+                row["name"]
+                for row in conn.execute("PRAGMA index_list(task_events)").fetchall()
+            }
+
+        assert "idx_events_created" in indexes
+
+    def test_timeline_empty_board(self, kanban_home):
+        """An empty board returns an empty list, not an error."""
+        timeline = kb.get_board_timeline()
+        assert isinstance(timeline, list)
+        assert len(timeline) == 0
+
+    def test_timeline_json_shape(self, kanban_home):
+        """Every entry has the expected keys for JSON serialization."""
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="shape test", assignee="carol")
+            kb.complete_task(conn, t, result="done")
+
+        timeline = kb.get_board_timeline()
+        assert len(timeline) >= 2  # created + completed
+
+        for entry in timeline:
+            # Required keys
+            assert isinstance(entry["task_id"], str)
+            assert isinstance(entry["task_title"], str)
+            assert isinstance(entry["task_status"], str)
+            assert "task_assignee" in entry
+            assert isinstance(entry["kind"], str)
+            assert isinstance(entry["created_at"], int)
+            # Optional keys
+            assert "payload" in entry
+            assert "run_id" in entry
+            assert "event_id" in entry
+
+    def test_timeline_board_isolation(self, kanban_home):
+        """Timeline only sees events from the current board."""
+        # Create a separate board
+        kb.create_board("other")
+        with kb.connect_closing(board="other") as conn:
+            kb.create_task(conn, title="other board task")
+
+        # Default board should not see events from 'other'
+        with kb.connect() as conn:
+            kb.create_task(conn, title="default board task")
+
+        timeline_default = kb.get_board_timeline()
+        titles = {e["task_title"] for e in timeline_default}
+        assert "default board task" in titles
+        assert "other board task" not in titles

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -690,6 +690,8 @@ hermes kanban unblock <id>...
 hermes kanban archive <id>...
 
 hermes kanban tail <id>                                # follow a single task's event stream
+hermes kanban timeline [--since 30m|2h|2d]             # chronological events across the board
+        [--status S] [--assignee P] [--limit N] [--json]
 hermes kanban watch [--assignee P] [--tenant T]        # live stream ALL events to the terminal
         [--kinds completed,blocked,…] [--interval SECS]
 hermes kanban heartbeat <id> [--note "..."]            # worker liveness signal for long ops
@@ -712,6 +714,8 @@ hermes kanban specify [<id> | --all] [--tenant T]      # flesh out a triage-colu
 hermes kanban gc [--event-retention-days N]            # workspaces + old events + old logs
         [--log-retention-days N]
 ```
+
+`timeline` is a read-only, cross-task audit feed. It joins each event to the task's current title, status, and assignee without embedding task bodies. By default it selects the newest 100 matching events and prints them in chronological order; use `--limit` to change that bound and `--json` for automation. Equal timestamps are ordered deterministically by event ID. `--since` uses the same relative duration syntax as `hermes logs --since` (`30m`, `2h`, `2d`).
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
 


### PR DESCRIPTION
## Summary

Adds a read-only board-wide event timeline for Kanban operators and forensic diagnostics:

```bash
hermes kanban --board <slug> timeline
```

Options:

- `--json`
- `--since 30m|2h|2d`
- `--status <status>`
- `--assignee <profile>`
- `--limit <N>` (default 100)

## Behavior

- Joins events across all cards on the selected board with task ID, current title/status/assignee, event kind, payload, run ID, and timestamp.
- Selects the newest bounded event window, then presents it chronologically.
- Uses event ID as a deterministic tiebreaker for equal timestamps.
- Never embeds task bodies; human output also truncates long titles and payload previews.
- Preserves complete structured payloads in JSON mode.
- Respects explicit board and profile isolation.
- Adds `idx_events_created(created_at, id)` so bounded cross-task scans avoid a full event-table sort.
- Documents the command in the official Kanban CLI reference and slash help.

## Verification

- Focused timeline/schema tests — **18 passed**
- `pytest test_kanban_cli.py test_kanban_db.py test_kanban_db_init.py` — **299 passed**
- Broader Kanban/tool suites — **363 passed, 1 skipped**
- `ruff check` on changed Python files — passed
- `git diff --check` — passed
- Read-only smoke against a copied IGI Portal board — valid 5-event JSON result and human timeline output
- Independent read-only audit — **PASS**, no P0/P1 findings

### Canonical runner note

The hermetic per-file runner reached **293 passed** but six existing worktree fixture tests could not create their synthetic initial Git commit because the clean environment lacked Git author identity. Running those same relevant files with the repository test environment configured completed at **299 passed**; the failures are outside this timeline change.
