### PR TITLE
fix(security): scrub GIT_CONFIG_COUNT and secrets from checkpoint git env

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -711,6 +711,21 @@ class TestGpgAndGlobalConfigIsolation:
         assert env["GIT_CONFIG_SYSTEM"] == os.devnull
         assert env["GIT_CONFIG_NOSYSTEM"] == "1"
 
+    def test_git_env_strips_config_count_and_ssh_wrappers(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+        monkeypatch.setenv("GIT_CONFIG_KEY_0", "core.sshCommand")
+        monkeypatch.setenv("GIT_CONFIG_VALUE_0", "touch /tmp/pwned")
+        monkeypatch.setenv("GIT_SSH_COMMAND", "evil-ssh")
+        monkeypatch.setenv("GIT_ASKPASS", "evil-askpass")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-should-not-leak")
+        env = _git_env(tmp_path / "store", str(tmp_path))
+        assert "GIT_CONFIG_COUNT" not in env
+        assert "GIT_CONFIG_KEY_0" not in env
+        assert "GIT_CONFIG_VALUE_0" not in env
+        assert "GIT_SSH_COMMAND" not in env
+        assert "GIT_ASKPASS" not in env
+        assert env.get("OPENAI_API_KEY") is None
+
     def test_init_sets_commit_gpgsign_false(self, work_dir, checkpoint_base, monkeypatch):
         monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
         store = _store_path(checkpoint_base)

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -494,6 +494,57 @@ class TestGitEnvIsolation:
         env = _git_env(store, f"~/{tilde_work.name}")
         assert env["GIT_WORK_TREE"] == str(tilde_work.resolve())
 
+    def test_git_child_cannot_apply_inherited_config_parameters(
+        self, tmp_path, monkeypatch,
+    ):
+        work = tmp_path / "work"
+        work.mkdir()
+        store = tmp_path / "store"
+        subprocess.run(
+            ["git", "init", "--bare", str(store)],
+            cwd=work,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        monkeypatch.setenv("GIT_CONFIG_PARAMETERS", "'core.pager=cat'")
+        monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+        monkeypatch.setenv("GIT_CONFIG_KEY_0", "core.editor")
+        monkeypatch.setenv("GIT_CONFIG_VALUE_0", "evil-editor")
+
+        env = _git_env(store, str(work))
+        result = subprocess.run(
+            ["git", "config", "--get", "core.pager"],
+            cwd=work,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode != 0
+        assert result.stdout == ""
+
+    def test_git_env_strips_credential_wrappers_and_provider_secrets(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.setenv("GIT_SSH_COMMAND", "evil-ssh")
+        monkeypatch.setenv("GIT_ASKPASS", "evil-askpass")
+        monkeypatch.setenv("SSH_ASKPASS", "evil-ssh-askpass")
+        monkeypatch.setenv("GIT_PROXY_COMMAND", "evil-proxy")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-should-not-leak")
+
+        env = _git_env(tmp_path / "store", str(tmp_path))
+
+        for key in (
+            "GIT_SSH_COMMAND",
+            "GIT_SSH",
+            "GIT_ASKPASS",
+            "SSH_ASKPASS",
+            "GIT_PROXY_COMMAND",
+            "OPENAI_API_KEY",
+        ):
+            assert key not in env
+
 
 # =========================================================================
 # Error resilience

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -253,12 +253,22 @@ def _git_env(
     * ``GIT_CONFIG_GLOBAL=<os.devnull>`` — ignore ``~/.gitconfig`` (git 2.32+).
     * ``GIT_CONFIG_SYSTEM=<os.devnull>`` — ignore ``/etc/gitconfig`` (git 2.32+).
     * ``GIT_CONFIG_NOSYSTEM=1`` — legacy belt-and-suspenders for older git.
+    * Drop ``GIT_CONFIG_COUNT`` / ``GIT_CONFIG_KEY_*`` / ``GIT_CONFIG_VALUE_*``
+      so an inherited env-config injection cannot override the null files.
+    * Drop ``GIT_SSH_COMMAND`` / ``GIT_ASKPASS`` / ``SSH_ASKPASS`` /
+      ``GIT_PROXY_COMMAND`` so credential helpers and SSH wrappers from the
+      parent Hermes process cannot fire during background snapshots.
+    * Strip Hermes provider/tool secrets via ``hermes_subprocess_env`` so
+      API keys are not visible to git credential helpers.
 
     ``index_file``, if given, forces git to use a per-project index under
     ``store/indexes/<hash>`` so projects don't race on a shared index.
     """
+    from tools.environments.local import hermes_subprocess_env
+
     normalized_working_dir = _normalize_path(working_dir)
-    env = os.environ.copy()
+    # Strip provider/tool credentials; keep PATH/HOME and non-secret tooling.
+    env = hermes_subprocess_env(inherit_credentials=False)
     env["GIT_DIR"] = str(store)
     env["GIT_WORK_TREE"] = str(normalized_working_dir)
     env.pop("GIT_NAMESPACE", None)
@@ -270,6 +280,22 @@ def _git_env(
     env["GIT_CONFIG_GLOBAL"] = os.devnull
     env["GIT_CONFIG_SYSTEM"] = os.devnull
     env["GIT_CONFIG_NOSYSTEM"] = "1"
+    # Env-based git config injection bypasses the null global/system files.
+    env.pop("GIT_CONFIG_COUNT", None)
+    for key in list(env):
+        upper = key.upper()
+        if upper.startswith("GIT_CONFIG_KEY_") or upper.startswith("GIT_CONFIG_VALUE_"):
+            env.pop(key, None)
+    for dangerous in (
+        "GIT_SSH_COMMAND",
+        "GIT_SSH",
+        "GIT_ASKPASS",
+        "SSH_ASKPASS",
+        "GIT_PROXY_COMMAND",
+        "GIT_EXTERNAL_DIFF",
+        "GIT_DIFF_OPTS",
+    ):
+        env.pop(dangerous, None)
     return env
 
 
@@ -441,15 +467,23 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
 
     # ``git init --bare`` rejects GIT_WORK_TREE, so we can't use _run_git
     # here (which always sets GIT_DIR + GIT_WORK_TREE).  Use a raw
-    # subprocess with just the config-isolation env vars.
-    init_env = os.environ.copy()
+    # subprocess with the same scrubbed env as _git_env (minus work-tree).
+    from tools.environments.local import hermes_subprocess_env
+
+    init_env = hermes_subprocess_env(inherit_credentials=False)
     init_env["GIT_CONFIG_GLOBAL"] = os.devnull
     init_env["GIT_CONFIG_SYSTEM"] = os.devnull
     init_env["GIT_CONFIG_NOSYSTEM"] = "1"
     # Drop any inherited GIT_* that would interfere.
     for k in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_NAMESPACE",
-              "GIT_ALTERNATE_OBJECT_DIRECTORIES"):
+              "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_CONFIG_COUNT",
+              "GIT_SSH_COMMAND", "GIT_SSH", "GIT_ASKPASS", "SSH_ASKPASS",
+              "GIT_PROXY_COMMAND", "GIT_EXTERNAL_DIFF", "GIT_DIFF_OPTS"):
         init_env.pop(k, None)
+    for key in list(init_env):
+        upper = key.upper()
+        if upper.startswith("GIT_CONFIG_KEY_") or upper.startswith("GIT_CONFIG_VALUE_"):
+            init_env.pop(key, None)
     try:
         result = subprocess.run(
             ["git", "init", "--bare", str(store)],

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -307,15 +307,14 @@ def _git_env(
     * ``GIT_CONFIG_GLOBAL=<os.devnull>`` — ignore ``~/.gitconfig`` (git 2.32+).
     * ``GIT_CONFIG_SYSTEM=<os.devnull>`` — ignore ``/etc/gitconfig`` (git 2.32+).
     * ``GIT_CONFIG_NOSYSTEM=1`` — legacy belt-and-suspenders for older git.
+    * Drop environment-based git configuration and credential wrappers.
 
     ``index_file``, if given, forces git to use a per-project index under
     ``store/indexes/<hash>`` so projects don't race on a shared index.
     """
     normalized_working_dir = _normalize_path(working_dir)
-    # git child with hand-isolated config env; exact preservation — a HOME
-    # rewrite would change which ~/.gitconfig the isolation vars are hiding.
     from tools.environments.local import build_subprocess_env
-    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    env = build_subprocess_env(scrub_secrets=True)
     env["GIT_DIR"] = str(store)
     env["GIT_WORK_TREE"] = str(normalized_working_dir)
     env.pop("GIT_NAMESPACE", None)
@@ -327,6 +326,22 @@ def _git_env(
     env["GIT_CONFIG_GLOBAL"] = os.devnull
     env["GIT_CONFIG_SYSTEM"] = os.devnull
     env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env.pop("GIT_CONFIG_PARAMETERS", None)
+    env.pop("GIT_CONFIG_COUNT", None)
+    for key in list(env):
+        upper = key.upper()
+        if upper.startswith("GIT_CONFIG_KEY_") or upper.startswith("GIT_CONFIG_VALUE_"):
+            env.pop(key, None)
+    for key in (
+        "GIT_SSH_COMMAND",
+        "GIT_SSH",
+        "GIT_ASKPASS",
+        "SSH_ASKPASS",
+        "GIT_PROXY_COMMAND",
+        "GIT_EXTERNAL_DIFF",
+        "GIT_DIFF_OPTS",
+    ):
+        env.pop(key, None)
     return env
 
 
@@ -500,14 +515,32 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
     # here (which always sets GIT_DIR + GIT_WORK_TREE).  Use a raw
     # subprocess with just the config-isolation env vars.
     from tools.environments.local import build_subprocess_env
-    init_env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    init_env = build_subprocess_env(scrub_secrets=True)
     init_env["GIT_CONFIG_GLOBAL"] = os.devnull
     init_env["GIT_CONFIG_SYSTEM"] = os.devnull
     init_env["GIT_CONFIG_NOSYSTEM"] = "1"
     # Drop any inherited GIT_* that would interfere.
-    for k in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_NAMESPACE",
-              "GIT_ALTERNATE_OBJECT_DIRECTORIES"):
+    for k in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_NAMESPACE",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_CONFIG_PARAMETERS",
+        "GIT_CONFIG_COUNT",
+        "GIT_SSH_COMMAND",
+        "GIT_SSH",
+        "GIT_ASKPASS",
+        "SSH_ASKPASS",
+        "GIT_PROXY_COMMAND",
+        "GIT_EXTERNAL_DIFF",
+        "GIT_DIFF_OPTS",
+    ):
         init_env.pop(k, None)
+    for key in list(init_env):
+        upper = key.upper()
+        if upper.startswith("GIT_CONFIG_KEY_") or upper.startswith("GIT_CONFIG_VALUE_"):
+            init_env.pop(key, None)
     try:
         result = subprocess.run(
             ["git", "init", "--bare", str(store)],


### PR DESCRIPTION
## Summary
- **Salvage:** #11261 / existing checkpoint isolation nulls `GIT_CONFIG_GLOBAL`/`SYSTEM`, but Git still honours `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_*` / `GIT_CONFIG_VALUE_*` from the parent environment, allowing config injection (e.g. `core.sshCommand`) during background snapshots.
- Also strip `GIT_SSH_COMMAND` / askpass / proxy wrappers and build the env via `hermes_subprocess_env(inherit_credentials=False)` so provider API keys are not visible to git credential helpers.
- Init path uses the same scrubbing.

## Test plan
- [x] `pytest tests/tools/test_checkpoint_manager.py::TestGpgAndGlobalConfigIsolation` (5 passed)
