### PR TITLE
fix(cli): forward the named custom-provider identity to background-task agents

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1672,6 +1672,14 @@ class CLICommandsMixin:
                     api_key=turn_route["runtime"].get("api_key"),
                     base_url=turn_route["runtime"].get("base_url"),
                     provider=turn_route["runtime"].get("provider"),
+                    # ``provider`` collapses a named custom provider to bare
+                    # ``custom``; without the routable ``custom:<name>`` identity
+                    # here, init_agent defaults requested_provider to the bare id
+                    # and per-model capability lookup (native vision) can no
+                    # longer find providers.<name>.models.<model> — the image
+                    # falls back to the aux-LLM path. Mirror the foreground
+                    # _init_agent / oneshot paths, which pass it. (#69894)
+                    requested_provider=turn_route["runtime"].get("requested_provider"),
                     api_mode=turn_route["runtime"].get("api_mode"),
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),

--- a/tests/agent/test_custom_providers_vision.py
+++ b/tests/agent/test_custom_providers_vision.py
@@ -340,3 +340,72 @@ class TestDecideImageInputMode:
             assert decide_image_input_mode("custom", "other-model", cfg) == "text"
         finally:
             clear_runtime_main()
+
+
+# ---------------------------------------------------------------------------
+# Background task (/background) must carry the named custom-provider identity
+# so per-model vision capability survives — #69894.
+# ---------------------------------------------------------------------------
+
+
+class TestBackgroundTaskCustomProviderIdentity:
+    def _run_background_and_capture_agent_kwargs(self, runtime: dict) -> dict:
+        """Invoke ``/background`` with a mocked route and return the kwargs the
+        handler passed to ``AIAgent``. Runs the background thread synchronously
+        and aborts right after construction so no real turn executes."""
+        from unittest.mock import MagicMock, patch
+        import hermes_cli.cli_commands_mixin as ccm
+
+        captured: dict = {}
+
+        class _Recorder:
+            def __init__(self, *args, **kwargs):
+                captured.update(kwargs)
+                raise RuntimeError("captured — stop before running the turn")
+
+        class _SyncThread:
+            def __init__(self, target=None, **_kw):
+                self._target = target
+
+            def start(self):
+                try:
+                    self._target()
+                except Exception:
+                    pass
+
+        shell = MagicMock()
+        shell._background_task_counter = 0
+        shell._ensure_runtime_credentials.return_value = True
+        shell._resolve_turn_agent_config.return_value = {
+            "model": "qwen3.8-max-preview",
+            "runtime": runtime,
+            "request_overrides": None,
+        }
+
+        with patch.object(ccm, "threading") as mock_threading, patch(
+            "cli.AIAgent", _Recorder
+        ):
+            mock_threading.Thread = _SyncThread
+            ccm.CLICommandsMixin._handle_background_command.__get__(shell)(
+                "/background inspect this screenshot"
+            )
+        return captured
+
+    def test_background_agent_receives_named_custom_provider(self):
+        """A ``--provider custom:<name>`` session's background task must forward
+        the routable ``custom:<name>`` identity to the AIAgent; otherwise
+        init_agent defaults requested_provider to the bare ``custom`` and native
+        vision breaks for the custom provider (#69894)."""
+        runtime = {
+            "provider": "custom",
+            "requested_provider": "custom:qwen-token-plan",
+            "api_key": "sk-test",
+            "base_url": "https://token-plan.example/v1",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "max_tokens": None,
+            "credential_pool": None,
+        }
+        captured = self._run_background_and_capture_agent_kwargs(runtime)
+        assert captured.get("requested_provider") == "custom:qwen-token-plan"


### PR DESCRIPTION
## What

Fixes #69894. The `/background` handler builds its `AIAgent` with `provider=turn_route["runtime"].get("provider")` but never passes `requested_provider`. `runtime["provider"]` collapses a named custom provider to bare `custom` (credential resolution strips the name), so init_agent's default kicks in:

```python
agent.requested_provider = (
    requested_provider.strip().lower() if <given> else agent.provider  # bare
)
```

and the routable `custom:<name>` identity is lost for the background agent. Any per-model capability lookup keyed on it then misses — most visibly **native vision**: `_should_use_native_vision_fast_path` resolves `providers.custom.models.<model>.supports_vision` (absent) instead of `providers.<name>.models.<model>`, so an attached image is analyzed through the **auxiliary vision LLM** instead of being sent to the model **natively**.

The foreground `_init_agent` and `oneshot` paths already forward it; the background path was the outlier.

## Fix

`turn_route["runtime"]` already carries the named form (`_resolve_turn_agent_config` sets `requested_provider = self.requested_provider`), so pass it through — mirroring the sibling paths.

## Tests

`tests/agent/test_custom_providers_vision.py` — new test drives the real `_handle_background_command` with a `custom:qwen-token-plan` route (background thread run synchronously, AIAgent construction captured) and asserts the agent receives `requested_provider="custom:qwen-token-plan"`. It **fails on `main`** (the kwarg is missing) and passes with the fix. Full custom-providers-vision suite: 17 passed; background-command + credential-routing suites: 62 passed. Tested on Ubuntu 24.04.