### PR TITLE
fix(agent): lock-contended compression skips soft-defer instead of exhausting (salvage #49874)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -355,6 +355,24 @@ def _emit_compression_attempt_telemetry(
         logger.debug("failed to emit compression attempt telemetry: %s", exc)
 
 
+def compression_skipped_due_to_lock(agent: Any) -> bool:
+    """Type-pinned read of the #69870 lock-skip signal.
+
+    ``agent._compression_skipped_due_to_lock`` is set by ``compress_context``
+    when a compression pass no-ops because another path holds the per-session
+    compression lock (holder string when the holder was confirmed, ``True``
+    otherwise) and cleared to ``None`` at the entry of every call.
+
+    The read MUST be type-pinned (``is True or isinstance(x, str)``), never
+    bare truthiness: MagicMock test-double agents auto-create truthy
+    attributes, and a bare ``if getattr(agent, ...)`` would hijack every
+    mocked agent in sibling suites into the lock-skip branch (the
+    #69870 × #69840 type-ahead incident).
+    """
+    _sig = getattr(agent, "_compression_skipped_due_to_lock", None)
+    return _sig is True or isinstance(_sig, str)
+
+
 def _compression_lock_holder(agent: Any) -> str:
     """Build a unique holder id for the lock: pid:tid:agent-instance:uuid.
 
@@ -1143,6 +1161,14 @@ def compress_context(
     # boundary, so the previous flush baseline remains authoritative.
     agent._last_compression_attempt_recorded = True
     agent._last_compression_attempt_in_place = None
+    # Clear the lock-skip signal at the VERY TOP, before the codex route and
+    # the breaker gates below can early-return (per-attempt state rule,
+    # #58630/#69853). A stale ``True``/holder value from a prior lock-skip
+    # must never make a later breaker/codex no-op look like lock contention
+    # to the automatic-path consumers (compression_deferred, #49874) — the
+    # second clear before lock acquisition below stays for the same reason
+    # it was added in #69870 and is simply idempotent now.
+    agent._compression_skipped_due_to_lock = None
 
     _attempt_started_at = time.monotonic()
     _attempt_id = uuid.uuid4().hex

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -34,6 +34,7 @@ from agent.conversation_compression import (
     COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE,
     COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE,
     PRE_API_COMPRESSION_STATUS_TEMPLATE,
+    compression_skipped_due_to_lock,
     conversation_history_after_compression,
 )
 from agent.context_engine import automatic_compaction_status_message
@@ -637,6 +638,55 @@ def _content_policy_blocked_result(
         "completed": False,
         "failed": True,
         "error": f"content_policy_blocked: {error_detail}",
+    }
+
+
+def _compression_deferred_result(
+    agent,
+    messages: List[Dict],
+    api_call_count: int,
+) -> Dict[str, Any]:
+    """Build the soft turn result for a lock-contended compression defer.
+
+    Another path (a sibling turn, a background review fork, a manual
+    ``/compress``) holds this session's compression lock, so every
+    compression pass this turn no-oped and the request still does not fit.
+    This is a TEMPORARY condition — the lock winner is actively shrinking
+    the same session — so the turn must end as a soft defer
+    (``compression_deferred``), never as ``compression_exhausted``: the
+    gateway auto-resets (wipes) the session on exhaustion (#9893/#35809),
+    which would destroy a session that the concurrent compressor is about
+    to make healthy again.
+
+    ``failed`` stays False so the gateway persists the user turn (transient
+    branch) and retry-next-message semantics apply.
+    """
+    holder = getattr(agent, "_compression_skipped_due_to_lock", None)
+    logger.info(
+        "turn deferred: compression lock held by another path "
+        "(session=%s holder=%s) — not counting as compression exhaustion",
+        agent.session_id or "none",
+        holder if isinstance(holder, str) else "unconfirmed",
+    )
+    try:
+        agent._flush_status_buffer()
+    except Exception:
+        pass
+    _final = (
+        "Context compression is already running for this session. "
+        "Please retry in a moment — your next message will be processed "
+        "once the concurrent compression finishes."
+    )
+    return {
+        "final_response": _final,
+        "messages": messages,
+        "completed": False,
+        "api_calls": api_call_count,
+        "error": _final,
+        "partial": True,
+        "failed": False,
+        "compression_deferred": True,
+        "session_id": agent.session_id,
     }
 
 
@@ -1354,36 +1404,52 @@ def run_conversation(
             if _pre_api_status:
                 agent._emit_status(_pre_api_status)
             _last_preflight_pressure = request_pressure_tokens
+            _pre_api_input = messages
             messages, active_system_prompt = agent._compress_context(
                 messages,
                 system_message,
                 approx_tokens=request_pressure_tokens,
                 task_id=effective_task_id,
             )
-            # Reset retry/empty-response state so the compacted request
-            # gets a fresh chance instead of inheriting stale recovery
-            # counters from the pre-compaction history.
-            agent._empty_content_retries = 0
-            agent._thinking_prefill_retries = 0
-            agent._last_content_with_tools = None
-            agent._last_content_tools_all_housekeeping = False
-            agent._mute_post_response = False
-            # Re-baseline the flush cursor for the compaction mode that just
-            # ran. Legacy session-rotation returns None (the child session has
-            # not seen the compacted transcript, so the next flush writes it
-            # whole); in-place compaction returns list(messages) because the
-            # compacted rows are already persisted under the same session id —
-            # leaving None there would re-append them, doubling the active
-            # context and retriggering compression. Mirrors the post-response
-            # and preflight compaction sites; see
-            # conversation_history_after_compression().
-            conversation_history = conversation_history_after_compression(
-                agent, messages, conversation_history
-            )
-            api_call_count -= 1
-            agent._api_call_count = api_call_count
-            agent.iteration_budget.refund()
-            continue
+            if messages is _pre_api_input and compression_skipped_due_to_lock(agent):
+                # #69870 lock-skip: another path holds this session's
+                # compression lock, so this pass no-oped. That is a temporary
+                # DEFER, not evidence about compressibility — refund the
+                # attempt (it must not burn the shared overflow-recovery
+                # budget toward compression_exhausted → gateway auto-reset,
+                # #9893/#35809) and leave the insufficient-progress blocker
+                # unarmed. Proceed with the current request: if it truly does
+                # not fit, the provider's 413/overflow handler returns the
+                # soft compression_deferred result with that stronger signal.
+                compression_attempts -= 1
+                _last_preflight_pressure = None
+                if pending_moa_prepared_request is _moa_prepared_request:
+                    pending_moa_prepared_request = None
+            else:
+                # Reset retry/empty-response state so the compacted request
+                # gets a fresh chance instead of inheriting stale recovery
+                # counters from the pre-compaction history.
+                agent._empty_content_retries = 0
+                agent._thinking_prefill_retries = 0
+                agent._last_content_with_tools = None
+                agent._last_content_tools_all_housekeeping = False
+                agent._mute_post_response = False
+                # Re-baseline the flush cursor for the compaction mode that just
+                # ran. Legacy session-rotation returns None (the child session has
+                # not seen the compacted transcript, so the next flush writes it
+                # whole); in-place compaction returns list(messages) because the
+                # compacted rows are already persisted under the same session id —
+                # leaving None there would re-append them, doubling the active
+                # context and retriggering compression. Mirrors the post-response
+                # and preflight compaction sites; see
+                # conversation_history_after_compression().
+                conversation_history = conversation_history_after_compression(
+                    agent, messages, conversation_history
+                )
+                api_call_count -= 1
+                agent._api_call_count = api_call_count
+                agent.iteration_budget.refund()
+                continue
         elif (
             agent.compression_enabled
             and len(messages) > 1
@@ -3841,10 +3907,23 @@ def run_conversation(
 
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
+                    _overflow_input = messages
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message, approx_tokens=approx_tokens,
                         task_id=effective_task_id,
                     )
+                    if messages is _overflow_input and compression_skipped_due_to_lock(agent):
+                        # #69870 lock-skip: the provider proved the request
+                        # does not fit, but this compression pass no-oped only
+                        # because another path holds the session's compression
+                        # lock. Temporary defer, not exhaustion — refund the
+                        # attempt and end the turn softly so the gateway does
+                        # NOT auto-reset the session (#9893/#35809).
+                        compression_attempts -= 1
+                        agent._persist_session(messages, conversation_history)
+                        return _compression_deferred_result(
+                            agent, messages, api_call_count
+                        )
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history
                     )
@@ -4082,10 +4161,23 @@ def run_conversation(
 
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
+                    _overflow_input = messages
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message, approx_tokens=approx_tokens,
                         task_id=effective_task_id,
                     )
+                    if messages is _overflow_input and compression_skipped_due_to_lock(agent):
+                        # #69870 lock-skip: the provider proved the request
+                        # does not fit, but this compression pass no-oped only
+                        # because another path holds the session's compression
+                        # lock. Temporary defer, not exhaustion — refund the
+                        # attempt and end the turn softly so the gateway does
+                        # NOT auto-reset the session (#9893/#35809).
+                        compression_attempts -= 1
+                        agent._persist_session(messages, conversation_history)
+                        return _compression_deferred_result(
+                            agent, messages, api_call_count
+                        )
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history
                     )
@@ -5488,14 +5580,27 @@ def run_conversation(
                     if callable(_clear_warn):
                         _clear_warn()
                     agent._safe_print("  ⟳ compacting context…")
+                    _post_tool_input = messages
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,
                         approx_tokens=agent.context_compressor.last_prompt_tokens,
                         task_id=effective_task_id,
                     )
-                    conversation_history = conversation_history_after_compression(
-                        agent, messages, conversation_history
-                    )
+                    if (
+                        messages is _post_tool_input
+                        and compression_skipped_due_to_lock(agent)
+                    ):
+                        # #69870 lock-skip: this pass no-oped because another
+                        # path holds the session's compression lock — a
+                        # temporary defer, not evidence about compressibility.
+                        # Refund the attempt so a lock-loser tool loop does not
+                        # burn the shared per-turn budget toward
+                        # compression_exhausted (#9893/#35809).
+                        compression_attempts -= 1
+                    else:
+                        conversation_history = conversation_history_after_compression(
+                            agent, messages, conversation_history
+                        )
                 elif agent.compression_enabled:
                     # Over threshold but compression is blocked (summary-LLM
                     # cooldown or anti-thrashing). Surface a deduped warning so

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List, Mapping, Optional
 from agent.conversation_compression import (
     IDLE_COMPACTION_STATUS_TEMPLATE,
     PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
+    compression_skipped_due_to_lock,
     conversation_history_after_compression,
 )
 from agent.context_engine import automatic_compaction_status_message
@@ -833,10 +834,29 @@ def build_turn_context(
             for _pass in range(_max_preflight_passes):
                 _orig_len = len(messages)
                 _orig_tokens = _preflight_tokens
+                _preflight_input = messages
                 messages, active_system_prompt = agent._compress_context(
                     messages, system_message, approx_tokens=_preflight_tokens,
                     task_id=effective_task_id,
                 )
+                if (
+                    messages is _preflight_input
+                    and compression_skipped_due_to_lock(agent)
+                ):
+                    # #69870 lock-skip: another path holds this session's
+                    # compression lock, so the pass no-oped. That is a
+                    # temporary DEFER, not proof the transcript cannot
+                    # compress — do NOT arm the insufficient-progress
+                    # blocker (the loop's error handlers must keep their
+                    # provider-proven retry budget) and stop preflight
+                    # passes for this turn; the lock winner is shrinking
+                    # the same session concurrently.
+                    logger.info(
+                        "Preflight compression deferred: compression lock "
+                        "held by another path (session %s)",
+                        agent.session_id or "none",
+                    )
+                    break
                 # Re-estimate now so size-only compression (same row count,
                 # lower token count — e.g. summarising tool outputs) is
                 # recognised as progress instead of being misread as

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13915,7 +13915,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # large to process.  Auto-reset it so the next message starts
             # fresh instead of replaying the same oversized context in an
             # infinite fail loop.  (#9893)
-            if agent_result.get("compression_exhausted") and session_entry and session_key:
+            #
+            # A lock-contended defer is the OPPOSITE case: the session is
+            # temporarily uncompressible only because a concurrent path holds
+            # the compression lock and is actively shrinking it. Never wipe
+            # the session for that — retry-next-message semantics apply
+            # (#69870 lock-skip consumer; salvaged from #49874).
+            if agent_result.get("compression_deferred"):
+                logger.info(
+                    "Compression deferred for session %s — the compression "
+                    "lock is held by a concurrent compressor. Keeping the "
+                    "session intact; the next message retries normally.",
+                    session_entry.session_id if session_entry else "?",
+                )
+            elif agent_result.get("compression_exhausted") and session_entry and session_key:
                 logger.info(
                     "Auto-resetting session %s after compression exhaustion.",
                     session_entry.session_id,
@@ -21996,6 +22009,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "interrupt_message": result.get("interrupt_message"),
                     "error": result.get("error"),
                     "compression_exhausted": result.get("compression_exhausted", False),
+                    "compression_deferred": result.get("compression_deferred", False),
                     "tools": tools_holder[0] or [],
                     "history_offset": _effective_history_offset,
                     "compacted_in_place": _compacted_in_place,
@@ -22113,6 +22127,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "partial": result_holder[0].get("partial", False) if result_holder[0] else False,
                 "error": result_holder[0].get("error") if result_holder[0] else None,
                 "interrupt_message": result_holder[0].get("interrupt_message") if result_holder[0] else None,
+                # Soft lock-contention defer (#69870 consumer): distinct from
+                # compression_exhausted so the gateway never auto-resets a
+                # session that a concurrent compressor is about to shrink.
+                "compression_deferred": (
+                    result_holder[0].get("compression_deferred", False)
+                    if result_holder[0] else False
+                ),
                 "tools": tools_holder[0] or [],
                 "history_offset": _effective_history_offset,
                 "compacted_in_place": _compacted_in_place,

--- a/tests/agent/test_preflight_lock_defer.py
+++ b/tests/agent/test_preflight_lock_defer.py
@@ -1,0 +1,121 @@
+"""Preflight lock-defer must not arm the insufficient-progress blocker.
+
+Companion to ``tests/run_agent/test_compression_lock_defer.py`` — pins the
+``build_turn_context`` preflight loop's handling of a lock-contended
+compression no-op (#69870 lock-skip signal, consumer salvaged from #49874):
+
+* the pass stops the preflight loop (the lock winner is already shrinking
+  the session) WITHOUT setting ``preflight_compression_blocked``, so the
+  loop's provider-proven error handlers keep their full retry budget;
+* a genuine no-progress no-op (flag unset) still arms the blocker exactly
+  as before;
+* a MagicMock-style truthy junk flag value does NOT take the defer branch
+  (type-pin rule).
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.agent.test_turn_context import _FakeAgent, _build
+
+
+@pytest.fixture(autouse=True)
+def _stub_runtime_main():
+    with patch("agent.auxiliary_client.set_runtime_main", lambda *a, **k: None):
+        yield
+
+
+def _pressured_compressor():
+    """Over-threshold compressor stub that opens the preflight threshold path."""
+    return types.SimpleNamespace(
+        protect_first_n=0,
+        protect_last_n=0,
+        threshold_tokens=1,
+        context_length=100_000,
+        last_prompt_tokens=0,
+        should_compress=lambda _tokens=None: True,
+        should_compress_info=lambda _tokens=None: (True, None),
+        should_defer_preflight_to_real_usage=lambda _t: False,
+        get_active_compression_failure_cooldown=lambda: None,
+    )
+
+
+def _make_agent():
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent.context_compressor = _pressured_compressor()
+    agent._emit_status = MagicMock()
+    return agent
+
+
+_HISTORY = [{"role": "user", "content": "old"}, {"role": "assistant", "content": "older"}]
+
+
+def test_preflight_lock_skip_does_not_set_blocked_flag():
+    agent = _make_agent()
+    calls = []
+
+    def _lock_skip_compress(messages, _system_message, **_kwargs):
+        calls.append(1)
+        agent._compression_skipped_due_to_lock = "pid=1:tid=2:agent=aa:nonce=bb"
+        return messages, "SYSTEM"
+
+    agent._compress_context = _lock_skip_compress
+
+    ctx = _build(agent, conversation_history=list(_HISTORY))
+
+    # Exactly one pass: the defer stops the loop without arming the blocker.
+    assert calls == [1]
+    assert ctx.preflight_compression_blocked is False
+
+
+def test_preflight_lock_skip_true_unconfirmed_holder_also_defers():
+    agent = _make_agent()
+    calls = []
+
+    def _lock_skip_compress(messages, _system_message, **_kwargs):
+        calls.append(1)
+        agent._compression_skipped_due_to_lock = True
+        return messages, "SYSTEM"
+
+    agent._compress_context = _lock_skip_compress
+
+    ctx = _build(agent, conversation_history=list(_HISTORY))
+
+    assert calls == [1]
+    assert ctx.preflight_compression_blocked is False
+
+
+def test_preflight_plain_noop_still_arms_blocker():
+    """Control: flag unset → unchanged pre-fix behavior (blocker armed)."""
+    agent = _make_agent()
+
+    def _noop_compress(messages, _system_message, **_kwargs):
+        agent._compression_skipped_due_to_lock = None
+        return messages, "SYSTEM"
+
+    agent._compress_context = _noop_compress
+
+    ctx = _build(agent, conversation_history=list(_HISTORY))
+
+    assert ctx.preflight_compression_blocked is True
+
+
+def test_preflight_magicmock_flag_value_is_not_a_defer():
+    """Type-pin: truthy junk (MagicMock auto-attribute shape) must not be
+    treated as lock contention — the blocker arms as for a plain no-op."""
+    agent = _make_agent()
+
+    def _junk_flag_compress(messages, _system_message, **_kwargs):
+        agent._compression_skipped_due_to_lock = MagicMock()
+        return messages, "SYSTEM"
+
+    agent._compress_context = _junk_flag_compress
+
+    ctx = _build(agent, conversation_history=list(_HISTORY))
+
+    assert ctx.preflight_compression_blocked is True

--- a/tests/gateway/test_compression_deferred_soft_result.py
+++ b/tests/gateway/test_compression_deferred_soft_result.py
@@ -1,0 +1,98 @@
+"""Gateway must treat ``compression_deferred`` as a soft result (#49874).
+
+A lock-contended compression defer means a CONCURRENT compressor is actively
+shrinking the session — the opposite of ``compression_exhausted`` (session
+permanently too large). The gateway's auto-reset (#9893/#35809) must never
+fire for a deferred turn: the session stays intact and the next message
+retries normally.
+
+AST invariants on ``gateway/run.py`` (mirrors
+``test_35809_auto_reset_clean_context.py``'s load-bearing pin style):
+
+* the ``compression_deferred`` branch guards the auto-reset block — a
+  deferred result can never reach ``reset_session``;
+* the deferred branch itself performs NO session mutation (no
+  ``reset_session``, no ``_evict_cached_agent``, no
+  ``_clear_conversation_scope``).
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+from gateway import run as gateway_run
+
+
+def _calls(node: ast.AST) -> set[str]:
+    return {
+        n.func.attr
+        for n in ast.walk(node)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+    }
+
+
+def _find_deferred_guarded_reset_chain() -> ast.If:
+    """Return the ``if agent_result.get('compression_deferred') ... elif
+    agent_result.get('compression_exhausted') ... reset_session`` chain."""
+    tree = ast.parse(inspect.getsource(gateway_run))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test_consts = [
+            n.value
+            for n in ast.walk(node.test)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+        ]
+        if "compression_deferred" not in test_consts:
+            continue
+        # The reset must live in the orelse (elif compression_exhausted ...),
+        # never in the deferred body.
+        orelse_calls = set()
+        for sub in node.orelse:
+            orelse_calls |= _calls(sub)
+        if "reset_session" in orelse_calls:
+            return node
+    raise AssertionError(
+        "Could not locate the compression_deferred guard in front of the "
+        "compression-exhausted auto-reset block in gateway/run.py. The "
+        "soft-defer contract (#49874: lock-contended defer must never "
+        "auto-reset the session) is no longer structurally guaranteed."
+    )
+
+
+class TestCompressionDeferredIsSoft:
+    def test_deferred_branch_guards_the_auto_reset(self):
+        """The auto-reset (``reset_session``) must be unreachable when
+        ``compression_deferred`` is set: the deferred check comes FIRST and
+        the reset lives only in its elif chain."""
+        node = _find_deferred_guarded_reset_chain()
+        # The exhaustion reset is in the orelse — verified by the finder.
+        # The deferred body must not mutate the session in any way.
+        body_calls = set()
+        for sub in node.body:
+            body_calls |= _calls(sub)
+        forbidden = {
+            "reset_session",
+            "_evict_cached_agent",
+            "_clear_conversation_scope",
+        }
+        assert not (body_calls & forbidden), (
+            f"The compression_deferred branch in gateway/run.py performs "
+            f"session mutation ({body_calls & forbidden}). A lock-contended "
+            f"defer is transient — the session must stay intact so the next "
+            f"message retries against the freshly compressed context "
+            f"(#49874, #69870)."
+        )
+
+    def test_deferred_result_key_is_passed_through_run_agent_inner(self):
+        """``_run_agent_inner``'s result dicts must carry the
+        ``compression_deferred`` key so the persistence block can see it —
+        the exact gap that made the exhaustion misclassification possible
+        (the flag existed but nothing consumed it)."""
+        src = inspect.getsource(gateway_run)
+        assert src.count('"compression_deferred"') >= 3, (
+            "gateway/run.py must read AND pass through compression_deferred "
+            "(persistence-block guard + both _run_agent_inner result dicts)."
+        )

--- a/tests/run_agent/test_compression_lock_defer.py
+++ b/tests/run_agent/test_compression_lock_defer.py
@@ -1,0 +1,374 @@
+"""Lock-contended compression no-ops must soft-DEFER, never exhaust (#49874).
+
+On main before this fix, nothing on the automatic compression paths consumed
+the #69870 lock-skip signal (``agent._compression_skipped_due_to_lock``):
+
+* a lock-loser preflight/pre-API no-op counted as "insufficient progress",
+* the oversized request went to the provider anyway, and
+* the lock-contended 413/overflow retry burned ``compression_attempts`` to
+  the cap and returned ``compression_exhausted`` — which the gateway answers
+  with a full session auto-reset (#9893/#35809).
+
+A temporary lock defer misclassified as exhaustion == session wipe.
+
+These tests pin the fix: when a compression pass returns its input unchanged
+AND the type-pinned lock-skip flag is set, the attempt is refunded and the
+turn ends (when it cannot proceed) with a soft ``compression_deferred``
+result distinct from ``compression_exhausted``.
+
+Salvaged from PR #49874 (@helix4u), rebuilt on the landed #69870 signal.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.conversation_compression import compression_skipped_due_to_lock
+from run_agent import AIAgent
+import run_agent
+
+
+LOCK_HOLDER = "pid=4242:tid=1:agent=deadbeef:nonce=abcd1234"
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors tests/run_agent/test_413_compression.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_compression_sleep(monkeypatch):
+    import time as _time
+
+    monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(run_agent, "jittered_backoff", lambda *a, **k: 0.0)
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _mock_response(content="Hello", finish_reason="stop"):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=None,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    resp = SimpleNamespace(choices=[choice], model="test/model")
+    resp.usage = None
+    return resp
+
+
+def _make_413_error(message="Request entity too large"):
+    err = Exception(message)
+    err.status_code = 413
+    return err
+
+
+def _make_overflow_error():
+    return Exception(
+        "Error code: 400 - {'type': 'error', 'error': {'type': "
+        "'invalid_request_error', 'message': 'prompt is too long: "
+        "233153 tokens > 200000 maximum'}}"
+    )
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.tool_delay = 0
+        a.compression_enabled = True
+        a.save_trajectories = False
+        return a
+
+
+_PREFILL = [
+    {"role": "user", "content": "previous question"},
+    {"role": "assistant", "content": "previous answer"},
+]
+
+
+def _lock_skipping_compress(agent, *, holder=LOCK_HOLDER):
+    """A compress double that no-ops because 'another path holds the lock'.
+
+    Mirrors the real ``compress_context`` lock-contended abort: returns the
+    INPUT list object unchanged and sets the #69870 lock-skip signal.
+    """
+
+    def _compress(messages, _system_message, **_kwargs):
+        agent._compression_skipped_due_to_lock = holder
+        return messages, "You are helpful."
+
+    return _compress
+
+
+def _plain_noop_compress(agent):
+    """A compress double that no-ops WITHOUT lock contention (real no-progress)."""
+
+    def _compress(messages, _system_message, **_kwargs):
+        agent._compression_skipped_due_to_lock = None
+        return messages, "You are helpful."
+
+    return _compress
+
+
+# ---------------------------------------------------------------------------
+# Type-pinned signal read (MagicMock test-double immunity)
+# ---------------------------------------------------------------------------
+
+
+class TestLockSkipSignalTypePin:
+    def test_true_and_holder_string_are_lock_skips(self):
+        a = SimpleNamespace(_compression_skipped_due_to_lock=True)
+        assert compression_skipped_due_to_lock(a) is True
+        a = SimpleNamespace(_compression_skipped_due_to_lock=LOCK_HOLDER)
+        assert compression_skipped_due_to_lock(a) is True
+
+    def test_none_and_missing_are_not_lock_skips(self):
+        assert compression_skipped_due_to_lock(
+            SimpleNamespace(_compression_skipped_due_to_lock=None)
+        ) is False
+        assert compression_skipped_due_to_lock(SimpleNamespace()) is False
+
+    def test_magicmock_agent_auto_attribute_is_not_a_lock_skip(self):
+        """MagicMock agents auto-create truthy attributes; bare truthiness
+        would hijack every mocked agent in sibling suites into the lock-skip
+        branch (the #69870 × #69840 incident). The read must be type-pinned."""
+        assert compression_skipped_due_to_lock(MagicMock()) is False
+
+    def test_truthy_non_true_non_str_values_are_not_lock_skips(self):
+        for junk in (1, 1.0, ["holder"], {"holder": True}, object(), MagicMock()):
+            a = SimpleNamespace(_compression_skipped_due_to_lock=junk)
+            assert compression_skipped_due_to_lock(a) is False, junk
+
+
+# ---------------------------------------------------------------------------
+# 413 handler: lock-contended no-op → soft defer, no exhaustion
+# ---------------------------------------------------------------------------
+
+
+class TestLockContended413Defer:
+    def test_lock_contended_413_returns_compression_deferred(self, agent):
+        """A 413 whose compression pass lost the lock must end the turn as a
+        soft ``compression_deferred`` — never ``compression_exhausted``."""
+        agent.client.chat.completions.create.side_effect = _make_413_error()
+
+        with (
+            patch.object(
+                agent, "_compress_context",
+                side_effect=_lock_skipping_compress(agent),
+            ) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=list(_PREFILL))
+
+        mock_compress.assert_called_once()
+        assert result.get("compression_deferred") is True
+        assert not result.get("compression_exhausted")
+        # Soft defer: transient, retry-next-message semantics — the gateway
+        # persists the user turn (failed=False) and never auto-resets.
+        assert result.get("failed") is False
+        assert result.get("completed") is False
+        assert result.get("partial") is True
+
+    def test_lock_contended_overflow_returns_compression_deferred(self, agent):
+        """Same contract on the context-length (400 prompt-too-long) handler."""
+        agent.client.chat.completions.create.side_effect = _make_overflow_error()
+
+        with (
+            patch.object(
+                agent, "_compress_context",
+                side_effect=_lock_skipping_compress(agent),
+            ) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=list(_PREFILL))
+
+        mock_compress.assert_called_once()
+        assert result.get("compression_deferred") is True
+        assert not result.get("compression_exhausted")
+        assert result.get("failed") is False
+
+    def test_unconfirmed_lock_skip_true_also_defers(self, agent):
+        """``_compression_skipped_due_to_lock = True`` (holder unconfirmed —
+        ``try_acquire`` swallowed a sqlite error) is still a lock skip."""
+        agent.client.chat.completions.create.side_effect = _make_413_error()
+
+        with (
+            patch.object(
+                agent, "_compress_context",
+                side_effect=_lock_skipping_compress(agent, holder=True),
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=list(_PREFILL))
+
+        assert result.get("compression_deferred") is True
+        assert not result.get("compression_exhausted")
+
+    def test_plain_noop_413_still_exhausts_unchanged(self, agent):
+        """Control: flag unset (real no-progress compression) keeps the
+        pre-fix behavior byte-for-byte — terminal ``compression_exhausted``."""
+        agent.client.chat.completions.create.side_effect = _make_413_error()
+
+        with (
+            patch.object(
+                agent, "_compress_context",
+                side_effect=_plain_noop_compress(agent),
+            ),
+            patch.object(
+                agent, "_try_strip_image_parts_from_tool_messages",
+                return_value=False,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=list(_PREFILL))
+
+        assert result.get("compression_exhausted") is True
+        assert not result.get("compression_deferred")
+        assert result.get("failed") is True
+
+    def test_magicmock_flag_value_does_not_defer(self, agent):
+        """Type-pin at the consumer site: a truthy non-True/non-str flag value
+        (e.g. a MagicMock auto-attribute) must NOT take the defer branch."""
+        agent.client.chat.completions.create.side_effect = _make_413_error()
+
+        def _junk_flag_compress(messages, _system_message, **_kwargs):
+            agent._compression_skipped_due_to_lock = MagicMock()  # truthy junk
+            return messages, "You are helpful."
+
+        with (
+            patch.object(agent, "_compress_context", side_effect=_junk_flag_compress),
+            patch.object(
+                agent, "_try_strip_image_parts_from_tool_messages",
+                return_value=False,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=list(_PREFILL))
+
+        assert not result.get("compression_deferred")
+        assert result.get("compression_exhausted") is True
+
+
+# ---------------------------------------------------------------------------
+# Pre-API gate: a lock-skipped pass must not burn the shared attempt budget
+# ---------------------------------------------------------------------------
+
+
+class TestPreApiLockDeferDoesNotBurnBudget:
+    def test_lock_loser_turn_recovers_after_lock_release(self, agent):
+        """End-to-end shape of the live bug at cap=1:
+
+        1. Pre-API pressure gate fires; the compression pass loses the lock
+           (no-op + lock-skip flag). Pre-fix this burned the single shared
+           attempt.
+        2. The oversized request goes to the provider → 413.
+        3. The 413 handler compresses again — the lock has been released and
+           the pass now succeeds — and the retry completes.
+
+        Pre-fix, step 3 found ``compression_attempts`` already at the cap and
+        returned ``compression_exhausted`` → gateway session wipe. The defer
+        refund keeps the budget intact for the provider-proven retry.
+        """
+        agent.max_compression_attempts = 1
+        # Compressor stub: pressure only on the fully-assembled request
+        # (pre-API site); the turn-context preflight stands down via the
+        # cheap-gate (small message count) and low turn-context estimate.
+        agent.context_compressor = SimpleNamespace(
+            protect_first_n=3,
+            protect_last_n=20,
+            threshold_tokens=100_000,
+            context_length=1_000_000,
+            last_prompt_tokens=0,
+            should_compress=lambda t: t >= 100_000,
+            should_defer_preflight_to_real_usage=lambda _t: False,
+            get_active_compression_failure_cooldown=lambda: None,
+        )
+
+        agent.client.chat.completions.create.side_effect = [
+            _make_413_error(),
+            _mock_response(content="Recovered after lock release"),
+        ]
+
+        compress_calls = []
+
+        def _lock_then_success(messages, _system_message, **_kwargs):
+            compress_calls.append(len(messages))
+            if len(compress_calls) == 1:
+                # Lock loser: no-op + #69870 signal.
+                agent._compression_skipped_due_to_lock = LOCK_HOLDER
+                return messages, "You are helpful."
+            # Lock released: real compaction (entry clears the signal).
+            agent._compression_skipped_due_to_lock = None
+            return (
+                [{"role": "user", "content": "hello"}],
+                "You are helpful.",
+            )
+
+        with (
+            patch(
+                "agent.turn_context.estimate_request_tokens_rough",
+                return_value=10,
+            ),
+            patch(
+                "agent.conversation_loop.estimate_request_tokens_rough",
+                return_value=500_000,
+            ),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                return_value=500_000,
+            ),
+            patch.object(agent, "_compress_context", side_effect=_lock_then_success),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=list(_PREFILL))
+
+        # Pass 1: pre-API (lock defer, refunded). Pass 2: 413 handler
+        # (succeeds within the cap because the defer did not count).
+        assert len(compress_calls) == 2
+        assert result.get("completed") is True
+        assert result["final_response"] == "Recovered after lock release"
+        assert not result.get("compression_exhausted")
+        assert not result.get("compression_deferred")


### PR DESCRIPTION
## Summary

Salvage of #49874 (@helix4u): make every **automatic** compression path treat a lock-contended compression skip as a soft **DEFER**, never as exhaustion.

Credit to @helix4u for identifying the exhaustion-misclassification: a turn that loses the per-session compression lock gets a no-op compression pass that is indistinguishable (to the callers) from "cannot compress further" — and the consequence chain ends in the gateway wiping the session.

### The live bug (verified on main @ c2c2449d05)

Nothing on the automatic paths consumed the #69870 lock-skip signal (`grep compression_deferred agent/` → 0; `conversation_loop.py` / `turn_context.py` never read `_compression_skipped_due_to_lock` — only manual `/compress` surfaces do). For a lock-loser turn:

1. The preflight / pre-API no-op counted as insufficient progress (`conversation_loop.py:1272-1292` via `turn_context.py:219-233`) and/or burned a shared `compression_attempts` slot.
2. The oversized request went to the provider anyway.
3. The lock-contended 413/overflow handler burned `compression_attempts` to the cap and returned **`compression_exhausted`** (`conversation_loop.py:3831/3887/3960/4072/4117`).
4. The gateway answers `compression_exhausted` with a full **session auto-reset** (#9893/#35809 contract) — a temporary concurrent-compression defer wiped the session that the lock winner was actively shrinking.

### What this PR does

**Agent side (contributor commit, rebuilt on main's landed signal):**

- New type-pinned reader `compression_skipped_due_to_lock(agent)` in `agent/conversation_compression.py` — reuses main's `_compression_skipped_due_to_lock` (#69870, set at the lock-contended abort, cleared at entry). Reads are pinned `is True or isinstance(x, str)` per the MagicMock auto-attribute rule; the PR's parallel `_compression_deferred_by_lock` triple was **not** carried (superseded by #69870).
- `compress_context()` now also clears the signal at the very top of every attempt (per-attempt state rule, #58629/#69853), so a stale value can never make a later breaker/codex early-return look like lock contention.
- All five automatic sites consume the signal when a pass returned the **input list object** unchanged AND the flag is set:
  - **preflight loop** (`turn_context.py`): stop passes for this turn WITHOUT arming `preflight_compression_blocked`;
  - **pre-API pressure gate**: refund the attempt, disarm the insufficient-progress comparison, proceed to the provider (its error handler has the stronger signal);
  - **413 handler**, **overflow handler**: refund the attempt and end the turn with a soft **`compression_deferred`** result (`failed=False`, `partial=True`) — distinct from `compression_exhausted`;
  - **post-tool compaction**: refund the attempt so a lock-loser tool loop keeps its budget.
- Flag unset → every path is behaviorally unchanged (pinned by control tests).

**Gateway side (composition commit):**

- `compression_deferred` passes through both `_run_agent_inner` result dicts.
- The persistence block guards the compression-exhausted auto-reset with the deferred check: a deferred turn keeps the session intact (log-only), retry-next-message semantics. `failed=False` means the user turn is persisted on the transient branch — nothing is lost.

### Dropped from the original PR (scope kept tight)

- `_compression_deferred_by_lock` / `_compression_deferred_session_id` / `_compression_deferred_holder` setter triple — superseded by the landed #69870 signal.
- `_sync_session_context_after_compression` cosmetic refactor and rotation-path touches (mooted by the `in_place` default).
- Early-return-from-`run_conversation`-entry via a TurnContext field — the salvage consumes the signal at each site instead, so the preflight defer no longer aborts the whole turn when the request may still fit.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/run_agent/test_compression_lock_defer.py` (new) | ✅ 10/10 — lock-contended 413 and 400-overflow produce `compression_deferred`, NOT `compression_exhausted`; flag-unset control keeps terminal exhaustion byte-identical; type-pin tests vs MagicMock agents/junk flag values; cap=1 e2e: refunded pre-API defer leaves budget for the provider-proven 413 retry |
| `scripts/run_tests.sh tests/agent/test_preflight_lock_defer.py` (new) | ✅ 4/4 — lock-skipped preflight pass does not arm `preflight_compression_blocked`; plain no-op still arms it; MagicMock junk does not defer |
| `scripts/run_tests.sh tests/gateway/test_compression_deferred_soft_result.py` (new) | ✅ 2/2 — AST pin: deferred branch guards the auto-reset chain and performs no session mutation (`reset_session`/`_evict_cached_agent`/`_clear_conversation_scope` forbidden) |
| Sibling suites: `test_turn_context.py`, `test_engine_preflight_wire.py`, `test_413_compression.py`, `test_post_tool_compression_attempt_cap.py`, `test_preflight_compression_cap_e2e.py`, `test_35809_auto_reset_clean_context.py`, `test_compression_concurrent_fork.py`, `test_idle_compaction_lock_and_guards.py` | ✅ 139 tests, 0 failed |
| Extra siblings: `test_compression_abort_state_reset.py`, `test_10710_auto_reset_evicts_cached_agent.py`, `test_48031_model_switch_after_auto_reset.py`, `test_api_content_sidecar.py`, pre-compress memory-context suites | ✅ all green |
| `ruff check` on all changed files | ✅ All checks passed |

## Attribution

- `fix(agent): defer turns during compression lock contention instead of exhausting` — authored `helix4u <4317663+helix4u@users.noreply.github.com>` (surgical reapply of the surviving caller half of #49874 onto current main; the ID+login noreply email needs no contributor-map entry).
- `fix(gateway): retry-next-message semantics for compression_deferred + regression suite` — maintainer composition commit.

Closes #49874 on merge (with credit).

## Infographic

![compression lock contention soft defer](https://v3b.fal.media/files/b/0aa371f7/1nexmZ_XvkLf-EObV6d1G_N3cIoSZB.png)
