### PR TITLE
feat(skills): add static quality audits

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -13,8 +13,11 @@ handler are thin wrappers that parse args and delegate.
 import json
 import re
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+import yaml
 
 from rich.console import Console
 from rich.panel import Panel
@@ -22,7 +25,7 @@ from rich.table import Table
 
 # Lazy imports to avoid circular dependencies and slow startup.
 # tools.skills_hub and tools.skills_guard are imported inside functions.
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, get_hermes_home
 from agent.skill_utils import is_excluded_skill_path
 
 _console = Console()
@@ -1063,49 +1066,150 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
     c.print(f"[bold green]Updated {len(updates)} skill(s).[/]\n")
 
 
-def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
-             deep: bool = False) -> None:
-    """Re-run security scan on installed hub skills.
+@dataclass(frozen=True)
+class AuditTarget:
+    name: str
+    source: str
+    path: Path
+    declared_name: str | None = None
+    hub_entry: dict | None = None
+    missing: bool = False
 
-    When ``deep=True``, also runs an opt-in AST-level diagnostic on Python
-    files (review aid only — not a security gate; skills_guard.py verdicts
-    are unchanged).
-    """
-    from tools.skills_hub import HubLockFile, SKILLS_DIR
-    from tools.skills_guard import scan_skill, format_scan_report
+
+def _skill_name_from_path(skill_md: Path) -> str | None:
+    try:
+        content = skill_md.read_text(encoding="utf-8").lstrip("\ufeff")
+        match = re.search(r"\n---\s*\n", content[3:]) if content.startswith("---") else None
+        if match:
+            frontmatter = yaml.safe_load(content[3:match.start() + 3]) or {}
+            if isinstance(frontmatter, dict) and isinstance(frontmatter.get("name"), str):
+                return frontmatter["name"]
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        return None
+    return skill_md.parent.name
+
+
+def discover_audit_targets(*, skills_dir: Path, hub_entries: list[dict],
+                           builtin_names: set[str], name: str | None) -> tuple[list[AuditTarget], str | None]:
+    """Discover on-disk skill targets without trusting lock-file paths blindly."""
+    root = skills_dir.resolve()
+    hub_by_path: dict[Path, dict] = {}
+    for entry in hub_entries:
+        install_path = entry.get("install_path")
+        if not isinstance(install_path, str) or not install_path:
+            continue
+        candidate = (root / install_path).resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError:
+            continue
+        hub_by_path[candidate] = entry
+
+    targets: list[AuditTarget] = []
+    try:
+        skill_files = sorted(root.rglob("SKILL.md")) if root.exists() else []
+    except OSError:
+        skill_files = []
+    for skill_md in skill_files:
+        if is_excluded_skill_path(skill_md):
+            continue
+        skill_dir = skill_md.parent.resolve()
+        try:
+            skill_dir.relative_to(root)
+        except ValueError:
+            continue
+        declared_name = _skill_name_from_path(skill_md)
+        if declared_name is None:
+            continue
+        hub_entry = hub_by_path.get(skill_dir)
+        identity_name = hub_entry["name"] if hub_entry else skill_dir.name
+        source = "hub" if hub_entry else (
+            "builtin" if declared_name in builtin_names or identity_name in builtin_names else "local"
+        )
+        targets.append(AuditTarget(
+            identity_name,
+            source,
+            skill_dir,
+            declared_name=declared_name,
+            hub_entry=hub_entry,
+        ))
+
+    seen_hub_paths = {target.path for target in targets if target.hub_entry}
+    for hub_path, hub_entry in hub_by_path.items():
+        if hub_path not in seen_hub_paths:
+            targets.append(AuditTarget(
+                hub_entry["name"],
+                "hub",
+                hub_path,
+                hub_entry=hub_entry,
+                missing=not hub_path.exists(),
+            ))
+
+    targets.sort(key=lambda target: (target.name, target.source, str(target.path)))
+    if name:
+        targets = [
+            target for target in targets
+            if target.name == name or target.declared_name == name
+        ]
+        if not targets:
+            return [], f"No installed skill named '{name}' was found."
+        if len(targets) > 1:
+            choices = ", ".join(f"{target.source}:{target.path}" for target in targets)
+            return [], f"Skill name '{name}' is ambiguous: {choices}"
+    return targets, None
+
+
+def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
+             deep: bool = False, all_skills: bool = False) -> None:
+    """Run static quality checks for installed skills and retain hub security scans."""
+    from tools.skill_quality_audit import (
+        audit_skill_quality,
+        format_quality_report,
+        save_verification_receipt,
+    )
+    from tools.skills_hub import HubLockFile
+    from tools.skills_sync import _read_manifest
+    from tools.skills_guard import format_scan_report, scan_skill
 
     c = console or _console
     lock = HubLockFile()
     installed = lock.list_installed()
-
-    if not installed:
-        c.print("[dim]No hub-installed skills to audit.[/]\n")
+    skills_dir = get_hermes_home() / "skills"
+    targets, error = discover_audit_targets(
+        skills_dir=skills_dir,
+        hub_entries=installed,
+        builtin_names=set(_read_manifest()),
+        name=name,
+    )
+    if error:
+        c.print(f"[bold red]Error:[/] {error}\n")
+        return
+    if not name and not all_skills:
+        targets = [target for target in targets if target.source == "hub"]
+        if not targets:
+            c.print("[dim]No hub-installed skills to audit. Use `hermes skills audit <name>` or `--all` for local skills.[/]\n")
+            return
+    if not targets:
+        c.print("[dim]No installed skills to audit.[/]\n")
         return
 
-    targets = installed
-    if name:
-        targets = [e for e in installed if e["name"] == name]
-        if not targets:
-            c.print(f"[bold red]Error:[/] '{name}' is not a hub-installed skill.\n")
-            return
-
     c.print(f"\n[bold]Auditing {len(targets)} skill(s)...[/]\n")
-
     if deep:
         from tools.skills_ast_audit import ast_scan_path, format_ast_report
 
-    for entry in targets:
-        skill_path = SKILLS_DIR / entry["install_path"]
-        if not skill_path.exists():
-            c.print(f"[yellow]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
+    for target in targets:
+        if target.missing:
+            install_path = target.hub_entry.get("install_path", str(target.path)) if target.hub_entry else str(target.path)
+            c.print(f"[yellow]Warning:[/] {target.name} — path missing: {install_path}")
             continue
-
-        result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
-        c.print(format_scan_report(result))
-
+        quality = audit_skill_quality(target.path, skill_name=target.name, source=target.source)
+        save_verification_receipt(skills_dir / ".verification.json", quality)
+        c.print(format_quality_report(quality))
+        if target.hub_entry:
+            source = target.hub_entry.get("identifier", target.hub_entry.get("source", "hub"))
+            c.print(format_scan_report(scan_skill(target.path, source=source)))
         if deep:
-            c.print(format_ast_report(ast_scan_path(skill_path), skill_name=entry["name"]))
-
+            c.print(format_ast_report(ast_scan_path(target.path), skill_name=target.name))
         c.print()
 
 
@@ -1726,7 +1830,8 @@ def skills_command(args) -> None:
         do_update(name=getattr(args, "name", None))
     elif action == "audit":
         do_audit(name=getattr(args, "name", None),
-                 deep=getattr(args, "deep", False))
+                 deep=getattr(args, "deep", False),
+                 all_skills=getattr(args, "all", False))
     elif action == "uninstall":
         do_uninstall(args.name)
     elif action == "reset":
@@ -1913,7 +2018,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
     elif action == "audit":
         name = args[0] if args and not args[0].startswith("--") else None
         deep = "--deep" in args
-        do_audit(name=name, console=c, deep=deep)
+        do_audit(name=name, console=c, deep=deep, all_skills="--all" in args)
 
     elif action == "uninstall":
         if not args:

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -141,10 +141,15 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
     )
 
     skills_audit = skills_subparsers.add_parser(
-        "audit", help="Re-scan installed hub skills"
+        "audit", help="Audit skill quality; hub security scans remain included"
     )
     skills_audit.add_argument(
-        "name", nargs="?", help="Specific skill to audit (default: all)"
+        "name", nargs="?", help="Specific builtin, local, or hub skill to audit"
+    )
+    skills_audit.add_argument(
+        "--all",
+        action="store_true",
+        help="Audit all builtin, local, and hub-installed skills",
     )
     skills_audit.add_argument(
         "--deep",

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,14 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import (
+    discover_audit_targets,
+    do_check,
+    do_install,
+    do_list,
+    do_update,
+    handle_skills_slash,
+)
 
 
 class _DummyLockFile:
@@ -60,6 +67,124 @@ def three_source_env(monkeypatch, hub_env):
     monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(_BUILTIN_MANIFEST))
 
     return hub_env
+
+
+def _write_audit_skill(root, name):
+    skill = root / name
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill.\n"
+        "---\n\n"
+        "# Test\n",
+        encoding="utf-8",
+    )
+    return skill
+
+
+def test_discover_audit_targets_classifies_all_local_sources(tmp_path):
+    skills_dir = tmp_path / "skills"
+    builtin = _write_audit_skill(skills_dir / "builtin", "builtin-skill")
+    local = _write_audit_skill(skills_dir / "local", "local-skill")
+    hub = _write_audit_skill(skills_dir / "hub", "hub-skill")
+    hub_entries = [{"name": "hub-skill", "install_path": "hub/hub-skill", "identifier": "owner/hub-skill"}]
+
+    targets, error = discover_audit_targets(
+        skills_dir=skills_dir,
+        hub_entries=hub_entries,
+        builtin_names={"builtin-skill"},
+        name=None,
+    )
+
+    assert error is None
+    assert [(target.name, target.source, target.path) for target in targets] == [
+        ("builtin-skill", "builtin", builtin),
+        ("hub-skill", "hub", hub),
+        ("local-skill", "local", local),
+    ]
+
+
+def test_discover_audit_targets_rejects_ambiguous_names(tmp_path):
+    skills_dir = tmp_path / "skills"
+    _write_audit_skill(skills_dir / "one", "same-name")
+    _write_audit_skill(skills_dir / "two", "same-name")
+
+    targets, error = discover_audit_targets(
+        skills_dir=skills_dir,
+        hub_entries=[],
+        builtin_names=set(),
+        name="same-name",
+    )
+
+    assert targets == []
+    assert "ambiguous" in error.lower()
+
+
+def test_discover_audit_targets_skips_unreadable_skill_files(tmp_path):
+    skills_dir = tmp_path / "skills"
+    bad = skills_dir / "bad-skill"
+    bad.mkdir(parents=True)
+    (bad / "SKILL.md").write_bytes(b"\xff\xfe")
+
+    targets, error = discover_audit_targets(
+        skills_dir=skills_dir,
+        hub_entries=[],
+        builtin_names=set(),
+        name=None,
+    )
+
+    assert targets == []
+    assert error is None
+
+
+def test_discover_audit_targets_keeps_missing_hub_lock_entry(tmp_path):
+    skills_dir = tmp_path / "skills"
+    targets, error = discover_audit_targets(
+        skills_dir=skills_dir,
+        hub_entries=[{"name": "missing-hub", "install_path": "hub/missing-hub"}],
+        builtin_names=set(),
+        name=None,
+    )
+
+    assert error is None
+    assert [(target.name, target.source, target.missing) for target in targets] == [
+        ("missing-hub", "hub", True),
+    ]
+
+
+def test_discovery_preserves_folder_identity_for_name_mismatch(tmp_path):
+    skills_dir = tmp_path / "skills"
+    _write_audit_skill(skills_dir, "folder-name").joinpath("SKILL.md").write_text(
+        "---\nname: declared-name\ndescription: Test skill.\n---\n\n# Test\n",
+        encoding="utf-8",
+    )
+
+    targets, error = discover_audit_targets(
+        skills_dir=skills_dir,
+        hub_entries=[],
+        builtin_names=set(),
+        name=None,
+    )
+
+    assert error is None
+    assert [(target.name, target.declared_name) for target in targets] == [
+        ("folder-name", "declared-name"),
+    ]
+
+
+def test_skills_audit_slash_forwards_all_flag(monkeypatch):
+    called = {}
+
+    def fake_audit(**kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr("hermes_cli.skills_hub.do_audit", fake_audit)
+    handle_skills_slash("/skills audit --all --deep")
+
+    assert called["name"] is None
+    assert called["deep"] is True
+    assert called["all_skills"] is True
 
 
 def _capture(source_filter: str = "all") -> str:

--- a/tests/tools/test_skill_quality_audit.py
+++ b/tests/tools/test_skill_quality_audit.py
@@ -1,0 +1,152 @@
+"""Tests for deterministic, static skill quality auditing."""
+
+from pathlib import Path
+
+from tools.skill_quality_audit import audit_skill_quality, save_verification_receipt
+
+
+def _write_skill(
+    root: Path,
+    *,
+    name: str = "demo-skill",
+    metadata: str = "",
+    body: str = "# Demo\n\n## Verification Checklist\n- [ ] Check output\n",
+) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: A test skill.\n"
+        f"{metadata}"
+        "---\n\n"
+        f"{body}",
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_valid_static_skill_passes(tmp_path):
+    skill = _write_skill(
+        tmp_path / "demo-skill",
+        metadata="metadata:\n  hermes:\n    verification:\n      level: static\n",
+    )
+    (skill / "references").mkdir()
+    (skill / "references" / "guide.md").write_text("Guide", encoding="utf-8")
+    skill_md = skill / "SKILL.md"
+    skill_md.write_text(
+        skill_md.read_text(encoding="utf-8") + "\nRead [the guide](references/guide.md).\n",
+        encoding="utf-8",
+    )
+
+    result = audit_skill_quality(skill, skill_name="demo-skill", source="local")
+
+    assert result.status == "pass"
+    assert all(finding.severity == "pass" for finding in result.findings)
+
+
+def test_missing_verification_metadata_is_warning(tmp_path):
+    skill = _write_skill(tmp_path / "demo-skill")
+
+    result = audit_skill_quality(skill, skill_name="demo-skill", source="local")
+
+    assert result.status == "warning"
+    assert any(finding.check == "verification_metadata" and finding.severity == "warning"
+               for finding in result.findings)
+
+
+def test_invalid_verification_level_fails(tmp_path):
+    skill = _write_skill(
+        tmp_path / "demo-skill",
+        metadata="metadata:\n  hermes:\n    verification:\n      level: execute\n",
+    )
+
+    result = audit_skill_quality(skill, skill_name="demo-skill", source="local")
+
+    assert result.status == "fail"
+    assert any(finding.check == "verification_metadata" and finding.severity == "fail"
+               for finding in result.findings)
+
+
+def test_missing_local_reference_fails(tmp_path):
+    skill = _write_skill(tmp_path / "demo-skill")
+    skill_md = skill / "SKILL.md"
+    skill_md.write_text(
+        skill_md.read_text(encoding="utf-8") + "\nRead [the guide](references/missing.md).\n",
+        encoding="utf-8",
+    )
+
+    result = audit_skill_quality(skill, skill_name="demo-skill", source="local")
+
+    assert result.status == "fail"
+    assert any(finding.check == "local_references" and finding.severity == "fail"
+               for finding in result.findings)
+
+
+def test_reference_path_escape_fails_without_reading_outside_skill(tmp_path):
+    outside = tmp_path / "outside.md"
+    outside.write_text("private", encoding="utf-8")
+    skill = _write_skill(tmp_path / "demo-skill")
+    skill_md = skill / "SKILL.md"
+    skill_md.write_text(
+        skill_md.read_text(encoding="utf-8") + "\nRead [outside](../outside.md).\n",
+        encoding="utf-8",
+    )
+
+    result = audit_skill_quality(skill, skill_name="demo-skill", source="local")
+
+    assert result.status == "fail"
+    assert any(finding.check == "local_references" and "outside" in finding.message
+               for finding in result.findings)
+
+
+def test_name_mismatch_fails(tmp_path):
+    skill = _write_skill(tmp_path / "demo-skill", name="different-skill")
+
+    result = audit_skill_quality(skill, skill_name="demo-skill", source="local")
+
+    assert result.status == "fail"
+    assert any(finding.check == "skill_name" and finding.severity == "fail"
+               for finding in result.findings)
+
+
+def test_missing_verification_checklist_is_warning(tmp_path):
+    skill = _write_skill(tmp_path / "demo-skill", body="# Demo\n\nInstructions.\n")
+
+    result = audit_skill_quality(skill, skill_name="demo-skill", source="local")
+
+    assert result.status == "warning"
+    assert any(finding.check == "verification_checklist" and finding.severity == "warning"
+               for finding in result.findings)
+
+
+def test_save_verification_receipt_is_local_and_replaces_same_skill(tmp_path):
+    skill = _write_skill(tmp_path / "demo-skill")
+    result = audit_skill_quality(skill, skill_name="demo-skill", source="local")
+    receipt = tmp_path / "skills" / ".verification.json"
+
+    save_verification_receipt(receipt, result)
+    save_verification_receipt(receipt, result)
+
+    import json
+
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    assert payload["version"] == 1
+    assert len(payload["receipts"]) == 1
+    saved = next(iter(payload["receipts"].values()))
+    assert saved["status"] == result.status
+    assert "content_hash" in saved
+
+
+def test_receipts_do_not_collide_for_distinct_same_named_skills(tmp_path):
+    first = _write_skill(tmp_path / "one", name="same")
+    second = _write_skill(tmp_path / "two", name="same")
+    receipt = tmp_path / "skills" / ".verification.json"
+
+    save_verification_receipt(receipt, audit_skill_quality(first, skill_name="same", source="local"))
+    save_verification_receipt(receipt, audit_skill_quality(second, skill_name="same", source="local"))
+
+    import json
+
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    assert len(payload["receipts"]) == 2
+    assert {entry["path"] for entry in payload["receipts"].values()} == {str(first), str(second)}

--- a/tools/skill_quality_audit.py
+++ b/tools/skill_quality_audit.py
@@ -1,0 +1,255 @@
+"""Deterministic, read-only quality checks for Hermes skills.
+
+This module is deliberately diagnostic. It validates skill structure and local
+supporting-file references, but never executes a skill-provided command, script,
+or URL.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import tempfile
+from typing import Literal
+
+import yaml
+
+from tools.skill_manager_tool import _validate_frontmatter
+
+Severity = Literal["pass", "warning", "fail"]
+_SUPPORTED_LINK_DIRS = {"references", "templates", "scripts", "assets"}
+_LINK_RE = re.compile(r"(?<!!)\[[^\]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)")
+_CHECKLIST_HEADING_RE = re.compile(r"^##\s+Verification Checklist\s*$", re.MULTILINE | re.IGNORECASE)
+_CHECKBOX_RE = re.compile(r"^\s*[-*+]\s+\[[ xX]\]\s+", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class QualityFinding:
+    check: str
+    severity: Severity
+    message: str
+    remediation: str | None = None
+
+
+@dataclass(frozen=True)
+class QualityAuditResult:
+    skill_name: str
+    path: Path
+    source: str
+    status: Severity
+    findings: tuple[QualityFinding, ...]
+
+
+def _finding(check: str, severity: Severity, message: str,
+             remediation: str | None = None) -> QualityFinding:
+    return QualityFinding(check, severity, message, remediation)
+
+
+def _status(findings: list[QualityFinding]) -> Severity:
+    if any(item.severity == "fail" for item in findings):
+        return "fail"
+    if any(item.severity == "warning" for item in findings):
+        return "warning"
+    return "pass"
+
+
+def _frontmatter(content: str) -> dict | None:
+    """Parse already-validated frontmatter, returning None for malformed input."""
+    normalized = content.lstrip("\ufeff")
+    match = re.search(r"\n---\s*\n", normalized[3:])
+    if not match:
+        return None
+    try:
+        data = yaml.safe_load(normalized[3:match.start() + 3])
+    except yaml.YAMLError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _audit_metadata(frontmatter: dict) -> QualityFinding:
+    metadata = frontmatter.get("metadata")
+    if metadata is None:
+        return _finding(
+            "verification_metadata", "warning",
+            "metadata.hermes.verification.level is not declared.",
+            "Add metadata.hermes.verification.level: static for an explicit v1 contract.",
+        )
+    if not isinstance(metadata, dict):
+        return _finding("verification_metadata", "fail", "metadata must be a YAML mapping.")
+    hermes = metadata.get("hermes")
+    if hermes is None:
+        return _finding(
+            "verification_metadata", "warning",
+            "metadata.hermes.verification.level is not declared.",
+            "Add metadata.hermes.verification.level: static for an explicit v1 contract.",
+        )
+    if not isinstance(hermes, dict):
+        return _finding("verification_metadata", "fail", "metadata.hermes must be a YAML mapping.")
+    verification = hermes.get("verification")
+    if verification is None:
+        return _finding(
+            "verification_metadata", "warning",
+            "metadata.hermes.verification.level is not declared.",
+            "Add metadata.hermes.verification.level: static for an explicit v1 contract.",
+        )
+    if not isinstance(verification, dict):
+        return _finding("verification_metadata", "fail", "metadata.hermes.verification must be a YAML mapping.")
+    if verification.get("level") != "static" or set(verification) != {"level"}:
+        return _finding(
+            "verification_metadata", "fail",
+            "metadata.hermes.verification accepts only level: static in v1.",
+            "Remove unsupported fields and set level to static.",
+        )
+    return _finding("verification_metadata", "pass", "Static verification metadata is valid.")
+
+
+def _audit_local_references(content: str, skill_dir: Path) -> QualityFinding:
+    skill_root = skill_dir.resolve()
+    failures: list[str] = []
+    checked = 0
+    for match in _LINK_RE.finditer(content):
+        raw_target = match.group(1).strip().strip("<>")
+        if not raw_target or raw_target.startswith(("#", "http://", "https://", "mailto:")):
+            continue
+        target = raw_target.split("#", 1)[0].split("?", 1)[0]
+        if not target:
+            continue
+        candidate = Path(target)
+        parts = candidate.parts
+        if ".." in parts:
+            failures.append(f"{raw_target} escapes the skill directory")
+            continue
+        if not parts or parts[0] not in _SUPPORTED_LINK_DIRS:
+            continue
+        resolved = (skill_root / candidate).resolve()
+        try:
+            resolved.relative_to(skill_root)
+        except ValueError:
+            failures.append(f"{raw_target} escapes the skill directory")
+            continue
+        checked += 1
+        if not resolved.is_file():
+            failures.append(f"{raw_target} is missing")
+    if failures:
+        return _finding(
+            "local_references", "fail",
+            "Invalid local reference(s): " + "; ".join(failures) + ".",
+            "Keep references under references/, templates/, scripts/, or assets/ and ensure each file exists.",
+        )
+    return _finding("local_references", "pass", f"{checked} supported local reference(s) resolved.")
+
+
+def _audit_checklist(content: str) -> QualityFinding:
+    heading = _CHECKLIST_HEADING_RE.search(content)
+    if heading and _CHECKBOX_RE.search(content, heading.end()):
+        return _finding("verification_checklist", "pass", "Verification Checklist contains a Markdown checkbox.")
+    return _finding(
+        "verification_checklist", "warning",
+        "No Verification Checklist with a Markdown checkbox was found.",
+        "Add a ## Verification Checklist section with at least one - [ ] item.",
+    )
+
+
+def audit_skill_quality(skill_dir: Path, *, skill_name: str, source: str) -> QualityAuditResult:
+    """Run static, non-executing quality checks for one skill directory."""
+    findings: list[QualityFinding] = []
+    root = skill_dir.resolve()
+    skill_md = root / "SKILL.md"
+    if not skill_md.is_file():
+        findings.append(_finding("skill_file", "fail", "SKILL.md is missing."))
+        return QualityAuditResult(skill_name, root, source, _status(findings), tuple(findings))
+    try:
+        content = skill_md.read_text(encoding="utf-8")
+    except OSError as exc:
+        findings.append(_finding("skill_file", "fail", f"SKILL.md could not be read: {exc}."))
+        return QualityAuditResult(skill_name, root, source, _status(findings), tuple(findings))
+
+    error = _validate_frontmatter(content)
+    if error:
+        findings.append(_finding("frontmatter", "fail", error))
+        return QualityAuditResult(skill_name, root, source, _status(findings), tuple(findings))
+    findings.append(_finding("frontmatter", "pass", "Frontmatter is valid."))
+    frontmatter = _frontmatter(content)
+    if frontmatter is None:
+        findings.append(_finding("frontmatter", "fail", "Frontmatter could not be parsed."))
+        return QualityAuditResult(skill_name, root, source, _status(findings), tuple(findings))
+
+    declared_name = frontmatter.get("name")
+    if declared_name != skill_name:
+        findings.append(_finding(
+            "skill_name", "fail",
+            f"Frontmatter name {declared_name!r} does not match resolved name {skill_name!r}.",
+        ))
+    else:
+        findings.append(_finding("skill_name", "pass", "Frontmatter name matches the resolved skill name."))
+    findings.append(_audit_metadata(frontmatter))
+    findings.append(_audit_local_references(content, root))
+    findings.append(_audit_checklist(content))
+    return QualityAuditResult(skill_name, root, source, _status(findings), tuple(findings))
+
+
+def format_quality_report(result: QualityAuditResult) -> str:
+    """Format a stable, human-readable quality-audit report."""
+    lines = [
+        f"Skill quality audit: {result.skill_name} [{result.source}]",
+        f"Path: {result.path}",
+        f"Result: {result.status.upper()}",
+        "",
+    ]
+    for finding in result.findings:
+        lines.append(f"{finding.severity.upper():7} {finding.check}: {finding.message}")
+    remediation = [finding.remediation for finding in result.findings if finding.remediation]
+    if remediation:
+        lines.extend(["", "Remediation:"])
+        lines.extend(f"- {item}" for item in remediation)
+    return "\n".join(lines)
+
+
+def save_verification_receipt(receipt_path: Path, result: QualityAuditResult) -> None:
+    """Atomically persist a local-only receipt for a completed static audit."""
+    try:
+        loaded = json.loads(receipt_path.read_text(encoding="utf-8")) if receipt_path.exists() else {}
+        payload: dict = loaded if isinstance(loaded, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        payload = {}
+    receipts = payload.get("receipts") if isinstance(payload.get("receipts"), dict) else {}
+    skill_md = result.path / "SKILL.md"
+    try:
+        content_hash = hashlib.sha256(skill_md.read_bytes()).hexdigest()
+    except OSError:
+        content_hash = ""
+    path_identity = hashlib.sha256(str(result.path.resolve()).encode("utf-8")).hexdigest()[:16]
+    key = f"{result.source}:{result.skill_name}:{path_identity}"
+    receipts[key] = {
+        "audited_at": datetime.now(timezone.utc).isoformat(),
+        "skill_name": result.skill_name,
+        "source": result.source,
+        "path": str(result.path),
+        "content_hash": content_hash,
+        "status": result.status,
+        "findings": [
+            {
+                "check": finding.check,
+                "severity": finding.severity,
+                "message": finding.message,
+                "remediation": finding.remediation,
+            }
+            for finding in result.findings
+        ],
+    }
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"version": 1, "receipts": receipts}
+    fd, temporary = tempfile.mkstemp(prefix=".verification-", suffix=".tmp", dir=receipt_path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2, ensure_ascii=False)
+            handle.write("\n")
+        os.replace(temporary, receipt_path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)


### PR DESCRIPTION
## Summary
- add deterministic, source-agnostic static skill quality audits
- persist local-only verification receipts
- preserve hub security scans and deep AST diagnostics

## Verification
- Focused audit/CLI/AST regression suite: 54 passed
- Full suite was exercised; 22 pre-existing failures occurred in 11 unrelated files (gateway/platform guards, file tools, approval, execution-flag detection, and Anthropic adapter).