### PR TITLE
fix(security): contain sync_back inferred host paths

### DIFF
--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -180,6 +180,29 @@ class TestSyncBackNewRemoteFile:
         assert expected_host_path.read_bytes() == new_remote_content
 
 
+class TestSyncBackContainment:
+    def test_sync_back_rejects_host_symlink_escape(self, tmp_path):
+        host_root = tmp_path / "host" / "skills"
+        host_file = host_root / "existing.py"
+        _write_file(host_file, b"existing")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        try:
+            (host_root / "linked").symlink_to(outside, target_is_directory=True)
+        except OSError:
+            pytest.skip("directory symlinks are unavailable on this host")
+
+        mapping = [(str(host_file), "/root/.hermes/skills/existing.py")]
+        download_fn = _make_download_fn({
+            "root/.hermes/skills/linked/escape.txt": b"blocked",
+        })
+        mgr = _make_manager(tmp_path, file_mapping=mapping, bulk_download_fn=download_fn)
+
+        mgr.sync_back(hermes_home=tmp_path / ".hermes")
+
+        assert not (outside / "escape.txt").exists()
+
+
 class TestSyncBackConflict:
     """Host AND remote both changed since push -- warning logged, remote wins."""
 

--- a/tests/tools/test_file_sync_infer_path.py
+++ b/tests/tools/test_file_sync_infer_path.py
@@ -1,0 +1,63 @@
+"""Unit tests for FileSyncManager host-path containment (no fcntl required)."""
+
+from pathlib import Path
+
+from tools.environments.file_sync import FileSyncManager
+
+
+def _write_file(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def _make_manager(tmp_path: Path, file_mapping=None) -> FileSyncManager:
+    mapping = file_mapping or []
+
+    def _get_files():
+        return list(mapping)
+
+    return FileSyncManager(
+        upload_fn=lambda *_a, **_k: None,
+        delete_fn=lambda *_a, **_k: None,
+        get_files_fn=_get_files,
+        bulk_download_fn=None,
+    )
+
+
+def test_infer_matching_prefix(tmp_path):
+    host_file = tmp_path / "host" / "skills" / "a.py"
+    _write_file(host_file, b"content")
+    mapping = [(str(host_file), "/root/.hermes/skills/a.py")]
+    mgr = _make_manager(tmp_path, file_mapping=mapping)
+    result = mgr._infer_host_path(
+        "/root/.hermes/skills/b.py",
+        file_mapping=mapping,
+    )
+    assert result == str(tmp_path / "host" / "skills" / "b.py")
+
+
+def test_infer_rejects_traversal_suffix(tmp_path):
+    host_file = tmp_path / "host" / "skills" / "a.py"
+    _write_file(host_file, b"content")
+    mapping = [(str(host_file), "/root/.hermes/skills/a.py")]
+    mgr = _make_manager(tmp_path, file_mapping=mapping)
+    result = mgr._infer_host_path(
+        "/root/.hermes/skills/../../.ssh/authorized_keys",
+        file_mapping=mapping,
+    )
+    assert result is None
+
+
+def test_host_path_containment_rejects_escape(tmp_path):
+    host_file = tmp_path / "host" / "skills" / "a.py"
+    _write_file(host_file, b"content")
+    mapping = [(str(host_file), "/root/.hermes/skills/a.py")]
+    mgr = _make_manager(tmp_path, file_mapping=mapping)
+    assert mgr._host_path_is_contained(
+        str(tmp_path / "host" / "skills" / "b.py"),
+        mapping,
+    )
+    assert not mgr._host_path_is_contained(
+        str(tmp_path / "host" / ".ssh" / "authorized_keys"),
+        mapping,
+    )

--- a/tests/tools/test_file_sync_infer_path.py
+++ b/tests/tools/test_file_sync_infer_path.py
@@ -61,3 +61,16 @@ def test_host_path_containment_rejects_escape(tmp_path):
         str(tmp_path / "host" / ".ssh" / "authorized_keys"),
         mapping,
     )
+
+
+def test_host_path_containment_ignores_upload_only_roots(tmp_path):
+    host_file = tmp_path / "host" / "credentials" / "token"
+    _write_file(host_file, b"secret")
+    mapping = [(str(host_file), "/root/.hermes/credentials/token")]
+    mgr = _make_manager(tmp_path, file_mapping=mapping)
+
+    assert not mgr._host_path_is_contained(
+        str(tmp_path / "host" / "credentials" / "new-token"),
+        mapping,
+        upload_only_host_paths={str(host_file.resolve())},
+    )

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -412,6 +412,13 @@ class FileSyncManager:
                             )
                             continue
 
+                        if not self._host_path_is_contained(host_path, file_mapping):
+                            logger.warning(
+                                "sync_back: refusing host path outside mapped roots: %s",
+                                host_path,
+                            )
+                            continue
+
                         if os.path.exists(host_path) and pushed_hash is not None:
                             host_hash = _sha256_file(host_path)
                             if host_hash != pushed_hash:
@@ -451,18 +458,69 @@ class FileSyncManager:
         For example, if the mapping has ``/root/.hermes/skills/a.md`` →
         ``~/.hermes/skills/a.md``, a new remote file at
         ``/root/.hermes/skills/b.md`` maps to ``~/.hermes/skills/b.md``.
+
+        Rejects remote suffixes that contain ``..`` and requires the
+        resolved host path to stay under the mapped host directory root.
+        Remote paths are always POSIX-shaped (sandbox); host paths use
+        local ``Path`` rules.
         """
         mapping = file_mapping if file_mapping is not None else []
         upload_only_host_paths = upload_only_host_paths or set()
         for host, remote in mapping:
             if self._is_upload_only_host_path(host, upload_only_host_paths):
                 continue
-            remote_dir = str(Path(remote).parent)
+            remote_dir = posixpath.dirname(remote)
             if remote_path.startswith(remote_dir + "/"):
                 host_dir = str(Path(host).parent)
                 suffix = remote_path[len(remote_dir):]
-                return host_dir + suffix
+                # Defence-in-depth: even if tar extract filtered ``..``,
+                # never concatenate a traversal suffix onto the host root.
+                suffix_parts = [p for p in suffix.replace("\\", "/").split("/") if p]
+                if ".." in suffix_parts:
+                    logger.warning(
+                        "sync_back: rejecting traversal suffix in remote path %s",
+                        remote_path,
+                    )
+                    return None
+                # Map POSIX suffix onto the local host directory.
+                local_suffix = suffix.replace("/", os.sep)
+                candidate = host_dir + local_suffix
+                try:
+                    resolved = Path(candidate).expanduser().resolve()
+                    root = Path(host_dir).expanduser().resolve()
+                    resolved.relative_to(root)
+                except (ValueError, OSError):
+                    logger.warning(
+                        "sync_back: inferred host path escapes mapped root: %s",
+                        candidate,
+                    )
+                    return None
+                return candidate
         return None
+
+    def _host_path_is_contained(
+        self,
+        host_path: str,
+        file_mapping: list[tuple[str, str]],
+    ) -> bool:
+        """Return True if *host_path* resolves under any mapped host directory."""
+        try:
+            resolved = Path(host_path).expanduser().resolve()
+        except OSError:
+            return False
+        roots: set[Path] = set()
+        for host, _remote in file_mapping:
+            try:
+                roots.add(Path(host).expanduser().resolve().parent)
+            except OSError:
+                continue
+        for root in roots:
+            try:
+                resolved.relative_to(root)
+                return True
+            except ValueError:
+                continue
+        return False
 
     @staticmethod
     def _is_upload_only_host_path(host_path: str, upload_only_host_paths: set[str]) -> bool:

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -423,6 +423,13 @@ class FileSyncManager:
                             )
                             continue
 
+                        if not self._host_path_is_contained(host_path, file_mapping):
+                            logger.warning(
+                                "sync_back: refusing host path outside mapped roots: %s",
+                                host_path,
+                            )
+                            continue
+
                         if os.path.exists(host_path) and pushed_hash is not None:
                             host_hash = _sha256_file(host_path)
                             if host_hash != pushed_hash:
@@ -462,18 +469,69 @@ class FileSyncManager:
         For example, if the mapping has ``/root/.hermes/skills/a.md`` →
         ``~/.hermes/skills/a.md``, a new remote file at
         ``/root/.hermes/skills/b.md`` maps to ``~/.hermes/skills/b.md``.
+
+        Rejects remote suffixes that contain ``..`` and requires the
+        resolved host path to stay under the mapped host directory root.
+        Remote paths are always POSIX-shaped (sandbox); host paths use
+        local ``Path`` rules.
         """
         mapping = file_mapping if file_mapping is not None else []
         upload_only_host_paths = upload_only_host_paths or set()
         for host, remote in mapping:
             if self._is_upload_only_host_path(host, upload_only_host_paths):
                 continue
-            remote_dir = str(Path(remote).parent)
+            remote_dir = posixpath.dirname(remote)
             if remote_path.startswith(remote_dir + "/"):
                 host_dir = str(Path(host).parent)
                 suffix = remote_path[len(remote_dir):]
-                return host_dir + suffix
+                # Defence-in-depth: even if tar extract filtered ``..``,
+                # never concatenate a traversal suffix onto the host root.
+                suffix_parts = [p for p in suffix.replace("\\", "/").split("/") if p]
+                if ".." in suffix_parts:
+                    logger.warning(
+                        "sync_back: rejecting traversal suffix in remote path %s",
+                        remote_path,
+                    )
+                    return None
+                # Map POSIX suffix onto the local host directory.
+                local_suffix = suffix.replace("/", os.sep)
+                candidate = host_dir + local_suffix
+                try:
+                    resolved = Path(candidate).expanduser().resolve()
+                    root = Path(host_dir).expanduser().resolve()
+                    resolved.relative_to(root)
+                except (ValueError, OSError):
+                    logger.warning(
+                        "sync_back: inferred host path escapes mapped root: %s",
+                        candidate,
+                    )
+                    return None
+                return candidate
         return None
+
+    def _host_path_is_contained(
+        self,
+        host_path: str,
+        file_mapping: list[tuple[str, str]],
+    ) -> bool:
+        """Return True if *host_path* resolves under any mapped host directory."""
+        try:
+            resolved = Path(host_path).expanduser().resolve()
+        except OSError:
+            return False
+        roots: set[Path] = set()
+        for host, _remote in file_mapping:
+            try:
+                roots.add(Path(host).expanduser().resolve().parent)
+            except OSError:
+                continue
+        for root in roots:
+            try:
+                resolved.relative_to(root)
+                return True
+            except ValueError:
+                continue
+        return False
 
     @staticmethod
     def _is_upload_only_host_path(host_path: str, upload_only_host_paths: set[str]) -> bool:

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -423,7 +423,11 @@ class FileSyncManager:
                             )
                             continue
 
-                        if not self._host_path_is_contained(host_path, file_mapping):
+                        if not self._host_path_is_contained(
+                            host_path,
+                            file_mapping,
+                            upload_only_host_paths=upload_only_host_paths,
+                        ):
                             logger.warning(
                                 "sync_back: refusing host path outside mapped roots: %s",
                                 host_path,
@@ -486,7 +490,7 @@ class FileSyncManager:
                 suffix = remote_path[len(remote_dir):]
                 # Defence-in-depth: even if tar extract filtered ``..``,
                 # never concatenate a traversal suffix onto the host root.
-                suffix_parts = [p for p in suffix.replace("\\", "/").split("/") if p]
+                suffix_parts = [part for part in suffix.split("/") if part]
                 if ".." in suffix_parts:
                     logger.warning(
                         "sync_back: rejecting traversal suffix in remote path %s",
@@ -513,14 +517,19 @@ class FileSyncManager:
         self,
         host_path: str,
         file_mapping: list[tuple[str, str]],
+        *,
+        upload_only_host_paths: set[str] | None = None,
     ) -> bool:
         """Return True if *host_path* resolves under any mapped host directory."""
         try:
             resolved = Path(host_path).expanduser().resolve()
         except OSError:
             return False
+        upload_only_host_paths = upload_only_host_paths or set()
         roots: set[Path] = set()
         for host, _remote in file_mapping:
+            if self._is_upload_only_host_path(host, upload_only_host_paths):
+                continue
             try:
                 roots.add(Path(host).expanduser().resolve().parent)
             except OSError:


### PR DESCRIPTION
## Summary
- **Salvage / defence-in-depth:** extract-side work (`filter=data`, open tar-limit PRs such as #62065 / #32807) reduces zip-slip style members, but `_infer_host_path` still concatenated raw remote suffixes onto host directory prefixes with no containment check before `copy2`.
- Reject `..` in remote suffixes; require the resolved host path to stay under a mapped host directory root; skip writes that escape those roots.
- Use POSIX dirname for remote sandbox paths so Windows hosts do not mis-parse remote prefixes.

## Test plan
- [x] `pytest tests/tools/test_file_sync_infer_path.py` (3 passed)
