### PR TITLE
fix(cron): don't drift-block an unpinned job when the resolved model is free

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3335,6 +3335,34 @@ def run_job(
                 _drift.append(
                     f"model '{_model_snapshot}' -> '{_current_model}'"
                 )
+        # The guard exists purely to prevent unintended SPEND (#44585). A
+        # free-tier model (``:free`` SKU, or cached-free pricing) forces spend
+        # to zero, so a drift whose RESOLVED model is free — including the
+        # free->free rotation every free-tier user hits when the global default
+        # swaps between free models — carries no billing risk and blocking it is
+        # pure friction with no safe recovery path (#70050). Clear the drift in
+        # that case only: ``is_free_tier_model`` fails closed to "paid" on any
+        # doubt (unknown model, empty cache), so a genuinely-paid or
+        # can't-tell drift still fails closed exactly as before.
+        if _drift:
+            try:
+                from agent.credits_tracker import is_free_tier_model
+
+                if is_free_tier_model(
+                    str(model or ""), str(runtime.get("base_url") or "")
+                ):
+                    logger.info(
+                        "Job '%s': inference config drifted (%s) but the "
+                        "resolved model is free-tier — no spend risk, running "
+                        "anyway.",
+                        job_id,
+                        "; ".join(_drift),
+                    )
+                    _drift = []
+            except Exception:
+                # Never let the free-tier check itself turn a safe run into a
+                # crash; on any error keep the original fail-closed behaviour.
+                pass
         if _drift:
             _changes = "; ".join(_drift)
             logger.warning(

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -297,6 +297,40 @@ class TestModelDriftGuard:
         assert "llama-3.3-70b-instruct:free" in blob
         assert "44585" in blob
 
+    def test_free_to_free_model_drift_does_not_block(self, tmp_path):
+        # Both snapshot and resolved model are ``:free`` SKUs — spend is forced
+        # to zero, so the anti-spend guard has nothing to protect. The drift
+        # must NOT block (#70050): a free-tier user whose global default rotates
+        # between free models would otherwise be stuck with no supported repin.
+        job = _base_job(
+            provider_snapshot="openrouter",
+            model_snapshot="stepfun/step-3.7-flash:free",
+        )
+        success, output, final_response, error, agent_constructed = \
+            _run_with_current_provider_and_model(
+                job, "openrouter", "tencent/hy3:free", tmp_path
+            )
+        assert agent_constructed is True, (
+            "free->free drift must not fail closed — no spend risk"
+        )
+        assert success is True
+
+    def test_free_to_paid_model_drift_still_blocks(self, tmp_path):
+        # Control: drift from a free snapshot INTO a paid model still fails
+        # closed — the resolved model can spend, which is exactly what the guard
+        # protects against. Only the resolved (new) model's free status matters.
+        job = _base_job(
+            provider_snapshot="openrouter",
+            model_snapshot="llama-3.3-70b-instruct:free",
+        )
+        success, output, final_response, error, agent_constructed = \
+            _run_with_current_provider_and_model(
+                job, "openrouter", "claude-fable-5", tmp_path
+            )
+        assert agent_constructed is False
+        assert success is False
+        assert "44585" in f"{error}\n{output}".lower()
+
     def test_model_snapshot_matches_runs(self, tmp_path):
         # Default model unchanged → runs normally.
         job = _base_job(


### PR DESCRIPTION
## What

The provider/model-drift guard (#44585) fails an unpinned cron job closed when the global default drifts since creation, to prevent it silently spending money on a newly-paid model/provider. But it fires even when the drift is **between free models**: a user whose global default rotates `stepfun/step-3.7-flash:free` → `tencent/hy3:free` gets every cron skipped with

> Skipped to prevent unintended spend: global inference config drifted …

despite `:free` SKUs forcing spend to zero. There's no billing risk to protect against, and no supported CLI repin path for that user (`cron edit` has no `--model`, `cronjob update` drops `model` — #68380), so it's pure friction (#70050).

## Fix

The guard's sole purpose is preventing spend, so clear the drift when the **resolved (new) model is free-tier** — via the existing `is_free_tier_model` (zero-network `:free`-suffix + cached-pricing check). It **fails closed to "paid" on any doubt** (unknown model, empty cache), so a genuinely-paid or can't-tell drift still fails closed exactly as before; only a provably-free resolved model is let through. Whichever axis drifted, a free resolved model can't spend.

```
snapshot stepfun/step-3.7-flash:free → resolved tencent/hy3:free
before: RuntimeError "Skipped to prevent unintended spend …"
after : job runs
```

## Tests

`tests/cron/test_cron_provider_pin.py` — `test_free_to_free_model_drift_does_not_block` drives the real `run_job` (fails on `main`, passes with the fix), plus a `test_free_to_paid_model_drift_still_blocks` control pinning that a free→paid drift still fails closed. Full cron provider-pin + scheduler suites: 254 passed. Tested on Ubuntu 24.04.