### PR TITLE
fix(cron): disable delegation toolset for cron sessions (#70294)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -156,17 +156,19 @@ class CronPromptInjectionBlocked(Exception):
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
-    Three protected toolsets are always disabled in cron context:
+    Four protected toolsets are always disabled in cron context:
       - ``cronjob`` — would let a cron-spawned agent schedule more cron jobs
       - ``messaging`` — interactive, needs a live gateway session
       - ``clarify`` — interactive, blocks waiting for user input
+      - ``delegation`` — results are silently dropped because cron sessions
+        have no routing metadata to deliver results back
 
     User-level ``agent.disabled_toolsets`` from config.yaml is layered on top
     so per-job ``enabled_toolsets`` cannot bypass policy that applies to
     ordinary agent runs (#25752 — LLM-supplied enabled_toolsets was widening
     past config.yaml's denylist).
     """
-    disabled = ["cronjob", "messaging", "clarify"]
+    disabled = ["cronjob", "messaging", "clarify", "delegation"]
     agent_cfg = (cfg or {}).get("agent") or {}
     user_disabled = agent_cfg.get("disabled_toolsets") or []
     for name in user_disabled:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1473,7 +1473,7 @@ class TestRunJobSessionPersistence:
         LLM-supplied cronjob() call re-enable tools the operator had globally
         disabled. The fix: ALWAYS include agent.disabled_toolsets in the
         disabled_toolsets passed to AIAgent, on top of the cron baseline
-        (cronjob/messaging/clarify). AIAgent's disabled_toolsets takes
+        (cronjob/messaging/clarify/delegation). AIAgent's disabled_toolsets takes
         precedence over enabled_toolsets, so this stops the bypass.
         """
         (tmp_path / "config.yaml").write_text(
@@ -1496,6 +1496,29 @@ class TestRunJobSessionPersistence:
         assert set(kwargs["disabled_toolsets"]) >= {
             "cronjob", "messaging", "clarify", "terminal", "file",
         }
+
+    def test_cron_baseline_disabled_toolsets_includes_delegation(self, tmp_path):
+        """``delegation`` must be in the cron baseline disabled toolsets — issue #70294.
+
+        delegate_task results are silently dropped in cron sessions because
+        cron sessions have no routing metadata (no gateway session, no origin
+        thread). Adding ``delegation`` to the baseline ensures the tool can
+        never be called in a cron context, preventing false-positive ``ok``
+        runs where the model delegates work and only returns narration.
+        """
+        job = {
+            "id": "delegation-check",
+            "name": "test",
+            "prompt": "hello",
+        }
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        disabled = kwargs.get("disabled_toolsets") or []
+        assert "delegation" in disabled, (
+            f"Expected 'delegation' in cron disabled_toolsets, got {disabled}"
+        )
 
     def test_run_job_enabled_toolsets_resolves_from_platform_config_when_not_set(self, tmp_path):
         """When a job has no explicit enabled_toolsets, the scheduler now


### PR DESCRIPTION
## Summary

Fixes #70294

`delegate_task` results are silently dropped in cron sessions because cron sessions have no gateway routing metadata to deliver results back. The model's delegation creates orphaned subagents whose results are discarded, while the parent turn ends with only narration text. The scheduler then marks the job as `ok` — a silent failure.

## Fix

Add `"delegation"` to the cron baseline disabled toolsets in `_resolve_cron_disabled_toolsets()`, alongside the existing `cronjob`, `messaging`, and `clarify` entries. This ensures `delegate_task` can never be called in a cron context.

This was suggested as **option 1** in the issue's list of suggested fixes.

## Changes

- **`cron/scheduler.py`**: Added `"delegation"` to the baseline disabled toolsets list and updated the docstring to explain why
- **`tests/cron/test_scheduler.py`**: Added `test_cron_baseline_disabled_toolsets_includes_delegation` test that validates `delegation` is in the disabled_toolsets passed to `AIAgent` for cron jobs; updated existing test docstring to mention delegation