### PR TITLE
feat(acp): opt-in profile tool policy for full-capability hosts

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -76,7 +76,6 @@ from acp_adapter.session import (
     SessionManager,
     SessionState,
     _expand_acp_enabled_toolsets,
-    resolve_acp_tool_policy,
 )
 from acp_adapter.tools import build_tool_complete, build_tool_start
 from agent.context_compressor import (
@@ -986,24 +985,14 @@ class HermesACPAgent(acp.Agent):
         if not mcp_servers:
             return
 
-        try:
-            from hermes_cli.config import load_config
-
-            if resolve_acp_tool_policy(load_config()) == "profile":
-                logger.info(
-                    "Session %s: ignoring %d host MCP server(s) under "
-                    "acp.tool_policy=profile (profile owns tool policy)",
-                    state.session_id,
-                    len(mcp_servers),
-                )
-                return
-        except Exception:
-            logger.debug(
-                "Session %s: could not resolve ACP tool policy before host MCP "
-                "registration; continuing with compatibility behaviour",
+        if getattr(state.agent, "acp_tool_policy", "hermes-acp") == "profile":
+            logger.info(
+                "Session %s: ignoring %d host MCP server(s) under "
+                "acp.tool_policy=profile (profile owns tool policy)",
                 state.session_id,
-                exc_info=True,
+                len(mcp_servers),
             )
+            return
 
         try:
             from tools.mcp_tool import register_mcp_servers
@@ -1038,7 +1027,7 @@ class HermesACPAgent(acp.Agent):
             from agent.memory_manager import inject_memory_provider_tools
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
+                getattr(state.agent, "enabled_toolsets", None),
                 mcp_server_names=[server.name for server in mcp_servers],
             )
             state.agent.enabled_toolsets = enabled_toolsets
@@ -2147,7 +2136,7 @@ class HermesACPAgent(acp.Agent):
             from agent.memory_manager import inject_memory_provider_tools
 
             toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
+                getattr(state.agent, "enabled_toolsets", None)
             )
             tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
             tool_view = SimpleNamespace(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -72,7 +72,12 @@ from acp_adapter.events import (
 )
 from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
-from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
+from acp_adapter.session import (
+    SessionManager,
+    SessionState,
+    _expand_acp_enabled_toolsets,
+    resolve_acp_tool_policy,
+)
 from acp_adapter.tools import build_tool_complete, build_tool_start
 from agent.context_compressor import (
     COMPRESSED_SUMMARY_METADATA_KEY,
@@ -971,9 +976,34 @@ class HermesACPAgent(acp.Agent):
         state: SessionState,
         mcp_servers: list[McpServerStdio | McpServerHttp | McpServerSse] | None,
     ) -> None:
-        """Register ACP-provided MCP servers and refresh the agent tool surface."""
+        """Register ACP-provided MCP servers and refresh the agent tool surface.
+
+        In ``acp.tool_policy: profile`` mode the host may not expand the
+        selected profile's capability set. Client-provided MCP servers are
+        ignored; profile-configured MCP remains whatever session construction
+        already resolved from Hermes config.
+        """
         if not mcp_servers:
             return
+
+        try:
+            from hermes_cli.config import load_config
+
+            if resolve_acp_tool_policy(load_config()) == "profile":
+                logger.info(
+                    "Session %s: ignoring %d host MCP server(s) under "
+                    "acp.tool_policy=profile (profile owns tool policy)",
+                    state.session_id,
+                    len(mcp_servers),
+                )
+                return
+        except Exception:
+            logger.debug(
+                "Session %s: could not resolve ACP tool policy before host MCP "
+                "registration; continuing with compatibility behaviour",
+                state.session_id,
+                exc_info=True,
+            )
 
         try:
             from tools.mcp_tool import register_mcp_servers

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -144,6 +144,90 @@ def _expand_acp_enabled_toolsets(
     return expanded
 
 
+# Compatibility values keep the historical coding-focused ACP toolset.
+_ACP_COMPAT_TOOL_POLICIES = frozenset({"", "hermes-acp", "compat", "default"})
+_ACP_PROFILE_TOOL_POLICY = "profile"
+
+
+def resolve_acp_tool_policy(config: dict | None) -> str:
+    """Return the effective ACP tool policy for *config*.
+
+    ``hermes-acp`` (default) preserves the coding-focused ACP toolset used by
+    editor hosts. ``profile`` resolves the selected Hermes profile's local CLI
+    tool configuration so remote ACP hosts can match interactive Hermes.
+
+    Absent, invalid, or unknown values fall back to the compatibility default.
+    """
+    if not isinstance(config, dict):
+        return "hermes-acp"
+    acp_cfg = config.get("acp")
+    if not isinstance(acp_cfg, dict):
+        return "hermes-acp"
+    raw = acp_cfg.get("tool_policy")
+    if raw is None:
+        return "hermes-acp"
+    if not isinstance(raw, str):
+        return "hermes-acp"
+    policy = raw.strip().lower()
+    if policy in _ACP_COMPAT_TOOL_POLICIES:
+        return "hermes-acp"
+    if policy == _ACP_PROFILE_TOOL_POLICY:
+        return _ACP_PROFILE_TOOL_POLICY
+    return "hermes-acp"
+
+
+def resolve_acp_base_toolsets(config: dict | None) -> List[str]:
+    """Resolve base ACP toolsets for *config* without host-provided MCP names.
+
+    Profile mode uses the canonical platform tool resolver against the
+    profile's local interactive policy (``platform_toolsets.cli``), or an
+    explicit ``platform_toolsets.acp`` list when the profile defines one.
+    Profile-configured MCP servers are included by that resolver. Host MCP
+    expansion is intentionally not applied here.
+    """
+    config = config if isinstance(config, dict) else {}
+    if resolve_acp_tool_policy(config) != _ACP_PROFILE_TOOL_POLICY:
+        return ["hermes-acp"]
+
+    from hermes_cli.tools_config import _get_platform_tools
+
+    platform_toolsets = config.get("platform_toolsets") or {}
+    # Explicit acp platform list wins when present; otherwise mirror CLI so a
+    # profile that already works interactively keeps the same capability set.
+    if isinstance(platform_toolsets.get("acp"), list):
+        platform = "acp"
+    else:
+        platform = "cli"
+
+    resolved = sorted(
+        _get_platform_tools(
+            config,
+            platform,
+            include_default_mcp_servers=True,
+        )
+    )
+    return resolved or ["hermes-acp"]
+
+
+def resolve_acp_enabled_toolsets(config: dict | None) -> List[str]:
+    """Resolve the full ACP enabled-toolset list for session creation/restore."""
+    config = config if isinstance(config, dict) else {}
+    base = resolve_acp_base_toolsets(config)
+    if resolve_acp_tool_policy(config) == _ACP_PROFILE_TOOL_POLICY:
+        # Profile MCP membership already lives in *base* via _get_platform_tools.
+        return _expand_acp_enabled_toolsets(base, mcp_server_names=None)
+
+    configured_mcp_servers = [
+        name
+        for name, cfg in (config.get("mcp_servers") or {}).items()
+        if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
+    ]
+    return _expand_acp_enabled_toolsets(
+        base,
+        mcp_server_names=configured_mcp_servers,
+    )
+
+
 def _clear_task_cwd(task_id: str) -> None:
     """Remove task-specific cwd overrides for an ACP session."""
     if not task_id:
@@ -614,18 +698,9 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
-        configured_mcp_servers = [
-            name
-            for name, cfg in (config.get("mcp_servers") or {}).items()
-            if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
-        ]
-
         kwargs = {
             "platform": "acp",
-            "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
-                mcp_server_names=configured_mcp_servers,
-            ),
+            "enabled_toolsets": resolve_acp_enabled_toolsets(config),
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -132,7 +132,8 @@ def _expand_acp_enabled_toolsets(
 ) -> List[str]:
     """Return ACP toolsets plus explicit MCP server toolsets for this session."""
     expanded: List[str] = []
-    for name in list(toolsets or ["hermes-acp"]):
+    base_toolsets = ["hermes-acp"] if toolsets is None else toolsets
+    for name in list(base_toolsets):
         if name and name not in expanded:
             expanded.append(name)
 
@@ -199,14 +200,19 @@ def resolve_acp_base_toolsets(config: dict | None) -> List[str]:
     else:
         platform = "cli"
 
-    resolved = sorted(
+    # An explicit empty list is an intentional deny-all selection. Return
+    # before the canonical resolver's non-configurable recovery and default MCP
+    # expansion can add capabilities the operator deliberately removed.
+    if platform_toolsets.get(platform) == []:
+        return []
+
+    return sorted(
         _get_platform_tools(
             config,
             platform,
             include_default_mcp_servers=True,
         )
     )
-    return resolved or ["hermes-acp"]
 
 
 def resolve_acp_enabled_toolsets(config: dict | None) -> List[str]:
@@ -698,6 +704,7 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
+        tool_policy = resolve_acp_tool_policy(config)
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": resolve_acp_enabled_toolsets(config),
@@ -724,6 +731,11 @@ class SessionManager:
 
         _register_task_cwd(session_id, cwd)
         agent = AIAgent(**kwargs)
+        # Keep host MCP admission bound to the same config snapshot that built
+        # this agent. Re-reading config later can otherwise create a hybrid
+        # session when the file changes between construction and ACP lifecycle
+        # registration.
+        agent.acp_tool_policy = tool_policy
         # Codex app-server sessions are spawned lazily on the first turn. Stamp
         # the ACP workspace onto the agent so the Codex runtime starts from the
         # editor/session cwd instead of the Hermes daemon's process cwd.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2991,6 +2991,17 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # ACP host integration (Zed, Buzz, and other Agent Client Protocol hosts).
+    # tool_policy:
+    #   "hermes-acp" (default) - coding-focused ACP toolset for editor hosts.
+    #   "profile" - use this profile's local CLI tool configuration so a remote
+    #               ACP host gets the same capability surface as interactive
+    #               Hermes (skills, memory, cron, kanban, etc. as configured).
+    # Absent or invalid values preserve the hermes-acp default. No migration.
+    "acp": {
+        "tool_policy": "hermes-acp",
+    },
+
 
     # Google Vertex AI provider (Gemini via the OpenAI-compatible endpoint).
     # Auth is OAuth2 (short-lived access tokens minted from a service-account

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1016,6 +1016,9 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # field — fold it into the agent tab rather than spawning a one-field
     # orphan category.
     "computer_use": "agent",
+    # `acp.tool_policy` is the only schema-surfaced ACP host field. Fold it
+    # into the agent tab rather than spawning a one-field orphan category.
+    "acp": "agent",
     # `telemetry.shared_metrics.enabled` is the only schema-surfaced telemetry
     # field — fold it into security alongside the other privacy-posture toggles.
     "telemetry": "security",

--- a/tests/acp/test_tool_policy.py
+++ b/tests/acp/test_tool_policy.py
@@ -1,0 +1,355 @@
+"""ACP tool policy: compatibility vs profile-owned capability.
+
+Covers the opt-in ``acp.tool_policy`` config that lets ACP hosts either keep
+the coding-focused ``hermes-acp`` toolset or resolve the selected profile's
+local CLI tool configuration through the canonical platform resolver.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from acp_adapter.session import (
+    SessionManager,
+    resolve_acp_enabled_toolsets,
+    resolve_acp_tool_policy,
+)
+from hermes_state import SessionDB
+
+
+# ---------------------------------------------------------------------------
+# pure policy resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAcpToolPolicy:
+    def test_absent_defaults_to_compat(self):
+        assert resolve_acp_tool_policy({}) == "hermes-acp"
+        assert resolve_acp_tool_policy(None) == "hermes-acp"
+
+    def test_invalid_falls_back_to_compat(self):
+        assert resolve_acp_tool_policy({"acp": {"tool_policy": "full"}}) == "hermes-acp"
+        assert resolve_acp_tool_policy({"acp": {"tool_policy": 12}}) == "hermes-acp"
+        assert resolve_acp_tool_policy({"acp": "profile"}) == "hermes-acp"
+
+    def test_compat_aliases(self):
+        for value in ("hermes-acp", "compat", "default", "", "  COMPAT  "):
+            assert resolve_acp_tool_policy({"acp": {"tool_policy": value}}) == "hermes-acp"
+
+    def test_profile_mode(self):
+        assert resolve_acp_tool_policy({"acp": {"tool_policy": "profile"}}) == "profile"
+        assert resolve_acp_tool_policy({"acp": {"tool_policy": " PROFILE "}}) == "profile"
+
+
+class TestResolveAcpEnabledToolsets:
+    def test_compat_mode_uses_hermes_acp_and_profile_mcp(self):
+        config = {
+            "acp": {"tool_policy": "hermes-acp"},
+            "mcp_servers": {
+                "olympus": {"command": "python", "enabled": True},
+                "disabled": {"command": "python", "enabled": False},
+            },
+        }
+        assert resolve_acp_enabled_toolsets(config) == [
+            "hermes-acp",
+            "mcp-olympus",
+        ]
+
+    def test_profile_mode_uses_cli_platform_policy(self, monkeypatch):
+        config = {
+            "acp": {"tool_policy": "profile"},
+            "platform_toolsets": {
+                "cli": [
+                    "terminal",
+                    "file",
+                    "memory",
+                    "skills",
+                    "cronjob",
+                    "kanban",
+                    "delegation",
+                ],
+            },
+            "mcp_servers": {},
+            "agent": {},
+        }
+
+        # Avoid environment-gated auto-enables polluting the assertion surface.
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._xai_credentials_present",
+            lambda: False,
+        )
+
+        enabled = resolve_acp_enabled_toolsets(config)
+        assert "hermes-acp" not in enabled
+        for required in (
+            "terminal",
+            "file",
+            "memory",
+            "skills",
+            "cronjob",
+            "kanban",
+            "delegation",
+        ):
+            assert required in enabled
+
+    def test_profile_mode_honours_disabled_and_default_off_toolsets(self, monkeypatch):
+        config = {
+            "acp": {"tool_policy": "profile"},
+            "platform_toolsets": {
+                # Explicit list without homeassistant/spotify — those stay off.
+                "cli": ["terminal", "file", "memory"],
+            },
+            "agent": {
+                "disabled_toolsets": ["memory"],
+            },
+            "mcp_servers": {},
+        }
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._xai_credentials_present",
+            lambda: False,
+        )
+
+        enabled = set(resolve_acp_enabled_toolsets(config))
+        assert "terminal" in enabled
+        assert "file" in enabled
+        assert "memory" not in enabled
+        assert "homeassistant" not in enabled
+        assert "spotify" not in enabled
+
+    def test_profile_mode_prefers_explicit_acp_platform_list(self, monkeypatch):
+        config = {
+            "acp": {"tool_policy": "profile"},
+            "platform_toolsets": {
+                "cli": ["terminal", "file", "cronjob", "kanban"],
+                "acp": ["terminal", "memory"],
+            },
+            "mcp_servers": {},
+            "agent": {},
+        }
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._xai_credentials_present",
+            lambda: False,
+        )
+
+        enabled = set(resolve_acp_enabled_toolsets(config))
+        assert "terminal" in enabled
+        assert "memory" in enabled
+        assert "cronjob" not in enabled
+        assert "kanban" not in enabled
+
+
+# ---------------------------------------------------------------------------
+# session construction / restore
+# ---------------------------------------------------------------------------
+
+
+def _fake_runtime_provider(requested=None, **kwargs):
+    return {
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "base_url": "https://openrouter.example/v1",
+        "api_key": "***",
+        "command": None,
+        "args": [],
+    }
+
+
+def _patch_agent_stack(monkeypatch, config, captured):
+    def fake_agent(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            model=kwargs.get("model"),
+            enabled_toolsets=kwargs.get("enabled_toolsets"),
+            session_cwd=None,
+            _print_fn=None,
+        )
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _fake_runtime_provider,
+    )
+    monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda *a, **k: None)
+    monkeypatch.setattr("run_agent.AIAgent", fake_agent)
+
+
+class TestSessionToolPolicy:
+    def test_default_compat_session_keeps_hermes_acp(self, tmp_path, monkeypatch):
+        captured = {}
+        config = {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "mcp_servers": {},
+        }
+        _patch_agent_stack(monkeypatch, config, captured)
+        db = SessionDB(tmp_path / "state.db")
+        SessionManager(db=db).create_session(cwd="/work")
+        assert captured["enabled_toolsets"] == ["hermes-acp"]
+
+    def test_profile_mode_session_exposes_configured_cli_toolsets(
+        self, tmp_path, monkeypatch
+    ):
+        captured = {}
+        config = {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "acp": {"tool_policy": "profile"},
+            "platform_toolsets": {
+                "cli": ["terminal", "skills", "memory", "cronjob", "delegation"],
+            },
+            "mcp_servers": {},
+            "agent": {},
+        }
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._xai_credentials_present",
+            lambda: False,
+        )
+        _patch_agent_stack(monkeypatch, config, captured)
+        db = SessionDB(tmp_path / "state.db")
+        SessionManager(db=db).create_session(cwd="/work")
+        enabled = set(captured["enabled_toolsets"])
+        assert "hermes-acp" not in enabled
+        assert {"terminal", "skills", "memory", "cronjob", "delegation"} <= enabled
+
+    def test_restored_session_uses_same_profile_policy(self, tmp_path, monkeypatch):
+        """Create under profile policy, drop memory, restore — policy must re-apply."""
+        captured_create = {}
+        captured_restore = {}
+        config = {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "acp": {"tool_policy": "profile"},
+            "platform_toolsets": {
+                "cli": ["terminal", "file", "cronjob"],
+            },
+            "mcp_servers": {},
+            "agent": {},
+        }
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._xai_credentials_present",
+            lambda: False,
+        )
+
+        def fake_agent(**kwargs):
+            # First construction is create; after memory drop, restore rebuilds.
+            if "enabled_toolsets" in kwargs:
+                if not captured_create:
+                    captured_create.update(kwargs)
+                else:
+                    captured_restore.update(kwargs)
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                session_cwd=None,
+                _print_fn=None,
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _fake_runtime_provider,
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda *a, **k: None)
+        monkeypatch.setattr("run_agent.AIAgent", fake_agent)
+
+        db = SessionDB(tmp_path / "state.db")
+        manager = SessionManager(db=db)
+        state = manager.create_session(cwd="/work")
+        sid = state.session_id
+
+        with manager._lock:
+            del manager._sessions[sid]
+
+        restored = manager.get_session(sid)
+        assert restored is not None
+        assert set(captured_create["enabled_toolsets"]) == set(
+            captured_restore["enabled_toolsets"]
+        )
+        assert "cronjob" in captured_restore["enabled_toolsets"]
+        assert "hermes-acp" not in captured_restore["enabled_toolsets"]
+
+    def test_restore_still_rejects_non_acp_source(self, tmp_path, monkeypatch):
+        config = {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "acp": {"tool_policy": "profile"},
+            "platform_toolsets": {"cli": ["terminal"]},
+            "mcp_servers": {},
+            "agent": {},
+        }
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _fake_runtime_provider,
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda *a, **k: None)
+        monkeypatch.setattr(
+            "run_agent.AIAgent",
+            lambda **kwargs: SimpleNamespace(
+                model="m",
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                session_cwd=None,
+                _print_fn=None,
+            ),
+        )
+
+        db = SessionDB(tmp_path / "state.db")
+        # Seed a non-ACP session row directly.
+        db.create_session(session_id="desktop-sess-1", source="cli")
+        manager = SessionManager(db=db)
+        assert manager.get_session("desktop-sess-1") is None
+
+
+# ---------------------------------------------------------------------------
+# host MCP expansion blocked in profile mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_mode_ignores_host_mcp_servers(tmp_path, monkeypatch):
+    from acp.schema import McpServerStdio
+    from acp_adapter.server import HermesACPAgent
+
+    config = {
+        "model": {"provider": "openrouter", "default": "test-model"},
+        "acp": {"tool_policy": "profile"},
+        "platform_toolsets": {"cli": ["terminal", "memory"]},
+        "mcp_servers": {},
+        "agent": {},
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+
+    agent = HermesACPAgent()
+    agent.session_manager = SessionManager(
+        agent_factory=lambda: SimpleNamespace(
+            enabled_toolsets=["terminal", "memory"],
+            disabled_toolsets=None,
+            tools=[],
+            valid_tool_names=set(),
+            session_id="s1",
+            model="m",
+        ),
+        db=SessionDB(tmp_path / "state.db"),
+    )
+    state = agent.session_manager.create_session(cwd="/work")
+    original = list(state.agent.enabled_toolsets)
+
+    register_calls = []
+
+    def fake_register(config_map):
+        register_calls.append(config_map)
+
+    monkeypatch.setattr(
+        "tools.mcp_tool.register_mcp_servers",
+        fake_register,
+    )
+
+    server = McpServerStdio(name="host-extra", command="echo", args=[], env=[])
+    await agent._register_session_mcp_servers(state, [server])
+    assert register_calls == []
+    assert state.agent.enabled_toolsets == original
+    assert "mcp-host-extra" not in state.agent.enabled_toolsets
+    assert "host-extra" not in state.agent.enabled_toolsets

--- a/tests/acp/test_tool_policy.py
+++ b/tests/acp/test_tool_policy.py
@@ -310,6 +310,7 @@ class TestSessionToolPolicy:
 
 @pytest.mark.asyncio
 async def test_profile_mode_ignores_host_mcp_servers(tmp_path, monkeypatch):
+    pytest.importorskip("acp.schema")
     from acp.schema import McpServerStdio
     from acp_adapter.server import HermesACPAgent
 

--- a/tests/acp/test_tool_policy.py
+++ b/tests/acp/test_tool_policy.py
@@ -142,6 +142,35 @@ class TestResolveAcpEnabledToolsets:
         assert "cronjob" not in enabled
         assert "kanban" not in enabled
 
+    @pytest.mark.parametrize(
+        "platform_toolsets",
+        [
+            {"cli": []},
+            {"cli": ["terminal"], "acp": []},
+        ],
+        ids=["cli-empty", "acp-empty"],
+    )
+    def test_profile_mode_preserves_explicit_empty_platform_list(
+        self, monkeypatch, platform_toolsets
+    ):
+        config = {
+            "acp": {"tool_policy": "profile"},
+            "platform_toolsets": platform_toolsets,
+            "mcp_servers": {},
+            "agent": {},
+        }
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._xai_credentials_present",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_plugin_toolset_keys",
+            lambda: set(),
+        )
+
+        assert resolve_acp_enabled_toolsets(config) == []
+
 
 # ---------------------------------------------------------------------------
 # session construction / restore
@@ -214,6 +243,26 @@ class TestSessionToolPolicy:
         enabled = set(captured["enabled_toolsets"])
         assert "hermes-acp" not in enabled
         assert {"terminal", "skills", "memory", "cronjob", "delegation"} <= enabled
+
+    def test_profile_mode_session_preserves_explicit_empty_toolsets(
+        self, tmp_path, monkeypatch
+    ):
+        captured = {}
+        config = {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "acp": {"tool_policy": "profile"},
+            "platform_toolsets": {"cli": []},
+            "mcp_servers": {},
+            "agent": {},
+        }
+        _patch_agent_stack(monkeypatch, config, captured)
+        db = SessionDB(tmp_path / "state.db")
+
+        state = SessionManager(db=db).create_session(cwd="/work")
+
+        assert captured["enabled_toolsets"] == []
+        assert state.agent.enabled_toolsets == []
+        assert state.agent.acp_tool_policy == "profile"
 
     def test_restored_session_uses_same_profile_policy(self, tmp_path, monkeypatch):
         """Create under profile policy, drop memory, restore — policy must re-apply."""
@@ -321,22 +370,20 @@ async def test_profile_mode_ignores_host_mcp_servers(tmp_path, monkeypatch):
         "mcp_servers": {},
         "agent": {},
     }
-    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
-
+    captured = {}
+    _patch_agent_stack(monkeypatch, config, captured)
     agent = HermesACPAgent()
-    agent.session_manager = SessionManager(
-        agent_factory=lambda: SimpleNamespace(
-            enabled_toolsets=["terminal", "memory"],
-            disabled_toolsets=None,
-            tools=[],
-            valid_tool_names=set(),
-            session_id="s1",
-            model="m",
-        ),
-        db=SessionDB(tmp_path / "state.db"),
-    )
+    agent.session_manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
     state = agent.session_manager.create_session(cwd="/work")
+    state.agent.disabled_toolsets = None
+    state.agent.tools = []
+    state.agent.valid_tool_names = set()
     original = list(state.agent.enabled_toolsets)
+    assert state.agent.acp_tool_policy == "profile"
+
+    # Admission must stay bound to the policy that built the session even if
+    # config changes before the host supplies MCP servers.
+    config["acp"]["tool_policy"] = "hermes-acp"
 
     register_calls = []
 

--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -23,7 +23,7 @@ conversation transport.
 
 ## What Hermes exposes in ACP mode
 
-Hermes runs with a curated `hermes-acp` toolset designed for editor workflows. It includes:
+By default Hermes runs with a curated `hermes-acp` toolset designed for editor workflows. It includes:
 
 - file tools: `read_file`, `write_file`, `patch`, `search_files`
 - terminal tools: `terminal`, `process`
@@ -34,6 +34,32 @@ Hermes runs with a curated `hermes-acp` toolset designed for editor workflows. I
 - vision
 
 It intentionally excludes things that do not fit typical editor UX, such as messaging delivery and cronjob management.
+
+### Full-capability hosts (`acp.tool_policy`)
+
+Editor hosts usually want that coding-focused default. Remote ACP hosts that attach
+an existing Hermes profile (for example a messaging desktop surface) often need the
+**same tools as interactive CLI** for that profile.
+
+In `~/.hermes/config.yaml` (or the selected profile home):
+
+```yaml
+acp:
+  # hermes-acp (default) — coding-focused editor toolset
+  # profile — use this profile's local CLI tool configuration
+  tool_policy: profile
+```
+
+When `tool_policy` is `profile`:
+
+- tools resolve through the canonical platform resolver against
+  `platform_toolsets.cli`, or an explicit `platform_toolsets.acp` list when set
+- host-provided MCP servers cannot expand the capability set (profile owns policy)
+- skills, memory, cron, kanban, delegation, and other profile-enabled surfaces
+  match interactive Hermes for that home
+
+Absent or invalid values keep `hermes-acp` (no behaviour change for existing
+editor installs).
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Add `acp.tool_policy` so ACP hosts (Buzz, Zed, and other full-capability hosts) can use a Hermes profile's local CLI tool configuration instead of the coding-only `hermes-acp` default.

- Default remains `hermes-acp` (editor-compatible, **no behaviour change**)
- `acp.tool_policy: profile` resolves tools via the canonical `_get_platform_tools` path against `platform_toolsets.cli` (or explicit `platform_toolsets.acp` when set)
- Same policy on session create and restore
- Host-provided MCP servers cannot expand capability under profile policy
- Dashboard: fold `acp.tool_policy` into the agent config tab
- Docs: document the knob in the ACP user guide
- No config version bump; deep-merge supplies the default

## Why

Remote ACP hosts that attach an existing full Hermes profile need the profile's configured tools (skills, memory, kanban, cron, delegation, …), not the reduced coding toolset. This is generic ACP surface — no host-specific code.

Live dogfood: Buzz Desktop owner-only Rocky DM with full profile tools after setting `acp.tool_policy: profile` (companion Buzz PR [#2633](https://github.com/block/buzz/pull/2633)).

## Relationship to other open PRs

| PR | Overlap | Notes |
|---|---|---|
| **This PR** | Opt-in policy switch: editor default vs full profile | Small, backward compatible |
| [#64045](https://github.com/NousResearch/hermes-agent/pull/64045) | Honor `platform_toolsets.acp` always | Complementary; under `tool_policy: profile` we already honour explicit `platform_toolsets.acp`, else mirror CLI |
| [#46832](https://github.com/NousResearch/hermes-agent/pull/46832) | Similar platform_toolsets idea | Covered for profile mode here |
| [#57421](https://github.com/NousResearch/hermes-agent/pull/57421) | Pass `agent.disabled_toolsets` | Profile path uses `_get_platform_tools`, which already applies global disables |
| [#69915](https://github.com/NousResearch/hermes-agent/pull/69915) | Docs-only Buzz host guide | Orthogonal; this PR documents the config knob on the Hermes side |

A deeper first-class product integration with Buzz (beyond ACP stdio) is still best owned by Nous Research if desired later. This PR unblocks full-capability hosts **now** without breaking editors.

## Test plan

- [x] `scripts/run_tests.sh tests/acp/test_tool_policy.py -q` (13 passed)
- [x] Default / invalid policy still yields `hermes-acp` + profile MCP
- [x] Profile mode exposes configured CLI toolsets and honours disabled/default-off
- [x] Restored sessions re-apply profile policy
- [x] Host MCP ignored under profile mode
- [x] Buzz owner Rocky dogfood (full tools + multi-turn DM)