### PR TITLE
test(gateway): use valid API server key fixture

### DIFF
--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -2472,10 +2472,11 @@ class TestApiServerEnvOverride:
             },
         )
 
-        with patch.dict(os.environ, {"API_SERVER_KEY": "secret-key"}, clear=True):
+        api_server_key = "valid-secret-key"
+        with patch.dict(os.environ, {"API_SERVER_KEY": api_server_key}, clear=True):
             _apply_env_overrides(config)
 
         # Explicit disable wins over the env-var presence.
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
-        assert config.platforms[Platform.API_SERVER].extra.get("key") == "secret-key"
+        assert config.platforms[Platform.API_SERVER].extra.get("key") == api_server_key


### PR DESCRIPTION
## Summary

- update the explicit-disable regression to use a key that meets the production 16-character enrollment gate
- keep the fixture and preservation assertion tied to one local value
- leave production behavior unchanged

## Root cause

The API-server enrollment hardening correctly rejects weak `API_SERVER_KEY` values, but this older regression still used `secret-key`. The stale fixture made current `main` fail while asserting that the rejected key was stored.

## Validation

- Before: `scripts/run_tests.sh tests/gateway/test_config.py` — 148 passed, 1 failed
- After: `scripts/run_tests.sh tests/gateway/test_config.py` — 149 passed
- `scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_platform_connected_checkers.py` — 247 passed
- `.venv/bin/ruff check tests/gateway/test_config.py`
- `git diff --check`
- publish gate and gitleaks

Fixes #70268