### PR TITLE
feat: add Apiário Dev as a native provider via plugin

### DIFF
--- a/plugins/model-providers/apiario-dev/__init__.py
+++ b/plugins/model-providers/apiario-dev/__init__.py
@@ -9,8 +9,8 @@ apiario_dev = ProviderProfile(
     display_name="Apiário Dev",
     description="Provedor oficial do Apiário Dev",
     fallback_models=(
-        "claude-3-5-sonnet-20240620",
-        "claude-3-haiku-20240307",
+        "deepseek/deepseek-v4-flash",
+        "openai/gpt-5.5",
     ),
     base_url="https://api.apiario.dev/v1", 
 )

--- a/plugins/model-providers/apiario-dev/__init__.py
+++ b/plugins/model-providers/apiario-dev/__init__.py
@@ -1,0 +1,18 @@
+"""Apiário Dev provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+apiario_dev = ProviderProfile(
+    name="apiario-dev",
+    env_vars=("APIARIO_API_KEY",),
+    display_name="Apiário Dev",
+    description="Provedor oficial do Apiário Dev",
+    fallback_models=(
+        "claude-3-5-sonnet-20240620",
+        "claude-3-haiku-20240307",
+    ),
+    base_url="https://api.apiario.dev/v1", 
+)
+
+register_provider(apiario_dev)

--- a/plugins/model-providers/apiario-dev/plugin.yaml
+++ b/plugins/model-providers/apiario-dev/plugin.yaml
@@ -1,0 +1,4 @@
+name: apiario-dev
+kind: model-provider
+version: 1.0.0
+description: Provedor oficial do Apiário Dev


### PR DESCRIPTION
## What does this PR do?

Adds **Apiário Dev** as a native model provider for Hermes Agent using the existing **Fast Path plugin architecture**.

Since Apiário Dev provides an OpenAI-compatible API, users only need to set the `APIARIO_API_KEY` environment variable to start using Apiário Dev models without manually configuring custom endpoints.

This implementation leverages Hermes' existing plugin architecture without modifying the core provider registry, keeping the integration isolated, maintainable, and aligned with the project's design.

---

## Related Issue

N/A

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

---

## Changes Made

- Added a new **Apiário Dev** provider plugin under `plugins/model-providers/apiario-dev/`.
- Added the provider manifest in `plugin.yaml`.
- Registered the provider using the standard `ProviderProfile` implementation.
- Configured the official Apiário Dev API endpoint.

---

## How to Test

1. Set the `APIARIO_API_KEY` environment variable.
2. Start Hermes Agent using this branch.
3. Verify that **Apiário Dev** appears as an available model provider.
4. Select the provider.
5. Send a test prompt and verify that requests are successfully routed to the Apiário Dev API.

---

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains **only** changes related to this feature.
- [ ] I've run `pytest tests/ -q` and all tests pass.
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features).
- [x] I've tested the plugin by validating its registration and integration with the existing Fast Path plugin architecture on Ubuntu 22.04 LTS.

### Documentation & Housekeeping

- [x] No documentation changes were required.
- [x] `cli-config.yaml.example` was not affected.
- [x] `CONTRIBUTING.md` and `AGENTS.md` were not affected.
- [x] Cross-platform impact was considered.
- [x] No tool descriptions or schemas were modified.

---

## Screenshots / Logs

The Apiário Dev provider is successfully registered through Hermes' Fast Path plugin system and becomes available as a native provider after setting the `APIARIO_API_KEY` environment variable.