### PR TITLE
test(gateway): use a 16+ char API_SERVER_KEY in the explicit-disable env test

### DIFF
--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -2472,10 +2472,15 @@ class TestApiServerEnvOverride:
             },
         )
 
-        with patch.dict(os.environ, {"API_SERVER_KEY": "secret-key"}, clear=True):
+        # 16+ chars: since the load-time strength gate (has_usable_secret,
+        # min_length=16) the api_server env branch only runs for keys the
+        # adapter would actually accept — a shorter key skips the branch
+        # entirely and this test would assert nothing.
+        strong_key = "secret-key-0123456789"
+        with patch.dict(os.environ, {"API_SERVER_KEY": strong_key}, clear=True):
             _apply_env_overrides(config)
 
         # Explicit disable wins over the env-var presence.
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
-        assert config.platforms[Platform.API_SERVER].extra.get("key") == "secret-key"
+        assert config.platforms[Platform.API_SERVER].extra.get("key") == strong_key


### PR DESCRIPTION
## Summary

Fixes the test failure currently red on `main` and failing CI slice 4/8 on every open PR: `test_env_key_does_not_reenable_explicitly_disabled_api_server` uses an 11-char `API_SERVER_KEY`, but 9e4b89857a (merged this morning) added a load-time strength gate (`has_usable_secret`, min_length=16) to the api_server env branch — so the branch the test pins is now skipped entirely and its `extra["key"]` assertion fails.

Classic two-green-PRs collision: c7fd3eb377's test and 9e4b89857a's gate each passed CI independently; the semantic conflict only manifests merged.

## Changes

- `tests/gateway/test_config.py`: use a 16+ char key so the test exercises the branch it was written to pin; comment explains the strength-gate dependency.

## Validation

| | Before | After |
|---|---|---|
| `tests/gateway/test_config.py` | 148 pass / 1 fail (also fails on bare main) | 149/149 |

## Infographic

![test-config-key-strength](https://v3b.fal.media/files/b/0aa37186/_Wn4-vKVldgFEEBR6Q2E0_lYYorur4.png)
