### PR TITLE
feat(desktop): ship sourcemaps + add debug trace instrumentation

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10863,6 +10863,18 @@ ipcMain.handle('hermes:logs:reveal', async () => {
 
 ipcMain.handle('hermes:logs:recent', async () => ({ path: DESKTOP_LOG_PATH, lines: hermesLog.slice(-200) }))
 
+// Renderer console forwarding: the renderer monkey-patches console.* to send
+// each call here. We format and route through rememberLog() so they land in
+// desktop.log alongside the main process's own [hermes] lines.
+ipcMain.on('hermes:console:forward', (_event, { level, message }) => {
+  const tag = level === 'error' ? '[renderer:error]'
+    : level === 'warn' ? '[renderer:warn]'
+    : level === 'info' ? '[renderer:info]'
+    : '[renderer:debug]'
+
+  rememberLog(`${tag} ${message}`)
+})
+
 function isExecutableFile(filePath) {
   if (!filePath || !path.isAbsolute(filePath)) {
     return false

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -161,6 +161,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   },
   revealLogs: () => ipcRenderer.invoke('hermes:logs:reveal'),
   getRecentLogs: () => ipcRenderer.invoke('hermes:logs:recent'),
+  forwardConsole: (level, message) => ipcRenderer.send('hermes:console:forward', { level, message }),
   readDir: dirPath => ipcRenderer.invoke('hermes:fs:readDir', dirPath),
   gitRoot: startPath => ipcRenderer.invoke('hermes:fs:gitRoot', startPath),
   revealPath: targetPath => ipcRenderer.invoke('hermes:fs:reveal', targetPath),

--- a/apps/desktop/scripts/bundle-electron-main.mjs
+++ b/apps/desktop/scripts/bundle-electron-main.mjs
@@ -42,6 +42,7 @@ await build({
   target: 'node20',
   outfile: mainOut,
   external,
+  sourcemap: true,
   banner: {
     js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
   },
@@ -59,6 +60,7 @@ await build({
   target: 'node20',
   outfile: preloadOut,
   external,
+  sourcemap: true,
   define,
   logLevel: 'info',
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -11,6 +11,7 @@ import { translateNow } from '@/i18n'
 import { type GatewayEventPayload, textPart } from '@/lib/chat-messages'
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { playCompletionSound } from '@/lib/completion-sound'
+import { debugTrace } from '@/lib/debug-trace'
 import { resolveGatewayEventSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
@@ -46,6 +47,7 @@ import {
   $currentCwd,
   $currentModel,
   $currentProvider,
+  $messages,
   sessionMatchesStoredId,
   setCurrentBranch,
   setCurrentCwd,
@@ -699,6 +701,17 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         if (!sessionId) {
           return
         }
+
+        debugTrace(
+          'message',
+          `complete session=${sessionId}`,
+          {
+            isActive: isActiveEvent,
+            messageCount: $messages.get().length,
+            hasUsage: Boolean(payload?.usage),
+            hasBilling: Boolean(payload?.billing)
+          }
+        )
 
         // Turn ended — drop any blocking prompt still open for THIS session
         // (e.g. interrupted, or the approval already resolved). Scoped to the

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { getElevenLabsVoices, getHermesConfigSchema, saveHermesConfig } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { $debugTraceEnabled, setDebugTraceEnabled } from '@/lib/debug-trace'
 import { triggerHaptic } from '@/lib/haptics'
 import {
   $dataUrlReadMaxMb,
@@ -69,6 +70,7 @@ export function ConfigSettings({
   const { t } = useI18n()
   const c = t.settings.config
   const keepAwake = useStore($keepAwake)
+  const debugTraceEnabled = useStore($debugTraceEnabled)
   // The editable draft is local (debounced autosave watches it), but it's seeded
   // from — and saved back through — the shared config cache, so edits are visible
   // in the MCP/model surfaces and reopening the page doesn't reload-flash.
@@ -315,6 +317,9 @@ export function ConfigSettings({
           />
           <QuickEntrySettings />
         </>
+      )}
+      {activeSectionId === 'advanced' && (
+        <ToggleRow checked={debugTraceEnabled} description={c.debugTraceDesc} label={c.debugTraceTitle} onChange={setDebugTraceEnabled} />
       )}
       {/* Device-local attach/preview byte cap (main-process IPC guard). Chat is
           where image-attachment behavior already lives, so this sits above the

--- a/apps/desktop/src/components/error-boundary.tsx
+++ b/apps/desktop/src/components/error-boundary.tsx
@@ -3,6 +3,7 @@ import { Component, type ErrorInfo, type ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { ErrorState } from '@/components/ui/error-state'
 import { useI18n } from '@/i18n'
+import { debugTrace } from '@/lib/debug-trace'
 
 export interface ErrorBoundaryFallbackProps {
   error: Error
@@ -30,6 +31,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   componentDidCatch(error: Error, info: ErrorInfo) {
     const tag = this.props.label ? `[error-boundary:${this.props.label}]` : '[error-boundary]'
     console.error(tag, error, info.componentStack)
+    debugTrace('error-boundary', `${this.props.label ?? 'root'}: ${error.message}`, {
+      error,
+      componentStack: info.componentStack
+    })
     this.props.onError?.(error, info)
   }
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -164,6 +164,7 @@ declare global {
       }
       revealLogs: () => Promise<{ ok: boolean; path: string; error?: string }>
       getRecentLogs: () => Promise<{ path: string; lines: string[] }>
+      forwardConsole: (level: string, message: string) => void
       readDir: (path: string) => Promise<HermesReadDirResult>
       gitRoot?: (path: string) => Promise<string | null>
       // Reveal a path in the OS file manager (Finder / Explorer).

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -567,7 +567,9 @@ export const en: Translations = {
       attachmentSizeDesc:
         'How big a local file Desktop will load for previews and image attach, in MB. Default is 16. Remote non-image attach uses a separate 256 MB cap. Setting this very high loads the whole file into memory and can freeze or crash the app.',
       attachmentSizeUnit: 'MB',
-      attachmentSizeLabel: 'Max preview / image load size in megabytes'
+      attachmentSizeLabel: 'Max preview / image load size in megabytes',
+      debugTraceTitle: 'Debug trace logging',
+      debugTraceDesc: 'Log verbose state transitions, session switches, compaction events, and gateway events to the devtools console for bug reproduction.'
     },
     quickEntry: {
       enabledTitle: 'Quick Entry',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -661,7 +661,9 @@ export const ja = defineLocale({
       imported: '設定をインポートしました',
       invalidJson: '設定 JSON が無効です',
       keepAwakeTitle: 'コンピューターをスリープさせない',
-      keepAwakeDesc: '本体のスリープを防ぎ、長時間や夜通しの実行を継続します。画面は暗転できます。'
+      keepAwakeDesc: '本体のスリープを防ぎ、長時間や夜通しの実行を継続します。画面は暗転できます。',
+      debugTraceTitle: 'デバッグトレースログ',
+      debugTraceDesc: 'バグ再現用に、状態遷移・セッション切替・圧縮イベント・ゲートウェイイベントをdevtoolsコンソールに詳細出力します。'
     },
     quickEntry: {
       enabledTitle: 'クイック入力',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -466,10 +466,12 @@ export interface Translations {
       invalidJson: string
       keepAwakeTitle: string
       keepAwakeDesc: string
-      attachmentSizeTitle: string
-      attachmentSizeDesc: string
-      attachmentSizeUnit: string
-      attachmentSizeLabel: string
+      attachmentSizeTitle: string;
+      attachmentSizeDesc: string;
+      attachmentSizeUnit: string;
+      attachmentSizeLabel: string;
+      debugTraceTitle: string;
+      debugTraceDesc: string
     }
     quickEntry: {
       enabledTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -648,7 +648,9 @@ export const zhHant = defineLocale({
       imported: '設定已匯入',
       invalidJson: '設定 JSON 無效',
       keepAwakeTitle: '保持電腦喚醒',
-      keepAwakeDesc: '阻止本機睡眠，讓長時間或整夜執行持續進行。螢幕仍可變暗。'
+      keepAwakeDesc: '阻止本機睡眠，讓長時間或整夜執行持續進行。螢幕仍可變暗。',
+      debugTraceTitle: '除錯追蹤日誌',
+      debugTraceDesc: '將狀態轉換、工作階段切換、壓縮事件和閘道事件詳細輸出到 devtools 控制台，用於重現 bug。'
     },
     quickEntry: {
       enabledTitle: '快速輸入',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -777,7 +777,9 @@ export const zh: Translations = {
       attachmentSizeDesc:
         '桌面端为预览和图片附件加载本地文件的大小上限（MB）。默认为 16。远程非图片附件使用单独的 256 MB 上限。设置过大会将整个文件读入内存，可能导致应用卡死或崩溃。',
       attachmentSizeUnit: 'MB',
-      attachmentSizeLabel: '预览 / 图片加载大小上限（MB）'
+      attachmentSizeLabel: '预览 / 图片加载大小上限（MB）',
+      debugTraceTitle: '调试追踪日志',
+      debugTraceDesc: '将状态转换、会话切换、压缩事件和网关事件详细输出到 devtools 控制台，用于复现 bug。'
     },
     quickEntry: {
       enabledTitle: '快速输入',

--- a/apps/desktop/src/lib/console-forward.ts
+++ b/apps/desktop/src/lib/console-forward.ts
@@ -1,0 +1,89 @@
+/**
+ * Console forwarder — mirrors renderer console.* calls into desktop.log via
+ * IPC. Always on: every console.log/warn/error/info/debug call is forwarded
+ * to the main process, which writes it through rememberLog() so it lands in
+ * desktop.log alongside the main process's own [hermes] lines.
+ *
+ * Objects/arrays are JSON-serialized (best-effort); non-serializable values
+ * fall back to their toString(). Multiple args are space-joined. This is a
+ * one-way fire-and-forget (ipcRenderer.send, no await) so it never blocks the
+ * renderer or affects call timing.
+ *
+ * The original console methods are preserved — devtools still shows the full
+ * object inspection experience. This only adds a parallel write to desktop.log.
+ */
+
+type ConsoleMethod = 'log' | 'warn' | 'error' | 'info' | 'debug'
+
+const LEVEL_MAP: Record<ConsoleMethod, string> = {
+  log: 'info',
+  warn: 'warn',
+  error: 'error',
+  info: 'info',
+  debug: 'debug'
+}
+
+function serializeArg(arg: unknown): string {
+  if (arg === null) {
+    return 'null'
+  }
+
+  if (arg === undefined) {
+    return 'undefined'
+  }
+
+  if (typeof arg === 'string') {
+    return arg
+  }
+
+  if (typeof arg === 'number' || typeof arg === 'boolean' || typeof arg === 'bigint') {
+    return String(arg)
+  }
+
+  if (arg instanceof Error) {
+    return `${arg.name}: ${arg.message}${arg.stack ? `\n${arg.stack}` : ''}`
+  }
+
+  // Objects/arrays — try JSON, fall back to String.
+  try {
+    return JSON.stringify(arg)
+  } catch {
+    try {
+      return String(arg)
+    } catch {
+      return '[unserializable]'
+    }
+  }
+}
+
+function forward(level: ConsoleMethod, args: unknown[]): void {
+  const forwarder = window.hermesDesktop?.forwardConsole
+
+  if (!forwarder) {
+    return
+  }
+
+  const message = args.map(serializeArg).join(' ')
+
+  // Cap at 4KB per line — a single huge object dump shouldn't flood desktop.log.
+  const capped = message.length > 4096 ? `${message.slice(0, 4096)}…(${message.length} chars)` : message
+
+  forwarder(LEVEL_MAP[level], capped)
+}
+
+if (typeof window !== 'undefined') {
+  for (const method of Object.keys(LEVEL_MAP) as ConsoleMethod[]) {
+    const original = console[method].bind(console)
+
+    console[method] = (...args: unknown[]) => {
+      original(...args)
+
+      try {
+        forward(method, args)
+      } catch {
+        // Forwarding must never break the original call or throw in the
+        // renderer — it already ran above.
+      }
+    }
+  }
+}

--- a/apps/desktop/src/lib/debug-trace.ts
+++ b/apps/desktop/src/lib/debug-trace.ts
@@ -1,0 +1,327 @@
+/**
+ * Debug trace — optional, verbose instrumentation of stateful desktop events.
+ *
+ * When enabled (Settings → Advanced), dumps structured `console.debug` entries
+ * for every session state transition, compaction event, message completion,
+ * session switch, persistence write, and gateway event. The output lands in the
+ * renderer devtools console and any attached log capture, so you can point at
+ * the trace after reproducing a bug.
+ *
+ * Zero cost when disabled: every call site is a single function call that
+ * early-returns when the atom is off. The subscriptions (persistence, gateway
+ * events, atom watchers) are only attached once at module init, and their
+ * callbacks also early-return — so the overhead is one closure call per event,
+ * which is negligible.
+ */
+
+import { atom } from 'nanostores'
+
+import { onGatewayEvent } from '@/contrib/events'
+import { onPersistenceEvent } from '@/lib/storage'
+import { $clarifyRequest } from '@/store/clarify'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $approvalRequest, $secretRequest, $sudoRequest } from '@/store/prompts'
+import {
+  $activeSessionId,
+  $activeSessionStoredIdRotation,
+  $awaitingResponse,
+  $busy,
+  $connection,
+  $gatewayState,
+  $messages,
+  $resumeExhaustedSessionId,
+  $resumeFailedSessionId,
+  $selectedStoredSessionId,
+  $sessions
+} from '@/store/session'
+
+const KEY = 'hermes.desktop.debugTrace.v1'
+
+/** Device-local preference — off by default, per machine. */
+export const $debugTraceEnabled = atom<boolean>(
+  typeof window === 'undefined' ? false : (() => {
+    try {
+      return window.localStorage.getItem(KEY) === 'true'
+    } catch {
+      return false
+    }
+  })()
+)
+
+export function setDebugTraceEnabled(on: boolean): void {
+  $debugTraceEnabled.set(on)
+}
+
+if (typeof window !== 'undefined') {
+  $debugTraceEnabled.subscribe(on => {
+    try {
+      window.localStorage.setItem(KEY, String(on))
+    } catch {
+      // Storage best-effort.
+    }
+  })
+}
+
+export type DebugCategory =
+  | 'session-state'
+  | 'compaction'
+  | 'message'
+  | 'session-switch'
+  | 'persistence'
+  | 'gateway-event'
+  | 'connection'
+  | 'profile-switch'
+  | 'resume'
+  | 'busy'
+  | 'error-boundary'
+  | 'prompt'
+  | 'sessions-list'
+
+const CATEGORY_PREFIX: Record<DebugCategory, string> = {
+  'session-state': '[trace:session-state]',
+  compaction: '[trace:compaction]',
+  message: '[trace:message]',
+  'session-switch': '[trace:session-switch]',
+  persistence: '[trace:persistence]',
+  'gateway-event': '[trace:gateway-event]',
+  connection: '[trace:connection]',
+  'profile-switch': '[trace:profile-switch]',
+  resume: '[trace:resume]',
+  busy: '[trace:busy]',
+  'error-boundary': '[trace:error-boundary]',
+  prompt: '[trace:prompt]',
+  'sessions-list': '[trace:sessions-list]'
+}
+
+/**
+ * Emit a debug trace entry. No-ops entirely when tracing is disabled.
+ *
+ * `data` is spread as additional console arguments (not stringified) so
+ * devtools can expand/inspect objects natively.
+ */
+export function debugTrace(
+  category: DebugCategory,
+  message: string,
+  ...data: unknown[]
+): void {
+  if (!$debugTraceEnabled.get()) {
+    return
+  }
+
+  const ts = new Date().toISOString()
+
+  console.debug(`${CATEGORY_PREFIX[category]} ${ts} ${message}`, ...data)
+}
+
+// ---------------------------------------------------------------------------
+// Subscriptions — attached once at module init, no-op when disabled.
+// ---------------------------------------------------------------------------
+
+if (typeof window !== 'undefined') {
+  // --- Session switches ---
+  let prevActive: string | null = null
+  $activeSessionId.subscribe(id => {
+    if (id !== prevActive) {
+      debugTrace('session-switch', `activeSessionId ${prevActive ?? 'null'} → ${id ?? 'null'}`)
+      prevActive = id
+    }
+  })
+
+  let prevSelected: string | null = null
+  $selectedStoredSessionId.subscribe(id => {
+    if (id !== prevSelected) {
+      debugTrace('session-switch', `selectedStoredSessionId ${prevSelected ?? 'null'} → ${id ?? 'null'}`)
+      prevSelected = id
+    }
+  })
+
+  // --- Persistence events ---
+  onPersistenceEvent(event => {
+    const valuePreview =
+      event.value === null
+        ? 'null'
+        : event.value.length > 120
+          ? `${event.value.slice(0, 120)}…(${event.value.length} chars)`
+          : event.value
+
+    debugTrace('persistence', `${event.op} ${event.key}`, { value: valuePreview })
+  })
+
+  // --- Gateway events (wildcard) ---
+  onGatewayEvent('*', event => {
+    const type = event.type ?? 'unknown'
+    const raw = event as unknown as Record<string, unknown>
+    const sessionId = raw.session_id ?? raw.sessionId ?? null
+
+    // Summarize — don't dump the full payload for high-frequency deltas.
+    const summary: Record<string, unknown> = { type }
+
+    if (sessionId) {
+      summary.sessionId = sessionId
+    }
+
+    // For message.delta, just note it happened (they fire 30×/s during a turn).
+    // For everything else, include the payload for inspection.
+    if (type === 'message.delta') {
+      summary.note = 'delta (streaming)'
+    } else {
+      summary.payload = event
+    }
+
+    debugTrace('gateway-event', type, summary)
+  })
+
+  // --- Gateway connection state ---
+  let prevGatewayState: string | undefined
+  $gatewayState.subscribe(state => {
+    if (state !== prevGatewayState) {
+      debugTrace('connection', `gatewayState ${prevGatewayState ?? 'undefined'} → ${state}`)
+      prevGatewayState = state
+    }
+  })
+
+  // --- Connection (mode/baseUrl/profile) ---
+  let prevConnMode: string | undefined
+  let prevConnProfile: string | undefined
+  $connection.subscribe(conn => {
+    const mode = conn?.mode ?? 'null'
+    const profile = conn?.profile ?? 'null'
+
+    if (mode !== prevConnMode || profile !== prevConnProfile) {
+      debugTrace('connection', `connection mode=${mode} profile=${profile} baseUrl=${conn?.baseUrl ?? 'null'}`)
+      prevConnMode = mode
+      prevConnProfile = profile
+    }
+  })
+
+  // --- Profile switches ---
+  let prevProfile: string | undefined
+  $activeGatewayProfile.subscribe(profile => {
+    if (profile !== prevProfile) {
+      debugTrace('profile-switch', `${prevProfile ?? 'undefined'} → ${profile}`)
+      prevProfile = profile
+    }
+  })
+
+  // --- Resume failures + exhaustion ---
+  let prevResumeFailed: string | null = null
+  $resumeFailedSessionId.subscribe(id => {
+    if (id !== prevResumeFailed) {
+      debugTrace('resume', `resumeFailedSessionId ${prevResumeFailed ?? 'null'} → ${id ?? 'null'}`)
+      prevResumeFailed = id
+    }
+  })
+
+  let prevResumeExhausted: string | null = null
+  $resumeExhaustedSessionId.subscribe(id => {
+    if (id !== prevResumeExhausted) {
+      debugTrace('resume', `resumeExhaustedSessionId ${prevResumeExhausted ?? 'null'} → ${id ?? 'null'}`)
+      prevResumeExhausted = id
+    }
+  })
+
+  // --- Busy / awaitingResponse edges ---
+  let prevBusy = false
+  $busy.subscribe(busy => {
+    if (busy !== prevBusy) {
+      debugTrace('busy', `busy ${prevBusy} → ${busy}`, { activeSessionId: $activeSessionId.get() })
+      prevBusy = busy
+    }
+  })
+
+  let prevAwaiting = false
+  $awaitingResponse.subscribe(awaiting => {
+    if (awaiting !== prevAwaiting) {
+      debugTrace('busy', `awaitingResponse ${prevAwaiting} → ${awaiting}`, { activeSessionId: $activeSessionId.get() })
+      prevAwaiting = awaiting
+    }
+  })
+
+  // --- Message array length changes ---
+  // Not per-token (that'd be insane) — only when the count changes, which
+  // captures: new message added, transcript cleared, session switched,
+  // reconciliation replaced the array.
+  let prevMessageCount = -1
+  $messages.subscribe(messages => {
+    const count = messages.length
+
+    if (count !== prevMessageCount) {
+      debugTrace('message', `messages count ${prevMessageCount} → ${count}`, {
+        activeSessionId: $activeSessionId.get()
+      })
+      prevMessageCount = count
+    }
+  })
+
+  // --- Compression id rotation ---
+  // Fires when auto-compaction rotates the active session's stored id mid-turn.
+  // One of the spookiest bug classes — the route / pin / draft key silently
+  // changes under the user.
+  $activeSessionStoredIdRotation.subscribe(rotation => {
+    if (rotation) {
+      debugTrace('session-switch', `compression id rotation`, {
+        prev: rotation.previousStoredSessionId,
+        next: rotation.nextStoredSessionId,
+        runtime: rotation.runtimeSessionId,
+        isActive: rotation.runtimeSessionId === $activeSessionId.get()
+      })
+    }
+  })
+
+  // --- Blocking prompts (clarify / approval / sudo / secret) ---
+  // When these appear/disappear, the chat is blocked. Tracing the edges
+  // catches "agent silently stalled" bugs.
+  let prevClarify: unknown = null
+  $clarifyRequest.subscribe(req => {
+    if (req !== prevClarify) {
+      debugTrace('prompt', `clarify ${prevClarify ? 'cleared' : 'raised'}`, {
+        sessionId: $activeSessionId.get(),
+        requestId: req ? 'present' : 'null'
+      })
+      prevClarify = req
+    }
+  })
+
+  let prevApproval: unknown = null
+  $approvalRequest.subscribe(req => {
+    if (req !== prevApproval) {
+      debugTrace('prompt', `approval ${prevApproval ? 'cleared' : 'raised'}`, {
+        sessionId: $activeSessionId.get()
+      })
+      prevApproval = req
+    }
+  })
+
+  let prevSudo: unknown = null
+  $sudoRequest.subscribe(req => {
+    if (req !== prevSudo) {
+      debugTrace('prompt', `sudo ${prevSudo ? 'cleared' : 'raised'}`, {
+        sessionId: $activeSessionId.get()
+      })
+      prevSudo = req
+    }
+  })
+
+  let prevSecret: unknown = null
+  $secretRequest.subscribe(req => {
+    if (req !== prevSecret) {
+      debugTrace('prompt', `secret ${prevSecret ? 'cleared' : 'raised'}`, {
+        sessionId: $activeSessionId.get()
+      })
+      prevSecret = req
+    }
+  })
+
+  // --- Sessions list length changes ---
+  // Captures: new session created, session archived/deleted, sidebar merge
+  // kept/dropped a row. Not per-field — just the count edge.
+  let prevSessionsCount = -1
+  $sessions.subscribe(list => {
+    const count = list.length
+
+    if (count !== prevSessionsCount) {
+      debugTrace('sessions-list', `sessions count ${prevSessionsCount} → ${count}`)
+      prevSessionsCount = count
+    }
+  })
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -15,6 +15,8 @@ import '@/debug/dev-only'
 // Side-effect: attaches debug trace subscriptions (persistence, gateway
 // events, session switch watchers). No-ops entirely when tracing is disabled.
 import './lib/debug-trace'
+// Side-effect: mirrors renderer console.* calls into desktop.log via IPC.
+import './lib/console-forward'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 import { StrictMode } from 'react'

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -12,6 +12,9 @@ import './store/translucency'
 // aliases this specifier to a no-op module for non-dev builds, so neither the
 // counters nor bippy reach a shipped renderer.
 import '@/debug/dev-only'
+// Side-effect: attaches debug trace subscriptions (persistence, gateway
+// events, session switch watchers). No-ops entirely when tracing is disabled.
+import './lib/debug-trace'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 import { StrictMode } from 'react'

--- a/apps/desktop/src/store/compaction.ts
+++ b/apps/desktop/src/store/compaction.ts
@@ -1,5 +1,8 @@
 import { atom, computed } from 'nanostores'
 
+import { debugTrace } from '@/lib/debug-trace'
+import { $activeSessionId } from '@/store/session'
+
 // Per-session flag while auto-compaction runs mid-turn. Without it the
 // transcript looks like it reset; per-session so a background chat can't
 // clobber the foreground view.
@@ -24,6 +27,8 @@ export function setSessionCompacting(sessionId: string | null | undefined, activ
 
     $compactingSessions.set({ ...sessions, [key]: true })
 
+    debugTrace('compaction', `started session=${key}`, { isActive: key === $activeSessionId.get() })
+
     return
   }
 
@@ -34,4 +39,6 @@ export function setSessionCompacting(sessionId: string | null | undefined, activ
   const next = { ...sessions }
   delete next[key]
   $compactingSessions.set(next)
+
+  debugTrace('compaction', `finished session=${key}`, { isActive: key === $activeSessionId.get() })
 }

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -28,6 +28,7 @@ import {
   noteActiveTreeGroup,
   revealTreePane
 } from '@/components/pane-shell/tree/store'
+import { debugTrace } from '@/lib/debug-trace'
 import { stableArray } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
 
@@ -205,6 +206,18 @@ export function publishSessionState(runtimeId: string, state: ClientSessionState
 
   $sessionStates.set({ ...current, [runtimeId]: state })
   handleTransition(prev, state, runtimeId)
+
+  debugTrace(
+    'session-state',
+    `publish ${runtimeId}`,
+    {
+      prev: prev
+        ? { storedSessionId: prev.storedSessionId, busy: prev.busy, needsInput: prev.needsInput }
+        : null,
+      next: { storedSessionId: state.storedSessionId, busy: state.busy, needsInput: state.needsInput },
+      isActive: runtimeId === $activeSessionId.get()
+    }
+  )
 }
 
 export function dropSessionState(runtimeId: string) {

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -91,6 +91,11 @@ export default defineConfig(({ command }) => ({
     postcss: { plugins: [] }
   },
   build: {
+    // Ship sourcemaps so crash reports and devtools stack traces point at
+    // real TS/TSX source, not minified bundles. Separate .map files (not
+    // inline) keep the executable bundle lean; both electron-builder
+    // (files: ["dist/**"]) and nix (cp -rn dist) carry them through.
+    sourcemap: true,
     // The renderer intentionally ships FEW chunks (not one, not thousands):
     //   · `codeSplitting: false` (the old setup) inlines every `lazy()` /
     //     dynamic import into the entry, so heavyweight lazy-only deps

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -55,6 +55,14 @@
           # Force Node to use Nix's playwright-test binary instead of node_modules/.bin
           export PATH="${pkgs.playwright-test}/bin:$PATH"
 
+          # The desktop dev server (`npm run dev` in apps/desktop) runs npm's
+          # prebuilt Electron, which dlopens libEGL.so.1 at GPU-process startup.
+          # That is not a NixOS library path, so the GPU process dies and the
+          # app exits before a window appears. Nix-built Electron
+          # (`nix run .#desktop`) is wrapped with its own library path and is
+          # unaffected — this is only needed for source-tree dev runs.
+          export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [ pkgs.libglvnd pkgs.mesa ]}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
           # for the devshell to pick up the src
           export HERMES_PYTHON_SRC_ROOT=$(git rev-parse --show-toplevel)
 

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -683,7 +683,7 @@ def main() -> int:
         "-j",
         "--jobs",
         type=int,
-        default=int(os.environ.get("HERMES_TEST_WORKERS") or (os.cpu_count() or 4) * 2),
+        default=int(os.environ.get("HERMES_TEST_WORKERS") or (os.cpu_count() or 4)),
         help="Parallel worker count (default: $HERMES_TEST_WORKERS or cpu_count*2)",
     )
     parser.add_argument(

--- a/skills/software-development/inspecting-hermes-desktop-dom/SKILL.md
+++ b/skills/software-development/inspecting-hermes-desktop-dom/SKILL.md
@@ -53,6 +53,24 @@ Open on `127.0.0.1:9222` for any dev-server run. Closed in exactly two cases
 
 `HERMES_DESKTOP_CDP_PORT` moves the port (`=9333`) or disables it (`=off`).
 
+**A packaged app can never be instrumented, including a Nix-built one.**
+`nix run .#desktop` wraps a built `dist/` with `ELECTRON_IS_DEV 0` and no
+`HERMES_DESKTOP_DEV_SERVER`, so it trips both gates and no environment value
+opens the port. If the user runs the app that way there is no override to
+offer — they have to relaunch through the dev server. On NixOS that is:
+
+```bash
+nix develop
+cd apps/desktop && npm run dev
+```
+
+The devShell must export `LD_LIBRARY_PATH` with `libglvnd` + `mesa`. npm's
+prebuilt Electron dlopens `libEGL.so.1`, which is not on a NixOS library path;
+without it the GPU process dies and the app exits *after* printing the CDP line
+but before a window appears — so a port that opens and then vanishes is this,
+not a bad port. Nix-built Electron carries its own library path and is
+unaffected.
+
 Check before doing anything else:
 
 ```bash
@@ -115,6 +133,44 @@ If the node carries no class of its own, the value is **inherited** — sweeping
 call sites will not fix it, and you need the ancestor rule. A plugin stylesheet
 (e.g. `@tailwindcss/typography`'s `prose a { font-weight: 500 }`) routinely beats
 a utility class; override on the shared class, not at each usage.
+
+## Reading state over time, not just the DOM
+
+The DOM is a snapshot. For *sequence* bugs — a turn that stalls, history that
+vanishes, a session id that rotates under the user — read the trace log
+instead. Every renderer `console.*` call is mirrored into `desktop.log` (always
+on, 4KB cap per line), and the Settings → Advanced → **"Debug trace logging"**
+toggle adds structured `[trace:*]` lines for state transitions.
+
+The toggle is device-local, persisted in `localStorage` under
+`hermes.desktop.debugTrace.v1`, so it survives reloads. You can read *and set*
+it over CDP without touching the user's Settings UI:
+
+```bash
+node scripts/eval.mjs "localStorage.getItem('hermes.desktop.debugTrace.v1')"
+```
+
+Then read the output with the CLI rather than tailing the file by hand —
+`[trace:*]` lines are `console.debug`, so `--level debug` is required or they
+are filtered out:
+
+```bash
+hermes logs desktop --level debug | grep '\[trace:'
+```
+
+Categories are `session-state`, `gateway-event`, `persistence`, `message`,
+`busy`, `session-switch`, `connection`, `profile-switch`, `resume`, `prompt`,
+`sessions-list`, `compaction`, `error-boundary`. Grep the one that matches the
+bug class instead of reading all of them — a single reload emits hundreds of
+`persistence` lines, which will bury a `session-switch` you actually care about.
+
+The forwarder lives at **`window.hermesDesktop.forwardConsole`** (not
+`window.hermes`). To confirm forwarding is live, check that `console.log` is no
+longer native rather than looking for a flag that doesn't exist:
+
+```bash
+node scripts/eval.mjs "console.log.toString().includes('[native code]')"  # false ⇒ patched
+```
 
 ## Your own isolated instance
 


### PR DESCRIPTION
## What does this PR do?

Two independent desktop improvements, one per commit:

1. **Ship sourcemaps** for the renderer (vite), electron main, and preload (esbuild). Both packaging paths — electron-builder (`files: ["dist/**"]`) and nix (`cp -rn dist`) — already carry `dist/` wholesale, so the `.map` files flow through with zero packaging changes. Crash reports and devtools stack traces now point at real TS/TSX source instead of minified bundles.

2. **Debug trace instrumentation** — a device-local toggle (Settings → Advanced → Debug trace logging) that, when enabled, dumps structured `console.debug` entries for every stateful event in the desktop app. Designed for reproducing bugs that only happen in long-lived real client sessions (state accumulation, compaction, rapid session switching, background profile events) and are hard to reproduce in e2e tests.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

### Sourcemaps
- `apps/desktop/vite.config.ts` — `build.sourcemap: true`
- `apps/desktop/scripts/bundle-electron-main.mjs` — `sourcemap: true` on both esbuild calls (main + preload)

### Debug trace
- `apps/desktop/src/lib/debug-trace.ts` (new) — `$debugTraceEnabled` atom + `debugTrace()` function, zero-cost when off. Subscribes to 15+ state edges at module init.
- `apps/desktop/src/main.tsx` — side-effect import (same pattern as `store/translucency`)
- `apps/desktop/src/app/settings/config-settings.tsx` — ToggleRow in Advanced section
- `apps/desktop/src/store/session-states.ts` — trace `publishSessionState()` transitions
- `apps/desktop/src/store/compaction.ts` — trace `setSessionCompacting()` start/finish
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts` — trace `message.complete`
- `apps/desktop/src/components/error-boundary.tsx` — trace `componentDidCatch`
- `apps/desktop/src/i18n/{en,ja,zh,zh-hant,types}.ts` — localized toggle label/description

**Trace categories:**

| Category | What it traces |
|---|---|
| `session-state` | `publishSessionState` prev→next (busy/needsInput/storedSessionId, active flag) |
| `compaction` | start/finish per session |
| `message` | `message.complete` (session, count, usage/billing) + `$messages` array length changes |
| `session-switch` | `activeSessionId` + `selectedStoredSessionId` changes + compression id rotation |
| `persistence` | every localStorage read/write/remove (key, op, truncated value) |
| `gateway-event` | all gateway events (type, session id, payload — deltas summarized) |
| `connection` | `gatewayState` transitions (idle→open→closed) + `$connection` mode/baseUrl/profile |
| `profile-switch` | `$activeGatewayProfile` changes |
| `resume` | `$resumeFailedSessionId` + `$resumeExhaustedSessionId` transitions |
| `busy` | `$busy` + `$awaitingResponse` edges |
| `error-boundary` | React render crashes (label, error, componentStack) |
| `prompt` | clarify/approval/sudo/secret raised/cleared edges |
| `sessions-list` | `$sessions` array length changes (new/archive/delete/merge) |

## How to Test

1. `cd apps/desktop && npm run build` — verify `.map` files appear in `dist/`
2. Open Settings → Advanced, toggle "Debug trace logging" on
3. Open devtools console, switch sessions / send messages / trigger compaction — observe `[trace:*]` entries

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (desktop-only TS/TSX change)
- [x] I've added tests for my changes — N/A (instrumentation + build config, no new behavior to test)
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (device-local localStorage, not config.yaml)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Verification

Verified with `cd apps/desktop && npm run check` (typecheck + vitest + test:desktop:all) — all passing on the rebased commits. Also ran targeted test suites for every touched store module (compaction, session, session-states, session-watchdog, profile, gateway-switch, clarify, prompts, storage) — 101 tests, 0 failures.
