### PR TITLE
fix(cron): honor one scheduler owner across gateway and Desktop

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -197,6 +197,14 @@ model:
 # worktree_sync: true   # Default — branch from the fetched remote tip
 # worktree_sync: false  # Branch from local HEAD (offline / pinned base)
 
+# Exactly one long-running runtime should dispatch due jobs for a HERMES_HOME.
+# auto (default) starts the gateway scheduler and keeps the built-in Desktop
+# fallback ticker ready; Desktop dispatches only while no gateway owns the profile.
+# External Desktop providers require explicit desktop ownership.
+# Invalid values fail closed so competing runtimes cannot both start a ticker.
+cron:
+  scheduler_owner: "auto"  # auto | gateway | desktop
+
 # =============================================================================
 # Terminal Tool Configuration
 # =============================================================================

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -19,9 +19,114 @@ selected via the `cron.provider` config key (empty = built-in).
 """
 from __future__ import annotations
 
+import io
+import logging
 import threading
 from abc import ABC, abstractmethod
 from typing import Any
+
+
+logger = logging.getLogger("cron.scheduler_provider")
+
+_CRON_SCHEDULER_RUNTIME_OWNERS = frozenset({"gateway", "desktop"})
+_CRON_SCHEDULER_OWNER_POLICIES = _CRON_SCHEDULER_RUNTIME_OWNERS | {"auto"}
+
+
+def _read_scheduler_owner_config_strict() -> dict[str, Any] | None:
+    """Read scheduler ownership without the normal tolerant config fallback."""
+    from hermes_cli import managed_scope
+    from hermes_cli.config import get_config_path
+    from utils import fast_safe_load
+
+    def _read_mapping(path) -> dict[str, Any]:
+        try:
+            with open(path, encoding="utf-8") as handle:
+                raw = handle.read()
+        except FileNotFoundError:
+            return {}
+        meaningful = [
+            line.split("#", 1)[0].strip()
+            for line in raw.splitlines()
+            if line.split("#", 1)[0].strip() not in {"", "---", "..."}
+        ]
+        if not meaningful:
+            return {}
+        parsed = fast_safe_load(io.StringIO(raw))
+        if not isinstance(parsed, dict):
+            raise ValueError("config root must be a mapping")
+        return parsed
+
+    try:
+        user_config = _read_mapping(get_config_path())
+        managed_dir = managed_scope.get_managed_dir()
+        managed_config = (
+            _read_mapping(managed_dir / "config.yaml")
+            if managed_dir is not None
+            else {}
+        )
+        user_cron = user_config.get("cron", {})
+        managed_cron = managed_config.get("cron", {})
+        if "cron" in user_config and not isinstance(user_cron, dict):
+            raise ValueError("cron section must be a mapping")
+        if "cron" in managed_config and not isinstance(managed_cron, dict):
+            raise ValueError("managed cron section must be a mapping")
+        effective_cron = dict(user_cron)
+        effective_cron.update(managed_cron)
+        return {"cron": effective_cron}
+    except Exception:
+        logger.error(
+            "Unable to read a valid cron.scheduler_owner; scheduler startup disabled. "
+            "Set it to auto, gateway, or desktop in config.yaml."
+        )
+        return None
+
+
+def resolve_cron_scheduler_policy(*, config: dict[str, Any] | None = None) -> str | None:
+    """Resolve the configured ownership policy, failing closed on errors."""
+    if config is None:
+        config = _read_scheduler_owner_config_strict()
+        if config is None:
+            return None
+    if not isinstance(config, dict):
+        logger.error("Invalid configuration root; scheduler startup disabled.")
+        return None
+    cron_config = config.get("cron", {})
+    if "cron" in config and not isinstance(cron_config, dict):
+        logger.error("Invalid cron configuration shape; scheduler startup disabled.")
+        return None
+    raw_owner = cron_config.get("scheduler_owner", "auto")
+    owner = raw_owner.strip().lower() if isinstance(raw_owner, str) else None
+    if owner in _CRON_SCHEDULER_OWNER_POLICIES:
+        return owner
+    logger.error(
+        "Invalid cron.scheduler_owner; scheduler startup disabled. "
+        "Use auto, gateway, or desktop in config.yaml."
+    )
+    return None
+
+
+def resolve_cron_scheduler_owner(*, config: dict[str, Any] | None = None) -> str | None:
+    """Resolve the deterministic primary owner for the configured policy."""
+    policy = resolve_cron_scheduler_policy(config=config)
+    return "gateway" if policy == "auto" else policy
+
+
+def should_start_cron_scheduler(
+    runtime_owner: str, *, config: dict[str, Any] | None = None
+) -> bool:
+    """Return whether this long-running runtime owns automatic dispatch."""
+    if runtime_owner not in _CRON_SCHEDULER_RUNTIME_OWNERS:
+        raise ValueError("Unknown cron scheduler runtime owner")
+    return resolve_cron_scheduler_owner(config=config) == runtime_owner
+
+
+def resolve_owned_cron_scheduler(
+    runtime_owner: str, *, config: dict[str, Any] | None = None
+) -> "CronScheduler | None":
+    """Resolve the provider only after the shared ownership gate succeeds."""
+    if not should_start_cron_scheduler(runtime_owner, config=config):
+        return None
+    return resolve_cron_scheduler()
 
 
 class CronScheduler(ABC):
@@ -127,10 +232,6 @@ def resolve_cron_scheduler() -> "CronScheduler":
     False`` falls back to the built-in with a warning — cron must never be left
     without a trigger.
     """
-    import logging
-
-    logger = logging.getLogger("cron.scheduler_provider")
-
     name = ""
     try:
         from hermes_cli.config import cfg_get, load_config

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23282,6 +23282,34 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     InProcessCronScheduler().start(stop_event, adapters=adapters, loop=loop, interval=interval)
 
 
+def _start_gateway_cron_scheduler_if_owned(runner, stop_event, loop):
+    """Start cron only when the shared ownership policy selects this gateway."""
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        resolve_owned_cron_scheduler,
+    )
+
+    provider = resolve_owned_cron_scheduler("gateway")
+    if provider is None:
+        logger.info("Gateway cron scheduler not started by ownership policy")
+        return None, None
+
+    start_kwargs = {"adapters": runner.adapters, "loop": loop}
+    if isinstance(provider, InProcessCronScheduler):
+        start_kwargs["can_dispatch"] = lambda: not (
+            runner._draining or runner._external_drain_active
+        )
+    thread = threading.Thread(
+        target=provider.start,
+        args=(stop_event,),
+        kwargs=start_kwargs,
+        daemon=True,
+        name="cron-scheduler",
+    )
+    thread.start()
+    return provider, thread
+
+
 # Upper bound for cooperatively draining the cron ticker on shutdown. The cron
 # thread delivers via ``safe_schedule_threadsafe`` and blocks on
 # ``future.result(timeout=60)`` (see cron/scheduler.py::_deliver_result), so a
@@ -23809,25 +23837,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # historical in-process 60s ticker; an external provider (e.g. chronos)
     # may arm a schedule and return. Pass the event loop so cron delivery can
     # use live adapters (E2EE support).
-    from cron.scheduler_provider import InProcessCronScheduler, resolve_cron_scheduler
     cron_stop = threading.Event()
-    cron_provider = resolve_cron_scheduler()
-    cron_start_kwargs = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
-    # External cron providers own their remote scheduling contract. Only the
-    # in-process ticker polls local due jobs, so only it receives the local
-    # external-drain dispatch gate.
-    if isinstance(cron_provider, InProcessCronScheduler):
-        cron_start_kwargs["can_dispatch"] = lambda: not (
-            runner._draining or runner._external_drain_active
-        )
-    cron_thread = threading.Thread(
-        target=cron_provider.start,
-        args=(cron_stop,),
-        kwargs=cron_start_kwargs,
-        daemon=True,
-        name="cron-scheduler",
+    cron_provider, cron_thread = _start_gateway_cron_scheduler_if_owned(
+        runner, cron_stop, asyncio.get_running_loop()
     )
-    cron_thread.start()
 
     # Gateway-only periodic housekeeping (channel dir, cache cleanup, paste
     # sweep, curator) — runs independently of which cron provider is active.
@@ -23873,11 +23886,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # silently dropped (#58818). Awaiting keeps the loop alive so the in-flight
     # delivery finishes before we tear down.
     cron_stop.set()
-    try:
-        cron_provider.stop()
-    except Exception as e:
-        logger.debug("Cron provider stop() error: %s", e)
-    if not await _await_thread_exit(cron_thread, timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT):
+    if cron_provider is not None:
+        try:
+            cron_provider.stop()
+        except Exception as e:
+            logger.debug("Cron provider stop() error: %s", e)
+    if cron_thread is not None and not await _await_thread_exit(
+        cron_thread, timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT
+    ):
         logger.warning(
             "Cron ticker did not exit within %.0fs of shutdown — an in-flight "
             "delivery may have been dropped.", _CRON_SHUTDOWN_DRAIN_TIMEOUT,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2768,6 +2768,11 @@ DEFAULT_CONFIG = {
     },
 
     "cron": {
+        # Exactly one long-running runtime may dispatch due jobs for a
+        # HERMES_HOME. "auto" starts the gateway and lets the built-in Desktop
+        # fallback dispatch only while no gateway holds the profile lock.
+        # External Desktop providers require explicit "desktop" ownership.
+        "scheduler_owner": "auto",
         # Active cron SCHEDULER provider (Axis B — the trigger that decides
         # WHEN a due job fires). Empty string = the built-in in-process 60s
         # ticker (default). Name an installed provider (plugins/cron_providers/<name>/ or

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -144,25 +144,124 @@ _log = logging.getLogger(__name__)
 # when the same module is used across TestClient instances or uvicorn reloads.
 # ---------------------------------------------------------------------------
 
-def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60) -> None:
-    """Tick the cron scheduler from inside the desktop dashboard backend.
+def _start_desktop_cron_ticker(
+    stop_event: "threading.Event",
+    interval: int = 60,
+    *,
+    provider: Any = None,
+    can_dispatch: Any = None,
+) -> None:
+    """Run the resolved provider for an explicitly owned Desktop ticker."""
+    if provider is None:
+        from cron.scheduler_provider import resolve_cron_scheduler
 
-    The scheduler tick loop normally lives in ``hermes gateway run`` — but the
-    desktop app spawns a ``hermes dashboard`` backend, not a gateway, so a cron
-    a user creates in the app would never fire. We run the resolved cron
-    scheduler provider here (no live adapters; delivery falls back to the
-    per-platform send path).
-
-    Cross-process safe: the built-in provider's ``cron.scheduler.tick`` takes
-    the ``cron/.tick.lock`` file lock, so this never double-fires alongside a
-    real gateway on the same HERMES_HOME — whichever process grabs the lock
-    first wins the tick.
-    """
-    from cron.scheduler_provider import resolve_cron_scheduler
-
-    provider = resolve_cron_scheduler()
+        provider = resolve_cron_scheduler()
     _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
-    provider.start(stop_event, interval=interval)
+    start_kwargs = {"interval": interval}
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    if isinstance(provider, InProcessCronScheduler):
+        start_kwargs["can_dispatch"] = can_dispatch
+    provider.start(stop_event, **start_kwargs)
+
+
+def _start_desktop_cron_scheduler_if_owned() -> tuple[
+    "Any | None", "threading.Event | None", "threading.Thread | None"
+]:
+    """Start Desktop's fallback ticker only when it owns automatic dispatch."""
+    if os.getenv("HERMES_DESKTOP") != "1":
+        return None, None, None
+
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        resolve_cron_scheduler_policy,
+        resolve_owned_cron_scheduler,
+    )
+
+    policy = resolve_cron_scheduler_policy()
+    if policy == "auto":
+        provider = InProcessCronScheduler()
+
+        def can_dispatch() -> bool:
+            try:
+                from gateway.status import is_gateway_runtime_lock_active
+
+                return not is_gateway_runtime_lock_active()
+            except Exception:
+                _log.error(
+                    "Unable to probe gateway ownership; Desktop cron dispatch disabled"
+                )
+                return False
+    elif policy == "desktop":
+        provider = resolve_owned_cron_scheduler("desktop")
+        can_dispatch = None
+    else:
+        provider = None
+        can_dispatch = None
+
+    if provider is None:
+        _log.info("Desktop cron scheduler not started by ownership policy")
+        return None, None, None
+
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_start_desktop_cron_ticker,
+        args=(stop_event,),
+        kwargs={"provider": provider, "can_dispatch": can_dispatch},
+        daemon=True,
+        name="desktop-cron-ticker",
+    )
+    thread.start()
+    return provider, stop_event, thread
+
+
+_DESKTOP_CRON_PROVIDER_STOP_TIMEOUT = 5.0
+_DESKTOP_CRON_SHUTDOWN_DRAIN_TIMEOUT = 65.0
+# Let the worker-thread join reach its own timeout before wait_for cancels it.
+_DESKTOP_CRON_SHUTDOWN_WAIT_TIMEOUT = _DESKTOP_CRON_SHUTDOWN_DRAIN_TIMEOUT + 5.0
+
+
+async def _shutdown_desktop_cron_scheduler(
+    provider: Any,
+    stop_event: "threading.Event",
+    thread: "threading.Thread",
+) -> None:
+    """Cooperatively stop Desktop cron without blocking the event loop."""
+    stop_event.set()
+    try:
+        await asyncio.wait_for(
+            asyncio.to_thread(provider.stop),
+            timeout=_DESKTOP_CRON_PROVIDER_STOP_TIMEOUT,
+        )
+    except TimeoutError:
+        _log.error(
+            "Desktop cron provider stop timed out after %.1fs",
+            _DESKTOP_CRON_PROVIDER_STOP_TIMEOUT,
+        )
+    except Exception:
+        _log.exception("Desktop cron provider stop failed")
+
+    try:
+        await asyncio.wait_for(
+            asyncio.to_thread(
+                thread.join,
+                _DESKTOP_CRON_SHUTDOWN_DRAIN_TIMEOUT,
+            ),
+            timeout=_DESKTOP_CRON_SHUTDOWN_WAIT_TIMEOUT,
+        )
+    except TimeoutError:
+        _log.error(
+            "Desktop cron thread drain timed out after %.1fs",
+            _DESKTOP_CRON_SHUTDOWN_WAIT_TIMEOUT,
+        )
+    except Exception:
+        _log.exception("Desktop cron thread drain failed")
+
+    if thread.is_alive():
+        _log.warning(
+            "Desktop cron thread remains alive after shutdown; "
+            "scheduled work may have been interrupted"
+        )
 
 
 def _warm_gateway_module() -> None:
@@ -200,20 +299,9 @@ async def _lifespan(app: "FastAPI"):
     # the server socket is already open and accepting probes.
     asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
 
-    # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
-    # since the app has no gateway running the scheduler. Server `hermes
-    # dashboard` is unaffected — it relies on its own gateway.
-    cron_stop: "threading.Event | None" = None
-    cron_thread: "threading.Thread | None" = None
-    if os.getenv("HERMES_DESKTOP") == "1":
-        cron_stop = threading.Event()
-        cron_thread = threading.Thread(
-            target=_start_desktop_cron_ticker,
-            args=(cron_stop,),
-            daemon=True,
-            name="desktop-cron-ticker",
-        )
-        cron_thread.start()
+    # Desktop remains available when the default gateway owns scheduling; an
+    # explicit desktop owner preserves the Desktop-only fallback.
+    cron_provider, cron_stop, cron_thread = _start_desktop_cron_scheduler_if_owned()
 
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))
@@ -228,8 +316,14 @@ async def _lifespan(app: "FastAPI"):
         pty_reaper_task.cancel()
         selftest_task.cancel()
         await PTY_REGISTRY.close_all()
-        if cron_stop is not None:
-            cron_stop.set()
+        if (
+            cron_provider is not None
+            and cron_stop is not None
+            and cron_thread is not None
+        ):
+            await _shutdown_desktop_cron_scheduler(
+                cron_provider, cron_stop, cron_thread
+            )
 
 
 def _get_event_state(app: "FastAPI"):

--- a/tests/cron/test_scheduler_ownership.py
+++ b/tests/cron/test_scheduler_ownership.py
@@ -1,0 +1,221 @@
+"""Behavior contracts for selecting one cron scheduler owner per Hermes home."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+
+class _RecordingThread:
+    instances = []
+
+    def __init__(self, *, target, args=(), kwargs=None, daemon=None, name=None):
+        self.target = target
+        self.args = args
+        self.kwargs = kwargs or {}
+        self.daemon = daemon
+        self.name = name
+        self.started = False
+        type(self).instances.append(self)
+
+    def start(self):
+        self.started = True
+
+
+def _write_config(home, body: str) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({}, "gateway"),
+        ({"cron": {}}, "gateway"),
+        ({"cron": {"scheduler_owner": "auto"}}, "gateway"),
+        ({"cron": {"scheduler_owner": " gateway "}}, "gateway"),
+        ({"cron": {"scheduler_owner": "DESKTOP"}}, "desktop"),
+    ],
+)
+def test_scheduler_owner_selection_contract(config, expected):
+    from cron.scheduler_provider import resolve_cron_scheduler_owner
+
+    assert resolve_cron_scheduler_owner(config=config) == expected
+
+
+@pytest.mark.parametrize("invalid", ["", "both", 42, None])
+def test_invalid_scheduler_owner_fails_closed_without_logging_value(invalid, caplog):
+    from cron.scheduler_provider import resolve_cron_scheduler_owner
+
+    with caplog.at_level("ERROR"):
+        assert resolve_cron_scheduler_owner(
+            config={"cron": {"scheduler_owner": invalid}}
+        ) is None
+    assert "scheduler startup disabled" in caplog.text
+    if isinstance(invalid, str) and invalid:
+        assert invalid not in caplog.text
+
+
+def test_default_config_uses_safe_auto_owner():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["cron"]["scheduler_owner"] == "auto"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        'cron:\n  scheduler_owner: "unterminated\n',
+        "cron: desktop\n",
+        "cron:\n  scheduler_owner: both\n",
+        "null\n",
+    ],
+)
+def test_owner_file_errors_fail_closed(tmp_path, monkeypatch, body):
+    from cron.scheduler_provider import resolve_cron_scheduler_owner
+
+    _write_config(tmp_path, body)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert resolve_cron_scheduler_owner() is None
+
+
+def test_named_profile_reads_its_config_not_default_config(tmp_path, monkeypatch):
+    from cron.scheduler_provider import should_start_cron_scheduler
+
+    default_home = tmp_path / ".hermes"
+    profile_home = default_home / "profiles" / "worker"
+    _write_config(default_home, "cron:\n  scheduler_owner: gateway\n")
+    _write_config(profile_home, "cron:\n  scheduler_owner: desktop\n")
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    assert should_start_cron_scheduler("gateway") is False
+    assert should_start_cron_scheduler("desktop") is True
+
+
+def test_managed_scheduler_owner_overrides_user_config(tmp_path, monkeypatch):
+    from cron.scheduler_provider import should_start_cron_scheduler
+
+    managed = tmp_path / "managed"
+    _write_config(tmp_path, "cron:\n  scheduler_owner: gateway\n")
+    _write_config(managed, "cron:\n  scheduler_owner: desktop\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+
+    assert should_start_cron_scheduler("gateway") is False
+    assert should_start_cron_scheduler("desktop") is True
+
+
+def test_gateway_and_desktop_use_same_owner_gate(tmp_path, monkeypatch):
+    from gateway import run as gateway_run
+    from hermes_cli import web_server
+
+    _write_config(tmp_path, "cron:\n  scheduler_owner: desktop\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(gateway_run.threading, "Thread", _RecordingThread)
+    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
+    _RecordingThread.instances.clear()
+    runner = SimpleNamespace(
+        adapters={},
+        _draining=False,
+        _external_drain_active=False,
+    )
+
+    gateway_provider, gateway_thread = gateway_run._start_gateway_cron_scheduler_if_owned(
+        runner, threading.Event(), object()
+    )
+    desktop_provider, desktop_stop, desktop_thread = (
+        web_server._start_desktop_cron_scheduler_if_owned()
+    )
+
+    assert gateway_provider is None
+    assert gateway_thread is None
+    assert isinstance(desktop_stop, threading.Event)
+    assert desktop_provider.name == "builtin"
+    assert desktop_thread is _RecordingThread.instances[0]
+    assert desktop_thread.started is True
+    assert desktop_thread.kwargs["provider"].name == "builtin"
+
+
+def test_auto_starts_gateway_and_builtin_desktop_fallback(tmp_path, monkeypatch):
+    from gateway import run as gateway_run
+    from hermes_cli import web_server
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(gateway_run.threading, "Thread", _RecordingThread)
+    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
+    _RecordingThread.instances.clear()
+    runner = SimpleNamespace(
+        adapters={"discord": object()},
+        _draining=False,
+        _external_drain_active=False,
+    )
+
+    gateway_provider, gateway_thread = gateway_run._start_gateway_cron_scheduler_if_owned(
+        runner, threading.Event(), object()
+    )
+    desktop_provider, desktop_stop, desktop_thread = (
+        web_server._start_desktop_cron_scheduler_if_owned()
+    )
+
+    assert gateway_provider.name == "builtin"
+    assert gateway_thread is _RecordingThread.instances[0]
+    assert gateway_thread.started is True
+    assert callable(gateway_thread.kwargs["can_dispatch"])
+    assert isinstance(desktop_stop, threading.Event)
+    assert desktop_provider.name == "builtin"
+    assert desktop_thread is _RecordingThread.instances[1]
+    assert desktop_thread.kwargs["provider"].name == "builtin"
+    assert callable(desktop_thread.kwargs["can_dispatch"])
+
+
+def test_auto_desktop_dispatch_rechecks_gateway_lock_and_fails_closed(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import web_server
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
+    lock_states = iter([False, True, False, False])
+
+    def probe():
+        state = next(lock_states)
+        probe.calls += 1
+        if state is False and probe.calls == 3:
+            raise OSError("probe failed")
+        return state
+
+    probe.calls = 0
+    monkeypatch.setattr("gateway.status.is_gateway_runtime_lock_active", probe)
+    _RecordingThread.instances.clear()
+
+    _, _, thread = web_server._start_desktop_cron_scheduler_if_owned()
+    can_dispatch = thread.kwargs["can_dispatch"]
+
+    assert can_dispatch() is True
+    assert can_dispatch() is False
+    assert can_dispatch() is False
+    assert can_dispatch() is True
+
+
+def test_auto_desktop_never_starts_external_provider(tmp_path, monkeypatch):
+    from hermes_cli import web_server
+
+    _write_config(tmp_path, "cron:\n  provider: remote\n  scheduler_owner: auto\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: pytest.fail("auto Desktop must not resolve external providers"),
+    )
+    _RecordingThread.instances.clear()
+
+    _, _, thread = web_server._start_desktop_cron_scheduler_if_owned()
+
+    assert thread.kwargs["provider"].name == "builtin"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -21,6 +21,39 @@ from hermes_cli.config import (
 )
 
 
+class _RecordingCronProvider:
+    name = "recording"
+
+    def __init__(self, stop_event):
+        self.stop_event = stop_event
+        self.stopped = False
+        self.stop_saw_event_set = False
+        self.stop_thread_id = None
+
+    def stop(self):
+        self.stop_saw_event_set = self.stop_event.is_set()
+        self.stop_thread_id = threading.get_ident()
+        self.stopped = True
+
+
+class _RecordingCronThread:
+    def __init__(self, provider, stop_event):
+        self.provider = provider
+        self.stop_event = stop_event
+        self.join_timeouts = []
+        self.join_thread_id = None
+        self.alive = False
+
+    def join(self, timeout=None):
+        assert self.provider.stopped is True
+        assert self.stop_event.is_set()
+        self.join_timeouts.append(timeout)
+        self.join_thread_id = threading.get_ident()
+
+    def is_alive(self):
+        return self.alive
+
+
 # ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
@@ -133,6 +166,89 @@ def _install_example_plugin(_isolate_hermes_home):
 # ---------------------------------------------------------------------------
 # reload_env tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_desktop_cron_shutdown_stops_signals_and_joins_provider():
+    from hermes_cli.web_server import _shutdown_desktop_cron_scheduler
+
+    stop_event = threading.Event()
+    provider = _RecordingCronProvider(stop_event)
+    thread = _RecordingCronThread(provider, stop_event)
+    event_loop_thread_id = threading.get_ident()
+
+    await _shutdown_desktop_cron_scheduler(provider, stop_event, thread)
+
+    assert provider.stopped is True
+    assert provider.stop_saw_event_set is True
+    assert provider.stop_thread_id != event_loop_thread_id
+    assert stop_event.is_set()
+    assert thread.join_timeouts == [pytest.approx(65.0)]
+    assert thread.join_thread_id != event_loop_thread_id
+
+
+@pytest.mark.asyncio
+async def test_desktop_cron_shutdown_stop_failure_still_joins(monkeypatch, caplog):
+    from hermes_cli import web_server
+
+    stop_event = threading.Event()
+
+    class FailingProvider(_RecordingCronProvider):
+        def stop(self):
+            super().stop()
+            raise RuntimeError("stop failed")
+
+    provider = FailingProvider(stop_event)
+    thread = _RecordingCronThread(provider, stop_event)
+
+    with caplog.at_level("ERROR"):
+        await web_server._shutdown_desktop_cron_scheduler(
+            provider, stop_event, thread
+        )
+
+    assert provider.stop_saw_event_set is True
+    assert thread.join_timeouts == [pytest.approx(65.0)]
+    assert "Desktop cron provider stop failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_desktop_cron_shutdown_timeouts_are_bounded_and_warn_if_alive(
+    monkeypatch, caplog
+):
+    from hermes_cli import web_server
+
+    stop_event = threading.Event()
+    provider = _RecordingCronProvider(stop_event)
+    thread = _RecordingCronThread(provider, stop_event)
+    thread.alive = True
+    calls = []
+
+    async def fake_to_thread(function, *args):
+        calls.append(("to_thread", function, args))
+
+    async def fake_wait_for(awaitable, *, timeout):
+        calls.append(("wait_for", timeout))
+        await awaitable
+        raise TimeoutError
+
+    monkeypatch.setattr(web_server.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(web_server.asyncio, "wait_for", fake_wait_for)
+
+    with caplog.at_level("WARNING"):
+        await web_server._shutdown_desktop_cron_scheduler(
+            provider, stop_event, thread
+        )
+
+    assert stop_event.is_set()
+    assert [call[1] for call in calls if call[0] == "wait_for"] == [5.0, 70.0]
+    offloaded = [call for call in calls if call[0] == "to_thread"]
+    assert offloaded == [
+        ("to_thread", provider.stop, ()),
+        ("to_thread", thread.join, (65.0,)),
+    ]
+    assert "Desktop cron provider stop timed out after 5.0s" in caplog.text
+    assert "Desktop cron thread drain timed out after 70.0s" in caplog.text
+    assert "Desktop cron thread remains alive after shutdown" in caplog.text
 
 
 class TestReloadEnv:
@@ -9429,7 +9545,7 @@ class TestValidateProviderCredential:
 
 
 class TestDesktopCronTicker:
-    """The dashboard backend fires cron jobs itself only when desktop-spawned."""
+    """Desktop cron fallback follows explicit and automatic ownership."""
 
     def _client(self):
         try:
@@ -9440,16 +9556,39 @@ class TestDesktopCronTicker:
 
         return TestClient(app)
 
-    def test_ticker_runs_when_desktop(self, monkeypatch, _isolate_hermes_home):
+    def test_ticker_runs_for_explicit_desktop_owner(
+        self, monkeypatch, _isolate_hermes_home
+    ):
         import threading
         import cron.scheduler as sched
 
         called = threading.Event()
         monkeypatch.setattr(sched, "tick", lambda *a, **k: called.set())
         monkeypatch.setenv("HERMES_DESKTOP", "1")
+        (Path(os.environ["HERMES_HOME"]) / "config.yaml").write_text(
+            "cron:\n  scheduler_owner: desktop\n",
+            encoding="utf-8",
+        )
 
         with self._client():
-            assert called.wait(3.0), "expected cron tick under HERMES_DESKTOP=1"
+            assert called.wait(3.0), "expected cron tick for explicit desktop owner"
+
+    def test_ticker_skipped_for_explicit_gateway_owner(
+        self, monkeypatch, _isolate_hermes_home
+    ):
+        import threading
+        import cron.scheduler as sched
+
+        called = threading.Event()
+        monkeypatch.setattr(sched, "tick", lambda *a, **k: called.set())
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        (Path(os.environ["HERMES_HOME"]) / "config.yaml").write_text(
+            "cron:\n  scheduler_owner: gateway\n",
+            encoding="utf-8",
+        )
+
+        with self._client():
+            assert not called.wait(0.5), "explicit gateway must suppress Desktop ticker"
 
     def test_ticker_skipped_without_desktop(self, monkeypatch, _isolate_hermes_home):
         import threading


### PR DESCRIPTION
## Summary

- honor `cron.scheduler_owner` in both the gateway and Hermes Desktop runtime
- fail closed on malformed/invalid ownership config without logging raw values
- preserve Desktop-only built-in fallback in `auto` mode while a gateway runtime lock is absent
- keep external scheduler providers gateway-owned in `auto`; explicit `desktop` remains available
- preserve profile-local and managed-config precedence
- retain/stop/drain the Desktop scheduler provider cooperatively on shutdown

## Root cause reproduced

Two long-running runtimes used the same `HERMES_HOME`. A due cron run was claimed by the Desktop backend rather than the BWS-authenticated gateway. Desktop had no live Discord adapter or BWS bootstrap, so standalone delivery failed even though the secure gateway remained connected.

The existing tick lock prevented simultaneous ticks but did not establish a delivery-capable owner: whichever process won the tick executed the job.

## Verification

- original source fails the new explicit-owner contract
- focused owner/provider/Desktop/gateway tests: 69 passed
- broad affected suite: 559 passed
- Ruff and `py_compile`: passed
- example YAML parse: passed
- `git diff --check`: passed
- production `jobs.json` checksum unchanged within every test run
- exact patch was reviewed after rebase onto current `main`

## Draft / residual review items

The local incident path uses literal, explicit `cron.scheduler_owner: gateway`; it is deterministic and is covered by the focused tests. The generic upstream patch remains draft pending these broader contracts:

- `auto` preserves backward-compatible Desktop-only fallback by probing the gateway runtime lock on each built-in dispatch, but a narrow gateway-startup check/use handoff window remains; an atomic lease would close it.
- A live ownership change can leave an already-running old owner active until restart; dynamic changes need a process-lifetime lease or coordinated revalidation.
- `hermes cron status/create/list` are not yet owner-aware and can report a false green for an unavailable configured owner.
- The strict owner reader does not yet apply the normal `${VAR}` substitution semantics. Literal values work; expanded values currently fail closed.
- Explicit Desktop external-provider resolution happens synchronously during FastAPI lifespan and should be moved back off the event loop or bounded.
- Gateway external-provider `stop()` remains synchronous/unbounded; that behavior predates this patch and is outside the ownership fix.

## Related

- Relates to #57191
- Relates to #52202
- Relates to #43965
- Supersedes the scheduler-ownership portion of draft #66162 with a current-main, narrower patch; excludes secret-refresh work
- Complements #70255, which is separate live-adapter fallback hardening
