### PR TITLE
fix(cron): retain adapter credentials for fallback delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1609,6 +1609,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             and loop is not None
             and getattr(loop, "is_running", lambda: False)()
         )
+        # A running adapter retains the PlatformConfig it was constructed with.
+        # Prefer that same config for the standalone fallback: credentials may
+        # have been injected only at gateway startup and subsequently scrubbed
+        # from the process environment, so a fresh config load can be missing
+        # secrets that the live adapter still holds.  True standalone delivery
+        # (no runtime adapter/config) continues to use the freshly loaded config.
+        runtime_pconfig = getattr(runtime_adapter, "__dict__", {}).get("config")
+        fallback_pconfig = runtime_pconfig if runtime_pconfig is not None else pconfig
         delivered = False
         target_errors = []
 
@@ -1997,7 +2005,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_to_platform(platform, fallback_pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -2026,7 +2034,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        future = pool.submit(asyncio.run, _send_to_platform(platform, fallback_pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3725,6 +3725,92 @@ class TestDeliverResultTimeoutCancelsFuture:
         standalone_send.assert_awaited_once()
         assert result is None, f"standalone should have delivered, got: {result!r}"
 
+    def test_live_adapter_fallback_uses_retained_runtime_config(self, monkeypatch):
+        """A scrubbed environment must not discard the live adapter's startup
+        credentials when its send fails and cron falls back to standalone."""
+        from concurrent.futures import Future
+        from gateway.config import Platform, PlatformConfig
+
+        monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+        retained_config = PlatformConfig(enabled=True, token="runtime-retained-token")
+        loaded_config = PlatformConfig(enabled=True, token=None)
+
+        class FailingRuntimeAdapter:
+            def __init__(self):
+                self.config = retained_config
+
+            async def send(self, *args, **kwargs):
+                return None
+
+        adapter = FailingRuntimeAdapter()
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: loaded_config}
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        failed_future = Future()
+        failed_future.result = MagicMock(side_effect=RuntimeError("websocket unhealthy"))
+
+        def fail_live_send(coro, _loop):
+            coro.close()
+            return failed_future
+
+        received_configs = []
+
+        async def standalone_send(_platform, pconfig, *_args, **_kwargs):
+            received_configs.append(pconfig)
+            assert pconfig.token == retained_config.token
+            return {"success": True}
+
+        job = {
+            "id": "discord-runtime-config-fallback",
+            "deliver": "origin",
+            "origin": {"platform": "discord", "chat_id": "123"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fail_live_send), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(
+                job,
+                "Hello world",
+                adapters={Platform.DISCORD: adapter},
+                loop=loop,
+            )
+
+        assert loaded_config.token is None
+        assert received_configs == [retained_config]
+        assert result is None
+
+    def test_standalone_without_runtime_adapter_uses_loaded_config(self, monkeypatch):
+        """Out-of-process cron delivery still uses the freshly loaded config."""
+        from gateway.config import Platform, PlatformConfig
+
+        monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+        loaded_config = PlatformConfig(enabled=True, token=None)
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: loaded_config}
+        received_configs = []
+
+        async def standalone_send(_platform, pconfig, *_args, **_kwargs):
+            received_configs.append(pconfig)
+            return {"success": True}
+
+        job = {
+            "id": "discord-standalone-loaded-config",
+            "deliver": "origin",
+            "origin": {"platform": "discord", "chat_id": "123"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(job, "Hello world")
+
+        assert received_configs == [loaded_config]
+        assert result is None
+
     def test_live_adapter_forum_topic_in_private_chat_routes_via_message_thread_id(self):
         """#52060: a cron target to a PRIVATE Telegram chat with a numeric topic
         id is a normal forum-style topic — it must route via ``message_thread_id``,


### PR DESCRIPTION
## Summary
- keep cron's fresh platform config for enablement/current routing checks
- when a live adapter exists but delivery fails, reuse that adapter's retained startup `PlatformConfig` for the standalone fallback
- preserve the existing fresh-config behavior for true standalone/no-adapter delivery

## Why
Gateway launchers can inject messaging credentials securely at startup and later scrub them from the process environment. The live adapter still retains its startup config, but cron previously discarded it during fallback and reloaded an empty-token config. If the live Discord WebSocket was unhealthy, the fallback then failed with `Discord standalone send: DISCORD_BOT_TOKEN is not set` even though the running adapter was authenticated.

## Tests
- `uv run --locked --extra dev python -m pytest tests/cron/test_scheduler.py::TestDeliverResultTimeoutCancelsFuture::test_live_adapter_fallback_uses_retained_runtime_config tests/cron/test_scheduler.py::TestDeliverResultTimeoutCancelsFuture::test_standalone_without_runtime_adapter_uses_loaded_config -o 'addopts=' -q` — 2 passed
- `uv run --locked --extra dev python -m pytest tests/cron/test_scheduler.py -o 'addopts=' -q` — 239 passed (existing unawaited-coroutine RuntimeWarning remains)
- `uv run --locked --extra dev ruff check cron/scheduler.py tests/cron/test_scheduler.py` — passed
- `python -m py_compile cron/scheduler.py tests/cron/test_scheduler.py` — passed
- real `~/.hermes/cron/jobs.json` SHA-256 unchanged across cron tests
