### PR TITLE
fix(moa): thought-signature integrity, stream close on interrupt, facade restore, advisor attribution (cluster salvage)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1025,49 +1025,20 @@ def init_agent(
                 elif isinstance(effective_key, str) and len(effective_key) > 12:
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
     elif agent.provider == "moa":
-        from agent.moa_loop import MoAClient
+        from agent.moa_loop import build_moa_facade
         agent.api_mode = "chat_completions"
 
-        # Route reference-model outputs to the agent's tool_progress_callback so
+        # build_moa_facade wires the reference relay that routes
+        # reference-model outputs to the agent's tool_progress_callback so
         # every surface that already consumes it (CLI spinner/scrollback, TUI,
-        # desktop, gateway) can show each reference's answer as a labelled block
-        # before the aggregator acts. The facade emits "moa.reference" and
-        # "moa.aggregating" events; we forward them through the same callback
-        # the tool lifecycle uses. Best-effort and cache-safe — these are
-        # display-only events, they never touch the message history.
-        def _moa_reference_relay(event: str, **kwargs: Any) -> None:
-            cb = getattr(agent, "tool_progress_callback", None)
-            if cb is None:
-                return
-            try:
-                if event == "moa.reference":
-                    label = str(kwargs.get("label") or "")
-                    text = str(kwargs.get("text") or "")
-                    idx = kwargs.get("index")
-                    count = kwargs.get("count")
-                    cb(
-                        "moa.reference",
-                        label,
-                        text,
-                        None,
-                        moa_index=idx,
-                        moa_count=count,
-                    )
-                elif event == "moa.aggregating":
-                    cb(
-                        "moa.aggregating",
-                        str(kwargs.get("aggregator") or ""),
-                        None,
-                        None,
-                        moa_ref_count=kwargs.get("ref_count"),
-                    )
-            except Exception:
-                pass
-
-        agent.client = MoAClient(
-            agent.model or "default",
-            reference_callback=_moa_reference_relay,
-        )
+        # desktop, gateway) can show each reference's answer as a labelled
+        # block before the aggregator acts. The facade emits "moa.reference"
+        # and "moa.aggregating" events, forwarded through the same callback
+        # the tool lifecycle uses. Best-effort and cache-safe — display-only
+        # events, they never touch the message history. The factory is shared
+        # with the fallback-restore/recovery paths so a restored facade keeps
+        # emitting these events (#53802).
+        agent.client = build_moa_facade(agent, agent.model)
         agent._client_kwargs = {}
         agent.api_key = api_key or "moa-virtual-provider"
         agent.base_url = "moa://local"

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1225,6 +1225,14 @@ def try_recover_primary_transport(
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
             agent.client = None
+        elif (agent.provider or "").strip().lower() == "moa":
+            # MoA is a virtual provider with empty client_kwargs — rebuilding
+            # via _create_openai_client would raise "api_key client option
+            # must be set". Recreate the facade through the shared factory so
+            # the reference_callback relay survives recovery (#53802).
+            from agent.moa_loop import build_moa_facade
+
+            agent.client = build_moa_facade(agent, agent.model)
         else:
             agent.client = agent._create_openai_client(
                 dict(rt["client_kwargs"]),
@@ -1391,10 +1399,13 @@ def restore_primary_runtime(agent) -> bool:
         if agent.provider == "moa":
             # MoA is a virtual chat-completions provider.  It never has real
             # OpenAI client kwargs; restoring it after a fallback must recreate
-            # the facade, not call OpenAI() with an empty api_key.
-            from agent.moa_loop import MoAClient
+            # the facade, not call OpenAI() with an empty api_key.  Use the
+            # shared factory so the restored facade keeps the reference_callback
+            # relay wired at init — a bare MoAClient() would silently stop
+            # emitting moa.reference/moa.aggregating display events (#53802).
+            from agent.moa_loop import build_moa_facade
 
-            agent.client = MoAClient(agent.model or "default")
+            agent.client = build_moa_facade(agent, agent.model)
             agent._anthropic_client = None
         elif agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -2132,7 +2143,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
         # ── Build new client ──
         if (new_provider or "").strip().lower() == "moa":
-            from agent.moa_loop import MoAClient
+            from agent.moa_loop import build_moa_facade
 
             # The MoA virtual provider speaks only chat.completions via the
             # MoAClient facade — the aggregator's real transport
@@ -2149,7 +2160,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent.api_key = api_key or "moa-virtual-provider"
             agent.base_url = "moa://local"
             agent._client_kwargs = {}
-            agent.client = MoAClient(agent.model or "default")
+            agent.client = build_moa_facade(agent, agent.model)
         elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1388,7 +1388,15 @@ def restore_primary_runtime(agent) -> bool:
         )
 
         # ── Rebuild client for the primary provider ──
-        if agent.api_mode == "anthropic_messages":
+        if agent.provider == "moa":
+            # MoA is a virtual chat-completions provider.  It never has real
+            # OpenAI client kwargs; restoring it after a fallback must recreate
+            # the facade, not call OpenAI() with an empty api_key.
+            from agent.moa_loop import MoAClient
+
+            agent.client = MoAClient(agent.model or "default")
+            agent._anthropic_client = None
+        elif agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
             agent._anthropic_api_key = rt["anthropic_api_key"]
             agent._anthropic_base_url = rt["anthropic_base_url"]

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3648,6 +3648,7 @@ def _retry_same_provider_sync(
     effective_timeout: float,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> Any:
     if task == "vision":
         _, retry_client, retry_model = resolve_vision_provider_client(
@@ -3685,6 +3686,11 @@ def _retry_same_provider_sync(
         base_url=retry_base or resolved_base_url,
         task=task,
     )
+    # Preserve per-request attribution headers (e.g. Copilot's
+    # ``x-initiator: user``) across the rebuilt-client retry — dropping them
+    # here would let a recovery retry silently lose capability gating (#60293).
+    if extra_headers:
+        retry_kwargs["extra_headers"] = dict(extra_headers)
     if _is_anthropic_compat_endpoint(resolved_provider, retry_base):
         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
     return _validate_llm_response(
@@ -3708,6 +3714,7 @@ async def _retry_same_provider_async(
     effective_timeout: float,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> Any:
     if task == "vision":
         _, retry_client, retry_model = resolve_vision_provider_client(
@@ -3745,6 +3752,10 @@ async def _retry_same_provider_async(
         base_url=retry_base or resolved_base_url,
         task=task,
     )
+    # Preserve per-request attribution headers across the rebuilt-client
+    # retry — see the sync variant above (#60293).
+    if extra_headers:
+        retry_kwargs["extra_headers"] = dict(extra_headers)
     if _is_anthropic_compat_endpoint(resolved_provider, retry_base):
         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
     return _validate_llm_response(
@@ -7090,6 +7101,7 @@ def call_llm(
     timeout: float = None,
     extra_body: dict = None,
     reasoning_config: Optional[dict] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
     api_mode: str = None,
     stream: bool = False,
     stream_options: dict = None,
@@ -7115,6 +7127,9 @@ def call_llm(
         extra_body: Additional request body fields.
         reasoning_config: Optional Hermes reasoning config for direct model calls
               such as MoA reference/aggregator slots.
+        extra_headers: Additional per-request HTTP headers. These override
+            client-level defaults for providers that gate capabilities on
+            request attribution (for example Copilot's ``x-initiator``).
         stream: When True, return the raw SDK streaming iterator instead of a
             validated complete response. The caller is responsible for consuming
             chunks (and for any fallback). Used by the MoA aggregator so its
@@ -7228,6 +7243,8 @@ def call_llm(
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
         base_url=_base_info or resolved_base_url, task=task)
+    if extra_headers:
+        kwargs["extra_headers"] = dict(extra_headers)
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     _client_base = str(getattr(client, "base_url", "") or "")
@@ -7481,6 +7498,7 @@ def call_llm(
                     effective_timeout=effective_timeout,
                     effective_extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
+                    extra_headers=extra_headers,
                 )
 
         # ── Same-provider credential-pool recovery ─────────────────────
@@ -7524,6 +7542,7 @@ def call_llm(
                         effective_timeout=effective_timeout,
                         effective_extra_body=effective_extra_body,
                         reasoning_config=reasoning_config,
+                        extra_headers=extra_headers,
                     )
                 except Exception as retry2_err:
                     # The rotated key also hit a quota/auth wall.  Mark it

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1946,7 +1946,17 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
                 api_msg.pop(internal_key, None)
             if _needs_sanitize:
-                agent._sanitize_tool_calls_for_strict_api(api_msg, model=agent.model)
+                # In MoA mode, agent.model is the virtual preset name,
+                # not the actual aggregator model.  Resolve the real
+                # aggregator model so Gemini preserves thought_signature.
+                _sanitize_model = agent.model
+                if agent.provider == "moa":
+                    _moa_client = getattr(agent, "client", None)
+                    if _moa_client is not None:
+                        _agg_slot = getattr(_moa_client, "last_aggregator_slot", None)
+                        if _agg_slot and _agg_slot.get("model"):
+                            _sanitize_model = _agg_slot["model"]
+                agent._sanitize_tool_calls_for_strict_api(api_msg, model=_sanitize_model)
             api_messages.append(api_msg)
 
         effective_system = agent._cached_system_prompt or ""

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2473,7 +2473,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     request_client_holder = {"client": None, "diag": None, "owner_tid": None}
     # Transport kind of the registered request client — see the non-streaming
     # variant. Routes _close_request_client_once to anthropic vs openai abort/
-    # close helpers (#67142).
+    # close helpers (#67142). ``kind="stream"`` registers a per-request
+    # *stream handle* instead of a client — used under the MoA facade, whose
+    # singleton client has no per-request sockets to abort
+    # (_abort_request_openai_client is a no-op on it), so interrupts must
+    # close the stream object itself (#57354).
     request_client_kind = {"value": "openai"}
     request_client_lock = threading.Lock()
     # Request-local cancellation flag — see interruptible_api_call for the full
@@ -2493,6 +2497,44 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             request_client_holder["owner_tid"] = threading.get_ident()
         return client
 
+    def _stream_close_callable(stream):
+        close = getattr(stream, "close", None)
+        if callable(close):
+            return close
+        response = getattr(stream, "response", None)
+        close = getattr(response, "close", None)
+        if callable(close):
+            return close
+        return None
+
+    def _set_request_stream_handle(stream):
+        # Register the per-request *stream* under kind="stream" so an
+        # interrupt closes the stream handle itself. Under the MoA facade the
+        # registered "client" is the shared facade singleton whose
+        # per-request abort helpers are no-ops, leaving the underlying HTTP
+        # stream open until the provider drained it (#57354).
+        if _stream_close_callable(stream) is None:
+            return stream
+        with request_client_lock:
+            request_client_holder["client"] = stream
+            request_client_kind["value"] = "stream"
+            request_client_holder["owner_tid"] = threading.get_ident()
+        return stream
+
+    def _close_request_stream_handle(stream, reason: str) -> None:
+        close = _stream_close_callable(stream)
+        if close is None:
+            return
+        try:
+            close()
+            logger.info("Streaming response handle closed (%s)", reason)
+        except Exception as exc:
+            logger.debug(
+                "Streaming response handle close failed (%s): %s",
+                reason,
+                exc,
+            )
+
     def _close_request_client_once(reason: str) -> None:
         # See #29507 explanation in the non-streaming variant above. A
         # stranger thread (the interrupt-check / stale-stream detector loop)
@@ -2500,9 +2542,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # so the worker thread retains ownership of the FD release.
         with request_client_lock:
             request_client = request_client_holder.get("client")
+            request_kind = request_client_kind.get("value", "openai")
             owner_tid = request_client_holder.get("owner_tid")
+            # A registered stream handle (kind="stream", MoA facade path) is
+            # safe to close from any thread — closing IS the abort — so the
+            # stranger-thread ownership carve-out only applies to real
+            # per-request clients (#57354).
             stranger_thread = (
-                request_client is not None
+                request_kind != "stream"
+                and request_client is not None
                 and owner_tid is not None
                 and owner_tid != threading.get_ident()
             )
@@ -2511,8 +2559,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 request_client_holder["owner_tid"] = None
         if request_client is None:
             return
-        kind = request_client_kind.get("value", "openai")
-        if kind == "anthropic_messages":
+        if request_kind == "stream":
+            _close_request_stream_handle(request_client, reason)
+        elif request_kind == "anthropic_messages":
             if stranger_thread:
                 agent._abort_request_anthropic_client(request_client, reason=reason)
             else:
@@ -2691,6 +2740,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
         stream = request_client.chat.completions.create(**stream_kwargs)
+        if agent.provider == "moa":
+            # The MoA facade is a shared singleton — abort/close of the
+            # registered client is a no-op, so register the stream handle
+            # itself for interrupt teardown (#57354).
+            stream = _set_request_stream_handle(stream)
         # Claim the delta sink for THIS attempt (#65991). If a prior attempt's
         # stream is somehow still alive (a stale-stream reconnect whose socket
         # abort raced), this claim supersedes it so its late chunks are fenced

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1108,10 +1108,22 @@ def run_conversation(
                 # the resolved aggregator model so Gemini aggregators
                 # correctly preserve thought_signature (extra_content).
                 _sanitize_model = agent.model
-                if agent.provider == "moa" and moa_config:
-                    _agg = moa_config.get("aggregator") or {}
-                    if _agg.get("model"):
-                        _sanitize_model = _agg["model"]
+                if agent.provider == "moa":
+                    if moa_config:
+                        _agg = moa_config.get("aggregator") or {}
+                        if _agg.get("model"):
+                            _sanitize_model = _agg["model"]
+                    if _sanitize_model == agent.model:
+                        # Virtual-provider mode: no moa_config is threaded
+                        # through run_conversation — the facade resolves the
+                        # preset internally. Ask the facade for the resolved
+                        # aggregator slot from the previous create() instead
+                        # (set before any history replay that could carry
+                        # thought_signature).
+                        _moa_client = getattr(agent, "client", None)
+                        _agg_slot = getattr(_moa_client, "last_aggregator_slot", None)
+                        if _agg_slot and _agg_slot.get("model"):
+                            _sanitize_model = _agg_slot["model"]
                 agent._sanitize_tool_calls_for_strict_api(api_msg, model=_sanitize_model)
             # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
             # The signature field helps maintain reasoning continuity

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1103,7 +1103,16 @@ def run_conversation(
             # Uses new dicts so the internal messages list retains the fields
             # for Codex Responses compatibility.
             if agent._should_sanitize_tool_calls():
-                agent._sanitize_tool_calls_for_strict_api(api_msg, model=agent.model)
+                # In MoA mode, agent.model is the virtual preset name
+                # (e.g. "closed"), not the actual aggregator model.  Use
+                # the resolved aggregator model so Gemini aggregators
+                # correctly preserve thought_signature (extra_content).
+                _sanitize_model = agent.model
+                if agent.provider == "moa" and moa_config:
+                    _agg = moa_config.get("aggregator") or {}
+                    if _agg.get("model"):
+                        _sanitize_model = _agg["model"]
+                agent._sanitize_tool_calls_for_strict_api(api_msg, model=_sanitize_model)
             # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
             # The signature field helps maintain reasoning continuity
             api_messages.append(api_msg)

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -270,8 +270,12 @@ def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
         }
     }
     thought_signature = _tool_call_extra_signature(tool_call)
-    if thought_signature:
-        part["thoughtSignature"] = thought_signature
+    # Fallback sentinel for cross-provider tool_calls (e.g. fallback from
+    # xAI/Anthropic to Gemini, where the original tool_call carries no
+    # Gemini thoughtSignature). Mirrors gemini_cloudcode_adapter.py:106.
+    # Without this, Gemini 3 thinking models reject replayed history with
+    # 400 INVALID_ARGUMENT on the missing thoughtSignature.
+    part["thoughtSignature"] = thought_signature or "skip_thought_signature_validator"
     return part
 
 

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1268,3 +1268,58 @@ class MoAClient:
         return self.chat.completions.consume_and_save_trace(
             session_id, aggregator_output_fallback=aggregator_output_fallback
         )
+
+
+def build_moa_facade(agent, preset_name: Any = None) -> MoAClient:
+    """Build the MoA facade client for ``agent``, wiring the reference relay.
+
+    Single construction point for ``MoAClient`` wherever the agent's shared
+    client is (re)built: initial setup (``agent_init``), turn-start fallback
+    restore (``restore_primary_runtime``), transient transport recovery
+    (``try_recover_primary_transport``), and mid-session model switches
+    (``switch_model``).
+
+    Constructing a bare ``MoAClient(preset)`` at any of those sites silently
+    drops the ``reference_callback`` relay that ``agent_init`` wires to
+    ``agent.tool_progress_callback`` — after a fallback+restore cycle the
+    facade would still work, but every frontend (CLI spinner, TUI, desktop,
+    gateway) would stop receiving ``moa.reference`` / ``moa.aggregating``
+    display events for the rest of the session (#53802).
+
+    The relay reads ``agent.tool_progress_callback`` at *emit* time, so a
+    callback attached after client construction is picked up automatically.
+    Best-effort and display-only — it never raises into the model call.
+    """
+    def _moa_reference_relay(event: str, **kwargs: Any) -> None:
+        cb = getattr(agent, "tool_progress_callback", None)
+        if cb is None:
+            return
+        try:
+            if event == "moa.reference":
+                label = str(kwargs.get("label") or "")
+                text = str(kwargs.get("text") or "")
+                idx = kwargs.get("index")
+                count = kwargs.get("count")
+                cb(
+                    "moa.reference",
+                    label,
+                    text,
+                    None,
+                    moa_index=idx,
+                    moa_count=count,
+                )
+            elif event == "moa.aggregating":
+                cb(
+                    "moa.aggregating",
+                    str(kwargs.get("aggregator") or ""),
+                    None,
+                    None,
+                    moa_ref_count=kwargs.get("ref_count"),
+                )
+        except Exception:
+            pass
+
+    return MoAClient(
+        str(preset_name or getattr(agent, "model", None) or "default"),
+        reference_callback=_moa_reference_relay,
+    )

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -338,12 +338,32 @@ def _run_reference(
         # reference model have its own output cap independently.
         _slot_max_tokens: int | None = slot.get("max_tokens")
         _effective_max_tokens = _slot_max_tokens if _slot_max_tokens is not None else max_tokens
+        extra_headers = None
+        # Normalize provider aliases (github, github-copilot, github-models,
+        # ...) through the auxiliary client's canonical alias table so slot
+        # configs that spell Copilot differently still get the header.
+        from agent.auxiliary_client import _normalize_aux_provider
+
+        if _normalize_aux_provider(str(runtime.get("provider") or "")) in (
+            "copilot",
+            "copilot-acp",
+        ):
+            # Copilot Pro/Pro+ gates some premium chat models on request
+            # attribution. The main agent marks the first API request of a
+            # user turn as ``x-initiator: user``; MoA reference fan-out is also
+            # directly serving the user's current turn, not a background agent
+            # task, so mirror that header here. Without it, Claude/Gemini
+            # Copilot advisors can be rejected as unavailable to the
+            # ``copilot-language-server`` integrator even though standalone
+            # Copilot calls work.
+            extra_headers = {"x-initiator": "user"}
         response = call_llm(
             task="moa_reference",
             messages=messages,
             temperature=temperature,
             max_tokens=_effective_max_tokens,
             reasoning_config=_slot_reasoning_config(slot),
+            extra_headers=extra_headers,
             **runtime,
         )
         usage = CanonicalUsage()

--- a/contributors/emails/idrisalmalki@Idriss-MacBook-Air.local
+++ b/contributors/emails/idrisalmalki@Idriss-MacBook-Air.local
@@ -1,0 +1,1 @@
+quantumbyte1617

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -52,6 +52,43 @@ def test_build_native_request_preserves_thought_signature_on_tool_replay():
     assert parts[0]["thoughtSignature"] == "sig-123"
 
 
+def test_build_native_request_emits_sentinel_for_cross_provider_tool_call():
+    """Cross-provider tool_calls (xAI/Anthropic -> Gemini fallback) carry no
+    Gemini thoughtSignature.  Without a sentinel, Gemini 3 thinking models
+    reject the request with 400 INVALID_ARGUMENT.  The native adapter must
+    emit the same ``skip_thought_signature_validator`` sentinel that the
+    Cloud Code Assist adapter already uses for the same scenario.
+    """
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Paris"}',
+                        },
+                        # No extra_content — this tool_call originated from a
+                        # non-Gemini provider during fallback.
+                    }
+                ],
+            },
+        ],
+        tools=[],
+        tool_choice=None,
+    )
+
+    parts = request["contents"][0]["parts"]
+    assert parts[0]["functionCall"]["name"] == "get_weather"
+    assert parts[0]["thoughtSignature"] == "skip_thought_signature_validator"
+
+
 def test_build_native_request_uses_original_function_name_for_tool_result():
     from agent.gemini_native_adapter import build_gemini_request
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -610,6 +610,98 @@ def test_retry_same_provider_sync_preserves_extra_headers(monkeypatch):
     assert captured.get("extra_headers") == {"x-initiator": "user"}
 
 
+def test_moa_gemini_aggregator_sanitize_uses_real_model(monkeypatch, tmp_path):
+    """MoA turns must sanitize tool_calls against the AGGREGATOR model, not the preset.
+
+    Regression for #66212 / #65092: under MoA, ``agent.model`` holds the
+    virtual preset name (e.g. "review"), so passing it to
+    _sanitize_tool_calls_for_strict_api makes
+    _model_consumes_thought_signature() return False and strips
+    ``extra_content`` (Gemini thought_signature) from replayed tool_calls —
+    the Gemini aggregator then 400s with "Function call is missing a
+    thought_signature in functionCall parts."
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+      aggregator:
+        provider: gemini
+        model: gemini-3-pro-preview
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    sanitize_models = []
+
+    tool_call = SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name="read_file", arguments='{"path": "x"}'),
+    )
+
+    responses = iter(
+        [
+            _response(None, tool_calls=[tool_call]),
+            _response("aggregator done"),
+        ]
+    )
+
+    def fake_call_llm(**kwargs):
+        if kwargs["task"] == "moa_reference":
+            return _response("reference advice")
+        return next(responses)
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    agent = AIAgent(
+        api_key="moa-virtual-provider",
+        base_url="moa://local",
+        model="review",
+        provider="moa",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        enabled_toolsets=["file"],
+        max_iterations=3,
+    )
+
+    real_sanitize = type(agent)._sanitize_tool_calls_for_strict_api
+
+    def spy_sanitize(api_msg, model=None):
+        sanitize_models.append(model)
+        return real_sanitize(api_msg, model=model)
+
+    monkeypatch.setattr(
+        type(agent), "_sanitize_tool_calls_for_strict_api", staticmethod(spy_sanitize)
+    )
+    monkeypatch.setattr(
+        agent, "execute_tool", lambda *_a, **_k: "file contents", raising=False
+    )
+
+    result = agent.run_conversation("read the file")
+
+    assert result["final_response"] == "aggregator done"
+    # Once the history contains an assistant tool_call turn, the sanitize
+    # pass must be asked about the REAL aggregator model — never the virtual
+    # preset name (which would strip Gemini's thought_signature). The very
+    # first API call may still see the preset (the facade hasn't resolved a
+    # slot yet), but no tool_calls exist in history at that point.
+    assert any(m == "gemini-3-pro-preview" for m in sanitize_models), sanitize_models
+    first_resolved = sanitize_models.index("gemini-3-pro-preview")
+    assert all(
+        m == "gemini-3-pro-preview" for m in sanitize_models[first_resolved:]
+    ), sanitize_models
+
+
 def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):
     """A slot whose provider can't be resolved still attempts the call with the
     bare provider/model rather than aborting the whole MoA turn."""

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -469,6 +469,147 @@ def test_moa_non_copilot_reference_does_not_forward_initiator_header(monkeypatch
     assert calls[0]["extra_headers"] is None
 
 
+@pytest.mark.parametrize(
+    "provider_spelling",
+    ["copilot", "github-copilot", "github", "github-models", "Copilot", "copilot-acp"],
+)
+def test_moa_copilot_alias_spellings_forward_initiator_header(
+    monkeypatch, provider_spelling
+):
+    """Every Copilot alias spelling must trigger the x-initiator header.
+
+    Slot configs spell the provider inconsistently (github, github-copilot,
+    github-models, copilot-acp, mixed case); the header gate goes through the
+    auxiliary client's canonical alias normalization so all of them get the
+    user-turn attribution, not just the literal string "copilot".
+    """
+    from agent import moa_loop
+
+    calls = []
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda _slot: {
+            "provider": provider_spelling,
+            "model": "claude-sonnet-4.6",
+            "api_mode": "chat_completions",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-token",
+        },
+    )
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("copilot advice")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+
+    _label, text, _acct = moa_loop._run_reference(
+        {"provider": provider_spelling, "model": "claude-sonnet-4.6"},
+        [{"role": "user", "content": "solve this"}],
+    )
+
+    assert text == "copilot advice"
+    assert calls[0]["extra_headers"] == {"x-initiator": "user"}
+
+
+def test_call_llm_extra_headers_reach_transport_create(monkeypatch):
+    """extra_headers must reach the SDK client's create() kwargs.
+
+    Transport-boundary regression for #60293: mocking call_llm proves nothing
+    about delivery — this asserts the header survives call_llm's request
+    building and lands in the kwargs handed to chat.completions.create().
+    """
+    from types import SimpleNamespace
+
+    from agent import auxiliary_client as ac
+
+    captured = {}
+
+    class _Completions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return _response("ok")
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=_Completions()),
+        base_url="https://api.githubcopilot.com",
+    )
+    monkeypatch.setattr(
+        ac,
+        "_resolve_task_provider_model",
+        lambda *a, **k: (
+            "copilot",
+            "claude-sonnet-4.6",
+            "https://api.githubcopilot.com",
+            "copilot-token",
+            "chat_completions",
+        ),
+    )
+    monkeypatch.setattr(ac, "_get_cached_client", lambda *a, **k: (fake_client, "claude-sonnet-4.6"))
+    monkeypatch.setattr(ac, "_validate_llm_response", lambda resp, task, **_kw: resp)
+
+    ac.call_llm(
+        provider="copilot",
+        model="claude-sonnet-4.6",
+        messages=[{"role": "user", "content": "hi"}],
+        extra_headers={"x-initiator": "user"},
+    )
+
+    assert captured.get("extra_headers") == {"x-initiator": "user"}
+    # And it must not leak into unrelated request fields.
+    assert "x-initiator" not in captured.get("extra_body", {}) if captured.get("extra_body") else True
+
+
+def test_retry_same_provider_sync_preserves_extra_headers(monkeypatch):
+    """The same-provider retry rebuild must carry extra_headers through.
+
+    Regression for #60293's follow-up: a credential-refresh/pool-rotation
+    retry rebuilds the request kwargs from scratch — without forwarding
+    extra_headers, the retried Copilot advisor call silently loses its
+    ``x-initiator: user`` attribution and can be rejected.
+    """
+    from types import SimpleNamespace
+
+    from agent import auxiliary_client as ac
+
+    captured = {}
+
+    class _Completions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return _response("retried ok")
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=_Completions()),
+        base_url="https://api.githubcopilot.com",
+    )
+    monkeypatch.setattr(ac, "_get_cached_client", lambda *a, **k: (fake_client, "claude-sonnet-4.6"))
+    monkeypatch.setattr(ac, "_validate_llm_response", lambda resp, task, **_kw: resp)
+
+    ac._retry_same_provider_sync(
+        task=None,
+        resolved_provider="copilot",
+        resolved_model="claude-sonnet-4.6",
+        resolved_base_url="https://api.githubcopilot.com",
+        resolved_api_key="copilot-token",
+        resolved_api_mode="chat_completions",
+        main_runtime=None,
+        final_model="claude-sonnet-4.6",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=None,
+        max_tokens=None,
+        tools=None,
+        effective_timeout=30.0,
+        effective_extra_body={},
+        reasoning_config=None,
+        extra_headers={"x-initiator": "user"},
+    )
+
+    assert captured.get("extra_headers") == {"x-initiator": "user"}
+
+
 def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):
     """A slot whose provider can't be resolved still attempts the call with the
     bare provider/model rather than aborting the whole MoA turn."""

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -141,6 +141,80 @@ moa:
     assert getattr(agent, "_fallback_activated") is False
 
 
+def test_moa_restored_facade_still_emits_reference_events(monkeypatch, tmp_path):
+    """A restored MoA facade must keep the reference_callback relay wired.
+
+    Regression for the naive-rebuild flaw in the original #53802 approach:
+    ``MoAClient(preset)`` without ``reference_callback`` restores a *working*
+    facade that silently stops emitting ``moa.reference``/``moa.aggregating``
+    display events for the rest of the session. The shared ``build_moa_facade``
+    factory rewires the relay to ``agent.tool_progress_callback`` on restore.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    agent = AIAgent(
+        api_key="moa-virtual-provider",
+        base_url="moa://local",
+        model="review",
+        provider="moa",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        enabled_toolsets=["file"],
+        max_iterations=1,
+    )
+
+    # Simulate a fallback to a real provider, then restore.
+    setattr(agent, "_fallback_activated", True)
+    setattr(agent, "provider", "zai")
+    setattr(agent, "model", "glm-5.2")
+    agent.base_url = "https://api.z.ai/api/coding/paas/v4"
+    agent.api_key = "fallback-key"
+    setattr(agent, "_client_kwargs", {"api_key": "fallback-key", "base_url": agent.base_url})
+    agent.client = SimpleNamespace(close=lambda: None, _client=SimpleNamespace(is_closed=True))
+    assert agent._restore_primary_runtime() is True
+
+    # The relay reads tool_progress_callback at emit time — attach a recorder
+    # and fire the facade's internal _emit exactly as the fan-out does.
+    events = []
+
+    def record_progress(event, *args, **kwargs):
+        events.append((event, args, kwargs))
+
+    agent.tool_progress_callback = record_progress
+    completions = agent.client.chat.completions
+    assert completions.reference_callback is not None, (
+        "restored MoA facade lost its reference_callback relay"
+    )
+    completions._emit(
+        "moa.reference", index=0, count=1, label="openai-codex/gpt-5.5", text="advice"
+    )
+    completions._emit("moa.aggregating", aggregator="openrouter", ref_count=1)
+
+    assert [e[0] for e in events] == ["moa.reference", "moa.aggregating"]
+    ref_event = events[0]
+    assert ref_event[1][0] == "openai-codex/gpt-5.5"
+    assert ref_event[1][1] == "advice"
+    assert ref_event[2] == {"moa_index": 0, "moa_count": 1}
+
+
 def test_moa_does_not_cap_output_tokens(monkeypatch, tmp_path):
     """MoA must not inject an output cap on reference or aggregator calls.
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -395,6 +395,80 @@ def test_moa_provider_backed_slot_survives_aux_resolution(monkeypatch, provider)
     assert api_key == f"token-for-{provider}"
 
 
+def test_moa_copilot_reference_forwards_user_initiator_header(monkeypatch):
+    """Copilot MoA advisors must carry the same user-turn attribution as main calls.
+
+    Copilot Pro/Pro+ gates some premium chat models on the ``x-initiator``
+    request header. MoA references are direct fan-out for the user's current
+    turn, so Copilot advisors need ``x-initiator: user`` rather than inheriting
+    the Copilot language-server default attribution.
+    """
+    from agent import moa_loop
+
+    calls = []
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda _slot: {
+            "provider": "copilot",
+            "model": "claude-sonnet-4.6",
+            "api_mode": "chat_completions",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-token",
+        },
+    )
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("copilot advice")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+
+    _label, text, _acct = moa_loop._run_reference(
+        {"provider": "copilot", "model": "claude-sonnet-4.6"},
+        [{"role": "user", "content": "solve this"}],
+    )
+
+    assert text == "copilot advice"
+    assert calls[0]["task"] == "moa_reference"
+    assert calls[0]["extra_headers"] == {"x-initiator": "user"}
+
+
+def test_moa_non_copilot_reference_does_not_forward_initiator_header(monkeypatch):
+    """The Copilot attribution header must stay scoped to Copilot advisors."""
+    from agent import moa_loop
+
+    calls = []
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda _slot: {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4.6",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "openrouter-token",
+        },
+    )
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("openrouter advice")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+
+    _label, text, _acct = moa_loop._run_reference(
+        {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+        [{"role": "user", "content": "solve this"}],
+    )
+
+    assert text == "openrouter advice"
+    assert calls[0]["task"] == "moa_reference"
+    assert calls[0]["extra_headers"] is None
+
+
 def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):
     """A slot whose provider can't be resolved still attempts the call with the
     bare provider/model rather than aborting the whole MoA turn."""

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -81,6 +81,66 @@ def test_moa_runtime_provider_uses_virtual_endpoint():
     assert runtime["api_key"] == "moa-virtual-provider"
 
 
+def test_moa_primary_restore_rebuilds_virtual_facade(monkeypatch, tmp_path):
+    """MoA sessions must restore from fallback without constructing OpenAI().
+
+    Regression for a long-lived MoA session that failed over to a real provider:
+    the next turn restored provider/model to MoA but tried to rebuild the shared
+    client from MoA's empty client_kwargs, raising "api_key client option must be
+    set" and then "Failed to recreate closed OpenAI client".
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    agent = AIAgent(
+        api_key="moa-virtual-provider",
+        base_url="moa://local",
+        model="review",
+        provider="moa",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        enabled_toolsets=["file"],
+        max_iterations=1,
+    )
+    primary_client = agent.client
+
+    def fail_openai_rebuild(*_args, **_kwargs):
+        raise AssertionError("MoA restore must not build a real OpenAI client")
+
+    monkeypatch.setattr(agent, "_create_openai_client", fail_openai_rebuild)
+    setattr(agent, "_fallback_activated", True)
+    setattr(agent, "provider", "zai")
+    setattr(agent, "model", "glm-5.2")
+    agent.base_url = "https://api.z.ai/api/coding/paas/v4"
+    agent.api_key = "fallback-key"
+    setattr(agent, "_client_kwargs", {"api_key": "fallback-key", "base_url": agent.base_url})
+    agent.client = SimpleNamespace(close=lambda: None, _client=SimpleNamespace(is_closed=True))
+
+    assert agent._restore_primary_runtime() is True
+    assert getattr(agent, "provider") == "moa"
+    assert getattr(agent, "model") == "review"
+    assert agent.client is not primary_client
+    assert hasattr(agent.client.chat, "completions")
+    assert getattr(agent, "_fallback_activated") is False
+
+
 def test_moa_does_not_cap_output_tokens(monkeypatch, tmp_path):
     """MoA must not inject an output cap on reference or aggregator calls.
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -3,6 +3,7 @@
 Tests the unified streaming API call, delta callbacks, tool-call
 suppression, provider fallback, and CLI streaming display.
 """
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -717,6 +718,68 @@ class TestStreamingFallback:
         assert response is final_response
         assert agent._disable_streaming is True
         assert deltas == []
+
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    def test_moa_interrupt_closes_stream_handle(
+        self, mock_create, mock_close_openai, mock_abort_openai
+    ):
+        """MoA interrupts must close the per-request stream, not the facade client."""
+        from run_agent import AIAgent
+
+        class _BlockingClosableStream:
+            def __init__(self):
+                self.entered = threading.Event()
+                self.closed = threading.Event()
+                self.close_calls = 0
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                self.entered.set()
+                if not self.closed.wait(timeout=5):
+                    raise TimeoutError("MoA test stream was not closed")
+                raise RuntimeError("stream closed")
+
+            def close(self):
+                self.close_calls += 1
+                self.closed.set()
+
+        stream = _BlockingClosableStream()
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = stream
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            model="default",
+            provider="moa",
+            api_key="test-key",
+            base_url="moa://local",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        agent.client = mock_client
+
+        def _request_interrupt():
+            assert stream.entered.wait(timeout=2)
+            agent._interrupt_requested = True
+
+        interrupter = threading.Thread(target=_request_interrupt, daemon=True)
+        interrupter.start()
+
+        with pytest.raises(InterruptedError):
+            agent._interruptible_streaming_api_call({"model": "default", "messages": []})
+
+        assert stream.closed.wait(timeout=2)
+        assert stream.close_calls == 1
+        mock_create.assert_called_once()
+        mock_close_openai.assert_not_called()
+        mock_abort_openai.assert_not_called()
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")


### PR DESCRIPTION
## Summary

Four runtime-identity gaps in the MoA virtual provider closed: Gemini thought signatures survive the aggregator path, the facade's stream actually closes on interrupt, post-fallback restore rebuilds a working facade without losing display events, and Copilot advisor calls carry user attribution. Consolidated salvage (cluster: MoA runtime/streaming).

## Changes (8 commits, authorship preserved)

- @AlexFucuson9 (#66212): both thought-signature sanitize call sites passed `agent.model` — under MoA that's the preset NAME, so `_model_consumes_thought_signature()` returned False and the signature was stripped → Gemini aggregator 400s. Now resolves the real aggregator model (moa config / `client.last_aggregator_slot`). Fixes the root-cause half of #65092.
- @quantumbyte1617 (#15676, earliest submitter — credit base): gemini-native adapter always emits `thoughtSignature`, falling back to the skip-validator sentinel when a signature was genuinely lost (cross-provider replay, session restore). The independent second half of #65092. (#65294 by @AlexFucuson9 is byte-equivalent and will be closed crediting both.)
- @deaneeth (#57354, reworked): the MoA facade's per-request stream was never closed on interrupt (`_abort_request_openai_client` is a socket-level no-op on the facade) — worker blocked until stream timeout. Re-expressed on main's `request_client_kind` mechanism (#67142) as `kind="stream"`; handles close from any thread. Blocking-stream regression test kept.
- @ildunari (#53802 core) + our fix-up: `restore_primary_runtime` / `try_recover_primary_transport` rebuilt clients from `client_kwargs` — empty for MoA → "api_key must be set" → restore failed after fallback. New shared `build_moa_facade` factory used at init + restore + recover, preserving the `reference_callback` (the original PR's naive `MoAClient()` reconstruction dropped all moa.reference/aggregating display events). Event-delivery test added.
- @dyreckt (#60293 core) + our fix-up: Copilot advisor calls send `x-initiator: user` (references are user-attributed work, not agent-initiated); our fixes: provider alias normalization (github-copilot/github/copilot-acp/…), `extra_headers` carried through same-provider retry rebuilds, transport-boundary test asserting the header reaches client create() kwargs.
- Our test commit: #66212 MoA resolution-path regression test (the sweeper's ask on the original PR).

## Validation

| Check | Result |
|---|---|
| test_gemini_native_adapter, test_moa_loop_mode, test_moa_slot_api_mode, test_streaming + PR test files | all pass |
| Premises | verified live on main pre-fix (conversation_loop:1049, chat_completion_helpers:1949/2478, gemini_native_adapter:272, agent_runtime_helpers:1166/1345) |

Salvages #66212, #15676, #57354, #53802, #60293. Fixes #65092. (#65294 closes with credit to both signature authors.)

## Infographic

![moa-runtime-streaming](https://v3b.fal.media/files/b/0aa371bd/eiykjf2pTSg3mlVufJ99Q_rFw9PvUf.png)
