### PR TITLE
fix: distinguish approval timeouts from denials

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11854,7 +11854,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._approval_deadline = 0
             self._paint_now()
             _cprint(f"\n{_DIM}  ⏱ Timeout — denying command{_RST}")
-            return "deny"
+            return "timeout"
 
     def _approval_choices(self, command: str, *, allow_permanent: bool = True,
                           smart_denied: bool = False) -> list[str]:

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -67,6 +67,22 @@ def _make_background_cli_stub():
 
 
 class TestCliApprovalUi:
+    def test_approval_callback_returns_timeout_when_user_does_not_respond(self):
+        cli = _make_cli_stub()
+        cli._paint_now = MagicMock()
+
+        with patch.object(cli_module, "CLI_CONFIG", {"approvals": {"timeout": 0}}), \
+             patch.object(queue.Queue, "get", side_effect=queue.Empty), \
+             patch.object(cli_module, "_cprint"):
+            result = cli._approval_callback(
+                "python3 <<'PY'\nprint('safe')\nPY",
+                "script execution via heredoc",
+            )
+
+        assert result == "timeout"
+        assert cli._approval_state is None
+        assert cli._approval_deadline == 0
+
     def test_smart_denied_callback_offers_only_once_and_deny(self):
         cli = _make_cli_stub()
         result = {}

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -106,6 +106,43 @@ class TestSmartApproval:
         assert is_approved(session_key, pattern_key) is False
 
 
+class TestCliApprovalTimeoutAttribution:
+    def test_timeout_blocks_without_claiming_user_denied(self, monkeypatch):
+        session_key = "test-cli-approval-timeout"
+        command = "python3 <<'PY'\nprint('safe')\nPY"
+
+        monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.setattr(
+            approval_module,
+            "_get_approval_config",
+            lambda: {"mode": "manual"},
+        )
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+        monkeypatch.setattr(
+            "tools.tirith_security.check_command_security",
+            lambda _command: {"action": "allow", "findings": [], "summary": ""},
+        )
+        approval_module.clear_session(session_key)
+        approval_module._permanent_approved.clear()
+
+        result = approval_module.check_all_command_guards(
+            command,
+            "local",
+            approval_callback=lambda *_args, **_kwargs: "timeout",
+        )
+
+        assert result["approved"] is False
+        assert result["outcome"] == "timeout"
+        assert result["user_consent"] is False
+        assert "timed out without user response" in result["message"]
+        assert "User denied" not in result["message"]
+        assert "Silence is not consent" in result["message"]
+
+
 class TestDetectDangerousRm:
     def test_rm_rf_detected(self):
         is_dangerous, key, desc = detect_dangerous_command("rm -rf /home/user")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3600,6 +3600,23 @@ def check_all_command_guards(command: str, env_type: str,
         choice=choice,
     )
 
+    if choice == "timeout":
+        return {
+            "approved": False,
+            "message": (
+                "BLOCKED: Approval timed out without user response. The user "
+                "has NOT consented to this action. Do NOT retry this command, "
+                "do NOT rephrase it, and do NOT attempt the same outcome via "
+                "a different command. Silence is not consent. Stop the current "
+                "workflow and wait for the user before taking any further "
+                "destructive or irreversible action."
+            ),
+            "pattern_key": primary_key,
+            "description": combined_desc,
+            "outcome": "timeout",
+            "user_consent": False,
+        }
+
     if choice == "deny":
         return {
             "approved": False,


### PR DESCRIPTION
## Summary
- return a distinct `timeout` result when the CLI approval window expires
- fail closed on that result without claiming the user explicitly denied the command
- add regression coverage for callback attribution and guard behavior

## Why
The CLI currently converts an unanswered approval prompt into `deny`, causing downstream messaging to report “User denied this command.” A distinct timeout result preserves the security boundary while accurately representing user intent.

## Test plan
- [x] Focused timeout regressions: 2 passed
- [x] `ruff check cli.py tools/approval.py tests/cli/test_cli_approval_ui.py tests/tools/test_approval.py`
- [x] `git diff --check origin/main...HEAD`
- [ ] Full local suite did not complete within the 10-minute foreground execution window; its partial run surfaced unrelated optional-dependency/baseline failures before timeout.