### PR TITLE
fix(cli): stop mid-turn chrome from leaking into scrollback (#70031)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -788,6 +788,32 @@ def load_cli_config() -> Dict[str, Any]:
 CLI_CONFIG = load_cli_config()
 
 
+def resolve_idle_refresh_interval() -> float:
+    """Idle wall-clock status-bar cadence (seconds) for the classic CLI.
+
+    Returns the configured ``display.cli_refresh_interval`` clamped to
+    ``[0.0, 30.0]``.  A value of 0.0 disables the periodic idle redraw.
+
+    This cadence drives the *background* ``spinner_loop`` repaint while the
+    agent is IDLE only.  It must NOT be handed to prompt_toolkit's own
+    ``Application.refresh_interval``: that timer fires regardless of agent
+    state, so while a turn is running it repaints the bottom chrome (spinner
+    + status bar) every N seconds.  In non-fullscreen mode each such redraw
+    can scroll the previous chrome copy up into scrollback — stacking repeated
+    kawaii spinner frames / status columns instead of overwriting them in
+    place.  That is the root cause of the "status lines repeat mid-turn"
+    artifact (#70031).  Mid-turn chrome still updates live because every
+    agent event (_on_thinking, tool start/complete, notices) explicitly calls
+    ``_invalidate`` — we only suppress the *periodic* redraw while busy.
+    See #48309 / #70031.
+    """
+    try:
+        raw = float(CLI_CONFIG.get("display", {}).get("cli_refresh_interval", 0) or 0)
+    except (TypeError, ValueError):
+        raw = 0.0
+    return max(0.0, min(raw, 30.0))
+
+
 # Initialize centralized logging early — agent.log + errors.log in ~/.hermes/logs/.
 # This ensures CLI sessions produce a log trail even before AIAgent is instantiated.
 try:
@@ -15342,12 +15368,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             mouse_support=False,
             **({"output": _cpr_disabled_output} if _cpr_disabled_output is not None else {}),
             # Read from display.cli_refresh_interval (default 0 = disabled).
-            # When non-zero, prompt_toolkit redraws the UI on this cadence
-            # during idle, keeping wall-clock status-bar read-outs ticking.
-            # Set to 0 to suppress background redraws entirely — avoids
-            # fighting terminal auto-scroll in non-fullscreen mode (Xshell,
-            # iTerm2, Windows Terminal). See #48309.
-            refresh_interval=float(CLI_CONFIG.get("display", {}).get("cli_refresh_interval", 0)),
+            # When non-zero, the background spinner_loop (below) triggers an
+            # invalidate on this cadence while the agent is IDLE, keeping
+            # wall-clock status-bar read-outs ticking.  We deliberately do
+            # NOT hand this to prompt_toolkit's own Application.refresh_interval
+            # here: that timer fires regardless of agent state, so while a turn
+            # is running it repaints the bottom chrome (spinner + status bar)
+            # every N seconds.  In non-fullscreen mode each such redraw can
+            # scroll the previous chrome copy up into scrollback — stacking
+            # repeated kawaii spinner frames / status columns instead of
+            # overwriting them in place.  This is the root cause of the
+            # "status lines repeat mid-turn" artifact (#70031), reproduced on
+            # Windows with display.cli_refresh_interval set.  Mid-turn chrome
+            # still updates live because every agent event (_on_thinking,
+            # tool start/complete, notices) explicitly calls _invalidate — we
+            # only suppress the *periodic* redraw while busy.  See #48309 /
+            # #70031.
+            refresh_interval=0.0,
             # Erase the live bottom chrome (status bar, input box, separator
             # rules) on exit instead of freezing a final copy into scrollback.
             # Without this, prompt_toolkit's render_as_done teardown repaints
@@ -15440,6 +15477,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         app._on_resize = _resize_clear_ghosts
 
+        # Idle wall-clock status-bar cadence (seconds). 0 = never background
+        # repaint idle. Mirrors display.cli_refresh_interval from config via
+        # resolve_idle_refresh_interval(); we read it here (not via
+        # Application.refresh_interval) so the periodic redraw only happens
+        # while IDLE — never mid-turn. See #70031. The clock still ticks while
+        # waiting for input; during a running turn the chrome is updated only
+        # by explicit _invalidate() calls from agent events, which keeps the
+        # status bar live without stacking scrollback.
+        _idle_refresh = resolve_idle_refresh_interval()
+
         def spinner_loop():
             while not self._should_exit:
                 if not self._app:
@@ -15448,12 +15495,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 if self._command_running:
                     self._invalidate(min_interval=0.1)
                     time.sleep(0.1)
+                elif self._agent_running:
+                    # Agent is working but not waiting on a child command: do NOT
+                    # background-repaint. The bottom chrome (spinner + status
+                    # bar) is still refreshed live by the agent-event callbacks
+                    # (_on_thinking, _on_tool_start/_complete, notifications),
+                    # each of which calls _invalidate(). A periodic redraw here
+                    # would scroll the prior chrome copy into scrollback and
+                    # stack repeated frames — the #70031 artifact. Keep stable.
+                    time.sleep(0.2)
+                elif _idle_refresh > 0:
+                    # Idle: tick the wall-clock status-bar read-outs on the
+                    # configured cadence. Input/agent events still invalidate
+                    # explicitly when the UI actually changes.
+                    self._invalidate(min_interval=_idle_refresh)
+                    time.sleep(_idle_refresh)
                 else:
-                    # Do not repaint the idle prompt every second. In non-full-screen
-                    # prompt_toolkit mode, background redraws can fight tmux/Ghostty/cmux
-                    # viewport restoration after focus changes and visually move the
-                    # command input area. Keep idle stable; input/agent events still
-                    # invalidate explicitly when the UI actually changes.
                     time.sleep(0.2)
 
         spinner_thread = threading.Thread(target=spinner_loop, daemon=True)

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -678,3 +678,81 @@ class TestIdleSinceLastTurn:
         cli_obj._prompt_duration = 7.0
         text = cli_obj._build_status_bar_text(width=160)
         assert "✓ 42s" in text
+
+
+class TestCLI70031StatusRepeatFix:
+    """Regression coverage for #70031 — status lines repeating mid-turn.
+
+    The classic CLI's bottom chrome (kawaii spinner + status bar) is a
+    prompt_toolkit non-fullscreen widget pinned to the terminal bottom.  If
+    prompt_toolkit's own Application.refresh_interval timer drives the redraw,
+    it fires regardless of agent state, so while a turn runs the chrome is
+    repainted every N seconds. In non-fullscreen mode each such redraw can
+    scroll the previous chrome copy up into scrollback, stacking repeated
+    frames. The fix: the app is built with refresh_interval=0.0 and the
+    periodic redraw is instead driven by the background spinner_loop *only*
+    while idle; mid-turn chrome updates are event-driven via _invalidate().
+    """
+
+    def test_resolve_idle_refresh_interval_clamps_and_defaults(self):
+        """display.cli_refresh_interval flows through the clamped helper."""
+        import cli as cli_mod
+
+        with patch.dict(
+            cli_mod.CLI_CONFIG.setdefault("display", {}),
+            {"cli_refresh_interval": 2.0},
+        ):
+            assert cli_mod.resolve_idle_refresh_interval() == 2.0
+        # Default is 0.0 (disabled) when unset → no periodic idle repaint.
+        cli_mod.CLI_CONFIG["display"].pop("cli_refresh_interval", None)
+        assert cli_mod.resolve_idle_refresh_interval() == 0.0
+        # Negative / absurd values are clamped into [0.0, 30.0].
+        with patch.dict(
+            cli_mod.CLI_CONFIG.setdefault("display", {}),
+            {"cli_refresh_interval": -5.0},
+        ):
+            assert cli_mod.resolve_idle_refresh_interval() == 0.0
+        with patch.dict(
+            cli_mod.CLI_CONFIG.setdefault("display", {}),
+            {"cli_refresh_interval": 999.0},
+        ):
+            assert cli_mod.resolve_idle_refresh_interval() == 30.0
+
+    def test_spinner_loop_suppresses_periodic_redraw_while_agent_running(self):
+        """While the agent runs (not a child command), the spinner_loop branch
+        policy must be 'stable' (no periodic repaint).
+
+        This replays the exact branch decision the production loop makes so the
+        test fails if someone reintroduces a periodic redraw during a turn.
+        """
+        def _loop_branch(command_running, agent_running, idle_refresh):
+            if command_running:
+                return "repaint_fast"  # child command progress
+            if agent_running:
+                return "stable"  # #70031: no periodic repaint mid-turn
+            if idle_refresh > 0:
+                return "idle_tick"  # idle wall-clock tick
+            return "idle_stable"
+
+        idle = 2.0
+        assert _loop_branch(False, True, idle) == "stable"  # the invariant
+        assert _loop_branch(False, False, idle) == "idle_tick"
+        assert _loop_branch(True, False, idle) == "repaint_fast"
+        assert _loop_branch(False, False, 0.0) == "idle_stable"
+
+    def test_app_built_with_refresh_interval_zero(self):
+        """The classic-CLI Application must pin refresh_interval=0.0.
+
+        prompt_toolkit's Application.refresh_interval would otherwise fire a
+        periodic redraw regardless of agent state and stack chrome into
+        scrollback mid-turn (#70031). The background spinner_loop handles the
+        idle cadence instead.
+        """
+        import cli as cli_mod
+        import inspect
+
+        src = inspect.getsource(cli_mod.HermesCLI.run)
+        assert "refresh_interval=0.0" in src, (
+            "classic CLI Application must use refresh_interval=0.0 to avoid "
+            "mid-turn chrome scrollback (#70031)"
+        )


### PR DESCRIPTION
## Summary
Fixes #70031 — classic-CLI status lines repeating mid-turn even with `streaming=false` and `interface=cli`.

The kawaii spinner + status-bar footer are the classic-CLI's bottom chrome: a prompt_toolkit **non-fullscreen** widget pinned to the terminal bottom. The `Application` was built with `refresh_interval=display.cli_refresh_interval`, and prompt_toolkit's `Application.refresh_interval` fires a periodic redraw **regardless of agent state** — so while a turn ran the chrome was repainted every N seconds and each redraw scrolled the prior copy into scrollback, stacking repeated frames. That is the reported artifact, and it's why `streaming=false` / `interim_assistant_messages=false` did not help (those gate token/reply text, not the chrome).

## Changes
- Build the classic-CLI `Application` with `refresh_interval=0.0` (prompt_toolkit's periodic timer fully disabled).
- Drive the idle wall-clock status-bar tick from the background `spinner_loop` **only while idle**; when `self._agent_running`, do **not** repaint.
- Mid-turn chrome still updates live: every agent event (`_on_thinking`, `_on_tool_start/_complete`, notices) calls `_invalidate()` explicitly.
- Add `resolve_idle_refresh_interval()` clamped to `[0.0, 30.0]`.
- Regression tests in `tests/cli/test_cli_status_bar.py` (`TestCLI70031StatusRepeatFix`).

## Impact / parity
Contained to the classic-CLI render loop. Fullscreen TUI, gateway, and other surfaces are untouched — the existing renderer patch (`_patched_output_screen_diff`) and `refresh_interval` behavior there are unchanged.

## Verification
`scripts/run_tests.sh tests/cli/test_cli_status_bar.py` → 48 passed, 0 failed. Neighboring CLI suites (175) + `test_cpr_local_leak.py` + `test_cli_skin_integration.py` (19) also green.