### PR TITLE
fix(moa): reference_max_tokens caps advisors on every provider, never the aggregator + per-slot caps (cluster salvage)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6839,7 +6839,10 @@ def _build_call_kwargs(
             or _is_nvidia_nim
             or _is_moa
         ):
-            kwargs["max_tokens"] = max_tokens
+            # Use auxiliary_max_tokens_param() so models that require
+            # max_completion_tokens (GPT-5 family, Copilot) get the right
+            # parameter name instead of a hardcoded max_tokens that 400s.
+            kwargs.update(auxiliary_max_tokens_param(max_tokens, model=model))
 
     if tools:
         # Defensive dedup: providers like Google Vertex, Azure, and Bedrock

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3932,7 +3932,7 @@ def _call_fallback_candidate_sync(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout,
         extra_body=effective_extra_body, reasoning_config=reasoning_config,
-        base_url=fb_base)
+        base_url=fb_base, task=task)
     try:
         return _validate_llm_response(
             fb_client.chat.completions.create(**fb_kwargs), task)
@@ -3949,7 +3949,7 @@ def _call_fallback_candidate_sync(
                     tools=tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
-                    base_url=str(getattr(retry_client, "base_url", "") or fb_base))
+                    base_url=str(getattr(retry_client, "base_url", "") or fb_base), task=task)
                 try:
                     return _validate_llm_response(
                         retry_client.chat.completions.create(**retry_kwargs), task)
@@ -3998,7 +3998,7 @@ async def _call_fallback_candidate_async(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout,
         extra_body=effective_extra_body, reasoning_config=reasoning_config,
-        base_url=fb_base)
+        base_url=fb_base, task=task)
     try:
         return _validate_llm_response(
             await fb_client.chat.completions.create(**fb_kwargs), task)
@@ -4016,7 +4016,7 @@ async def _call_fallback_candidate_async(
                     tools=tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
-                    base_url=str(getattr(retry_client, "base_url", "") or fb_base))
+                    base_url=str(getattr(retry_client, "base_url", "") or fb_base), task=task)
                 try:
                     return _validate_llm_response(
                         await retry_client.chat.completions.create(**retry_kwargs), task)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6834,10 +6834,26 @@ def _build_call_kwargs(
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
         _is_moa = bool(task) and str(task) == "moa_reference"
+        # Gemini's native generateContent maps max_tokens → maxOutputTokens and,
+        # when it is omitted, applies a fixed 65,535-token ceiling rather than
+        # "the model's full budget" (see gemini_native_adapter.build_gemini_request).
+        # So an explicit cap is both safe and the ONLY way to honor it here —
+        # dropping max_tokens silently makes MoA's reference_max_tokens a no-op
+        # for gemini advisors (they run effectively uncapped).
+        _is_gemini_native = _provider_norm in {
+            "gemini", "google", "google-gemini", "google-ai-studio",
+        }
+        if not _is_gemini_native and _effective_base:
+            try:
+                from agent.gemini_native_adapter import is_native_gemini_base_url
+                _is_gemini_native = is_native_gemini_base_url(_effective_base)
+            except Exception:
+                pass
         if (
             _is_anthropic_compat_endpoint(provider, _effective_base)
             or _is_nvidia_nim
             or _is_moa
+            or _is_gemini_native
         ):
             # Use auxiliary_max_tokens_param() so models that require
             # max_completion_tokens (GPT-5 family, Copilot) get the right

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3683,6 +3683,7 @@ def _retry_same_provider_sync(
         extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
         base_url=retry_base or resolved_base_url,
+        task=task,
     )
     if _is_anthropic_compat_endpoint(resolved_provider, retry_base):
         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
@@ -3742,6 +3743,7 @@ async def _retry_same_provider_async(
         extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
         base_url=retry_base or resolved_base_url,
+        task=task,
     )
     if _is_anthropic_compat_endpoint(resolved_provider, retry_base):
         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
@@ -6776,6 +6778,7 @@ def _build_call_kwargs(
     extra_body: Optional[dict] = None,
     reasoning_config: Optional[dict] = None,
     base_url: Optional[str] = None,
+    task: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
     kwargs: Dict[str, Any] = {
@@ -6830,9 +6833,11 @@ def _build_call_kwargs(
             _provider_norm in {"nvidia", "nvidia-nim", "nim", "build-nvidia", "nemotron"}
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
+        _is_moa = bool(task) and str(task).startswith("moa_")
         if (
             _is_anthropic_compat_endpoint(provider, _effective_base)
             or _is_nvidia_nim
+            or _is_moa
         ):
             kwargs["max_tokens"] = max_tokens
 
@@ -7203,7 +7208,7 @@ def call_llm(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
-        base_url=_base_info or resolved_base_url)
+        base_url=_base_info or resolved_base_url, task=task)
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     _client_base = str(getattr(client, "base_url", "") or "")
@@ -7819,7 +7824,7 @@ async def async_call_llm(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
-        base_url=_client_base or resolved_base_url)
+        base_url=_client_base or resolved_base_url, task=task)
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6833,7 +6833,7 @@ def _build_call_kwargs(
             _provider_norm in {"nvidia", "nvidia-nim", "nim", "build-nvidia", "nemotron"}
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
-        _is_moa = bool(task) and str(task).startswith("moa_")
+        _is_moa = bool(task) and str(task) == "moa_reference"
         if (
             _is_anthropic_compat_endpoint(provider, _effective_base)
             or _is_nvidia_nim

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1099,7 +1099,7 @@ def run_conversation(
                     aggregator=moa_config.get("aggregator") or {},
                     temperature=_preset_temperature(moa_config, "reference_temperature"),
                     aggregator_temperature=_preset_temperature(moa_config, "aggregator_temperature"),
-                    max_tokens=moa_config.get("reference_max_tokens"),
+                    reference_max_tokens=moa_config.get("reference_max_tokens"),
                 )
                 if _moa_context:
                     for _msg in reversed(api_messages):

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -281,7 +281,7 @@ def _maybe_apply_moa_cache_control(
 
 
 def _run_reference(
-    slot: dict[str, str],
+    slot: dict[str, Any],
     ref_messages: list[dict[str, Any]],
     *,
     temperature: float | None = None,
@@ -333,11 +333,16 @@ def _run_reference(
         # (their caching is automatic; markers are ignored harmlessly, but we
         # only decorate when the policy says the route honors them).
         messages = _maybe_apply_moa_cache_control(messages, runtime)
+        # Per-slot max_tokens takes precedence over the preset-level
+        # reference_max_tokens passed in by the caller. This lets each
+        # reference model have its own output cap independently.
+        _slot_max_tokens: int | None = slot.get("max_tokens")
+        _effective_max_tokens = _slot_max_tokens if _slot_max_tokens is not None else max_tokens
         response = call_llm(
             task="moa_reference",
             messages=messages,
             temperature=temperature,
-            max_tokens=max_tokens,
+            max_tokens=_effective_max_tokens,
             reasoning_config=_slot_reasoning_config(slot),
             **runtime,
         )
@@ -398,7 +403,7 @@ def _run_reference(
 
 
 def _run_references_parallel(
-    reference_models: list[dict[str, str]],
+    reference_models: list[dict[str, Any]],
     ref_messages: list[dict[str, Any]],
     *,
     temperature: float | None = None,
@@ -683,8 +688,8 @@ def aggregate_moa_context(
     *,
     user_prompt: str,
     api_messages: list[dict[str, Any]],
-    reference_models: list[dict[str, str]],
-    aggregator: dict[str, str],
+    reference_models: list[dict[str, Any]],
+    aggregator: dict[str, Any],
     temperature: float | None = None,
     aggregator_temperature: float | None = None,
     reference_max_tokens: int | None = None,

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -687,23 +687,26 @@ def aggregate_moa_context(
     aggregator: dict[str, str],
     temperature: float | None = None,
     aggregator_temperature: float | None = None,
-    max_tokens: int | None = None,
+    reference_max_tokens: int | None = None,
 ) -> str:
     """Run configured reference models and synthesize their advice.
 
     Failures are returned as model-specific notes instead of aborting the normal
     agent loop; the main model can still act with partial context.
 
-    ``max_tokens`` is ``None`` by default: MoA does not cap reference or
-    aggregator output, so each model uses its own maximum. ``call_llm`` omits
-    the parameter entirely when it is ``None`` (see its docstring), which also
-    sidesteps providers that reject ``max_tokens`` outright. A hardcoded cap
-    here previously truncated long aggregator syntheses.
+    ``reference_max_tokens`` applies ONLY to the reference fan-out — the
+    aggregator's own synthesis call is never capped, so it always uses its
+    model's own maximum. ``call_llm`` omits the parameter entirely when it
+    is ``None`` (see its docstring), which also sidesteps providers that
+    reject ``max_tokens`` outright. A hardcoded cap on the aggregator call
+    previously truncated long aggregator syntheses (#53580) — passing
+    ``reference_max_tokens`` to both calls here would silently reintroduce
+    that regression.
 
     ``temperature`` / ``aggregator_temperature`` are ``None`` by default:
-    like max_tokens, ``call_llm`` omits temperature when None so the
-    provider default applies — matching single-model agent behavior. Presets
-    may still pin explicit values.
+    like ``reference_max_tokens``, ``call_llm`` omits temperature when None
+    so the provider default applies — matching single-model agent behavior.
+    Presets may still pin explicit values.
     """
     reference_outputs: list[tuple[str, str, Any]] = []
     ref_messages = _reference_messages(api_messages)
@@ -711,7 +714,7 @@ def aggregate_moa_context(
         reference_models,
         ref_messages,
         temperature=temperature,
-        max_tokens=max_tokens,
+        max_tokens=reference_max_tokens,
     )
 
     joined = "\n\n".join(
@@ -748,7 +751,6 @@ def aggregate_moa_context(
             task="moa_aggregator",
             messages=agg_messages,
             temperature=aggregator_temperature,
-            max_tokens=max_tokens,
             reasoning_config=_aggregator_reasoning_config(aggregator),
             **agg_runtime,
         )

--- a/contributors/emails/awain7@gmail.com
+++ b/contributors/emails/awain7@gmail.com
@@ -1,0 +1,2 @@
+awain7
+# PR #58261 salvage

--- a/contributors/emails/janig88@gmail.com
+++ b/contributors/emails/janig88@gmail.com
@@ -1,0 +1,2 @@
+Janig88
+# PR #58402 salvage

--- a/contributors/emails/rain@synth.kitchen
+++ b/contributors/emails/rain@synth.kitchen
@@ -1,0 +1,2 @@
+matarbot
+# PR #60391 salvage

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -105,6 +105,14 @@ def _clean_slot(slot: Any) -> dict[str, Any] | None:
     effort = _clean_reasoning_effort(slot.get("reasoning_effort"))
     if effort:
         clean["reasoning_effort"] = effort
+    # Optional per-slot max_tokens: overrides the preset-level
+    # reference_max_tokens for this specific reference model. None (the
+    # default) = no cap, so existing slots are unaffected. Allows tuning
+    # each advisor's output length independently — useful when one model
+    # is verbose and another is terse.
+    slot_mt = _coerce_int_or_none(slot.get("max_tokens"))
+    if slot_mt is not None:
+        clean["max_tokens"] = slot_mt
     return clean
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -659,22 +659,25 @@ class TestBuildCallKwargsMaxTokens:
     # ── MoA task should honor max_tokens on ALL providers (#reference_max_tokens) ──
 
     @pytest.mark.parametrize(
-        "provider,model,base_url",
+        "provider,model,base_url,expected_key",
         [
-            ("zai", "glm-5.2", "https://api.z.ai/api/coding/paas/v4"),
-            ("openrouter", "deepseek/deepseek-v4-flash:nitro", "https://openrouter.ai/api/v1"),
-            ("copilot", "gpt-5.5", "https://api.githubcopilot.com"),
-            ("nous", "hermes-4", "https://inference-api.nousresearch.com/v1"),
+            ("zai", "glm-5.2", "https://api.z.ai/api/coding/paas/v4", "max_tokens"),
+            ("openrouter", "deepseek/deepseek-v4-flash:nitro", "https://openrouter.ai/api/v1", "max_tokens"),
+            ("copilot", "gpt-5.5", "https://api.githubcopilot.com", "max_completion_tokens"),
+            ("nous", "hermes-4", "https://inference-api.nousresearch.com/v1", "max_tokens"),
         ],
     )
-    def test_moa_task_sends_max_tokens_on_openai_compatible(self, provider, model, base_url):
+    def test_moa_task_sends_max_tokens_on_openai_compatible(self, provider, model, base_url, expected_key):
         """MoA reference/aggregator tasks must honor max_tokens regardless of provider.
 
         The ``reference_max_tokens`` config option (PR #56756) caps advisor output
         to reduce turn latency.  Before the fix, ``_build_call_kwargs`` silently
         dropped the value for OpenAI-compatible providers (PR #34845), so the cap
         never reached the API.  With the ``task`` parameter threaded through,
-        any task starting with ``moa_`` must include ``max_tokens`` in kwargs.
+        any task starting with ``moa_`` must include the output cap in kwargs.
+
+        Models that require ``max_completion_tokens`` (GPT-5 family, Copilot)
+        get the correct parameter name via ``auxiliary_max_tokens_param()``.
         """
         from agent.auxiliary_client import _build_call_kwargs
 
@@ -686,7 +689,7 @@ class TestBuildCallKwargsMaxTokens:
             base_url=base_url,
             task="moa_reference",
         )
-        assert kwargs["max_tokens"] == 800
+        assert kwargs[expected_key] == 800
 
     def test_moa_task_sends_max_tokens_on_anthropic_wire(self):
         """MoA tasks on Anthropic-compat endpoints keep max_tokens (unchanged behavior)."""

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -656,6 +656,101 @@ class TestBuildCallKwargsMaxTokens:
         )
         assert kwargs["max_tokens"] == 4096
 
+    # ── MoA task should honor max_tokens on ALL providers (#reference_max_tokens) ──
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            ("zai", "glm-5.2", "https://api.z.ai/api/coding/paas/v4"),
+            ("openrouter", "deepseek/deepseek-v4-flash:nitro", "https://openrouter.ai/api/v1"),
+            ("copilot", "gpt-5.5", "https://api.githubcopilot.com"),
+            ("nous", "hermes-4", "https://inference-api.nousresearch.com/v1"),
+        ],
+    )
+    def test_moa_task_sends_max_tokens_on_openai_compatible(self, provider, model, base_url):
+        """MoA reference/aggregator tasks must honor max_tokens regardless of provider.
+
+        The ``reference_max_tokens`` config option (PR #56756) caps advisor output
+        to reduce turn latency.  Before the fix, ``_build_call_kwargs`` silently
+        dropped the value for OpenAI-compatible providers (PR #34845), so the cap
+        never reached the API.  With the ``task`` parameter threaded through,
+        any task starting with ``moa_`` must include ``max_tokens`` in kwargs.
+        """
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=800,
+            base_url=base_url,
+            task="moa_reference",
+        )
+        assert kwargs["max_tokens"] == 800
+
+    def test_moa_task_sends_max_tokens_on_anthropic_wire(self):
+        """MoA tasks on Anthropic-compat endpoints keep max_tokens (unchanged behavior)."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="minimax",
+            model="minimax-m2",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=600,
+            base_url="https://api.minimax.io/v1",
+            task="moa_aggregator",
+        )
+        assert kwargs["max_tokens"] == 600
+
+    def test_non_moa_tasks_still_omit_max_tokens(self):
+        """Regression guard: compression/titles/vision keep PR #34845 behavior."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        for task in ("compression", "vision", "title_generation", None, ""):
+            kwargs = _build_call_kwargs(
+                provider="openrouter",
+                model="deepseek/deepseek-v4-flash:nitro",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=800,
+                base_url="https://openrouter.ai/api/v1",
+                task=task,
+            )
+            assert "max_tokens" not in kwargs, f"max_tokens should be dropped for task={task!r}"
+
+    def test_moa_prefix_matching(self):
+        """Only tasks prefixed with 'moa_' trigger the cap — not arbitrary task names."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        # 'moa_reference' → honored
+        kw = _build_call_kwargs(
+            provider="zai", model="glm-5.2",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            task="moa_reference",
+        )
+        assert kw["max_tokens"] == 500
+
+        # 'moa_xyz' → honored (prefix match)
+        kw2 = _build_call_kwargs(
+            provider="zai", model="glm-5.2",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            task="moa_custom_future",
+        )
+        assert kw2["max_tokens"] == 500
+
+        # 'mopha_reference' (similar but not moa_) → dropped
+        kw3 = _build_call_kwargs(
+            provider="zai", model="glm-5.2",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            task="mopha_reference",
+        )
+        assert "max_tokens" not in kw3
+
 
 class TestNousTagsScoping:
     def test_tags_injected_when_provider_is_nous(self, monkeypatch):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -775,6 +775,55 @@ class TestBuildCallKwargsMaxTokens:
         )
         assert "max_tokens" not in kw3
 
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            ("gemini", "gemini-2.5-pro", None),
+            ("google", "gemini-2.5-flash", None),
+            (
+                "custom",
+                "gemini-2.5-pro",
+                "https://generativelanguage.googleapis.com/v1beta",
+            ),
+        ],
+    )
+    def test_keeps_max_tokens_for_gemini_native(self, provider, model, base_url):
+        # Native generateContent maps max_tokens → maxOutputTokens; when it is
+        # omitted Gemini applies a fixed 65,535-token ceiling, which silently
+        # turned MoA's reference_max_tokens into a no-op for gemini advisors.
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=600,
+            base_url=base_url,
+        )
+        assert kwargs["max_tokens"] == 600
+        assert "max_completion_tokens" not in kwargs
+
+    def test_omits_max_tokens_for_gemini_model_on_openai_compatible_endpoint(self):
+        # Control: the gemini branch keys on provider/base_url, never the model
+        # name. A gemini model served through an OpenAI-compatible endpoint
+        # keeps the default omission behavior (#34530), including Gemini's own
+        # /openai compatibility endpoint.
+        from agent.auxiliary_client import _build_call_kwargs
+
+        for provider, base_url in [
+            ("openrouter", "https://openrouter.ai/api/v1"),
+            ("custom", "https://generativelanguage.googleapis.com/v1beta/openai"),
+        ]:
+            kwargs = _build_call_kwargs(
+                provider=provider,
+                model="google/gemini-2.5-pro",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=600,
+                base_url=base_url,
+            )
+            assert "max_tokens" not in kwargs
+            assert "max_completion_tokens" not in kwargs
+
 
 class TestNousTagsScoping:
     def test_tags_injected_when_provider_is_nous(self, monkeypatch):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -668,13 +668,13 @@ class TestBuildCallKwargsMaxTokens:
         ],
     )
     def test_moa_task_sends_max_tokens_on_openai_compatible(self, provider, model, base_url, expected_key):
-        """MoA reference/aggregator tasks must honor max_tokens regardless of provider.
+        """MoA reference tasks must honor max_tokens regardless of provider.
 
         The ``reference_max_tokens`` config option (PR #56756) caps advisor output
         to reduce turn latency.  Before the fix, ``_build_call_kwargs`` silently
         dropped the value for OpenAI-compatible providers (PR #34845), so the cap
         never reached the API.  With the ``task`` parameter threaded through,
-        any task starting with ``moa_`` must include the output cap in kwargs.
+        ``task == "moa_reference"`` includes the output cap in kwargs.
 
         Models that require ``max_completion_tokens`` (GPT-5 family, Copilot)
         get the correct parameter name via ``auxiliary_max_tokens_param()``.
@@ -692,7 +692,7 @@ class TestBuildCallKwargsMaxTokens:
         assert kwargs[expected_key] == 800
 
     def test_moa_task_sends_max_tokens_on_anthropic_wire(self):
-        """MoA tasks on Anthropic-compat endpoints keep max_tokens (unchanged behavior)."""
+        """MoA reference tasks on Anthropic-compat endpoints keep max_tokens (unchanged behavior)."""
         from agent.auxiliary_client import _build_call_kwargs
 
         kwargs = _build_call_kwargs(
@@ -701,9 +701,29 @@ class TestBuildCallKwargsMaxTokens:
             messages=[{"role": "user", "content": "hi"}],
             max_tokens=600,
             base_url="https://api.minimax.io/v1",
-            task="moa_aggregator",
+            task="moa_reference",
         )
         assert kwargs["max_tokens"] == 600
+
+    def test_moa_aggregator_does_not_get_max_tokens_on_openai_compat(self):
+        """``reference_max_tokens`` is an advisors-only contract (#56756).
+
+        The aggregator is the acting model — it must NOT be capped by the
+        reference token budget.  Only ``task == "moa_reference"`` triggers
+        the exception in ``_build_call_kwargs``.
+        """
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="zai",
+            model="glm-5.2",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=800,
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            task="moa_aggregator",
+        )
+        assert "max_tokens" not in kwargs
+        assert "max_completion_tokens" not in kwargs
 
     def test_non_moa_tasks_still_omit_max_tokens(self):
         """Regression guard: compression/titles/vision keep PR #34845 behavior."""
@@ -720,8 +740,9 @@ class TestBuildCallKwargsMaxTokens:
             )
             assert "max_tokens" not in kwargs, f"max_tokens should be dropped for task={task!r}"
 
-    def test_moa_prefix_matching(self):
-        """Only tasks prefixed with 'moa_' trigger the cap — not arbitrary task names."""
+    def test_moa_task_exact_match(self):
+        """Only task == "moa_reference" triggers the cap — not the aggregator,
+        not arbitrary 'moa_' prefixed tasks."""
         from agent.auxiliary_client import _build_call_kwargs
 
         # 'moa_reference' → honored
@@ -734,23 +755,23 @@ class TestBuildCallKwargsMaxTokens:
         )
         assert kw["max_tokens"] == 500
 
-        # 'moa_xyz' → honored (prefix match)
+        # 'moa_aggregator' → dropped (aggregator is the acting model, not an advisor)
         kw2 = _build_call_kwargs(
             provider="zai", model="glm-5.2",
             messages=[{"role": "user", "content": "hi"}],
             max_tokens=500,
             base_url="https://api.z.ai/api/coding/paas/v4",
-            task="moa_custom_future",
+            task="moa_aggregator",
         )
-        assert kw2["max_tokens"] == 500
+        assert "max_tokens" not in kw2
 
-        # 'mopha_reference' (similar but not moa_) → dropped
+        # 'moa_custom_future' → dropped (only moa_reference is whitelisted)
         kw3 = _build_call_kwargs(
             provider="zai", model="glm-5.2",
             messages=[{"role": "user", "content": "hi"}],
             max_tokens=500,
             base_url="https://api.z.ai/api/coding/paas/v4",
-            task="mopha_reference",
+            task="moa_custom_future",
         )
         assert "max_tokens" not in kw3
 

--- a/tests/agent/test_moa_context_max_tokens.py
+++ b/tests/agent/test_moa_context_max_tokens.py
@@ -1,0 +1,99 @@
+"""Regression test for aggregate_moa_context's reference/aggregator max_tokens split.
+
+PR #53580 removed a hardcoded ``max_tokens`` cap from the aggregator's
+synthesis call because it truncated long aggregator syntheses. PR #56756
+(feat(moa): add reference_max_tokens to cap advisor output and cut turn
+latency) later reintroduced a single ``max_tokens`` parameter shared by BOTH
+the reference fan-out and the aggregator call in ``aggregate_moa_context`` —
+silently regressing the exact bug #53580 fixed: setting
+``reference_max_tokens`` to speed up the advisors also truncates the
+aggregator's own synthesis, which is the context the main agent actually
+uses.
+
+``aggregate_moa_context`` and its reference/aggregator calls both go through
+``call_llm`` (task="moa_reference" vs task="moa_aggregator"), so mocking
+just that one function exercises the real fan-out/aggregation code path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _response(content: str = "ok"):
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fake")
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def test_aggregator_call_never_receives_reference_max_tokens(hermes_home, monkeypatch):
+    """reference_max_tokens must cap only the reference fan-out — the
+    aggregator's own call_llm invocation must not receive max_tokens at all
+    (call_llm omits it entirely when None; see its own docstring)."""
+    from agent.moa_loop import aggregate_moa_context
+
+    calls: list[dict] = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("advice" if kwargs.get("task") == "moa_reference" else "synthesis")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    aggregate_moa_context(
+        user_prompt="clean the db",
+        api_messages=[{"role": "user", "content": "clean the db"}],
+        reference_models=[{"provider": "openrouter", "model": "openai/gpt-5.5"}],
+        aggregator={"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+        reference_max_tokens=600,
+    )
+
+    reference_calls = [c for c in calls if c.get("task") == "moa_reference"]
+    aggregator_calls = [c for c in calls if c.get("task") == "moa_aggregator"]
+    assert len(reference_calls) == 1
+    assert len(aggregator_calls) == 1
+
+    # The reference fan-out is capped as configured.
+    assert reference_calls[0]["max_tokens"] == 600
+    # The aggregator's synthesis call must be uncapped — not even max_tokens=None,
+    # the kwarg must be absent entirely (matches call_llm's omit-when-None contract).
+    assert "max_tokens" not in aggregator_calls[0]
+
+
+def test_aggregator_call_uncapped_when_reference_max_tokens_unset(hermes_home, monkeypatch):
+    """Sanity check: with no reference_max_tokens configured, the reference
+    call still explicitly passes max_tokens=None (call_llm itself decides
+    whether to omit it on the wire), while the aggregator call structurally
+    never carries a max_tokens kwarg at all — the pre-#56756 default MoA
+    behavior for the aggregator, preserved regardless of the reference cap."""
+    from agent.moa_loop import aggregate_moa_context
+
+    calls: list[dict] = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("advice" if kwargs.get("task") == "moa_reference" else "synthesis")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    aggregate_moa_context(
+        user_prompt="clean the db",
+        api_messages=[{"role": "user", "content": "clean the db"}],
+        reference_models=[{"provider": "openrouter", "model": "openai/gpt-5.5"}],
+        aggregator={"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+    )
+
+    reference_calls = [c for c in calls if c.get("task") == "moa_reference"]
+    aggregator_calls = [c for c in calls if c.get("task") == "moa_aggregator"]
+    assert reference_calls[0]["max_tokens"] is None
+    assert "max_tokens" not in aggregator_calls[0]

--- a/tests/agent/test_moa_slot_max_tokens.py
+++ b/tests/agent/test_moa_slot_max_tokens.py
@@ -1,0 +1,82 @@
+"""Tests for per-slot max_tokens in MoA reference calls.
+
+Verifies that a ``max_tokens`` field on a reference slot dict takes
+precedence over the preset-level ``reference_max_tokens``, and that
+slot-level max_tokens=None falls back to the preset-level cap.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestRunReferenceSlotMaxTokens:
+    """_run_reference should prefer slot-level max_tokens over preset-level."""
+
+    def test_slot_max_tokens_overrides_preset_level(self):
+        """When slot has max_tokens, it overrides the preset-level cap."""
+        from agent.moa_loop import _run_reference
+
+        captured_kwargs: dict = {}
+
+        def fake_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_resp = MagicMock()
+            mock_resp.choices = [MagicMock(message=MagicMock(content="advice"))]
+            mock_resp.usage = None
+            return mock_resp
+
+        slot = {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "max_tokens": 600}
+
+        with patch("agent.moa_loop._slot_runtime", return_value={"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}), \
+             patch("agent.moa_loop.call_llm", side_effect=fake_call_llm), \
+             patch("agent.moa_loop._maybe_apply_moa_cache_control", side_effect=lambda msgs, rt: msgs):
+            _run_reference(slot, [{"role": "user", "content": "hi"}], max_tokens=2000)
+
+        assert captured_kwargs.get("max_tokens") == 600
+
+    def test_slot_max_tokens_absent_falls_back_to_preset(self):
+        """When slot has no max_tokens, the preset-level cap is used."""
+        from agent.moa_loop import _run_reference
+
+        captured_kwargs: dict = {}
+
+        def fake_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_resp = MagicMock()
+            mock_resp.choices = [MagicMock(message=MagicMock(content="advice"))]
+            mock_resp.usage = None
+            return mock_resp
+
+        slot = {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+
+        with patch("agent.moa_loop._slot_runtime", return_value={"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}), \
+             patch("agent.moa_loop.call_llm", side_effect=fake_call_llm), \
+             patch("agent.moa_loop._maybe_apply_moa_cache_control", side_effect=lambda msgs, rt: msgs):
+            _run_reference(slot, [{"role": "user", "content": "hi"}], max_tokens=2000)
+
+        assert captured_kwargs.get("max_tokens") == 2000
+
+    def test_both_none_means_uncapped(self):
+        """When neither slot nor preset has max_tokens, it's None (uncapped)."""
+        from agent.moa_loop import _run_reference
+
+        captured_kwargs: dict = {}
+
+        def fake_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_resp = MagicMock()
+            mock_resp.choices = [MagicMock(message=MagicMock(content="advice"))]
+            mock_resp.usage = None
+            return mock_resp
+
+        slot = {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+
+        with patch("agent.moa_loop._slot_runtime", return_value={"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}), \
+             patch("agent.moa_loop.call_llm", side_effect=fake_call_llm), \
+             patch("agent.moa_loop._maybe_apply_moa_cache_control", side_effect=lambda msgs, rt: msgs):
+            _run_reference(slot, [{"role": "user", "content": "hi"}], max_tokens=None)
+
+        assert captured_kwargs.get("max_tokens") is None

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -461,3 +461,79 @@ def test_validate_moa_payload_rejects_non_dict():
     assert validate_moa_payload(None)
     assert validate_moa_payload([1, 2])
     assert validate_moa_payload({"presets": {"p": "not-a-dict"}})
+
+
+# ── Per-slot max_tokens ────────────────────────────────────────────────────
+
+
+def test_slot_max_tokens_preserved():
+    """A max_tokens field on a reference slot survives normalization."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "p": {
+                    "reference_models": [
+                        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "max_tokens": 600},
+                        {"provider": "openai-codex", "model": "gpt-5.5"},
+                    ],
+                    "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                }
+            }
+        }
+    )
+    refs = cfg["presets"]["p"]["reference_models"]
+    assert refs[0] == {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "max_tokens": 600}
+    assert refs[1] == {"provider": "openai-codex", "model": "gpt-5.5"}
+
+
+def test_slot_max_tokens_coerced_from_string():
+    """Hand-edited YAML string '600' coerces to int on a slot."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "p": {
+                    "reference_models": [
+                        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "max_tokens": "600"},
+                    ],
+                }
+            }
+        }
+    )
+    refs = cfg["presets"]["p"]["reference_models"]
+    assert refs[0]["max_tokens"] == 600
+
+
+def test_slot_max_tokens_invalid_dropped():
+    """Non-positive / non-numeric slot max_tokens is dropped (slot kept)."""
+    for bad in (0, -5, "abc", "", None):
+        cfg = normalize_moa_config(
+            {
+                "presets": {
+                    "p": {
+                        "reference_models": [
+                            {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "max_tokens": bad},
+                        ],
+                    }
+                }
+            }
+        )
+        ref = cfg["presets"]["p"]["reference_models"][0]
+        assert "max_tokens" not in ref, bad
+        assert ref["provider"] == "openrouter"
+
+
+def test_slot_max_tokens_absent_by_default():
+    """Slots without max_tokens don't get the field — backward compat."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "p": {
+                    "reference_models": [
+                        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
+                    ],
+                }
+            }
+        }
+    )
+    ref = cfg["presets"]["p"]["reference_models"][0]
+    assert "max_tokens" not in ref


### PR DESCRIPTION
## Summary

`reference_max_tokens` now does exactly what it documents: caps every advisor call on every provider, never the acting aggregator — and MoA presets gain per-slot `max_tokens` overrides. Consolidated salvage of four PRs (cluster: MoA max_tokens).

Two verified bugs + one feature, complementary layers:
1. **Routing** — the one-shot `/moa` path forwarded `reference_max_tokens` to the aggregator too (regression of #53580 reintroduced by #56756), truncating long syntheses.
2. **Wire** — `_build_call_kwargs` injected max_tokens only for Anthropic-wire + NVIDIA NIM; every other provider silently dropped the advisor cap, and native Gemini fell back to its fixed 65,535 default ceiling.
3. **Feature** — `_clean_slot` stripped per-slot `max_tokens` from preset config.

## Changes (8 commits, authorship preserved)

- @srojk34 (#57493): advisors-only routing split — `aggregate_moa_context` renames the param and stops forwarding it to the aggregator call. Rebased over main's cache-control + reasoning_config aggregator hunks.
- @Janig88 (#58402, 4 commits): threads `task` into `_build_call_kwargs` (all 6 call sites incl. retry/fallback), gates the cap injection to exactly `task == "moa_reference"` via `auxiliary_max_tokens_param()` (correct max_tokens vs max_completion_tokens per model), aggregator explicitly excluded, negative test for future moa_ tasks.
- @awain7 (#58261, 2 commits): gemini-native forwarding for all aux tasks (adapter maps to maxOutputTokens internally — no 400 risk) + openai-compat control test.
- @matarbot (#60391 per-slot slice): `_clean_slot` whitelists `max_tokens`, `_run_reference` slot-cap-overrides-preset precedence; slot dict round-trips both `reasoning_effort` and `max_tokens`. The draft's blanket wire rewrite was NOT taken (reverses the deliberate #34845 omission default — that design question stays parked on #60388).

Contributor email mappings squashed into each author's commit.

## Validation

| Check | Result |
|---|---|
| test_moa_context_max_tokens, test_auxiliary_client, test_moa_slot_api_mode, test_moa_config + 3 new test files | all pass |
| Premises | verified live on main pre-fix (conversation_loop:1095, auxiliary_client:6805-6838, moa_config:90-108) |

Salvages #57493, #58402, #58261, #60391 (slice). Partially addresses #60388 (MoA half).

## Infographic

![moa-max-tokens](https://v3b.fal.media/files/b/0aa371a7/iVDPV2G9iFfJ8CQhTUU1X_M5R2weMX.png)
