### PR TITLE
fix(memory): warn when a configured provider reports unavailable (#2765)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -60,6 +60,34 @@ from utils import base_url_host_matches, is_truthy_value
 logger = logging.getLogger("run_agent")
 
 
+# Memory providers we've already warned are unavailable. Deduped because the
+# gateway builds a fresh AIAgent per message, so an un-deduped warning would
+# fire on every turn.
+_warned_unavailable_providers: set[str] = set()
+
+
+def _warn_memory_provider_unavailable(name: str) -> None:
+    """Warn (once per provider) when a configured memory provider is unavailable.
+
+    ``is_available()`` is a fast, side-effect-free hot-path check, so it can't
+    log for itself. Without this warning a provider whose credentials/config are
+    missing is silently dropped — the user has ``memory.provider`` set but gets
+    no memory and no diagnostic. A common trigger is systemd/gateway services
+    not inheriting ``~/.hermes/.env``. See NousResearch/hermes-agent#2765.
+    """
+    if name in _warned_unavailable_providers:
+        return
+    _warned_unavailable_providers.add(name)
+    logger.warning(
+        "Memory provider %r is selected but reports unavailable — external memory "
+        "is disabled for this session (built-in memory still works). Check the "
+        "provider's credentials/config with 'hermes memory status'. Note: "
+        "systemd/gateway services do not inherit ~/.hermes/.env automatically; set "
+        "any required variables in the service environment.",
+        name,
+    )
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.OpenAI`` / ``run_agent.cleanup_vm`` / ... and have those
@@ -1622,6 +1650,8 @@ def init_agent(
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
                     agent._memory_manager.add_provider(_mp)
+                elif _mp is not None:
+                    _warn_memory_provider_unavailable(_mem_provider_name)
                 if agent._memory_manager.providers:
                     _init_kwargs = {
                         "session_id": agent.session_id,

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -485,6 +485,12 @@ def cmd_status(args) -> None:
                         if url and not is_set:
                             line += f"  → {url}"
                         print(line)
+                print(
+                    "  Note: systemd/gateway services do not inherit ~/.hermes/.env —"
+                )
+                print(
+                    "        set any variables above in the service environment."
+                )
         else:
             print("\n  Plugin:    NOT installed ✗")
             print(f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/")

--- a/tests/agent/test_memory_provider_unavailable_warning.py
+++ b/tests/agent/test_memory_provider_unavailable_warning.py
@@ -1,0 +1,35 @@
+"""Regression tests for NousResearch/hermes-agent#2765.
+
+A memory provider configured via ``memory.provider`` but reporting
+``is_available() == False`` (e.g. missing credentials, or a systemd/gateway
+service that didn't inherit ``~/.hermes/.env``) used to be dropped silently.
+``agent_init`` now emits a one-time, deduped warning instead.
+"""
+
+import logging
+
+from agent import agent_init
+
+
+def test_warns_once_and_dedupes(caplog):
+    agent_init._warned_unavailable_providers.clear()
+    with caplog.at_level(logging.WARNING, logger="run_agent"):
+        agent_init._warn_memory_provider_unavailable("hindsight")
+        agent_init._warn_memory_provider_unavailable("hindsight")
+
+    warnings = [r for r in caplog.records if "unavailable" in r.getMessage()]
+    assert len(warnings) == 1, "should warn exactly once per provider (gateway dedup)"
+    msg = warnings[0].getMessage()
+    assert "hindsight" in msg
+    assert "hermes memory status" in msg
+    assert ".env" in msg  # surfaces the systemd/gateway root cause
+
+
+def test_distinct_providers_each_warn(caplog):
+    agent_init._warned_unavailable_providers.clear()
+    with caplog.at_level(logging.WARNING, logger="run_agent"):
+        agent_init._warn_memory_provider_unavailable("hindsight")
+        agent_init._warn_memory_provider_unavailable("mem0")
+
+    warnings = [r for r in caplog.records if "unavailable" in r.getMessage()]
+    assert len(warnings) == 2

--- a/tests/hermes_cli/test_memory_status_env_hint.py
+++ b/tests/hermes_cli/test_memory_status_env_hint.py
@@ -1,0 +1,43 @@
+"""`hermes memory status` should explain *why* a provider is unavailable.
+
+Regression coverage for NousResearch/hermes-agent#2765: when the selected
+provider reports unavailable, status lists the missing env vars and surfaces
+the systemd/gateway ``.env``-inheritance gotcha that most often causes it.
+"""
+
+import hermes_cli.memory_setup as memory_setup
+
+
+class _UnavailableProvider:
+    def is_available(self):
+        return False
+
+    def get_config_schema(self):
+        return [
+            {
+                "key": "api_key",
+                "env_var": "HINDSIGHT_API_KEY",
+                "secret": True,
+                "url": "https://ui.hindsight.vectorize.io",
+            }
+        ]
+
+
+def test_status_surfaces_env_inheritance_hint_when_unavailable(monkeypatch, capsys):
+    monkeypatch.delenv("HINDSIGHT_API_KEY", raising=False)
+    monkeypatch.setattr(
+        memory_setup,
+        "_get_available_providers",
+        lambda: [("hindsight", "cloud", _UnavailableProvider())],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"provider": "hindsight", "hindsight": {}}},
+    )
+
+    memory_setup.cmd_status(object())
+    out = capsys.readouterr().out
+
+    assert "not available" in out
+    assert "HINDSIGHT_API_KEY" in out  # names the missing var
+    assert ".env" in out               # systemd/gateway root-cause hint


### PR DESCRIPTION
Fixes #2765.

## Problem

When `memory.provider` is set but the provider's `is_available()` returns `False`, `agent_init` silently drops it — the user has a provider configured but gets **no memory and no warning/error**. The most common trigger is exactly the one in #2765: **systemd/gateway services don't inherit `~/.hermes/.env`** (the CLI reads it via python-dotenv; services need explicit `Environment=`), so `HINDSIGHT_API_KEY` / `HINDSIGHT_API_URL` are absent at runtime.

The behavior is still reproducible on `main`:

```python
# cloud mode, no api_key/api_url/oauth (the systemd/.env-not-inherited case)
HindsightMemoryProvider().is_available()  # -> False, and nothing is logged
```

At `agent/agent_init.py`:
```python
if _mp and _mp.is_available():
    agent._memory_manager.add_provider(_mp)
# else: provider silently dropped, no diagnostic
```

## Fix

- **`agent_init`** — emit a **one-time, deduped** warning when a *configured* provider reports unavailable, naming the provider and the `.env`-inheritance gotcha. `is_available()` sits on the side-effect-free hot path (per the reasoning in #70123), so it can't log for itself; the dedup set prevents the gateway's per-message `AIAgent` construction from spamming the warning every turn.
- **`hermes memory status`** — surface the systemd/`.env` root cause in the existing `not available ✗` block, next to the missing-env-var checklist, so users debugging via `status` see *why*.

Provider-agnostic — helps every external memory provider, not just Hindsight.

## Tests

- `tests/agent/test_memory_provider_unavailable_warning.py` — warns once, dedupes per provider, distinct providers each warn, message names the provider + `hermes memory status` + `.env`.
- `tests/hermes_cli/test_memory_status_env_hint.py` — status prints the missing var and the `.env`-inheritance hint when unavailable.

```
scripts/run_tests.sh tests/agent/test_memory_provider_unavailable_warning.py tests/hermes_cli/test_memory_status_env_hint.py
# 3 passed
```

Verified no regressions in adjacent memory tests. (Two pre-existing failures in `tests/plugins/memory/test_hindsight_provider.py::TestAvailability` reproduce on a clean `main` and are unrelated to this change.)