### PR TITLE
fix(agent): recover from unsupported reasoning_details replay

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -30,6 +30,7 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse, urlunparse
 
+from agent.backend_identity import BackendIdentity
 from agent.context_compressor import ContextCompressor
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import StreamingContextScrubber
@@ -708,6 +709,10 @@ def init_agent(
     agent.base_url = base_url or ""
     provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
     agent.provider = provider_name or ""
+    # Negative capability knowledge is intentionally process/session-local.
+    # A reconstructed agent may probe once again, while model switches on this
+    # agent retain deployment-specific schema knowledge.
+    agent._reasoning_details_rejected_backends: set[BackendIdentity] = set()
     agent.requested_provider = (
         requested_provider.strip().lower()
         if isinstance(requested_provider, str) and requested_provider.strip()

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -4899,6 +4899,22 @@ def _connection_candidates(conn: Any):
             stack.append(inner)
 
 
+def strip_reasoning_details_from_api_messages(api_messages: list) -> int:
+    """Remove rejected reasoning replay metadata from request-local messages.
+
+    ``api_messages`` contains shallow copies of canonical history.  Removing
+    the top-level field here repairs the wire payload without deleting signed
+    reasoning blocks from the persisted conversation, where a later switch
+    back to OpenRouter or Anthropic may still need them.
+    """
+    stripped = 0
+    for api_msg in api_messages:
+        if isinstance(api_msg, dict) and "reasoning_details" in api_msg:
+            api_msg.pop("reasoning_details", None)
+            stripped += 1
+    return stripped
+
+
 def _iter_pool_sockets(client: Any):
     """Yield raw sockets reachable from an OpenAI/httpx client pool.
 
@@ -5258,6 +5274,7 @@ __all__ = [
     "sanitize_api_messages",
     "looks_like_codex_intermediate_ack",
     "copy_reasoning_content_for_api",
+    "strip_reasoning_details_from_api_messages",
     "cleanup_dead_connections",
     "extract_api_error_context",
     "apply_pending_steer_to_tool_results",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3443,6 +3443,22 @@ def _connection_candidates(conn: Any):
             stack.append(inner)
 
 
+def strip_reasoning_details_from_api_messages(api_messages: list) -> int:
+    """Remove rejected reasoning replay metadata from request-local messages.
+
+    ``api_messages`` contains shallow copies of canonical history.  Removing
+    the top-level field here repairs the wire payload without deleting signed
+    reasoning blocks from the persisted conversation, where a later switch
+    back to OpenRouter or Anthropic may still need them.
+    """
+    stripped = 0
+    for api_msg in api_messages:
+        if isinstance(api_msg, dict) and "reasoning_details" in api_msg:
+            api_msg.pop("reasoning_details", None)
+            stripped += 1
+    return stripped
+
+
 def _iter_pool_sockets(client: Any):
     """Yield raw sockets reachable from an OpenAI/httpx client pool.
 
@@ -3781,6 +3797,7 @@ __all__ = [
     "sanitize_api_messages",
     "looks_like_codex_intermediate_ack",
     "copy_reasoning_content_for_api",
+    "strip_reasoning_details_from_api_messages",
     "cleanup_dead_connections",
     "extract_api_error_context",
     "apply_pending_steer_to_tool_results",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1956,6 +1956,12 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
 
     # ── chat_completions (default) ─────────────────────────────────────
     _ct = agent._get_transport()
+    from agent.reasoning_replay import (
+        reasoning_details_rejected_for_current_backend,
+    )
+    _strip_reasoning_details = reasoning_details_rejected_for_current_backend(
+        agent
+    )
 
     # xAI's chat-completions endpoint reserves the function name
     # ``tool_search`` for its native server-side tool and rejects the whole
@@ -2105,6 +2111,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             anthropic_max_output=_ant_max,
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
+            strip_reasoning_details=_strip_reasoning_details,
         )
 
     # ── Legacy flag path ────────────────────────────────────────────
@@ -2153,6 +2160,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         lmstudio_reasoning_options=agent._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
+        strip_reasoning_details=_strip_reasoning_details,
     )
 
 
@@ -3112,6 +3120,31 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # _thinking_prefill must survive until here so the drop pass can
         # recognize stubs after reasoning fields are stripped.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+
+        # This path hand-builds a Chat Completions request and therefore does
+        # not pass through build_api_kwargs(). Reuse the same deployment
+        # capability decision and the transport's copy-on-write conversion so
+        # a learned rejection cannot leak through the iteration summary.
+        if agent.api_mode == "chat_completions":
+            from agent.reasoning_replay import (
+                reasoning_details_rejected_for_current_backend,
+            )
+            from agent.transports.chat_completions import (
+                ChatCompletionsTransport,
+            )
+
+            # Use the concrete request-boundary converter directly.  The
+            # transport returned by ``_get_transport()`` is also used later
+            # to normalize the response, and tests/extensions may provide a
+            # narrow normalize-only adapter there; summary serialization must
+            # not enlarge that existing contract.
+            api_messages = ChatCompletionsTransport().convert_messages(
+                api_messages,
+                model=agent.model,
+                strip_reasoning_details=(
+                    reasoning_details_rejected_for_current_backend(agent)
+                ),
+            )
 
         # Strip all remaining underscore-prefixed scaffolding keys before the
         # wire. The summary path calls chat.completions.create() directly,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5242,13 +5242,9 @@ def run_conversation(
 
                 # Thinking block signature recovery.
                 #
-                # Anthropic signs thinking blocks against the full turn
-                # content. Any upstream mutation (context compression,
-                # session truncation, message merging) invalidates the
-                # signature and the API replies HTTP 400 ("invalid
-                # signature" or "cannot be modified"). Recovery strips
-                # ``reasoning_details`` so the retry sends no thinking
-                # blocks at all. One-shot per outer loop.
+                # Anthropic can reject mutated signed thinking blocks. Recover
+                # by stripping reasoning_details from request-local copies and
+                # retrying once.
                 #
                 # The strip targets ``api_messages``, which is the
                 # API-call-time list that ``_build_api_kwargs`` consumes
@@ -5273,11 +5269,12 @@ def run_conversation(
                     and not _retry.thinking_sig_retry_attempted
                 ):
                     _retry.thinking_sig_retry_attempted = True
-                    _api_stripped = 0
-                    for _m in api_messages:
-                        if isinstance(_m, dict) and "reasoning_details" in _m:
-                            _m.pop("reasoning_details", None)
-                            _api_stripped += 1
+                    from agent.agent_runtime_helpers import (
+                        strip_reasoning_details_from_api_messages,
+                    )
+                    _api_stripped = strip_reasoning_details_from_api_messages(
+                        api_messages
+                    )
                     agent._vprint(
                         f"{agent.log_prefix}⚠️  Thinking block signature invalid, "
                         f"stripped reasoning_details from api_messages for retry...",
@@ -5290,6 +5287,59 @@ def run_conversation(
                         agent.log_prefix, _api_stripped,
                     )
                     continue
+
+                # Strict Chat Completions schema recovery. Learn only from an
+                # explicit 400/422 rejection whose actual failed outbound
+                # payload contained reasoning_details. The next build uses the
+                # recorded BackendIdentity to ask the transport for a
+                # copy-on-write strip; canonical history remains untouched.
+                if (
+                    classified.reason
+                    == FailoverReason.reasoning_details_unsupported
+                    and not _retry.reasoning_details_retry_attempted
+                ):
+                    from agent.reasoning_replay import (
+                        outbound_messages_contain_reasoning_details,
+                        remember_reasoning_details_rejection,
+                    )
+
+                    if outbound_messages_contain_reasoning_details(api_kwargs):
+                        _identity, _learned = (
+                            remember_reasoning_details_rejection(
+                                agent, model=api_kwargs.get("model")
+                            )
+                        )
+                        if _learned:
+                            _retry.reasoning_details_retry_attempted = True
+                            agent._vprint(
+                                f"{agent.log_prefix}⚠️  Provider rejected reasoning_details "
+                                f"replay — learned this model deployment and retrying...",
+                                force=True,
+                            )
+                            logger.warning(
+                                "%sReasoning replay capability recovery: "
+                                "provider=%s model=%s base_url=%s "
+                                "(canonical messages unchanged)",
+                                agent.log_prefix,
+                                _identity.provider,
+                                _identity.model,
+                                _identity.base_url,
+                            )
+                            continue
+                        logger.info(
+                            "%sIgnored reasoning_details rejection classification: "
+                            "could not identify a concrete provider/model/endpoint",
+                            agent.log_prefix,
+                        )
+                        # Do not repeat the same payload when no concrete
+                        # capability entry can make the retry different.
+                        _retry.reasoning_details_retry_attempted = True
+                    else:
+                        logger.info(
+                            "%sIgnored reasoning_details rejection classification: "
+                            "failed outbound messages did not contain the field",
+                            agent.log_prefix,
+                        )
 
                 # ── Invalid encrypted reasoning replay recovery ───────
                 # OpenAI Responses API surfaces (and some compatible relays)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3905,15 +3905,13 @@ def run_conversation(
                     print(f"{agent.log_prefix}     • Legacy cleanup: hermes config set ANTHROPIC_TOKEN \"\"")
                     print(f"{agent.log_prefix}     • Clear stale keys: hermes config set ANTHROPIC_API_KEY \"\"")
 
-                # Thinking block signature recovery.
+                # Reasoning replay recovery.
                 #
-                # Anthropic signs thinking blocks against the full turn
-                # content. Any upstream mutation (context compression,
-                # session truncation, message merging) invalidates the
-                # signature and the API replies HTTP 400 ("invalid
-                # signature" or "cannot be modified"). Recovery strips
-                # ``reasoning_details`` so the retry sends no thinking
-                # blocks at all. One-shot per outer loop.
+                # Anthropic can reject mutated signed thinking blocks, while
+                # strict OpenAI-compatible targets can reject reasoning_details
+                # emitted by a different model as an unsupported property.
+                # Both recover by stripping reasoning_details from the
+                # request-local copies and retrying once.
                 #
                 # The strip targets ``api_messages``, which is the
                 # API-call-time list that ``_build_api_kwargs`` consumes
@@ -3934,25 +3932,38 @@ def run_conversation(
                 # cascading compaction-ended sessions chained off the
                 # corrupted parent.
                 if (
-                    classified.reason == FailoverReason.thinking_signature
+                    classified.reason in {
+                        FailoverReason.thinking_signature,
+                        FailoverReason.reasoning_details_unsupported,
+                    }
                     and not _retry.thinking_sig_retry_attempted
                 ):
                     _retry.thinking_sig_retry_attempted = True
-                    _api_stripped = 0
-                    for _m in api_messages:
-                        if isinstance(_m, dict) and "reasoning_details" in _m:
-                            _m.pop("reasoning_details", None)
-                            _api_stripped += 1
+                    from agent.agent_runtime_helpers import (
+                        strip_reasoning_details_from_api_messages,
+                    )
+                    _api_stripped = strip_reasoning_details_from_api_messages(
+                        api_messages
+                    )
+                    _unsupported = (
+                        classified.reason
+                        == FailoverReason.reasoning_details_unsupported
+                    )
+                    _reason = (
+                        "Provider rejected reasoning replay metadata"
+                        if _unsupported
+                        else "Thinking block signature invalid"
+                    )
                     agent._vprint(
-                        f"{agent.log_prefix}⚠️  Thinking block signature invalid, "
+                        f"{agent.log_prefix}⚠️  {_reason}, "
                         f"stripped reasoning_details from api_messages for retry...",
                         force=True,
                     )
                     logger.warning(
-                        "%sThinking block signature recovery: stripped "
+                        "%sReasoning replay recovery (%s): stripped "
                         "reasoning_details from %d api_messages "
                         "(canonical messages unchanged)",
-                        agent.log_prefix, _api_stripped,
+                        agent.log_prefix, classified.reason.value, _api_stripped,
                     )
                     continue
 
@@ -4860,6 +4871,7 @@ def run_conversation(
                             FailoverReason.payload_too_large,
                             FailoverReason.long_context_tier,
                             FailoverReason.thinking_signature,
+                            FailoverReason.reasoning_details_unsupported,
                         }
                     )
                 ) and not is_context_length_error

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -66,6 +66,7 @@ class FailoverReason(enum.Enum):
 
     # Request format
     format_error = "format_error"        # 400 bad request — abort or strip + retry
+    reasoning_details_unsupported = "reasoning_details_unsupported"  # Target rejects replay metadata
     invalid_encrypted_content = "invalid_encrypted_content"  # Responses replay blob rejected — strip replay state and retry
     multimodal_tool_content_unsupported = "multimodal_tool_content_unsupported"  # Provider rejected list-type content in tool messages (e.g. Xiaomi MiMo) — downgrade to text and retry
 
@@ -955,9 +956,45 @@ def classify_api_error(
             should_fallback=True,
         )
 
+    # Some strict OpenAI-compatible targets reject replay metadata emitted by
+    # a reasoning-capable model used earlier in the same session.  Detect the
+    # provider's explicit schema rejection rather than guessing capabilities:
+    # OpenRouter and Anthropic need reasoning_details preserved, while Groq
+    # and other strict routes reject it for non-reasoning models.  The turn
+    # loop strips only the API-call copies and retries once, leaving canonical
+    # history intact for a later switch back to a replay-capable model.
+    if (
+        status_code in {400, 422}
+        and "reasoning_details" in error_msg
+        and any(
+            marker in error_msg
+            for marker in (
+                "unsupported",
+                "not supported",
+                "extra inputs are not permitted",
+                "extra inputs not permitted",
+                "unknown field",
+                "unknown property",
+                "unrecognized field",
+                "unrecognized property",
+                "unexpected field",
+                "unexpected property",
+                "additional properties are not allowed",
+            )
+        )
+    ):
+        return _result(
+            FailoverReason.reasoning_details_unsupported,
+            # The unchanged payload is deterministically invalid. The turn
+            # loop performs one transformed retry only after confirming the
+            # actual outbound messages carried the rejected field.
+            retryable=False,
+            should_compress=False,
+        )
+
     # Anthropic thinking block recovery (400).  Two distinct failure modes,
-    # same recovery (strip all reasoning_details and retry without thinking
-    # blocks — see the thinking_signature handler in conversation_loop.py):
+    # same request-copy recovery as above (strip all reasoning_details and
+    # retry without thinking blocks):
     #   1. Signature mismatch: a thinking block is signed against the full
     #      turn content; any upstream mutation (context compression, session
     #      truncation, message merging) invalidates the signature.

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -59,6 +59,7 @@ class FailoverReason(enum.Enum):
 
     # Request format
     format_error = "format_error"        # 400 bad request — abort or strip + retry
+    reasoning_details_unsupported = "reasoning_details_unsupported"  # Target rejects replay metadata
     invalid_encrypted_content = "invalid_encrypted_content"  # Responses replay blob rejected — strip replay state and retry
     multimodal_tool_content_unsupported = "multimodal_tool_content_unsupported"  # Provider rejected list-type content in tool messages (e.g. Xiaomi MiMo) — downgrade to text and retry
 
@@ -705,9 +706,37 @@ def classify_api_error(
             should_fallback=True,
         )
 
+    # Some strict OpenAI-compatible targets reject replay metadata emitted by
+    # a reasoning-capable model used earlier in the same session.  Detect the
+    # provider's explicit schema rejection rather than guessing capabilities:
+    # OpenRouter and Anthropic need reasoning_details preserved, while Groq
+    # and other strict routes reject it for non-reasoning models.  The turn
+    # loop strips only the API-call copies and retries once, leaving canonical
+    # history intact for a later switch back to a replay-capable model.
+    if (
+        status_code in {400, 422}
+        and "reasoning_details" in error_msg
+        and any(
+            marker in error_msg
+            for marker in (
+                "unsupported",
+                "not supported",
+                "extra inputs are not permitted",
+                "unknown field",
+                "unrecognized field",
+                "not permitted",
+            )
+        )
+    ):
+        return _result(
+            FailoverReason.reasoning_details_unsupported,
+            retryable=True,
+            should_compress=False,
+        )
+
     # Anthropic thinking block recovery (400).  Two distinct failure modes,
-    # same recovery (strip all reasoning_details and retry without thinking
-    # blocks — see the thinking_signature handler in conversation_loop.py):
+    # same request-copy recovery as above (strip all reasoning_details and
+    # retry without thinking blocks):
     #   1. Signature mismatch: a thinking block is signed against the full
     #      turn content; any upstream mutation (context compression, session
     #      truncation, message merging) invalidates the signature.

--- a/agent/reasoning_replay.py
+++ b/agent/reasoning_replay.py
@@ -1,0 +1,80 @@
+"""Session-local capability tracking for structured reasoning replay."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.backend_identity import (
+    BackendIdentity,
+    FailureScope,
+    should_skip_candidate,
+)
+
+
+def current_backend_identity(
+    agent: Any, *, model: Any = None
+) -> BackendIdentity:
+    """Build the normalized identity for the agent's active deployment."""
+    return BackendIdentity.build(
+        provider=getattr(agent, "provider", None),
+        model=getattr(agent, "model", None) if model is None else model,
+        base_url=getattr(agent, "base_url", None),
+    )
+
+
+def reasoning_details_rejected_for_current_backend(agent: Any) -> bool:
+    """Return whether this exact model deployment rejected replay metadata."""
+    candidate = current_backend_identity(agent)
+    rejected = getattr(agent, "_reasoning_details_rejected_backends", set())
+    return any(
+        should_skip_candidate(candidate, failed, FailureScope.MODEL)
+        for failed in rejected
+    )
+
+
+def remember_reasoning_details_rejection(
+    agent: Any, *, model: Any = None
+) -> tuple[BackendIdentity, bool]:
+    """Remember a schema rejection for the active model deployment.
+
+    Returns ``(identity, learned)`` where ``learned`` is false when an
+    equivalent deployment was already recorded.
+    """
+    identity = current_backend_identity(agent, model=model)
+    # A model-scoped negative capability is useful only when all three axes
+    # identify one concrete deployment.  Never create a wildcard-like entry
+    # that could suppress replay for an unrelated model or endpoint.
+    if not (identity.provider and identity.model and identity.base_url):
+        return identity, False
+    rejected = getattr(agent, "_reasoning_details_rejected_backends", None)
+    if rejected is None:
+        rejected = set()
+        agent._reasoning_details_rejected_backends = rejected
+    if any(
+        should_skip_candidate(identity, failed, FailureScope.MODEL)
+        for failed in rejected
+    ):
+        return identity, False
+    rejected.add(identity)
+    return identity, True
+
+
+def outbound_messages_contain_reasoning_details(api_kwargs: Any) -> bool:
+    """Check the actual outbound Chat Completions payload for the field."""
+    if not isinstance(api_kwargs, dict):
+        return False
+    messages = api_kwargs.get("messages")
+    if not isinstance(messages, list):
+        return False
+    return any(
+        isinstance(message, dict) and "reasoning_details" in message
+        for message in messages
+    )
+
+
+__all__ = [
+    "current_backend_identity",
+    "outbound_messages_contain_reasoning_details",
+    "reasoning_details_rejected_for_current_backend",
+    "remember_reasoning_details_rejection",
+]

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -368,6 +368,10 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - ``reasoning_details`` only when the caller has learned that the
+          active model deployment rejects structured reasoning replay. The
+          transport deliberately receives only this boolean capability
+          decision; it does not know about agent state or backend identity.
         - Hermes-internal scaffolding markers — any top-level message key
           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
@@ -382,6 +386,7 @@ class ChatCompletionsTransport(ProviderTransport):
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
         )
+        strip_reasoning_details = bool(kwargs.get("strip_reasoning_details"))
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
@@ -394,6 +399,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "timestamp" in msg  # #47868 — strict providers reject this
                 or "platform_message_id" in msg  # gateway dedup id (persistence-only)
                 or "api_content" in msg  # persist-what-you-send sidecar
+                or (strip_reasoning_details and "reasoning_details" in msg)
             ):
                 needs_sanitize = True
                 break
@@ -466,6 +472,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "timestamp" in msg  # #47868 — leak into strict providers
                 or "platform_message_id" in msg  # gateway dedup id (persistence-only)
                 or "api_content" in msg  # persist-what-you-send sidecar
+                or (strip_reasoning_details and "reasoning_details" in msg)
             ):
                 out_msg = mutable_msg()
                 out_msg.pop("codex_reasoning_items", None)
@@ -475,6 +482,8 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg.pop("timestamp", None)  # #47868 — leak into strict providers
                 out_msg.pop("platform_message_id", None)  # gateway dedup id
                 out_msg.pop("api_content", None)  # persist-what-you-send sidecar
+                if strip_reasoning_details:
+                    out_msg.pop("reasoning_details", None)
 
 
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
@@ -586,11 +595,17 @@ class ChatCompletionsTransport(ProviderTransport):
             extra_body_additions: dict | None
             supports_prompt_cache_key: bool — explicit endpoint capability for
                 the top-level Chat Completions request field; defaults off.
+            strip_reasoning_details: bool — deployment rejected structured
+                reasoning replay; remove it from request-local message copies.
         """
         # Codex sanitization: drop reasoning_items / call_id / response_item_id.
         # Pass model so the Gemini thought_signature (extra_content) is kept for
         # Gemini targets and stripped for strict non-Gemini providers.
-        sanitized = self.convert_messages(messages, model=model)
+        sanitized = self.convert_messages(
+            messages,
+            model=model,
+            strip_reasoning_details=bool(params.get("strip_reasoning_details")),
+        )
 
         # ── Provider profile: single-path when present ──────────────────
         _profile = params.get("provider_profile")

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -4,8 +4,8 @@ The inner retry loop in ``run_conversation`` (``while retry_count <
 max_retries``) makes several distinct recovery attempts on a single model API
 call: a credential-pool 429 retry, a per-provider OAuth refresh (codex,
 anthropic, nous, copilot), a long-context compression restart, a length-
-continuation restart, and a handful of format-recovery branches (thinking-
-signature stripping, multimodal-tool-content stripping, llama.cpp grammar
+continuation restart, and a handful of format-recovery branches (reasoning-
+details stripping, multimodal-tool-content stripping, llama.cpp grammar
 fallback, image shrink, invalid-encrypted-content, 1M-beta header).
 
 Each of those branches is guarded by a one-shot boolean so it fires at most
@@ -48,6 +48,8 @@ class TurnRetryState:
     vertex_auth_retry_attempted: bool = False
 
     # ── Format / payload recovery guards ─────────────────────────────────
+    # Shared by signed-thinking failures and explicit unsupported-property
+    # errors because both recover by stripping request-local reasoning_details.
     thinking_sig_retry_attempted: bool = False
     invalid_encrypted_content_retry_attempted: bool = False
     image_shrink_retry_attempted: bool = False

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -4,8 +4,8 @@ The inner retry loop in ``run_conversation`` (``while retry_count <
 max_retries``) makes several distinct recovery attempts on a single model API
 call: a credential-pool 429 retry, a per-provider OAuth refresh (codex,
 anthropic, nous, copilot), a long-context compression restart, a length-
-continuation restart, and a handful of format-recovery branches (thinking-
-signature stripping, multimodal-tool-content stripping, llama.cpp grammar
+continuation restart, and a handful of format-recovery branches (reasoning-
+details stripping, multimodal-tool-content stripping, llama.cpp grammar
 fallback, image shrink, invalid-encrypted-content, 1M-beta header).
 
 Each of those branches is guarded by a one-shot boolean so it fires at most
@@ -57,6 +57,9 @@ class TurnRetryState:
 
     # ── Format / payload recovery guards ─────────────────────────────────
     thinking_sig_retry_attempted: bool = False
+    # Separate from signed-thinking recovery: an unsupported-property retry
+    # records deployment capability and rebuilds through the transport.
+    reasoning_details_retry_attempted: bool = False
     invalid_encrypted_content_retry_attempted: bool = False
     native_compaction_reject_retry_attempted: bool = False
     image_shrink_retry_attempted: bool = False

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -67,7 +67,8 @@ class TestFailoverReason:
             "multimodal_tool_content_unsupported",
             "provider_policy_blocked",
             "content_policy_blocked",
-            "thinking_signature", "long_context_tier",
+            "thinking_signature", "reasoning_details_unsupported",
+            "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",
             "unknown",
@@ -671,6 +672,54 @@ class TestClassifyApiError:
     # ── Provider-specific: Anthropic thinking signature ──
 
 
+    @pytest.mark.parametrize("status_code", [400, 422])
+    @pytest.mark.parametrize(
+        "schema_rejection",
+        [
+            "property 'reasoning_details' is unsupported",
+            "Extra inputs are not permitted, field: reasoning_details",
+            "Extra inputs not permitted, field: reasoning_details",
+            "unknown property reasoning_details",
+        ],
+    )
+    def test_unsupported_reasoning_details_uses_replay_recovery(
+        self, status_code, schema_rejection
+    ):
+        e = MockAPIError(
+            f"'messages.2' : for 'role:assistant' {schema_rejection}",
+            status_code=status_code,
+        )
+        result = classify_api_error(e, provider="custom:groq")
+        assert result.reason == FailoverReason.reasoning_details_unsupported
+        assert result.retryable is False
+        assert result.should_compress is False
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "messages.2.reasoning_details must be an array",
+            "reasoning_details items must be objects",
+            "reasoning_details signature is invalid",
+        ],
+    )
+    def test_malformed_reasoning_details_is_not_treated_as_unsupported(
+        self, message
+    ):
+        e = MockAPIError(
+            message,
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.format_error
+
+    @pytest.mark.parametrize("status_code", [200, 401, 409, 429, 500])
+    def test_reasoning_details_schema_text_requires_400_or_422(self, status_code):
+        e = MockAPIError(
+            "property reasoning_details is unsupported",
+            status_code=status_code,
+        )
+        result = classify_api_error(e, provider="custom")
+        assert result.reason != FailoverReason.reasoning_details_unsupported
 
 
 
@@ -1578,5 +1627,3 @@ class TestServerInjectedParameterRejection:
         result = classify_api_error(e, provider="custom", model="m")
         assert result.reason == FailoverReason.format_error
         assert result.retryable is False
-
-

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -62,7 +62,8 @@ class TestFailoverReason:
             "multimodal_tool_content_unsupported",
             "provider_policy_blocked",
             "content_policy_blocked",
-            "thinking_signature", "long_context_tier",
+            "thinking_signature", "reasoning_details_unsupported",
+            "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",
             "unknown",
@@ -429,6 +430,25 @@ class TestClassifyApiError:
     # ── Provider-specific: Anthropic thinking signature ──
 
 
+    @pytest.mark.parametrize("status_code", [400, 422])
+    def test_unsupported_reasoning_details_uses_replay_recovery(self, status_code):
+        e = MockAPIError(
+            "'messages.2' : for 'role:assistant' property "
+            "'reasoning_details' is unsupported",
+            status_code=status_code,
+        )
+        result = classify_api_error(e, provider="custom:groq")
+        assert result.reason == FailoverReason.reasoning_details_unsupported
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_malformed_reasoning_details_is_not_treated_as_unsupported(self):
+        e = MockAPIError(
+            "messages.2.reasoning_details must be an array",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.format_error
 
 
 
@@ -1047,6 +1067,5 @@ class TestExpandedOverflowPatterns:
         )
         result = classify_api_error(e, provider="openrouter", model="m")
         assert result.reason == FailoverReason.context_overflow
-
 
 

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -22,6 +22,7 @@ EXPECTED_FIELDS = {
     "copilot_stale_cred_retry_attempted",
     "vertex_auth_retry_attempted",
     "thinking_sig_retry_attempted",
+    "reasoning_details_retry_attempted",
     "invalid_encrypted_content_retry_attempted",
     "native_compaction_reject_retry_attempted",
     "image_shrink_retry_attempted",

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -146,6 +146,58 @@ class TestChatCompletionsBasic:
         msgs = [{"role": "user", "content": "hi"}]
         assert transport.convert_messages(msgs) is msgs
 
+    def test_convert_messages_strips_reasoning_details_only_when_requested(
+        self, transport
+    ):
+        details = [
+            {
+                "type": "thinking",
+                "thinking": "private",
+                "signature": "signed",
+                "nested": {"keep": ["shared"]},
+            }
+        ]
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_details": details,
+            }
+        ]
+
+        unchanged = transport.convert_messages(
+            msgs, model="model-a", strip_reasoning_details=False
+        )
+        stripped = transport.convert_messages(
+            msgs, model="model-a", strip_reasoning_details=True
+        )
+
+        assert unchanged is msgs
+        assert stripped is not msgs
+        assert stripped[0] is not msgs[0]
+        assert "reasoning_details" not in stripped[0]
+        assert msgs[0]["reasoning_details"] is details
+        assert details[0]["nested"]["keep"] == ["shared"]
+
+    def test_build_kwargs_forwards_reasoning_details_strip_flag(self, transport):
+        details = [{"type": "thinking", "signature": "signed"}]
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_details": details,
+            }
+        ]
+
+        kwargs = transport.build_kwargs(
+            model="model-a",
+            messages=msgs,
+            strip_reasoning_details=True,
+        )
+
+        assert "reasoning_details" not in kwargs["messages"][0]
+        assert msgs[0]["reasoning_details"] is details
+
     def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
         """Hermes-internal ``_``-prefixed markers must never reach the wire.
 

--- a/tests/run_agent/test_reasoning_details_capability.py
+++ b/tests/run_agent/test_reasoning_details_capability.py
@@ -1,0 +1,409 @@
+"""Behavior coverage for deployment-scoped reasoning_details recovery."""
+
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.backend_identity import BackendIdentity
+from agent.reasoning_replay import remember_reasoning_details_rejection
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _tool_defs() -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def _make_agent(
+    *,
+    provider: str = "custom:strict",
+    model: str = "model-a",
+    base_url: str = "https://strict.example/v1",
+) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            provider=provider,
+            model=model,
+            base_url=base_url,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _history(details: list[dict] | None = None) -> list[dict]:
+    messages = [
+        {"role": "user", "content": "previous question"},
+        {"role": "assistant", "content": "previous answer"},
+    ]
+    if details is not None:
+        messages[1]["reasoning_details"] = details
+    return messages
+
+
+def _unsupported(status_code: int = 400) -> Exception:
+    error = Exception(
+        "Extra inputs are not permitted, field: messages[1].reasoning_details"
+    )
+    error.status_code = status_code
+    return error
+
+
+def _chunk(*, content=None, tool_calls=None, finish_reason=None):
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(model="test/model", choices=[choice])
+
+
+def _content_stream(text: str):
+    return iter([_chunk(content=text), _chunk(finish_reason="stop")])
+
+
+def _tool_stream():
+    function = SimpleNamespace(name="web_search", arguments="{}")
+    tool_call = SimpleNamespace(index=0, id="call_1", function=function)
+    return iter(
+        [
+            _chunk(tool_calls=[tool_call]),
+            _chunk(finish_reason="tool_calls"),
+        ]
+    )
+
+
+def _wire_has_reasoning_details(kwargs: dict) -> bool:
+    return any(
+        "reasoning_details" in message
+        for message in kwargs.get("messages", [])
+        if isinstance(message, dict)
+    )
+
+
+@pytest.mark.parametrize("status_code", [400, 422])
+def test_real_streaming_learns_once_across_user_turns(status_code):
+    agent = _make_agent()
+    agent.stream_delta_callback = MagicMock()
+    details = [
+        {"type": "thinking", "thinking": "private", "signature": "signed"}
+    ]
+    history = _history(details)
+    wire_payloads: list[dict] = []
+
+    def send(**kwargs):
+        wire_payloads.append(copy.deepcopy(kwargs))
+        assert kwargs.get("stream") is True
+        if len(wire_payloads) == 1:
+            raise _unsupported(status_code)
+        return _content_stream("first recovered" if len(wire_payloads) == 2 else "second turn")
+
+    agent.client.chat.completions.create.side_effect = send
+    with (
+        patch.object(agent, "_replace_primary_openai_client", return_value=False),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        first = agent.run_conversation("first", conversation_history=history)
+        second = agent.run_conversation(
+            "second", conversation_history=first["messages"]
+        )
+
+    assert first["completed"] is True
+    assert second["completed"] is True
+    assert len(wire_payloads) == 3
+    assert _wire_has_reasoning_details(wire_payloads[0])
+    assert not _wire_has_reasoning_details(wire_payloads[1])
+    assert not _wire_has_reasoning_details(wire_payloads[2])
+    assert history[1]["reasoning_details"] is details
+    assert any(
+        message.get("reasoning_details") is details
+        for message in first["messages"]
+    )
+    assert len(agent._reasoning_details_rejected_backends) == 1
+
+
+def test_tool_loop_followup_is_filtered_before_its_first_attempt():
+    agent = _make_agent()
+    agent.stream_delta_callback = MagicMock()
+    details = [{"type": "thinking", "signature": "signed"}]
+    wire_payloads: list[dict] = []
+
+    def send(**kwargs):
+        wire_payloads.append(copy.deepcopy(kwargs))
+        assert kwargs.get("stream") is True
+        if len(wire_payloads) == 1:
+            raise _unsupported(400)
+        if len(wire_payloads) == 2:
+            return _tool_stream()
+        return _content_stream("done")
+
+    agent.client.chat.completions.create.side_effect = send
+    with (
+        patch.object(agent, "_replace_primary_openai_client", return_value=False),
+        patch("run_agent.handle_function_call", return_value="search result"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            "next", conversation_history=_history(details)
+        )
+
+    assert result["completed"] is True
+    assert len(wire_payloads) == 3
+    assert _wire_has_reasoning_details(wire_payloads[0])
+    assert all(
+        not _wire_has_reasoning_details(payload)
+        for payload in wire_payloads[1:]
+    )
+
+
+def test_recovery_preserves_returned_history_and_state_db(tmp_path):
+    agent = _make_agent()
+    agent._disable_streaming = True
+    details = [
+        {
+            "type": "thinking",
+            "thinking": "private",
+            "signature": "signed",
+            "nested": {"opaque": ["value"]},
+        }
+    ]
+    history = _history(details)
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(
+        session_id="reasoning-replay-session",
+        source="cli",
+        model=agent.model,
+    )
+    # The reasoning-bearing assistant row belongs to the prior turn and would
+    # already be durable when this recovery runs.  Seed that real resume shape
+    # so the assertion proves the retry path cannot erase it from state.db.
+    db.replace_messages("reasoning-replay-session", history)
+    agent._session_db = db
+    agent._session_db_created = True
+    agent.session_id = "reasoning-replay-session"
+    agent._last_flushed_db_idx = len(history)
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._persist_disabled = False
+
+    recovered = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="recovered", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        model="test/model",
+        usage=None,
+    )
+    agent.client.chat.completions.create.side_effect = [_unsupported(400), recovered]
+
+    try:
+        with (
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "next", conversation_history=history
+            )
+
+        durable = db.get_messages_as_conversation(agent.session_id)
+    finally:
+        db.close()
+
+    assert result["completed"] is True
+    assert history[1]["reasoning_details"] is details
+    assert any(
+        message.get("reasoning_details") is details
+        for message in result["messages"]
+    )
+    persisted = next(
+        message for message in durable if message.get("reasoning_details")
+    )
+    assert persisted["reasoning_details"] == details
+    assert persisted["reasoning_details"][0]["nested"] == {"opaque": ["value"]}
+
+
+def test_model_and_explicit_endpoint_identity_scope():
+    endpoint_a = "HTTPS://STRICT.EXAMPLE/v1/"
+    agent = _make_agent(model="model-a", base_url=endpoint_a)
+    agent._disable_streaming = True
+    details = [{"type": "thinking", "signature": "signed"}]
+    history = _history(details)
+    recovered = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="ok", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        model="test/model",
+        usage=None,
+    )
+    agent.client.chat.completions.create.side_effect = [_unsupported(400), recovered]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("next", conversation_history=history)
+
+    assert result["completed"] is True
+    assert agent._reasoning_details_rejected_backends == {
+        BackendIdentity.build(
+            provider="custom:strict",
+            model="model-a",
+            base_url=endpoint_a,
+        )
+    }
+
+    agent.model = "model-b"
+    model_b = agent._build_api_kwargs(history)
+    assert _wire_has_reasoning_details(model_b)
+
+    agent.model = "model-a"
+    agent.base_url = "https://strict.example/v1"
+    model_a_again = agent._build_api_kwargs(history)
+    assert not _wire_has_reasoning_details(model_a_again)
+
+    agent.base_url = "https://other.example/v1"
+    other_endpoint = agent._build_api_kwargs(history)
+    assert _wire_has_reasoning_details(other_endpoint)
+
+
+def test_incomplete_backend_identity_is_not_recorded():
+    agent = _make_agent(model="")
+
+    identity, learned = remember_reasoning_details_rejection(agent)
+
+    assert identity.model == ""
+    assert learned is False
+    assert agent._reasoning_details_rejected_backends == set()
+
+
+def test_openrouter_signed_replay_keeps_reasoning_details():
+    agent = _make_agent(
+        provider="openrouter",
+        model="anthropic/claude-sonnet-4",
+        base_url="https://openrouter.ai/api/v1",
+    )
+    details = [{"type": "thinking", "thinking": "plan", "signature": "signed"}]
+    messages = _history(details)
+
+    kwargs = agent._build_api_kwargs(messages)
+
+    assert _wire_has_reasoning_details(kwargs)
+    assert messages[1]["reasoning_details"] is details
+
+
+def test_nous_signed_replay_keeps_anthropic_thinking_block():
+    agent = _make_agent(
+        provider="nous",
+        model="anthropic/claude-sonnet-4",
+        base_url="https://inference-api.nousresearch.com/v1",
+    )
+    details = [{"type": "thinking", "thinking": "plan", "signature": "signed"}]
+    messages = _history(details)
+
+    kwargs = agent._build_api_kwargs(messages)
+
+    assistant = next(
+        message for message in kwargs["messages"] if message["role"] == "assistant"
+    )
+    assert assistant["content"][0] == details[0]
+    assert messages[1]["reasoning_details"] is details
+
+
+def test_anthropic_signed_replay_conversion_is_unchanged():
+    from agent.anthropic_adapter import convert_messages_to_anthropic
+
+    details = [{"type": "thinking", "thinking": "plan", "signature": "signed"}]
+    messages = _history(details)
+
+    _system, converted = convert_messages_to_anthropic(
+        messages,
+        base_url=None,
+        model="claude-opus-4-8",
+    )
+
+    assistant = next(message for message in converted if message["role"] == "assistant")
+    thinking = [
+        block
+        for block in assistant["content"]
+        if isinstance(block, dict) and block.get("type") == "thinking"
+    ]
+    assert thinking == details
+    assert messages[1]["reasoning_details"] is details
+
+
+def test_max_iteration_summary_reuses_learned_filter():
+    agent = _make_agent()
+    agent._disable_streaming = True
+    details = [{"type": "thinking", "signature": "signed"}]
+    messages = _history(details)
+    identity, learned = remember_reasoning_details_rejection(agent)
+    assert learned is True
+    assert identity in agent._reasoning_details_rejected_backends
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="summary", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        model="test/model",
+        usage=None,
+    )
+    agent.client.chat.completions.create.return_value = response
+
+    result = agent._handle_max_iterations(messages, 60)
+
+    assert result == "summary"
+    sent = agent.client.chat.completions.create.call_args.kwargs
+    assert not _wire_has_reasoning_details(sent)
+    assert messages[1]["reasoning_details"] is details
+
+
+def test_error_text_without_field_on_wire_does_not_learn_or_retry():
+    agent = _make_agent()
+    agent._disable_streaming = True
+    history = _history()
+    agent.client.chat.completions.create.side_effect = _unsupported(400)
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("next", conversation_history=history)
+
+    assert result["completed"] is False
+    assert agent.client.chat.completions.create.call_count == 1
+    assert agent._reasoning_details_rejected_backends == set()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4285,6 +4285,60 @@ class TestRunConversation:
         assert result["final_response"] == "Recovered after compression"
         assert result["completed"] is True
 
+    def test_unsupported_reasoning_details_retries_without_mutating_history(self, agent):
+        """A strict target gets a stripped retry while canonical history stays signed."""
+        self._setup_agent(agent)
+        agent.provider = "custom:groq"
+        agent.model = "strict-model"
+        reasoning_details = [
+            {"type": "thinking", "thinking": "private", "signature": "signed"}
+        ]
+        history = [
+            {"role": "user", "content": "previous question"},
+            {
+                "role": "assistant",
+                "content": "previous answer",
+                "reasoning_details": reasoning_details,
+            },
+        ]
+        unsupported = Exception(
+            "'messages.2' property 'reasoning_details' is unsupported"
+        )
+        unsupported.status_code = 400
+        recovered = _mock_response(content="Recovered", finish_reason="stop")
+        wire_payloads = []
+
+        def send(**kwargs):
+            wire_payloads.append(json.loads(json.dumps(kwargs["messages"])))
+            if len(wire_payloads) == 1:
+                raise unsupported
+            return recovered
+
+        agent.client.chat.completions.create.side_effect = send
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "next question", conversation_history=history
+            )
+
+        calls = agent.client.chat.completions.create.call_args_list
+        first_wire, retry_wire = wire_payloads
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered"
+        assert len(calls) == 2
+        assert any("reasoning_details" in message for message in first_wire)
+        assert all("reasoning_details" not in message for message in retry_wire)
+        assert history[1]["reasoning_details"] is reasoning_details
+        assert any(
+            message.get("reasoning_details") is reasoning_details
+            for message in result["messages"]
+        )
+
 
 
     def test_length_finish_reason_requests_continuation(self, agent):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3481,6 +3481,59 @@ class TestRunConversation:
         assert result["final_response"] == "Recovered after compression"
         assert result["completed"] is True
 
+    def test_unsupported_reasoning_details_retries_without_mutating_history(self, agent):
+        """A strict target gets a stripped retry while canonical history stays signed."""
+        self._setup_agent(agent)
+        agent.provider = "custom:groq"
+        reasoning_details = [
+            {"type": "thinking", "thinking": "private", "signature": "signed"}
+        ]
+        history = [
+            {"role": "user", "content": "previous question"},
+            {
+                "role": "assistant",
+                "content": "previous answer",
+                "reasoning_details": reasoning_details,
+            },
+        ]
+        unsupported = Exception(
+            "'messages.2' property 'reasoning_details' is unsupported"
+        )
+        unsupported.status_code = 400
+        recovered = _mock_response(content="Recovered", finish_reason="stop")
+        wire_payloads = []
+
+        def send(**kwargs):
+            wire_payloads.append(json.loads(json.dumps(kwargs["messages"])))
+            if len(wire_payloads) == 1:
+                raise unsupported
+            return recovered
+
+        agent.client.chat.completions.create.side_effect = send
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "next question", conversation_history=history
+            )
+
+        calls = agent.client.chat.completions.create.call_args_list
+        first_wire, retry_wire = wire_payloads
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered"
+        assert len(calls) == 2
+        assert any("reasoning_details" in message for message in first_wire)
+        assert all("reasoning_details" not in message for message in retry_wire)
+        assert history[1]["reasoning_details"] is reasoning_details
+        assert any(
+            message.get("reasoning_details") is reasoning_details
+            for message in result["messages"]
+        )
+
 
 
     def test_length_finish_reason_requests_continuation(self, agent):
@@ -5712,5 +5765,3 @@ class TestMemoryContextSanitization:
         assert "memory-context" not in result.lower()
         assert "stale observation" not in result
         assert "how is the honcho working" in result
-
-

--- a/tests/run_agent/test_thinking_sig_recovery_persistence.py
+++ b/tests/run_agent/test_thinking_sig_recovery_persistence.py
@@ -1,8 +1,8 @@
-"""Regression tests for the thinking-block signature recovery.
+"""Regression tests for request-local reasoning-details recovery.
 
-The recovery in ``agent/conversation_loop.py`` strips ``reasoning_details``
-from ``api_messages`` (the API-call-time list rebuilt on every retry) and
-leaves ``messages`` (the canonical store) untouched. The previous
+The recovery used by ``agent/conversation_loop.py`` strips
+``reasoning_details`` from ``api_messages`` (the API-call-time list rebuilt on
+every retry) and leaves ``messages`` (the canonical store) untouched. The previous
 implementation popped from ``messages`` directly, which never reached
 ``api_messages`` because each entry in ``api_messages`` was a shallow
 copy of the corresponding entry in ``messages``, and the mutation also
@@ -20,12 +20,18 @@ def _shallow_copies(messages):
     return [m.copy() for m in messages]
 
 
+def _strip(api_messages):
+    from agent.agent_runtime_helpers import strip_reasoning_details_from_api_messages
+
+    return strip_reasoning_details_from_api_messages(api_messages)
+
+
 def test_pop_on_shallow_copy_does_not_affect_source():
     rd = [{"type": "thinking", "thinking": "r", "signature": "s"}]
     src = {"role": "assistant", "content": "x", "reasoning_details": rd}
     cp = src.copy()
 
-    cp.pop("reasoning_details", None)
+    assert _strip([cp]) == 1
 
     assert "reasoning_details" not in cp
     assert "reasoning_details" in src
@@ -48,11 +54,7 @@ def test_strip_api_messages_leaves_canonical_messages_intact():
     ]
     api_messages = _shallow_copies(messages)
 
-    stripped = 0
-    for m in api_messages:
-        if isinstance(m, dict) and "reasoning_details" in m:
-            m.pop("reasoning_details", None)
-            stripped += 1
+    stripped = _strip(api_messages)
 
     assert stripped == 2
     assert all("reasoning_details" not in m for m in api_messages)
@@ -70,10 +72,8 @@ def test_strip_is_idempotent_when_run_twice():
         {"role": "assistant", "content": "a", "reasoning_details": [{"x": 1}]},
         {"role": "user", "content": "q"},
     ]
-    for _ in range(2):
-        for m in api_messages:
-            if isinstance(m, dict) and "reasoning_details" in m:
-                m.pop("reasoning_details", None)
+    assert _strip(api_messages) == 1
+    assert _strip(api_messages) == 0
 
     assert all("reasoning_details" not in m for m in api_messages)
 
@@ -86,8 +86,6 @@ def test_strip_skips_messages_without_reasoning_details():
     ]
     snapshot = [dict(m) for m in api_messages]
 
-    for m in api_messages:
-        if isinstance(m, dict) and "reasoning_details" in m:
-            m.pop("reasoning_details", None)
+    assert _strip(api_messages) == 0
 
     assert api_messages == snapshot


### PR DESCRIPTION
## What does this PR do?

Fixes sessions that become permanently wedged when a strict Chat Completions deployment rejects replayed `reasoning_details`.

Hermes intentionally keeps signed `reasoning_details` in canonical history for OpenRouter, Nous, Anthropic, and other compatible deployments. The original version of this PR could detect an explicit HTTP 400/422 schema rejection and strip the current request-local `api_messages`, but the Aug 4 report showed the remaining gap: streaming, the next tool-loop API iteration, and the next user turn rebuild the wire payload from canonical history and re-inject the field, causing the same rejection again.

This revision learns a negative replay capability for the exact model deployment for the lifetime of the current `AIAgent`. Once that deployment rejects the field, every later Chat Completions request—including streaming, tool-loop iterations, later turns, and the max-iterations summary request—is filtered before its first send. Canonical messages, returned history, and `state.db` keep the signed metadata unchanged.

## Related Issue

Fixes #70233

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- classify only HTTP 400/422 responses that name `reasoning_details` and contain explicit unsupported/unknown/extra-input schema rejection language; malformed-value errors such as “must be an array” remain ordinary format errors
- confirm the actual failed outbound `api_kwargs["messages"]` contained `reasoning_details` before learning a capability or retrying
- store session-local rejected deployments in `AIAgent._reasoning_details_rejected_backends`
- build normalized identities with `BackendIdentity.build()` and compare them with `should_skip_candidate(..., FailureScope.MODEL)`, preserving provider + normalized endpoint + model isolation
- use a dedicated `TurnRetryState.reasoning_details_retry_attempted` guard, separate from signed-thinking recovery
- have the agent’s Chat Completions build path compute a boolean capability decision and pass it to `ChatCompletionsTransport`
- make the transport perform only boolean-driven, copy-on-write removal; it does not read `AIAgent` or understand backend identity
- apply the same capability decision to `handle_max_iterations()`, which otherwise bypasses the normal transport build path
- preserve replay behavior for OpenRouter, Nous, and Anthropic-compatible signed thinking
- add no provider allowlist, config, environment variable, persistence schema, or permanent history mutation

A static endpoint/provider allowlist was deliberately avoided. Whether replay is accepted is a property of a specific model deployment and can differ between two models on the same endpoint or the same model on two explicit endpoints. Learning from the deployment’s actual schema rejection keeps compatible routes working and avoids broad, stale assumptions.

## How to Test

```bash
scripts/run_tests.sh   tests/agent/test_backend_identity.py   tests/agent/test_error_classifier.py   tests/agent/test_turn_retry_state.py   tests/agent/transports/test_chat_completions.py   tests/agent/test_anthropic_adapter.py   tests/agent/test_anthropic_kimi_signed_thinking_replay.py   tests/agent/test_anthropic_thinking_block_order.py   tests/run_agent/test_run_agent.py   tests/run_agent/test_provider_parity.py   tests/run_agent/test_reasoning_details_capability.py   tests/run_agent/test_thinking_sig_recovery_persistence.py -q

scripts/run_tests.sh tests/agent/transports tests/agent/test_api_content_sidecar.py tests/run_agent -q
python3 scripts/check-windows-footguns.py --diff upstream/main
git diff --check upstream/main..HEAD
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open, closed, and merged issues/PRs for duplicates, including #64296, #65983, and #70107
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added behavior-focused regression tests
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; internal recovery only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Verification

Rebased onto current `upstream/main` `4a9411cf7f`; PR head `c2bf19cfd97fcbd8169896edd182a76dfa193ee1`.

- focused recovery/component selection: 6 files, 24 passed
- CI slice-5 failure regression selection (summary sidecar + reasoning paths): 3 files, 23 passed
- complete directly related files: 11 files, 591 passed
- broader affected surface (`tests/agent/transports` + `tests/agent/test_api_content_sidecar.py` + `tests/run_agent`): 189 files, 1,952 passed, 0 failed, 5 Windows-only tests skipped on macOS
- Python byte compilation for every changed Python file: passed
- Windows footgun check: passed (14 changed files scanned)
- `git diff --check upstream/main..HEAD`: passed
- [CI run 31929290592](https://github.com/NousResearch/hermes-agent/actions/runs/31929290592): all required checks passed, including 12/12 Python slices, Windows/macOS, lint, e2e, and supply-chain gates
- [Docker run 31929290314](https://github.com/NousResearch/hermes-agent/actions/runs/31929290314): amd64 and arm64 builds passed

Coverage includes real streaming (`stream=True`) for both 400 and 422, consecutive user turns, a tool-call loop, model and endpoint isolation, no-field/no-retry behavior, copy-on-write preservation of canonical/returned/SQLite history, OpenRouter/Nous/Anthropic signed replay compatibility, and the max-iterations summary bypass.

Live OpenCodeGo/Groq API validation was not performed; the regression tests reproduce the reported HTTP schema responses through the real conversation loop and streaming branch. Capability knowledge is intentionally session-local, so a reconstructed agent or gateway restart may probe once again and then recover automatically.