### PR TITLE
Add configurable WhatsApp inbound read receipts

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1506,6 +1506,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["cron_continuable_surface"] = platform_cfg["cron_continuable_surface"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if "send_read_receipts" in platform_cfg:
+                    bridged["send_read_receipts"] = platform_cfg["send_read_receipts"]
                 if plat == Platform.TELEGRAM and "allowed_chats" in platform_cfg:
                     bridged["allowed_chats"] = platform_cfg["allowed_chats"]
                 if plat == Platform.TELEGRAM and "group_allowed_chats" in platform_cfg:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -379,6 +379,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     - allow_from: List of sender IDs allowed in DMs (when dm_policy="allowlist")
     - group_policy: "open" | "allowlist" | "disabled" | "pairing" — which groups are processed (default: "pairing")
     - group_allow_from: List of group JIDs allowed (when group_policy="allowlist")
+    - send_read_receipts: Mark accepted inbound WhatsApp messages as read
 
     Behavior (gating, mention parsing, markdown conversion, chunking) is
     provided by ``WhatsAppBehaviorMixin`` so the Cloud API adapter can
@@ -410,6 +411,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
         self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        read_receipts = config.extra.get("send_read_receipts", False)
+        self._send_read_receipts = (
+            read_receipts if isinstance(read_receipts, bool)
+            else str(read_receipts or "").strip().lower() in {"1", "true", "yes", "on"}
+        )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
@@ -626,6 +632,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env = with_hermes_node_path()
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
+            bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
+                "true" if self._send_read_receipts else "false"
+            )
             # Pass the profile-aware cache directories so the bridge writes
             # media where the Python side reads it.  Without these the bridge
             # hardcodes ~/.hermes/{image,audio,document}_cache, which diverges

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -596,17 +596,26 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 # treated as stale by definition.
                                 running_hash = data.get("scriptHash", "")
                                 disk_hash = _file_content_hash(bridge_path)
-                                if running_hash and disk_hash and running_hash == disk_hash:
+                                running_read_receipts = bool(data.get("sendReadReceipts", False))
+                                config_matches = running_read_receipts == self._send_read_receipts
+                                if (
+                                    running_hash
+                                    and disk_hash
+                                    and running_hash == disk_hash
+                                    and config_matches
+                                ):
                                     print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
                                     self._mark_connected()
                                     self._bridge_process = None  # Not managed by us
                                     self._http_session = aiohttp.ClientSession()
                                     self._poll_task = asyncio.create_task(self._poll_messages())
                                     return True
-                                print(
-                                    f"[{self.name}] Running bridge is stale "
-                                    f"(running={running_hash or 'unversioned'}, disk={disk_hash}), restarting"
+                                stale_reason = (
+                                    f"running={running_hash or 'unversioned'}, disk={disk_hash}"
+                                    if running_hash != disk_hash
+                                    else "send_read_receipts config changed"
                                 )
+                                print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
                             else:
                                 print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
             except Exception:
@@ -1260,6 +1269,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         for msg_data in messages:
                             event = await self._build_message_event(msg_data)
                             if event:
+                                await self._send_read_receipt(msg_data)
                                 if event.message_type == MessageType.TEXT:
                                     self._enqueue_text_event(event)
                                 else:
@@ -1275,6 +1285,30 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 await asyncio.sleep(5)
             
             await asyncio.sleep(1)  # Poll interval
+
+    async def _send_read_receipt(self, data: Dict[str, Any]) -> None:
+        """Mark a policy-accepted inbound message as read via the bridge."""
+        if not self._send_read_receipts or not self._http_session:
+            return
+        key = data.get("readReceiptKey")
+        if not isinstance(key, dict):
+            return
+        try:
+            import aiohttp
+
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/read",
+                json={"key": key},
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                if resp.status != 200:
+                    logger.warning(
+                        "[%s] WhatsApp read receipt failed with HTTP %s",
+                        self.name,
+                        resp.status,
+                    )
+        except Exception as exc:
+            logger.warning("[%s] WhatsApp read receipt failed: %s", self.name, exc)
 
     # ── Text debounce batching ──────────────────────────────────────
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -654,15 +654,6 @@ async function startSocket() {
         }
       }
 
-      const receiptKeys = inboundReadReceiptKeys({ key: msg.key, enabled: SEND_READ_RECEIPTS });
-      if (receiptKeys.length > 0) {
-        try {
-          await sock.readMessages(receiptKeys);
-        } catch (err) {
-          console.warn('[bridge] failed to send read receipt:', err.message);
-        }
-      }
-
       const messageContent = getMessageContent(msg);
       if (messageContent.pollUpdateMessage) {
         const pollUpdateMessage = messageContent.pollUpdateMessage;
@@ -1055,6 +1046,30 @@ app.post('/typing', async (req, res) => {
     res.json({ success: true });
   } catch (err) {
     res.json({ success: false });
+  }
+});
+
+// Mark an inbound message as read only after the Python adapter has accepted
+// it through the authoritative DM/group/mention intake policy.
+app.post('/read', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected' });
+  }
+
+  const receiptKeys = inboundReadReceiptKeys({
+    key: req.body?.key,
+    enabled: SEND_READ_RECEIPTS,
+  });
+  if (receiptKeys.length === 0) {
+    return res.json({ success: true, marked: false });
+  }
+
+  try {
+    await sock.readMessages(receiptKeys);
+    return res.json({ success: true, marked: true });
+  } catch (err) {
+    console.warn('[bridge] failed to send read receipt:', err.message);
+    return res.status(500).json({ error: 'Failed to send read receipt' });
   }
 });
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -39,6 +39,7 @@ import {
   buildTextSendPayload,
   createBoundedMessageStore,
   extractBridgeEvent,
+  inboundReadReceiptKeys,
   inferMediaType,
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
@@ -74,6 +75,12 @@ const FORWARD_OWNER_MESSAGES =
   process.env &&
   typeof process.env.WHATSAPP_FORWARD_OWNER_MESSAGES === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_FORWARD_OWNER_MESSAGES.toLowerCase());
+
+const SEND_READ_RECEIPTS =
+  typeof process !== 'undefined' &&
+  process.env &&
+  typeof process.env.WHATSAPP_SEND_READ_RECEIPTS === 'string' &&
+  ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_SEND_READ_RECEIPTS.toLowerCase());
 
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
@@ -647,6 +654,15 @@ async function startSocket() {
         }
       }
 
+      const receiptKeys = inboundReadReceiptKeys({ key: msg.key, enabled: SEND_READ_RECEIPTS });
+      if (receiptKeys.length > 0) {
+        try {
+          await sock.readMessages(receiptKeys);
+        } catch (err) {
+          console.warn('[bridge] failed to send read receipt:', err.message);
+        }
+      }
+
       const messageContent = getMessageContent(msg);
       if (messageContent.pollUpdateMessage) {
         const pollUpdateMessage = messageContent.pollUpdateMessage;
@@ -1074,6 +1090,7 @@ app.get('/health', (req, res) => {
     queueLength: messageQueue.length,
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
+    sendReadReceipts: SEND_READ_RECEIPTS,
   });
 });
 

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -18,10 +18,32 @@ import {
   createBoundedMessageStore,
   appendMediaFailureNote,
   extractBridgeEvent,
+  inboundReadReceiptKeys,
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
+
+// -- inbound read receipts ------------------------------------------------
+{
+  const groupKey = {
+    id: 'incoming-group-1',
+    remoteJid: '120363001234567890@g.us',
+    participant: '15550001111@s.whatsapp.net',
+    fromMe: false,
+  };
+
+  assert.deepEqual(inboundReadReceiptKeys({ key: groupKey, enabled: false }), []);
+  assert.deepEqual(
+    inboundReadReceiptKeys({ key: { ...groupKey, fromMe: true }, enabled: true }),
+    [],
+  );
+  const receiptKeys = inboundReadReceiptKeys({ key: groupKey, enabled: true });
+  assert.equal(receiptKeys.length, 1);
+  assert.equal(receiptKeys[0], groupKey);
+  assert.equal(receiptKeys[0].participant, groupKey.participant);
+  console.log('  ✓ inbound read receipts preserve the original group message key');
+}
 
 // -- quoted outbound text -------------------------------------------------
 {

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -118,6 +118,12 @@ import {
   assert.equal(event.quotedParticipant, '15559998888@s.whatsapp.net');
   assert.equal(event.quotedRemoteJid, '15551234567@s.whatsapp.net');
   assert.equal(event.quotedText, 'approve deploy?');
+  assert.deepEqual(event.readReceiptKey, {
+    id: 'incoming-1',
+    remoteJid: '15551234567@s.whatsapp.net',
+    participant: '15550001111@s.whatsapp.net',
+    fromMe: false,
+  });
   assert.equal(event.hasQuotedMessage, true);
   assert.equal(event.body, 'approved');
   console.log('  ✓ inbound quoted metadata includes quoted text');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -483,6 +483,12 @@ export async function extractBridgeEvent({
     quotedText,
     hasQuotedMessage,
     botIds,
+    readReceiptKey: {
+      remoteJid: msg.key.remoteJid || chatId,
+      id: msg.key.id,
+      participant: msg.key.participant || senderId,
+      fromMe: Boolean(msg.key.fromMe),
+    },
     timestamp: msg.messageTimestamp,
   };
 }

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -494,6 +494,12 @@ export function inferMediaType(ext) {
   return 'document';
 }
 
+export function inboundReadReceiptKeys({ key, enabled }) {
+  if (!enabled || !key || key.fromMe || !key.id || !key.remoteJid) return [];
+  // Preserve participant for group messages: Baileys needs the original key.
+  return [key];
+}
+
 export function mediaPayloadForFile({ buffer, filePath, mediaType, caption, fileName }) {
   const ext = filePath.toLowerCase().split('.').pop();
   const type = mediaType || inferMediaType(ext);

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -53,6 +53,7 @@ def _make_adapter():
     adapter._bridge_log = None
     adapter._bridge_process = None
     adapter._reply_prefix = None
+    adapter._send_read_receipts = False
     adapter._running = False
     adapter._message_handler = None
     adapter._fatal_error_code = None

--- a/tests/gateway/test_whatsapp_reply_prefix.py
+++ b/tests/gateway/test_whatsapp_reply_prefix.py
@@ -4,6 +4,8 @@ Covers:
 - config.yaml whatsapp.reply_prefix bridging into PlatformConfig.extra
 - WhatsAppAdapter reading reply_prefix from config.extra
 - Bridge subprocess receiving WHATSAPP_REPLY_PREFIX env var
+- config.yaml whatsapp.send_read_receipts bridging into PlatformConfig.extra
+- WhatsAppAdapter parsing send_read_receipts as a boolean
 - Config version covers all ENV_VARS_BY_VERSION keys (regression guard)
 """
 
@@ -77,6 +79,20 @@ class TestConfigYamlBridging:
         wa_config = config.platforms.get(Platform.WHATSAPP)
         assert "reply_prefix" not in wa_config.extra
 
+    def test_send_read_receipts_bridged_from_yaml(self, tmp_path):
+        """whatsapp.send_read_receipts reaches the adapter extra config."""
+        config_yaml = tmp_path / "config.yaml"
+        config_yaml.write_text("whatsapp:\n  send_read_receipts: true\n")
+
+        with patch("gateway.config.get_hermes_home", return_value=tmp_path):
+            from gateway.config import load_gateway_config
+            with patch.dict("os.environ", {"WHATSAPP_ENABLED": "true"}, clear=False):
+                config = load_gateway_config()
+
+        wa_config = config.platforms.get(Platform.WHATSAPP)
+        assert wa_config is not None
+        assert wa_config.extra.get("send_read_receipts") is True
+
 
 # ---------------------------------------------------------------------------
 # WhatsAppAdapter __init__
@@ -103,6 +119,19 @@ class TestAdapterInit:
         config = PlatformConfig(enabled=True, extra={"reply_prefix": ""})
         adapter = WhatsAppAdapter(config)
         assert adapter._reply_prefix == ""
+
+    def test_send_read_receipts_boolean_and_string_values(self):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        assert WhatsAppAdapter(
+            PlatformConfig(enabled=True, extra={"send_read_receipts": True})
+        )._send_read_receipts is True
+        assert WhatsAppAdapter(
+            PlatformConfig(enabled=True, extra={"send_read_receipts": "yes"})
+        )._send_read_receipts is True
+        assert WhatsAppAdapter(
+            PlatformConfig(enabled=True, extra={"send_read_receipts": "off"})
+        )._send_read_receipts is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_whatsapp_reply_prefix.py
+++ b/tests/gateway/test_whatsapp_reply_prefix.py
@@ -9,10 +9,25 @@ Covers:
 - Config version covers all ENV_VARS_BY_VERSION keys (regression guard)
 """
 
-from unittest.mock import patch
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+
+
+class _AsyncResponseContext:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +147,91 @@ class TestAdapterInit:
         assert WhatsAppAdapter(
             PlatformConfig(enabled=True, extra={"send_read_receipts": "off"})
         )._send_read_receipts is False
+
+
+class TestReadReceiptPolicyOrdering:
+    @pytest.mark.asyncio
+    async def test_accepted_receipt_key_is_sent_to_bridge(self):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter(
+            PlatformConfig(enabled=True, extra={"send_read_receipts": True})
+        )
+        response = SimpleNamespace(status=200)
+        session = MagicMock()
+        session.post.return_value = _AsyncResponseContext(response)
+        adapter._http_session = session
+        key = {
+            "id": "incoming-1",
+            "remoteJid": "120363001234567890@g.us",
+            "participant": "15550001111@s.whatsapp.net",
+            "fromMe": False,
+        }
+
+        await adapter._send_read_receipt({"readReceiptKey": key})
+
+        assert session.post.call_args.kwargs["json"] == {"key": key}
+        assert session.post.call_args.args[0].endswith("/read")
+
+    @pytest.mark.asyncio
+    async def test_rejected_message_is_not_marked_read(self, monkeypatch):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter(
+            PlatformConfig(enabled=True, extra={"send_read_receipts": True})
+        )
+        response = SimpleNamespace(
+            status=200,
+            json=AsyncMock(return_value=[{"messageId": "ignored"}]),
+        )
+        session = MagicMock()
+        session.get.return_value = _AsyncResponseContext(response)
+        adapter._http_session = session
+        adapter._running = True
+        adapter._check_managed_bridge_exit = AsyncMock(return_value=None)
+        adapter._send_read_receipt = AsyncMock()
+
+        async def _reject(data):
+            adapter._running = False
+            return None
+
+        adapter._build_message_event = _reject
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+        await adapter._poll_messages()
+
+        adapter._send_read_receipt.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_policy_accepted_message_is_marked_read_before_dispatch(self, monkeypatch):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter(
+            PlatformConfig(enabled=True, extra={"send_read_receipts": True})
+        )
+        raw = {"messageId": "accepted"}
+        response = SimpleNamespace(status=200, json=AsyncMock(return_value=[raw]))
+        session = MagicMock()
+        session.get.return_value = _AsyncResponseContext(response)
+        adapter._http_session = session
+        adapter._running = True
+        adapter._check_managed_bridge_exit = AsyncMock(return_value=None)
+        adapter._send_read_receipt = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        event = MagicMock(spec=MessageEvent)
+        event.message_type = MessageType.PHOTO
+
+        async def _accept(data):
+            adapter._running = False
+            return event
+
+        adapter._build_message_event = _accept
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+        await adapter._poll_messages()
+
+        adapter._send_read_receipt.assert_awaited_once_with(raw)
+        adapter.handle_message.assert_awaited_once_with(event)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -53,6 +53,7 @@ def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
     adapter._bridge_log = None
     adapter._bridge_process = None
     adapter._reply_prefix = None
+    adapter._send_read_receipts = False
     adapter._running = False
     adapter._message_handler = None
     adapter._fatal_error_code = None
@@ -317,6 +318,7 @@ class TestCacheDirEnvPassthrough:
             bridge_script=str(bridge_dir / "bridge.js"),
             session_path=tmp_path / "session",
         )
+        adapter._send_read_receipts = True
         mock_proc = MagicMock()
         mock_proc.poll.return_value = 1
         mock_proc.returncode = 1
@@ -339,3 +341,4 @@ class TestCacheDirEnvPassthrough:
         assert env["HERMES_IMAGE_CACHE_DIR"] == str(get_image_cache_dir())
         assert env["HERMES_AUDIO_CACHE_DIR"] == str(get_audio_cache_dir())
         assert env["HERMES_DOCUMENT_CACHE_DIR"] == str(get_document_cache_dir())
+        assert env["WHATSAPP_SEND_READ_RECEIPTS"] == "true"

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -198,6 +198,40 @@ class TestStaleBridgeHandshake:
         mock_kill_port.assert_called_once_with(adapter._bridge_port)
 
     @pytest.mark.asyncio
+    async def test_restarts_bridge_when_read_receipt_config_changed(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        adapter._send_read_receipts = True
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health(
+            {
+                "status": "connected",
+                "scriptHash": disk_hash,
+                "sendReadReceipts": False,
+            }
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_restarts_unversioned_bridge(self, tmp_path):
         """Bridges predating the handshake report no scriptHash → stale."""
         bridge_dir = _setup_bridge_dir(tmp_path)


### PR DESCRIPTION
## Summary
- add a `send_read_receipts` WhatsApp config setting
- pass it through the platform adapter to the bridge
- mark only policy-accepted inbound messages as read, after DM/group/mention filtering
- preserve original WhatsApp group message keys
- restart a reused bridge when the configured read-receipt value changes
- expose the active setting through bridge health
- add Python and native bridge regression coverage

## Test plan
- `pytest -q -o addopts= tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_reply_prefix.py tests/gateway/test_whatsapp_stale_bridge.py` (54 passed)
- `node --test scripts/whatsapp-bridge/bridge.native.test.mjs` (passed)
- Python compilation, Node syntax checks, and `git diff --check` passed