### PR TITLE
fix(compression): recover the summary from the reasoning field when content is empty

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3002,6 +3002,26 @@ This compaction should PRIORITISE preserving all information related to the focu
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):
                 content = str(content) if content else ""
+            # Reasoning/thinking models (DeepSeek, GLM, Qwen 3 via Ollama 0.22+,
+            # etc.) return their output in the reasoning field with ``content``
+            # empty — especially under the constrained ``max_tokens`` compression
+            # uses, where reasoning tokens consume the whole budget. Without a
+            # fallback the summary reads as empty and the entire compaction is
+            # discarded for a static marker (#19003). Recover from the structured
+            # reasoning fields, mirroring ``auxiliary_client.extract_content_or_
+            # reasoning`` and the main agent loop, before the empty-content guard
+            # below treats it as a failure. Handles both object- and dict-shaped
+            # messages, like the coercion above.
+            if not content.strip():
+                for _reasoning_field in ("reasoning", "reasoning_content"):
+                    _reasoning_val = (
+                        message.get(_reasoning_field)
+                        if isinstance(message, dict)
+                        else getattr(message, _reasoning_field, None)
+                    )
+                    if isinstance(_reasoning_val, str) and _reasoning_val.strip():
+                        content = _reasoning_val
+                        break
             # Some OpenAI-compatible proxies (e.g. cmkey.cn, one-api channels)
             # return a well-formed HTTP 200 with an empty or whitespace-only
             # ``content`` instead of an error or empty ``choices``. That payload

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -725,6 +725,58 @@ class TestNonStringContent:
         assert "do something" in summary
         assert summary.endswith("plain summary text")
 
+    def test_empty_content_recovers_summary_from_reasoning_field(self):
+        """Reasoning/thinking models (DeepSeek, GLM, Qwen 3 via Ollama 0.22+)
+        return their output in ``reasoning`` with ``content`` empty — especially
+        under the constrained max_tokens compression uses. The summary must be
+        recovered from the reasoning field, not discarded as an empty-content
+        failure that drops the whole compaction (#19003)."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+        mock_response.choices[0].message.reasoning = "recovered summary body"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            summary = c._generate_summary(messages)
+
+        # A real summary is produced from the reasoning field — NOT dropped as
+        # an empty-content failure, and no failure cooldown is engaged.
+        assert summary is not None
+        assert "recovered summary body" in summary
+        assert c._summary_failure_cooldown_until == 0
+
+    def test_empty_content_recovers_from_reasoning_content_dict_message(self):
+        """Same recovery when the backend returns a dict-shaped message with the
+        text in ``reasoning_content`` (llama.cpp / some proxies) (#19003)."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message = {
+            "content": "",
+            "reasoning_content": "dict reasoning summary",
+        }
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            summary = c._generate_summary(messages)
+
+        assert summary is not None
+        assert "dict reasoning summary" in summary
+
     def test_summary_call_does_not_force_temperature(self):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]


### PR DESCRIPTION
## What

Context compression reads the aux summary from `choices[0].message.content` only. Reasoning/thinking models (DeepSeek, GLM-5.x, Qwen 3 via Ollama 0.22+, etc.) return their output in the `reasoning` / `reasoning_content` field with `content` empty — and it's worst exactly here, because compression constrains `max_tokens`, so reasoning tokens consume the whole budget and `content` comes back `""`.

The empty-content guard (added for null-returning proxies, #11978) then treats it as a failure and **drops the entire compaction** for a static fallback marker — the model loses the summarized context every time it compacts on one of these models. Hermes already resolves this everywhere else via `auxiliary_client.extract_content_or_reasoning`; the compressor was the outlier.

```
aux response: content="", reasoning="…summary…"
before: RuntimeError "returned empty content" → compaction dropped, 60s cooldown
after : summary recovered from reasoning → compaction succeeds
```

## Fix

When `content` is empty, fall back to `reasoning` / `reasoning_content` before the empty-content guard fires — handling both object- and dict-shaped messages, exactly like the coercion just above it. Fixes #19003 (dup #70207).

## Tests

`tests/agent/test_context_compressor.py` — two new tests drive `_generate_summary` with an empty `content` plus a reasoning field (object- and dict-shaped messages); both **fail on `main`** (the guard drops the summary and engages the cooldown) and pass with the fix. The existing null/empty-content failure tests (#11978) still pass — the fallback only fires on a non-empty string reasoning value. Full suite: 197 passed. Tested on Ubuntu 24.04.