### PR TITLE
fix(windows): hide LSP server + installer console flashes under editor hosts (salvage #47971)

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -56,6 +56,8 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 from urllib.parse import quote, unquote
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 from agent.lsp.protocol import (
     ERROR_CONTENT_MODIFIED,
     ERROR_METHOD_NOT_FOUND,
@@ -294,6 +296,12 @@ class LSPClient:
         cmd = self._command
         if sys.platform == "win32":
             cmd = self._win_wrap_cmd(cmd)
+        # Suppress the cmd.exe console window that would otherwise flash
+        # every time we launch a ``.cmd``-wrapped language server
+        # (e.g. pyright-langserver.CMD) from a console-less host such as
+        # a VS Code/Zed extension running the ACP adapter.
+        # windows_hide_flags() is CREATE_NO_WINDOW on Windows, 0 on POSIX.
+        creationflags = windows_hide_flags()
 
         try:
             # start_new_session=True detaches the LSP server into its own
@@ -312,6 +320,7 @@ class LSPClient:
                 env=env,
                 cwd=self._cwd,
                 start_new_session=True,
+                creationflags=creationflags,
             )
         except FileNotFoundError as e:
             raise LSPProtocolError(

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -35,6 +35,8 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger("agent.lsp.install")
 
 # Package-name → install-strategy hint registry.  Each entry is a
@@ -268,6 +270,7 @@ def _install_npm(
             text=True,
             timeout=300,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         if proc.returncode != 0:
             logger.warning(
@@ -317,6 +320,7 @@ def _install_go(pkg: str, bin_name: str) -> Optional[str]:
             timeout=600,
             env=env,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         if proc.returncode != 0:
             logger.warning(

--- a/contributors/emails/hellofrommorgan@users.noreply.github.com
+++ b/contributors/emails/hellofrommorgan@users.noreply.github.com
@@ -1,0 +1,1 @@
+hellofrommorgan

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -837,3 +837,107 @@ def test_codex_app_server_transport_hides_console_window(monkeypatch):
     # Hide-only: the app-server wire still needs its pipes.
     assert kwargs["stdin"] == subprocess.PIPE
     assert kwargs["stdout"] == subprocess.PIPE
+
+
+# ── #47971 LSP spawn + installer paths (salvage) ────────────────────────────
+#
+# The LSP language-server spawn (agent/lsp/client.py::_spawn) and the
+# npm/go LSP auto-installers (agent/lsp/install.py) are reachable from
+# console-less parents — a VS Code/Zed extension host running the ACP
+# adapter — where a .cmd-wrapped server (pyright-langserver.CMD via
+# cmd.exe /c) or an npm/go console app flashes a window on Windows.
+# All are hide-only (creationflags); PIPE stdio must stay intact and the
+# POSIX start_new_session detach must be preserved on the client spawn.
+
+
+def test_lsp_client_spawn_hides_console_window(monkeypatch):
+    import asyncio
+
+    from agent.lsp import client as lsp_client
+
+    captured = []
+
+    class _FakeProc:
+        stdin = None
+        stdout = None
+        stderr = None
+
+    async def fake_exec(*cmd, **kwargs):
+        captured.append((list(cmd), kwargs))
+        return _FakeProc()
+
+    monkeypatch.setattr(lsp_client, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(
+        lsp_client.asyncio, "create_subprocess_exec", fake_exec
+    )
+
+    client = lsp_client.LSPClient(
+        server_id="test-server",
+        workspace_root="/tmp/ws",
+        command=["fake-langserver", "--stdio"],
+    )
+    asyncio.run(client._spawn())
+
+    assert len(captured) == 1, captured
+    cmd, kwargs = captured[0]
+    assert cmd == ["fake-langserver", "--stdio"]
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+    # Hide-only: the LSP wire still needs its pipes, and the POSIX
+    # process-group detach (mcp orphan-sweep guard) must survive.
+    assert kwargs["stdin"] == asyncio.subprocess.PIPE
+    assert kwargs["stdout"] == asyncio.subprocess.PIPE
+    assert kwargs["start_new_session"] is True
+
+
+def test_lsp_install_npm_hides_console_window(monkeypatch, tmp_path):
+    from agent.lsp import install as lsp_install
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="")
+
+    monkeypatch.setattr(lsp_install, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(lsp_install.subprocess, "run", fake_run)
+    monkeypatch.setattr(lsp_install.shutil, "which", lambda name: f"/fake/bin/{name}")
+    monkeypatch.setattr(
+        lsp_install, "hermes_lsp_bin_dir", lambda: tmp_path / "lsp" / "bin"
+    )
+
+    # Bin lookup after the install misses (nothing staged) → None; the
+    # spawn contract is what is under test here.
+    lsp_install._install_npm("pyright", "pyright-langserver")
+
+    spawns = _spawns(captured, "/fake/bin/npm", "install", "pyright")
+    assert len(spawns) == 1, captured
+    cmd, kwargs = spawns[0]
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+    assert kwargs["stdin"] == subprocess.DEVNULL
+    assert kwargs["capture_output"] is True
+
+
+def test_lsp_install_go_hides_console_window(monkeypatch, tmp_path):
+    from agent.lsp import install as lsp_install
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="")
+
+    monkeypatch.setattr(lsp_install, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(lsp_install.subprocess, "run", fake_run)
+    monkeypatch.setattr(lsp_install.shutil, "which", lambda name: f"/fake/bin/{name}")
+    monkeypatch.setattr(
+        lsp_install, "hermes_lsp_bin_dir", lambda: tmp_path / "lsp" / "bin"
+    )
+
+    lsp_install._install_go("golang.org/x/tools/gopls@latest", "gopls")
+
+    spawns = _spawns(captured, "/fake/bin/go", "install")
+    assert len(spawns) == 1, captured
+    cmd, kwargs = spawns[0]
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+    assert kwargs["stdin"] == subprocess.DEVNULL
+    assert kwargs["capture_output"] is True


### PR DESCRIPTION
## Summary

Salvages the still-live subset of PR #47971 by @hellofrommorgan: hides console flashes from the LSP language-server spawn and the npm/go installer spawns — the one flash class still reachable after the #70205 hidden-console daemon fix, because these run in-process under console-less editor extension hosts (VS Code/Zed via the ACP adapter), a parent Hermes doesn't launch.

## Changes

- `agent/lsp/client.py::_spawn`: `creationflags=windows_hide_flags()` on the language-server spawn (kept main's `start_new_session=True` — POSIX-only, compatible)
- `agent/lsp/install.py`: hide flags on the npm + go installer spawns
- `tests/test_windows_subprocess_no_window_flags.py`: +3 regression tests (ours), following the file's mocked-subprocess pattern

Scope discipline vs the original PR: dropped `coding_context.py` / `context_references.py` / `checkpoint_manager.py` hunks (already fixed on main via `bounded_git_probe` / existing flags), dropped the pip-path hunk (routes through `_pip_install` which already applies flags internally — the PR's kwargs would have crashed it), dropped the `nearest_root` cache (separate perf review), and converted the hand-rolled `_NO_WINDOW` constant to the repo's `windows_hide_flags()` helper.

## Validation

| | Result |
|---|---|
| `test_windows_subprocess_no_window_flags.py` + `tests/agent/lsp/` | 199 passed, 0 failed |
| A/B (source hunks reverted) | exactly the 3 new tests fail |
| ruff | clean |

Authorship preserved via cherry-pick; rebase-merge.

Closes #47971.

## Infographic

![lsp-hide-flags](https://v3b.fal.media/files/b/0aa3712a/aB_VO8GOk7evDeyDCtKZR_hwZhdyXk.png)
