### PR TITLE
fix(security): guard browse.sh skillMdUrl fetches against SSRF

### DIFF
--- a/tests/tools/test_skills_hub_browse_sh.py
+++ b/tests/tools/test_skills_hub_browse_sh.py
@@ -77,7 +77,7 @@ class TestBrowseShSource(unittest.TestCase):
         results_all = self.src.search("", limit=10)
         self.assertEqual(len(results_all), 2)
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._guarded_http_get")
     @patch.object(BrowseShSource, "_fetch_catalog", return_value=SAMPLE_CATALOG)
     def test_fetch_returns_bundle(self, _mock_catalog, mock_get):
         # First call: GET /api/skills/{slug} returns the detail object with skillMdUrl.
@@ -107,7 +107,7 @@ class TestBrowseShSource(unittest.TestCase):
         self.assertIn("/api/skills/airbnb.com/search-listings-ddgioa", first_url)
         self.assertEqual(second_url, blob_url)
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._guarded_http_get")
     @patch.object(BrowseShSource, "_fetch_catalog", return_value=SAMPLE_CATALOG)
     def test_fetch_falls_back_to_raw_github_url(self, _mock_catalog, mock_get):
         # Detail endpoint fails → fall back to a raw.githubusercontent.com sourceUrl.
@@ -124,6 +124,26 @@ class TestBrowseShSource(unittest.TestCase):
             bundle = self.src.fetch("browse-sh/airbnb.com/search-listings-ddgioa")
             self.assertIsNotNone(bundle)
             self.assertEqual(bundle.files["SKILL.md"], "# Fallback content")
+
+    @patch("tools.skills_hub._guarded_http_get")
+    @patch.object(BrowseShSource, "_fetch_catalog", return_value=SAMPLE_CATALOG)
+    def test_fetch_blocks_private_skill_md_url(self, _mock_catalog, mock_get):
+        """External skillMdUrl pointing at private/link-local must not be fetched."""
+        mock_get.side_effect = [
+            _MockResponse(
+                status_code=200,
+                json_data={"skillMdUrl": "http://127.0.0.1/secret.md"},
+            ),
+            # Guarded fetcher returns None when SSRF policy blocks the URL.
+            None,
+        ]
+        bundle = self.src.fetch("browse-sh/airbnb.com/search-listings-ddgioa")
+        self.assertIsNone(bundle)
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(
+            mock_get.call_args_list[1].args[0],
+            "http://127.0.0.1/secret.md",
+        )
 
     @patch.object(BrowseShSource, "_fetch_catalog", return_value=SAMPLE_CATALOG)
     def test_fetch_missing_slug_returns_none(self, _mock_catalog):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3104,13 +3104,13 @@ class BrowseShSource(SkillSource):
         md_url = self._resolve_skill_md_url(slug, item)
         if not md_url:
             return None
-        try:
-            resp = httpx.get(md_url, timeout=20, follow_redirects=True)
-            if resp.status_code != 200:
-                return None
-            content = resp.text
-        except httpx.HTTPError:
+        # skillMdUrl is supplied by an external catalog/CDN and can redirect
+        # to private/link-local targets. Route through the shared guarded
+        # fetcher (SSRF + hop re-validation) rather than raw httpx.
+        resp = _guarded_http_get(md_url, timeout=20)
+        if resp is None or resp.status_code != 200:
             return None
+        content = resp.text
 
         meta = self._item_to_meta(item)
         name = meta.name if meta else slug.split("/")[-1]
@@ -3136,18 +3136,17 @@ class BrowseShSource(SkillSource):
         ``sourceUrl`` (some entries may), use it directly.
         """
         try:
-            detail = httpx.get(
+            detail = _guarded_http_get(
                 self.SKILL_DETAIL_URL.format(slug=slug),
                 timeout=20,
-                follow_redirects=True,
             )
-            if detail.status_code == 200:
+            if detail is not None and detail.status_code == 200:
                 data = detail.json()
                 if isinstance(data, dict):
                     md_url = data.get("skillMdUrl")
                     if isinstance(md_url, str) and md_url.startswith("http"):
                         return md_url
-        except (httpx.HTTPError, json.JSONDecodeError):
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
             pass
 
         source_url = item.get("sourceUrl", "") if isinstance(item, dict) else ""


### PR DESCRIPTION
## Summary
- BrowseShSource fetched catalog-supplied `skillMdUrl` (and the detail endpoint) with raw `httpx.get(..., follow_redirects=True)`, so a malicious CDN URL or redirect hop could reach private/link-local addresses.
- Route both the detail lookup and content download through the existing `_guarded_http_get` helper (SSRF + hop re-validation), matching the rest of Skills Hub.
- Add a regression test that a private `skillMdUrl` is refused.

## Test plan
- [x] `pytest tests/tools/test_skills_hub_browse_sh.py` (8 passed)
