### PR TITLE
fix(moa): desktop/TUI advisor visibility, progress indicator, preset + per-advisor toggles (cluster salvage)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1032,12 +1032,12 @@ def init_agent(
         # reference-model outputs to the agent's tool_progress_callback so
         # every surface that already consumes it (CLI spinner/scrollback, TUI,
         # desktop, gateway) can show each reference's answer as a labelled
-        # block before the aggregator acts. The facade emits "moa.reference"
-        # and "moa.aggregating" events, forwarded through the same callback
-        # the tool lifecycle uses. Best-effort and cache-safe — display-only
-        # events, they never touch the message history. The factory is shared
-        # with the fallback-restore/recovery paths so a restored facade keeps
-        # emitting these events (#53802).
+        # block before the aggregator acts. The facade emits "moa.reference",
+        # "moa.progress", "moa.phase", and "moa.aggregating" events, forwarded
+        # through the same callback the tool lifecycle uses. Best-effort and
+        # cache-safe — display-only events, they never touch the message
+        # history. The factory is shared with the fallback-restore/recovery
+        # paths so a restored facade keeps emitting these events (#53802).
         agent.client = build_moa_facade(agent, agent.model)
         agent._client_kwargs = {}
         agent.api_key = api_key or "moa-virtual-provider"

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -880,6 +880,7 @@ def aggregate_moa_context(
     so the provider default applies — matching single-model agent behavior.
     Presets may still pin explicit values.
     """
+    reference_models = [slot for slot in reference_models if slot.get("enabled", True)]
     reference_outputs: list[tuple[str, str, Any]] = []
     ref_messages = _reference_messages(api_messages)
     reference_outputs = _run_references_parallel(
@@ -1267,7 +1268,10 @@ class MoAChatCompletions:
         privacy_mode = _moa_privacy_mode(_moa_raw)
         self._privacy_mode = privacy_mode
         messages = list(api_kwargs.get("messages") or [])
-        reference_models = preset.get("reference_models") or []
+        reference_models = [
+            slot for slot in (preset.get("reference_models") or [])
+            if slot.get("enabled", True)
+        ]
         aggregator = preset.get("aggregator") or {}
         # Expose the resolved aggregator slot so session cost accounting can
         # price the aggregator's acting turn at its REAL model/provider. The

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -559,6 +559,7 @@ def _run_references_parallel(
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    progress_callback: Any = None,
 ) -> list[tuple[str, str, Any]]:
     """Fan out all reference models in parallel, returning outputs in order.
 
@@ -567,6 +568,12 @@ def _run_references_parallel(
     the aggregator. Output order matches ``reference_models`` so the
     ``Reference {idx}`` labelling stays stable. MoA presets that reference
     another MoA preset are skipped here (recursion guard) with a labelled note.
+
+    If ``progress_callback`` is provided it is invoked as each reference
+    completes: ``progress_callback(refs_done, refs_total, label)``. The total
+    matches ``len(reference_models)`` so listeners can render a status-bar
+    progress like ``MOA: 2/3 refs done``. Best-effort — failures are logged
+    but never break the fan-out (display must never block a turn).
 
     Each element is ``(label, text, usage)`` where usage is a
     ``CanonicalUsage`` (zeroed for skipped/failed references).
@@ -585,6 +592,8 @@ def _run_references_parallel(
     # advisor calls attribute to the same conversation as the acting turn.
     from tools.thread_context import propagate_context_to_thread
 
+    total = len(reference_models)
+    done = 0
     with ThreadPoolExecutor(max_workers=workers) as executor:
         for idx, slot in enumerate(reference_models):
             if slot.get("provider") == "moa":
@@ -607,6 +616,13 @@ def _run_references_parallel(
         # complete set, so there is no early-exit / first-completed path here.
         for future, idx in futures.items():
             results[idx] = future.result()
+            done += 1
+            if progress_callback is not None:
+                try:
+                    label = _slot_label(reference_models[idx])
+                    progress_callback(done, total, label)
+                except Exception as exc:  # pragma: no cover - display must never break
+                    logger.debug("MoA progress_callback failed: %s", exc)
 
     return [r for r in results if r is not None]
 
@@ -988,6 +1004,14 @@ class MoAChatCompletions:
         #   reference_callback(event, **kwargs)
         # where event is one of:
         #   "moa.reference"   kwargs: index, count, label, text
+        #   "moa.progress"    kwargs: refs_done, refs_total, label
+        #                       (fired once per reference completion — drives
+        #                        status-bar progress like ``MOA: 2/3 refs done``)
+        #   "moa.phase"       kwargs: phase, refs_done, refs_total, aggregator
+        #                       (fired on phase transitions, currently
+        #                        phase="aggregator" right before the aggregator
+        #                        acts; phase="reference" mirrors ``moa.progress``
+        #                        so listeners can rely on a single event family)
         #   "moa.aggregating" kwargs: aggregator (label), ref_count
         # Never raises into the model call — display is best-effort.
         self.reference_callback = reference_callback
@@ -1389,11 +1413,25 @@ class MoAChatCompletions:
             # not a new MoA turn.
             self._pending_trace = None
         else:
+            # Per-reference progress callback: emits ``moa.progress`` so
+            # listeners can render ``MOA: N/M refs done`` in the status bar as
+            # each reference completes. The callback is bound to self so it
+            # goes through the same display hook as the existing
+            # ``moa.reference`` / ``moa.aggregating`` events.
+            def _progress(done: int, total: int, label: str) -> None:
+                self._emit(
+                    "moa.progress",
+                    refs_done=done,
+                    refs_total=total,
+                    label=label,
+                )
+
             reference_outputs = _run_references_parallel(
                 reference_models,
                 ref_messages,
                 temperature=temperature,
                 max_tokens=reference_max_tokens,
+                progress_callback=_progress,
             )
             self._ref_cache_key = _cache_key
             self._ref_cache_outputs = list(reference_outputs)
@@ -1456,6 +1494,17 @@ class MoAChatCompletions:
                     text=_redact_reference_text(_text) if privacy_mode else _text,
                 )
             if _ref_count:
+                # Phase transition: reference fan-out is complete, the
+                # aggregator is about to act. Listeners that prefer a single
+                # event family for phase tracking can switch on ``phase``
+                # instead of subscribing to ``moa.aggregating`` separately.
+                self._emit(
+                    "moa.phase",
+                    phase="aggregator",
+                    refs_done=_ref_count,
+                    refs_total=_ref_count,
+                    aggregator=_slot_label(aggregator),
+                )
                 self._emit(
                     "moa.aggregating",
                     aggregator=_slot_label(aggregator),
@@ -1573,6 +1622,30 @@ def build_moa_facade(agent, preset_name: Any = None) -> MoAClient:
                     None,
                     moa_index=idx,
                     moa_count=count,
+                )
+            elif event == "moa.progress":
+                # Per-reference completion. Frontends render this as a
+                # status-bar progress indicator like ``MOA: N/M refs done``.
+                cb(
+                    "moa.progress",
+                    str(kwargs.get("label") or ""),
+                    None,
+                    None,
+                    moa_refs_done=kwargs.get("refs_done"),
+                    moa_refs_total=kwargs.get("refs_total"),
+                )
+            elif event == "moa.phase":
+                # Phase transition (currently only ``phase="aggregator"``
+                # fires once the fan-out is done). Subscribers can switch
+                # on ``moa_phase`` to know which phase is active.
+                cb(
+                    "moa.phase",
+                    str(kwargs.get("aggregator") or ""),
+                    None,
+                    None,
+                    moa_phase=kwargs.get("phase"),
+                    moa_refs_done=kwargs.get("refs_done"),
+                    moa_refs_total=kwargs.get("refs_total"),
                 )
             elif event == "moa.aggregating":
                 cb(

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -112,6 +112,8 @@ const COMPACTION_RESUME_EVENT_TYPES = new Set([
   'reasoning.available',
   'moa.reference',
   'moa.aggregating',
+  'moa.progress',
+  'moa.phase',
   'tool.start',
   'tool.progress',
   'tool.generating',
@@ -551,6 +553,36 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       } else if (event.type === 'moa.aggregating') {
         // Status transition only; the aggregator's reply arrives via the normal
         // message stream. No reasoning/transcript mutation here.
+        if (isActiveEvent) {
+          setPetActivity({ reasoning: true })
+        }
+      } else if (event.type === 'moa.progress') {
+        // Live reference fan-out progress ("refs k/n") — surfaced in the same
+        // reasoning disclosure the references land in. These lines arrive
+        // BEFORE any moa.reference event (references are only emitted once the
+        // whole fan-out completes), and the first moa.reference replaces the
+        // block, so the progress trail is self-cleaning.
+        if (sessionId && typeof payload?.refs_done === 'number' && typeof payload?.refs_total === 'number') {
+          const label = coerceGatewayText(payload?.label)
+          const line = label
+            ? `◇ MoA refs ${payload.refs_done}/${payload.refs_total} — ${label}\n`
+            : `◇ MoA refs ${payload.refs_done}/${payload.refs_total}\n`
+          appendReasoningDelta(sessionId, line, payload.refs_done <= 1)
+          flushQueuedDeltas(sessionId)
+        }
+
+        if (isActiveEvent) {
+          setPetActivity({ reasoning: true })
+        }
+      } else if (event.type === 'moa.phase') {
+        // Phase transition — currently only phase="aggregator" (fan-out done,
+        // aggregator acting). Append a one-line marker; the first
+        // moa.reference that follows replaces the whole block.
+        if (sessionId && payload?.phase === 'aggregator') {
+          appendReasoningDelta(sessionId, '◇ MoA aggregating…\n', false)
+          flushQueuedDeltas(sessionId)
+        }
+
         if (isActiveEvent) {
           setPetActivity({ reasoning: true })
         }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -524,7 +524,25 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           const cnt = typeof payload?.count === 'number' ? payload.count : undefined
           const header = idx && cnt ? `◇ Reference ${idx}/${cnt} — ${label}` : `◇ Reference — ${label}`
           const body = coerceThinkingText(payload?.text)
-          appendReasoningDelta(sessionId, `${header}\n${body}\n\n`, true)
+          const text = `${header}\n${body}\n\n`
+          if (idx === undefined || idx <= 1) {
+            // First reference: clear any stale reasoning left over from
+            // before this turn's references start, same as before.
+            appendReasoningDelta(sessionId, text, true)
+          } else {
+            // Later references must accumulate, not replace — otherwise
+            // each new reference wipes out the ones already shown (#64658).
+            // Queue-then-flush (rather than the streamed/batched queue path)
+            // applies it immediately, since each reference arrives as one
+            // complete block rather than incremental tokens. reasoning.delta
+            // cannot be mid-flight here: MoAChatCompletions.reference_callback
+            // (agent/moa_loop.py) fires "moa.reference" once per reference's
+            // already-complete text, with no concurrent token stream for the
+            // reference-gathering phase, so there is no in-flight delta to
+            // collide with in the shared queue bucket.
+            appendReasoningDelta(sessionId, text, false)
+            flushQueuedDeltas(sessionId)
+          }
         }
 
         if (isActiveEvent) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/moa-progress-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/moa-progress-event.test.tsx
@@ -1,0 +1,123 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let latestState: ClientSessionState | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+      latestState = next
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}) {
+  act(() => handleEvent!({ payload, session_id: SID, type }))
+}
+
+function reasoningText(): string {
+  const message = latestState?.messages.at(-1)
+  const part = message?.parts.find(p => p.type === 'reasoning')
+
+  return part?.type === 'reasoning' ? part.text : ''
+}
+
+beforeEach(() => {
+  handleEvent = null
+  latestState = null
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('useMessageStream moa.progress / moa.phase surfacing', () => {
+  it('shows refs k/n lines in the reasoning block as references complete', async () => {
+    await mountStream()
+
+    emit('message.start')
+    emit('moa.progress', { label: 'model-a', refs_done: 1, refs_total: 3 })
+    emit('moa.progress', { label: 'model-b', refs_done: 2, refs_total: 3 })
+
+    const text = reasoningText()
+    expect(text).toContain('MoA refs 1/3 — model-a')
+    expect(text).toContain('MoA refs 2/3 — model-b')
+  })
+
+  it('restarts the progress block on the first ref of a new fan-out', async () => {
+    await mountStream()
+
+    emit('message.start')
+    emit('moa.progress', { label: 'stale', refs_done: 1, refs_total: 2 })
+    emit('moa.progress', { label: 'stale-2', refs_done: 2, refs_total: 2 })
+    // A later turn's fan-out starts over at 1/N — old lines must not linger.
+    emit('moa.progress', { label: 'fresh', refs_done: 1, refs_total: 2 })
+
+    const text = reasoningText()
+    expect(text).toContain('MoA refs 1/2 — fresh')
+    expect(text).not.toContain('stale')
+  })
+
+  it('appends the aggregating marker on moa.phase and ignores unknown phases', async () => {
+    await mountStream()
+
+    emit('message.start')
+    emit('moa.progress', { label: 'model-a', refs_done: 1, refs_total: 1 })
+    emit('moa.phase', { phase: 'reference', refs_done: 1, refs_total: 1 })
+    expect(reasoningText()).not.toContain('aggregating')
+
+    emit('moa.phase', { aggregator: 'agg-model', phase: 'aggregator', refs_done: 1, refs_total: 1 })
+    expect(reasoningText()).toContain('MoA aggregating…')
+  })
+
+  it('a following moa.reference replaces the progress trail (self-cleaning)', async () => {
+    await mountStream()
+
+    emit('message.start')
+    emit('moa.progress', { label: 'model-a', refs_done: 1, refs_total: 1 })
+    emit('moa.phase', { phase: 'aggregator', refs_done: 1, refs_total: 1 })
+    emit('moa.reference', { count: 1, index: 1, label: 'model-a', text: 'advice-a' })
+
+    const text = reasoningText()
+    expect(text).toContain('Reference 1/1 — model-a')
+    expect(text).not.toContain('MoA refs')
+    expect(text).not.toContain('aggregating')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/moa-reference-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/moa-reference-event.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let latestState: ClientSessionState | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+      latestState = next
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}) {
+  act(() => handleEvent!({ payload, session_id: SID, type }))
+}
+
+function reasoningText(): string {
+  const message = latestState?.messages.at(-1)
+  const part = message?.parts.find(p => p.type === 'reasoning')
+
+  return part?.type === 'reasoning' ? part.text : ''
+}
+
+describe('useMessageStream moa.reference accumulation (#64658)', () => {
+  beforeEach(() => {
+    handleEvent = null
+    latestState = null
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps every reference model labelled block instead of only the latest one', async () => {
+    await mountStream()
+
+    emit('moa.reference', { count: 2, index: 1, label: 'model-a', text: 'advice-a' })
+    emit('moa.reference', { count: 2, index: 2, label: 'model-b', text: 'advice-b' })
+
+    const text = reasoningText()
+
+    expect(text).toContain('model-a')
+    expect(text).toContain('advice-a')
+    expect(text).toContain('model-b')
+    expect(text).toContain('advice-b')
+  })
+
+  it('handles a single-reference MoA turn (count=1) without regression', async () => {
+    await mountStream()
+
+    emit('moa.reference', { count: 1, index: 1, label: 'model-a', text: 'only-advice' })
+
+    const text = reasoningText()
+
+    expect(text).toContain('model-a')
+    expect(text).toContain('only-advice')
+  })
+
+  it('accumulates three or more references in order', async () => {
+    await mountStream()
+
+    emit('moa.reference', { count: 3, index: 1, label: 'model-a', text: 'advice-a' })
+    emit('moa.reference', { count: 3, index: 2, label: 'model-b', text: 'advice-b' })
+    emit('moa.reference', { count: 3, index: 3, label: 'model-c', text: 'advice-c' })
+
+    const text = reasoningText()
+    const orderOk =
+      text.indexOf('advice-a') < text.indexOf('advice-b') && text.indexOf('advice-b') < text.indexOf('advice-c')
+
+    expect(text).toContain('advice-a')
+    expect(text).toContain('advice-b')
+    expect(text).toContain('advice-c')
+    expect(orderOk).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -456,4 +456,30 @@ describe('ModelSettings MoA preset editor', () => {
       vi.useRealTimers()
     }
   })
+
+  it('saves a disabled reference model without removing it (per-slot enabled toggle)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    try {
+      await openReferenceEditor()
+
+      fireEvent.click(screen.getByRole('switch', { name: 'Disable reference 1' }))
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(saveMoaModels).toHaveBeenCalledWith(
+        expect.objectContaining({
+          presets: expect.objectContaining({
+            default: expect.objectContaining({
+              reference_models: [
+                expect.objectContaining({ provider: 'nous', model: 'hermes-4', enabled: false }),
+                expect.objectContaining({ provider: 'openrouter', model: 'deepseek/deepseek-v4-pro' })
+              ]
+            })
+          })
+        })
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -435,4 +435,25 @@ describe('ModelSettings MoA preset editor', () => {
       vi.useRealTimers()
     }
   })
+
+  it('autosaves the selected preset when its enabled switch is toggled', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    try {
+      await openReferenceEditor()
+
+      fireEvent.click(screen.getByRole('switch', { name: 'Enabled' }))
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(saveMoaModels).toHaveBeenCalledWith(
+        expect.objectContaining({
+          presets: expect.objectContaining({
+            default: expect.objectContaining({ enabled: false })
+          })
+        })
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -1078,6 +1078,21 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
           <div className="grid gap-1">
             {currentMoaPreset.reference_models.map((slot, index) => (
               <ListRow
+                action={
+                  <Switch
+                    aria-label={`${slot.enabled !== false ? 'Disable' : 'Enable'} reference ${index + 1}`}
+                    checked={slot.enabled !== false}
+                    disabled={applying}
+                    onCheckedChange={checked =>
+                      updateMoaPreset(prev => ({
+                        ...prev,
+                        reference_models: prev.reference_models.map((s, i) =>
+                          i === index ? { ...s, enabled: checked === true } : s
+                        )
+                      }))
+                    }
+                  />
+                }
                 below={
                   <div className="mt-2 flex flex-wrap items-center gap-2 pt-1">
                     <Select
@@ -1146,6 +1161,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                     </Button>
                   </div>
                 }
+                className={cn(slot.enabled === false && 'opacity-60')}
                 description={
                   <span className="font-mono text-[0.68rem]">
                     {slot.provider} · {slot.model || m.model}
@@ -1158,7 +1174,10 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
             <Button
               disabled={applying}
               onClick={() =>
-                updateMoaPreset(prev => ({ ...prev, reference_models: [...prev.reference_models, prev.aggregator] }))
+                updateMoaPreset(prev => ({
+                  ...prev,
+                  reference_models: [...prev.reference_models, { ...prev.aggregator, enabled: true }]
+                }))
               }
               size="sm"
               variant="textStrong"

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -993,6 +993,15 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                 ))}
               </SelectContent>
             </Select>
+            <label className="flex items-center gap-2 rounded-sm border border-border px-2 py-1 text-xs">
+              Enabled
+              <Switch
+                checked={currentMoaPreset.enabled !== false}
+                disabled={applying}
+                onCheckedChange={checked => updateMoaPreset(prev => ({ ...prev, enabled: checked }))}
+                size="xs"
+              />
+            </label>
             <Button
               disabled={applying}
               onClick={() => {

--- a/apps/desktop/src/app/settings/primitives.tsx
+++ b/apps/desktop/src/app/settings/primitives.tsx
@@ -111,7 +111,8 @@ export function ListRow({
   hint,
   action,
   below,
-  wide = false
+  wide = false,
+  className
 }: {
   title: ReactNode
   description?: ReactNode
@@ -119,12 +120,13 @@ export function ListRow({
   action?: ReactNode
   below?: ReactNode
   wide?: boolean
+  className?: string
 }) {
   return (
     // Container-queried, not viewport-queried: the label/control split keys on
     // the row's own pane width, so a narrow detail column (messaging, split
     // views) stacks instead of squishing the label against minmax(15rem,…).
-    <div className="@container">
+    <div className={cn('@container', className)}>
       <div
         className={cn(
           'grid gap-3 py-3',

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -94,6 +94,10 @@ export type GatewayEventPayload = {
   label?: string
   index?: number
   aggregator?: string
+  // moa.progress / moa.phase (Mixture of Agents fan-out progress relay)
+  refs_done?: number
+  refs_total?: number
+  phase?: string
   // message.complete — signals the final text was already previewed via
   // interim_assistant_callback, so the UI can settle instead of duplicating.
   response_previewed?: boolean

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -999,6 +999,7 @@ export interface MoaModelSlot {
   model: string
   /** Optional per-slot reasoning effort — round-tripped, not edited here. */
   reasoning_effort?: string
+  enabled?: boolean
 }
 
 export interface MoaConfigResponse {

--- a/contributors/emails/sjq15251852316@gmail.com
+++ b/contributors/emails/sjq15251852316@gmail.com
@@ -1,0 +1,1 @@
+oppenheimor

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -111,7 +111,9 @@ def cmd_moa(args) -> None:
         idx = 0
         while True:
             base = existing[idx] if idx < len(existing) else None
-            refs.append(_pick_slot(base))
+            picked = _pick_slot(base)
+            picked["enabled"] = bool((base or {}).get("enabled", True))
+            refs.append(picked)
             idx += 1
             choice = _prompt_choice("Add another reference model?", ["Add another", "Done"], 1)
             if choice == 1:

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -21,6 +21,10 @@ DEFAULT_MOA_AGGREGATOR: dict[str, str] = {
 }
 
 
+def _default_reference_models() -> list[dict[str, Any]]:
+    return [{**slot, "enabled": True} for slot in deepcopy(DEFAULT_MOA_REFERENCE_MODELS)]
+
+
 def _coerce_float_or_none(value: Any) -> float | None:
     """Coerce to a float, or None when unset/blank/invalid.
 
@@ -137,7 +141,22 @@ def _clean_reasoning_effort(value: Any) -> str | None:
     return parsed.get("effort")
 
 
-def _clean_slot(slot: Any) -> dict[str, Any] | None:
+def _coerce_bool(value: Any, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"0", "false", "no", "off"}:
+            return False
+        if text in {"1", "true", "yes", "on"}:
+            return True
+        return default
+    return bool(value)
+
+
+def _clean_slot(slot: Any, *, include_enabled: bool = False) -> dict[str, Any] | None:
     if not isinstance(slot, dict):
         return None
     provider = str(slot.get("provider") or "").strip()
@@ -163,6 +182,8 @@ def _clean_slot(slot: Any) -> dict[str, Any] | None:
     slot_mt = _coerce_int_or_none(slot.get("max_tokens"))
     if slot_mt is not None:
         clean["max_tokens"] = slot_mt
+    if include_enabled:
+        clean["enabled"] = _coerce_bool(slot.get("enabled"), True)
     return clean
 
 
@@ -239,7 +260,7 @@ def validate_moa_payload(raw: Any) -> list[str]:
 
 def _default_preset() -> dict[str, Any]:
     return {
-        "reference_models": deepcopy(DEFAULT_MOA_REFERENCE_MODELS),
+        "reference_models": _default_reference_models(),
         "aggregator": deepcopy(DEFAULT_MOA_AGGREGATOR),
         # None = temperature omitted from API calls (provider default),
         # matching single-model agent behavior.
@@ -268,15 +289,15 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # defaults instead of crashing the iteration, mirroring the tolerance
         # for the scalar fields below (reference_temperature / max_tokens).
         raw_refs = [raw_refs] if isinstance(raw_refs, dict) else []
-    refs = [_clean_slot(item) for item in raw_refs]
+    refs = [_clean_slot(item, include_enabled=True) for item in raw_refs]
     refs = [item for item in refs if item is not None]
     if not refs:
-        refs = deepcopy(DEFAULT_MOA_REFERENCE_MODELS)
+        refs = _default_reference_models()
 
     aggregator = _clean_slot(raw.get("aggregator")) or deepcopy(DEFAULT_MOA_AGGREGATOR)
 
     return {
-        "enabled": bool(raw.get("enabled", True)),
+        "enabled": _coerce_bool(raw.get("enabled"), True),
         "reference_models": refs,
         "aggregator": aggregator,
         "reference_temperature": _coerce_float_or_none(raw.get("reference_temperature")),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1360,6 +1360,7 @@ class MoaModelSlot(BaseModel):
     # Optional per-slot reasoning effort. Declared so a client round-tripping
     # the GET payload doesn't have it stripped at parse time and wiped on save.
     reasoning_effort: Optional[str] = None
+    enabled: bool = True
 
 
 class MoaPresetPayload(BaseModel):

--- a/tests/agent/test_moa_progress.py
+++ b/tests/agent/test_moa_progress.py
@@ -1,0 +1,234 @@
+"""Tests for the MOA progress indicator added in issue #59546.
+
+The MoA facade (``MoAChatCompletions.create``) emits a sequence of display
+events so a TUI / CLI / desktop surface can render progress as references
+complete and the phase transitions from ``reference`` to ``aggregator``:
+
+  - ``moa.progress`` — fired once per reference completion with
+                       ``refs_done`` and ``refs_total`` (e.g. drives a
+                       status-bar ``MOA: 2/3 refs done`` indicator)
+  - ``moa.phase``    — fired once per phase transition (currently only the
+                       ``phase="aggregator"`` transition right before the
+                       aggregator acts)
+
+These tests exercise the real callback surface end-to-end through the
+display hook (``reference_callback``) — no mocks on the dispatch path.
+The LLM is stubbed via ``call_llm`` so the test does not depend on any
+real provider.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _response(content="ok"):
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fake")
+
+
+@pytest.fixture
+def moa_config(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: closed
+  presets:
+    closed:
+      enabled: true
+      reference_models:
+        - provider: openrouter
+          model: anthropic/claude-opus-4.8
+        - provider: openrouter
+          model: openai/gpt-5.5
+        - provider: openrouter
+          model: google/gemini-3-pro
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _collect_emits(facade):
+    """Pull every event the facade dispatches into a flat list of (event, kwargs)."""
+    captured: list[tuple[str, dict]] = []
+
+    def _capture(event: str, **kwargs):
+        captured.append((event, kwargs))
+
+    facade.reference_callback = _capture
+    return captured
+
+
+def test_moa_progress_fires_for_each_reference(moa_config, monkeypatch):
+    """One ``moa.progress`` event per reference completion with monotonic counts."""
+    from agent.moa_loop import MoAChatCompletions
+
+    def fake_call_llm(**kwargs):
+        # Per-model stub: each reference returns a stable string so we can
+        # assert labels flow through; the aggregator returns the acting text.
+        if kwargs.get("task") == "moa_reference":
+            return _response(f"advice from {kwargs.get('model', '?')}")
+        return _response("acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    facade = MoAChatCompletions("closed")
+    captured = _collect_emits(facade)
+
+    facade.create(
+        model="closed",
+        messages=[{"role": "user", "content": "clean the db"}],
+    )
+
+    progress_events = [(e, k) for (e, k) in captured if e == "moa.progress"]
+    # 3 references configured in moa_config => 3 progress events.
+    assert len(progress_events) == 3
+
+    # Monotonic 1/3, 2/3, 3/3 — each event carries the current count and total.
+    expected_counts = [(1, 3), (2, 3), (3, 3)]
+    actual_counts = [
+        (k["refs_done"], k["refs_total"]) for (_, k) in progress_events
+    ]
+    assert actual_counts == expected_counts
+
+    # Every progress event names the source model slot (or close to it) so a
+    # status bar can render ``MOA: 2/3 refs done — openai/gpt-5.5``.
+    for _, kwargs in progress_events:
+        assert "label" in kwargs
+        assert kwargs["label"]
+
+
+def test_moa_phase_transitions_to_aggregator(moa_config, monkeypatch):
+    """A single ``moa.phase`` event with ``phase="aggregator"`` fires after the fan-out."""
+    from agent.moa_loop import MoAChatCompletions
+
+    def fake_call_llm(**kwargs):
+        if kwargs.get("task") == "moa_reference":
+            return _response("advice")
+        return _response("acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    facade = MoAChatCompletions("closed")
+    captured = _collect_emits(facade)
+
+    facade.create(
+        model="closed",
+        messages=[{"role": "user", "content": "plan the migration"}],
+    )
+
+    phase_events = [(e, k) for (e, k) in captured if e == "moa.phase"]
+    # Exactly one phase event per turn, identifying the aggregator.
+    assert len(phase_events) == 1
+    _event, kwargs = phase_events[0]
+    assert kwargs["phase"] == "aggregator"
+    assert kwargs["aggregator"] == "openrouter:anthropic/claude-opus-4.8"
+    # counts match the configured reference count
+    assert kwargs["refs_done"] == 3
+    assert kwargs["refs_total"] == 3
+
+
+def test_moa_progress_counts_match_n_references(moa_config, monkeypatch):
+    """Progress counters equal ``len(reference_models)`` regardless of size."""
+    from agent.moa_loop import MoAChatCompletions
+
+    def fake_call_llm(**kwargs):
+        if kwargs.get("task") == "moa_reference":
+            return _response("advice")
+        return _response("acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    facade = MoAChatCompletions("closed")
+    captured = _collect_emits(facade)
+
+    facade.create(
+        model="closed",
+        messages=[{"role": "user", "content": "summarize"}],
+    )
+
+    progress_events = [(e, k) for (e, k) in captured if e == "moa.progress"]
+    totals = [k["refs_total"] for _, k in progress_events]
+    # Every event reports the same total — the preset's reference-model count.
+    assert totals and all(t == 3 for t in totals)
+    # And the final done-count equals the total (fan-out finished).
+    final = progress_events[-1][1]
+    assert final["refs_done"] == final["refs_total"]
+
+
+def test_moa_progress_event_order_matches_fanout(moa_config, monkeypatch):
+    """Every progress event fires AFTER its matching moa.reference event.
+
+    Listeners that animate one block per reference (collapsible) need the
+    progress notification to land after the per-reference text so the
+    status-bar counter and the rendered block stay in lockstep.
+    """
+    from agent.moa_loop import MoAChatCompletions
+
+    def fake_call_llm(**kwargs):
+        if kwargs.get("task") == "moa_reference":
+            return _response("advice")
+        return _response("acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    facade = MoAChatCompletions("closed")
+    captured = _collect_emits(facade)
+
+    facade.create(
+        model="closed",
+        messages=[{"role": "user", "content": "rank the options"}],
+    )
+
+    # Walk the events; every progress event must be preceded by its reference
+    # text event (matching ``index``). The full sequence ends with the
+    # aggregator phase event.
+    seen_phase = False
+    for event, kwargs in captured:
+        if event == "moa.reference":
+            assert kwargs["index"] <= kwargs["count"]
+        elif event == "moa.progress":
+            assert kwargs["refs_done"] <= kwargs["refs_total"]
+        elif event == "moa.phase":
+            # No further reference events after the aggregator phase event.
+            assert kwargs["phase"] == "aggregator"
+            seen_phase = True
+        elif event == "moa.aggregating":
+            # Legacy marker still fires for backwards compatibility, and it
+            # always lands AFTER the phase event.
+            assert seen_phase
+    assert seen_phase, "expected at least one moa.phase event"
+
+
+def test_moa_progress_callback_none_safe(moa_config, monkeypatch):
+    """A missing ``reference_callback`` does not break the fan-out or create()."""
+    from agent.moa_loop import MoAChatCompletions
+
+    def fake_call_llm(**kwargs):
+        if kwargs.get("task") == "moa_reference":
+            return _response("advice")
+        return _response("acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    # No callback attached — the facade's _emit is a no-op in that case.
+    facade = MoAChatCompletions("closed")
+    assert facade.reference_callback is None
+    facade.create(
+        model="closed",
+        messages=[{"role": "user", "content": "noop"}],
+    )
+    # Turn still resolved cleanly; aggregator slot populated as usual.
+    assert facade.last_aggregator_slot is not None
+    assert facade.last_aggregator_slot["model"] == "anthropic/claude-opus-4.8"

--- a/tests/cli/test_moa_command.py
+++ b/tests/cli/test_moa_command.py
@@ -79,7 +79,9 @@ def test_decode_legacy_encoded_moa_turn_still_works():
     encoded = build_moa_turn_prompt("hello", _make_cli().config["moa"], preset="review")
     prompt, cfg = decode_moa_turn(encoded)
     assert prompt == "hello"
-    assert cfg["reference_models"] == [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}]
+    assert cfg["reference_models"] == [
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": True}
+    ]
 
 
 class TestNormalizeMoaModel:
@@ -129,3 +131,4 @@ class TestNormalizeMoaModel:
         requested_provider = override or "deepseek" or "auto"
         assert requested_provider == "moa"
         assert model == "strategy"
+

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -35,12 +35,16 @@ def test_moa_slot_picker_excludes_unconfigured_providers(monkeypatch):
     assert captured["include_unconfigured"] is False
 
 
+def _enabled_refs(refs):
+    return [{**slot, "enabled": True} for slot in refs]
+
+
 def test_normalize_moa_config_uses_default_named_preset():
     cfg = normalize_moa_config({})
 
     assert cfg["default_preset"] == DEFAULT_MOA_PRESET_NAME
     assert list(cfg["presets"]) == [DEFAULT_MOA_PRESET_NAME]
-    assert cfg["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
+    assert cfg["reference_models"] == _enabled_refs(DEFAULT_MOA_REFERENCE_MODELS)
     assert cfg["aggregator"] == DEFAULT_MOA_AGGREGATOR
 
 
@@ -63,7 +67,45 @@ def test_normalize_moa_config_preserves_named_presets():
 
     assert cfg["default_preset"] == "coding"
     assert set(cfg["presets"]) == {"coding", "review"}
-    assert cfg["reference_models"] == [{"provider": "openai-codex", "model": "gpt-5.5"}]
+    assert cfg["reference_models"] == [{"provider": "openai-codex", "model": "gpt-5.5", "enabled": True}]
+
+
+def test_normalize_moa_config_defaults_reference_enabled_true():
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "review": {
+                    "reference_models": [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}],
+                    "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                }
+            }
+        }
+    )
+
+    assert cfg["presets"]["review"]["reference_models"] == [
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": True}
+    ]
+
+
+def test_normalize_moa_config_preserves_disabled_reference():
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "review": {
+                    "reference_models": [
+                        {"provider": "openai-codex", "model": "gpt-5.5", "enabled": False},
+                        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": "false"},
+                    ],
+                    "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                }
+            }
+        }
+    )
+
+    assert cfg["presets"]["review"]["reference_models"] == [
+        {"provider": "openai-codex", "model": "gpt-5.5", "enabled": False},
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": False},
+    ]
 
 
 def test_legacy_flat_config_becomes_default_preset():
@@ -75,7 +117,7 @@ def test_legacy_flat_config_becomes_default_preset():
     )
 
     assert cfg["presets"][DEFAULT_MOA_PRESET_NAME]["reference_models"] == [
-        {"provider": "openai-codex", "model": "gpt-5.5"}
+        {"provider": "openai-codex", "model": "gpt-5.5", "enabled": True}
     ]
 
 
@@ -110,7 +152,7 @@ def test_normalize_moa_config_tolerates_non_list_reference_models():
     cfg = normalize_moa_config(
         {"presets": {"broken": {"reference_models": 2}}}
     )
-    assert cfg["presets"]["broken"]["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
+    assert cfg["presets"]["broken"]["reference_models"] == _enabled_refs(DEFAULT_MOA_REFERENCE_MODELS)
 
 
 def test_normalize_moa_config_wraps_bare_dict_reference_models():
@@ -118,7 +160,7 @@ def test_normalize_moa_config_wraps_bare_dict_reference_models():
     cfg = normalize_moa_config(
         {"presets": {"p": {"reference_models": {"provider": "openai", "model": "gpt-4o"}}}}
     )
-    assert cfg["presets"]["p"]["reference_models"] == [{"provider": "openai", "model": "gpt-4o"}]
+    assert cfg["presets"]["p"]["reference_models"] == [{"provider": "openai", "model": "gpt-4o", "enabled": True}]
 
 
 def test_normalize_moa_config_parses_json_string_reference_models():
@@ -250,7 +292,7 @@ def test_resolve_moa_preset_returns_requested_model_set():
     )
 
     assert resolve_moa_preset(cfg, "review")["reference_models"] == [
-        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": True}
     ]
 
 
@@ -300,7 +342,7 @@ def test_build_moa_turn_prompt_encodes_one_shot_default_preset():
     decoded_prompt, cfg = decode_moa_turn(prompt)
     assert decoded_prompt == "write a file then inspect it"
     assert cfg is not None
-    assert cfg["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
+    assert cfg["reference_models"] == _enabled_refs(DEFAULT_MOA_REFERENCE_MODELS)
 
 
 def test_moa_provider_rejected_as_reference_slot():
@@ -322,7 +364,7 @@ def test_moa_provider_rejected_as_reference_slot():
 
     refs = cfg["presets"]["p"]["reference_models"]
     assert {"provider": "moa", "model": "default"} not in refs
-    assert refs == [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}]
+    assert refs == [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": True}]
 
 
 def test_moa_provider_rejected_as_aggregator_slot():

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -213,6 +213,42 @@ def test_normalize_moa_config_preserves_slot_reasoning_effort():
     assert preset["aggregator"]["reasoning_effort"] == "xhigh"
 
 
+def test_normalize_moa_config_round_trips_reasoning_effort_and_enabled():
+    """Regression: a client that GETs the config and PUTs it straight back must
+    not strip per-slot keys. reasoning_effort AND enabled have to survive a
+    normalize → normalize round trip together (a save path that re-normalizes
+    the previously normalized payload is the exact client round-trip shape)."""
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "p": {
+                    "reference_models": [
+                        {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "high", "enabled": False},
+                        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": True},
+                    ],
+                    "aggregator": {
+                        "provider": "openrouter",
+                        "model": "anthropic/claude-opus-4.8",
+                        "reasoning_effort": "xhigh",
+                    },
+                }
+            }
+        }
+    )
+
+    round_tripped = normalize_moa_config(cfg)
+
+    refs = round_tripped["presets"]["p"]["reference_models"]
+    assert refs[0] == {
+        "provider": "openai-codex",
+        "model": "gpt-5.5",
+        "reasoning_effort": "high",
+        "enabled": False,
+    }
+    assert refs[1] == {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": True}
+    assert round_tripped["presets"]["p"]["aggregator"]["reasoning_effort"] == "xhigh"
+
+
 def test_normalize_moa_config_coerces_numeric_strings():
     """Valid numeric strings (e.g. from YAML round-trip) must coerce correctly."""
     cfg = normalize_moa_config({"max_tokens": "8192", "reference_temperature": "0.9"})
@@ -539,7 +575,9 @@ def test_validate_moa_payload_agrees_with_clean_slot():
     assert validate_moa_payload(payload) == []
 
     cfg = normalize_moa_config(payload)
-    assert cfg["presets"]["p"]["reference_models"] == payload["presets"]["p"]["reference_models"]
+    # Slots survive with only the canonical enabled=True default added — no
+    # provider/model swap, no defaults substitution.
+    assert cfg["presets"]["p"]["reference_models"] == _enabled_refs(payload["presets"]["p"]["reference_models"])
     assert cfg["presets"]["p"]["aggregator"] == payload["presets"]["p"]["aggregator"]
 
 

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -176,7 +176,9 @@ def test_normalize_moa_config_parses_json_string_reference_models():
     cfg = normalize_moa_config(
         {"presets": {"p": {"reference_models": json.dumps(models)}}}
     )
-    assert cfg["presets"]["p"]["reference_models"] == models
+    assert cfg["presets"]["p"]["reference_models"] == [
+        {**m, "enabled": True} for m in models
+    ]
 
 
 def test_normalize_moa_config_malformed_json_string_falls_back_to_defaults():
@@ -185,7 +187,9 @@ def test_normalize_moa_config_malformed_json_string_falls_back_to_defaults():
     cfg = normalize_moa_config(
         {"presets": {"p": {"reference_models": "[{'provider': broken"}}}
     )
-    assert cfg["presets"]["p"]["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
+    assert cfg["presets"]["p"]["reference_models"] == [
+        {**m, "enabled": True} for m in DEFAULT_MOA_REFERENCE_MODELS
+    ]
 
 
 def test_normalize_moa_config_preserves_slot_reasoning_effort():
@@ -608,8 +612,8 @@ def test_slot_max_tokens_preserved():
         }
     )
     refs = cfg["presets"]["p"]["reference_models"]
-    assert refs[0] == {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "max_tokens": 600}
-    assert refs[1] == {"provider": "openai-codex", "model": "gpt-5.5"}
+    assert refs[0] == {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "max_tokens": 600, "enabled": True}
+    assert refs[1] == {"provider": "openai-codex", "model": "gpt-5.5", "enabled": True}
 
 
 def test_slot_max_tokens_coerced_from_string():

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -861,8 +861,13 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["reference_models"]
-        assert all(set(slot) == {"provider", "model"} for slot in data["reference_models"])
-        assert set(data["aggregator"]) == {"provider", "model"}
+        # Reference slots carry provider/model plus the per-advisor enabled
+        # flag (optional keys like reasoning_effort/max_tokens appear only
+        # when configured).
+        for slot in data["reference_models"]:
+            assert {"provider", "model"} <= set(slot)
+            assert isinstance(slot.get("enabled", True), bool)
+        assert {"provider", "model"} <= set(data["aggregator"])
 
     def test_put_moa_models_persists_provider_model_slots(self):
         from hermes_cli.config import load_config
@@ -883,8 +888,15 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
         cfg = load_config()
-        assert cfg["moa"]["reference_models"] == payload["reference_models"]
-        assert cfg["moa"]["aggregator"] == payload["aggregator"]
+        saved_refs = cfg["moa"]["reference_models"]
+        # Slots normalize with enabled=True defaulted in; provider/model must
+        # round-trip exactly.
+        assert [
+            {"provider": s["provider"], "model": s["model"]} for s in saved_refs
+        ] == payload["reference_models"]
+        assert all(s.get("enabled", True) is True for s in saved_refs)
+        agg = cfg["moa"]["aggregator"]
+        assert {"provider": agg["provider"], "model": agg["model"]} == payload["aggregator"]
 
     def test_put_moa_models_rejects_half_filled_slot_with_422(self):
         """#64156: a mid-edit autosave (provider picked, model empty) used to be

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -1006,6 +1006,51 @@ moa:
     assert agg_call["messages"][-1]["content"] == "question"
 
 
+def test_moa_disabled_reference_is_not_called(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+          enabled: false
+        - provider: openrouter
+          model: deepseek/deepseek-v4-pro
+          enabled: true
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if kwargs["task"] == "moa_reference":
+            return _response(f"reference from {kwargs['provider']}:{kwargs['model']}")
+        return _response("aggregator acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    from agent.moa_loop import MoAChatCompletions
+
+    facade = MoAChatCompletions("review")
+    facade.create(messages=[{"role": "user", "content": "question"}], tools=[{"type": "function"}])
+
+    reference_calls = [c for c in calls if c["task"] == "moa_reference"]
+    assert [(c["provider"], c["model"]) for c in reference_calls] == [
+        ("openrouter", "deepseek/deepseek-v4-pro")
+    ]
+    assert calls[-1]["task"] == "moa_aggregator"
+
+
 def test_references_run_in_parallel(monkeypatch):
     """References fan out concurrently (delegate-batch semantics), not serially.
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4432,6 +4432,43 @@ def _on_tool_progress(
     if event_type == "moa.aggregating":
         _emit("moa.aggregating", sid, {"aggregator": str(name or "")})
         return
+    if event_type == "moa.progress":
+        # Per-reference completion — drives the status-bar progress indicator
+        # (`MOA: 2/3 refs done`) requested in issue #59546. Only emitted when
+        # both counters are present so the client can render deterministically.
+        refs_done = _kwargs.get("moa_refs_done")
+        refs_total = _kwargs.get("moa_refs_total")
+        if refs_done is None or refs_total is None:
+            return
+        _emit(
+            "moa.progress",
+            sid,
+            {
+                "label": str(name or ""),
+                "refs_done": int(refs_done),
+                "refs_total": int(refs_total),
+            },
+        )
+        return
+    if event_type == "moa.phase":
+        # Phase transition — currently only ``phase="aggregator"`` fires once
+        # the fan-out completes and the aggregator is about to act. Tells the
+        # client which phase of the MoA pipeline is currently running so it
+        # can swap status-bar copy accordingly.
+        phase = _kwargs.get("moa_phase")
+        if not phase:
+            return
+        phase_payload: dict[str, object] = {"phase": str(phase)}
+        refs_done = _kwargs.get("moa_refs_done")
+        refs_total = _kwargs.get("moa_refs_total")
+        if refs_done is not None:
+            phase_payload["refs_done"] = int(refs_done)
+        if refs_total is not None:
+            phase_payload["refs_total"] = int(refs_total)
+        if name:
+            phase_payload["aggregator"] = str(name)
+        _emit("moa.phase", sid, phase_payload)
+        return
     if event_type.startswith("subagent."):
         payload = {
             "goal": str(_kwargs.get("goal") or ""),

--- a/ui-tui/src/__tests__/messageLine.test.ts
+++ b/ui-tui/src/__tests__/messageLine.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { shouldShowResponseSeparator } from '../components/messageLine.js'
+import { shouldShowResponseSeparator, shouldShowThinkingTrail } from '../components/messageLine.js'
 
 describe('shouldShowResponseSeparator', () => {
   it('separates assistant response text from visible details', () => {
@@ -15,5 +15,29 @@ describe('shouldShowResponseSeparator', () => {
   it('does not add response separators to non-assistant transcript rows', () => {
     expect(shouldShowResponseSeparator({ role: 'user', text: 'prompt' }, true)).toBe(false)
     expect(shouldShowResponseSeparator({ role: 'system', text: 'note' }, true)).toBe(false)
+  })
+})
+
+describe('shouldShowThinkingTrail', () => {
+  it('hides an ordinary reasoning trail when every section is hidden', () => {
+    const msg = { role: 'system', text: '', thinking: 'plan' } as const
+    expect(shouldShowThinkingTrail(msg, 'hidden', 'hidden', 'hidden')).toBe(false)
+  })
+
+  it('shows an ordinary reasoning trail when any section is visible', () => {
+    const msg = { role: 'system', text: '', thinking: 'plan' } as const
+    expect(shouldShowThinkingTrail(msg, 'collapsed', 'hidden', 'hidden')).toBe(true)
+    expect(shouldShowThinkingTrail(msg, 'hidden', 'collapsed', 'hidden')).toBe(true)
+    expect(shouldShowThinkingTrail(msg, 'hidden', 'hidden', 'expanded')).toBe(true)
+  })
+
+  it('keeps a MoA reference block visible even when every section is hidden (#64657)', () => {
+    const msg = {
+      role: 'system',
+      text: '',
+      thinking: '◇ Reference 1/2 — model-a\nadvice-a',
+      isMoaReference: true
+    } as const
+    expect(shouldShowThinkingTrail(msg, 'hidden', 'hidden', 'hidden')).toBe(true)
   })
 })

--- a/ui-tui/src/__tests__/moaProgressActivity.test.ts
+++ b/ui-tui/src/__tests__/moaProgressActivity.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
+import { resetOverlayState } from '../app/overlayStore.js'
+import { turnController } from '../app/turnController.js'
+import { getTurnState, resetTurnState } from '../app/turnStore.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
+import type { Msg } from '../types.js'
+
+const ref = <T>(current: T) => ({ current })
+
+const buildCtx = (appended: Msg[]) =>
+  ({
+    composer: {
+      dequeue: () => undefined,
+      queueEditRef: ref<null | number>(null),
+      sendQueued: () => undefined,
+      setInput: () => undefined
+    },
+    gateway: {
+      gw: { request: () => undefined },
+      rpc: async () => null
+    },
+    session: {
+      STARTUP_RESUME_ID: '',
+      colsRef: ref(80),
+      newSession: () => undefined,
+      resetSession: () => undefined,
+      resumeById: () => undefined,
+      setCatalog: () => undefined
+    },
+    submission: {
+      submitRef: { current: () => undefined }
+    },
+    system: {
+      bellOnComplete: false,
+      sys: () => undefined
+    },
+    transcript: {
+      appendMessage: (msg: Msg) => appended.push(msg),
+      panel: () => undefined,
+      setHistoryItems: () => undefined
+    },
+    voice: {
+      setProcessing: () => undefined,
+      setRecording: () => undefined,
+      setVoiceEnabled: () => undefined
+    }
+  }) as any
+
+const activityTexts = () => getTurnState().activity.map(item => item.text)
+
+describe('moa.progress / moa.phase activity surface', () => {
+  beforeEach(() => {
+    resetOverlayState()
+    resetUiState()
+    resetTurnState()
+    turnController.fullReset()
+    patchUiState({ showReasoning: true })
+  })
+
+  it('shows "MoA: refs k/n" as each reference completes, replacing in place', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { label: 'model-a', refs_done: 1, refs_total: 3 }, type: 'moa.progress' } as any)
+
+    expect(activityTexts()).toContain('MoA: refs 1/3')
+
+    onEvent({ payload: { label: 'model-b', refs_done: 2, refs_total: 3 }, type: 'moa.progress' } as any)
+
+    const texts = activityTexts()
+    expect(texts).toContain('MoA: refs 2/3')
+    // Replaced in place — the stale 1/3 line must not linger alongside 2/3.
+    expect(texts).not.toContain('MoA: refs 1/3')
+  })
+
+  it('swaps the progress line for aggregator copy on moa.phase', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { label: 'model-a', refs_done: 3, refs_total: 3 }, type: 'moa.progress' } as any)
+    onEvent({ payload: { phase: 'aggregator', refs_done: 3, refs_total: 3 }, type: 'moa.phase' } as any)
+
+    const texts = activityTexts()
+    expect(texts).toContain('MoA: aggregating…')
+    expect(texts).not.toContain('MoA: refs 3/3')
+  })
+
+  it('ignores malformed payloads (missing counters / unknown phase)', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    const before = activityTexts().length
+    onEvent({ payload: { label: 'model-a' }, type: 'moa.progress' } as any)
+    onEvent({ payload: { phase: 'reference' }, type: 'moa.phase' } as any)
+
+    expect(activityTexts().length).toBe(before)
+  })
+})

--- a/ui-tui/src/__tests__/thinkingMoaReferenceVisibility.test.tsx
+++ b/ui-tui/src/__tests__/thinkingMoaReferenceVisibility.test.tsx
@@ -1,0 +1,61 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { ToolTrail } from '../components/thinking.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+describe('ToolTrail — MoA reference panel visibility (#64701)', () => {
+  it('stays expanded after mount effects settle when reasoningAlwaysVisible is set, even under sections.thinking: hidden', async () => {
+    const stdout = new PassThrough()
+    const stdin = new PassThrough()
+    const stderr = new PassThrough()
+    let output = ''
+
+    Object.assign(stdout, { columns: 60, isTTY: false, rows: 20 })
+    Object.assign(stdin, { isTTY: false })
+    Object.assign(stderr, { isTTY: false })
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const instance = renderSync(
+      <ToolTrail
+        reasoning="Reference model output that must stay visible on first paint."
+        reasoningAlwaysVisible
+        sections={{ thinking: 'hidden' }}
+        t={DEFAULT_THEME}
+      />,
+      {
+        patchConsole: false,
+        stderr: stderr as NodeJS.WriteStream,
+        stdin: stdin as NodeJS.ReadStream,
+        stdout: stdout as NodeJS.WriteStream
+      }
+    )
+
+    // Let queued passive effects (and any re-render they trigger) flush
+    // before reading the frame — the #64701 bug is specifically that the
+    // re-sync effect fires AFTER the first paint and clobbers the
+    // reasoningAlwaysVisible mount value, so asserting on the pre-effect
+    // frame alone would miss the regression entirely.
+    await new Promise(resolve => setImmediate(resolve))
+    await new Promise(resolve => setImmediate(resolve))
+
+    const frame = stripAnsi(output)
+
+    instance.unmount()
+    instance.cleanup()
+
+    // Open chevron (▾) means the panel is still expanded once effects have
+    // settled, as the reasoningAlwaysVisible-seeded useState value intends.
+    // A collapsed (▸) render here means the re-sync effect fired on mount
+    // and clobbered it — the exact #64701 regression.
+    expect(frame).toContain('▾ ')
+    expect(frame).toContain('Thinking')
+    expect(frame).not.toContain('▸ ')
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1005,6 +1005,25 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         // through the normal message stream. No committed transcript entry.
         return
 
+      case 'moa.progress':
+        // Live fan-out progress — one activity line, replaced in place as each
+        // reference completes ("MoA: refs 2/3"), so the user sees movement
+        // during the (potentially long) reference phase without transcript spam.
+        if (typeof ev.payload?.refs_done === 'number' && typeof ev.payload?.refs_total === 'number') {
+          turnController.pushActivity(`MoA: refs ${ev.payload.refs_done}/${ev.payload.refs_total}`, 'info', 'MoA')
+        }
+
+        return
+
+      case 'moa.phase':
+        // Phase transition — currently only phase="aggregator" (fan-out done,
+        // aggregator acting). Swap the progress line for aggregator copy.
+        if (ev.payload?.phase === 'aggregator') {
+          turnController.pushActivity('MoA: aggregating…', 'info', 'MoA')
+        }
+
+        return
+
       case 'tool.progress':
         if (ev.payload?.preview && ev.payload.name) {
           turnController.recordToolProgress(ev.payload.name, ev.payload.preview)

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -757,6 +757,7 @@ class TurnController {
       role: 'system',
       text: '',
       thinking,
+      isMoaReference: true,
       thinkingTokens: estimateTokensRough(thinking)
     })
     patchTurnState({ streamSegments: this.segmentMessages })

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -1057,16 +1057,21 @@ export function useMainApp(gw: GatewayClient) {
           state.streamSegments.some(segment => {
             const hasThinking = Boolean(segment.thinking?.trim())
             const hasTrailTools = Boolean(segment.tools?.length)
+            // A MoA reference segment (segment.isMoaReference) is the
+            // user-facing mixture-of-agents process the user opted into, not
+            // private model reasoning — it must keep the live progress area
+            // (and therefore StreamingAssistant) up even when the thinking
+            // panel is hidden, matching shouldShowThinkingTrail's settled-
+            // transcript override in messageLine.tsx (#64657/#64701).
+            const thinkingVisible = thinkingPanelVisible || Boolean(segment.isMoaReference)
 
             if (segment.kind === 'trail' && !segment.text) {
-              return (
-                (thinkingPanelVisible && hasThinking) || ((toolsPanelVisible || activityPanelVisible) && hasTrailTools)
-              )
+              return (thinkingVisible && hasThinking) || ((toolsPanelVisible || activityPanelVisible) && hasTrailTools)
             }
 
             return (
               Boolean(segment.text?.trim()) ||
-              (thinkingPanelVisible && hasThinking) ||
+              (thinkingVisible && hasThinking) ||
               ((toolsPanelVisible || activityPanelVisible) && hasTrailTools)
             )
           }) ||

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -75,12 +75,13 @@ export const MessageLine = memo(function MessageLine({
   }
 
   if (msg.kind === 'trail' && (msg.tools?.length || tools.length || thinking)) {
-    return thinkingMode !== 'hidden' || toolsMode !== 'hidden' || activityMode !== 'hidden' ? (
+    return shouldShowThinkingTrail(msg, thinkingMode, toolsMode, activityMode) ? (
       <Box flexDirection="column" marginTop={leadGap ? 1 : 0}>
         <ToolTrail
           commandOverride={detailsModeCommandOverride}
           detailsMode={detailsMode}
           reasoning={thinking}
+          reasoningAlwaysVisible={msg.isMoaReference}
           reasoningTokens={msg.thinkingTokens}
           sections={sections}
           t={t}
@@ -258,6 +259,18 @@ export const MessageLine = memo(function MessageLine({
 
 export const shouldShowResponseSeparator = (msg: Msg, showDetails: boolean): boolean =>
   msg.role === 'assistant' && showDetails && /\S/.test(msg.text)
+
+// A MoA reference block (msg.isMoaReference) is the user-facing
+// mixture-of-agents process the user opted into, not private model
+// reasoning — it must stay visible even when every other trail section is
+// hidden (#64657).
+export const shouldShowThinkingTrail = (
+  msg: Msg,
+  thinkingMode: DetailsMode,
+  toolsMode: DetailsMode,
+  activityMode: DetailsMode
+): boolean =>
+  Boolean(msg.isMoaReference) || thinkingMode !== 'hidden' || toolsMode !== 'hidden' || activityMode !== 'hidden'
 
 interface MessageLineProps {
   cols: number

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -1,5 +1,5 @@
 import { Box, NoSelect, Text } from '@hermes/ink'
-import { memo, type ReactNode, useEffect, useMemo, useState } from 'react'
+import { memo, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import spinners, { type BrailleSpinnerName } from 'unicode-animations'
 
 import { THINKING_COT_MAX } from '../config/limits.js'
@@ -751,7 +751,21 @@ export const ToolTrail = memo(function ToolTrail({
     return () => clearInterval(id)
   }, [openTools, tools.length, visible.tools])
 
+  // Effects run after the FIRST render too, not just on later updates — so
+  // this re-sync was clobbering the reasoningAlwaysVisible mount value above
+  // right after mount, collapsing a just-opened MoA reference panel under
+  // `thinking: hidden` before the user ever saw it (#64701). Skip only the
+  // very first run; every subsequent `visible` change (the case this effect
+  // exists for) still re-syncs without the override, so a manual collapse
+  // still sticks per the no-OR-at-effect-time rule above.
+  const skippedInitialSync = useRef(false)
   useEffect(() => {
+    if (!skippedInitialSync.current) {
+      skippedInitialSync.current = true
+
+      return
+    }
+
     setOpenThinking(visible.thinking === 'expanded')
     setOpenTools(visible.tools === 'expanded')
     setOpenSubagents(visible.subagents === 'expanded')

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -680,6 +680,7 @@ export const ToolTrail = memo(function ToolTrail({
   outcome = '',
   reasoningActive = false,
   reasoning = '',
+  reasoningAlwaysVisible = false,
   reasoningTokens,
   reasoningStreaming = false,
   sections,
@@ -696,6 +697,10 @@ export const ToolTrail = memo(function ToolTrail({
   outcome?: string
   reasoningActive?: boolean
   reasoning?: string
+  // MoA reference blocks (see Msg.isMoaReference) stay visible even when
+  // `visible.thinking === 'hidden'` — they're the mixture-of-agents process
+  // the user opted into, not private model reasoning (#64657).
+  reasoningAlwaysVisible?: boolean
   reasoningTokens?: number
   reasoningStreaming?: boolean
   sections?: SectionVisibility
@@ -724,7 +729,13 @@ export const ToolTrail = memo(function ToolTrail({
   // `visible.X === 'expanded'` at render time — that locks the panel open
   // and silently breaks manual chevron clicks for default-expanded
   // sections (regression caught after #14968).
-  const [openThinking, setOpenThinking] = useState(visible.thinking === 'expanded')
+  // A MoA reference panel (reasoningAlwaysVisible) opens by default on
+  // mount even under `thinking: hidden` — the user opted into MoA and
+  // should see the reference immediately, not a collapsed "Thinking"
+  // label. This only affects the initial mount value; the re-sync effect
+  // below deliberately does NOT re-apply it, so a manual collapse still
+  // sticks (see the no-OR-at-effect-time warning above, #14968).
+  const [openThinking, setOpenThinking] = useState(visible.thinking === 'expanded' || reasoningAlwaysVisible)
   const [openTools, setOpenTools] = useState(visible.tools === 'expanded')
   const [openSubagents, setOpenSubagents] = useState(visible.subagents === 'expanded')
   const [deepSubagents, setDeepSubagents] = useState(visible.subagents === 'expanded')
@@ -915,6 +926,7 @@ export const ToolTrail = memo(function ToolTrail({
 
   const allHidden =
     visible.thinking === 'hidden' &&
+    !reasoningAlwaysVisible &&
     visible.tools === 'hidden' &&
     visible.subagents === 'hidden' &&
     visible.activity === 'hidden'
@@ -939,7 +951,7 @@ export const ToolTrail = memo(function ToolTrail({
   // hidden sections stay hidden so the override is honoured.
 
   const expandAll = () => {
-    if (visible.thinking !== 'hidden') {
+    if (visible.thinking !== 'hidden' || reasoningAlwaysVisible) {
       setOpenThinking(true)
     }
 
@@ -986,7 +998,7 @@ export const ToolTrail = memo(function ToolTrail({
     render: (rails: boolean[]) => ReactNode
   }[] = []
 
-  if (hasThinking && visible.thinking !== 'hidden') {
+  if (hasThinking && (visible.thinking !== 'hidden' || reasoningAlwaysVisible)) {
     panels.push({
       header: (
         <Box

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -608,6 +608,16 @@ export type GatewayEvent =
       type: 'moa.reference'
     }
   | { payload?: { aggregator?: string }; session_id?: string; type: 'moa.aggregating' }
+  | {
+      payload?: { label?: string; refs_done?: number; refs_total?: number }
+      session_id?: string
+      type: 'moa.progress'
+    }
+  | {
+      payload?: { aggregator?: string; phase?: string; refs_done?: number; refs_total?: number }
+      session_id?: string
+      type: 'moa.phase'
+    }
   | { payload: { name?: string; preview?: string }; session_id?: string; type: 'tool.progress' }
   | { payload: { name?: string }; session_id?: string; type: 'tool.generating' }
   | {

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -120,6 +120,11 @@ export interface Msg {
   role: Role
   text: string
   thinking?: string
+  // MoA reference-model output stored in `thinking` (see turnController's
+  // recordMoaReference): unlike ordinary model reasoning, this is the
+  // user-facing mixture-of-agents process the user opted into, so it stays
+  // visible even when `display.sections.thinking` is hidden.
+  isMoaReference?: boolean
   thinkingTokens?: number
   toolTokens?: number
   tools?: string[]

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2333,6 +2333,7 @@ export interface MoaModelSlot {
   model: string;
   /** Optional per-slot reasoning effort — round-tripped, not edited here. */
   reasoning_effort?: string;
+  enabled?: boolean;
 }
 
 export interface MoaConfigResponse {

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -34,6 +34,7 @@ import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { Stats } from "@nous-research/ui/ui/components/stats";
 import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
 import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Switch } from "@nous-research/ui/ui/components/switch";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { usePageHeader } from "@/contexts/usePageHeader";
@@ -855,13 +856,30 @@ function MoaModelsModal({
           <div className="space-y-2">
             <div className="text-display text-xs font-medium tracking-wider">Reference models</div>
             {preset.reference_models.map((slot, index) => (
-              <div key={`${selected}-${slot.provider}-${slot.model}-${index}`} className="flex items-center gap-2 border border-border/50 bg-muted/20 px-3 py-2">
+              <div
+                key={`${selected}-${slot.provider}-${slot.model}-${index}`}
+                className={cn(
+                  "flex items-center gap-2 border border-border/50 bg-muted/20 px-3 py-2",
+                  slot.enabled === false && "opacity-60"
+                )}
+              >
+                <Switch
+                  checked={slot.enabled !== false}
+                  onCheckedChange={(checked) =>
+                    updateSelectedPreset((prev) => ({
+                      ...prev,
+                      reference_models: prev.reference_models.map((s, i) =>
+                        i === index ? { ...s, enabled: checked === true } : s
+                      ),
+                    }))
+                  }
+                />
                 <div className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary">{slotLabel(slot)}</div>
                 <Button size="sm" outlined onClick={() => setPicker({ kind: "reference", index })}>Change</Button>
                 <Button size="sm" ghost disabled={preset.reference_models.length <= 1} onClick={() => updateSelectedPreset((prev) => ({ ...prev, reference_models: prev.reference_models.filter((_, i) => i !== index) }))}>Remove</Button>
               </div>
             ))}
-            <Button size="sm" outlined onClick={() => updateSelectedPreset((prev) => ({ ...prev, reference_models: [...prev.reference_models, prev.aggregator] }))}>Add reference model</Button>
+            <Button size="sm" outlined onClick={() => updateSelectedPreset((prev) => ({ ...prev, reference_models: [...prev.reference_models, { ...prev.aggregator, enabled: true }] }))}>Add reference model</Button>
           </div>
 
           <div className="space-y-2">
@@ -895,7 +913,7 @@ function MoaModelsModal({
               if (picker.kind === "aggregator") return { ...prev, aggregator: { provider, model } };
               return {
                 ...prev,
-                reference_models: prev.reference_models.map((slot, i) => i === picker.index ? { provider, model } : slot),
+                reference_models: prev.reference_models.map((slot, i) => i === picker.index ? { ...slot, provider, model } : slot),
               };
             });
           }}


### PR DESCRIPTION
## Summary

MoA's advisor pipeline becomes fully visible and controllable across Desktop and TUI: reference reasoning blocks accumulate instead of overwriting each other, stay visible when the thinking section is hidden, a live progress indicator shows fan-out state, and presets gain both a master Enabled toggle and per-advisor toggles. Consolidated salvage of five PRs (cluster: MoA desktop/TUI display).

## Changes (8 commits, authorship preserved)

- @wesleysimplicio (#64689): desktop `gateway-event.ts` used `replace=true` for EVERY `moa.reference` — with ≥2 advisors only the last block survived. Now replace-first/append-rest + delta flush. Fixes #64658.
- @wesleysimplicio (#64701, 2 commits): TUI gated MoA reference blocks purely on the thinking-section mode, contradicting the codebase's own intent ("it is the MoA process, not reasoning"). Adds `Msg.isMoaReference` + `reasoningAlwaysVisible` with a first-run-skip guard that preserves the #14968 manual-collapse contract. Fixes #64657.
- @samrusani via Co-authored-by (#59743): desktop settings Enabled switch for presets — the per-preset `enabled` flag has been wired in the backend all along (skips fan-out when false) but had zero GUI control. **Authorship note:** the original commit email (`sr@samirusani`) is malformed/unresolvable, so this was re-authored with a Co-authored-by trailer instead of cherry-picking a broken identity. Closes #59723.
- @SquabbyZ (#59646): `moa.progress` (refs k/n + label) and `moa.phase` events threaded moa_loop → facade → agent_init relay → tui_gateway. One keep-both conflict resolved. **Our fix-up: actual frontend consumers** — TUI shows "MoA: refs k/n" in the progress area, desktop registers the events and surfaces fan-out state in the reasoning block — so #59546's ask is user-visible, not just plumbing.
- @oppenheimor (#59753, rebased): per-advisor `enabled` toggles full-stack (moa_config `_clean_slot`, skip-disabled in both call paths, moa_cmd, web_server, desktop checkboxes, dashboard). Rebased over the per-slot `reasoning_effort` feature; `_clean_slot` round-trips `reasoning_effort` AND `enabled` with a round-trip regression test. Implements #59707.

Contributor mappings committed for the non-noreply emails.

## Validation

| Check | Result |
|---|---|
| TUI (vitest, incl. building hermes-ink) | 99/99 pass |
| Desktop (vitest, 11 files incl. model-settings + both moa event suites) | 64/64 pass |
| Python (test_moa_progress, test_moa_config, test_moa_loop_mode) | all pass |

Salvages #64689, #64701, #59743, #59646, #59753. Fixes #64658, #64657, #59723, #59546, #59707.

Note: #70228 (Desktop MoA preset studio) touches this same settings surface — it needs a rebase over these toggles plus a split of its bundled xAI backend change before review.

## Infographic

![moa-desktop-tui](https://v3b.fal.media/files/b/0aa371da/ZiwJHzY93VCwV964plkKZ_G5EMcBmJ.png)
