### PR TITLE
fix(acp): forward resolved credential pool

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -640,6 +640,7 @@ class SessionManager:
                     "api_mode": api_mode or runtime.get("api_mode"),
                     "base_url": base_url or runtime.get("base_url"),
                     "api_key": runtime.get("api_key"),
+                    "credential_pool": runtime.get("credential_pool"),
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                 }

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -77,7 +77,9 @@ class TestCreateSession:
     def test_get_nonexistent_session_returns_none(self, manager):
         assert manager.get_session("does-not-exist") is None
 
-    def test_make_agent_stamps_session_cwd_for_codex_runtime(self, monkeypatch):
+    def test_make_agent_stamps_cwd_and_forwards_runtime_credential_pool(self, monkeypatch):
+        sentinel_pool = object()
+
         class FakeAgent:
             model = "fake-model"
 
@@ -113,6 +115,7 @@ class TestCreateSession:
                 "api_mode": "codex_app_server",
                 "base_url": "https://example.invalid",
                 "api_key": "test-key",
+                "credential_pool": sentinel_pool,
             },
         )
         monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
@@ -120,8 +123,7 @@ class TestCreateSession:
         state = SessionManager(db=None).create_session(cwd="/tmp/project")
 
         assert state.agent.session_cwd == "/tmp/project"
-
-
+        assert state.agent.kwargs["credential_pool"] is sentinel_pool
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

ACP resolved complete provider runtime state but dropped the selected `credential_pool` when constructing `AIAgent`. Long-lived OpenAI Codex ACP sessions therefore could not use Hermes' existing in-process OAuth 401 refresh/rotation path and required an ACP restart after token expiry.

This forwards the already resolved, provider-scoped pool into ACP-created agents. It keeps authentication ownership in Hermes core, preserves existing account/provider guards, and requires no VS Code extension-side token handling or routine ACP replacement.

## Related Issue

Fixes #70292

Related to #70097 / #70111, but distinct: those address refresh/adoption once a credential pool is attached; this fixes ACP omitting the pool entirely.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/session.py`: forward `runtime["credential_pool"]` into ACP-created `AIAgent` instances.
- `tests/acp/test_session.py`: extend the ACP construction regression to assert that resolved credential pools are retained.

## How to Test

1. Configure `openai-codex` OAuth and start a long-lived `hermes acp` process.
2. Let or simulate the active access token expiring while current token state remains refreshable/adoptable through Hermes' credential pool.
3. Send another prompt through the same ACP process and verify it refreshes/rotates and retries without terminating ACP.

Automated/local verification:

```text
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/acp/ tests/acp_adapter/ tests/run_agent/test_run_agent_codex_responses.py
438 passed, 0 failed
```

A real patched ACP JSON-RPC smoke request returned exactly `ACP_POOL_OK` in the same ACP PID; the temporary session was deleted. A live runtime invariant check also confirmed that the selected pool entry matches the agent API key and that the pool provider matches the agent provider.

Full-suite baseline comparison:

- The complete `scripts/run_tests.sh` run reported 28 failures in 17 files outside the changed ACP/Codex scope.
- Running those exact 17 files against the untouched base commit `c4f5a45d` reproduced the same 28 failures.
- Neither the branch nor baseline failures include `acp_adapter/session.py`, `tests/acp/`, `tests/acp_adapter/`, or the Codex-response recovery suite.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository `AGENTS.md`.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the repository's required `scripts/run_tests.sh` CI-parity wrapper.
- [x] I've added tests for my changes.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration or command changes.
- [x] `cli-config.yaml.example`: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow change.
- [x] Cross-platform impact considered: the change forwards an existing Python object and is platform-independent.
- [x] Tool descriptions/schemas: N/A; no tool behavior changed.

## Screenshots / Logs

```text
same_acp_pid: 20791
response: ACP_POOL_OK
stopReason: end_turn
stderr_error_lines: []
```
