### PR TITLE
fix(compression): roll back interrupted preflight display-token seed (salvage of #54805)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1856,6 +1856,16 @@ class ContextCompressor(ContextEngine):
         self._verify_compaction_cleared_threshold = False
         self.awaiting_real_usage_after_compression = False
 
+    def snapshot_preflight_display_tokens(self) -> int:
+        """Capture the display token count before a speculative preflight seed."""
+        return self.last_prompt_tokens
+
+    def rollback_interrupted_preflight_display_tokens(self, snapshot: int) -> None:
+        """Restore a speculative display seed without touching compaction state."""
+        if self.awaiting_real_usage_after_compression and self.last_prompt_tokens == -1:
+            return
+        self.last_prompt_tokens = snapshot
+
     def should_defer_preflight_to_real_usage(self, rough_tokens: int) -> bool:
         """Return True when a high rough preflight estimate is known-noisy.
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2065,6 +2065,8 @@ def run_conversation(
                             )
                     continue  # Retry the API call
 
+                agent._turn_received_provider_response = True
+
                 # Check finish_reason before proceeding
                 if agent.api_mode == "codex_responses":
                     status = getattr(response, "status", None)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -706,6 +706,8 @@ def build_turn_context(
     # issue #27405 (a few very large messages slipping past the count gate).
     _preflight_compressed = False
     _preflight_compression_blocked = False
+    agent._turn_received_provider_response = False
+    agent._turn_preflight_display_snapshot = None
     if agent.compression_enabled and _should_run_preflight_estimate(
         messages,
         agent.context_compressor.protect_first_n,
@@ -718,6 +720,9 @@ def build_turn_context(
             tools=agent.tools or None,
         )
         _compressor = agent.context_compressor
+        agent._turn_preflight_display_snapshot = (
+            _compressor.snapshot_preflight_display_tokens()
+        )
         _defer_preflight = getattr(
             _compressor,
             "should_defer_preflight_to_real_usage",

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -720,9 +720,21 @@ def build_turn_context(
             tools=agent.tools or None,
         )
         _compressor = agent.context_compressor
-        agent._turn_preflight_display_snapshot = (
-            _compressor.snapshot_preflight_display_tokens()
+        # getattr guard: minimal compressor doubles (SimpleNamespace in the
+        # engine-preflight tests) and plugin context engines lack this
+        # ContextCompressor-only method — absence means no snapshot, and the
+        # finalizer's rollback stays disarmed for the turn (display-only).
+        _snapshot_fn = getattr(
+            _compressor, "snapshot_preflight_display_tokens", None
         )
+        if callable(_snapshot_fn):
+            _snapshot_val = _snapshot_fn()
+            # Type pin: MagicMock compressors return truthy Mock objects —
+            # only a real int snapshot may arm the interrupted-turn rollback.
+            if isinstance(_snapshot_val, int) and not isinstance(
+                _snapshot_val, bool
+            ):
+                agent._turn_preflight_display_snapshot = _snapshot_val
         _defer_preflight = getattr(
             _compressor,
             "should_defer_preflight_to_real_usage",

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -201,6 +201,23 @@ def finalize_turn(
         )
     )
 
+    # Preflight can seed the display count before the provider receives the
+    # request. Roll that estimate back only when an interrupt wins the race
+    # before any successful provider response. Compaction state remains owned
+    # by the real-usage/post-compaction path, including its ``-1`` sentinel.
+    _preflight_snapshot = getattr(
+        agent, "_turn_preflight_display_snapshot", None
+    )
+    if (
+        interrupted
+        and _preflight_snapshot is not None
+        and not getattr(agent, "_turn_received_provider_response", False)
+        and getattr(agent, "context_compressor", None) is not None
+    ):
+        agent.context_compressor.rollback_interrupted_preflight_display_tokens(
+            _preflight_snapshot
+        )
+
     # Post-loop cleanup must never lose the response.  Trajectory save,
     # resource teardown, and session persistence all touch fallible
     # surfaces — file I/O / JSON serialization (_save_trajectory), remote
@@ -624,5 +641,8 @@ def finalize_turn(
         )
     except Exception as exc:
         logger.warning("on_session_end hook failed: %s", exc)
+
+    agent._turn_preflight_display_snapshot = None
+    agent._turn_received_provider_response = False
 
     return result

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -205,18 +205,31 @@ def finalize_turn(
     # request. Roll that estimate back only when an interrupt wins the race
     # before any successful provider response. Compaction state remains owned
     # by the real-usage/post-compaction path, including its ``-1`` sentinel.
+    # Guard rules (test-double density on this path is high):
+    #  - snapshot is type-pinned to a real int — MagicMock agents auto-create
+    #    truthy Mock attributes that must never arm the rollback;
+    #  - the received-response flag is pinned to ``is not True`` — its real
+    #    domain is True/False, and only a literal True means a provider
+    #    response completed;
+    #  - the compressor method gets a getattr+callable guard — SimpleNamespace
+    #    compressor doubles and plugin context engines lack it.
     _preflight_snapshot = getattr(
         agent, "_turn_preflight_display_snapshot", None
     )
     if (
-        interrupted
-        and _preflight_snapshot is not None
-        and not getattr(agent, "_turn_received_provider_response", False)
+        interrupted is True
+        and isinstance(_preflight_snapshot, int)
+        and not isinstance(_preflight_snapshot, bool)
+        and getattr(agent, "_turn_received_provider_response", False) is not True
         and getattr(agent, "context_compressor", None) is not None
     ):
-        agent.context_compressor.rollback_interrupted_preflight_display_tokens(
-            _preflight_snapshot
+        _rollback_fn = getattr(
+            agent.context_compressor,
+            "rollback_interrupted_preflight_display_tokens",
+            None,
         )
+        if callable(_rollback_fn):
+            _rollback_fn(_preflight_snapshot)
 
     # Post-loop cleanup must never lose the response.  Trajectory save,
     # resource teardown, and session persistence all touch fallible

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -1465,6 +1465,127 @@ class TestPreflightCompression:
         assert mock_compress.call_count == 2
 
 
+    def test_interrupt_before_first_provider_call_restores_preflight_display_seed(self, agent):
+        """Interrupted turns must not keep a speculative preflight display seed.
+
+        Preflight runs before the main loop checks ``_interrupt_requested``.
+        If the user interrupts during that window, no provider usage ever
+        arrives to validate the rough estimate, so the old display token count
+        must be restored instead of leaking the speculative value forward.
+        """
+        agent.compression_enabled = True
+        agent._interrupt_requested = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 130_000
+        agent.context_compressor.last_prompt_tokens = 74_400
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i} padded text"})
+            big_history.append({"role": "assistant", "content": f"Response {i} padded text"})
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=144_669),
+            patch.object(agent.context_compressor, "should_compress", return_value=False),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        assert result["interrupted"] is True
+        assert agent.client.chat.completions.create.call_count == 0
+        assert agent.context_compressor.last_prompt_tokens == 74_400
+
+    def test_usage_less_provider_response_prevents_display_seed_rollback(self, agent):
+        """A successful response counts even when the provider omits usage."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 130_000
+        agent.context_compressor.last_prompt_tokens = 74_400
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i} padded text"})
+            big_history.append({"role": "assistant", "content": f"Response {i} padded text"})
+
+        tool_call = SimpleNamespace(
+            id="tc1",
+            type="function",
+            function=SimpleNamespace(name="web_search", arguments='{"query":"test"}'),
+        )
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(
+                content=None,
+                finish_reason="tool_calls",
+                tool_calls=[tool_call],
+                usage=None,
+            )
+        ]
+
+        def _interrupt_after_tool(*_args, **_kwargs):
+            agent._interrupt_requested = True
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=144_669),
+            patch.object(agent.context_compressor, "should_compress", return_value=False),
+            patch.object(agent, "_execute_tool_calls", side_effect=_interrupt_after_tool),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        assert result["interrupted"] is True
+        assert agent.client.chat.completions.create.call_count == 1
+        assert agent.context_compressor.last_prompt_tokens == 144_669
+
+    def test_interrupt_keeps_post_compression_state(self, agent):
+        """Display rollback must not restore real post-compaction state.
+
+        A completed preflight compaction still leaves the conversation in the
+        post-compression ``-1`` sentinel state. Its anti-thrashing verdict also
+        remains owned by the completed compaction boundary rather than the
+        speculative display snapshot.
+        """
+        agent.compression_enabled = True
+        agent._interrupt_requested = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 130_000
+        agent.context_compressor.last_prompt_tokens = 74_400
+        agent.context_compressor._ineffective_compression_count = 1
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i} padded text"})
+            big_history.append({"role": "assistant", "content": f"Response {i} padded text"})
+
+        def _fake_preflight_compress(msgs, *_args, **_kwargs):
+            agent.context_compressor.last_prompt_tokens = -1
+            agent.context_compressor.awaiting_real_usage_after_compression = True
+            agent.context_compressor.compression_count += 1
+            agent.context_compressor._ineffective_compression_count = 2
+            agent.context_compressor._last_compression_savings_pct = 0.0
+            return msgs, agent._cached_system_prompt
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=144_669),
+            patch.object(agent.context_compressor, "should_compress", return_value=True),
+            patch.object(agent, "_compress_context", side_effect=_fake_preflight_compress),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        assert result["interrupted"] is True
+        assert agent.client.chat.completions.create.call_count == 0
+        assert agent.context_compressor.last_prompt_tokens == -1
+        assert agent.context_compressor.awaiting_real_usage_after_compression is True
+        assert agent.context_compressor._ineffective_compression_count == 2
+        assert agent.context_compressor._last_compression_savings_pct == 0.0
+
+
 class TestToolResultPreflightCompression:
     """Compression should trigger when tool results push context past the threshold."""
 


### PR DESCRIPTION
Salvage of PR #54805 by @izumi0uu — roll back the speculative preflight display-token seed when a turn is interrupted before ANY successful provider response.

## Problem

`build_turn_context` (agent/turn_context.py) seeds the compressor's display counter with the rough preflight estimate (`_compressor.last_prompt_tokens = _preflight_tokens`) **before** the main loop's interrupt check in `conversation_loop.py`. If the user interrupts in that window, no provider usage ever arrives to validate the estimate, and the speculative value leaks forward into subsequent turns' display/thresholding state. No rollback/snapshot machinery existed anywhere on main (grep → 0 hits). Original report: #54776.

This is distinct from the paths already fixed on main:
- **#69853** covers compression-*attempt abort* state (flush baseline) — a different path from turn *interrupt*.
- **#45535** defer machinery only dampens post-compaction estimates; it does not undo an interrupted turn's seed.

## Fix (cherry-picked from the contributor's current revision, 298b05c)

- `ContextCompressor.snapshot_preflight_display_tokens()` / `rollback_interrupted_preflight_display_tokens(snapshot)` — display-only pair. Rollback **preserves the `-1` post-compaction sentinel** (`awaiting_real_usage_after_compression` + `last_prompt_tokens == -1` → no-op) and never touches `_ineffective_compression_count` or any durable anti-thrash guard (#69872).
- `turn_context.py` captures the snapshot just before the preflight seed and resets the per-turn flags at preflight setup.
- `conversation_loop.py` marks `agent._turn_received_provider_response = True` after unified response validation — **independent of usage metadata** (a usage-less provider response still counts, per sweeper review #4702305384).
- `turn_finalizer.py` rolls back only when `interrupted` AND no provider response completed; clears both per-turn attributes at turn end.

## Salvage hardening (maintainer follow-up commit)

Per the compression-path guard rules (MagicMock/SimpleNamespace test-double density is high in turn_context/conversation_loop/turn_finalizer):

- `snapshot_preflight_display_tokens` call gets a **getattr+callable guard** (SimpleNamespace compressor doubles / plugin context engines lack the ContextCompressor-only method) and the returned snapshot is **type-pinned to a real int** (bool excluded) before arming the rollback.
- In the finalizer: `interrupted is True` pin, `_turn_received_provider_response ... is not True` pin (MagicMock auto-attributes are truthy), and the rollback method call gets its own getattr+callable guard.
- Re-anchored to current line positions (the PR predates the #69315/#69865/#69857 preflight-region churn; the `_preflight_compression_blocked` initializer is kept alongside the new per-turn flags).

## Regression coverage (contributor's tests, all three scenarios)

`tests/run_agent/test_413_compression.py::TestPreflightCompression`:
1. `test_interrupt_before_first_provider_call_restores_preflight_display_seed` — interrupt wins the race, 0 provider calls, display seed restored to 74,400.
2. `test_usage_less_provider_response_prevents_display_seed_rollback` — a usage-less tool-call response still counts as a provider response; no rollback (144,669 kept).
3. `test_interrupt_keeps_post_compression_state` — completed preflight compaction before the interrupt: `-1` sentinel, `awaiting_real_usage_after_compression`, `_ineffective_compression_count == 2`, and savings pct all preserved.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/run_agent/test_413_compression.py` (46 tests incl. 3 new) | ✅ pass |
| `scripts/run_tests.sh tests/agent/test_turn_context.py` | ✅ pass |
| `scripts/run_tests.sh tests/agent/test_engine_preflight_wire.py` | ✅ pass |
| `scripts/run_tests.sh tests/agent/test_idle_compaction.py` + `test_idle_compaction_lock_and_guards.py` | ✅ pass |
| `scripts/run_tests.sh tests/run_agent/test_compression_abort_state_reset.py` | ✅ pass |
| `scripts/run_tests.sh tests/agent/test_context_compressor.py` | ✅ pass |
| `scripts/run_tests.sh tests/run_agent/test_preflight_compression_cap_e2e.py` | ✅ pass |
| `scripts/run_tests.sh tests/agent/test_turn_finalizer_*.py` (4 files) | ✅ pass |
| `scripts/run_tests.sh tests/agent/test_compression_anti_thrash_persistence.py` | ✅ pass |
| `scripts/run_tests.sh tests/run_agent/test_run_agent.py` | ✅ pass |
| `ruff check` on all touched files | ✅ clean |
| Rebased onto current main; diff = only the 5 intended files | ✅ |

## Attribution

Contributor commit cherry-picked with authorship preserved: `izumi0uu <izumi0uu@gmail.com>` (already mapped in `contributors/emails/`). Closes #54805 on merge (with credit); fixes #54776.

## Infographic

![preflight-display-rollback](https://v3b.fal.media/files/b/0aa37040/HZmz9T1KlRhWuLcEkIEYo_TQEMLBhy.png)
