### PR TITLE
test(gateway): use valid API server key in env override test

### DIFF
--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -2472,10 +2472,11 @@ class TestApiServerEnvOverride:
             },
         )
 
-        with patch.dict(os.environ, {"API_SERVER_KEY": "secret-key"}, clear=True):
+        api_server_key = "secret-key-at-least-16"
+        with patch.dict(os.environ, {"API_SERVER_KEY": api_server_key}, clear=True):
             _apply_env_overrides(config)
 
         # Explicit disable wins over the env-var presence.
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
-        assert config.platforms[Platform.API_SERVER].extra.get("key") == "secret-key"
+        assert config.platforms[Platform.API_SERVER].extra.get("key") == api_server_key


### PR DESCRIPTION
## What does this PR do?

Updates the explicit `api_server.enabled: false` regression fixture to use a
key that passes the API server loader's 16-character usability check. The test
now reaches the env-override branch it is meant to cover.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/gateway/test_config.py`: replace the weak API-server key fixture with
  a valid-length key and reuse that fixture value in the assertion.

## How to Test

1. Run `nix develop -c scripts/run_tests.sh tests/gateway/test_config.py`.
2. Confirm `test_env_key_does_not_reenable_explicitly_disabled_api_server`
   reaches `_apply_env_overrides()`'s valid-key branch.
3. Confirm the explicit disable remains false and the key is still stored in
   platform config.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (the targeted config-file run was interrupted before completion)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A