### PR TITLE
fix(gateway): run adapter connect detach-on-timeout so a swallowed cancel can't wedge reconnect

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3943,18 +3943,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         server-side queue) from a watcher reconnect after a prolonged outage
         (preserve the queue so messages sent during the outage are delivered
         rather than silently dropped — #46621).
+
+        The connect is run detach-on-timeout, mirroring
+        ``_await_adapter_cleanup_with_timeout``: ``asyncio.wait_for`` cancels an
+        overdue child but then *awaits* it, so a ``connect()`` that swallows
+        ``CancelledError`` would block the reconnect watcher forever. Instead we
+        release the runner at the deadline and raise ``TimeoutError`` — the
+        watcher then disposes the unowned adapter and backs off exactly as it
+        already does for this exception. The detached connect task is cancelled
+        and drained; a timed-out connect is never installed on ``self.adapters``,
+        so a late-completing swallowed-cancel connect stays unowned and is
+        disposed rather than leaving a half-registered adapter (#55992).
         """
         timeout = self._platform_connect_timeout_secs()
         if timeout <= 0:
             return await adapter.connect(is_reconnect=is_reconnect)
+
+        task = asyncio.ensure_future(adapter.connect(is_reconnect=is_reconnect))
         try:
-            return await asyncio.wait_for(
-                adapter.connect(is_reconnect=is_reconnect), timeout=timeout
-            )
-        except asyncio.TimeoutError as exc:
-            raise TimeoutError(
-                f"{platform.value} connect timed out after {timeout:g}s"
-            ) from exc
+            done, _pending = await asyncio.wait({task}, timeout=timeout)
+        except asyncio.CancelledError:
+            task.cancel()
+            task.add_done_callback(consume_detached_task_result)
+            raise
+        if task in done:
+            # Propagates the connect result, or re-raises whatever connect raised
+            # (same surface as the previous ``await asyncio.wait_for``).
+            return task.result()
+
+        task.cancel()
+        task.add_done_callback(consume_detached_task_result)
+        raise TimeoutError(
+            f"{platform.value} connect timed out after {timeout:g}s"
+        )
 
     async def _connect_initial_adapter_with_timeout(self, adapter, platform) -> bool:
         """Connect one cold-start adapter with tightly scoped replace intent.

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -154,6 +154,55 @@ class TestStartupPlatformIsolation:
         with pytest.raises(TimeoutError, match="telegram connect timed out"):
             await runner._connect_adapter_with_timeout(adapter, Platform.TELEGRAM)
 
+    @pytest.mark.asyncio
+    async def test_connect_timeout_releases_when_connect_swallows_cancel(self, monkeypatch):
+        """A connect() that traps CancelledError must not wedge the caller.
+
+        ``asyncio.wait_for`` cancels an overdue child and then *awaits* it, so a
+        connect() whose teardown swallows CancelledError (a broad ``except``)
+        keeps the reconnect watcher blocked forever — the gateway stays alive
+        but never rebuilds the deaf adapter. ``_connect_adapter_with_timeout``
+        runs connect detach-on-timeout instead, so it releases the runner at the
+        deadline and raises ``TimeoutError`` regardless of the child's behavior.
+
+        On the unhardened plain-``wait_for`` implementation the inner call hangs;
+        the 2s outer bound then trips with a bare ``asyncio.TimeoutError`` whose
+        message does NOT match, so this test fails. With the detach fix the inner
+        call raises the bounded ``"... connect timed out"`` error promptly.
+        """
+        runner = _make_runner()
+        adapter = StubAdapter()
+        release = asyncio.Event()
+
+        async def swallow(*, is_reconnect: bool = False):
+            adapter.connect_calls.append(is_reconnect)
+            try:
+                await asyncio.Event().wait()  # never completes on its own
+            except asyncio.CancelledError:
+                # Trap the cancellation and keep "connecting" — reproduces a
+                # connect() that does not propagate CancelledError. ``release``
+                # only lets the detached task finish during test teardown.
+                await release.wait()
+                return False
+
+        adapter.connect = swallow
+        monkeypatch.setenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "0.001")
+
+        try:
+            with pytest.raises(TimeoutError, match="telegram connect timed out"):
+                await asyncio.wait_for(
+                    runner._connect_adapter_with_timeout(adapter, Platform.TELEGRAM),
+                    timeout=2,
+                )
+            # connect was attempted, but the timed-out adapter is left unowned
+            # for the caller's failure path to dispose (never half-registered).
+            assert adapter.connect_calls == [False]
+            assert Platform.TELEGRAM not in runner.adapters
+        finally:
+            # Let the detached connect task complete so no task lingers.
+            release.set()
+            await asyncio.sleep(0)
+
 
 class TestStartupFailureQueuing:
     """Verify that failed platforms are queued during startup."""


### PR DESCRIPTION
## What does this PR do?

Hardens `GatewayRunner._connect_adapter_with_timeout` against a `connect()` that
swallows `CancelledError`.

Every other bounded teardown/cleanup await in the gateway goes through
`_await_adapter_cleanup_with_timeout` (`gateway/run.py:3796`), which runs the child as a
detached task so that when the deadline fires the runner is released **even if the child
traps its cancellation**. The connect path was the one exception: it used plain
`asyncio.wait_for(adapter.connect(...))`. `wait_for` cancels an overdue child and then
*awaits* it — so a `connect()` whose teardown swallows `CancelledError` would keep the
background reconnect watcher blocked indefinitely, leaving the gateway alive but never
rebuilding a deaf adapter.

This converts connect to the same detach-on-timeout pattern: on deadline the connect task
is cancelled and detached (drained via `consume_detached_task_result`), and the call
raises `TimeoutError` exactly as before, so the watcher's existing failure/backoff path is
unchanged.

**Honesty note:** this was found while investigating a ~22h silent-deaf wedge on 0.19.0
(issue linked below). That incident's freeze happened *before* the reconnect watcher ever
ran, so this is **not** a proven fix for it — it closes a real, separate
`plain-wait_for` inconsistency (defense-in-depth). The incident itself needs a stack dump
to localize, as described in the issue.

## Related Issue

Fixes #70344

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_connect_adapter_with_timeout` now runs `adapter.connect()` as a
  detached task via `asyncio.wait({task}, timeout=...)`, returning `task.result()` on
  success (same result/exception surface as the old `await wait_for`) and, on deadline,
  cancelling + detaching the task and raising `TimeoutError`. A timed-out connect is never
  installed in `self.adapters`, so a late-completing swallowed-cancel connect stays
  unowned and is disposed by the existing failure path rather than leaving a
  half-registered adapter (the race class addressed by #55992/#56200).
- `tests/gateway/test_platform_reconnect.py` — regression test
  `test_connect_timeout_releases_when_connect_swallows_cancel`: a `connect()` that traps
  `CancelledError` and keeps running. It hangs the old plain-`wait_for` implementation
  (verified: the 2s outer bound trips with a bare `asyncio.TimeoutError`) and returns
  promptly with the bounded `"... connect timed out"` error after this change.

## How to Test

1. Check out this branch.
2. `pytest tests/gateway/test_platform_reconnect.py -q` — 39 passed.
3. To confirm it's a real regression test: `git stash` the `gateway/run.py` change and
   re-run just `test_connect_timeout_releases_when_connect_swallows_cancel` — it fails
   (inner call hangs, outer 2s guard trips); restore and it passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected gateway suite
      (`tests/gateway/test_platform_reconnect.py`, 39 passed); did not run the full
      `tests/` (heavy optional deps, e.g. torch, not installed in my env)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.13

### Documentation & Housekeeping

- [x] Docstring updated on the changed method — no other docs affected — N/A elsewhere
- [x] No config keys changed — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform: pure asyncio, no platform-specific primitives — N/A
- [x] No tool descriptions/schemas changed — N/A
