### PR TITLE
test(desktop): cover interrupted turns and compression queueing

### DIFF
--- a/apps/desktop/e2e/cancel-turn-persistence.spec.ts
+++ b/apps/desktop/e2e/cancel-turn-persistence.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression coverage for Stop while an assistant reply is streaming.
+ *
+ * Desktop keeps the visible partial reply optimistically when Stop is clicked.
+ * That same partial reply must survive the actual interrupted-turn persistence
+ * path: release the blocked provider stream, restart Desktop, then hydrate the
+ * saved session again. Without persistence, the restart drops the partial
+ * assistant work even though it appeared correct at the instant of cancellation.
+ */
+
+import { type TestInfo } from '@playwright/test'
+
+import { expect, test, type Page } from './test'
+
+import {
+  buildAppEnv,
+  launchDesktop,
+  type MockBackendFixture,
+  setupMockBackend,
+  waitForAppReady,
+} from './fixtures'
+import { CORRECTION_SWITCH_TRIGGER, MOCK_REPLY } from './mock-server'
+
+const CANCELLED_PROMPT = `${CORRECTION_SWITCH_TRIGGER}: stop must retain prior streamed work.`
+const STREAMED_WORK = 'Checking the long-running task before I continue.'
+const INFERENCE_SESSION_PREFIX = 'E2E_CANCELLED_INFERENCE'
+const INFERENCE_PROMPT = `${INFERENCE_SESSION_PREFIX}: keep only the partial reply after Stop.`
+const FIRST_INFERENCE_TOKEN = 'Hello'
+
+async function send(page: Page, text: string): Promise<void> {
+  const composer = page.locator('[contenteditable="true"]').first()
+  await composer.waitFor({ state: 'visible', timeout: 15_000 })
+  await composer.click()
+  await composer.type(text, { delay: 5 })
+  await page.keyboard.press('Enter')
+}
+
+async function waitForTranscriptText(page: Page, text: string, timeout = 30_000): Promise<void> {
+  await page.waitForFunction(
+    expected => (document.querySelector('[data-slot="aui_thread-viewport"]')?.textContent ?? '').includes(expected),
+    text,
+    { timeout },
+  )
+}
+
+test('Stop preserves streamed assistant text after Desktop restarts and rehydrates the session', async ({}, testInfo: TestInfo) => {
+  const fixture: MockBackendFixture = await setupMockBackend()
+
+  try {
+    const { sandbox } = fixture
+    let { page } = fixture
+    await waitForAppReady(fixture, 120_000)
+
+    await send(page, CANCELLED_PROMPT)
+    // This trigger streams real assistant commentary then starts a foreground
+    // tool which remains active for five seconds. Stop during that tool phase:
+    // it exercises both the sealed interim message and the interrupted tool
+    // history cleanup, rather than only a one-token inference cancellation.
+    await waitForTranscriptText(page, STREAMED_WORK)
+
+    const stop = page.locator('[data-slot="composer-root"] button[aria-label="Stop"]')
+    await expect(stop).toBeVisible()
+    await stop.click()
+    await waitForTranscriptText(page, STREAMED_WORK)
+    await page.screenshot({ path: testInfo.outputPath('cancelled-turn-before-restart.png') })
+
+    // Let the cooperative tool cancellation settle so the gateway persists its
+    // authoritative interrupted history before we restart Desktop.
+    await expect(stop).toHaveCount(0)
+
+    await fixture.app.close()
+    const relaunched = await launchDesktop(buildAppEnv(sandbox))
+    fixture.app = relaunched.app
+    page = relaunched.page
+    fixture.page = page
+    await waitForAppReady(fixture, 120_000)
+
+    // Session titles are preview-truncated in the persisted sidebar. Match the
+    // stable trigger prefix rather than assuming the full prompt is retained as
+    // the title, then activate it to exercise the real resume/hydration path.
+    const sessionRow = page.locator('[data-slot="sidebar"] button').filter({ hasText: CORRECTION_SWITCH_TRIGGER }).first()
+    await sessionRow.waitFor({ state: 'visible', timeout: 30_000 })
+    await sessionRow.click()
+    await waitForTranscriptText(page, CANCELLED_PROMPT)
+
+    const transcript = page.locator('[data-slot="aui_thread-viewport"]')
+    await expect(transcript).toContainText(CANCELLED_PROMPT)
+    await expect(transcript).toContainText(STREAMED_WORK)
+    await expect(transcript).toContainText('Ran sleep')
+    await page.screenshot({ path: testInfo.outputPath('cancelled-turn-after-restart.png') })
+  } finally {
+    await fixture.cleanup()
+  }
+})
+
+test('Stop preserves a partial inference reply after Desktop restarts and rehydrates the session', async ({}, testInfo: TestInfo) => {
+  const fixture: MockBackendFixture = await setupMockBackend({
+    mockServer: { holdFirstStreamForPrompt: INFERENCE_SESSION_PREFIX },
+  })
+
+  try {
+    const { mock, sandbox } = fixture
+    let { page } = fixture
+    await waitForAppReady(fixture, 120_000)
+
+    await send(page, INFERENCE_PROMPT)
+    await mock.waitForHeldStream()
+    await waitForTranscriptText(page, FIRST_INFERENCE_TOKEN)
+
+    const stop = page.locator('[data-slot="composer-root"] button[aria-label="Stop"]')
+    await expect(stop).toBeVisible()
+    await stop.click()
+    await waitForTranscriptText(page, FIRST_INFERENCE_TOKEN)
+    await page.screenshot({ path: testInfo.outputPath('cancelled-inference-before-restart.png') })
+
+    // The provider completes after Stop, so this proves Desktop does not merely
+    // keep a live optimistic buffer — it must preserve the interrupted partial
+    // through the backend's terminal event and subsequent persistence.
+    mock.releaseHeldStream()
+    await expect(stop).toHaveCount(0)
+
+    await fixture.app.close()
+    const relaunched = await launchDesktop(buildAppEnv(sandbox))
+    fixture.app = relaunched.app
+    page = relaunched.page
+    fixture.page = page
+    await waitForAppReady(fixture, 120_000)
+
+    const sessionRow = page.locator('[data-slot="sidebar"] button').filter({ hasText: INFERENCE_SESSION_PREFIX }).first()
+    await sessionRow.waitFor({ state: 'visible', timeout: 30_000 })
+    await sessionRow.click()
+
+    const transcript = page.locator('[data-slot="aui_thread-viewport"]')
+    await expect(transcript).toContainText(INFERENCE_PROMPT)
+    await expect(transcript).toContainText(FIRST_INFERENCE_TOKEN)
+    await expect(transcript).not.toContainText(MOCK_REPLY)
+    await page.screenshot({ path: testInfo.outputPath('cancelled-inference-after-restart.png') })
+  } finally {
+    await fixture.cleanup()
+  }
+})

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -23,8 +23,10 @@ export const MOCK_REPLY = 'Hello from the mock inference server! The full boot c
 export interface MockServerOptions {
   /** Pause the matching stream after its first token for session-switch E2E coverage. */
   holdFirstStreamForPrompt?: string
-/** Pause the first completion whose request JSON contains this text. */
+  /** Pause the first completion whose request JSON contains this text. */
 holdFirstCompletionContaining?: string
+/** Pause the first completion after another hold whose request JSON contains this text. */
+holdFirstCompletionContainingAfterHeldCompletion?: string
 /** Absolute sandbox path written by the verify-on-stop scripted tool call. */
 verificationWritePath?: string
 }
@@ -285,12 +287,20 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
     let resolveHeldStreamStarted: (() => void) | null = null
     let releaseHeldStream: (() => void) | null = null
     let heldCompletionCount = 0
-    const heldStreamStarted = new Promise<void>(resolveHeld => {
-      resolveHeldStreamStarted = resolveHeld
-    })
-    const heldStreamReleased = new Promise<void>(resolveRelease => {
-      releaseHeldStream = resolveRelease
-    })
+    let heldCompletionAfterHeldCompletion = false
+    let heldStreamStarted: Promise<void>
+    let heldStreamReleased: Promise<void>
+
+    const resetHeldStreamGate = (): void => {
+      heldStreamStarted = new Promise<void>(resolveHeld => {
+        resolveHeldStreamStarted = resolveHeld
+      })
+      heldStreamReleased = new Promise<void>(resolveRelease => {
+        releaseHeldStream = resolveRelease
+      })
+    }
+
+    resetHeldStreamGate()
     const server = http.createServer((req, res) => {
       // CORS headers — the Electron renderer doesn't need them, but they
       // don't hurt and make the server usable from a browser context too.
@@ -355,6 +365,15 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
             heldCompletionCount === 0 &&
             JSON.stringify(parsed).includes(options.holdFirstCompletionContaining),
           )
+          const holdThisCompletionAfterHeldCompletion = Boolean(
+            options.holdFirstCompletionContainingAfterHeldCompletion &&
+            heldCompletionCount === 1 &&
+            !heldCompletionAfterHeldCompletion &&
+            JSON.stringify(parsed).includes(options.holdFirstCompletionContainingAfterHeldCompletion),
+          )
+          if (holdThisCompletionAfterHeldCompletion) {
+            heldCompletionAfterHeldCompletion = true
+          }
 
           // Detect the interim-message test trigger: the user's message
           // contains a specific keyword. The mock walks through the
@@ -459,10 +478,11 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
 
           if (stream) {
             const holdThisStream = Boolean(
-              options.holdFirstStreamForPrompt && typeof lastUserMessage?.content === 'string' &&
-                lastUserMessage.content.includes(options.holdFirstStreamForPrompt),
+              (typeof lastUserMessage?.content === 'string' && (
+                options.holdFirstStreamForPrompt && lastUserMessage.content.includes(options.holdFirstStreamForPrompt)
+              )),
             )
-            streamTextResponse(res, model, MOCK_REPLY, holdThisStream || holdThisCompletion ? () => {
+            streamTextResponse(res, model, MOCK_REPLY, holdThisStream || holdThisCompletion || holdThisCompletionAfterHeldCompletion ? () => {
               if (holdThisCompletion) {
                 heldCompletionCount++
               }
@@ -470,8 +490,10 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
               return heldStreamReleased
             } : undefined)
           } else {
-            if (holdThisCompletion) {
-              heldCompletionCount++
+            if (holdThisCompletion || holdThisCompletionAfterHeldCompletion) {
+              if (holdThisCompletion) {
+                heldCompletionCount++
+              }
               resolveHeldStreamStarted?.()
               void heldStreamReleased.then(() => nonStreamingTextResponse(res, model, MOCK_REPLY))
             } else {
@@ -510,7 +532,10 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
         receivedPrompts,
         waitForHeldStream: () => heldStreamStarted,
         waitForHeldCompletion: () => heldStreamStarted,
-        releaseHeldStream: () => releaseHeldStream?.(),
+        releaseHeldStream: () => {
+          releaseHeldStream?.()
+          resetHeldStreamGate()
+        },
         heldCompletionCount: () => heldCompletionCount,
         close: () =>
           new Promise((resolveClose, rejectClose) => {

--- a/apps/desktop/e2e/session-compression-and-queue-stop.spec.ts
+++ b/apps/desktop/e2e/session-compression-and-queue-stop.spec.ts
@@ -144,3 +144,66 @@ auxiliary:
     expect(fixture.mock.heldCompletionCount()).toBe(1)
   })
 })
+
+test.describe('session compression handoff queueing', () => {
+  let fixture: MockBackendFixture
+
+  test.beforeEach(async () => {
+    fixture = await setupMockBackend({
+      modelContextLength: 64_000,
+      extraConfig: `compression:
+  threshold_tokens: 22000
+  protect_first_n: 0
+  protect_last_n: 1
+auxiliary:
+  compression:
+    provider: custom
+    model: mock-model`,
+      mockServer: {
+        holdFirstCompletionContaining: 'You are a summarization agent creating a context checkpoint.',
+        holdFirstCompletionContainingAfterHeldCompletion: 'E2E_POST_COMPACTION_RUNNING',
+      },
+    })
+    await waitForAppReady(fixture, 120_000)
+  })
+
+  test.afterEach(async () => {
+    await fixture?.cleanup()
+  })
+
+  test('queues an Enter-submitted prompt while the post-compression turn is still running', async ({}, testInfo) => {
+    const { mock, page } = fixture
+    const compressionTrigger = 'E2E_TRIGGER_AUTOMATIC_COMPACTION '.repeat(500)
+    const running = 'E2E_POST_COMPACTION_RUNNING'
+    const queued = 'E2E_QUEUED_AFTER_COMPACTION'
+    const primary = page.locator('[data-slot="composer-root"] button[type="submit"]')
+
+    // Cross the threshold, complete compaction, then start a separate normal
+    // turn. This mirrors the user-visible sequence rather than holding the
+    // turn that caused the compaction itself.
+    await pasteAndSend(page, 'E2E_POST_COMPACTION_HISTORY_ONE '.repeat(5))
+    await waitForTranscript(page, MOCK_REPLY)
+    await pasteAndSend(page, 'E2E_POST_COMPACTION_HISTORY_TWO '.repeat(5))
+    await waitForTranscript(page, MOCK_REPLY)
+    await pasteAndSend(page, compressionTrigger)
+    await mock.waitForHeldCompletion()
+    expect(mock.heldCompletionCount()).toBe(1)
+    await expect(page.getByRole('status', { name: 'Summarizing thread' }).last()).toBeVisible()
+
+    mock.releaseHeldStream()
+    await expect(page.getByText(MOCK_REPLY, { exact: true })).toHaveCount(4)
+
+    await pasteAndSend(page, running)
+    await mock.waitForHeldStream()
+
+    await expect(primary).toHaveAttribute('aria-label', 'Queue message')
+    await pasteAndSend(page, queued)
+
+    await expect(page.getByText('1 Queued')).toBeVisible()
+    expect(mock.receivedPrompts).not.toContain(queued)
+    await page.screenshot({ path: testInfo.outputPath('queued-after-compression-handoff.png') })
+
+    mock.releaseHeldStream()
+    await expect.poll(() => mock.receivedPrompts.filter(prompt => prompt === queued), { timeout: 30_000 }).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Adds Electron end-to-end regressions for two Desktop session-lifecycle boundaries:

- interrupted output persists across a Desktop restart and saved-session hydration;
- a follow-up submitted while a normal turn runs **after automatic context compression** stays queued until that turn finishes.

## Related Issue

No issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `apps/desktop/e2e/cancel-turn-persistence.spec.ts`.
  - Stop during a foreground tool, restart Desktop, and hydrate the saved session.
  - Stop after the first inference token, release the provider stream, restart Desktop, and ensure later output is not accepted.
- Extend `apps/desktop/e2e/session-compression-and-queue-stop.spec.ts`.
  - Force automatic compression with a held summary request.
  - Complete compression, start and hold a separate ordinary turn, then submit a second prompt with Enter.
  - Assert the second prompt is queued and absent from provider requests until the held turn completes, then dispatches exactly once.
- Extend the mock inference server with renewable, one-shot held-completion gates for the two-phase scenario.

## How to Test

```bash
nix develop -c bash -lc 'cd apps/desktop && npx tsc -p tsconfig.e2e.json --noEmit && WLR_BACKENDS=headless WLR_NO_HARDWARE_CURSORS=1 cage -- npx playwright test e2e/session-compression-and-queue-stop.spec.ts --reporter=list'
```

Expected result: 3 passing compression tests, including the post-compression queue handoff.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** related Desktop regression coverage
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A; this is a Desktop TypeScript/Electron E2E-only change.
- [x] I've added tests for my changes
- [x] I've tested on my platform: NixOS Linux, headless Wayland (`cage`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; no user-facing behavior changed.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've considered cross-platform impact — N/A; this changes test-only mock and Electron E2E coverage.

## Screenshots / Logs

- `nix develop -c bash -lc 'cd apps/desktop && npm run check'` passed before the prior interrupted-turn commit.
- Focused interrupted-turn E2E: 2 passed.
- Full compression E2E: 3 passed.
