### PR TITLE
fix(anthropic): don't crash when an assistant message has tool_calls=None

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2012,7 +2012,15 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
                 blocks.extend(converted_content)
         else:
             blocks.append({"type": "text", "text": str(content)})
-    for tc in m.get("tool_calls", []):
+    # ``or []`` mirrors the sibling loop above (~L1978): ``.get("tool_calls",
+    # [])`` returns None — not the default — when the key is PRESENT with a
+    # null value, which happens for tool-less assistant rows (``get_messages``
+    # surfaces the SQL NULL as ``dict(row)["tool_calls"] = None``, and
+    # ``auxiliary_client``/``bedrock_adapter`` build messages with
+    # ``tool_calls=... or None``). Without the guard, ``for tc in None`` raises
+    # ``TypeError: 'NoneType' object is not iterable`` and the whole Anthropic
+    # request build fails.
+    for tc in m.get("tool_calls", []) or []:
         if not tc or not isinstance(tc, dict):
             continue
         fn = tc.get("function", {})

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -864,6 +864,29 @@ class TestConvertTools:
 
 
 class TestConvertMessages:
+    def test_assistant_with_null_tool_calls_does_not_crash(self):
+        """A present-but-null ``tool_calls`` must not crash the conversion.
+
+        ``.get("tool_calls", [])`` returns ``None`` (not the default) when the
+        key exists with a null value — the shape ``get_messages`` surfaces for
+        a tool-less assistant row (SQL NULL → ``dict(row)["tool_calls"] = None``)
+        and that ``auxiliary_client``/``bedrock_adapter`` build via
+        ``tool_calls=... or None``. Before the guard, ``for tc in None`` raised
+        ``TypeError: 'NoneType' object is not iterable`` and the whole Anthropic
+        request build failed. The sibling replay loop already guards this.
+        """
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "Here is my answer.", "tool_calls": None},
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        assert result[-1]["role"] == "assistant"
+        assert result[-1]["content"] == [
+            {"type": "text", "text": "Here is my answer."}
+        ]
+
     def test_extracts_system_prompt(self):
         messages = [
             {"role": "system", "content": "You are helpful."},


### PR DESCRIPTION
## What

`_convert_assistant_message` iterates `m.get("tool_calls", [])`. `.get(key, default)` returns the default only when the key is **absent** — a key present with a **null** value returns `None`. So an assistant message shaped `{"role": "assistant", "content": ..., "tool_calls": None}` makes the loop `for tc in None`, raising `TypeError: 'NoneType' object is not iterable` and failing the whole Anthropic request build.

That shape is produced in-tree: `get_messages` surfaces a tool-less assistant row's SQL `NULL` as `dict(row)["tool_calls"] = None`, and `auxiliary_client` / `bedrock_adapter` build messages via `tool_calls=... or None`. The **sibling** replay loop ~12 lines above (~L1978) already guards this exact shape with `or []`; the fallback loop at ~L2015 was left unguarded.

```
{"role": "assistant", "content": "...", "tool_calls": None}
before: TypeError: 'NoneType' object is not iterable
after : converts cleanly (assistant text, no tool_use blocks)
```

## Fix

`m.get("tool_calls", []) or []`, matching the sibling — a present-null `tool_calls` now behaves like an absent one.

## Tests

`tests/agent/test_anthropic_adapter.py` — new test feeding a present-null `tool_calls`; it fails on `main` with the `TypeError` and passes with the guard. Full adapter suite: 182 passed, 1 skipped. Tested on Ubuntu 24.04.