### PR TITLE
fix(security): SSRF-safe GitHub Skills Hub API fetches

### DIFF
--- a/tests/tools/test_lobehub_skills_http_ssrf.py
+++ b/tests/tools/test_lobehub_skills_http_ssrf.py
@@ -1,0 +1,32 @@
+"""LobeHub Skills Hub fetch uses guarded HTTP + agent-id sanitization."""
+
+from unittest.mock import MagicMock, patch
+
+from tools.skills_hub import LobeHubSource
+
+
+def test_lobehub_sanitize_rejects_traversal():
+    src = LobeHubSource()
+    assert src._sanitize_agent_id("../etc/passwd") is None
+    assert src._sanitize_agent_id("http://evil.example/x") is None
+    assert src._sanitize_agent_id("a/b") is None
+    assert src._sanitize_agent_id("safe-agent_1") == "safe-agent_1"
+
+
+def test_lobehub_fetch_index_uses_guarded_http():
+    src = LobeHubSource()
+    fake = MagicMock()
+    fake.status_code = 200
+    fake.json.return_value = {"agents": []}
+    with patch("tools.skills_hub._read_index_cache", return_value=None), patch(
+        "tools.skills_hub._write_index_cache"
+    ), patch("tools.skills_hub._guarded_http_get", return_value=fake) as guarded:
+        assert src._fetch_index() == {"agents": []}
+        guarded.assert_called_once_with(src.INDEX_URL, timeout=30)
+
+
+def test_lobehub_fetch_agent_rejects_unsafe_id():
+    src = LobeHubSource()
+    with patch("tools.skills_hub._guarded_http_get") as guarded:
+        assert src._fetch_agent("../../x") is None
+        guarded.assert_not_called()

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -170,7 +170,7 @@ class TestSkillsShGroupings:
              patch.object(src, "_write_cache"), \
              patch.object(src, "_get_skillsh_groupings", return_value=groupings), \
              patch.object(src, "inspect", return_value=meta), \
-             patch("tools.skills_hub.httpx.get", return_value=resp):
+             patch("tools.skills_hub._ssrf_safe_http_get", return_value=resp):
             skills = src._list_skills_in_repo("NVIDIA/skills", "skills/")
 
         assert len(skills) == 1
@@ -192,7 +192,7 @@ class TestSkillsShGroupings:
              patch.object(src, "_write_cache"), \
              patch.object(src, "_get_skillsh_groupings", return_value=None), \
              patch.object(src, "inspect", return_value=meta), \
-             patch("tools.skills_hub.httpx.get", return_value=resp):
+             patch("tools.skills_hub._ssrf_safe_http_get", return_value=resp):
             skills = src._list_skills_in_repo("acme/skills", "skills/")
 
         assert len(skills) == 1
@@ -286,7 +286,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_search_maps_skills_sh_results_to_prefixed_identifiers(self, mock_get, _mock_read_cache, _mock_write_cache):
         mock_get.return_value = MagicMock(
             status_code=200,
@@ -315,7 +315,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_empty_search_uses_featured_homepage_links(self, mock_get, _mock_read_cache, _mock_write_cache):
         mock_get.return_value = MagicMock(
             status_code=200,
@@ -371,7 +371,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch.object(GitHubSource, "inspect")
     def test_inspect_delegates_to_github_source_and_relabels_meta(self, mock_inspect, mock_get, _mock_read_cache, _mock_write_cache):
         mock_inspect.return_value = SkillMeta(
@@ -446,7 +446,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch.object(GitHubSource, "_list_skills_in_repo")
     @patch.object(GitHubSource, "inspect")
     def test_inspect_uses_detail_page_to_resolve_alias_skill(self, mock_inspect, mock_list_skills, mock_get, _mock_read_cache, _mock_write_cache):
@@ -479,7 +479,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch.object(GitHubSource, "_list_skills_in_repo")
     @patch.object(GitHubSource, "fetch")
     def test_fetch_uses_detail_page_to_resolve_alias_skill(self, mock_fetch, mock_list_skills, mock_get, _mock_read_cache, _mock_write_cache):
@@ -552,7 +552,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch.object(GitHubSource, "fetch")
     def test_fetch_falls_back_to_tree_search_for_deeply_nested_skills(
         self, mock_fetch, mock_get, _mock_read_cache, _mock_write_cache,
@@ -614,7 +614,7 @@ class TestSkillsShSource:
 
     @patch.object(GitHubSource, "_find_skill_in_repo_tree")
     @patch.object(GitHubSource, "_list_skills_in_repo")
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_discover_identifier_uses_tree_search_before_root_scan(
         self,
         mock_get,
@@ -644,7 +644,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_empty_query_walks_sitemap_not_homepage(
         self, mock_get, _mock_read_cache, _mock_write_cache,
     ):
@@ -713,7 +713,7 @@ class TestFindSkillInRepoTree:
         auth.get_headers.return_value = {"Accept": "application/vnd.github.v3+json"}
         return GitHubSource(auth=auth)
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_finds_deeply_nested_skill(self, mock_get):
         tree_entries = [
             {"path": "README.md", "type": "blob"},
@@ -738,7 +738,7 @@ class TestFindSkillInRepoTree:
         result = self._source()._find_skill_in_repo_tree("davila7/claude-code-templates", "senior-backend")
         assert result == "davila7/claude-code-templates/cli-tool/components/skills/development/senior-backend"
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_finds_root_level_skill(self, mock_get):
         tree_entries = [
             {"path": "my-skill/SKILL.md", "type": "blob"},
@@ -761,7 +761,7 @@ class TestFindSkillInRepoTree:
         result = self._source()._find_skill_in_repo_tree("owner/repo", "my-skill")
         assert result == "owner/repo/my-skill"
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_returns_none_when_skill_not_found(self, mock_get):
         tree_entries = [
             {"path": "other-skill/SKILL.md", "type": "blob"},
@@ -784,7 +784,7 @@ class TestFindSkillInRepoTree:
         result = self._source()._find_skill_in_repo_tree("owner/repo", "nonexistent")
         assert result is None
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_returns_none_when_repo_api_fails(self, mock_get):
         mock_get.return_value = MagicMock(status_code=404)
         result = self._source()._find_skill_in_repo_tree("owner/repo", "my-skill")
@@ -889,7 +889,7 @@ class TestWellKnownSkillSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_fetch_rejects_unsafe_file_paths_from_well_known_endpoint(self, mock_get, _mock_read_cache, _mock_write_cache):
         def fake_get(url, *args, **kwargs):
             if url.endswith("/index.json"):
@@ -1133,7 +1133,7 @@ class TestUrlSource:
         )
 
         assert self._source().fetch("https://example.com/SKILL.md") is None
-        mock_get.assert_called_once_with("https://example.com/SKILL.md", timeout=20)
+        mock_get.assert_called_once_with("https://example.com/SKILL.md", timeout=20, headers=None, params=None)
 
     @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_fetch_skips_non_matching_identifier(self, mock_get):
@@ -1995,7 +1995,7 @@ class TestDownloadDirectoryViaTree:
         return GitHubSource(auth=auth)
 
     @patch.object(GitHubSource, "_fetch_file_content")
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_tree_api_downloads_subdirectories(self, mock_get, mock_fetch):
         """Tree API returns files from nested subdirectories."""
         repo_resp = MagicMock(status_code=200, json=lambda: {"default_branch": "main"})
@@ -2022,7 +2022,7 @@ class TestDownloadDirectoryViaTree:
         assert len(files) == 3
 
     @patch.object(GitHubSource, "_download_directory_recursive", return_value={"SKILL.md": "# ok"})
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_falls_back_on_truncated_tree(self, mock_get, mock_fallback):
         """When tree is truncated, fall back to recursive Contents API."""
         repo_resp = MagicMock(status_code=200, json=lambda: {"default_branch": "main"})
@@ -2036,7 +2036,7 @@ class TestDownloadDirectoryViaTree:
         mock_fallback.assert_called_once_with("owner/repo", "skills/my-skill")
 
     @patch.object(GitHubSource, "_download_directory_recursive", return_value={"SKILL.md": "# ok"})
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_falls_back_on_repo_api_failure(self, mock_get, mock_fallback):
         """When the repo endpoint returns non-200, fall back to Contents API."""
         mock_get.return_value = MagicMock(status_code=404)
@@ -2048,7 +2048,7 @@ class TestDownloadDirectoryViaTree:
         mock_fallback.assert_called_once()
 
     @patch.object(GitHubSource, "_fetch_file_content")
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_tree_api_skips_failed_file_fetches(self, mock_get, mock_fetch):
         """Files that fail to fetch are skipped, not fatal."""
         repo_resp = MagicMock(status_code=200, json=lambda: {"default_branch": "main"})
@@ -2071,7 +2071,7 @@ class TestDownloadDirectoryViaTree:
         assert "scripts/run.py" not in files
 
     @patch.object(GitHubSource, "_download_directory_recursive", return_value={})
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_falls_back_on_network_error(self, mock_get, mock_fallback):
         """Network errors in tree API trigger fallback."""
         mock_get.side_effect = httpx.ConnectError("connection refused")
@@ -2091,7 +2091,7 @@ class TestDownloadDirectoryRecursive:
         return GitHubSource(auth=auth)
 
     @patch.object(GitHubSource, "_fetch_file_content")
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_recursive_downloads_subdirectories(self, mock_get, mock_fetch):
         """Contents API recursion includes subdirectories."""
         root_resp = MagicMock(status_code=200, json=lambda: [
@@ -2111,7 +2111,7 @@ class TestDownloadDirectoryRecursive:
         assert "scripts/run.py" in files
 
     @patch.object(GitHubSource, "_fetch_file_content")
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_recursive_handles_subdir_failure(self, mock_get, mock_fetch):
         """Subdirectory 403/rate-limit returns empty but doesn't crash."""
         root_resp = MagicMock(status_code=200, json=lambda: [

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -286,7 +286,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub._ssrf_safe_http_get")
+    @patch("tools.skills_hub.httpx.get")
     def test_search_maps_skills_sh_results_to_prefixed_identifiers(self, mock_get, _mock_read_cache, _mock_write_cache):
         mock_get.return_value = MagicMock(
             status_code=200,
@@ -315,7 +315,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub._ssrf_safe_http_get")
+    @patch("tools.skills_hub.httpx.get")
     def test_empty_search_uses_featured_homepage_links(self, mock_get, _mock_read_cache, _mock_write_cache):
         mock_get.return_value = MagicMock(
             status_code=200,
@@ -371,7 +371,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub._ssrf_safe_http_get")
+    @patch("tools.skills_hub.httpx.get")
     @patch.object(GitHubSource, "inspect")
     def test_inspect_delegates_to_github_source_and_relabels_meta(self, mock_inspect, mock_get, _mock_read_cache, _mock_write_cache):
         mock_inspect.return_value = SkillMeta(
@@ -446,7 +446,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub._ssrf_safe_http_get")
+    @patch("tools.skills_hub.httpx.get")
     @patch.object(GitHubSource, "_list_skills_in_repo")
     @patch.object(GitHubSource, "inspect")
     def test_inspect_uses_detail_page_to_resolve_alias_skill(self, mock_inspect, mock_list_skills, mock_get, _mock_read_cache, _mock_write_cache):
@@ -479,7 +479,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub._ssrf_safe_http_get")
+    @patch("tools.skills_hub.httpx.get")
     @patch.object(GitHubSource, "_list_skills_in_repo")
     @patch.object(GitHubSource, "fetch")
     def test_fetch_uses_detail_page_to_resolve_alias_skill(self, mock_fetch, mock_list_skills, mock_get, _mock_read_cache, _mock_write_cache):
@@ -553,9 +553,10 @@ class TestSkillsShSource:
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
     @patch("tools.skills_hub._ssrf_safe_http_get")
+    @patch("tools.skills_hub.httpx.get")
     @patch.object(GitHubSource, "fetch")
     def test_fetch_falls_back_to_tree_search_for_deeply_nested_skills(
-        self, mock_fetch, mock_get, _mock_read_cache, _mock_write_cache,
+        self, mock_fetch, mock_httpx_get, mock_safe_get, _mock_read_cache, _mock_write_cache,
     ):
         """Skills in deeply nested dirs (e.g. cli-tool/components/skills/dev/my-skill/)
         are found via the GitHub Trees API when candidate paths and shallow scan fail."""
@@ -593,7 +594,10 @@ class TestSkillsShSource:
             resp.text = "<h1>my-skill</h1>"
             return resp
 
-        mock_get.side_effect = _httpx_get_side_effect
+        # skills.sh detail/root still use httpx.get; GitHub tree/contents use
+        # _ssrf_safe_http_get via _guarded_http_get after the GitHub SSRF fix.
+        mock_safe_get.side_effect = _httpx_get_side_effect
+        mock_httpx_get.side_effect = _httpx_get_side_effect
 
         resolved_bundle = SkillBundle(
             name="my-skill",
@@ -614,7 +618,7 @@ class TestSkillsShSource:
 
     @patch.object(GitHubSource, "_find_skill_in_repo_tree")
     @patch.object(GitHubSource, "_list_skills_in_repo")
-    @patch("tools.skills_hub._ssrf_safe_http_get")
+    @patch("tools.skills_hub.httpx.get")
     def test_discover_identifier_uses_tree_search_before_root_scan(
         self,
         mock_get,
@@ -644,7 +648,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub._ssrf_safe_http_get")
+    @patch("tools.skills_hub.httpx.get")
     def test_empty_query_walks_sitemap_not_homepage(
         self, mock_get, _mock_read_cache, _mock_write_cache,
     ):

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -286,7 +286,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_search_maps_skills_sh_results_to_prefixed_identifiers(self, mock_get, _mock_read_cache, _mock_write_cache):
         mock_get.return_value = MagicMock(
             status_code=200,
@@ -315,7 +315,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_empty_search_uses_featured_homepage_links(self, mock_get, _mock_read_cache, _mock_write_cache):
         mock_get.return_value = MagicMock(
             status_code=200,
@@ -371,7 +371,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch.object(GitHubSource, "inspect")
     def test_inspect_delegates_to_github_source_and_relabels_meta(self, mock_inspect, mock_get, _mock_read_cache, _mock_write_cache):
         mock_inspect.return_value = SkillMeta(
@@ -446,7 +446,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch.object(GitHubSource, "_list_skills_in_repo")
     @patch.object(GitHubSource, "inspect")
     def test_inspect_uses_detail_page_to_resolve_alias_skill(self, mock_inspect, mock_list_skills, mock_get, _mock_read_cache, _mock_write_cache):
@@ -479,7 +479,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch.object(GitHubSource, "_list_skills_in_repo")
     @patch.object(GitHubSource, "fetch")
     def test_fetch_uses_detail_page_to_resolve_alias_skill(self, mock_fetch, mock_list_skills, mock_get, _mock_read_cache, _mock_write_cache):
@@ -594,8 +594,8 @@ class TestSkillsShSource:
             resp.text = "<h1>my-skill</h1>"
             return resp
 
-        # skills.sh detail/root still use httpx.get; GitHub tree/contents use
-        # _ssrf_safe_http_get via _guarded_http_get after the GitHub SSRF fix.
+        # skills.sh detail + GitHub tree/contents use _ssrf_safe_http_get via
+        # _guarded_http_get; root contents scan still uses raw httpx.get.
         mock_safe_get.side_effect = _httpx_get_side_effect
         mock_httpx_get.side_effect = _httpx_get_side_effect
 
@@ -648,7 +648,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_empty_query_walks_sitemap_not_homepage(
         self, mock_get, _mock_read_cache, _mock_write_cache,
     ):

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -524,6 +524,26 @@ class TestTapsManager:
         assert mgr.load() == []
 
 # ---------------------------------------------------------------------------
+# LobeHubSource._fetch_agent
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAgent:
+    @patch("tools.skills_hub._guarded_http_get")
+    def test_valid_id_uses_guarded_fetch_with_agent_url_and_timeout(self, mock_get):
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"identifier": "test-agent"}
+        mock_get.return_value = response
+
+        result = LobeHubSource()._fetch_agent("test-agent")
+
+        assert result == {"identifier": "test-agent"}
+        mock_get.assert_called_once_with(
+            "https://chat-agents.lobehub.com/test-agent.json", timeout=15
+        )
+
+
+# ---------------------------------------------------------------------------
 # LobeHubSource._convert_to_skill_md
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -106,7 +106,7 @@ class TestSkillsShGroupings:
              patch.object(src, "_write_cache"), \
              patch.object(src, "_get_skillsh_groupings", return_value=groupings), \
              patch.object(src, "inspect", return_value=meta), \
-             patch("tools.skills_hub.httpx.get", return_value=resp):
+             patch("tools.skills_hub._ssrf_safe_http_get", return_value=resp):
             skills = src._list_skills_in_repo("NVIDIA/skills", "skills/")
 
         assert len(skills) == 1
@@ -159,7 +159,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_search_maps_skills_sh_results_to_prefixed_identifiers(self, mock_get, _mock_read_cache, _mock_write_cache):
         mock_get.return_value = MagicMock(
             status_code=200,
@@ -189,7 +189,7 @@ class TestSkillsShSource:
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch.object(GitHubSource, "fetch")
     def test_fetch_falls_back_to_tree_search_for_deeply_nested_skills(
         self, mock_fetch, mock_get, _mock_read_cache, _mock_write_cache,
@@ -257,7 +257,7 @@ class TestFindSkillInRepoTree:
         auth.get_headers.return_value = {"Accept": "application/vnd.github.v3+json"}
         return GitHubSource(auth=auth)
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_finds_deeply_nested_skill(self, mock_get):
         tree_entries = [
             {"path": "README.md", "type": "blob"},
@@ -282,7 +282,7 @@ class TestFindSkillInRepoTree:
         result = self._source()._find_skill_in_repo_tree("davila7/claude-code-templates", "senior-backend")
         assert result == "davila7/claude-code-templates/cli-tool/components/skills/development/senior-backend"
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_returns_none_when_repo_api_fails(self, mock_get):
         mock_get.return_value = MagicMock(status_code=404)
         result = self._source()._find_skill_in_repo_tree("owner/repo", "my-skill")
@@ -1095,7 +1095,7 @@ class TestDownloadDirectoryViaTree:
         return GitHubSource(auth=auth)
 
     @patch.object(GitHubSource, "_fetch_file_content")
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_tree_api_downloads_subdirectories(self, mock_get, mock_fetch):
         """Tree API returns files from nested subdirectories."""
         repo_resp = MagicMock(status_code=200, json=lambda: {"default_branch": "main"})
@@ -1122,7 +1122,7 @@ class TestDownloadDirectoryViaTree:
         assert len(files) == 3
 
     @patch.object(GitHubSource, "_download_directory_recursive", return_value={"SKILL.md": "# ok"})
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_falls_back_on_truncated_tree(self, mock_get, mock_fallback):
         """When tree is truncated, fall back to recursive Contents API."""
         repo_resp = MagicMock(status_code=200, json=lambda: {"default_branch": "main"})
@@ -1144,7 +1144,7 @@ class TestDownloadDirectoryRecursive:
         return GitHubSource(auth=auth)
 
     @patch.object(GitHubSource, "_fetch_file_content")
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_recursive_downloads_subdirectories(self, mock_get, mock_fetch):
         """Contents API recursion includes subdirectories."""
         root_resp = MagicMock(status_code=200, json=lambda: [

--- a/tests/tools/test_skills_hub_clawhub.py
+++ b/tests/tools/test_skills_hub_clawhub.py
@@ -246,7 +246,7 @@ class TestClawHubSource(unittest.TestCase):
         self.assertIn("SKILL.md", bundle.files)
         self.assertEqual(bundle.files["SKILL.md"], "# Skill")
         self.assertEqual(bundle.files["README.md"], "hello")
-        mock_safe_get.assert_called_once_with("https://files.example/skill-md", timeout=20)
+        mock_safe_get.assert_called_once_with("https://files.example/skill-md", timeout=20, headers=None, params=None)
 
     @patch("tools.skills_hub.httpx.get")
     def test_fetch_falls_back_to_versions_list(self, mock_get):

--- a/tests/tools/test_skills_hub_clawhub.py
+++ b/tests/tools/test_skills_hub_clawhub.py
@@ -32,9 +32,10 @@ class TestClawHubSource(unittest.TestCase):
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
     @patch.object(ClawHubSource, "_load_catalog_index", return_value=[])
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     @patch("tools.skills_hub.httpx.get")
     def test_search_uses_listing_endpoint_as_fallback(
-        self, mock_get, _mock_load_catalog, _mock_read_cache, _mock_write_cache
+        self, mock_get, mock_safe_get, _mock_load_catalog, _mock_read_cache, _mock_write_cache
     ):
         def side_effect(url, *args, **kwargs):
             if url.endswith("/skills"):
@@ -55,6 +56,7 @@ class TestClawHubSource(unittest.TestCase):
                 return _MockResponse(status_code=404, json_data={})
             return _MockResponse(status_code=404, json_data={})
 
+        mock_safe_get.return_value = _MockResponse(status_code=404, json_data={})
         mock_get.side_effect = side_effect
 
         results = self.src.search("caldav", limit=5)
@@ -64,13 +66,13 @@ class TestClawHubSource(unittest.TestCase):
         self.assertEqual(results[0].name, "CalDAV Calendar")
         self.assertEqual(results[0].description, "Calendar integration")
 
-        self.assertGreaterEqual(mock_get.call_count, 2)
+        self.assertEqual(mock_get.call_count, 1)
         args, kwargs = mock_get.call_args_list[0]
         self.assertTrue(args[0].endswith("/skills"))
         self.assertEqual(kwargs["params"], {"search": "caldav", "limit": 5})
 
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_inspect_maps_display_name_and_summary(self, mock_get):
         mock_get.return_value = _MockResponse(
             status_code=200,
@@ -89,7 +91,7 @@ class TestClawHubSource(unittest.TestCase):
         self.assertEqual(meta.description, "Calendar integration")
         self.assertEqual(meta.identifier, "caldav-calendar")
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_inspect_handles_nested_skill_payload(self, mock_get):
         mock_get.return_value = _MockResponse(
             status_code=200,
@@ -113,10 +115,9 @@ class TestClawHubSource(unittest.TestCase):
         self.assertEqual(meta.tags, ["automation"])
 
     @patch("tools.skills_hub._ssrf_safe_http_get")
-    @patch("tools.skills_hub.httpx.get")
-    def test_inspect_captures_owner_from_detail_api(self, mock_get, mock_safe_get):
+    def test_inspect_captures_owner_from_detail_api(self, mock_safe_get):
         """inspect() fetches the detail API which includes owner — capture it."""
-        mock_get.return_value = _MockResponse(
+        mock_safe_get.return_value = _MockResponse(
             status_code=200,
             json_data={
                 "skill": {
@@ -135,7 +136,7 @@ class TestClawHubSource(unittest.TestCase):
         self.assertIsNotNone(meta)
         self.assertEqual(meta.extra.get("owner"), "thesethrose")
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_inspect_tolerates_missing_owner(self, mock_get):
         """inspect() should still work when the API omits owner."""
         mock_get.return_value = _MockResponse(
@@ -157,9 +158,10 @@ class TestClawHubSource(unittest.TestCase):
         self.assertNotIn("owner", meta.extra or {})
 
     @patch("tools.skills_hub._ssrf_safe_http_get")
-    @patch("tools.skills_hub.httpx.get")
-    def test_fetch_resolves_latest_version_and_downloads_raw_files(self, mock_get, mock_safe_get):
+    def test_fetch_resolves_latest_version_and_downloads_raw_files(self, mock_safe_get):
         def side_effect(url, *args, **kwargs):
+            if "/download" in url:
+                return _MockResponse(status_code=404, json_data={})
             if url.endswith("/skills/caldav-calendar"):
                 return _MockResponse(
                     status_code=200,
@@ -178,10 +180,11 @@ class TestClawHubSource(unittest.TestCase):
                         ]
                     },
                 )
+            if url == "https://files.example/skill-md":
+                return _MockResponse(status_code=200, text="# Skill")
             return _MockResponse(status_code=404, json_data={})
 
-        mock_get.side_effect = side_effect
-        mock_safe_get.return_value = _MockResponse(status_code=200, text="# Skill")
+        mock_safe_get.side_effect = side_effect
 
         bundle = self.src.fetch("caldav-calendar")
 
@@ -190,9 +193,11 @@ class TestClawHubSource(unittest.TestCase):
         self.assertIn("SKILL.md", bundle.files)
         self.assertEqual(bundle.files["SKILL.md"], "# Skill")
         self.assertEqual(bundle.files["README.md"], "hello")
-        mock_safe_get.assert_called_once_with("https://files.example/skill-md", timeout=20)
+        mock_safe_get.assert_any_call(
+            "https://files.example/skill-md", timeout=20, headers=None, params=None
+        )
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_fetch_falls_back_to_versions_list(self, mock_get):
         def side_effect(url, *args, **kwargs):
             if url.endswith("/skills/caldav-calendar"):
@@ -211,9 +216,8 @@ class TestClawHubSource(unittest.TestCase):
 
     @patch("tools.skills_hub.check_website_access", return_value=None)
     @patch("tools.skills_hub.is_safe_url")
-    @patch("tools.skills_hub.httpx.get")
     @patch("tools.skills_hub._ssrf_safe_http_get")
-    def test_fetch_blocks_private_raw_url(self, mock_safe_get, mock_get, mock_safe, _mock_policy):
+    def test_fetch_blocks_private_raw_url(self, mock_safe_get, mock_safe, _mock_policy):
         def side_effect(url, *args, **kwargs):
             if url.endswith("/skills/caldav-calendar"):
                 return _MockResponse(
@@ -236,14 +240,19 @@ class TestClawHubSource(unittest.TestCase):
                 )
             return _MockResponse(status_code=404, json_data={})
 
-        mock_get.side_effect = side_effect
+        mock_safe_get.side_effect = side_effect
         mock_safe.side_effect = lambda url: not url.startswith("http://127.0.0.1/")
 
         bundle = self.src.fetch("caldav-calendar")
 
         self.assertIsNone(bundle)
-        self.assertEqual(mock_get.call_count, 3)
-        mock_safe_get.assert_not_called()
+        self.assertEqual(mock_safe_get.call_count, 3)
+        private_calls = [
+            call
+            for call in mock_safe_get.call_args_list
+            if call.args and str(call.args[0]).startswith("http://127.0.0.1/")
+        ]
+        self.assertEqual(private_calls, [])
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
@@ -409,7 +418,7 @@ class TestClawHubSource(unittest.TestCase):
         self.assertIsNone(bundle)
         mock_get.assert_not_called()
 
-    @patch("tools.skills_hub.httpx.get")
+    @patch("tools.skills_hub._ssrf_safe_http_get")
     def test_inspect_rejects_owner_mismatch_on_clawhub_url_path(self, mock_get):
         mock_get.return_value = _MockResponse(
             status_code=200,

--- a/tests/tools/test_skills_hub_clawhub_ssrf.py
+++ b/tests/tools/test_skills_hub_clawhub_ssrf.py
@@ -1,0 +1,23 @@
+"""Regression: ClawHub ZIP download must use SSRF-guarded HTTP."""
+
+from unittest.mock import patch
+
+from tools.skills_hub import ClawHubSource
+
+
+def test_download_zip_uses_guarded_http_get():
+    src = ClawHubSource()
+    with patch("tools.skills_hub._guarded_http_get", return_value=None) as mock_get:
+        files = src._download_zip("demo-skill", "1.0.0")
+    assert files == {}
+    assert mock_get.call_count == 1
+    called_url = mock_get.call_args.args[0]
+    assert "/download" in called_url
+    assert "slug=demo-skill" in called_url
+    assert "version=1.0.0" in called_url
+
+
+def test_download_zip_returns_empty_when_ssrf_blocked():
+    src = ClawHubSource()
+    with patch("tools.skills_hub._guarded_http_get", return_value=None):
+        assert src._download_zip("evil", "9.9.9") == {}

--- a/tests/tools/test_skills_hub_clawhub_ssrf.py
+++ b/tests/tools/test_skills_hub_clawhub_ssrf.py
@@ -2,7 +2,9 @@
 
 from unittest.mock import patch
 
-from tools.skills_hub import ClawHubSource
+import httpx
+
+from tools.skills_hub import ClawHubSource, _guarded_http_get
 
 
 def test_download_zip_uses_guarded_http_get():
@@ -21,3 +23,22 @@ def test_download_zip_returns_empty_when_ssrf_blocked():
     src = ClawHubSource()
     with patch("tools.skills_hub._guarded_http_get", return_value=None):
         assert src._download_zip("evil", "9.9.9") == {}
+
+
+def test_guarded_http_get_blocks_private_redirect_before_safe_http_get():
+    public_url = "https://clawhub.example/download?slug=demo-skill&version=1.0.0"
+    private_url = "http://127.0.0.1:8080/admin"
+    redirect = httpx.Response(
+        302,
+        headers={"location": private_url},
+        request=httpx.Request("GET", public_url),
+    )
+
+    with (
+        patch("tools.skills_hub.is_safe_url", side_effect=lambda url: url == public_url),
+        patch("tools.skills_hub.check_website_access", return_value=None),
+        patch("tools.skills_hub._ssrf_safe_http_get", return_value=redirect) as mock_safe_get,
+    ):
+        assert _guarded_http_get(public_url) is None
+
+    mock_safe_get.assert_called_once_with(public_url, timeout=20)

--- a/tests/tools/test_skills_hub_clawhub_ssrf.py
+++ b/tests/tools/test_skills_hub_clawhub_ssrf.py
@@ -41,4 +41,6 @@ def test_guarded_http_get_blocks_private_redirect_before_safe_http_get():
     ):
         assert _guarded_http_get(public_url) is None
 
-    mock_safe_get.assert_called_once_with(public_url, timeout=20)
+    mock_safe_get.assert_called_once_with(
+        public_url, timeout=20, headers=None, params=None
+    )

--- a/tests/tools/test_skills_hub_github_ssrf.py
+++ b/tests/tools/test_skills_hub_github_ssrf.py
@@ -1,0 +1,99 @@
+"""SSRF + auth-strip coverage for GitHub Skills Hub API fetches.
+
+Salvages the incomplete open #63920 surface that still leaves
+``GitHubSource._get_repo_tree`` / ``_github_get`` on raw ``httpx.get``
+with ``follow_redirects=True`` on ``upstream/main``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+
+def _resp(status: int, *, location: str | None = None, json_data=None):
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status
+    r.headers = {"location": location} if location else {}
+    r.json.return_value = json_data or {}
+    return r
+
+
+class TestGuardedHttpGetAuthStrip:
+    def test_strips_authorization_on_cross_origin_redirect(self):
+        from tools.skills_hub import _guarded_http_get
+
+        seen = []
+
+        def fake_ssrf_get(url, *, timeout=20, headers=None, params=None):
+            seen.append({"url": url, "headers": dict(headers or {})})
+            if len(seen) == 1:
+                return _resp(302, location="https://cdn.example.com/blob")
+            return _resp(200, json_data={"ok": True})
+
+        with patch("tools.skills_hub.is_safe_url", return_value=True), patch(
+            "tools.skills_hub.check_website_access", return_value=None
+        ), patch("tools.skills_hub._ssrf_safe_http_get", side_effect=fake_ssrf_get):
+            resp = _guarded_http_get(
+                "https://api.github.com/repos/org/repo",
+                headers={
+                    "Accept": "application/vnd.github.v3+json",
+                    "Authorization": "token ghp_secret",
+                },
+                timeout=15,
+            )
+
+        assert resp is not None
+        assert resp.status_code == 200
+        assert seen[0]["headers"].get("Authorization") == "token ghp_secret"
+        assert "Authorization" not in seen[1]["headers"]
+        assert seen[1]["headers"]["Accept"] == "application/vnd.github.v3+json"
+
+    def test_blocks_private_redirect_target(self):
+        from tools.skills_hub import _guarded_http_get
+
+        def fake_ssrf_get(url, *, timeout=20, headers=None, params=None):
+            return _resp(302, location="http://169.254.169.254/latest/meta-data")
+
+        def safe(url: str) -> bool:
+            return "169.254" not in url
+
+        with patch("tools.skills_hub.is_safe_url", side_effect=safe), patch(
+            "tools.skills_hub.check_website_access", return_value=None
+        ), patch("tools.skills_hub._ssrf_safe_http_get", side_effect=fake_ssrf_get):
+            resp = _guarded_http_get(
+                "https://api.github.com/repos/org/repo",
+                headers={"Authorization": "token ghp_secret"},
+            )
+
+        assert resp is None
+
+
+class TestGetRepoTreeUsesGuardedFetch:
+    def test_get_repo_tree_does_not_call_raw_httpx_get(self):
+        from tools.skills_hub import GitHubAuth, GitHubSource
+
+        src = GitHubSource(auth=GitHubAuth())
+        calls = {"n": 0}
+
+        def fake_guarded(url, **kwargs):
+            calls["n"] += 1
+            if "git/trees" in url:
+                return _resp(
+                    200,
+                    json_data={
+                        "sha": "abc",
+                        "truncated": False,
+                        "tree": [{"path": "SKILL.md", "type": "blob"}],
+                    },
+                )
+            return _resp(200, json_data={"default_branch": "main"})
+
+        with patch("tools.skills_hub._guarded_http_get", side_effect=fake_guarded), patch(
+            "tools.skills_hub.httpx.get"
+        ) as raw_get:
+            result = src._get_repo_tree("org/repo")
+
+        assert result is not None
+        assert calls["n"] == 2
+        raw_get.assert_not_called()

--- a/tests/tools/test_skills_hub_github_ssrf.py
+++ b/tests/tools/test_skills_hub_github_ssrf.py
@@ -49,6 +49,29 @@ class TestGuardedHttpGetAuthStrip:
         assert "Authorization" not in seen[1]["headers"]
         assert seen[1]["headers"]["Accept"] == "application/vnd.github.v3+json"
 
+    def test_strips_authorization_on_https_to_http_downgrade(self):
+        from tools.skills_hub import _guarded_http_get
+
+        seen = []
+
+        def fake_ssrf_get(url, *, timeout=20, headers=None, params=None):
+            seen.append((url, dict(headers or {})))
+            if len(seen) == 1:
+                return _resp(302, location="http://api.github.com/blob")
+            return _resp(200, json_data={"ok": True})
+
+        with patch("tools.skills_hub.is_safe_url", return_value=True), patch(
+            "tools.skills_hub.check_website_access", return_value=None
+        ), patch("tools.skills_hub._ssrf_safe_http_get", side_effect=fake_ssrf_get):
+            response = _guarded_http_get(
+                "https://api.github.com/repos/org/repo",
+                headers={"Authorization": "token ghp_secret"},
+            )
+
+        assert response is not None
+        assert "Authorization" in seen[0][1]
+        assert "Authorization" not in seen[1][1]
+
     def test_blocks_private_redirect_target(self):
         from tools.skills_hub import _guarded_http_get
 

--- a/tests/tools/test_skills_hub_github_ssrf.py
+++ b/tests/tools/test_skills_hub_github_ssrf.py
@@ -120,3 +120,28 @@ class TestGetRepoTreeUsesGuardedFetch:
         assert result is not None
         assert calls["n"] == 2
         raw_get.assert_not_called()
+
+
+class TestSkillsShRootListingUsesGuardedFetch:
+    def test_root_listing_fallback_uses_github_guard(self):
+        from tools.skills_hub import SkillsShSource
+
+        source = SkillsShSource(auth=MagicMock())
+        source.github._list_skills_in_repo = MagicMock(return_value=[])
+        source.github._find_skill_in_repo_tree = MagicMock(return_value=None)
+        source.github._github_get = MagicMock(
+            return_value=_resp(
+                200,
+                json_data=[{"name": "community", "type": "dir"}],
+            )
+        )
+        source.github.inspect = MagicMock(return_value=None)
+
+        with patch("tools.skills_hub.httpx.get") as raw_get:
+            result = source._discover_identifier("owner/repo/missing-skill")
+
+        assert result is None
+        source.github._github_get.assert_called_once_with(
+            "https://api.github.com/repos/owner/repo/contents/"
+        )
+        raw_get.assert_not_called()

--- a/tests/tools/test_skills_sh_ssrf.py
+++ b/tests/tools/test_skills_sh_ssrf.py
@@ -1,0 +1,18 @@
+"""skills.sh sitemap/detail fetches must stay on skills.sh (SSRF)."""
+
+from tools.skills_hub import SkillsShSource
+
+
+def test_is_skills_sh_url_accepts_www_and_apex():
+    assert SkillsShSource._is_skills_sh_url("https://skills.sh/sitemap-skills-1.xml")
+    assert SkillsShSource._is_skills_sh_url("https://www.skills.sh/sitemap-skills-2.xml")
+
+
+def test_is_skills_sh_url_rejects_foreign_hosts():
+    assert not SkillsShSource._is_skills_sh_url(
+        "http://169.254.169.254/sitemap-skills.xml"
+    )
+    assert not SkillsShSource._is_skills_sh_url(
+        "https://evil.example/sitemap-skills.xml"
+    )
+    assert not SkillsShSource._is_skills_sh_url("ftp://skills.sh/sitemap-skills.xml")

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1695,6 +1695,16 @@ class SkillsShSource(SkillSource):
     def trust_level_for(self, identifier: str) -> str:
         return self.github.trust_level_for(self._normalize_identifier(identifier))
 
+    @staticmethod
+    def _is_skills_sh_url(url: str) -> bool:
+        """Return True when *url* targets the skills.sh site (www optional)."""
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            return False
+        host = (parsed.hostname or "").lower().rstrip(".")
+        return host in {"skills.sh", "www.skills.sh"} and parsed.scheme in {"http", "https"}
+
     def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
         if not query.strip():
             # Empty query = bulk catalog dump (what build_skills_index.py
@@ -1708,15 +1718,15 @@ class SkillsShSource(SkillSource):
             return [SkillMeta(**item) for item in cached][:limit]
 
         try:
-            resp = httpx.get(
+            resp = _guarded_http_get(
                 self.SEARCH_URL,
-                params={"q": query, "limit": limit},
                 timeout=20,
+                params={"q": query, "limit": limit},
             )
-            if resp.status_code != 200:
+            if resp is None or resp.status_code != 200:
                 return []
             data = resp.json()
-        except (httpx.HTTPError, json.JSONDecodeError):
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
             return []
 
         items = data.get("skills", []) if isinstance(data, dict) else []
@@ -1785,18 +1795,19 @@ class SkillsShSource(SkillSource):
         # Step 1: fetch the sitemap index → list of skill-sitemap URLs.
         skill_sitemap_urls: List[str] = []
         try:
-            resp = httpx.get(
+            resp = _guarded_http_get(
                 self.SITEMAP_INDEX_URL,
                 timeout=20,
-                follow_redirects=True,
                 headers=sitemap_headers,
             )
-            if resp.status_code != 200:
+            if resp is None or resp.status_code != 200:
                 return self._featured_skills(limit)
             for match in self._SITEMAP_LOC_RE.finditer(resp.text):
                 loc = match.group(1).strip()
                 # Sitemap index entries that point at the per-skill maps.
-                if "sitemap-skills" in loc:
+                # Only follow locs that stay on skills.sh — a compromised or
+                # redirected index must not pull arbitrary hosts (SSRF).
+                if "sitemap-skills" in loc and self._is_skills_sh_url(loc):
                     skill_sitemap_urls.append(loc)
         except httpx.HTTPError:
             return self._featured_skills(limit)
@@ -1809,13 +1820,12 @@ class SkillsShSource(SkillSource):
         results: List[SkillMeta] = []
         for sitemap_url in skill_sitemap_urls:
             try:
-                resp = httpx.get(
+                resp = _guarded_http_get(
                     sitemap_url,
                     timeout=30,
-                    follow_redirects=True,
                     headers=sitemap_headers,
                 )
-                if resp.status_code != 200:
+                if resp is None or resp.status_code != 200:
                     continue
             except httpx.HTTPError:
                 continue
@@ -1859,8 +1869,8 @@ class SkillsShSource(SkillSource):
             return [SkillMeta(**item) for item in cached][:limit]
 
         try:
-            resp = httpx.get(self.BASE_URL, timeout=20)
-            if resp.status_code != 200:
+            resp = _guarded_http_get(self.BASE_URL, timeout=20)
+            if resp is None or resp.status_code != 200:
                 return []
         except httpx.HTTPError:
             return []
@@ -1935,8 +1945,11 @@ class SkillsShSource(SkillSource):
             return cached
 
         try:
-            resp = httpx.get(f"{self.BASE_URL}/{identifier}", timeout=20)
-            if resp.status_code != 200:
+            # Identifier is already normalized; still refuse path traversal / host escape.
+            if ".." in identifier or identifier.startswith("/") or "://" in identifier:
+                return None
+            resp = _guarded_http_get(f"{self.BASE_URL}/{identifier}", timeout=20)
+            if resp is None or resp.status_code != 200:
                 return None
         except httpx.HTTPError:
             return None

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -291,19 +291,40 @@ def _resolve_lock_install_path(install_path: str, skill_name: str) -> Path:
     return target
 
 
-def _ssrf_safe_http_get(url: str, *, timeout: int = 20) -> httpx.Response:
+def _ssrf_safe_http_get(
+    url: str,
+    *,
+    timeout: int = 20,
+    headers: Optional[Dict[str, str]] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> httpx.Response:
     """Fetch one URL with connect-time SSRF validation and no automatic redirects."""
     from tools.url_safety import create_ssrf_safe_client
 
     with create_ssrf_safe_client(timeout=timeout, follow_redirects=False) as client:
-        return client.get(url)
+        return client.get(url, headers=headers, params=params)
 
 
-def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response]:
-    """Fetch a URL with SSRF and redirect-target validation."""
+def _guarded_http_get(
+    url: str,
+    *,
+    timeout: int = 20,
+    headers: Optional[Dict[str, str]] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Optional[httpx.Response]:
+    """Fetch a URL with SSRF and redirect-target validation.
+
+    Optional ``headers`` / ``params`` support GitHub API callers. On a
+    cross-origin redirect hop, ``Authorization`` is stripped so a token
+    cannot ride a safe CDN Location (salvage of open #63920 GitHub paths).
+    """
+    from urllib.parse import urlparse
+
     from tools.url_safety import SSRFConnectionBlocked
 
     current_url = url
+    current_headers = dict(headers) if headers else None
+    current_params = params
 
     for _ in range(_MAX_SKILL_FETCH_REDIRECTS + 1):
         if not is_safe_url(current_url):
@@ -320,7 +341,12 @@ def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response
             return None
 
         try:
-            resp = _ssrf_safe_http_get(current_url, timeout=timeout)
+            resp = _ssrf_safe_http_get(
+                current_url,
+                timeout=timeout,
+                headers=current_headers,
+                params=current_params,
+            )
         except (SSRFConnectionBlocked, httpx.HTTPError) as exc:
             logger.debug("Skills Hub fetch failed for %s: %s", current_url, exc)
             return None
@@ -329,13 +355,24 @@ def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response
             location = getattr(resp, "headers", {}).get("location")
             if not location:
                 return None
-            current_url = urljoin(current_url, location)
+            next_url = urljoin(current_url, location)
+            if current_headers and urlparse(next_url).netloc != urlparse(
+                current_url
+            ).netloc:
+                current_headers = {
+                    k: v
+                    for k, v in current_headers.items()
+                    if k.lower() != "authorization"
+                }
+            current_url = next_url
+            current_params = None  # params apply only to the first hop
             continue
 
         return resp
 
     logger.warning("Skills Hub fetch exceeded redirect limit for %s", url)
     return None
+
 
 
 def _validate_bundle_rel_path(rel_path: str) -> str:
@@ -810,14 +847,16 @@ class GitHubSource(SkillSource):
 
         headers = self.auth.get_headers()
 
-        # Resolve default branch
+        # Resolve default branch (SSRF-safe; no auto-follow redirects)
         try:
-            resp = httpx.get(
+            resp = _guarded_http_get(
                 f"https://api.github.com/repos/{repo}",
-                headers=headers, timeout=15, follow_redirects=True,
+                headers=headers,
+                timeout=15,
             )
-            if resp.status_code != 200:
-                self._check_rate_limit_response(resp)
+            if resp is None or resp.status_code != 200:
+                if resp is not None:
+                    self._check_rate_limit_response(resp)
                 return None
             default_branch = resp.json().get("default_branch", "main")
         except (httpx.HTTPError, ValueError):
@@ -825,13 +864,15 @@ class GitHubSource(SkillSource):
 
         # Fetch recursive tree
         try:
-            resp = httpx.get(
+            resp = _guarded_http_get(
                 f"https://api.github.com/repos/{repo}/git/trees/{default_branch}",
+                headers=headers,
                 params={"recursive": "1"},
-                headers=headers, timeout=30, follow_redirects=True,
+                timeout=30,
             )
-            if resp.status_code != 200:
-                self._check_rate_limit_response(resp)
+            if resp is None or resp.status_code != 200:
+                if resp is not None:
+                    self._check_rate_limit_response(resp)
                 return None
             tree_data = resp.json()
             if tree_data.get("truncated"):
@@ -889,13 +930,19 @@ class GitHubSource(SkillSource):
         last_resp: Optional["httpx.Response"] = None
         for attempt in range(max_retries):
             try:
-                resp = httpx.get(
-                    url, params=params, headers=hdrs,
-                    timeout=timeout, follow_redirects=True,
+                resp = _guarded_http_get(
+                    url, params=params, headers=hdrs, timeout=timeout,
                 )
             except httpx.HTTPError as e:
                 logger.debug("GitHub GET %s failed (attempt %d/%d): %s",
                              url, attempt + 1, max_retries, e)
+                if attempt < max_retries - 1:
+                    time.sleep(backoff)
+                    backoff = min(backoff * 2, 30.0)
+                    continue
+                return None
+
+            if resp is None:
                 if attempt < max_retries - 1:
                     time.sleep(backoff)
                     backoff = min(backoff * 2, 30.0)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -305,6 +305,22 @@ def _ssrf_safe_http_get(
         return client.get(url, headers=headers, params=params)
 
 
+def _normalized_origin(url: str) -> Optional[Tuple[str, str, int]]:
+    """Return scheme, normalized hostname, and effective port for a URL."""
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    hostname = parsed.hostname
+    if not scheme or not hostname:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    if port is None:
+        port = {"http": 80, "https": 443}.get(scheme, -1)
+    return scheme, hostname.rstrip(".").lower(), port
+
+
 def _guarded_http_get(
     url: str,
     *,
@@ -318,13 +334,12 @@ def _guarded_http_get(
     cross-origin redirect hop, ``Authorization`` is stripped so a token
     cannot ride a safe CDN Location (salvage of open #63920 GitHub paths).
     """
-    from urllib.parse import urlparse
-
     from tools.url_safety import SSRFConnectionBlocked
 
     current_url = url
     current_headers = dict(headers) if headers else None
     current_params = params
+    initial_origin = _normalized_origin(url)
 
     for _ in range(_MAX_SKILL_FETCH_REDIRECTS + 1):
         if not is_safe_url(current_url):
@@ -356,9 +371,7 @@ def _guarded_http_get(
             if not location:
                 return None
             next_url = urljoin(current_url, location)
-            if current_headers and urlparse(next_url).netloc != urlparse(
-                current_url
-            ).netloc:
+            if current_headers and _normalized_origin(next_url) != initial_origin:
                 current_headers = {
                     k: v
                     for k, v in current_headers.items()

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2055,9 +2055,8 @@ class SkillsShSource(SkillSource):
         # Fallback: scan repo root for directories that might contain skills
         try:
             root_url = f"https://api.github.com/repos/{repo}/contents/"
-            resp = httpx.get(root_url, headers=self.github.auth.get_headers(),
-                             timeout=15, follow_redirects=True)
-            if resp.status_code == 200:
+            resp = self.github._github_get(root_url)
+            if resp is not None and resp.status_code == 200:
                 entries = resp.json()
                 if isinstance(entries, list):
                     for entry in entries:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -297,19 +297,40 @@ def _resolve_lock_install_path(install_path: str, skill_name: str) -> Path:
     return target
 
 
-def _ssrf_safe_http_get(url: str, *, timeout: int = 20) -> httpx.Response:
+def _ssrf_safe_http_get(
+    url: str,
+    *,
+    timeout: int = 20,
+    headers: Optional[Dict[str, str]] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> httpx.Response:
     """Fetch one URL with connect-time SSRF validation and no automatic redirects."""
     from tools.url_safety import create_ssrf_safe_client
 
     with create_ssrf_safe_client(timeout=timeout, follow_redirects=False) as client:
-        return client.get(url)
+        return client.get(url, headers=headers, params=params)
 
 
-def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response]:
-    """Fetch a URL with SSRF and redirect-target validation."""
+def _guarded_http_get(
+    url: str,
+    *,
+    timeout: int = 20,
+    headers: Optional[Dict[str, str]] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Optional[httpx.Response]:
+    """Fetch a URL with SSRF and redirect-target validation.
+
+    Optional ``headers`` / ``params`` support GitHub API callers. On a
+    cross-origin redirect hop, ``Authorization`` is stripped so a token
+    cannot ride a safe CDN Location (salvage of open #63920 GitHub paths).
+    """
+    from urllib.parse import urlparse
+
     from tools.url_safety import SSRFConnectionBlocked
 
     current_url = url
+    current_headers = dict(headers) if headers else None
+    current_params = params
 
     for _ in range(_MAX_SKILL_FETCH_REDIRECTS + 1):
         if not is_safe_url(current_url):
@@ -326,7 +347,12 @@ def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response
             return None
 
         try:
-            resp = _ssrf_safe_http_get(current_url, timeout=timeout)
+            resp = _ssrf_safe_http_get(
+                current_url,
+                timeout=timeout,
+                headers=current_headers,
+                params=current_params,
+            )
         except (SSRFConnectionBlocked, httpx.HTTPError) as exc:
             logger.debug("Skills Hub fetch failed for %s: %s", current_url, exc)
             return None
@@ -335,13 +361,24 @@ def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response
             location = getattr(resp, "headers", {}).get("location")
             if not location:
                 return None
-            current_url = urljoin(current_url, location)
+            next_url = urljoin(current_url, location)
+            if current_headers and urlparse(next_url).netloc != urlparse(
+                current_url
+            ).netloc:
+                current_headers = {
+                    k: v
+                    for k, v in current_headers.items()
+                    if k.lower() != "authorization"
+                }
+            current_url = next_url
+            current_params = None  # params apply only to the first hop
             continue
 
         return resp
 
     logger.warning("Skills Hub fetch exceeded redirect limit for %s", url)
     return None
+
 
 
 def _validate_bundle_rel_path(rel_path: str) -> str:
@@ -818,14 +855,16 @@ class GitHubSource(SkillSource):
 
         headers = self.auth.get_headers()
 
-        # Resolve default branch
+        # Resolve default branch (SSRF-safe; no auto-follow redirects)
         try:
-            resp = httpx.get(
+            resp = _guarded_http_get(
                 f"https://api.github.com/repos/{repo}",
-                headers=headers, timeout=15, follow_redirects=True,
+                headers=headers,
+                timeout=15,
             )
-            if resp.status_code != 200:
-                self._check_rate_limit_response(resp)
+            if resp is None or resp.status_code != 200:
+                if resp is not None:
+                    self._check_rate_limit_response(resp)
                 return None
             default_branch = resp.json().get("default_branch", "main")
         except (httpx.HTTPError, ValueError):
@@ -833,13 +872,15 @@ class GitHubSource(SkillSource):
 
         # Fetch recursive tree
         try:
-            resp = httpx.get(
+            resp = _guarded_http_get(
                 f"https://api.github.com/repos/{repo}/git/trees/{default_branch}",
+                headers=headers,
                 params={"recursive": "1"},
-                headers=headers, timeout=30, follow_redirects=True,
+                timeout=30,
             )
-            if resp.status_code != 200:
-                self._check_rate_limit_response(resp)
+            if resp is None or resp.status_code != 200:
+                if resp is not None:
+                    self._check_rate_limit_response(resp)
                 return None
             tree_data = resp.json()
             if tree_data.get("truncated"):
@@ -897,13 +938,19 @@ class GitHubSource(SkillSource):
         last_resp: Optional["httpx.Response"] = None
         for attempt in range(max_retries):
             try:
-                resp = httpx.get(
-                    url, params=params, headers=hdrs,
-                    timeout=timeout, follow_redirects=True,
+                resp = _guarded_http_get(
+                    url, params=params, headers=hdrs, timeout=timeout,
                 )
             except httpx.HTTPError as e:
                 logger.debug("GitHub GET %s failed (attempt %d/%d): %s",
                              url, attempt + 1, max_retries, e)
+                if attempt < max_retries - 1:
+                    time.sleep(backoff)
+                    backoff = min(backoff * 2, 30.0)
+                    continue
+                return None
+
+            if resp is None:
                 if attempt < max_retries - 1:
                     time.sleep(backoff)
                     backoff = min(backoff * 2, 30.0)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2770,11 +2770,11 @@ class ClawHubSource(SkillSource):
 
     def _get_json(self, url: str, timeout: int = 20) -> Optional[Any]:
         try:
-            resp = httpx.get(url, timeout=timeout)
-            if resp.status_code != 200:
+            resp = _guarded_http_get(url, timeout=timeout)
+            if resp is None or resp.status_code != 200:
                 return None
             return resp.json()
-        except (httpx.HTTPError, json.JSONDecodeError):
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
             return None
 
     def _resolve_latest_version(self, slug: str, skill_data: Dict[str, Any]) -> Optional[str]:
@@ -2994,14 +2994,19 @@ class ClawHubSource(SkillSource):
 
         files: Dict[str, str] = {}
         max_retries = 3
+        download_url = f"{self.BASE_URL}/download"
+        # Build the absolute URL once so guarded redirects can re-validate hops.
+        from urllib.parse import urlencode
+
+        download_url_with_qs = f"{download_url}?{urlencode({'slug': slug, 'version': version})}"
         for attempt in range(max_retries):
             try:
-                resp = httpx.get(
-                    f"{self.BASE_URL}/download",
-                    params={"slug": slug, "version": version},
-                    timeout=30,
-                    follow_redirects=True,
-                )
+                # Salvage #57571 (size caps): also block redirect-based SSRF.
+                # ClawHub CDN may 302; raw follow_redirects=True would allow a
+                # hop into private/link-local space.
+                resp = _guarded_http_get(download_url_with_qs, timeout=30)
+                if resp is None:
+                    return files
                 if resp.status_code == 429:
                     try:
                         retry_after = int(resp.headers.get("retry-after", "5"))

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1703,6 +1703,16 @@ class SkillsShSource(SkillSource):
     def trust_level_for(self, identifier: str) -> str:
         return self.github.trust_level_for(self._normalize_identifier(identifier))
 
+    @staticmethod
+    def _is_skills_sh_url(url: str) -> bool:
+        """Return True when *url* targets the skills.sh site (www optional)."""
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            return False
+        host = (parsed.hostname or "").lower().rstrip(".")
+        return host in {"skills.sh", "www.skills.sh"} and parsed.scheme in {"http", "https"}
+
     def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
         if not query.strip():
             # Empty query = bulk catalog dump (what build_skills_index.py
@@ -1716,15 +1726,15 @@ class SkillsShSource(SkillSource):
             return [SkillMeta(**item) for item in cached][:limit]
 
         try:
-            resp = httpx.get(
+            resp = _guarded_http_get(
                 self.SEARCH_URL,
-                params={"q": query, "limit": limit},
                 timeout=20,
+                params={"q": query, "limit": limit},
             )
-            if resp.status_code != 200:
+            if resp is None or resp.status_code != 200:
                 return []
             data = resp.json()
-        except (httpx.HTTPError, json.JSONDecodeError):
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
             return []
 
         items = data.get("skills", []) if isinstance(data, dict) else []
@@ -1793,18 +1803,19 @@ class SkillsShSource(SkillSource):
         # Step 1: fetch the sitemap index → list of skill-sitemap URLs.
         skill_sitemap_urls: List[str] = []
         try:
-            resp = httpx.get(
+            resp = _guarded_http_get(
                 self.SITEMAP_INDEX_URL,
                 timeout=20,
-                follow_redirects=True,
                 headers=sitemap_headers,
             )
-            if resp.status_code != 200:
+            if resp is None or resp.status_code != 200:
                 return self._featured_skills(limit)
             for match in self._SITEMAP_LOC_RE.finditer(resp.text):
                 loc = match.group(1).strip()
                 # Sitemap index entries that point at the per-skill maps.
-                if "sitemap-skills" in loc:
+                # Only follow locs that stay on skills.sh — a compromised or
+                # redirected index must not pull arbitrary hosts (SSRF).
+                if "sitemap-skills" in loc and self._is_skills_sh_url(loc):
                     skill_sitemap_urls.append(loc)
         except httpx.HTTPError:
             return self._featured_skills(limit)
@@ -1817,13 +1828,12 @@ class SkillsShSource(SkillSource):
         results: List[SkillMeta] = []
         for sitemap_url in skill_sitemap_urls:
             try:
-                resp = httpx.get(
+                resp = _guarded_http_get(
                     sitemap_url,
                     timeout=30,
-                    follow_redirects=True,
                     headers=sitemap_headers,
                 )
-                if resp.status_code != 200:
+                if resp is None or resp.status_code != 200:
                     continue
             except httpx.HTTPError:
                 continue
@@ -1867,8 +1877,8 @@ class SkillsShSource(SkillSource):
             return [SkillMeta(**item) for item in cached][:limit]
 
         try:
-            resp = httpx.get(self.BASE_URL, timeout=20)
-            if resp.status_code != 200:
+            resp = _guarded_http_get(self.BASE_URL, timeout=20)
+            if resp is None or resp.status_code != 200:
                 return []
         except httpx.HTTPError:
             return []
@@ -1943,8 +1953,11 @@ class SkillsShSource(SkillSource):
             return cached
 
         try:
-            resp = httpx.get(f"{self.BASE_URL}/{identifier}", timeout=20)
-            if resp.status_code != 200:
+            # Identifier is already normalized; still refuse path traversal / host escape.
+            if ".." in identifier or identifier.startswith("/") or "://" in identifier:
+                return None
+            resp = _guarded_http_get(f"{self.BASE_URL}/{identifier}", timeout=20)
+            if resp is None or resp.status_code != 200:
                 return None
         except httpx.HTTPError:
             return None

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3156,6 +3156,18 @@ class LobeHubSource(SkillSource):
                 )
         return None
 
+    @staticmethod
+    def _sanitize_agent_id(agent_id: str) -> Optional[str]:
+        """Reject path traversal / absolute / scheme-bearing agent ids."""
+        cleaned = (agent_id or "").strip()
+        if not cleaned or len(cleaned) > 200:
+            return None
+        if any(ch in cleaned for ch in ("/", "\\", ":", "?", "#", "@")):
+            return None
+        if ".." in cleaned or cleaned.startswith("."):
+            return None
+        return cleaned
+
     def _fetch_index(self) -> Optional[Any]:
         """Fetch the LobeHub agent index (cached for 1 hour)."""
         cache_key = "lobehub_index"
@@ -3163,27 +3175,32 @@ class LobeHubSource(SkillSource):
         if cached is not None:
             return cached
 
+        resp = _guarded_http_get(self.INDEX_URL, timeout=30)
+        if resp is None or resp.status_code != 200:
+            return None
         try:
-            resp = httpx.get(self.INDEX_URL, timeout=30)
-            if resp.status_code != 200:
-                return None
             data = resp.json()
-        except (httpx.HTTPError, json.JSONDecodeError):
+        except (ValueError, json.JSONDecodeError):
             return None
 
         _write_index_cache(cache_key, data)
         return data
 
     def _fetch_agent(self, agent_id: str) -> Optional[dict]:
-        """Fetch a single agent's JSON file."""
-        url = f"https://chat-agents.lobehub.com/{agent_id}.json"
+        """Fetch a single agent's JSON file via the guarded Skills Hub HTTP path."""
+        safe_id = self._sanitize_agent_id(agent_id)
+        if not safe_id:
+            logger.warning("LobeHub: rejected unsafe agent id %r", agent_id)
+            return None
+        url = f"https://chat-agents.lobehub.com/{safe_id}.json"
+        resp = _guarded_http_get(url, timeout=15)
+        if resp is None or resp.status_code != 200:
+            return None
         try:
-            resp = httpx.get(url, timeout=15)
-            if resp.status_code == 200:
-                return resp.json()
-        except (httpx.HTTPError, json.JSONDecodeError) as e:
+            return resp.json()
+        except (ValueError, json.JSONDecodeError) as e:
             logger.debug("LobeHub agent fetch failed: %s", e)
-        return None
+            return None
 
     @staticmethod
     def _convert_to_skill_md(agent_data: dict) -> str:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -311,6 +311,22 @@ def _ssrf_safe_http_get(
         return client.get(url, headers=headers, params=params)
 
 
+def _normalized_origin(url: str) -> Optional[Tuple[str, str, int]]:
+    """Return scheme, normalized hostname, and effective port for a URL."""
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    hostname = parsed.hostname
+    if not scheme or not hostname:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    if port is None:
+        port = {"http": 80, "https": 443}.get(scheme, -1)
+    return scheme, hostname.rstrip(".").lower(), port
+
+
 def _guarded_http_get(
     url: str,
     *,
@@ -324,13 +340,12 @@ def _guarded_http_get(
     cross-origin redirect hop, ``Authorization`` is stripped so a token
     cannot ride a safe CDN Location (salvage of open #63920 GitHub paths).
     """
-    from urllib.parse import urlparse
-
     from tools.url_safety import SSRFConnectionBlocked
 
     current_url = url
     current_headers = dict(headers) if headers else None
     current_params = params
+    initial_origin = _normalized_origin(url)
 
     for _ in range(_MAX_SKILL_FETCH_REDIRECTS + 1):
         if not is_safe_url(current_url):
@@ -362,9 +377,7 @@ def _guarded_http_get(
             if not location:
                 return None
             next_url = urljoin(current_url, location)
-            if current_headers and urlparse(next_url).netloc != urlparse(
-                current_url
-            ).netloc:
+            if current_headers and _normalized_origin(next_url) != initial_origin:
                 current_headers = {
                     k: v
                     for k, v in current_headers.items()


### PR DESCRIPTION
## Summary
- **Salvage of incomplete open #63920** (Skills Hub redirect revalidation). That PR covers many hub paths, but on current `upstream/main` `GitHubSource._get_repo_tree` and `_github_get` still use raw `httpx.get(..., follow_redirects=True)`, so a malicious redirect can reach private/metadata space and/or carry `Authorization` cross-origin.
- Extends `_guarded_http_get` / `_ssrf_safe_http_get` with optional `headers`/`params`, strips `Authorization` on cross-origin hops, and routes the GitHub tree + retry GET helpers through it.

## Prior coverage vs remaining gap
| Prior (#63920 / earlier hub guards) | This PR |
|-------------------------------------|---------|
| `_guarded_http_get` for many catalog URLs | Same helper, now header-aware |
| Open PR aims to move GitHub API off raw httpx | Lands that GitHub API gap on main now |
| Auth strip intended in #63920 | Covered here with focused tests |

Related narrower landings already opened in this campaign: browse.sh (#70330), ClawHub (#70334), skills.sh (#70336). This PR is specifically the **GitHub API** sibling still open on main.

## Capability note
Authenticated GitHub skill installs still work; tokens are not forwarded to foreign redirect hosts.

## Test plan
- [x] `pytest tests/tools/test_skills_hub_github_ssrf.py`