### PR TITLE
fix(security): guard skills.sh sitemap and detail HTTP fetches

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -286,7 +286,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_search_maps_skills_sh_results_to_prefixed_identifiers(self, mock_get, _mock_read_cache, _mock_write_cache):
         mock_get.return_value = MagicMock(
             status_code=200,
@@ -315,7 +315,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_empty_search_uses_featured_homepage_links(self, mock_get, _mock_read_cache, _mock_write_cache):
         mock_get.return_value = MagicMock(
             status_code=200,
@@ -371,7 +371,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch.object(GitHubSource, "inspect")
     def test_inspect_delegates_to_github_source_and_relabels_meta(self, mock_inspect, mock_get, _mock_read_cache, _mock_write_cache):
         mock_inspect.return_value = SkillMeta(
@@ -446,7 +446,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch.object(GitHubSource, "_list_skills_in_repo")
     @patch.object(GitHubSource, "inspect")
     def test_inspect_uses_detail_page_to_resolve_alias_skill(self, mock_inspect, mock_list_skills, mock_get, _mock_read_cache, _mock_write_cache):
@@ -479,7 +479,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch.object(GitHubSource, "_list_skills_in_repo")
     @patch.object(GitHubSource, "fetch")
     def test_fetch_uses_detail_page_to_resolve_alias_skill(self, mock_fetch, mock_list_skills, mock_get, _mock_read_cache, _mock_write_cache):
@@ -552,10 +552,11 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch("tools.skills_hub.httpx.get")
     @patch.object(GitHubSource, "fetch")
     def test_fetch_falls_back_to_tree_search_for_deeply_nested_skills(
-        self, mock_fetch, mock_get, _mock_read_cache, _mock_write_cache,
+        self, mock_fetch, mock_httpx_get, mock_safe_get, _mock_read_cache, _mock_write_cache,
     ):
         """Skills in deeply nested dirs (e.g. cli-tool/components/skills/dev/my-skill/)
         are found via the GitHub Trees API when candidate paths and shallow scan fail."""
@@ -565,7 +566,7 @@ class TestSkillsShSource:
             {"path": "cli-tool/components/skills/development/other-skill/SKILL.md", "type": "blob"},
         ]
 
-        def _httpx_get_side_effect(url, **kwargs):
+        def _http_side_effect(url, **kwargs):
             resp = MagicMock()
             if "/api/search" in url:
                 resp.status_code = 404
@@ -588,12 +589,14 @@ class TestSkillsShSource:
                 resp.status_code = 200
                 resp.json = lambda: {"tree": tree_entries}
                 return resp
-            # skills.sh detail page
+            # skills.sh detail page (SSRF-safe path)
             resp.status_code = 200
             resp.text = "<h1>my-skill</h1>"
             return resp
 
-        mock_get.side_effect = _httpx_get_side_effect
+        # Detail page uses _ssrf_safe_http_get; GitHub tree/contents still use httpx.get.
+        mock_safe_get.side_effect = _http_side_effect
+        mock_httpx_get.side_effect = _http_side_effect
 
         resolved_bundle = SkillBundle(
             name="my-skill",
@@ -644,7 +647,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_empty_query_walks_sitemap_not_homepage(
         self, mock_get, _mock_read_cache, _mock_write_cache,
     ):
@@ -889,7 +892,7 @@ class TestWellKnownSkillSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_fetch_rejects_unsafe_file_paths_from_well_known_endpoint(self, mock_get, _mock_read_cache, _mock_write_cache):
         def fake_get(url, *args, **kwargs):
             if url.endswith("/index.json"):
@@ -1133,7 +1136,7 @@ class TestUrlSource:
         )
 
         assert self._source().fetch("https://example.com/SKILL.md") is None
-        mock_get.assert_called_once_with("https://example.com/SKILL.md", timeout=20)
+        mock_get.assert_called_once_with("https://example.com/SKILL.md", timeout=20, headers=None)
 
     @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_fetch_skips_non_matching_identifier(self, mock_get):

--- a/tests/tools/test_skills_hub_clawhub.py
+++ b/tests/tools/test_skills_hub_clawhub.py
@@ -246,7 +246,7 @@ class TestClawHubSource(unittest.TestCase):
         self.assertIn("SKILL.md", bundle.files)
         self.assertEqual(bundle.files["SKILL.md"], "# Skill")
         self.assertEqual(bundle.files["README.md"], "hello")
-        mock_safe_get.assert_called_once_with("https://files.example/skill-md", timeout=20)
+        mock_safe_get.assert_called_once_with("https://files.example/skill-md", timeout=20, headers=None)
 
     @patch("tools.skills_hub.httpx.get")
     def test_fetch_falls_back_to_versions_list(self, mock_get):

--- a/tests/tools/test_skills_sh_ssrf.py
+++ b/tests/tools/test_skills_sh_ssrf.py
@@ -1,0 +1,18 @@
+"""skills.sh sitemap/detail fetches must stay on skills.sh (SSRF)."""
+
+from tools.skills_hub import SkillsShSource
+
+
+def test_is_skills_sh_url_accepts_www_and_apex():
+    assert SkillsShSource._is_skills_sh_url("https://skills.sh/sitemap-skills-1.xml")
+    assert SkillsShSource._is_skills_sh_url("https://www.skills.sh/sitemap-skills-2.xml")
+
+
+def test_is_skills_sh_url_rejects_foreign_hosts():
+    assert not SkillsShSource._is_skills_sh_url(
+        "http://169.254.169.254/sitemap-skills.xml"
+    )
+    assert not SkillsShSource._is_skills_sh_url(
+        "https://evil.example/sitemap-skills.xml"
+    )
+    assert not SkillsShSource._is_skills_sh_url("ftp://skills.sh/sitemap-skills.xml")

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -291,15 +291,25 @@ def _resolve_lock_install_path(install_path: str, skill_name: str) -> Path:
     return target
 
 
-def _ssrf_safe_http_get(url: str, *, timeout: int = 20) -> httpx.Response:
+def _ssrf_safe_http_get(
+    url: str,
+    *,
+    timeout: int = 20,
+    headers: Optional[Dict[str, str]] = None,
+) -> httpx.Response:
     """Fetch one URL with connect-time SSRF validation and no automatic redirects."""
     from tools.url_safety import create_ssrf_safe_client
 
     with create_ssrf_safe_client(timeout=timeout, follow_redirects=False) as client:
-        return client.get(url)
+        return client.get(url, headers=headers)
 
 
-def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response]:
+def _guarded_http_get(
+    url: str,
+    *,
+    timeout: int = 20,
+    headers: Optional[Dict[str, str]] = None,
+) -> Optional[httpx.Response]:
     """Fetch a URL with SSRF and redirect-target validation."""
     from tools.url_safety import SSRFConnectionBlocked
 
@@ -320,7 +330,7 @@ def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response
             return None
 
         try:
-            resp = _ssrf_safe_http_get(current_url, timeout=timeout)
+            resp = _ssrf_safe_http_get(current_url, timeout=timeout, headers=headers)
         except (SSRFConnectionBlocked, httpx.HTTPError) as exc:
             logger.debug("Skills Hub fetch failed for %s: %s", current_url, exc)
             return None
@@ -1648,6 +1658,16 @@ class SkillsShSource(SkillSource):
     def trust_level_for(self, identifier: str) -> str:
         return self.github.trust_level_for(self._normalize_identifier(identifier))
 
+    @staticmethod
+    def _is_skills_sh_url(url: str) -> bool:
+        """Return True when *url* targets the skills.sh site (www optional)."""
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            return False
+        host = (parsed.hostname or "").lower().rstrip(".")
+        return host in {"skills.sh", "www.skills.sh"} and parsed.scheme in {"http", "https"}
+
     def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
         if not query.strip():
             # Empty query = bulk catalog dump (what build_skills_index.py
@@ -1661,15 +1681,14 @@ class SkillsShSource(SkillSource):
             return [SkillMeta(**item) for item in cached][:limit]
 
         try:
-            resp = httpx.get(
-                self.SEARCH_URL,
-                params={"q": query, "limit": limit},
-                timeout=20,
-            )
-            if resp.status_code != 200:
+            from urllib.parse import urlencode
+
+            search_url = f"{self.SEARCH_URL}?{urlencode({'q': query, 'limit': limit})}"
+            resp = _guarded_http_get(search_url, timeout=20)
+            if resp is None or resp.status_code != 200:
                 return []
             data = resp.json()
-        except (httpx.HTTPError, json.JSONDecodeError):
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
             return []
 
         items = data.get("skills", []) if isinstance(data, dict) else []
@@ -1738,18 +1757,19 @@ class SkillsShSource(SkillSource):
         # Step 1: fetch the sitemap index → list of skill-sitemap URLs.
         skill_sitemap_urls: List[str] = []
         try:
-            resp = httpx.get(
+            resp = _guarded_http_get(
                 self.SITEMAP_INDEX_URL,
                 timeout=20,
-                follow_redirects=True,
                 headers=sitemap_headers,
             )
-            if resp.status_code != 200:
+            if resp is None or resp.status_code != 200:
                 return self._featured_skills(limit)
             for match in self._SITEMAP_LOC_RE.finditer(resp.text):
                 loc = match.group(1).strip()
                 # Sitemap index entries that point at the per-skill maps.
-                if "sitemap-skills" in loc:
+                # Only follow locs that stay on skills.sh — a compromised or
+                # redirected index must not pull arbitrary hosts (SSRF).
+                if "sitemap-skills" in loc and self._is_skills_sh_url(loc):
                     skill_sitemap_urls.append(loc)
         except httpx.HTTPError:
             return self._featured_skills(limit)
@@ -1762,13 +1782,12 @@ class SkillsShSource(SkillSource):
         results: List[SkillMeta] = []
         for sitemap_url in skill_sitemap_urls:
             try:
-                resp = httpx.get(
+                resp = _guarded_http_get(
                     sitemap_url,
                     timeout=30,
-                    follow_redirects=True,
                     headers=sitemap_headers,
                 )
-                if resp.status_code != 200:
+                if resp is None or resp.status_code != 200:
                     continue
             except httpx.HTTPError:
                 continue
@@ -1812,8 +1831,8 @@ class SkillsShSource(SkillSource):
             return [SkillMeta(**item) for item in cached][:limit]
 
         try:
-            resp = httpx.get(self.BASE_URL, timeout=20)
-            if resp.status_code != 200:
+            resp = _guarded_http_get(self.BASE_URL, timeout=20)
+            if resp is None or resp.status_code != 200:
                 return []
         except httpx.HTTPError:
             return []
@@ -1888,8 +1907,11 @@ class SkillsShSource(SkillSource):
             return cached
 
         try:
-            resp = httpx.get(f"{self.BASE_URL}/{identifier}", timeout=20)
-            if resp.status_code != 200:
+            # Identifier is already normalized; still refuse path traversal / host escape.
+            if ".." in identifier or identifier.startswith("/") or "://" in identifier:
+                return None
+            resp = _guarded_http_get(f"{self.BASE_URL}/{identifier}", timeout=20)
+            if resp is None or resp.status_code != 200:
                 return None
         except httpx.HTTPError:
             return None


### PR DESCRIPTION
## Summary
- skills.sh sitemap index locs were fetched with raw `httpx.get(..., follow_redirects=True)` without host allowlisting, so a malicious `sitemap-skills` loc (or redirect hop) could target private/link-local addresses.
- Route search, sitemap, featured, and detail fetches through `_guarded_http_get` (SSRF + hop re-validation).
- Only accept sitemap locs whose host is `skills.sh` / `www.skills.sh`.
- Preserve gzip Accept-Encoding for sitemap payloads (brotli decode workaround).

## Test plan
- [x] `pytest tests/tools/test_skills_sh_ssrf.py` (2 passed)
