### PR TITLE
fix(compression): ghost-skill defense — [SKILL_PRUNED] markers, protected prune, deterministic survival (salvage #44166)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -891,7 +891,13 @@ def _summarize_tool_result_unguarded(tool_name: str, tool_args: str, tool_conten
             code_preview += "..."
         return f"[execute_code] `{code_preview}` ({line_count} lines output)"
 
-    if tool_name in {"skill_view", "skills_list", "skill_manage"}:
+    if tool_name == "skill_view":
+        name = args.get("name", "?")
+        if content_len > 5000:
+            return f"[skill_view] name={name} ({content_len:,} chars) [SKILL_PRUNED: content lost in compression; reload with skill_view before relying on it]"
+        return f"[skill_view] name={name} ({content_len:,} chars)"
+
+    if tool_name in {"skills_list", "skill_manage"}:
         name = args.get("name", "?")
         return f"[{tool_name}] name={name} ({content_len:,} chars)"
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -329,6 +329,10 @@ _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 # ``[SKILL_PRUNED:`` but presence-checked ``[SKILL_PRUNED]``, making
 # re-injection fire even when the marker had survived).
 SKILL_PRUNED_MARKER_PREFIX = "[SKILL_PRUNED:"
+# skill_view results at or below this size stay verbatim in pruned
+# summaries — small skills are cheap to keep and their loss is unlikely to
+# ghost the model. Shared by the emit site and the summarizer-input scan.
+_SKILL_VIEW_PRUNE_MIN_CHARS = 5000
 # Cap for the deterministic marker re-injection list — keeps a very long
 # session from growing an unbounded "## Pruned Skills" block in every
 # iterative summary update. Newest-referenced skills win.
@@ -364,6 +368,51 @@ def _extract_pruned_skill_names(text: str) -> list[str]:
         name = match.group(1)
         if name not in names:
             names.append(name)
+    return names
+
+
+def _collect_ghosted_skill_names(turns: List[Dict[str, Any]]) -> list[str]:
+    """Skill names whose instructions are about to be lost in compaction.
+
+    Covers BOTH shapes a compacted middle window can carry:
+
+    - a ``skill_view`` result already demoted by Phase-1 pruning — the
+      canonical ``[SKILL_PRUNED: ...]`` marker is in the row content;
+    - a RAW ``skill_view`` body that was never demoted (it sat inside the
+      protected tail of an earlier prune, then aged into the compression
+      window). The summarizer will paraphrase the instructions away, which
+      is exactly the ghost-skill failure — so it needs a marker too.
+    """
+    names: list[str] = []
+
+    def _add(name: str) -> None:
+        if name and name not in names:
+            names.append(name)
+
+    call_id_to_skill: dict[str, str] = {}
+    for idx, skill in _skill_view_call_sites(turns):
+        msg = turns[idx]
+        for tc in msg.get("tool_calls") or []:
+            tc_fn = tc.get("function", {}) if isinstance(tc, dict) else getattr(tc, "function", None)
+            tc_name = tc_fn.get("name", "") if isinstance(tc_fn, dict) else getattr(tc_fn, "name", "")
+            if tc_name != "skill_view":
+                continue
+            cid = tc.get("id", "") if isinstance(tc, dict) else (getattr(tc, "id", "") or "")
+            if cid:
+                call_id_to_skill[cid] = skill
+    for msg in turns:
+        content = msg.get("content")
+        text = content if isinstance(content, str) else _content_text_for_contains(content)
+        for name in _extract_pruned_skill_names(text):
+            _add(name)
+        if (
+            msg.get("role") == "tool"
+            and isinstance(content, str)
+            and len(content) > _SKILL_VIEW_PRUNE_MIN_CHARS
+        ):
+            skill = call_id_to_skill.get(str(msg.get("tool_call_id") or ""))
+            if skill:
+                _add(skill)
     return names
 
 
@@ -1059,7 +1108,7 @@ def _summarize_tool_result_unguarded(tool_name: str, tool_args: str, tool_conten
 
     if tool_name == "skill_view":
         name = args.get("name", "?")
-        if content_len > 5000:
+        if content_len > _SKILL_VIEW_PRUNE_MIN_CHARS:
             # Ghost-skill defense (#32106): a metadata-only summary makes the
             # model believe the skill is still loaded. The canonical marker
             # tells it the instructions are gone AND how to get them back.
@@ -2950,16 +2999,10 @@ Continue from the most recent unfulfilled user ask and protected tail messages. 
 Summary generation was unavailable, so this is a best-effort deterministic fallback for {len(turns_to_summarize)} compacted message(s).{reason_text}"""
         # Ghost-skill defense (#32106): the fallback's per-turn truncation
         # (``_FALLBACK_TURN_MAX_CHARS``) routinely cuts [SKILL_PRUNED: ...]
-        # markers out of the compacted turns. Re-derive them from the raw
-        # turn contents and re-inject deterministically, exactly like the
-        # LLM-summary path.
-        _pruned_names: list[str] = []
-        for _turn in turns_to_summarize:
-            for _name in _extract_pruned_skill_names(
-                _content_text_for_contains(_turn.get("content"))
-            ):
-                if _name not in _pruned_names:
-                    _pruned_names.append(_name)
+        # markers out of the compacted turns. Re-derive the ghosted skills
+        # from the raw turn contents and re-inject deterministically,
+        # exactly like the LLM-summary path.
+        _pruned_names = _collect_ghosted_skill_names(turns_to_summarize)
         del _pruned_names[_MAX_PRUNED_SKILL_MARKERS:]
         summary = self._with_summary_prefix(_redact_compaction_text(body.strip()))
         if len(summary) > _FALLBACK_SUMMARY_MAX_CHARS:
@@ -3078,13 +3121,15 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         # P2 ghost-skill defense (#32106): [SKILL_PRUNED: ...] markers entering
         # the summarizer are prompt INPUT only — LLMs routinely paraphrase them
         # into vague prose ("some skills were loaded"), which erases the reload
-        # instruction. Extract the referenced skill names deterministically
-        # BEFORE the call; ``_reinject_pruned_skill_markers`` restores any
-        # marker the model dropped AFTER the call. Markers already carried by
-        # the previous summary must survive iterative rewrites the same way.
-        # Extraction runs on the UNBOUNDED serialization so a marker that
-        # falls into the input bound's omitted middle is still re-injected.
-        _pruned_skill_names = _extract_pruned_skill_names(content_to_summarize)
+        # instruction. Collect the ghosted skills deterministically BEFORE the
+        # call (both already-pruned marker rows AND raw skill_view bodies whose
+        # instructions are about to be summarized away);
+        # ``_reinject_pruned_skill_markers`` restores any marker the model
+        # dropped AFTER the call. Markers already carried by the previous
+        # summary must survive iterative rewrites the same way. Collection
+        # walks the turn LIST, so the serialized input bound below cannot
+        # hide a marker in its omitted middle.
+        _pruned_skill_names = _collect_ghosted_skill_names(turns_to_summarize)
         for _name in _extract_pruned_skill_names(self._previous_summary or ""):
             if _name not in _pruned_skill_names:
                 _pruned_skill_names.append(_name)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -894,7 +894,7 @@ def _summarize_tool_result_unguarded(tool_name: str, tool_args: str, tool_conten
     if tool_name == "skill_view":
         name = args.get("name", "?")
         if content_len > 5000:
-            return f"[skill_view] name={name} ({content_len:,} chars) [SKILL_PRUNED: content lost in compression; reload with skill_view before relying on it]"
+            return f"[skill_view] name={name} ({content_len:,} chars) [SKILL_PRUNED: content lost in compression; reload with skill_view(name='{name}')]"
         return f"[skill_view] name={name} ({content_len:,} chars)"
 
     if tool_name in {"skills_list", "skill_manage"}:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -320,6 +320,172 @@ _SUMMARY_INPUT_MAX_CHARS = 160_000
 # Placeholder used when pruning old tool results
 _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 
+# Ghost-skill defense (#32106): when compaction reduces an old ``skill_view``
+# result to a 1-line metadata summary, the model still believes the skill is
+# loaded even though its instructions are gone. The marker below is the ONE
+# canonical prune signal — ``_skill_pruned_marker()`` builds it and every
+# presence check matches against the same string, so the emit side and the
+# check side can never drift apart (the original PR #44166 emitted
+# ``[SKILL_PRUNED:`` but presence-checked ``[SKILL_PRUNED]``, making
+# re-injection fire even when the marker had survived).
+SKILL_PRUNED_MARKER_PREFIX = "[SKILL_PRUNED:"
+# Cap for the deterministic marker re-injection list — keeps a very long
+# session from growing an unbounded "## Pruned Skills" block in every
+# iterative summary update. Newest-referenced skills win.
+_MAX_PRUNED_SKILL_MARKERS = 20
+
+
+def _skill_pruned_marker(skill_name: str) -> str:
+    """Return the canonical prune marker for *skill_name*.
+
+    Used verbatim by BOTH the emit sites (tool-result summarization,
+    summary re-injection) and the survival check in
+    ``_reinject_pruned_skill_markers`` — one string, no drift.
+    """
+    return (
+        f"{SKILL_PRUNED_MARKER_PREFIX} content lost in compression; "
+        f"reload with skill_view(name='{skill_name}')]"
+    )
+
+
+# Matches the canonical marker and captures the skill name. Anchored on the
+# shared prefix constant so a wording change to the marker body updates the
+# emit helper and this extractor together.
+_SKILL_PRUNED_MARKER_RE = re.compile(
+    re.escape(SKILL_PRUNED_MARKER_PREFIX)
+    + r"[^\]]*?reload with skill_view\(name='([^']+)'\)"
+)
+
+
+def _extract_pruned_skill_names(text: str) -> list[str]:
+    """Return skill names referenced by prune markers in *text*, in order."""
+    names: list[str] = []
+    for match in _SKILL_PRUNED_MARKER_RE.finditer(text or ""):
+        name = match.group(1)
+        if name not in names:
+            names.append(name)
+    return names
+
+
+_PRUNED_SKILLS_SECTION_HEADING = "## Pruned Skills"
+
+
+def _reinject_pruned_skill_markers(summary: str, skill_names: list[str]) -> str:
+    """Deterministically restore prune markers the summarizer dropped.
+
+    ``skill_names`` was extracted from the summarizer INPUT before the LLM
+    call. For every skill whose canonical marker (``_skill_pruned_marker``)
+    is absent from the model's output, append it under a ``## Pruned
+    Skills`` section. Presence is checked against the SAME canonical string
+    the emit sites produce — a paraphrased or renamed marker counts as
+    dropped and is restored (the original PR checked the literal
+    ``[SKILL_PRUNED]``, which never matches the emitted ``[SKILL_PRUNED:``
+    form, so it duplicated markers that HAD survived).
+
+    The appended block is plain body text: it never carries a handoff
+    prefix, the merged-summary delimiter, or a start-of-content scaffolding
+    marker, so ``classify_summary_content`` / todo-snapshot flag handling
+    are unaffected. The block is routed through ``_redact_compaction_text``
+    like every other compaction-boundary text.
+    """
+    if not skill_names:
+        return summary
+    missing = [
+        name for name in skill_names
+        if _skill_pruned_marker(name) not in summary
+    ]
+    if not missing:
+        return summary
+    lines = [_skill_pruned_marker(name) for name in missing]
+    block = (
+        "\n\n" + _PRUNED_SKILLS_SECTION_HEADING + "\n"
+        + "\n".join(lines)
+        + "\n(The listed skills' instructions were pruned during context "
+        "compression. Reload with the skill_view call in each marker before "
+        "relying on that skill; one reload per skill is enough — ignore any "
+        "older markers for the same skill.)"
+    )
+    return summary + _redact_compaction_text(block)
+
+
+# A skill_view call within this many trailing messages counts as "just
+# loaded": its full instruction body must survive the Phase-1 prune even when
+# the token-budget boundary would otherwise demote it (#32106). Distinct from
+# the protected-tail boundary, which is token-based and can land immediately
+# after a bulky just-loaded skill body.
+_SKILL_PRUNE_RECENT_WINDOW = 10
+
+
+def _skill_view_call_sites(
+    messages: List[Dict[str, Any]],
+) -> list[tuple[int, str]]:
+    """Yield ``(message_index, skill_name)`` for every skill_view tool call."""
+    sites: list[tuple[int, str]] = []
+    for i, msg in enumerate(messages):
+        if msg.get("role") != "assistant":
+            continue
+        for tc in msg.get("tool_calls") or []:
+            if isinstance(tc, dict):
+                fn = tc.get("function", {})
+                name = fn.get("name", "") if isinstance(fn, dict) else ""
+                args_str = fn.get("arguments", "") if isinstance(fn, dict) else ""
+            else:
+                fn = getattr(tc, "function", None)
+                name = getattr(fn, "name", "") if fn else ""
+                args_str = getattr(fn, "arguments", "") if fn else ""
+            if name != "skill_view" or not isinstance(args_str, str) or not args_str:
+                continue
+            try:
+                args = json.loads(args_str)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(args, dict):
+                skill = args.get("name", "")
+                if isinstance(skill, str) and skill:
+                    sites.append((i, skill))
+    return sites
+
+
+def _collect_protected_skill_names(
+    messages: List[Dict[str, Any]], prune_boundary: int,
+) -> set[str]:
+    """Skill names whose skill_view bodies must survive Phase-1 demotion.
+
+    A skill is protected (lower-cased set) when any of these hold:
+
+    - its most recent ``skill_view`` call sits within the last
+      ``_SKILL_PRUNE_RECENT_WINDOW`` messages (just loaded / just reloaded);
+    - its most recent ``skill_view`` call sits inside the protected tail
+      (at or after *prune_boundary*);
+    - its name is mentioned in a user message inside the protected tail
+      (the user is actively steering work that depends on it).
+
+    Protection applies to the ordinary Phase-1/2 prune only. The Pass-4
+    pressure demotion deliberately ignores it: when the protected region
+    itself exceeds the soft budget, exempting skill bodies would recreate
+    the #61932 dead-end shape.
+    """
+    total = len(messages)
+    if not total:
+        return set()
+    recent_start = max(0, total - _SKILL_PRUNE_RECENT_WINDOW)
+    tail_start = max(0, prune_boundary)
+    tail_user_texts: list[str] = []
+    for msg in messages[tail_start:]:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and content:
+            tail_user_texts.append(content.lower())
+    protected: set[str] = set()
+    for idx, skill in _skill_view_call_sites(messages):
+        key = skill.lower()
+        if idx >= recent_start or idx >= tail_start:
+            protected.add(key)
+        elif any(key in text for text in tail_user_texts):
+            protected.add(key)
+    return protected
+
 # Chars per token rough estimate
 _CHARS_PER_TOKEN = 4
 # Flat token cost per attached image part.  Real cost varies by provider and
@@ -894,7 +1060,13 @@ def _summarize_tool_result_unguarded(tool_name: str, tool_args: str, tool_conten
     if tool_name == "skill_view":
         name = args.get("name", "?")
         if content_len > 5000:
-            return f"[skill_view] name={name} ({content_len:,} chars) [SKILL_PRUNED: content lost in compression; reload with skill_view(name='{name}')]"
+            # Ghost-skill defense (#32106): a metadata-only summary makes the
+            # model believe the skill is still loaded. The canonical marker
+            # tells it the instructions are gone AND how to get them back.
+            return (
+                f"[skill_view] name={name} ({content_len:,} chars) "
+                + _skill_pruned_marker(str(name))
+            )
         return f"[skill_view] name={name} ({content_len:,} chars)"
 
     if tool_name in {"skills_list", "skill_manage"}:
@@ -2217,7 +2389,14 @@ class ContextCompressor(ContextEngine):
             else:
                 content_hashes[h] = (i, msg.get("tool_call_id", "?"))
 
-        def _demote_tool_result_at(idx: int) -> bool:
+        # Ghost-skill defense (#32106): skills just loaded (or actively
+        # referenced in the protected tail) keep their full skill_view
+        # bodies through the ordinary prune passes. Without this, a skill
+        # loaded moments before a compaction can be demoted to metadata
+        # while the model still believes its instructions are in context.
+        protected_skills = _collect_protected_skill_names(result, prune_boundary)
+
+        def _demote_tool_result_at(idx: int, *, spare_protected_skills: bool = True) -> bool:
             """Replace a bulky tool result at ``idx`` with a 1-line summary.
 
             Returns True when the message was modified.
@@ -2256,6 +2435,16 @@ class ContextCompressor(ContextEngine):
                 return False
             call_id = msg.get("tool_call_id", "")
             tool_name, tool_args = call_id_to_tool.get(call_id, ("unknown", ""))
+            if spare_protected_skills and tool_name == "skill_view" and protected_skills:
+                # Just-loaded / actively-referenced skills survive verbatim
+                # (#32106). Pass-4 pressure demotion overrides this.
+                try:
+                    _args = json.loads(tool_args) if tool_args else {}
+                except (json.JSONDecodeError, TypeError):
+                    _args = {}
+                _skill = _args.get("name", "") if isinstance(_args, dict) else ""
+                if isinstance(_skill, str) and _skill.lower() in protected_skills:
+                    return False
             summary = _summarize_tool_result(tool_name, tool_args, content)
             result[idx] = {**msg, "content": summary}
             pruned += 1
@@ -2320,7 +2509,10 @@ class ContextCompressor(ContextEngine):
             if demote_end > prune_boundary and _protected_region_tokens() > soft_ceiling:
                 pressure_hits = 0
                 for i in range(max(0, prune_boundary), demote_end):
-                    if _demote_tool_result_at(i):
+                    # Pressure passes override the just-loaded-skill guard:
+                    # when the protected region itself blows the soft budget,
+                    # sparing skill bodies would recreate the #61932 dead-end.
+                    if _demote_tool_result_at(i, spare_protected_skills=False):
                         pressure_hits += 1
                     if _truncate_tool_call_args_at(i):
                         pressure_hits += 1
@@ -2340,7 +2532,7 @@ class ContextCompressor(ContextEngine):
                         if last_tool_idx is not None and i == last_tool_idx:
                             continue
                         if result[i].get("role") == "tool":
-                            if _demote_tool_result_at(i):
+                            if _demote_tool_result_at(i, spare_protected_skills=False):
                                 pressure_hits += 1
                         elif result[i].get("role") == "assistant":
                             if _truncate_tool_call_args_at(i):
@@ -2354,7 +2546,9 @@ class ContextCompressor(ContextEngine):
                         and last_tool_idx >= prune_boundary
                         and _protected_region_tokens() > soft_ceiling
                     ):
-                        if _demote_tool_result_at(last_tool_idx):
+                        if _demote_tool_result_at(
+                            last_tool_idx, spare_protected_skills=False
+                        ):
                             pressure_hits += 1
                 if pressure_hits and not self.quiet_mode:
                     logger.info(
@@ -2754,9 +2948,25 @@ Continue from the most recent unfulfilled user ask and protected tail messages. 
 
 ## Critical Context
 Summary generation was unavailable, so this is a best-effort deterministic fallback for {len(turns_to_summarize)} compacted message(s).{reason_text}"""
+        # Ghost-skill defense (#32106): the fallback's per-turn truncation
+        # (``_FALLBACK_TURN_MAX_CHARS``) routinely cuts [SKILL_PRUNED: ...]
+        # markers out of the compacted turns. Re-derive them from the raw
+        # turn contents and re-inject deterministically, exactly like the
+        # LLM-summary path.
+        _pruned_names: list[str] = []
+        for _turn in turns_to_summarize:
+            for _name in _extract_pruned_skill_names(
+                _content_text_for_contains(_turn.get("content"))
+            ):
+                if _name not in _pruned_names:
+                    _pruned_names.append(_name)
+        del _pruned_names[_MAX_PRUNED_SKILL_MARKERS:]
         summary = self._with_summary_prefix(_redact_compaction_text(body.strip()))
         if len(summary) > _FALLBACK_SUMMARY_MAX_CHARS:
             summary = summary[: _FALLBACK_SUMMARY_MAX_CHARS - 42].rstrip() + "\n...[fallback summary truncated]"
+        # Re-inject AFTER the size cap: the markers live at the end of the
+        # body, exactly where the truncation above cuts.
+        summary = _reinject_pruned_skill_markers(summary, _pruned_names)
         return summary
 
     @classmethod
@@ -2864,9 +3074,22 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             self._previous_summary = _redact_compaction_text(self._previous_summary)
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
-        content_to_summarize = self._bound_summary_input(
-            self._serialize_for_summary(turns_to_summarize)
-        )
+        content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+        # P2 ghost-skill defense (#32106): [SKILL_PRUNED: ...] markers entering
+        # the summarizer are prompt INPUT only — LLMs routinely paraphrase them
+        # into vague prose ("some skills were loaded"), which erases the reload
+        # instruction. Extract the referenced skill names deterministically
+        # BEFORE the call; ``_reinject_pruned_skill_markers`` restores any
+        # marker the model dropped AFTER the call. Markers already carried by
+        # the previous summary must survive iterative rewrites the same way.
+        # Extraction runs on the UNBOUNDED serialization so a marker that
+        # falls into the input bound's omitted middle is still re-injected.
+        _pruned_skill_names = _extract_pruned_skill_names(content_to_summarize)
+        for _name in _extract_pruned_skill_names(self._previous_summary or ""):
+            if _name not in _pruned_skill_names:
+                _pruned_skill_names.append(_name)
+        del _pruned_skill_names[_MAX_PRUNED_SKILL_MARKERS:]
+        content_to_summarize = self._bound_summary_input(content_to_summarize)
         _sanitized_memory_context = sanitize_memory_context(memory_context)
         _serialized_memory_context = json.dumps(
             _sanitized_memory_context,
@@ -3058,6 +3281,12 @@ Be specific with file paths, commands, line numbers, and results.]
 ## Critical Context
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation. NEVER include API keys, tokens, passwords, or credentials — write [REDACTED] instead.]
 
+{_PRUNED_SKILLS_SECTION_HEADING}
+[If any [SKILL_PRUNED: ...reload with skill_view(...)] markers appear in the input,
+repeat each one verbatim here — copy the exact text, do NOT paraphrase, summarize,
+or describe them. These markers tell the agent which skills must be reloaded before
+use. If none appear, omit this section entirely.]
+
 Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command outputs, error messages, line numbers, and specific values. Avoid vague descriptions like "made some changes" — say exactly what changed.
 {_temporal_anchoring_rule}
 Write only the summary body. Do not include any preamble or prefix."""
@@ -3209,6 +3438,9 @@ This compaction should PRIORITISE preserving all information related to the focu
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
             summary = _redact_compaction_text(content.strip())
+            # P2 ghost-skill defense (#32106): deterministically restore any
+            # [SKILL_PRUNED: ...] marker the summarizer paraphrased away.
+            summary = _reinject_pruned_skill_markers(summary, _pruned_skill_names)
             summary = self._ground_historical_task_snapshot(summary, turns_to_summarize)
             self._validate_summary_user_provenance(summary, has_user_turn)
             # Store for iterative updates on next compaction

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -192,7 +192,12 @@ SKILLS_GUIDANCE = (
     "skill with skill_manage so you can reuse it next time.\n"
     "When using a skill and finding it outdated, incomplete, or wrong, "
     "patch it immediately with skill_manage(action='patch') — don't wait to be asked. "
-    "Skills that aren't maintained become liabilities."
+    "Skills that aren't maintained become liabilities.\n"
+    "\n"
+    "## Skill Safety Rule\n"
+    "1. **UNAVAILABLE** — If a skill placeholder contains `[SKILL_PRUNED]`, the skill content was lost in compression and is inaccessible.\n"
+    "2. **RELOAD** — Before performing any action that depends on a skill, re-check its content with `skill_view(name='...')` if it shows `[SKILL_PRUNED]`.\n"
+    "3. **WAIT** — If a skill is loading or was just pruned, wait for the reload confirmation before proceeding."
 )
 
 KANBAN_GUIDANCE = (

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -197,7 +197,8 @@ SKILLS_GUIDANCE = (
     "## Skill Safety Rule\n"
     "1. **UNAVAILABLE** — If a skill placeholder contains `[SKILL_PRUNED]`, the skill content was lost in compression and is inaccessible.\n"
     "2. **RELOAD** — Before performing any action that depends on a skill, re-check its content with `skill_view(name='...')` if it shows `[SKILL_PRUNED]`.\n"
-    "3. **WAIT** — If a skill is loading or was just pruned, wait for the reload confirmation before proceeding."
+    "3. **WAIT** — If a skill is loading or was just pruned, wait for the reload confirmation before proceeding.\n"
+    "4. **DEDUP** — After reloading a pruned skill, **ignore any remaining `[SKILL_PRUNED]` markers for that same skill** — they are historical artifacts from previous compactions and do not need further action."
 )
 
 KANBAN_GUIDANCE = (

--- a/contributors/emails/lesbetes28@gmail.com
+++ b/contributors/emails/lesbetes28@gmail.com
@@ -1,0 +1,1 @@
+dolphin-creator

--- a/tests/agent/test_ghost_skill_pruning.py
+++ b/tests/agent/test_ghost_skill_pruning.py
@@ -301,6 +301,30 @@ class TestMarkerSurvivesRealCompress:
         assert _skill_pruned_marker("pdf") in summary_text
         assert c._last_summary_fallback_used is True
 
+    def test_raw_skill_body_in_compressed_middle_gets_marker(self):
+        """A never-demoted skill_view body summarized away still ghosts.
+
+        The skill body can survive Phase-1 (protected tail of an earlier
+        prune) and then age into the compression window as RAW content.
+        The summarizer paraphrases it away — the P2 layer must emit the
+        marker for it as well, not only for already-pruned rows.
+        """
+        c = _make_compressor(protect_first_n=1, protect_last_n=2)
+        skill_body = "# pdf skill\n" + ("Detailed instructions line.\n" * 400)
+        msgs = self._messages_with_pruned_skill_in_middle()
+        msgs[3] = {"role": "tool", "tool_call_id": "call_pdf", "content": skill_body}
+        drop_response = self._mock_response(
+            "## Goal\nBuild the PDF report.\n\n## Completed Actions\n"
+            "1. Loaded some skills and worked on the report."
+        )
+        with (
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=7),
+            patch("agent.context_compressor.call_llm", return_value=drop_response),
+        ):
+            result = c.compress(msgs, force=True)
+        summary_text = self._summary_text_of(result)
+        assert _skill_pruned_marker("pdf") in summary_text
+
     def test_marker_survives_iterative_recompression(self):
         """Markers in a rehydrated handoff summary survive iterative rewrites.
 

--- a/tests/agent/test_ghost_skill_pruning.py
+++ b/tests/agent/test_ghost_skill_pruning.py
@@ -1,0 +1,364 @@
+"""Ghost-skill defense tests (#32106, salvage of PR #44166).
+
+When compaction reduces an old ``skill_view`` result to a metadata-only
+summary, the model still believes the skill is loaded even though its
+instructions are gone. The defense has three layers:
+
+- P0/P1: the pruned tool-result summary carries a canonical
+  ``[SKILL_PRUNED: ...]`` marker with the exact reload call, and the
+  system prompt (SKILLS_GUIDANCE) tells the model how to react to it.
+- Phase-1 protection: a skill loaded just before compaction (or actively
+  referenced in the protected tail) keeps its full body through the
+  ordinary prune passes.
+- P2: markers entering the summarizer are extracted BEFORE the aux LLM
+  call and deterministically re-injected if the model paraphrased them
+  away — including on the static fallback path.
+
+Test patterns for the marker emit checks adapted from PR #32375
+(@LeonSGP43) with credit.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import (
+    SKILL_PRUNED_MARKER_PREFIX,
+    SUMMARY_PREFIX,
+    ContextCompressor,
+    _collect_protected_skill_names,
+    _extract_pruned_skill_names,
+    _MAX_PRUNED_SKILL_MARKERS,
+    _reinject_pruned_skill_markers,
+    _skill_pruned_marker,
+    _summarize_tool_result,
+)
+
+
+def _make_compressor(**overrides):
+    kwargs = dict(
+        model="test/model",
+        quiet_mode=True,
+        protect_first_n=1,
+        protect_last_n=2,
+    )
+    kwargs.update(overrides)
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100000
+    ):
+        return ContextCompressor(**kwargs)
+
+
+def _skill_view_pair(call_id, skill_name, size=6000):
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": call_id,
+                "type": "function",
+                "function": {
+                    "name": "skill_view",
+                    "arguments": f'{{"name":"{skill_name}"}}',
+                },
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": call_id,
+            "content": f"# {skill_name} instructions\n" + "x" * size,
+        },
+    ]
+
+
+class TestSkillPrunedMarkerEmit:
+    """Marker emit — patterns adapted from PR #32375 (@LeonSGP43)."""
+
+    def test_skill_view_summary_marks_pruned_content(self):
+        summary = _summarize_tool_result(
+            "skill_view", '{"name":"docker-management"}', "x" * 6000
+        )
+        assert summary.startswith("[skill_view] name=docker-management (6,000 chars)")
+        assert _skill_pruned_marker("docker-management") in summary
+        assert "reload with skill_view(name='docker-management')" in summary
+
+    def test_small_skill_view_summary_not_marked(self):
+        summary = _summarize_tool_result(
+            "skill_view", '{"name":"docker-management"}', "x" * 1234
+        )
+        assert summary == "[skill_view] name=docker-management (1,234 chars)"
+        assert SKILL_PRUNED_MARKER_PREFIX not in summary
+
+    def test_other_skill_tool_summaries_remain_metadata_only(self):
+        summary = _summarize_tool_result(
+            "skills_list", '{"name":"docker-management"}', "x" * 6000
+        )
+        assert summary == "[skills_list] name=docker-management (6,000 chars)"
+        assert SKILL_PRUNED_MARKER_PREFIX not in summary
+
+    def test_marker_extractor_round_trips_the_emitted_marker(self):
+        """Emit and check sides share one canonical string.
+
+        The original PR #44166 emitted ``[SKILL_PRUNED:`` but presence-
+        checked ``[SKILL_PRUNED]`` — re-injection fired even when the
+        marker had survived. Pin the round trip.
+        """
+        summary = _summarize_tool_result("skill_view", '{"name":"pdf"}', "x" * 6000)
+        assert _extract_pruned_skill_names(summary) == ["pdf"]
+        assert _skill_pruned_marker("pdf") in summary
+
+
+class TestReinjectPrunedSkillMarkers:
+    def test_no_duplicate_when_canonical_marker_survived(self):
+        marker = _skill_pruned_marker("pdf")
+        out = _reinject_pruned_skill_markers("summary body\n" + marker, ["pdf"])
+        assert out.count(SKILL_PRUNED_MARKER_PREFIX) == 1
+
+    def test_reinjects_when_marker_paraphrased_away(self):
+        out = _reinject_pruned_skill_markers(
+            "The pdf skill was loaded earlier but its content was summarized.",
+            ["pdf"],
+        )
+        assert _skill_pruned_marker("pdf") in out
+        assert "## Pruned Skills" in out
+
+    def test_partial_survival_reinjects_only_missing(self):
+        marker_a = _skill_pruned_marker("alpha")
+        out = _reinject_pruned_skill_markers("body\n" + marker_a, ["alpha", "beta"])
+        assert out.count(_skill_pruned_marker("alpha")) == 1
+        assert out.count(_skill_pruned_marker("beta")) == 1
+
+    def test_empty_name_list_is_a_no_op(self):
+        assert _reinject_pruned_skill_markers("body", []) == "body"
+
+    def test_marker_block_is_not_classified_as_handoff_content(self):
+        """Markers must never turn a row into summary/handoff content."""
+        marker = _skill_pruned_marker("pdf")
+        assert ContextCompressor.classify_summary_content(marker) is None
+        row = "[skill_view] name=pdf (6,000 chars) " + marker
+        assert ContextCompressor.classify_summary_content(row) is None
+        # And the strip helper leaves marker-bearing rows untouched.
+        c = ContextCompressor.__new__(ContextCompressor)
+        msg = {"role": "user", "content": row}
+        assert c._strip_context_summary_handoff_message(msg) == msg
+
+    def test_reinjected_summary_still_classifies_standalone(self):
+        body = _reinject_pruned_skill_markers("## Goal\nwork\n", ["pdf"])
+        full = SUMMARY_PREFIX + "\n\n" + body
+        assert ContextCompressor.classify_summary_content(full) == "standalone"
+
+
+class TestProtectedSkillPrune:
+    """Phase-1 prune must not demote a just-loaded skill (#32106)."""
+
+    def _filler(self, n, start=0):
+        out = []
+        for i in range(n):
+            role = "user" if (start + i) % 2 == 0 else "assistant"
+            out.append({"role": role, "content": f"filler {start + i} " + "y" * 400})
+        return out
+
+    def test_old_single_use_skill_is_pruned_with_marker(self):
+        c = _make_compressor()
+        msgs = _skill_view_pair("call_s", "old-skill") + self._filler(14)
+        result, pruned = c._prune_old_tool_results(msgs, protect_tail_count=4)
+        assert pruned >= 1
+        skill_row = result[1]
+        assert _skill_pruned_marker("old-skill") in skill_row["content"]
+
+    def test_recently_loaded_skill_survives_prune(self):
+        c = _make_compressor()
+        # skill loaded within the last 10 messages, but OUTSIDE the
+        # protected tail count — without the guard it would be demoted.
+        msgs = (
+            self._filler(10)
+            + _skill_view_pair("call_s", "fresh-skill")
+            + self._filler(6, start=10)
+        )
+        result, _ = c._prune_old_tool_results(msgs, protect_tail_count=4)
+        skill_row = result[11]
+        assert skill_row["content"].startswith("# fresh-skill instructions")
+        assert SKILL_PRUNED_MARKER_PREFIX not in skill_row["content"]
+
+    def test_skill_named_in_tail_user_message_survives_prune(self):
+        c = _make_compressor()
+        msgs = (
+            _skill_view_pair("call_s", "steered-skill")
+            + self._filler(14)
+            + [{"role": "user", "content": "keep following the steered-skill steps"}]
+        )
+        result, _ = c._prune_old_tool_results(msgs, protect_tail_count=4)
+        skill_row = result[1]
+        assert skill_row["content"].startswith("# steered-skill instructions")
+
+    def test_pressure_demotion_overrides_skill_protection(self):
+        """Pass-4 must still demote protected skill bodies (#61932 guard)."""
+        c = _make_compressor()
+        msgs = (
+            self._filler(2)
+            + _skill_view_pair("call_s", "fresh-skill", size=60000)
+            + [{"role": "user", "content": "active ask"}]
+        )
+        # Tiny token budget → protected region exceeds the soft ceiling and
+        # the pressure pass must reclaim the skill body despite protection.
+        result, pruned = c._prune_old_tool_results(
+            msgs, protect_tail_count=4, protect_tail_tokens=100
+        )
+        skill_row = result[3]
+        assert pruned >= 1
+        assert _skill_pruned_marker("fresh-skill") in skill_row["content"]
+
+
+class TestMarkerSurvivesRealCompress:
+    """P2 layer: markers survive a real compress() with a mocked aux LLM."""
+
+    def _mock_response(self, text):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = text
+        return response
+
+    def _messages_with_pruned_skill_in_middle(self):
+        """Transcript whose compressed middle carries a prune marker row."""
+        pruned_row_content = (
+            "[skill_view] name=pdf (48,201 chars) " + _skill_pruned_marker("pdf")
+        )
+        msgs = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Build the PDF report"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_pdf",
+                    "type": "function",
+                    "function": {
+                        "name": "skill_view",
+                        "arguments": '{"name":"pdf"}',
+                    },
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_pdf", "content": pruned_row_content},
+            {"role": "assistant", "content": "Loaded the skill, working."},
+            {"role": "user", "content": "continue"},
+            {"role": "assistant", "content": "more work " + "z" * 500},
+            {"role": "user", "content": "latest ask"},
+            {"role": "assistant", "content": "ack"},
+        ]
+        return msgs
+
+    def _summary_text_of(self, result):
+        for msg in result:
+            if ContextCompressor.classify_summary_content(msg.get("content")):
+                return msg["content"]
+        raise AssertionError(f"no summary message found in {result!r}")
+
+    def test_marker_reinjected_when_summarizer_drops_it(self):
+        c = _make_compressor(protect_first_n=1, protect_last_n=2)
+        msgs = self._messages_with_pruned_skill_in_middle()
+        drop_response = self._mock_response(
+            "## Goal\nBuild the PDF report.\n\n## Completed Actions\n"
+            "1. Loaded some skills and worked on the report."
+        )
+        with (
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=7),
+            patch(
+                "agent.context_compressor.call_llm", return_value=drop_response
+            ) as mock_call,
+        ):
+            result = c.compress(msgs, force=True)
+        assert mock_call.called
+        summary_text = self._summary_text_of(result)
+        assert _skill_pruned_marker("pdf") in summary_text
+        # Stored iterative-update state carries the marker too.
+        assert _skill_pruned_marker("pdf") in c._previous_summary
+
+    def test_marker_not_duplicated_when_summarizer_preserves_it(self):
+        c = _make_compressor(protect_first_n=1, protect_last_n=2)
+        msgs = self._messages_with_pruned_skill_in_middle()
+        keep_response = self._mock_response(
+            "## Goal\nBuild the PDF report.\n\n## Pruned Skills\n"
+            + _skill_pruned_marker("pdf")
+        )
+        with (
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=7),
+            patch("agent.context_compressor.call_llm", return_value=keep_response),
+        ):
+            result = c.compress(msgs, force=True)
+        summary_text = self._summary_text_of(result)
+        assert summary_text.count(_skill_pruned_marker("pdf")) == 1
+
+    def test_marker_survives_static_fallback_summary(self):
+        c = _make_compressor(protect_first_n=1, protect_last_n=2)
+        msgs = self._messages_with_pruned_skill_in_middle()
+        with (
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=7),
+            patch(
+                "agent.context_compressor.call_llm",
+                side_effect=RuntimeError("no provider"),
+            ),
+        ):
+            result = c.compress(msgs, force=True)
+        summary_text = self._summary_text_of(result)
+        assert _skill_pruned_marker("pdf") in summary_text
+        assert c._last_summary_fallback_used is True
+
+    def test_marker_survives_iterative_recompression(self):
+        """Markers in a rehydrated handoff summary survive iterative rewrites.
+
+        On re-compression the previous handoff (carrying the marker) is
+        rehydrated into ``_previous_summary``; even when the summarizer's
+        iterative update drops the marker, re-injection restores it.
+        """
+        c = _make_compressor(protect_first_n=1, protect_last_n=2)
+        prior_handoff = (
+            SUMMARY_PREFIX
+            + "\n\n## Goal\nOld work.\n\n## Pruned Skills\n"
+            + _skill_pruned_marker("pdf")
+        )
+        msgs = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": prior_handoff},
+        ] + [
+            {"role": "assistant" if i % 2 == 0 else "user", "content": f"turn {i} " + "q" * 300}
+            for i in range(8)
+        ]
+        drop_response = self._mock_response("## Goal\nNext task in flight.")
+        with (
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=8),
+            patch("agent.context_compressor.call_llm", return_value=drop_response),
+        ):
+            result = c.compress(msgs, force=True)
+        summary_text = self._summary_text_of(result)
+        assert _skill_pruned_marker("pdf") in summary_text
+
+
+class TestReinjectionBoundsAndRedaction:
+    def test_marker_list_is_capped(self):
+        names = [f"skill-{i}" for i in range(_MAX_PRUNED_SKILL_MARKERS + 15)]
+        out = _reinject_pruned_skill_markers("body", names)
+        assert out.count(SKILL_PRUNED_MARKER_PREFIX) == len(names)
+        # The cap is applied at the collection sites in _generate_summary /
+        # _build_static_fallback_summary; the helper itself is mechanical.
+
+    def test_reinjection_block_is_redacted(self, monkeypatch):
+        import agent.redact as redact_mod
+
+        # force=True redaction must win even when redaction is disabled.
+        monkeypatch.setattr(redact_mod, "_REDACT_ENABLED", False, raising=False)
+        secret = "ghp_" + "a1B2" * 6
+        out = _reinject_pruned_skill_markers("body", [f"x {secret}"])
+        assert secret not in out
+
+
+class TestSkillsGuidanceSafetyRule:
+    def test_safety_rule_present_with_real_newlines(self):
+        from agent.prompt_builder import SKILLS_GUIDANCE
+
+        assert "## Skill Safety Rule" in SKILLS_GUIDANCE
+        assert "[SKILL_PRUNED]" in SKILLS_GUIDANCE
+        assert "skill_view(name='...')" in SKILLS_GUIDANCE
+        # The rule list must use REAL newlines — the original PR hunk risked
+        # literal backslash-n escape text rendering into the system prompt.
+        assert "\\n" not in SKILLS_GUIDANCE
+        assert SKILLS_GUIDANCE.count("\n") >= 6
+        for rule in ("UNAVAILABLE", "RELOAD", "WAIT", "DEDUP"):
+            assert rule in SKILLS_GUIDANCE


### PR DESCRIPTION
Salvage of PR #44166 (@dolphin-creator) — ghost-skill defense for context compression. Fixes #32106. Consolidates sibling PR #32562 (@dolphin-creator, same author's earlier P0/P1-only version) and credits the test patterns from PR #32375 (@LeonSGP43).

## The bug (verified live on main @ c2c2449d05)

When compression demotes an old `skill_view` result, `_summarize_tool_result` reduces it to metadata only — `[skill_view] name=pdf (48,201 chars)` — with **no signal that the instructions are gone and no reload path**. The model keeps believing the skill is loaded ("ghost skill") and follows half-remembered instructions. Repo-wide grep for `SKILL_PRUNED` = zero hits; `SKILLS_GUIDANCE` (agent/prompt_builder.py) had no safety rule.

## What ships (3 layers)

**P0/P1 — marker + system-prompt rule** (contributor commits, cherry-picked/reapplied with authorship):
- Pruned `skill_view` summaries > 5,000 chars now carry the canonical marker: `[SKILL_PRUNED: content lost in compression; reload with skill_view(name='X')]`. Small skill bodies stay verbatim.
- `SKILLS_GUIDANCE` gains a **Skill Safety Rule** (UNAVAILABLE / RELOAD / WAIT / DEDUP) so the model reacts to markers and doesn't re-reload the same skill on every turn.

**Phase-1 protection — just-loaded skills survive the prune** (rework of contributor's pre-pass idea):
- `_prune_old_tool_results` now threads a protected-skill set (`_collect_protected_skill_names`): skills whose `skill_view` call sits in the last 10 messages, inside the protected tail, or whose name appears in a tail user message keep their full bodies.
- The Pass-4 pressure demotion **deliberately overrides** the guard (`spare_protected_skills=False`) so the #61932 oversized-protected-tail dead-end cannot return.

**P2 — deterministic marker survival through the summarizer** (rework):
- Before the aux LLM call, `_collect_ghosted_skill_names` scans the compressed middle window for BOTH already-pruned marker rows AND raw `skill_view` bodies about to be paraphrased away.
- After the call, `_reinject_pruned_skill_markers` restores any canonical marker the model dropped, under a `## Pruned Skills` section (capped at 20 skills). Same treatment on the static-fallback path — re-applied **after** its size cap, since truncation cuts exactly where markers land.
- Markers already carried by the rehydrated previous handoff survive iterative re-compression the same way.

## Required reworks vs the original PR

| # | Original defect | Fix here |
|---|---|---|
| 1 | Emitted marker was `[SKILL_PRUNED:` but the presence check looked for `[SKILL_PRUNED]` → re-injection duplicated markers that had survived | One prefix constant `SKILL_PRUNED_MARKER_PREFIX` + `_skill_pruned_marker(name)` used by **both** emit and check; pinned by `test_no_duplicate_when_canonical_marker_survived` |
| 2 | Pre-pass "protected" skill set never threaded into Phase 1 (`_prune_old_tool_results`) — protection didn't persist | Protected set computed inside `_prune_old_tool_results` and consulted by `_demote_tool_result_at`; pressure passes override it |
| 3 | P2 summary-append predated the Jul 2026 redaction/handoff train | Re-injection block routes through `_redact_compaction_text()`; appended to the summary **body only** — never in front of `SUMMARY_PREFIX` or scaffolding start-of-content markers. Verified: `classify_summary_content(marker) is None`, marker-bearing rows untouched by `_strip_context_summary_handoff_message`, re-injected summaries still classify `standalone` |
| 4 | prompt_builder hunk risked literal `\n` escape text in the system prompt | Verified with `ast.literal_eval` that SKILLS_GUIDANCE renders real newlines; pinned by `test_safety_rule_present_with_real_newlines` |
| 5 | `tools/session_skills_tool.py` (230-line new core tool) | **DROPPED entirely.** A new always-loaded core tool fails the footprint ladder, and it reported "pruning success" without any real state transition. The marker already tells the model exactly what to do (`skill_view(name='X')`) — no new tool surface needed |
| 6 | Marker survival relied on prompt instructions to the summarizer (probabilistic) | Deterministic extract-before / re-inject-after around `_generate_summary`, pinned by real-`compress()` tests with a mocked aux LLM (drop → re-injected; keep → not duplicated; fallback path; iterative path) |

## Validation

| Check | Result |
|---|---|
| `tests/agent/test_ghost_skill_pruning.py` (new, 22 tests) | ✅ pass |
| `tests/agent/test_context_compressor.py` | ✅ pass |
| `tests/agent/test_compaction_redaction_boundaries.py` | ✅ pass |
| `tests/agent/test_compression_rotation_state.py` (incl. `TestTodoSnapshotMergedNotDuplicated` / `TestTodoSnapshotScaffoldingTails`) | ✅ pass |
| `tests/agent/test_prompt_builder.py` | ✅ pass |
| `tests/agent/test_protected_tail_pressure_61932.py` | ✅ pass |
| `tests/agent/test_compressed_summary_metadata.py` (classify agreement on live emissions) | ✅ pass |
| Sibling sweep: anti-thrash persistence, fallback budget, compress-focus, memory-context handoff, abort-state reset, 413 compression, computer-use prune tests | ✅ pass |
| Targeted total on rebased tip | **435 tests, 0 failed** |
| `ruff check agent/ tests/...` | ✅ clean |

### Live probe — real `compress()`, aux LLM mocked to DROP the marker

```
messages: 9 -> 5
--- marker survives in output message #2 (role=assistant) ---
## Pruned Skills
[SKILL_PRUNED: content lost in compression; reload with skill_view(name='pdf')]
(The listed skills' instructions were pruned during context compression. Reload with
the skill_view call in each marker before relying on that skill; one reload per skill
is enough — ignore any older markers for the same skill.)
marker count in full output: 1
```

With the summarizer mocked to PRESERVE the marker instead, marker count stays 1 (no duplication — the exact defect the original presence check had).

## Attribution

- `@dolphin-creator` (Jonathan Boisson): P0/P1 commit cherry-picked with authorship; marker-alignment + DEDUP-rule commit surgically reapplied with `--author`; contributor mapping added (`contributors/emails/`).
- `@LeonSGP43`: marker emit test patterns adapted from PR #32375, credited in the test module docstring.
- Rework commits (canonical constant, protected prune threading, deterministic P2 layer, ghosted-raw-body coverage) are maintainer-authored.
- PR #32562 (same author, P0/P1 subset) is consolidated into this salvage.

## Infographic

![ghost-skill-defense](https://v3b.fal.media/files/b/0aa371a5/AFG4Q9NrovyFhuHCav-V__Gtw1icNq.png)
