### PR TITLE
fix(compression): reclaim compression leases held by dead PIDs (salvage of #65775)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,6 +31,11 @@ from agent.message_sanitization import _sanitize_surrogates
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
+try:  # Hard dependency, but tolerate scaffold-phase imports before pip install.
+    import psutil
+except ImportError:  # pragma: no cover - stripped/scaffold installs only
+    psutil = None  # type: ignore[assignment]
+
 logger = logging.getLogger(__name__)
 
 _COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
@@ -44,11 +49,14 @@ def _compression_lock_holder_process_is_dead(holder: str) -> bool:
     process killed during gateway shutdown cannot release its lease, so waiting
     for the full TTL makes every new turn repeatedly attempt compaction. Reclaim
     only when the kernel proves that PID no longer exists; legacy/unstructured
-    holders and permission errors remain protected until normal TTL expiry.
+    holders, same-process holders, permission errors, and any probe doubt
+    remain protected until normal TTL expiry (conservative: PID reuse must
+    never steal a live lease, and a wrongly-kept lease self-heals via TTL).
     """
-    # Python's os.kill(pid, 0) is a non-destructive liveness probe on POSIX.
-    # On Windows, any non-CTRL signal value is implemented with
-    # TerminateProcess, so fall back to TTL-only recovery there.
+    # Windows stays TTL-only: stdlib os.kill(pid, 0) is NOT a no-op probe
+    # there (bpo-14484 — sig=0 maps to CTRL_C_EVENT and can kill the target's
+    # console group), and PID recycling semantics make liveness a weaker
+    # deadness signal. The 300s lease TTL remains the recovery path.
     if os.name == "nt":
         return False
     match = _COMPRESSION_LOCK_HOLDER_PID_RE.search(holder or "")
@@ -60,8 +68,22 @@ def _compression_lock_holder_process_is_dead(holder: str) -> bool:
         return False
     if pid <= 0:
         return False
+    if pid == os.getpid():
+        # Same-process holder (e.g. another thread's live lease): never
+        # self-reclaim — the lease refresher and release path own it.
+        return False
+    if psutil is not None:
+        try:
+            # psutil is the canonical cross-platform liveness answer
+            # (CONTRIBUTING.md "Critical rules" #1). pid_exists() reports
+            # recycled PIDs as alive — conservative, the TTL still applies.
+            return not psutil.pid_exists(pid)
+        except Exception:
+            return False  # any doubt → keep the lease until TTL expiry
+    # Scaffold-phase fallback only (psutil missing). POSIX-only by the
+    # os.name gate above.
     try:
-        os.kill(pid, 0)
+        os.kill(pid, 0)  # windows-footgun: ok — function early-returns on nt above
     except ProcessLookupError:
         return True
     except (PermissionError, OSError, OverflowError):

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -46,6 +46,11 @@ def _compression_lock_holder_process_is_dead(holder: str) -> bool:
     only when the kernel proves that PID no longer exists; legacy/unstructured
     holders and permission errors remain protected until normal TTL expiry.
     """
+    # Python's os.kill(pid, 0) is a non-destructive liveness probe on POSIX.
+    # On Windows, any non-CTRL signal value is implemented with
+    # TerminateProcess, so fall back to TTL-only recovery there.
+    if os.name == "nt":
+        return False
     match = _COMPRESSION_LOCK_HOLDER_PID_RE.search(holder or "")
     if match is None:
         return False
@@ -59,7 +64,7 @@ def _compression_lock_holder_process_is_dead(holder: str) -> bool:
         os.kill(pid, 0)
     except ProcessLookupError:
         return True
-    except (PermissionError, OSError):
+    except (PermissionError, OSError, OverflowError):
         return False
     return False
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,6 +33,36 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
 
+_COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
+
+
+def _compression_lock_holder_process_is_dead(holder: str) -> bool:
+    """Return True only when a structured lock holder's local PID is gone.
+
+    Compression locks are stored in a host-local SQLite database and holder
+    IDs created by ``conversation_compression`` start with ``pid=<n>``. A
+    process killed during gateway shutdown cannot release its lease, so waiting
+    for the full TTL makes every new turn repeatedly attempt compaction. Reclaim
+    only when the kernel proves that PID no longer exists; legacy/unstructured
+    holders and permission errors remain protected until normal TTL expiry.
+    """
+    match = _COMPRESSION_LOCK_HOLDER_PID_RE.search(holder or "")
+    if match is None:
+        return False
+    try:
+        pid = int(match.group(1))
+    except (TypeError, ValueError):
+        return False
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
+    except (PermissionError, OSError):
+        return False
+    return False
+
 
 def _scrub_surrogates(value: Any) -> Any:
     """Replace lone surrogates when *value* is text; pass anything else through.
@@ -4152,10 +4182,10 @@ class SessionDB:
         MUST NOT proceed with compression in that case (its rotation would
         race against the holder's, splitting the session lineage).
 
-        Expired locks (``expires_at < now``) are reclaimed transparently:
-        the stale row is deleted and the new holder acquires it. This
-        prevents a crashed compressor from permanently blocking the
-        session.
+        Expired locks (``expires_at < now``) are reclaimed transparently.
+        Structured holders whose local ``pid=`` no longer exists are reclaimed
+        immediately, so a gateway killed during compression does not stall the
+        replacement process for the full lease TTL.
 
         Implementation: single-transaction DELETE-expired + INSERT-or-IGNORE,
         followed by a SELECT to confirm we got the row. SQLite serialises
@@ -4167,12 +4197,29 @@ class SessionDB:
         expires_at = now + ttl_seconds
 
         def _do(conn):
-            # First: reclaim any expired lock for this session_id.
-            conn.execute(
-                "DELETE FROM compression_locks "
-                "WHERE session_id = ? AND expires_at < ?",
-                (session_id, now),
-            )
+            reclaimed_holder = None
+            row = conn.execute(
+                "SELECT holder, expires_at FROM compression_locks "
+                "WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is not None:
+                current_holder = (
+                    row["holder"] if isinstance(row, sqlite3.Row) else row[0]
+                )
+                current_expires_at = (
+                    row["expires_at"] if isinstance(row, sqlite3.Row) else row[1]
+                )
+                if (
+                    current_expires_at < now
+                    or _compression_lock_holder_process_is_dead(current_holder)
+                ):
+                    conn.execute(
+                        "DELETE FROM compression_locks "
+                        "WHERE session_id = ? AND holder = ?",
+                        (session_id, current_holder),
+                    )
+                    reclaimed_holder = current_holder
             # Then: try to insert. INSERT OR IGNORE returns no rowcount
             # difference — verify ownership via SELECT.
             conn.execute(
@@ -4185,12 +4232,21 @@ class SessionDB:
                 "SELECT holder FROM compression_locks WHERE session_id = ?",
                 (session_id,),
             ).fetchone()
-            return row is not None and (
+            acquired = row is not None and (
                 row["holder"] if isinstance(row, sqlite3.Row) else row[0]
             ) == holder
+            return acquired, reclaimed_holder
 
         try:
-            return bool(self._execute_write(_do))
+            acquired, reclaimed_holder = self._execute_write(_do)
+            if reclaimed_holder:
+                logger.warning(
+                    "Reclaimed stale compression lock for session=%s "
+                    "(holder=%s)",
+                    session_id,
+                    reclaimed_holder,
+                )
+            return bool(acquired)
         except sqlite3.Error as exc:
             logger.warning(
                 "try_acquire_compression_lock(%s) failed: %s",

--- a/tests/test_hermes_state_compression_locks.py
+++ b/tests/test_hermes_state_compression_locks.py
@@ -16,6 +16,7 @@ import os
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -109,6 +110,33 @@ def test_non_expired_lock_from_dead_pid_is_reclaimed(
         "sess1", dead_holder, ttl_seconds=300
     ) is True
 
+    probed: list[int] = []
+
+    def process_is_gone(pid: int) -> bool:
+        probed.append(pid)
+        return False
+
+    monkeypatch.setattr(
+        hermes_state, "psutil", SimpleNamespace(pid_exists=process_is_gone)
+    )
+
+    assert db.try_acquire_compression_lock(
+        "sess1", "pid=525252:tid=2:agent=def:nonce=fresh", ttl_seconds=300
+    ) is True
+    assert probed == [424242]
+
+
+def test_dead_pid_reclaim_via_os_kill_fallback_when_psutil_missing(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scaffold-phase installs (no psutil) fall back to os.kill(pid, 0)."""
+    dead_holder = "pid=424242:tid=1:agent=abc:nonce=deadbeef"
+    assert db.try_acquire_compression_lock(
+        "sess1", dead_holder, ttl_seconds=300
+    ) is True
+
+    monkeypatch.setattr(hermes_state, "psutil", None)
+
     def process_is_gone(pid: int, signal: int) -> None:
         assert pid == 424242
         assert signal == 0
@@ -121,6 +149,28 @@ def test_non_expired_lock_from_dead_pid_is_reclaimed(
     ) is True
 
 
+def test_probe_doubt_keeps_lease_until_ttl(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A probe that errors out is doubt, not proof of death → TTL protects."""
+    holder = "pid=424242:tid=1:agent=abc:nonce=doubt"
+    assert db.try_acquire_compression_lock(
+        "sess1", holder, ttl_seconds=300
+    ) is True
+
+    def probe_blows_up(pid: int) -> bool:
+        raise RuntimeError("transient probe failure")
+
+    monkeypatch.setattr(
+        hermes_state, "psutil", SimpleNamespace(pid_exists=probe_blows_up)
+    )
+
+    assert db.try_acquire_compression_lock(
+        "sess1", "pid=525252:tid=2:agent=def:nonce=other", ttl_seconds=300
+    ) is False
+    assert db.get_compression_lock_holder("sess1") == holder
+
+
 def test_non_expired_lock_from_live_pid_is_not_reclaimed(db: SessionDB) -> None:
     live_holder = f"pid={os.getpid()}:tid=1:agent=abc:nonce=live"
     assert db.try_acquire_compression_lock(
@@ -131,12 +181,51 @@ def test_non_expired_lock_from_live_pid_is_not_reclaimed(db: SessionDB) -> None:
     ) is False
 
 
+def test_same_process_holder_is_never_self_reclaimed(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A holder from THIS pid is never probed — even a lying probe can't steal it."""
+    live_holder = f"pid={os.getpid()}:tid=1:agent=abc:nonce=self"
+    assert db.try_acquire_compression_lock(
+        "sess1", live_holder, ttl_seconds=300
+    ) is True
+    # Even if a (broken) probe were to claim our own PID is dead, the
+    # same-process guard short-circuits before any probe runs.
+    monkeypatch.setattr(
+        hermes_state,
+        "psutil",
+        SimpleNamespace(
+            pid_exists=lambda _pid: pytest.fail(
+                "same-process holder must not be probed"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        hermes_state.os,
+        "kill",
+        lambda *_args: pytest.fail("same-process holder must not be probed"),
+    )
+    assert db.try_acquire_compression_lock(
+        "sess1", "pid=525252:tid=2:agent=def:nonce=other", ttl_seconds=300
+    ) is False
+    assert db.get_compression_lock_holder("sess1") == live_holder
+
+
 def test_unstructured_holder_waits_for_ttl(
     db: SessionDB, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     assert db.try_acquire_compression_lock(
         "sess1", "legacy_holder", ttl_seconds=300
     ) is True
+    monkeypatch.setattr(
+        hermes_state,
+        "psutil",
+        SimpleNamespace(
+            pid_exists=lambda _pid: pytest.fail(
+                "unstructured holder must not probe a PID"
+            )
+        ),
+    )
     monkeypatch.setattr(
         hermes_state.os,
         "kill",
@@ -147,7 +236,7 @@ def test_unstructured_holder_waits_for_ttl(
     ) is False
 
 
-def test_windows_uses_ttl_only_without_os_kill(
+def test_windows_uses_ttl_only_without_pid_probe(
     db: SessionDB, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     holder = "pid=424242:tid=1:agent=abc:nonce=windows"
@@ -155,6 +244,15 @@ def test_windows_uses_ttl_only_without_os_kill(
         "sess1", holder, ttl_seconds=300
     ) is True
     monkeypatch.setattr(hermes_state.os, "name", "nt")
+    monkeypatch.setattr(
+        hermes_state,
+        "psutil",
+        SimpleNamespace(
+            pid_exists=lambda _pid: pytest.fail(
+                "Windows must stay TTL-only — no PID probe"
+            )
+        ),
+    )
     monkeypatch.setattr(
         hermes_state.os,
         "kill",

--- a/tests/test_hermes_state_compression_locks.py
+++ b/tests/test_hermes_state_compression_locks.py
@@ -12,12 +12,14 @@ diagnostic accessor) — not the wiring into compression.
 
 from __future__ import annotations
 
+import os
 import threading
 import time
 from pathlib import Path
 
 import pytest
 
+import hermes_state
 from hermes_state import SessionDB
 
 
@@ -97,6 +99,53 @@ def test_non_expired_lock_is_held(db: SessionDB) -> None:
     db.try_acquire_compression_lock("sess1", "holder1", ttl_seconds=60)
     # Immediately after, still held
     assert db.try_acquire_compression_lock("sess1", "holder2") is False
+
+
+def test_non_expired_lock_from_dead_pid_is_reclaimed(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dead_holder = "pid=424242:tid=1:agent=abc:nonce=deadbeef"
+    assert db.try_acquire_compression_lock(
+        "sess1", dead_holder, ttl_seconds=300
+    ) is True
+
+    def process_is_gone(pid: int, signal: int) -> None:
+        assert pid == 424242
+        assert signal == 0
+        raise ProcessLookupError
+
+    monkeypatch.setattr(hermes_state.os, "kill", process_is_gone)
+
+    assert db.try_acquire_compression_lock(
+        "sess1", "pid=525252:tid=2:agent=def:nonce=fresh", ttl_seconds=300
+    ) is True
+
+
+def test_non_expired_lock_from_live_pid_is_not_reclaimed(db: SessionDB) -> None:
+    live_holder = f"pid={os.getpid()}:tid=1:agent=abc:nonce=live"
+    assert db.try_acquire_compression_lock(
+        "sess1", live_holder, ttl_seconds=300
+    ) is True
+    assert db.try_acquire_compression_lock(
+        "sess1", "pid=525252:tid=2:agent=def:nonce=other", ttl_seconds=300
+    ) is False
+
+
+def test_unstructured_holder_waits_for_ttl(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert db.try_acquire_compression_lock(
+        "sess1", "legacy_holder", ttl_seconds=300
+    ) is True
+    kill = monkeypatch.setattr(
+        hermes_state.os,
+        "kill",
+        lambda *_args: pytest.fail("unstructured holder must not probe a PID"),
+    )
+    assert kill is None
+    assert db.try_acquire_compression_lock(
+        "sess1", "pid=525252:tid=2:agent=def:nonce=other", ttl_seconds=300
+    ) is False
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_hermes_state_compression_locks.py
+++ b/tests/test_hermes_state_compression_locks.py
@@ -137,12 +137,30 @@ def test_unstructured_holder_waits_for_ttl(
     assert db.try_acquire_compression_lock(
         "sess1", "legacy_holder", ttl_seconds=300
     ) is True
-    kill = monkeypatch.setattr(
+    monkeypatch.setattr(
         hermes_state.os,
         "kill",
         lambda *_args: pytest.fail("unstructured holder must not probe a PID"),
     )
-    assert kill is None
+    assert db.try_acquire_compression_lock(
+        "sess1", "pid=525252:tid=2:agent=def:nonce=other", ttl_seconds=300
+    ) is False
+
+
+def test_windows_uses_ttl_only_without_os_kill(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    holder = "pid=424242:tid=1:agent=abc:nonce=windows"
+    assert db.try_acquire_compression_lock(
+        "sess1", holder, ttl_seconds=300
+    ) is True
+    monkeypatch.setattr(hermes_state.os, "name", "nt")
+    monkeypatch.setattr(
+        hermes_state.os,
+        "kill",
+        lambda *_args: pytest.fail("Windows must not use os.kill as a PID probe"),
+    )
+
     assert db.try_acquire_compression_lock(
         "sess1", "pid=525252:tid=2:agent=def:nonce=other", ttl_seconds=300
     ) is False


### PR DESCRIPTION
# Salvage PR #65775: reclaim compression leases from dead PIDs

Salvages the **dead-PID compression-lease reclamation** half of DRAFT PR #65775 by **@the3asic** (author of merged #69324 — active contributor). Their two `hermes_state.py` commits are cherry-picked onto current main **with authorship preserved**, plus one hardening follow-up commit of ours.

## Problem (verified on main @ c2c2449d05)

`SessionDB.try_acquire_compression_lock` (`hermes_state.py:4139`) reclaims **only expired rows** (`DELETE … WHERE expires_at < ?`). The lease refresher keeps live holders alive, but a gateway **killed mid-compression** cannot release its lease — its replacement process is blocked from compressing for up to the full **300s TTL**, and every new turn re-attempts compaction against the stale lock. The holder string is structured (`pid=<n>:tid=…`, `conversation_compression.py:370-375`), so a local PID liveness probe is applicable.

## Fix

On acquire contention, `_compression_lock_holder_process_is_dead()` parses the current holder; if it carries a `pid=` and that PID is **provably dead** on this host, the stale lease is reclaimed immediately (single write transaction — same atomicity as the expired-row path). Everything else stays conservative:

- **Legacy/unstructured holders** — TTL-protected, never probed.
- **Same-process holders** (`pid == os.getpid()`) — never self-reclaimed; the lease refresher/release path owns them.
- **Windows** — TTL-only (`os.name == "nt"` early return; stdlib `os.kill(pid, 0)` is destructive there, bpo-14484).
- **Any probe doubt** (permission errors, probe exceptions) — keep the lease until normal TTL expiry. PID reuse yields a conservative false-negative (probe says "alive"), never a stolen live lease.
- **DB error contract unchanged** — `sqlite3.Error` still swallows to `False`; contention/DB errors never raise to callers.
- The reclamation lives **inside `hermes_state.py`**, so every acquire path (auto, manual /compress, idle, preflight) inherits it.
- The reclaim log line is **server-side `logger.warning` only** — no user-facing status (per the routine-compression-silence design; no new noise-regex entries needed).

## What was cherry-picked vs added

| Commit | Author | Content |
|---|---|---|
| `fix(compression): reclaim locks from dead processes` | @the3asic (cherry-picked) | holder parse + dead-PID probe + single-txn reclaim + 3 lock tests |
| `fix(compression): keep PID probing POSIX-only` | @the3asic (cherry-picked) | `os.name == "nt"` TTL-only gate + Windows test |
| `fix(compression): prefer psutil.pid_exists …; same-pid guard` | ours (hardening) | see below |

**Hardening follow-up (ours):**
- Probe via **`psutil.pid_exists`** (psutil is a hard dependency; CONTRIBUTING.md critical rule #1 bans `os.kill(pid, 0)` liveness probes), keeping the contributor's `os.kill(pid, 0)` POSIX probe only as a scaffold-phase fallback when psutil is missing (gated behind the `nt` early-return, `# windows-footgun: ok` suppressed).
- **Same-process guard**: a holder whose `pid` equals `os.getpid()` is never probed and never self-reclaimed.
- Probe-doubt path pinned: any probe exception conservatively keeps the lease.
- Tests extended to pin the psutil-first probe (probe-call recorded), the os.kill fallback, probe-doubt retention, and no-probe assertions on **both** APIs for legacy/same-pid/Windows paths.

**Dropped from the draft:** the `conversation_loop.py` hardcoded `attempts = 3` retry-suppression hunk (`ab5f70fd7b`). It is superseded by the insufficient-progress blocker and the configurable `compression.max_attempts` knob from #69315 — hardcoding 3 would clamp user config above the default (a regression), so that half is intentionally not salvaged.

## Validation

| Check | Result |
|---|---|
| `tests/test_hermes_state_compression_locks.py` (lock suite, 12 → 19 tests) | ✅ 19/19 |
| `tests/agent/test_compression_concurrent_fork.py` (fork/lease-refresher suite) | ✅ 43/43 |
| `tests/agent/test_compression_anti_thrash_persistence.py` | ✅ 10/10 |
| Dead-pid reclaim / live-pid untouched / legacy untouched / same-pid no self-reclaim / Windows TTL-only / probe-doubt keeps lease | ✅ all pinned |
| `ruff check` on changed files | ✅ clean |
| `scripts/check-windows-footguns.py` on changed files | ✅ no footguns |
| Rebased onto current main; diff = 2 files only | ✅ |

Contributor mapping: `contributors/emails/the3asic@users.noreply.github.com` already exists on main — no mapping change needed.

Closes-when-merged note: original draft #65775 should be closed with credit after this merges (its remaining loop hunk is superseded by #69315).

## Infographic

![dead-pid-lease-reclaim](https://v3b.fal.media/files/b/0aa37054/apZNwOtyh63bsQk7sg_Bg_EAupsW0e.png)
