### PR TITLE
fix(trajectory-compressor): net-savings guard — skip compaction when the region is no larger than the summary (salvage #56415)

### DIFF
--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -628,3 +628,67 @@ class TestCompressionToolPairIntegrity:
             {"from": "tool", "value": "<tool_response>a</tool_response>"},
         ]
         assert tc._snap_boundary(trajectory, 1, 0, 1) == 0
+
+
+# ---------------------------------------------------------------------------
+# TrajectoryCompressor — compression must never increase the token count
+# ---------------------------------------------------------------------------
+
+
+class TestCompressionNetSavingsGuard:
+    """When the compressible middle is no larger than the summary that would
+    replace it, compression cannot help — it must be skipped rather than grow
+    the trajectory (and burn a summarization call)."""
+
+    def _tiny_middle_trajectory(self):
+        # Large protected head (system+human), tiny compressible middle.
+        big = "w " * 400  # ~200 tokens each (1 token / 4 chars)
+        small = "ok " * 2
+        return [
+            {"from": "system", "value": big},  # protected (first_system)
+            {"from": "human", "value": big},  # protected (first_human)
+            {"from": "gpt", "value": small},  # protected (first_gpt)
+            {"from": "tool", "value": small},  # protected (first_tool)
+            {"from": "gpt", "value": small},  # compressible middle
+            {"from": "tool", "value": small},  # compressible middle
+            {"from": "gpt", "value": small},  # protected (last 2)
+            {"from": "human", "value": small},  # protected (last 2)
+        ]
+
+    def _config(self):
+        config = CompressionConfig()
+        config.protect_last_n_turns = 2
+        config.summary_target_tokens = 20
+        config.target_max_tokens = 100  # trajectory is far over this
+        return config
+
+    def test_sync_skips_compression_when_middle_smaller_than_summary(self):
+        tc = _make_compressor(self._config())
+        tc._generate_summary = MagicMock(
+            return_value="[CONTEXT SUMMARY]: " + "blah " * 30
+        )
+        trajectory = self._tiny_middle_trajectory()
+        before = sum(tc.count_turn_tokens(trajectory))
+
+        compressed, metrics = tc.compress_trajectory(trajectory)
+
+        assert metrics.was_compressed is False
+        assert compressed == trajectory
+        assert sum(tc.count_turn_tokens(compressed)) == before
+        tc._generate_summary.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_skips_compression_when_middle_smaller_than_summary(self):
+        tc = _make_compressor(self._config())
+        tc._generate_summary_async = AsyncMock(
+            return_value="[CONTEXT SUMMARY]: " + "blah " * 30
+        )
+        trajectory = self._tiny_middle_trajectory()
+        before = sum(tc.count_turn_tokens(trajectory))
+
+        compressed, metrics = await tc.compress_trajectory_async(trajectory)
+
+        assert metrics.was_compressed is False
+        assert compressed == trajectory
+        assert sum(tc.count_turn_tokens(compressed)) == before
+        tc._generate_summary_async.assert_not_called()

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -831,6 +831,18 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             metrics.still_over_limit = total_tokens > self.config.target_max_tokens
             return trajectory, metrics
 
+        # If the region we can safely compress is no larger than the summary
+        # that would replace it, compression cannot reduce the token count --
+        # it would grow the trajectory and still spend a summarization call.
+        if (
+            sum(turn_tokens[compress_start:compress_until])
+            <= self.config.summary_target_tokens
+        ):
+            metrics.compressed_tokens = total_tokens
+            metrics.compressed_turns = len(trajectory)
+            metrics.still_over_limit = total_tokens > self.config.target_max_tokens
+            return trajectory, metrics
+
         # Record compression region
         metrics.turns_compressed_start_idx = compress_start
         metrics.turns_compressed_end_idx = compress_until
@@ -941,6 +953,18 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         compress_until = self._snap_boundary(trajectory, compress_until, compress_start, compress_end)
         if compress_until <= compress_start:
             # Snapping collapsed the region; nothing can be safely compressed.
+            metrics.compressed_tokens = total_tokens
+            metrics.compressed_turns = len(trajectory)
+            metrics.still_over_limit = total_tokens > self.config.target_max_tokens
+            return trajectory, metrics
+
+        # If the region we can safely compress is no larger than the summary
+        # that would replace it, compression cannot reduce the token count --
+        # it would grow the trajectory and still spend a summarization call.
+        if (
+            sum(turn_tokens[compress_start:compress_until])
+            <= self.config.summary_target_tokens
+        ):
             metrics.compressed_tokens = total_tokens
             metrics.compressed_turns = len(trajectory)
             metrics.still_over_limit = total_tokens > self.config.target_max_tokens


### PR DESCRIPTION
Salvages PR #56415 by @golldyck onto current main (clean cherry-pick, authorship preserved).

## Problem

`trajectory_compressor.py` (the root-level **training-trajectory** compressor — a separate subsystem from `agent/context_compressor.py`) computes `target_tokens_to_compress` but never verifies the compressible middle region is actually larger than the summary that will replace it. The only guards were nothing-to-compress and `compress_until <= compress_start`.

When a large protected head (system + first human) dominates the budget, the compressible middle can be tiny — replacing e.g. a ~2-token middle with a ~60-token `[CONTEXT SUMMARY]` turn **grows** the trajectory (observed 406→465 tokens), marks `was_compressed=True`, and still burns a summarization call — the opposite of intent, on exactly the hard over-budget cases. The same gap existed in the async twin `compress_trajectory_async`.

## Fix (contributor's, cherry-picked)

Net-savings guard in **both** sync and async paths: if `sum(turn_tokens[compress_start:compress_until]) <= summary_target_tokens`, return the trajectory unchanged (metrics report no compression, `still_over_limit` set honestly) before spending any summarizer call. Mirrors the code's own `net_savings = region_tokens - summary_target_tokens` comment.

Diff is exactly `trajectory_compressor.py` + `tests/test_trajectory_compressor.py` — no drive-by changes.

## Validation

| Check | Result |
|---|---|
| Cherry-pick onto main | Clean, zero conflicts (file untouched since #52336) |
| Sync guard present (L~834) | ✅ |
| Async guard present (L~961) | ✅ |
| `scripts/run_tests.sh tests/test_trajectory_compressor.py` | ✅ 37/37 passed (incl. 2 new sync+async regression tests) |
| Counterfactual (tests vs pre-fix `origin/main` source) | ✅ both new tests FAIL on unfixed main, pass with fix |
| `git diff --stat origin/main..HEAD` | 2 files, +88 only |

## Credit

All substantive work by @golldyck (original PR #56415); commit cherry-picked with authorship preserved. Noreply email — no contributor mapping needed.

## Infographic

![net-savings-guard](https://v3b.fal.media/files/b/0aa37005/1zjE9gPpyOZzv3z7IOwz4_co2OLmlE.png)
