### PR TITLE
fix: classify Kimi billing-cycle quota as billing

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -112,6 +112,7 @@ _BILLING_PATTERNS = [
     "top up your credits",
     "payment required",
     "billing hard limit",
+    "usage limit for this billing cycle",
     "exceeded your current quota",
     "account is deactivated",
     "plan does not include",

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -261,6 +261,27 @@ class TestClassifyApiError:
         result = classify_api_error(e, provider="openrouter")
         assert result.reason == FailoverReason.billing
 
+    def test_kimi_403_billing_cycle_usage_limit_classified_as_billing(self):
+        e = MockAPIError(
+            "Error code: 403",
+            status_code=403,
+            body={
+                "error": {
+                    "message": (
+                        "You've reached your usage limit for this billing cycle. "
+                        "Your quota will be refreshed in the next cycle."
+                    )
+                }
+            },
+        )
+
+        result = classify_api_error(e, provider="kimi-coding")
+
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
     def test_xai_403_structured_spending_limit_code_classified_as_billing(self):
         """xAI reports exhausted Grok credits as a provider-specific 403 code."""
         e = MockAPIError(


### PR DESCRIPTION
## Summary
- classify Kimi's exact HTTP 403 billing-cycle quota message as `billing`
- preserve generic HTTP 403 classification as `auth`
- add a regression test using the observed nested provider response body

## Provider response covered

```text
You've reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle.
```

This is quota exhaustion, not invalid credentials. Classifying it as `billing` keeps the failure non-retryable for the same route, permits credential rotation/fallback, and avoids stale `permission_error` auth state.

## Verification
- RED before classifier change: exact Kimi case classified as `auth`
- GREEN after change
- `scripts/run_tests.sh tests/agent/test_error_classifier.py -q` — 200 passed
- `python3 -m compileall -q agent/error_classifier.py tests/agent/test_error_classifier.py`
- `git diff --check`
