### PR TITLE
fix(security): re-validate MCP HTTP/SSE redirect targets

### DIFF
--- a/tests/tools/test_mcp_client_cert.py
+++ b/tests/tools/test_mcp_client_cert.py
@@ -398,9 +398,8 @@ def patch_sse_client():
 
 
 class TestSSEClientCert:
-    def test_no_factory_when_defaults(self, patch_sse_client):
-        """With no cert and ssl_verify=True (default), the SDK's own factory is
-        used — we don't inject one."""
+    def test_factory_injected_when_defaults(self, patch_sse_client):
+        """The default SSE path also uses our guarded httpx factory."""
         from tools.mcp_tool import MCPServerTask
 
         server = MCPServerTask("sse-test")
@@ -423,7 +422,44 @@ class TestSSEClientCert:
                     pass
 
         asyncio.run(drive())
-        assert "httpx_client_factory" not in patch_sse_client
+        assert patch_sse_client.get("httpx_client_factory") is not None
+
+    def test_redirect_guard_uses_location_without_next_request(self, patch_sse_client):
+        """A redirect hook must validate Location when next_request is absent."""
+        from tools.mcp_tool import MCPServerTask
+        import httpx
+
+        server = MCPServerTask("sse-test")
+        server._auth_type = ""
+        server._sampling = None
+
+        async def drive():
+            with patch.object(MCPServerTask, "_wait_for_lifecycle_event",
+                              new=AsyncMock(return_value="shutdown")), \
+                 patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()):
+                await server._run_http({
+                    "url": "https://example.com/mcp/sse",
+                    "transport": "sse",
+                })
+
+        asyncio.run(drive())
+        factory = patch_sse_client["httpx_client_factory"]
+        captured = {}
+
+        class DummyAsyncClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        with patch.object(httpx, "AsyncClient", DummyAsyncClient):
+            factory()
+        hook = captured["event_hooks"]["response"][0]
+        response = httpx.Response(
+            302,
+            headers={"Location": "http://169.254.169.254/latest/meta-data"},
+            request=httpx.Request("GET", "https://example.com/mcp/sse"),
+        )
+        with pytest.raises(ValueError, match="Blocked MCP redirect"):
+            asyncio.run(hook(response))
 
     def test_factory_injected_when_cert_set(self, patch_sse_client, tmp_path):
         """With client_cert set, an httpx_client_factory is injected that

--- a/tests/tools/test_mcp_http_redirect_ssrf.py
+++ b/tests/tools/test_mcp_http_redirect_ssrf.py
@@ -1,0 +1,79 @@
+"""MCP HTTP redirect hooks: salvage #62929 + close redirect SSRF."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools.mcp_tool import _make_mcp_http_redirect_hooks
+
+
+class _FakeURL:
+    def __init__(self, url: str):
+        from urllib.parse import urlparse
+
+        p = urlparse(url)
+        self.scheme = p.scheme
+        self.host = p.hostname
+        self.port = p.port
+        self._url = url
+
+    def __str__(self):
+        return self._url
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_public_mcp_redirect_to_metadata_blocked():
+    with patch("tools.url_safety.is_safe_url", return_value=True), patch(
+        "tools.url_safety.is_always_blocked_url", return_value=True
+    ):
+        hooks = _make_mcp_http_redirect_hooks("https://mcp.example.com/v1")
+        hook = hooks[0]
+        next_req = SimpleNamespace(
+            url=_FakeURL("http://169.254.169.254/latest/meta-data/"),
+            headers={},
+        )
+        response = SimpleNamespace(is_redirect=True, next_request=next_req)
+        with pytest.raises(ValueError, match="metadata|always-blocked|Blocked MCP redirect"):
+            _run(hook(response))
+
+
+def test_public_mcp_redirect_to_private_blocked():
+    def _safe(url: str) -> bool:
+        return "127.0.0.1" not in url and "169.254." not in url
+
+    with patch("tools.url_safety.is_safe_url", side_effect=_safe), patch(
+        "tools.url_safety.is_always_blocked_url", return_value=False
+    ):
+        hooks = _make_mcp_http_redirect_hooks("https://mcp.example.com/v1")
+        hook = hooks[0]
+        next_req = SimpleNamespace(
+            url=_FakeURL("http://127.0.0.1:9000/secret"),
+            headers={"Authorization": "Bearer leak"},
+        )
+        response = SimpleNamespace(is_redirect=True, next_request=next_req)
+        with pytest.raises(ValueError, match="private/internal"):
+            _run(hook(response))
+        assert "Authorization" not in next_req.headers
+
+
+def test_loopback_mcp_redirect_to_loopback_allowed():
+    def _safe(url: str) -> bool:
+        # Loopback origin is not "public" for SSRF purposes.
+        return "127.0.0.1" not in url
+
+    with patch("tools.url_safety.is_safe_url", side_effect=_safe), patch(
+        "tools.url_safety.is_always_blocked_url", return_value=False
+    ):
+        hooks = _make_mcp_http_redirect_hooks("http://127.0.0.1:3100/mcp")
+        hook = hooks[0]
+        next_req = SimpleNamespace(
+            url=_FakeURL("http://127.0.0.1:3100/mcp/v2"),
+            headers={},
+        )
+        response = SimpleNamespace(is_redirect=True, next_request=next_req)
+        _run(hook(response))

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -468,6 +468,48 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
     return env
 
 
+def _make_mcp_http_redirect_hooks(original_url: str):
+    """Build httpx response hooks for MCP HTTP/SSE clients.
+
+    Salvages #62929 (strip Authorization on cross-origin redirects) and closes
+    the remaining redirect-SSRF gap:
+
+    * A **public** configured MCP URL must not 302 into private/link-local
+      space (``is_safe_url``).
+    * Cloud metadata endpoints are always blocked via ``is_always_blocked_url``,
+      even when the original URL was intentionally private/loopback (local MCP).
+    """
+    import httpx
+
+    from tools.url_safety import is_always_blocked_url, is_safe_url
+
+    _original = httpx.URL(original_url)
+    _original_is_public = is_safe_url(original_url)
+
+    async def _on_redirect(response):
+        if not (response.is_redirect and response.next_request):
+            return
+        target = response.next_request.url
+        if (target.scheme, target.host, target.port) != (
+            _original.scheme, _original.host, _original.port,
+        ):
+            response.next_request.headers.pop("authorization", None)
+            response.next_request.headers.pop("Authorization", None)
+
+        target_url = str(target)
+        if is_always_blocked_url(target_url):
+            raise ValueError(
+                f"Blocked MCP redirect to cloud metadata / always-blocked "
+                f"address: {target_url}"
+            )
+        if _original_is_public and not is_safe_url(target_url):
+            raise ValueError(
+                f"Blocked MCP redirect to private/internal address: {target_url}"
+            )
+
+    return [_on_redirect]
+
+
 def _sanitize_error(text: str) -> str:
     """Strip credential-like patterns from error text before returning to LLM.
 
@@ -2599,6 +2641,7 @@ class MCPServerTask:
             "verify": ssl_verify,
             "follow_redirects": True,
             "timeout": _httpx.Timeout(timeout),
+            "event_hooks": {"response": _make_mcp_http_redirect_hooks(url)},
         }
         if client_cert is not None:
             client_kwargs["cert"] = client_cert
@@ -2811,6 +2854,9 @@ class MCPServerTask:
                     kwargs: dict = {
                         "follow_redirects": True,
                         "verify": _verify_for_factory,
+                        "event_hooks": {
+                            "response": _make_mcp_http_redirect_hooks(url),
+                        },
                     }
                     if timeout is not None:
                         kwargs["timeout"] = timeout
@@ -2863,23 +2909,12 @@ class MCPServerTask:
             # matching the SDK's own create_mcp_http_client defaults.
             import httpx
 
-            _original_url = httpx.URL(url)
-
-            async def _strip_auth_on_cross_origin_redirect(response):
-                """Strip Authorization headers when redirected to a different origin."""
-                if response.is_redirect and response.next_request:
-                    target = response.next_request.url
-                    if (target.scheme, target.host, target.port) != (
-                        _original_url.scheme, _original_url.host, _original_url.port,
-                    ):
-                        response.next_request.headers.pop("authorization", None)
-                        response.next_request.headers.pop("Authorization", None)
-
             client_kwargs: dict = {
                 "follow_redirects": True,
                 "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
                 "verify": ssl_verify,
-                "event_hooks": {"response": [_strip_auth_on_cross_origin_redirect]},
+                # Salvage #62929 auth stripping + close redirect-SSRF gap.
+                "event_hooks": {"response": _make_mcp_http_redirect_hooks(url)},
             }
             if headers:
                 client_kwargs["headers"] = headers

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -481,22 +481,28 @@ def _make_mcp_http_redirect_hooks(original_url: str):
     """
     import httpx
 
-    from tools.url_safety import is_always_blocked_url, is_safe_url
+    from tools.url_safety import (
+        is_always_blocked_url,
+        is_safe_url,
+        redirect_target_from_response,
+    )
 
     _original = httpx.URL(original_url)
     _original_is_public = is_safe_url(original_url)
 
     async def _on_redirect(response):
-        if not (response.is_redirect and response.next_request):
+        target_url = redirect_target_from_response(response)
+        if not target_url:
             return
-        target = response.next_request.url
-        if (target.scheme, target.host, target.port) != (
-            _original.scheme, _original.host, _original.port,
+        target = httpx.URL(target_url)
+        if (
+            response.next_request is not None
+            and (target.scheme, target.host, target.port)
+            != (_original.scheme, _original.host, _original.port)
         ):
             response.next_request.headers.pop("authorization", None)
             response.next_request.headers.pop("Authorization", None)
 
-        target_url = str(target)
         if is_always_blocked_url(target_url):
             raise ValueError(
                 f"Blocked MCP redirect to cloud metadata / always-blocked "
@@ -2837,40 +2843,34 @@ class MCPServerTask:
                 # behind OAuth 2.1 PKCE work. Previously built but never
                 # forwarded — SSE OAuth would silently fail with 401s.
                 _sse_kwargs["auth"] = _oauth_auth
-            if client_cert is not None or ssl_verify is not True:
-                # SSE transport doesn't expose verify/cert as kwargs, so route
-                # them through an httpx_client_factory that wraps the SDK's
-                # defaults (follow_redirects=True) and adds our TLS settings.
-                # The SDK calls the factory with (headers, auth, timeout); we
-                # forward all of those and layer verify/cert on top.
-                import httpx as _httpx_mod
+            # Always install the factory so the default SSE path also gets the
+            # redirect SSRF guard; the SDK's default client follows redirects.
+            import httpx as _httpx_mod
 
-                _cert_for_factory = client_cert
-                _verify_for_factory = ssl_verify
+            _cert_for_factory = client_cert
+            _verify_for_factory = ssl_verify
 
-                def _mcp_http_client_factory(
-                    headers=None, timeout=None, auth=None,
-                ):
-                    kwargs: dict = {
-                        "follow_redirects": True,
-                        "verify": _verify_for_factory,
-                        "event_hooks": {
-                            "response": _make_mcp_http_redirect_hooks(url),
-                        },
-                    }
-                    if timeout is not None:
-                        kwargs["timeout"] = timeout
-                    else:
-                        kwargs["timeout"] = _httpx_mod.Timeout(30.0, read=300.0)
-                    if headers is not None:
-                        kwargs["headers"] = headers
-                    if auth is not None:
-                        kwargs["auth"] = auth
-                    if _cert_for_factory is not None:
-                        kwargs["cert"] = _cert_for_factory
-                    return _httpx_mod.AsyncClient(**kwargs)
+            def _mcp_http_client_factory(headers=None, timeout=None, auth=None):
+                kwargs: dict = {
+                    "follow_redirects": True,
+                    "verify": _verify_for_factory,
+                    "event_hooks": {
+                        "response": _make_mcp_http_redirect_hooks(url),
+                    },
+                }
+                if timeout is not None:
+                    kwargs["timeout"] = timeout
+                else:
+                    kwargs["timeout"] = _httpx_mod.Timeout(30.0, read=300.0)
+                if headers is not None:
+                    kwargs["headers"] = headers
+                if auth is not None:
+                    kwargs["auth"] = auth
+                if _cert_for_factory is not None:
+                    kwargs["cert"] = _cert_for_factory
+                return _httpx_mod.AsyncClient(**kwargs)
 
-                _sse_kwargs["httpx_client_factory"] = _mcp_http_client_factory
+            _sse_kwargs["httpx_client_factory"] = _mcp_http_client_factory
             try:
                 async with sse_client(**_sse_kwargs) as (read_stream, write_stream):
                     async with ClientSession(


### PR DESCRIPTION
## Summary
- **Salvage:** #62929 strips Authorization on cross-origin MCP redirects but does not block redirect-based SSRF.
- Shared `_make_mcp_http_redirect_hooks`: keep auth stripping; block public MCP URLs from redirecting into private space; always block cloud-metadata hops (even for intentional loopback MCP).
- Applied to Streamable HTTP clients, SSE httpx factories, and the HTML/content-type probe client.
- Localhost MCP remains usable; capability preserved.

## Test plan
- [x] `pytest tests/tools/test_mcp_http_redirect_ssrf.py` (3 passed)
