### PR TITLE
fix(desktop): preview remote artifact rows in app

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
@@ -1,11 +1,22 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $previewTabs, closeRightRail } from '@/store/preview'
+import { $connection } from '@/store/session'
 
 import { PreviewStatusRow } from './preview-row'
 
 describe('PreviewStatusRow', () => {
+  beforeEach(() => {
+    $connection.set(null)
+    closeRightRail()
+  })
+
   afterEach(() => {
     cleanup()
+    $connection.set(null)
+    closeRightRail()
+    vi.restoreAllMocks()
   })
 
   it('keeps the preview tooltip label inline inside the portaled decoration', async () => {
@@ -26,5 +37,78 @@ describe('PreviewStatusRow', () => {
     expect(view.container.contains(content)).toBe(false)
     expect(label?.classList.contains('inline-flex')).toBe(true)
     expect(label?.classList.contains('flex')).toBe(false)
+  })
+
+  it('opens remote file artifacts in the in-app preview instead of the local browser bridge', async () => {
+    const remotePath = '/home/agent/report.pdf'
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+
+    $connection.set({ mode: 'remote' } as never)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        api: vi.fn(async () => ({ binary: true, byteSize: 42, mimeType: 'application/pdf' })),
+        normalizePreviewTarget: vi.fn(async () => ({
+          kind: 'file',
+          label: 'report.pdf',
+          path: remotePath,
+          previewKind: 'binary',
+          source: remotePath,
+          url: 'file:///home/agent/report.pdf'
+        })),
+        openPreviewInBrowser
+      }
+    })
+
+    render(
+      <PreviewStatusRow
+        item={{ cwd: '/home/agent', id: remotePath, label: 'report.pdf', target: remotePath }}
+        onDismiss={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByText('report.pdf'))
+
+    await waitFor(() => {
+      expect($previewTabs.get()).toEqual([
+        expect.objectContaining({ target: expect.objectContaining({ kind: 'file', path: remotePath }) })
+      ])
+    })
+    expect(openPreviewInBrowser).not.toHaveBeenCalled()
+  })
+
+  it('keeps local file artifacts on the browser bridge', async () => {
+    const localPath = '/Users/alice/report.pdf'
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+
+    $connection.set({ mode: 'local' } as never)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        normalizePreviewTarget: vi.fn(async () => ({
+          kind: 'file',
+          label: 'report.pdf',
+          path: localPath,
+          previewKind: 'binary',
+          source: localPath,
+          url: 'file:///Users/alice/report.pdf'
+        })),
+        openPreviewInBrowser
+      }
+    })
+
+    render(
+      <PreviewStatusRow
+        item={{ cwd: '/Users/alice', id: localPath, label: 'report.pdf', target: localPath }}
+        onDismiss={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByText('report.pdf'))
+
+    await waitFor(() => {
+      expect(openPreviewInBrowser).toHaveBeenCalledWith('file:///Users/alice/report.pdf')
+    })
+    expect($previewTabs.get()).toEqual([])
   })
 })

--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
+import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
 import { PREVIEW_PANE_ID } from '@/store/layout'
@@ -59,15 +60,27 @@ export const PreviewStatusRow = memo(function PreviewStatusRow({ item, onDismiss
     }
   }
 
-  const openInBrowser = async () => {
+  const openDefaultTarget = async () => {
     try {
+      const target = await resolveTarget()
+
+      // A file:// URL resolved by a remote backend names a file on that
+      // backend, not on the machine running Electron. Keep local files and
+      // ordinary URLs on the browser path, but route remote files through the
+      // existing preview pane so its filesystem adapter reads from the gateway.
+      if (target.kind === 'file' && isDesktopFsRemoteMode()) {
+        openPreview(target, 'tool-result')
+
+        return
+      }
+
       const bridge = window.hermesDesktop?.openPreviewInBrowser
 
       if (!bridge) {
         throw new Error('Desktop preview browser bridge is unavailable')
       }
 
-      await bridge((await resolveTarget()).url)
+      await bridge(target.url)
     } catch (error) {
       notifyError(error, t.preview.unavailable)
     }
@@ -83,13 +96,14 @@ export const PreviewStatusRow = memo(function PreviewStatusRow({ item, onDismiss
           size="0.8rem"
         />
       }
-      // Plain click opens the link in the browser; ⌘/Ctrl-click opens it in the
-      // in-app preview pane instead. (isOpen still toggles the pane closed.)
+      // Plain click opens the link in the browser, except remote files which
+      // only the in-app gateway-backed preview can read. ⌘/Ctrl-click always
+      // uses the in-app preview pane. (isOpen still toggles the pane closed.)
       onActivate={event => {
         if (event.metaKey || event.ctrlKey) {
           void togglePreview()
         } else {
-          void openInBrowser()
+          void openDefaultTarget()
         }
       }}
       trailing={


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop's composer status row now opens remote file artifacts in the existing in-app preview pane instead of sending their backend-owned `file://` URL to the local Electron browser bridge.

Local files and ordinary URLs keep their existing browser behavior. The change only redirects file targets while the Desktop filesystem facade is in remote mode.

## Related Issue

Fixes #70236

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Root Cause

`PreviewStatusRow` normalizes a remote artifact such as `/home/agent/report.pdf` to a `file://` URL, then its plain-click path always calls Electron's local `openPreviewInBrowser` bridge. That bridge correctly rejects or cannot resolve a backend-host path on the Desktop machine, producing “Preview unavailable / Invalid preview URL.”

The in-app preview pane already reads remote file targets through the authenticated gateway filesystem adapter, so this reuses that existing path rather than widening Electron's local file access.

## Changes Made

- `apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx`
  - route remote file targets to the gateway-backed in-app preview
  - preserve browser opening for local files and normal URLs
- `apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx`
  - assert remote files open in-app without calling the local browser bridge
  - assert local files retain browser-bridge behavior

## How to Test

1. Connect Hermes Desktop to a remote backend.
2. Produce a remote file artifact such as `MEDIA:/home/agent/report.pdf`.
3. Click its composer status row and verify the in-app preview opens without an invalid local URL error.

Automated verification on macOS after rebasing onto current `main` (`98105f31f`), head `cf1f941a1`:

- `npm run typecheck` — passed
- `npm run lint` — passed with 0 errors (74 existing warnings)
- `npm run test:ui` — 356 files, 3159 tests passed
- `npm exec vitest run -- --project ui src/app/chat/composer/status-stack/preview-row.test.tsx` — 1 file, 3 tests passed
- `git diff --check` — passed

## Risk and Validation Limits

Risk is limited to the default click routing for remote file artifacts. Local files, remote/local HTTP(S) URLs, modifier-click preview behavior, and the filesystem API are unchanged.

This is a **Draft** because I did not run a packaged Electron client against a live remote Linux backend. Automated renderer coverage proves the routing contract, but the reported Tailscale/remote-host topology still needs a manual GUI smoke test.

## Checklist

### Code

- [x] I've read the Contributing Guide, root `AGENTS.md`, and `apps/desktop/AGENTS.md`
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed issues/PRs for duplicates and inspected related draft PR #57878
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` (not run; this is a Desktop-only TypeScript change)
- [x] I've added behavior-focused regression coverage
- [x] Automated checks were run on macOS

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration or command changed
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered; no OS-specific primitives were added
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

N/A — no visual styling changed.