### PR TITLE
feat(compress): N-user tail guarantee via compression.min_tail_user_messages (salvage of #22566)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1810,7 +1810,28 @@ def init_agent(
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
-    compression_min_tail_users = int(_compression_cfg.get("min_tail_user_messages", 3))
+    # Minimum REAL (actionable) user messages guaranteed to survive in the
+    # uncompressed tail (compression.min_tail_user_messages).  Default 1
+    # preserves current behavior exactly — the existing single-user tail
+    # anchor.  Values > 1 extend the guarantee to the last N actionable
+    # user turns.  Booleans rejected (bool subclasses int), non-int-like
+    # values fall back to 1, floor at 1.
+    _raw_min_tail_users = _compression_cfg.get("min_tail_user_messages", 1)
+    if isinstance(_raw_min_tail_users, bool):
+        compression_min_tail_users = 1
+    elif isinstance(_raw_min_tail_users, int):
+        compression_min_tail_users = _raw_min_tail_users
+    elif isinstance(_raw_min_tail_users, float):
+        compression_min_tail_users = (
+            int(_raw_min_tail_users) if _raw_min_tail_users.is_integer() else 1
+        )
+    else:
+        try:
+            compression_min_tail_users = int(str(_raw_min_tail_users).strip())
+        except (TypeError, ValueError):
+            compression_min_tail_users = 1
+    if compression_min_tail_users < 1:
+        compression_min_tail_users = 1
     # Cap on compression retry rounds before a turn gives up with "max
     # compression attempts reached" (compression.max_attempts).  Hardcoding 3
     # strands sessions that legitimately need more rounds — e.g. a restart

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1810,6 +1810,7 @@ def init_agent(
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
+    compression_min_tail_users = int(_compression_cfg.get("min_tail_user_messages", 3))
     # Cap on compression retry rounds before a turn gives up with "max
     # compression attempts reached" (compression.max_attempts).  Hardcoding 3
     # strands sessions that legitimately need more rounds — e.g. a restart
@@ -2348,6 +2349,7 @@ def init_agent(
             proactive_prune_tokens=compression_proactive_prune_tokens,
             proactive_prune_min_result_chars=compression_proactive_prune_min_chars,
             proactive_prune_min_reclaim_tokens=compression_proactive_prune_min_reclaim,
+            min_tail_user_messages=compression_min_tail_users,
         )
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4272,18 +4272,25 @@ This compaction should PRIORITISE preserving all information related to the focu
         head_end: int,
         n: int,
     ) -> int:
-        """Guarantee the last N user messages are in the protected tail.
+        """Guarantee the last N actionable user messages are in the protected tail.
 
         Generalizes ``_ensure_last_user_message_in_tail`` to preserve an
         arbitrary number of recent user messages.  This prevents the token-
         budget-based tail cut from consuming recent conversation turns
-        when large tool outputs fill the budget (COMPRESS-01).
+        when large tool outputs fill the budget.
 
         When *n* <= 1, delegates directly to the existing single-message
-        method for byte-identical regression safety (COMPRESS-08).
+        method for byte-identical regression safety.
 
         If the conversation has fewer than *n* user messages, the earliest
-        available user message is used without error (COMPRESS-07).
+        available user message is used without error.
+
+        Only REAL actionable user turns count toward N — the collector uses
+        the same ``_is_actionable_user_turn`` /
+        ``_is_synthetic_compression_user_turn`` pair as
+        ``_find_last_user_message_idx``, so blank platform echoes, compaction
+        handoffs, continuation markers, and todo-snapshot rows never consume
+        a slot (#69291 bug class).
 
         A user message is already a clean boundary — there is no
         tool_call/result group that spans across it, so
@@ -4295,13 +4302,15 @@ This compaction should PRIORITISE preserving all information related to the focu
             return self._ensure_last_user_message_in_tail(messages, cut_idx, head_end)
 
         # Collect real user message indices walking backward from end.
-        # Skip context-summary handoff banners — they are internal
-        # continuity state, not real user turns.
+        # Mirror _find_last_user_message_idx's filters: compaction handoffs,
+        # blank platform echoes, and synthetic continuation/todo rows are
+        # continuity artifacts, not real user turns.
         user_indices = []
         for i in range(len(messages) - 1, head_end - 1, -1):
             msg = messages[i]
-            if msg.get("role") == "user" and not self._is_context_summary_content(
-                msg.get("content")
+            if (
+                self._is_actionable_user_turn(msg)
+                and not self._is_synthetic_compression_user_turn(msg)
             ):
                 user_indices.append(i)
 
@@ -4449,15 +4458,20 @@ This compaction should PRIORITISE preserving all information related to the focu
         cut_idx = self._ensure_last_assistant_message_in_tail(messages, cut_idx, head_end)
 
         # Extend to the last N actionable user messages when configured
-        # (compression.min_tail_user_messages).  This prevents the
+        # (compression.min_tail_user_messages > 1).  This prevents the
         # token-budget tail from consuming recent turns when large tool
         # outputs fill the budget.  The anchor only walks ``cut_idx``
         # backward (monotonic — the tail can only grow, never shrink), and
         # a user message is a clean boundary, so the forward re-alignment
-        # below remains a no-op for the anchored index.
-        cut_idx = self._ensure_last_n_user_messages_in_tail(
-            messages, cut_idx, head_end, self.min_tail_user_messages,
-        )
+        # below remains a no-op for the anchored index.  Gated at the call
+        # site so the default (1) path is byte-identical to the historical
+        # single-anchor pipeline — the single-user anchor already ran above,
+        # and re-invoking it here could re-trigger the causal-coupling
+        # forward push (#22523) after the assistant anchor adjusted the cut.
+        if self.min_tail_user_messages > 1:
+            cut_idx = self._ensure_last_n_user_messages_in_tail(
+                messages, cut_idx, head_end, self.min_tail_user_messages,
+            )
 
         # The floor guarantees forward progress — compression must always claim
         # at least one message or the caller's compress_start >= compress_end

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1646,6 +1646,7 @@ class ContextCompressor(ContextEngine):
         proactive_prune_tokens: int = 0,
         proactive_prune_min_result_chars: int = 8000,
         proactive_prune_min_reclaim_tokens: int = 4096,
+        min_tail_user_messages: int = 1,
     ):
         self.model = model
         self.base_url = base_url
@@ -1700,6 +1701,7 @@ class ContextCompressor(ContextEngine):
         self.proactive_prune_min_reclaim_tokens = max(
             0, int(proactive_prune_min_reclaim_tokens or 0)
         )
+        self.min_tail_user_messages = min_tail_user_messages
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))
         self.quiet_mode = quiet_mode
         # Output-token reservation: the provider carves max_tokens out of the
@@ -4263,6 +4265,60 @@ This compaction should PRIORITISE preserving all information related to the focu
             return max(pair_end, head_end + 1)
         return adjusted
 
+    def _ensure_last_n_user_messages_in_tail(
+        self,
+        messages: List[Dict[str, Any]],
+        cut_idx: int,
+        head_end: int,
+        n: int,
+    ) -> int:
+        """Guarantee the last N user messages are in the protected tail.
+
+        Generalizes ``_ensure_last_user_message_in_tail`` to preserve an
+        arbitrary number of recent user messages.  This prevents the token-
+        budget-based tail cut from consuming recent conversation turns
+        when large tool outputs fill the budget (COMPRESS-01).
+
+        When *n* <= 1, delegates directly to the existing single-message
+        method for byte-identical regression safety (COMPRESS-08).
+
+        If the conversation has fewer than *n* user messages, the earliest
+        available user message is used without error (COMPRESS-07).
+
+        A user message is already a clean boundary — there is no
+        tool_call/result group that spans across it, so
+        ``_align_boundary_backward`` is intentionally NOT called.
+        Calling it can pull the cut past the user message into the
+        preceding assistant(tool_calls)→tool group and split it (#22566).
+        """
+        if n <= 1:
+            return self._ensure_last_user_message_in_tail(messages, cut_idx, head_end)
+
+        # Collect real user message indices walking backward from end.
+        # Skip context-summary handoff banners — they are internal
+        # continuity state, not real user turns.
+        user_indices = []
+        for i in range(len(messages) - 1, head_end - 1, -1):
+            msg = messages[i]
+            if msg.get("role") == "user" and not self._is_context_summary_content(
+                msg.get("content")
+            ):
+                user_indices.append(i)
+
+        if len(user_indices) == 0:
+            return cut_idx
+
+        if len(user_indices) < n:
+            target_idx = user_indices[-1]
+        else:
+            target_idx = user_indices[n - 1]
+
+        if target_idx >= cut_idx:
+            return cut_idx
+
+        cut_idx = target_idx
+        return max(cut_idx, head_end + 1)
+
     def _find_turn_pair_end(
         self,
         messages: List[Dict[str, Any]],
@@ -4391,6 +4447,17 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Each anchor only walks ``cut_idx`` backward, so chaining them is
         # monotonic — the tail can only grow, never shrink.
         cut_idx = self._ensure_last_assistant_message_in_tail(messages, cut_idx, head_end)
+
+        # Extend to the last N actionable user messages when configured
+        # (compression.min_tail_user_messages).  This prevents the
+        # token-budget tail from consuming recent turns when large tool
+        # outputs fill the budget.  The anchor only walks ``cut_idx``
+        # backward (monotonic — the tail can only grow, never shrink), and
+        # a user message is a clean boundary, so the forward re-alignment
+        # below remains a no-op for the anchored index.
+        cut_idx = self._ensure_last_n_user_messages_in_tail(
+            messages, cut_idx, head_end, self.min_tail_user_messages,
+        )
 
         # The floor guarantees forward progress — compression must always claim
         # at least one message or the caller's compress_start >= compress_end

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4468,9 +4468,13 @@ This compaction should PRIORITISE preserving all information related to the focu
         # single-anchor pipeline — the single-user anchor already ran above,
         # and re-invoking it here could re-trigger the causal-coupling
         # forward push (#22523) after the assistant anchor adjusted the cut.
-        if self.min_tail_user_messages > 1:
+        # getattr-guarded: bare ``ContextCompressor.__new__`` test doubles
+        # (and plugin engines) skip __init__, so the attribute may be absent
+        # (see the compression-path test-double pitfall).
+        _min_tail_users = getattr(self, "min_tail_user_messages", 1)
+        if isinstance(_min_tail_users, int) and not isinstance(_min_tail_users, bool) and _min_tail_users > 1:
             cut_idx = self._ensure_last_n_user_messages_in_tail(
-                messages, cut_idx, head_end, self.min_tail_user_messages,
+                messages, cut_idx, head_end, _min_tail_users,
             )
 
         # The floor guarantees forward progress — compression must always claim

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -448,6 +448,15 @@ compression:
   # compression of older turns.
   protect_last_n: 20
 
+  # Minimum number of REAL (actionable) user messages guaranteed to survive in
+  # the uncompressed tail (default: 1 = the existing single last-user anchor,
+  # behavior-preserving). Raise to e.g. 3 to keep the last 3 real user turns
+  # verbatim even when bulky tool outputs fill the tail token budget — blank
+  # platform echoes, compaction handoffs, and synthetic continuation rows never
+  # count toward N. The tail can exceed the token budget when this pulls the
+  # cut back; the guarantee wins over the budget by design.
+  min_tail_user_messages: 1
+
   # Compression retry rounds before a turn gives up with "max compression
   # attempts reached" (default: 3, same as the previous hardcoded value).
   # Raise (e.g. 6) for tool-schema-heavy sessions where 3 rounds cannot bring

--- a/cli.py
+++ b/cli.py
@@ -468,6 +468,7 @@ def load_cli_config() -> Dict[str, Any]:
         "compression": {
             "enabled": True,      # Auto-compress when approaching context limit
             "threshold": 0.50,    # Compress at 50% of model's context limit
+            "min_tail_user_messages": 3,  # Min recent user messages to preserve in tail after compression
         },
         "agent": {
             "max_turns": 90,  # Default max tool-calling iterations (shared with subagents)

--- a/cli.py
+++ b/cli.py
@@ -468,7 +468,7 @@ def load_cli_config() -> Dict[str, Any]:
         "compression": {
             "enabled": True,      # Auto-compress when approaching context limit
             "threshold": 0.50,    # Compress at 50% of model's context limit
-            "min_tail_user_messages": 3,  # Min recent user messages to preserve in tail after compression
+            "min_tail_user_messages": 1,  # Real user messages guaranteed in the tail (1 = existing single anchor)
         },
         "agent": {
             "max_turns": 90,  # Default max tool-calling iterations (shared with subagents)

--- a/contributors/emails/jerry@hermes.local
+++ b/contributors/emails/jerry@hermes.local
@@ -1,0 +1,1 @@
+zhangyang-crazy-one

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18125,6 +18125,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "proactive_prune_tokens"),
         ("compression", "proactive_prune_min_result_chars"),
         ("compression", "proactive_prune_min_reclaim_tokens"),
+        ("compression", "min_tail_user_messages"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
         ("checkpoints", "enabled"),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1409,6 +1409,12 @@ DEFAULT_CONFIG = {
                                       # the model's context length at apply-time.
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
+        "min_tail_user_messages": 1,  # REAL (actionable) user messages guaranteed to
+                                      # survive in the uncompressed tail. 1 = existing
+                                      # single last-user anchor (default, behavior-
+                                      # preserving); raise to e.g. 3 to keep the last
+                                      # 3 real user turns verbatim when bulky tool
+                                      # outputs fill the tail token budget.
         "max_attempts": 3,            # compression retry rounds before a turn gives up
                                       # with "max compression attempts reached". Raise
                                       # (e.g. 6) for tool-schema-heavy sessions where 3

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -4094,6 +4094,7 @@ class TestMinTailUserMessages:
                 threshold_percent=0.50,
                 protect_first_n=2,
                 quiet_mode=True,
+                min_tail_user_messages=3,
             )
         c.tail_token_budget = 200
         messages = [
@@ -4134,6 +4135,7 @@ class TestMinTailUserMessages:
                 threshold_percent=0.50,
                 protect_first_n=1,
                 quiet_mode=True,
+                min_tail_user_messages=3,
             )
         c.tail_token_budget = 200
         messages = [
@@ -4299,3 +4301,215 @@ class TestMinTailUserMessages:
             messages, cut_idx=2, head_end=head_end, n=3
         )
         assert result == 2  # unchanged
+
+    def test_default_is_behavior_preserving(self):
+        """Default min_tail_user_messages=1 leaves the tail cut byte-identical
+        to the historical single-anchor pipeline.
+
+        A default of 3 was measured to CHANGE the cut on transcripts whose
+        tail budget covers only the last turn, so the default is gated to 1
+        (= the existing single last-user anchor) and N>1 is opt-in.
+        """
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c_default = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=2,
+                quiet_mode=True,
+            )
+            c_explicit = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=2,
+                quiet_mode=True,
+                min_tail_user_messages=1,
+            )
+        assert c_default.min_tail_user_messages == 1
+        c_default.tail_token_budget = 200
+        c_explicit.tail_token_budget = 200
+        messages = [
+            {"role": "user", "content": "head msg"},
+            {"role": "assistant", "content": "head reply"},
+        ]
+        for i in range(3):
+            messages.append({"role": "user", "content": f"user {i}"})
+            messages.append({"role": "assistant", "content": "X" * 4000})
+        messages.append({"role": "user", "content": "final user"})
+        messages.append({"role": "assistant", "content": "final reply"})
+        head_end = c_default.protect_first_n
+        assert (
+            c_default._find_tail_cut_by_tokens(messages, head_end)
+            == c_explicit._find_tail_cut_by_tokens(messages, head_end)
+        )
+
+    def test_blank_echo_does_not_count_toward_n(self):
+        """A blank platform echo (empty user row) must not consume one of the
+        N slots — otherwise the guarantee silently degrades to N-1 real turns
+        (the #69291 bug class the single anchor already fixed)."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=1,
+                quiet_mode=True,
+                min_tail_user_messages=3,
+            )
+        messages = [
+            {"role": "user", "content": "head"},                 # 0 (head)
+            {"role": "assistant", "content": "head reply"},      # 1
+            {"role": "user", "content": "real oldest"},          # 2  <- 3rd real user
+            {"role": "assistant", "content": "reply oldest"},    # 3
+            {"role": "user", "content": "real middle"},          # 4
+            {"role": "assistant", "content": "reply middle"},    # 5
+            {"role": "user", "content": ""},                     # 6  blank echo
+            {"role": "assistant", "content": "reply to echo"},   # 7
+            {"role": "user", "content": "   "},                  # 8  whitespace echo
+            {"role": "assistant", "content": "another reply"},   # 9
+            {"role": "user", "content": "real latest"},          # 10
+            {"role": "assistant", "content": "final reply"},     # 11
+        ]
+        head_end = c.protect_first_n  # = 1
+        # cut_idx=10 → only "real latest" in tail; N=3 must walk back to
+        # index 2 ("real oldest"), NOT stop at a blank echo (6/8).
+        result = c._ensure_last_n_user_messages_in_tail(
+            messages, cut_idx=10, head_end=head_end, n=3
+        )
+        assert result == 2, (
+            f"3rd real user is at index 2, got cut {result} — blank echoes "
+            "must not count toward N"
+        )
+        tail_users = [
+            m["content"] for m in messages[result:]
+            if m["role"] == "user" and m["content"].strip()
+        ]
+        assert {"real oldest", "real middle", "real latest"} <= set(tail_users)
+
+    def test_synthetic_compression_rows_do_not_count_toward_n(self):
+        """Compaction handoff banners and continuation markers carry
+        role="user" after SessionDB projection but are continuity artifacts —
+        they must not consume N slots."""
+        from agent.context_compressor import (
+            COMPRESSION_CONTINUATION_USER_CONTENT,
+        )
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=1,
+                quiet_mode=True,
+                min_tail_user_messages=2,
+            )
+        messages = [
+            {"role": "user", "content": "head"},                              # 0 (head)
+            {"role": "assistant", "content": "head reply"},                   # 1
+            {"role": "user", "content": "real second"},                       # 2
+            {"role": "assistant", "content": "reply second"},                 # 3
+            {"role": "user", "content": SUMMARY_PREFIX + " old summary"},     # 4 handoff
+            {"role": "assistant", "content": "ack"},                          # 5
+            {"role": "user", "content": COMPRESSION_CONTINUATION_USER_CONTENT},  # 6 marker
+            {"role": "assistant", "content": "ack 2"},                        # 7
+            {"role": "user", "content": "real latest"},                       # 8
+            {"role": "assistant", "content": "final reply"},                  # 9
+        ]
+        head_end = c.protect_first_n
+        result = c._ensure_last_n_user_messages_in_tail(
+            messages, cut_idx=8, head_end=head_end, n=2
+        )
+        assert result == 2, (
+            f"2nd real user is at index 2, got cut {result} — synthetic "
+            "compression rows must not count toward N"
+        )
+
+    def test_n_boundary_never_orphans_tool_results(self):
+        """Integration: with N=3 the full tail-cut pipeline must never place
+        a tool result in the tail whose parent assistant(tool_calls) was
+        summarized away, or vice versa (no-orphan in BOTH directions)."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=1,
+                quiet_mode=True,
+                min_tail_user_messages=3,
+            )
+        c.tail_token_budget = 100
+        messages = [
+            {"role": "user", "content": "head"},                                   # 0
+            {"role": "assistant", "content": "head reply"},                        # 1
+            {"role": "user", "content": "real 3"},                                 # 2
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "call_a", "function": {"name": "t", "arguments": "{}"}}]},  # 3
+            {"role": "tool", "content": "R" * 2000, "tool_call_id": "call_a"},     # 4
+            {"role": "assistant", "content": "reply 3"},                           # 5
+            {"role": "user", "content": "real 2"},                                 # 6
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "call_b", "function": {"name": "t", "arguments": "{}"}}]},  # 7
+            {"role": "tool", "content": "S" * 2000, "tool_call_id": "call_b"},     # 8
+            {"role": "assistant", "content": "reply 2"},                           # 9
+            {"role": "user", "content": "real 1"},                                 # 10
+            {"role": "assistant", "content": "reply 1"},                           # 11
+        ]
+        head_end = c.protect_first_n
+        cut = c._find_tail_cut_by_tokens(messages, head_end)
+        tail = messages[cut:]
+        tail_call_ids = {
+            tc.get("id")
+            for m in tail if m.get("role") == "assistant"
+            for tc in (m.get("tool_calls") or [])
+        }
+        tail_result_ids = {
+            m.get("tool_call_id") for m in tail if m.get("role") == "tool"
+        }
+        assert tail_call_ids == tail_result_ids, (
+            f"tool pair split across N-boundary: calls={tail_call_ids} "
+            f"results={tail_result_ids}"
+        )
+        tail_users = [m["content"] for m in tail if m["role"] == "user"]
+        assert {"real 1", "real 2", "real 3"} <= set(tail_users)
+
+    def test_n_guarantee_wins_over_tail_token_budget_and_floor(self):
+        """Interaction contract: the N-user guarantee WINS over both
+        tail_token_budget and _MAX_TAIL_MESSAGE_FLOOR.
+
+        The budget walk (and its bounded message floor) computes the initial
+        cut; the N-anchor then only ever pulls the cut BACKWARD (tail can
+        grow, never shrink), exactly like the existing single-user and
+        assistant anchors. So a tiny budget cannot roll real users 2..N into
+        the summary, and the floor remains a lower bound, not a cap, on the
+        anchored tail.
+        """
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=1,
+                quiet_mode=True,
+                min_tail_user_messages=3,
+            )
+        # Budget covers roughly one bulky turn — without the N-anchor the
+        # cut lands after users 2..3.
+        c.tail_token_budget = 150
+        messages = [{"role": "user", "content": "head"},
+                    {"role": "assistant", "content": "head reply"}]
+        for i in (3, 2, 1):
+            messages.append({"role": "user", "content": f"real {i}"})
+            messages.append({"role": "assistant", "content": "B" * 6000})
+        head_end = c.protect_first_n
+        cut = c._find_tail_cut_by_tokens(messages, head_end)
+        tail = messages[cut:]
+        tail_users = [m["content"] for m in tail if m["role"] == "user"]
+        assert {"real 1", "real 2", "real 3"} <= set(tail_users), (
+            f"N-guarantee must win over the token budget; tail users: {tail_users}"
+        )
+        # The anchored tail legitimately exceeds the budget (and the 8-message
+        # floor is a minimum, not a cap): the guarantee is the stronger
+        # invariant by design.
+        from agent.context_compressor import _estimate_msg_budget_tokens
+        accumulated = sum(_estimate_msg_budget_tokens(m) for m in tail)
+        assert accumulated > c.tail_token_budget
+
+    def test_default_config_ships_behavior_preserving_value(self):
+        """DEFAULT_CONFIG ships min_tail_user_messages=1 so an unset key is
+        exactly the pre-feature single-anchor behavior."""
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert DEFAULT_CONFIG["compression"]["min_tail_user_messages"] == 1

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -4076,3 +4076,226 @@ class TestSummaryPromptBounding:
         # handoff prefix either.
         marker_only = bounded[bounded.index("\n\n...[summary input truncated"):]
         assert ContextCompressor.classify_summary_content(marker_only.lstrip()) is None
+
+
+class TestMinTailUserMessages:
+    """COMPRESS-01,02,07,08: N-user-message tail protection.
+
+    Tests the ``_ensure_last_n_user_messages_in_tail`` method and its
+    integration through ``_find_tail_cut_by_tokens``.
+    """
+
+    def test_n3_preserves_last_3_user_messages(self):
+        """COMPRESS-01: _find_tail_cut_by_tokens with min_tail_user_messages=3
+        guarantees the last 3 user-role messages are in the tail."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=2,
+                quiet_mode=True,
+            )
+        c.tail_token_budget = 200
+        messages = [
+            {"role": "user", "content": "head msg 1"},
+            {"role": "assistant", "content": "head reply 1"},
+            {"role": "user", "content": "middle 1"},
+            {"role": "assistant", "content": "middle 1 reply"},
+            {"role": "user", "content": "middle 2"},
+            {"role": "assistant", "content": "middle 2 reply"},
+            {"role": "user", "content": "recent 3"},
+            {"role": "assistant", "content": "recent 3 reply"},
+            {"role": "user", "content": "recent 2"},
+            {"role": "assistant", "content": "recent 2 reply"},
+            {"role": "user", "content": "recent 1"},
+            {"role": "assistant", "content": "recent 1 reply"},
+        ]
+        head_end = c.protect_first_n
+        cut = c._find_tail_cut_by_tokens(messages, head_end)
+        tail_messages = messages[cut:]
+        tail_user_contents = [m["content"] for m in tail_messages if m["role"] == "user"]
+        assert len(tail_user_contents) >= 3, (
+            f"Expected >= 3 user messages in tail, got {len(tail_user_contents)}"
+        )
+        assert "recent 1" in tail_user_contents
+        assert "recent 2" in tail_user_contents
+        assert "recent 3" in tail_user_contents
+        assert cut >= head_end + 1
+
+    def test_n3_tool_group_integrity(self):
+        """COMPRESS-02: When the 3rd-to-last user message is preceded by
+        assistant(tool_calls) + tool results, the boundary is set at the
+        user message (a clean boundary).  The preceding tool group stays
+        together — it is either entirely in the compressed region or
+        entirely in the tail, never split across the boundary."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=1,
+                quiet_mode=True,
+            )
+        c.tail_token_budget = 200
+        messages = [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"function": {"name": "read_file", "arguments": "{}"}}]},
+            {"role": "tool", "content": "result content",
+             "tool_call_id": "call_1"},
+            {"role": "user", "content": "user 3rd last"},
+            {"role": "assistant", "content": "reply 3rd last"},
+            {"role": "user", "content": "user 2nd last"},
+            {"role": "assistant", "content": "reply 2nd last"},
+            {"role": "user", "content": "user last"},
+            {"role": "assistant", "content": "reply last"},
+        ]
+        head_end = c.protect_first_n
+        cut = c._find_tail_cut_by_tokens(messages, head_end)
+        compressed = messages[:cut]
+        tool_positions = [
+            i for i, m in enumerate(compressed)
+            if m.get("role") in ("assistant", "tool")
+            and (m.get("tool_calls") or m.get("tool_call_id"))
+        ]
+        if len(tool_positions) >= 2:
+            assert tool_positions[-1] - tool_positions[0] == len(tool_positions) - 1, (
+                "Tool group must stay contiguous across the boundary"
+            )
+        tail_messages = messages[cut:]
+        tail_users = [m["content"] for m in tail_messages if m["role"] == "user"]
+        assert "user 3rd last" in tail_users
+        assert "user 2nd last" in tail_users
+        assert "user last" in tail_users
+        assert cut >= head_end + 1
+
+    def test_n1_regression_safety(self):
+        """COMPRESS-08: N=1 produces identical tail positioning to the existing
+        _ensure_last_user_message_in_tail method."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.85,
+                protect_first_n=2,
+                quiet_mode=True,
+            )
+            c.min_tail_user_messages = 1
+        messages = [
+            {"role": "user", "content": "head 1"},
+            {"role": "assistant", "content": "head reply 1"},
+            {"role": "user", "content": "middle user"},
+            {"role": "assistant", "content": "middle reply"},
+            {"role": "user", "content": "last user"},
+            {"role": "assistant", "content": "last reply"},
+        ]
+        head_end = c.protect_first_n
+        cut1 = c._find_tail_cut_by_tokens(messages, head_end)
+        tail1 = messages[cut1:]
+        # Verify the last user message is in the tail
+        tail_users = [m["content"] for m in tail1 if m["role"] == "user"]
+        assert "last user" in tail_users
+        assert cut1 >= head_end + 1
+
+    def test_fewer_than_n_user_messages(self):
+        """COMPRESS-07: When the conversation has fewer than N user messages,
+        the earliest available user message is used without error."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=2,
+                quiet_mode=True,
+            )
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply 1"},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "reply 2"},
+        ]
+        # Only 2 user messages, but N=5 — should use earliest found
+        head_end = c.protect_first_n
+        result = c._ensure_last_n_user_messages_in_tail(
+            messages, cut_idx=3, head_end=head_end, n=5
+        )
+        # Should not crash, boundary should be before the first user message
+        # (index 0) or at most cut_idx
+        assert result <= 3
+
+    def test_nth_user_already_in_tail_no_reposition(self):
+        """When the Nth user message is already in the tail, cut_idx is unchanged."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=2,
+                quiet_mode=True,
+            )
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply 1"},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "reply 2"},
+            {"role": "user", "content": "third"},
+            {"role": "assistant", "content": "reply 3"},
+        ]
+        head_end = c.protect_first_n
+        # cut_idx at 2 means all users from index 2 onward are in tail
+        result = c._ensure_last_n_user_messages_in_tail(
+            messages, cut_idx=2, head_end=head_end, n=3
+        )
+        assert result == 2  # unchanged
+
+    def test_n5_preserves_last_5_user_messages(self):
+        """COMPRESS-06: min_tail_user_messages=5 protects last 5 user messages."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=1,
+                quiet_mode=True,
+            )
+            c.min_tail_user_messages = 5
+        c.tail_token_budget = 500
+        # protect_first_n=1 → head_end=1, so index 0 is head.
+        # u1..u5 must all be at indices >= head_end+1 (=2) to survive the clamp.
+        messages = [
+            {"role": "user", "content": "head 1"},            # 0 (head)
+            {"role": "assistant", "content": "head reply"},   # 1 (head_end boundary)
+            {"role": "user", "content": "u1"},                # 2
+            {"role": "assistant", "content": "a1"},           # 3
+            {"role": "user", "content": "u2"},                # 4
+            {"role": "assistant", "content": "a2"},           # 5
+            {"role": "user", "content": "u3"},                # 6
+            {"role": "assistant", "content": "a3"},           # 7
+            {"role": "user", "content": "u4"},                # 8
+            {"role": "assistant", "content": "a4"},           # 9
+            {"role": "user", "content": "u5"},                # 10
+            {"role": "assistant", "content": "a5"},           # 11
+        ]
+        head_end = c.protect_first_n  # = 1
+        cut = c._find_tail_cut_by_tokens(messages, head_end)
+        tail_users = [m["content"] for m in messages[cut:] if m["role"] == "user"]
+        assert len(tail_users) >= 5, f"Expected >=5 users in tail, got {len(tail_users)}"
+        for u in ("u1", "u2", "u3", "u4", "u5"):
+            assert u in tail_users
+        assert cut >= head_end + 1
+
+    def test_no_user_messages_beyond_head(self):
+        """When there are no user messages beyond head_end, cut_idx is unchanged."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=5,
+                quiet_mode=True,
+            )
+        messages = [
+            {"role": "user", "content": "msg 1"},
+            {"role": "assistant", "content": "reply 1"},
+            {"role": "user", "content": "msg 2"},
+            {"role": "assistant", "content": "reply 2"},
+        ]
+        head_end = c.protect_first_n  # = 5 > len(messages)
+        result = c._ensure_last_n_user_messages_in_tail(
+            messages, cut_idx=2, head_end=head_end, n=3
+        )
+        assert result == 2  # unchanged

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -87,6 +87,7 @@ compression:
   #   "claude-sonnet": 0.35  # overrides" below.
   target_ratio: 0.20         # How much of threshold to keep as tail (default: 0.20)
   protect_last_n: 20         # Minimum protected tail messages (default: 20)
+  min_tail_user_messages: 1  # Real user messages guaranteed in the tail (default: 1)
   codex_gpt55_autoraise: true  # gpt-5.5 on Codex OAuth: raise trigger to 85% (default: true)
   codex_gpt55_autoraise_notice: true  # Show the one-time autoraise notice (default: true)
   codex_app_server_auto: native  # native|hermes|off for Codex app-server thread compaction
@@ -107,6 +108,7 @@ auxiliary:
 | `model_thresholds` | `{}` | map | Per-model overrides of `threshold`. Keys are substring-matched against the model name (longest match wins). The small-context floor still applies on top (see below) |
 | `target_ratio` | `0.20` | 0.10-0.80 | Controls tail protection token budget: `threshold_tokens × target_ratio` |
 | `protect_last_n` | `20` | ≥1 | Minimum number of recent messages always preserved |
+| `min_tail_user_messages` | `1` | ≥1 | Minimum number of REAL (actionable) user messages guaranteed to survive in the uncompressed tail. `1` = the existing single last-user anchor (behavior-preserving default). Raise to e.g. `3` to keep the last 3 real user turns verbatim even when bulky tool outputs fill the tail token budget. Blank platform echoes, compaction handoffs, and synthetic continuation rows never count toward N. The guarantee wins over the tail token budget — the tail may exceed the budget when the anchor pulls the cut back |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
 | `idle_compact_after_seconds` | `0` | ≥0 seconds | Opt-in: compact up front when a session resumes after this many seconds idle (0 = disabled). Skips when context ≤ threshold × target_ratio; honors cooldown/anti-thrash/lock guards |
 | `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.5 on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |


### PR DESCRIPTION
## Salvage of PR #22566 — `compression.min_tail_user_messages` (N-user tail guarantee)

Salvages @zhangyang-crazy-one's #22566: a config-driven guarantee that the last **N real user messages** survive in the uncompressed tail during context compression. Contributor commit cherry-picked with authorship preserved (`Jerry <jerry@hermes.local>`, mapped to @zhangyang-crazy-one via `contributors/emails/`).

### The gap on main

Main has a single last-user tail anchor (`_ensure_last_user_message_in_tail`, #10896/#22523) plus the actionable-turn filters from #69291 — but **nothing guarantees more than one** real user turn survives. When bulky tool outputs fill `tail_token_budget`, users 2..N roll into the summary. Verified live on main:

```
N=1 (main behavior): cut=4 → tail users: ['real 2', 'real 1']   ← 'real 3' summarized away
N=3 (this PR):       cut=2 → tail users: ['real 3', 'real 2', 'real 1']
```

(3 user turns each followed by a 6 000-char tool-heavy assistant reply, tail budget 150 tokens.)

### What was salvaged from the contributor (cherry-picked)

- `_ensure_last_n_user_messages_in_tail()` — generalizes the single anchor to N; `N<=1` delegates directly to `_ensure_last_user_message_in_tail` for byte-identical regression safety.
- `min_tail_user_messages` ContextCompressor param + `agent_init.py` parse + `cli.py` embedded default + gateway cache-busting key `("compression", "min_tail_user_messages")`.
- 7 tests in `TestMinTailUserMessages` (N=3, N=5, tool-group integrity, fewer-than-N, already-in-tail no-op, no-users-beyond-head, N=1 parity).
- The contributor's head **already fixed 2 of 3 sweeper-review concerns**: the N-helper doesn't call `_align_boundary_backward` (a user message is a clean boundary — calling it can pull the cut into the preceding tool group and split it), and summary handoffs are filtered out of the collection walk. Credit where due.

Dropped from the branch (out of scope): unrelated DeepSeek/Weixin/run_agent hunks — only the compressor mechanism + config wiring is ported.

### Follow-up fixes on top (maintainer commit)

1. **N-collector now counts only REAL actionable turns.** The contributor's collector used bare `role == "user"` + `_is_context_summary_content` — blank platform echoes and synthetic continuation/todo rows would consume N slots, silently degrading the guarantee to N−1 (or worse) real turns and re-importing the #69291 bug class. The collector now uses the exact filter pair `_find_last_user_message_idx` uses post-#69291: `_is_actionable_user_turn(msg) and not _is_synthetic_compression_user_turn(msg)`.
2. **Default flipped 3 → 1 (behavior-preserving).** Verified empirically: a default of 3 CHANGES the tail cut on current main for transcripts whose budget covers only the last turn (`cut N=1: 5` vs `cut N=3: 4` on a 12-message probe). Since the salvage bar is "existing behavior unchanged unless configured", the default ships as **1** — exactly the existing single-user anchor — and N>1 is opt-in. The `_find_tail_cut_by_tokens` call site is additionally gated on `min_tail_user_messages > 1`, so the default path is byte-identical to main (and the single anchor's #22523 causal-coupling forward-push logic is never re-run after the assistant anchor).
3. **Hardened config parse** in `agent_init.py` matching the `max_attempts` parser shape: booleans rejected (bool subclasses int), fractional floats rejected, floor 1.
4. **Closed the recurring external-PR config gap:** the original PR only wired `cli.py`. Added `hermes_cli/config.py` `DEFAULT_CONFIG` + `cli-config.yaml.example` + docs table row (`website/docs/developer-guide/context-compression-and-caching.md`).

### Precedence semantics (documented contract)

**The N-guarantee wins over `tail_token_budget`, and `_MAX_TAIL_MESSAGE_FLOOR` stays a minimum, not a cap.** The budget walk (bounded by the 8-message floor and the 1.5× soft ceiling) computes the initial cut; the N-anchor then only ever pulls the cut **backward** — the same monotonic "tail can only grow" contract as the existing user/assistant anchors, applied after them and before the final forward tool-group re-alignment. Rationale: the anchors exist precisely for the case where the budget makes the wrong call (bulky tool outputs), so budget-wins would make the knob a no-op in the one scenario it targets. A user message is a clean boundary, so the anchored index can never split a tool_call/result pair; the pinned test asserts no-orphan in **both** directions.

### Regression tests added

| Test | Pins |
|---|---|
| `test_blank_echo_does_not_count_toward_n` | Blank/whitespace platform echoes don't consume N slots (#69291 class) |
| `test_synthetic_compression_rows_do_not_count_toward_n` | Compaction handoffs + continuation markers don't count toward N |
| `test_n_boundary_never_orphans_tool_results` | Full pipeline: tool call/result ids in the tail match exactly (no split in either direction) |
| `test_n_guarantee_wins_over_tail_token_budget_and_floor` | N-anchor beats a tiny budget; anchored tail legitimately exceeds it |
| `test_default_is_behavior_preserving` | Default cut byte-identical to explicit `min_tail_user_messages=1` |
| `test_default_config_ships_behavior_preserving_value` | `DEFAULT_CONFIG["compression"]["min_tail_user_messages"] == 1` |

### Validation

| Check | Result |
|---|---|
| `tests/agent/test_context_compressor.py` (incl. 13 `TestMinTailUserMessages` tests) | ✅ 208 passed |
| Sibling anchor/provenance/rotation suites (`test_compression_rotation_state`, `test_compressor_actionable_tail_anchor`, `test_compressor_assistant_tail_anchor`, `test_context_compressor_temporal_anchoring`, `test_context_compressor_zero_user_provenance`) | ✅ 79 passed |
| `tests/agent/test_compression_max_attempts_config.py` (adjacent parser seam) | ✅ 9 passed |
| Combined re-run post-rebase | ✅ 296 passed, 0 failed |
| `ruff check` on all touched files | ✅ clean |
| Live probe: N=1 vs N=3 cut on tool-heavy transcript | ✅ gap reproduced, fix verified (numbers above) |
| Default-3 behavior change probe | ✅ confirmed change → default gated to 1 |

Credit: @zhangyang-crazy-one for the mechanism, the clean-boundary insight (no `_align_boundary_backward` in the N-helper), and the handoff filtering — both post-review fixes were already on their head.

## Infographic

![n-user-tail-guarantee](https://v3b.fal.media/files/b/0aa37065/zvujls9eUGZVeOJKKhC5a_fFvtRsyp.png)
