### PR TITLE
test: isolate Tirith import policy from process env

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2426,13 +2426,37 @@ class TestTirithImportErrorFailOpenPolicy:
         with _patch("builtins.__import__", side_effect=self._make_failing_import(real_import)):
             with _patch("hermes_cli.config.load_config", return_value=cfg):
                 with _patch("tools.approval.detect_dangerous_command", return_value=(False, None, None)):
-                    with mock_patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}, clear=False):
-                        result = check_all_command_guards("echo hello", "local")
+                    with _patch("tools.approval._YOLO_MODE_FROZEN", False):
+                        with _patch("tools.approval.is_current_session_yolo_enabled", return_value=False):
+                            with _patch("tools.approval._is_gateway_approval_context", return_value=False):
+                                with mock_patch.dict(
+                                    "os.environ",
+                                    {
+                                        "HERMES_INTERACTIVE": "1",
+                                        "HERMES_YOLO_MODE": "",
+                                        "HERMES_GATEWAY_SESSION": "",
+                                        "HERMES_EXEC_ASK": "",
+                                        "HERMES_CRON_SESSION": "",
+                                    },
+                                    clear=False,
+                                ):
+                                    result = check_all_command_guards("echo hello", "local")
 
         assert result.get("approved") is True
 
     def test_fail_open_false_escalates_to_approval_on_import_error(self):
-        """Fail-closed: ImportError must NOT silently allow when tirith_fail_open=false."""
+        """Fail-closed: ImportError must NOT silently allow when tirith_fail_open=false.
+
+        The previous test suite inadvertently inherited the host process's
+        ``HERMES_YOLO_MODE=1`` (and other approval-bypass env vars), which
+        caused ``_YOLO_MODE_FROZEN=True`` to short-circuit the gate at the
+        very first branch and return ``{"approved": True}`` before the
+        fail-closed synthesis could run. That made the test's assertion
+        trivially true for the wrong reason and masked the real question
+        ("does fail-closed synthesis work?"). Explicitly zeroing those env
+        vars in the patch ensures the test exercises the code path it
+        claims to exercise.
+        """
         import builtins
         from unittest.mock import patch as _patch
         from tools.approval import check_all_command_guards
@@ -2451,12 +2475,25 @@ class TestTirithImportErrorFailOpenPolicy:
         with _patch("builtins.__import__", side_effect=self._make_failing_import(real_import)):
             with _patch("hermes_cli.config.load_config", return_value=cfg):
                 with _patch("tools.approval.detect_dangerous_command", return_value=(False, None, None)):
-                    with mock_patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}, clear=False):
-                        result = check_all_command_guards(
-                            "echo hello",
-                            "local",
-                            approval_callback=approval_callback,
-                        )
+                    with _patch("tools.approval._YOLO_MODE_FROZEN", False):
+                        with _patch("tools.approval.is_current_session_yolo_enabled", return_value=False):
+                            with _patch("tools.approval._is_gateway_approval_context", return_value=False):
+                                with mock_patch.dict(
+                                    "os.environ",
+                                    {
+                                        "HERMES_INTERACTIVE": "1",
+                                        "HERMES_YOLO_MODE": "",
+                                        "HERMES_GATEWAY_SESSION": "",
+                                        "HERMES_EXEC_ASK": "",
+                                        "HERMES_CRON_SESSION": "",
+                                    },
+                                    clear=False,
+                                ):
+                                    result = check_all_command_guards(
+                                        "echo hello",
+                                        "local",
+                                        approval_callback=approval_callback,
+                                    )
 
         # The user must have been consulted — the command should NOT be silently allowed.
         assert result.get("approved") is not True or calls, (
@@ -2482,8 +2519,21 @@ class TestTirithImportErrorFailOpenPolicy:
         with _patch("builtins.__import__", side_effect=self._make_failing_import(real_import)):
             with _patch("hermes_cli.config.load_config", return_value=cfg):
                 with _patch("tools.approval.detect_dangerous_command", return_value=(False, None, None)):
-                    with mock_patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}, clear=False):
-                        result = check_all_command_guards("echo hello", "local")
+                    with _patch("tools.approval._YOLO_MODE_FROZEN", False):
+                        with _patch("tools.approval.is_current_session_yolo_enabled", return_value=False):
+                            with _patch("tools.approval._is_gateway_approval_context", return_value=False):
+                                with mock_patch.dict(
+                                    "os.environ",
+                                    {
+                                        "HERMES_INTERACTIVE": "1",
+                                        "HERMES_YOLO_MODE": "",
+                                        "HERMES_GATEWAY_SESSION": "",
+                                        "HERMES_EXEC_ASK": "",
+                                        "HERMES_CRON_SESSION": "",
+                                    },
+                                    clear=False,
+                                ):
+                                    result = check_all_command_guards("echo hello", "local")
 
         assert result.get("approved") is True
 


### PR DESCRIPTION
## Summary

TestTirithImportErrorFailOpenPolicy in tests/tools/test_approval.py asserts that `check_all_command_guards` honors `security.tirith_fail_open` when `tools.tirith_security` cannot be imported.

In CI environments where `HERMES_YOLO_MODE=1`, `HERMES_GATEWAY_SESSION=1`, or `HERMES_EXEC_ASK=1` are set on the test runner process (e.g. shared self-hosted runners, multi-tenant containers, ops scripts that exec the test suite), the very first branch of `check_all_command_guards` short-circuits to `{"approved": True, "message": None}` via the frozen YOLO flag or the gateway approval context, returning *before* the fail-closed synthesis branch ever runs.

This made the `test_fail_open_false_escalates_to_approval_on_import_error` assertion trivially pass for the wrong reason: the assertion evaluated True not because the fail-closed synthesis honored `tirith_fail_open=false`, but because `_YOLO_MODE_FROZEN=True` (or the gateway context) made every result approved regardless of policy.

## Changes

1. Patch the three tests in TestTirithImportErrorFailOpenPolicy to explicitly force `_YOLO_MODE_FROZEN=False`, `is_current_session_yolo_enabled=lambda: False`, and `_is_gateway_approval_context=lambda: False` inside the existing mock block, AND to zero `HERMES_YOLO_MODE`, `HERMES_GATEWAY_SESSION`, `HERMES_EXEC_ASK`, and `HERMES_CRON_SESSION` in the env dict patch.
2. Preserve the existing `clear=False` semantics so unrelated env vars from the runner are not destroyed.
3. Add a docstring to the fail-closed test explaining *why* the isolation matters, so a future maintainer who strips the patches "to make the test simpler" gets a warning instead of a silent regression.

## Validation

```
$ uv run pytest tests/tools/test_approval.py -k TirithImportErrorFailOpenPolicy
3 passed, 309 deselected
```

## Out of scope

- `package-lock.json` (separate concern).

## Author

승상 Hermes 명장 작성 (현재 MiniMax-M3 모델) · 2026-07-23 PDT