### PR TITLE
fix(desktop): rename a branched-draft session before its first turn (#70317)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
+import { $sessionStates, $sessionTiles } from '@/store/session-states'
 
 import { renameSessionPreferringRpc } from './session-actions-menu'
 
@@ -53,6 +54,8 @@ afterEach(() => {
   activeGateway.mockReturnValue({ request })
   $activeSessionId.set(null)
   $selectedStoredSessionId.set(null)
+  $sessionTiles.set([])
+  $sessionStates.set({})
 })
 
 describe('renameSessionPreferringRpc', () => {
@@ -82,6 +85,44 @@ describe('renameSessionPreferringRpc', () => {
   it('uses REST for a non-active row (background/persisted session)', async () => {
     $selectedStoredSessionId.set('some-other-active-session')
     $activeSessionId.set(RUNTIME_ID)
+
+    await renameSessionPreferringRpc(STORED_ID, 'My branch', 'work')
+
+    expect(request).not.toHaveBeenCalled()
+    expect(renameSession).toHaveBeenCalledWith(STORED_ID, 'My branch', 'work')
+  })
+
+  it('renames a branched-draft TILE via RPC even when it is not the selected row (#70317)', async () => {
+    // Branch opens as its own tab: NOT the selected primary row, and no DB row
+    // yet — but the tile carries the bound runtime id. REST would 404 here.
+    $selectedStoredSessionId.set('some-other-active-session')
+    $activeSessionId.set('rt-other')
+    $sessionTiles.set([{ storedSessionId: STORED_ID, runtimeId: RUNTIME_ID }])
+
+    const result = await renameSessionPreferringRpc(STORED_ID, 'My branch')
+
+    expect(request).toHaveBeenCalledWith('session.title', { session_id: RUNTIME_ID, title: 'My branch' })
+    expect(renameSession).not.toHaveBeenCalled()
+    expect(result.title).toBe('rpc-title')
+  })
+
+  it('resolves the runtime id from $sessionStates when no tile holds it (#70317)', async () => {
+    $selectedStoredSessionId.set('some-other-active-session')
+    $activeSessionId.set('rt-other')
+    $sessionStates.set({
+      [RUNTIME_ID]: { storedSessionId: STORED_ID } as never
+    })
+
+    await renameSessionPreferringRpc(STORED_ID, 'My branch')
+
+    expect(request).toHaveBeenCalledWith('session.title', { session_id: RUNTIME_ID, title: 'My branch' })
+    expect(renameSession).not.toHaveBeenCalled()
+  })
+
+  it('still uses REST when no surface holds a runtime id (persisted, not open)', async () => {
+    // Nothing selected, no tile, no live state → genuinely a persisted-only
+    // row; REST is correct (and resolves, because it has a DB row).
+    $selectedStoredSessionId.set('some-other-active-session')
 
     await renameSessionPreferringRpc(STORED_ID, 'My branch', 'work')
 

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -58,7 +58,7 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
-import { $sessionTiles, openSessionTile } from '@/store/session-states'
+import { $sessionStates, $sessionTiles, openSessionTile } from '@/store/session-states'
 import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
 
 import type { SessionTitleResponse } from '../../types'
@@ -79,13 +79,49 @@ import type { SessionTitleResponse } from '../../types'
 // background profile) keeps the REST path, which handles profile scoping and a
 // non-empty title is required by the RPC (it rejects clears), so clears stay on
 // REST too.
+/** Resolve a live runtime id for a stored session id, from any surface that
+ *  currently holds one — not just the selected-primary row.
+ *
+ *  A branched session opens as its own TAB and deliberately does NOT become the
+ *  selected primary row, so `$selectedStoredSessionId`/`$activeSessionId` do not
+ *  see it. Until its first turn it also has no persisted DB row, so a REST
+ *  rename 404s "session not found". But the branch flow binds a runtime and
+ *  stores it on the tile (`patchSessionTile(..., { runtimeId })`), and
+ *  `$sessionStates` is keyed by runtime id with `storedSessionId` on each state.
+ *  Consulting those lets the working `session.title` RPC path fire for a
+ *  just-branched draft instead of falling through to a 404. (#70317) */
+function resolveRuntimeIdForStored(storedSessionId: string): null | string {
+  if (storedSessionId === $selectedStoredSessionId.get()) {
+    const active = $activeSessionId.get()
+
+    if (active) {
+      return active
+    }
+  }
+
+  const tileRuntimeId = $sessionTiles
+    .get()
+    .find(tile => tile.storedSessionId === storedSessionId)?.runtimeId
+
+  if (tileRuntimeId) {
+    return tileRuntimeId
+  }
+
+  for (const [runtimeId, state] of Object.entries($sessionStates.get())) {
+    if (state.storedSessionId === storedSessionId) {
+      return runtimeId
+    }
+  }
+
+  return null
+}
+
 export async function renameSessionPreferringRpc(
   storedSessionId: string,
   title: string,
   profile?: string
 ): Promise<{ title?: string }> {
-  const isActiveRow = storedSessionId === $selectedStoredSessionId.get()
-  const runtimeId = isActiveRow ? $activeSessionId.get() : null
+  const runtimeId = resolveRuntimeIdForStored(storedSessionId)
   const gateway = activeGateway()
 
   if (title && runtimeId && gateway) {


### PR DESCRIPTION
## Summary

Fixes #70317. A branched session can't be renamed until it takes its first turn — the `draft: branch #N` placeholder is stuck, and renaming (rename box or `/title`) fails with **"session not found."**

## Root cause

When you branch, `forkBranch` (`use-session-actions/index.ts`) calls `session.create` and opens the result as its **own tab**, deliberately **not** making it the selected primary row. It also has **no persisted DB row** until its first turn ("backend persists + auto-names it then").

`renameSessionPreferringRpc` (`session-actions-menu.tsx`) only routed through the working `session.title` RPC when the target was the selected/active row:

```ts
const isActiveRow = storedSessionId === $selectedStoredSessionId.get()
const runtimeId = isActiveRow ? $activeSessionId.get() : null
```

A just-branched draft is neither the selected row (→ `runtimeId` null → RPC skipped) nor a persisted row (→ REST `renameSession()` 404s "Session not found"). So it falls through both guards.

Confirmed live: branching a stored session produced a draft; a `SELECT` against `state.db` showed **no row** for the draft and no `draft: branch #N` title — it's a client-side placeholder with only a runtime binding.

## Fix

Resolve the runtime id from **any surface that currently holds one**, not just the selected row, before falling back to REST:

1. the selected primary row (as before), then
2. the **session tile** — `forkBranch` binds the runtime via `patchSessionTile(routedSessionId, { runtimeId })`, so a branched-draft tile carries it, then
3. `$sessionStates` — keyed by runtime id, with `storedSessionId` on each state.

The `session.title` RPC persists the row on demand, so the rename lands. REST is still used for genuinely persisted-only rows, title clears (RPC rejects empty), and when no gateway is connected. This also matches the codebase's existing "runtime id, not REST, for unpersisted sessions" convention (see the `/title` slash handler comment).

## Tests

`session-actions-menu.test.ts` (logic file) — **8/8 pass**, adds:
- renames a branched-draft **tile** via RPC even when it isn't the selected row (#70317)
- resolves the runtime id from `$sessionStates` when no tile holds it (#70317)
- still uses REST when no surface holds a runtime id (persisted-only row)

Existing behavior (active-row RPC, REST fallback on RPC failure, title clears, no-gateway) unchanged.

Gate: `tsc -p apps/desktop --noEmit` clean, `eslint` clean on both files.

> Note: the sibling `session-actions-menu.test.tsx` shows 2 pre-existing failures (`TypeError: React.act is not a function`) that reproduce identically on unmodified `main` — a react-testing-lib/React version quirk in the local env, unrelated to this change.

---
*Developed with AI assistance during triage of a live install.*

