### PR TITLE
Fix pre-dispatch silence while gateway is busy

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5949,7 +5949,66 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._enqueue_fifo(session_key, event, adapter)
 
+    def _apply_pre_gateway_dispatch_hook(self, event: MessageEvent) -> tuple[MessageEvent, bool]:
+        """Run the pre-dispatch hook once, including for busy-session messages.
+
+        Busy messages normally bypass ``_handle_message`` until their queued turn.
+        That allowed generic queue acknowledgements to escape plugin silence rules
+        (notably T2B WhatsApp project/site groups).  Mark the event after applying
+        the hook so allowed/re-written queued events are not processed twice when
+        their normal turn begins.
+        """
+        if bool(getattr(event, "internal", False)):
+            return event, False
+
+        metadata = dict(getattr(event, "metadata", None) or {})
+        if metadata.get("_pre_gateway_dispatch_applied"):
+            return event, False
+        metadata["_pre_gateway_dispatch_applied"] = True
+        event = dataclasses.replace(event, metadata=metadata)
+
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            hook_results = _invoke_hook(
+                "pre_gateway_dispatch",
+                event=event,
+                gateway=self,
+                session_store=self.session_store,
+            )
+        except Exception as hook_exc:
+            logger.warning("pre_gateway_dispatch invocation failed: %s", hook_exc)
+            hook_results = []
+
+        source = event.source
+        for result in hook_results:
+            if not isinstance(result, dict):
+                continue
+            action = result.get("action")
+            if action == "skip":
+                logger.info(
+                    "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
+                    result.get("reason"),
+                    source.platform.value if source and source.platform else "unknown",
+                    source.chat_id if source and source.chat_id else "unknown",
+                )
+                return event, True
+            if action == "rewrite":
+                new_text = result.get("text")
+                if isinstance(new_text, str):
+                    event = dataclasses.replace(event, text=new_text)
+                break
+            if action == "allow":
+                break
+        return event, False
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
+        # Busy events reach this path before _handle_message. Apply the same
+        # pre-dispatch policy first so a plugin-level silence/skip decision cannot
+        # leak a generic "queued" or "interrupting" acknowledgement into groups.
+        event, hook_skipped = self._apply_pre_gateway_dispatch_hook(event)
+        if hook_skipped:
+            return True
+
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
         # creating a session.  The busy path must enforce the same check;
@@ -10494,46 +10553,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not is_internal:
             self._scale_to_zero_note_real_inbound()
 
-        # Fire pre_gateway_dispatch plugin hook for user-originated messages.
-        # Plugins receive the MessageEvent and may return a dict influencing flow:
-        #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
-        #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
-        #   {"action": "allow"}   /   None          -> normal dispatch
-        # Hook runs BEFORE auth so plugins can handle unauthorized senders
-        # (e.g. customer handover ingest) without triggering the pairing flow.
+        # Fire pre_gateway_dispatch once for user-originated messages. Busy-session
+        # messages may already have passed through this hook before being queued;
+        # the per-event marker prevents duplicate plugin side effects.
         if not is_internal:
-            try:
-                from hermes_cli.plugins import invoke_hook as _invoke_hook
-                _hook_results = _invoke_hook(
-                    "pre_gateway_dispatch",
-                    event=event,
-                    gateway=self,
-                    session_store=self.session_store,
-                )
-            except Exception as _hook_exc:
-                logger.warning("pre_gateway_dispatch invocation failed: %s", _hook_exc)
-                _hook_results = []
-
-            for _result in _hook_results:
-                if not isinstance(_result, dict):
-                    continue
-                _action = _result.get("action")
-                if _action == "skip":
-                    logger.info(
-                        "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
-                        _result.get("reason"),
-                        source.platform.value if source.platform else "unknown",
-                        source.chat_id or "unknown",
-                    )
-                    return None
-                if _action == "rewrite":
-                    _new_text = _result.get("text")
-                    if isinstance(_new_text, str):
-                        event = dataclasses.replace(event, text=_new_text)
-                        source = event.source
-                    break
-                if _action == "allow":
-                    break
+            event, hook_skipped = self._apply_pre_gateway_dispatch_hook(event)
+            source = event.source
+            if hook_skipped:
+                return None
 
         if is_internal:
             pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5965,7 +5965,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if metadata.get("_pre_gateway_dispatch_applied"):
             return event, False
         metadata["_pre_gateway_dispatch_applied"] = True
-        event = dataclasses.replace(event, metadata=metadata)
+        # Keep the original MessageEvent object in sync.  The busy-session
+        # handler may return False so BasePlatformAdapter can queue that same
+        # object; replacing it only in this local scope would lose both the
+        # marker and any rewrite before the queued turn is drained.
+        event.metadata = metadata
 
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
@@ -5995,7 +5999,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if action == "rewrite":
                 new_text = result.get("text")
                 if isinstance(new_text, str):
-                    event = dataclasses.replace(event, text=new_text)
+                    event.text = new_text
                 break
             if action == "allow":
                 break

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -198,6 +198,35 @@ def test_pre_dispatch_marker_prevents_duplicate_plugin_side_effects(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_busy_queue_fallback_preserves_rewrite_and_hook_marker(monkeypatch):
+    calls = {"count": 0}
+
+    def _fake_hook(name, **kwargs):
+        calls["count"] += 1
+        return [{"action": "rewrite", "text": "REWRITTEN"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    runner._draining = False
+    runner._busy_input_mode = "queue"
+    runner._busy_text_mode = "queue"
+    runner._is_user_authorized = lambda source: True
+    runner._adapter_for_source = lambda source: adapter
+    event = _make_event("original")
+
+    handled = await runner._handle_active_session_busy_message(event, "busy-session")
+
+    assert handled is False
+    assert event.text == "REWRITTEN"
+    assert event.metadata["_pre_gateway_dispatch_applied"] is True
+
+    queued_event, skipped = runner._apply_pre_gateway_dispatch_hook(event)
+    assert queued_event.text == "REWRITTEN"
+    assert skipped is False
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_internal_events_bypass_hook(monkeypatch):
     """Internal events (event.internal=True) skip the plugin hook entirely."""
     _clear_auth_env(monkeypatch)

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -152,6 +152,52 @@ async def test_hook_exception_does_not_break_dispatch(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_busy_group_hook_skip_suppresses_queue_ack(monkeypatch):
+    """A silent group policy must run before the generic busy acknowledgement."""
+    calls = {"count": 0}
+
+    def _fake_hook(name, **kwargs):
+        assert name == "pre_gateway_dispatch"
+        calls["count"] += 1
+        return [{"action": "skip", "reason": "site-group-silent"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    event = _make_event("[image received]")
+    event.source = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="15551234567@s.whatsapp.net",
+        chat_id="120363426021041405@g.us",
+        user_name="tester",
+        chat_type="group",
+    )
+
+    handled = await runner._handle_active_session_busy_message(event, "busy-site-session")
+
+    assert handled is True
+    assert calls["count"] == 1
+    adapter.send.assert_not_awaited()
+
+
+def test_pre_dispatch_marker_prevents_duplicate_plugin_side_effects(monkeypatch):
+    calls = {"count": 0}
+
+    def _fake_hook(name, **kwargs):
+        calls["count"] += 1
+        return [{"action": "allow"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    event, skipped = runner._apply_pre_gateway_dispatch_hook(_make_event())
+    event, skipped_again = runner._apply_pre_gateway_dispatch_hook(event)
+
+    assert skipped is False
+    assert skipped_again is False
+    assert calls["count"] == 1
+    assert event.metadata["_pre_gateway_dispatch_applied"] is True
+
+
+@pytest.mark.asyncio
 async def test_internal_events_bypass_hook(monkeypatch):
     """Internal events (event.internal=True) skip the plugin hook entirely."""
     _clear_auth_env(monkeypatch)


### PR DESCRIPTION
## Summary
- preserve pre-dispatch skip decisions while the gateway is busy
- prevent queued fallback text from leaking into silent messaging routes
- preserve hook markers and rewritten text when busy queue handling falls through to the platform adapter
- add regression coverage for skip, rewrite, queue fallback, and duplicate-hook prevention

## Test plan
- `pytest -q -o addopts= tests/gateway/test_pre_gateway_dispatch.py`
- 8 passed