### PR TITLE
fix(tts): honor OpenAI config for streaming

### DIFF
--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -130,9 +130,62 @@ def test_elevenlabs_available_reflects_key(monkeypatch):
     assert ts.ElevenLabsStreamer.available() is False
 
 
-def test_openai_available_reflects_key(monkeypatch):
-    monkeypatch.setattr(ts, "get_env_value", lambda k, *a: "key" if k == "OPENAI_API_KEY" else None)
+def test_openai_available_reflects_audio_key_resolution(monkeypatch):
+    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "voice-key")
     assert ts.OpenAIStreamer.available() is True
+    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "")
+    assert ts.OpenAIStreamer.available() is False
+
+
+def test_openai_streamer_prefers_configured_base_url(monkeypatch):
+    captured = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def iter_bytes(self):
+            yield b"\x01\x00"
+
+    class _StreamingCreate:
+        @staticmethod
+        def create(**kwargs):
+            captured["request"] = kwargs
+            return _Response()
+
+    class _OpenAI:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+            self.audio = MagicMock()
+            self.audio.speech.with_streaming_response = _StreamingCreate()
+
+    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "voice-key")
+    monkeypatch.setattr(
+        ts,
+        "get_env_value",
+        lambda key, *args: "https://env.example/v1" if key == "OPENAI_BASE_URL" else None,
+    )
+    monkeypatch.setattr("openai.OpenAI", _OpenAI)
+
+    config = {
+        "provider": "openai",
+        "openai": {
+            "base_url": "http://local-tts.example/v1",
+            "model": "tts-1",
+            "voice": "local-voice",
+        },
+    }
+    streamer = ts.resolve_streaming_provider(config)
+
+    assert streamer is not None
+    assert list(streamer.stream("Streaming test.")) == [b"\x01\x00"]
+    assert captured["client"] == {
+        "api_key": "voice-key",
+        "base_url": "http://local-tts.example/v1",
+    }
 
 
 # ── Dispatch: chunked streamer path ──────────────────────────────────────

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -27,6 +27,7 @@ import time
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, Iterator, List, Optional
 
+from tools.tool_backend_helpers import resolve_openai_audio_api_key
 from tools.tts_tool import _get_provider, get_env_value
 
 logger = logging.getLogger(__name__)
@@ -202,14 +203,18 @@ class OpenAIStreamer(StreamingTTSProvider):
 
     @staticmethod
     def available() -> bool:
-        return bool(get_env_value("OPENAI_API_KEY"))
+        return bool(resolve_openai_audio_api_key())
 
     def stream(self, text: str) -> Iterator[bytes]:
         from openai import OpenAI
 
         client = OpenAI(
-            api_key=get_env_value("OPENAI_API_KEY"),
-            base_url=get_env_value("OPENAI_BASE_URL") or None,
+            api_key=resolve_openai_audio_api_key(),
+            base_url=(
+                self.section.get("base_url")
+                or get_env_value("OPENAI_BASE_URL")
+                or None
+            ),
         )
         model = self.section.get("model", "gpt-4o-mini-tts")
         voice = self.section.get("voice", "alloy")


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop streaming TTS for local and other OpenAI-compatible speech endpoints.

The normal OpenAI TTS path honors `tts.openai.base_url` and the shared audio-key resolution order, but `OpenAIStreamer` used only `OPENAI_BASE_URL` and `OPENAI_API_KEY`. With a local endpoint configured solely in `config.yaml`, Desktop therefore attempted the public OpenAI endpoint, failed, and fell back to whole-response synthesis.

This change makes the streaming path:

- use the shared `resolve_openai_audio_api_key()` resolver, including `VOICE_TOOLS_OPENAI_KEY` support;
- prefer `tts.openai.base_url` from the configured provider section;
- preserve `OPENAI_BASE_URL` as the compatibility fallback.

## Related Issue

No existing issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/tts_streaming.py` to share OpenAI audio credential resolution with batch TTS.
- Made `tts.openai.base_url` take precedence over the legacy environment fallback.
- Added regression coverage for audio-key availability and configured base-URL propagation through the streaming provider resolver.

## How to Test

1. Configure `tts.provider: openai`, `tts.use_gateway: false`, and a local OpenAI-compatible `/v1` root in `tts.openai.base_url`.
2. Set `VOICE_TOOLS_OPENAI_KEY`, leave `OPENAI_BASE_URL` unset, restart Desktop, and enable spoken replies.
3. Confirm speech begins from streamed PCM chunks and the backend does not contact the public OpenAI endpoint.

Automated checks run locally on Windows 10:

```text
39 passed in 7.24s
ruff: All checks passed
```

The test set included:

```text
tests/tools/test_tts_streaming.py
tests/tools/test_tts_dotenv_fallback.py
tests/hermes_cli/test_web_server_speak_stream.py
```

A live OpenAI-compatible Qwen TTS service was also verified with `response_format: pcm`; playback streamed successfully without `OPENAI_BASE_URL` after applying the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire `pytest tests/ -q` suite locally (targeted affected tests passed; full CI is delegated to GitHub Actions)
- [x] I've added tests for my changes
- [x] I've tested on Windows 10 with Hermes Desktop and a local OpenAI-compatible TTS endpoint

### Documentation & Housekeeping

- [x] Documentation update is N/A; this fixes existing documented configuration behavior
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the change uses existing config and credential helpers
- [x] Tool descriptions/schemas update is N/A
