### PR TITLE
fix(security): re-validate Weixin media download redirects

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -29,11 +29,13 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 logger = logging.getLogger(__name__)
 
 WEIXIN_COPY_LINE_WIDTH = 120
+_WEIXIN_MEDIA_MAX_REDIRECTS = 5
+_WEIXIN_MEDIA_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 
 try:
     import aiohttp
@@ -2091,14 +2093,36 @@ class WeixinAdapter(BasePlatformAdapter):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
         assert self._send_session is not None
-        # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
-        # "Timeout context manager should be used inside a task" errors.
+        # Pre-flight is_safe_url alone is insufficient: a public URL can
+        # 302 to link-local / RFC1918 / cloud metadata. Follow redirects
+        # manually and re-validate every hop (same pattern as Discord/Matrix).
         async def _do_fetch():
-            async with self._send_session.get(url) as response:
-                response.raise_for_status()
-                return await response.read()
-        data = await asyncio.wait_for(_do_fetch(), timeout=30)
-        suffix = Path(url.split("?", 1)[0]).suffix or ".bin"
+            current_url = url
+            for _ in range(_WEIXIN_MEDIA_MAX_REDIRECTS + 1):
+                if not is_safe_url(current_url):
+                    raise ValueError(
+                        f"Blocked redirect to private/internal address: {current_url}"
+                    )
+                async with self._send_session.get(
+                    current_url, allow_redirects=False
+                ) as response:
+                    if response.status in _WEIXIN_MEDIA_REDIRECT_STATUSES:
+                        location = response.headers.get("Location")
+                        if not location:
+                            raise ValueError("redirect missing Location")
+                        next_url = urljoin(current_url, location)
+                        if not is_safe_url(next_url):
+                            raise ValueError(
+                                f"Blocked redirect to private/internal address: {next_url}"
+                            )
+                        current_url = next_url
+                        continue
+                    response.raise_for_status()
+                    return await response.read(), current_url
+            raise ValueError("Too many media URL redirects")
+
+        data, final_url = await asyncio.wait_for(_do_fetch(), timeout=30)
+        suffix = Path(final_url.split("?", 1)[0]).suffix or ".bin"
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
             handle.write(data)
             return handle.name

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2087,22 +2087,18 @@ class WeixinAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     async def _download_remote_media(self, url: str) -> str:
-        from tools.url_safety import is_safe_url
+        from tools.url_safety import async_is_safe_url
 
-        if not is_safe_url(url):
+        if not await async_is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
         assert self._send_session is not None
-        # Pre-flight is_safe_url alone is insufficient: a public URL can
+        # Pre-flight async_is_safe_url alone is insufficient: a public URL can
         # 302 to link-local / RFC1918 / cloud metadata. Follow redirects
         # manually and re-validate every hop (same pattern as Discord/Matrix).
         async def _do_fetch():
             current_url = url
             for _ in range(_WEIXIN_MEDIA_MAX_REDIRECTS + 1):
-                if not is_safe_url(current_url):
-                    raise ValueError(
-                        f"Blocked redirect to private/internal address: {current_url}"
-                    )
                 async with self._send_session.get(
                     current_url, allow_redirects=False
                 ) as response:
@@ -2111,7 +2107,7 @@ class WeixinAdapter(BasePlatformAdapter):
                         if not location:
                             raise ValueError("redirect missing Location")
                         next_url = urljoin(current_url, location)
-                        if not is_safe_url(next_url):
+                        if not await async_is_safe_url(next_url):
                             raise ValueError(
                                 f"Blocked redirect to private/internal address: {next_url}"
                             )

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -29,11 +29,13 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 logger = logging.getLogger(__name__)
 
 WEIXIN_COPY_LINE_WIDTH = 120
+_WEIXIN_MEDIA_MAX_REDIRECTS = 5
+_WEIXIN_MEDIA_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 
 try:
     import aiohttp
@@ -2159,14 +2161,36 @@ class WeixinAdapter(BasePlatformAdapter):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
         assert self._send_session is not None
-        # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
-        # "Timeout context manager should be used inside a task" errors.
+        # Pre-flight is_safe_url alone is insufficient: a public URL can
+        # 302 to link-local / RFC1918 / cloud metadata. Follow redirects
+        # manually and re-validate every hop (same pattern as Discord/Matrix).
         async def _do_fetch():
-            async with self._send_session.get(url) as response:
-                response.raise_for_status()
-                return await response.read()
-        data = await asyncio.wait_for(_do_fetch(), timeout=30)
-        suffix = Path(url.split("?", 1)[0]).suffix or ".bin"
+            current_url = url
+            for _ in range(_WEIXIN_MEDIA_MAX_REDIRECTS + 1):
+                if not is_safe_url(current_url):
+                    raise ValueError(
+                        f"Blocked redirect to private/internal address: {current_url}"
+                    )
+                async with self._send_session.get(
+                    current_url, allow_redirects=False
+                ) as response:
+                    if response.status in _WEIXIN_MEDIA_REDIRECT_STATUSES:
+                        location = response.headers.get("Location")
+                        if not location:
+                            raise ValueError("redirect missing Location")
+                        next_url = urljoin(current_url, location)
+                        if not is_safe_url(next_url):
+                            raise ValueError(
+                                f"Blocked redirect to private/internal address: {next_url}"
+                            )
+                        current_url = next_url
+                        continue
+                    response.raise_for_status()
+                    return await response.read(), current_url
+            raise ValueError("Too many media URL redirects")
+
+        data, final_url = await asyncio.wait_for(_do_fetch(), timeout=30)
+        suffix = Path(final_url.split("?", 1)[0]).suffix or ".bin"
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
             handle.write(data)
             return handle.name

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2155,22 +2155,18 @@ class WeixinAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     async def _download_remote_media(self, url: str) -> str:
-        from tools.url_safety import is_safe_url
+        from tools.url_safety import async_is_safe_url
 
-        if not is_safe_url(url):
+        if not await async_is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
         assert self._send_session is not None
-        # Pre-flight is_safe_url alone is insufficient: a public URL can
+        # Pre-flight async_is_safe_url alone is insufficient: a public URL can
         # 302 to link-local / RFC1918 / cloud metadata. Follow redirects
         # manually and re-validate every hop (same pattern as Discord/Matrix).
         async def _do_fetch():
             current_url = url
             for _ in range(_WEIXIN_MEDIA_MAX_REDIRECTS + 1):
-                if not is_safe_url(current_url):
-                    raise ValueError(
-                        f"Blocked redirect to private/internal address: {current_url}"
-                    )
                 async with self._send_session.get(
                     current_url, allow_redirects=False
                 ) as response:
@@ -2179,7 +2175,7 @@ class WeixinAdapter(BasePlatformAdapter):
                         if not location:
                             raise ValueError("redirect missing Location")
                         next_url = urljoin(current_url, location)
-                        if not is_safe_url(next_url):
+                        if not await async_is_safe_url(next_url):
                             raise ValueError(
                                 f"Blocked redirect to private/internal address: {next_url}"
                             )

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2181,6 +2181,10 @@ class WeixinAdapter(BasePlatformAdapter):
                             )
                         current_url = next_url
                         continue
+                    if 300 <= response.status < 400:
+                        raise ValueError(
+                            f"Unsupported media redirect status: {response.status}"
+                        )
                     response.raise_for_status()
                     return await response.read(), current_url
             raise ValueError("Too many media URL redirects")

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -627,6 +627,55 @@ class TestWeixinRemoteMediaSafety:
             else:
                 raise AssertionError("expected ValueError for unsafe URL")
 
+    def test_download_remote_media_blocks_redirect_to_private(self):
+        """Public URL that 302s to link-local must be refused (salvage #40255)."""
+        adapter = _make_adapter()
+
+        class _Resp:
+            def __init__(self, status, headers=None, body=b""):
+                self.status = status
+                self.headers = headers or {}
+                self._body = body
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            def raise_for_status(self):
+                if self.status >= 400:
+                    raise RuntimeError(f"HTTP {self.status}")
+
+            async def read(self):
+                return self._body
+
+        class _Session:
+            def get(self, url, allow_redirects=False):
+                assert allow_redirects is False
+                if url == "https://cdn.example.com/public.png":
+                    return _Resp(302, {"Location": "http://169.254.169.254/latest/meta-data/"})
+                raise AssertionError(f"unexpected fetch of {url}")
+
+        adapter._send_session = _Session()
+
+        def _safe(u: str) -> bool:
+            return not (
+                "127.0.0.1" in u
+                or "169.254." in u
+                or "localhost" in u
+            )
+
+        with patch("tools.url_safety.is_safe_url", side_effect=_safe):
+            try:
+                asyncio.run(
+                    adapter._download_remote_media("https://cdn.example.com/public.png")
+                )
+            except ValueError as exc:
+                assert "Blocked redirect" in str(exc)
+            else:
+                raise AssertionError("expected ValueError for redirect SSRF")
+
 
 class TestWeixinMarkdownLinks:
     """Markdown links should be preserved so WeChat can render them natively."""

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -619,7 +619,7 @@ class TestWeixinRemoteMediaSafety:
     def test_download_remote_media_blocks_unsafe_urls(self):
         adapter = _make_adapter()
 
-        with patch("tools.url_safety.is_safe_url", return_value=False):
+        with patch("tools.url_safety.async_is_safe_url", new=AsyncMock(return_value=False)):
             try:
                 asyncio.run(adapter._download_remote_media("http://127.0.0.1/private.png"))
             except ValueError as exc:
@@ -659,14 +659,14 @@ class TestWeixinRemoteMediaSafety:
 
         adapter._send_session = _Session()
 
-        def _safe(u: str) -> bool:
+        async def _safe(u: str) -> bool:
             return not (
                 "127.0.0.1" in u
                 or "169.254." in u
                 or "localhost" in u
             )
 
-        with patch("tools.url_safety.is_safe_url", side_effect=_safe):
+        with patch("tools.url_safety.async_is_safe_url", side_effect=_safe):
             try:
                 asyncio.run(
                     adapter._download_remote_media("https://cdn.example.com/public.png")

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -343,7 +343,7 @@ class TestWeixinRemoteMediaSafety:
     def test_download_remote_media_blocks_unsafe_urls(self):
         adapter = _make_adapter()
 
-        with patch("tools.url_safety.is_safe_url", return_value=False):
+        with patch("tools.url_safety.async_is_safe_url", new=AsyncMock(return_value=False)):
             try:
                 asyncio.run(adapter._download_remote_media("http://127.0.0.1/private.png"))
             except ValueError as exc:
@@ -383,14 +383,14 @@ class TestWeixinRemoteMediaSafety:
 
         adapter._send_session = _Session()
 
-        def _safe(u: str) -> bool:
+        async def _safe(u: str) -> bool:
             return not (
                 "127.0.0.1" in u
                 or "169.254." in u
                 or "localhost" in u
             )
 
-        with patch("tools.url_safety.is_safe_url", side_effect=_safe):
+        with patch("tools.url_safety.async_is_safe_url", side_effect=_safe):
             try:
                 asyncio.run(
                     adapter._download_remote_media("https://cdn.example.com/public.png")

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -351,6 +351,55 @@ class TestWeixinRemoteMediaSafety:
             else:
                 raise AssertionError("expected ValueError for unsafe URL")
 
+    def test_download_remote_media_blocks_redirect_to_private(self):
+        """Public URL that 302s to link-local must be refused (salvage #40255)."""
+        adapter = _make_adapter()
+
+        class _Resp:
+            def __init__(self, status, headers=None, body=b""):
+                self.status = status
+                self.headers = headers or {}
+                self._body = body
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            def raise_for_status(self):
+                if self.status >= 400:
+                    raise RuntimeError(f"HTTP {self.status}")
+
+            async def read(self):
+                return self._body
+
+        class _Session:
+            def get(self, url, allow_redirects=False):
+                assert allow_redirects is False
+                if url == "https://cdn.example.com/public.png":
+                    return _Resp(302, {"Location": "http://169.254.169.254/latest/meta-data/"})
+                raise AssertionError(f"unexpected fetch of {url}")
+
+        adapter._send_session = _Session()
+
+        def _safe(u: str) -> bool:
+            return not (
+                "127.0.0.1" in u
+                or "169.254." in u
+                or "localhost" in u
+            )
+
+        with patch("tools.url_safety.is_safe_url", side_effect=_safe):
+            try:
+                asyncio.run(
+                    adapter._download_remote_media("https://cdn.example.com/public.png")
+                )
+            except ValueError as exc:
+                assert "Blocked redirect" in str(exc)
+            else:
+                raise AssertionError("expected ValueError for redirect SSRF")
+
 
 class TestWeixinMarkdownLinks:
     """Markdown links should be preserved so WeChat can render them natively."""

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import json
 import os
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -399,6 +400,106 @@ class TestWeixinRemoteMediaSafety:
                 assert "Blocked redirect" in str(exc)
             else:
                 raise AssertionError("expected ValueError for redirect SSRF")
+
+    def test_download_remote_media_follows_safe_public_redirect(self):
+        adapter = _make_adapter()
+        initial_url = "https://cdn.example.com/public.png"
+        final_url = "https://cdn.example.com/assets/final/public.jpg"
+
+        class _Resp:
+            def __init__(self, status, headers=None, body=b""):
+                self.status = status
+                self.headers = headers or {}
+                self._body = body
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            def raise_for_status(self):
+                if self.status >= 400:
+                    raise RuntimeError(f"HTTP {self.status}")
+
+            async def read(self):
+                return self._body
+
+        class _Session:
+            def __init__(self):
+                self.calls = []
+
+            def get(self, url, allow_redirects=False):
+                self.calls.append((url, allow_redirects))
+                if url == initial_url:
+                    return _Resp(302, {"Location": "/assets/final/public.jpg"})
+                if url == final_url:
+                    return _Resp(200, body=b"safe-image")
+                raise AssertionError(f"unexpected fetch of {url}")
+
+        session = _Session()
+        adapter._send_session = session
+
+        with patch(
+            "tools.url_safety.async_is_safe_url", new=AsyncMock(return_value=True)
+        ) as safe_url_check:
+            output_path = asyncio.run(adapter._download_remote_media(initial_url))
+
+        try:
+            assert Path(output_path).read_bytes() == b"safe-image"
+            assert Path(output_path).suffix == ".jpg"
+            assert session.calls == [(initial_url, False), (final_url, False)]
+            assert [call.args[0] for call in safe_url_check.await_args_list] == [
+                initial_url,
+                final_url,
+            ]
+        finally:
+            Path(output_path).unlink(missing_ok=True)
+
+    def test_download_remote_media_rejects_unsupported_redirect_status(self):
+        adapter = _make_adapter()
+
+        class _Resp:
+            def __init__(self):
+                self.status = 304
+                self.headers = {}
+                self.read_called = False
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            def raise_for_status(self):
+                if self.status >= 400:
+                    raise RuntimeError(f"HTTP {self.status}")
+
+            async def read(self):
+                self.read_called = True
+                return b"must-not-be-saved"
+
+        class _Session:
+            def __init__(self, response):
+                self.response = response
+
+            def get(self, url, allow_redirects=False):
+                assert url == "https://cdn.example.com/public.png"
+                assert allow_redirects is False
+                return self.response
+
+        response = _Resp()
+        adapter._send_session = _Session(response)
+
+        with patch(
+            "tools.url_safety.async_is_safe_url", new=AsyncMock(return_value=True)
+        ):
+            with pytest.raises(ValueError, match="Unsupported media redirect status: 304"):
+                asyncio.run(
+                    adapter._download_remote_media("https://cdn.example.com/public.png")
+                )
+
+        assert response.read_called is False
 
 
 class TestWeixinMarkdownLinks:
@@ -876,4 +977,3 @@ class TestWeixinVoiceGatewayHandoff:
             "VOICE event body leaked Tencent's STT text — runner would trust "
             "the wrong transcript instead of re-transcribing (#27300)."
         )
-


### PR DESCRIPTION
## Summary
- **Salvage:** prior Weixin work (#40255 and related) added a pre-flight `is_safe_url` check, but `_download_remote_media` still followed aiohttp redirects unchecked. A public URL that 302s to link-local/RFC1918/cloud metadata bypassed that gate.
- Follow redirects manually (`allow_redirects=False`) and re-validate every hop, matching the Discord/Matrix media pattern.
- Capability preserved: legitimate public CDN media still downloads.

## Test plan
- [x] `pytest tests/gateway/test_weixin.py::TestWeixinRemoteMediaSafety` (2 passed)
