### PR TITLE
fix(security): SSRF-guard save_url_video redirects

### DIFF
--- a/agent/video_gen_provider.py
+++ b/agent/video_gen_provider.py
@@ -268,16 +268,53 @@ def save_url_video(
 
     Raises on any network / HTTP / oversize error so callers can fall back to
     returning the bare URL.
+
+    Provider-returned delivery URLs are treated as untrusted for host-side
+    fetches: each hop is validated with ``is_safe_url`` (same posture as
+    ``save_url_image`` / #44728) so a malicious or compromised backend cannot
+    redirect Hermes into loopback, RFC1918, or cloud-metadata ranges.
     """
     import requests
+    from urllib.parse import urljoin
 
-    response = requests.get(url, timeout=timeout, stream=True)
+    from tools.url_safety import is_safe_url
+
+    current_url = url
+    if not is_safe_url(current_url):
+        raise ValueError(
+            f"Blocked: provider-returned URL targets a private or internal address: {current_url}"
+        )
+
+    _max_redirects = 10
+    response = None
+    for _hop in range(_max_redirects + 1):
+        response = requests.get(
+            current_url, timeout=timeout, stream=True, allow_redirects=False
+        )
+        if response.is_redirect and response.headers.get("Location"):
+            next_url = urljoin(current_url, response.headers["Location"])
+            if not is_safe_url(next_url):
+                response.close()
+                raise ValueError(
+                    f"Blocked: redirect target is a private or internal address: {next_url}"
+                )
+            current_url = next_url
+            response.close()
+            continue
+        break
+    else:
+        if response is not None:
+            response.close()
+        raise ValueError(
+            f"Blocked: too many redirects (>{_max_redirects}) fetching provider-returned URL"
+        )
+
     response.raise_for_status()
 
     content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
     extension = _URL_VIDEO_CONTENT_TYPES.get(content_type)
     if extension is None:
-        url_path = url.split("?", 1)[0].lower()
+        url_path = current_url.split("?", 1)[0].lower()
         for ext in ("mp4", "webm", "mov", "mkv"):
             if url_path.endswith(f".{ext}"):
                 extension = ext
@@ -290,21 +327,24 @@ def save_url_video(
     path = _videos_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
 
     bytes_written = 0
-    with path.open("wb") as fh:
-        for chunk in response.iter_content(chunk_size=256 * 1024):
-            if not chunk:
-                continue
-            bytes_written += len(chunk)
-            if bytes_written > max_bytes:
-                fh.close()
-                try:
-                    path.unlink()
-                except OSError:
-                    pass
-                raise ValueError(
-                    f"Video at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
-                )
-            fh.write(chunk)
+    try:
+        with path.open("wb") as fh:
+            for chunk in response.iter_content(chunk_size=256 * 1024):
+                if not chunk:
+                    continue
+                bytes_written += len(chunk)
+                if bytes_written > max_bytes:
+                    fh.close()
+                    try:
+                        path.unlink()
+                    except OSError:
+                        pass
+                    raise ValueError(
+                        f"Video at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
+                    )
+                fh.write(chunk)
+    finally:
+        response.close()
 
     if bytes_written == 0:
         try:

--- a/agent/video_gen_provider.py
+++ b/agent/video_gen_provider.py
@@ -274,16 +274,53 @@ def save_url_video(
 
     Raises on any network / HTTP / oversize error so callers can fall back to
     returning the bare URL.
+
+    Provider-returned delivery URLs are treated as untrusted for host-side
+    fetches: each hop is validated with ``is_safe_url`` (same posture as
+    ``save_url_image`` / #44728) so a malicious or compromised backend cannot
+    redirect Hermes into loopback, RFC1918, or cloud-metadata ranges.
     """
     import requests
+    from urllib.parse import urljoin
 
-    response = requests.get(url, timeout=timeout, stream=True)
+    from tools.url_safety import is_safe_url
+
+    current_url = url
+    if not is_safe_url(current_url):
+        raise ValueError(
+            f"Blocked: provider-returned URL targets a private or internal address: {current_url}"
+        )
+
+    _max_redirects = 10
+    response = None
+    for _hop in range(_max_redirects + 1):
+        response = requests.get(
+            current_url, timeout=timeout, stream=True, allow_redirects=False
+        )
+        if response.is_redirect and response.headers.get("Location"):
+            next_url = urljoin(current_url, response.headers["Location"])
+            if not is_safe_url(next_url):
+                response.close()
+                raise ValueError(
+                    f"Blocked: redirect target is a private or internal address: {next_url}"
+                )
+            current_url = next_url
+            response.close()
+            continue
+        break
+    else:
+        if response is not None:
+            response.close()
+        raise ValueError(
+            f"Blocked: too many redirects (>{_max_redirects}) fetching provider-returned URL"
+        )
+
     response.raise_for_status()
 
     content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
     extension = _URL_VIDEO_CONTENT_TYPES.get(content_type)
     if extension is None:
-        url_path = url.split("?", 1)[0].lower()
+        url_path = current_url.split("?", 1)[0].lower()
         for ext in ("mp4", "webm", "mov", "mkv"):
             if url_path.endswith(f".{ext}"):
                 extension = ext
@@ -296,21 +333,24 @@ def save_url_video(
     path = _videos_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
 
     bytes_written = 0
-    with path.open("wb") as fh:
-        for chunk in response.iter_content(chunk_size=256 * 1024):
-            if not chunk:
-                continue
-            bytes_written += len(chunk)
-            if bytes_written > max_bytes:
-                fh.close()
-                try:
-                    path.unlink()
-                except OSError:
-                    pass
-                raise ValueError(
-                    f"Video at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
-                )
-            fh.write(chunk)
+    try:
+        with path.open("wb") as fh:
+            for chunk in response.iter_content(chunk_size=256 * 1024):
+                if not chunk:
+                    continue
+                bytes_written += len(chunk)
+                if bytes_written > max_bytes:
+                    fh.close()
+                    try:
+                        path.unlink()
+                    except OSError:
+                        pass
+                    raise ValueError(
+                        f"Video at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
+                    )
+                fh.write(chunk)
+    finally:
+        response.close()
 
     if bytes_written == 0:
         try:

--- a/tests/agent/test_save_url_video_ssrf.py
+++ b/tests/agent/test_save_url_video_ssrf.py
@@ -1,0 +1,71 @@
+﻿"""SSRF invariants for agent.video_gen_provider.save_url_video."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+
+def _final_response(content_type: str = "video/mp4") -> MagicMock:
+    resp = MagicMock()
+    resp.headers = {"Content-Type": content_type}
+    resp.raise_for_status = MagicMock()
+    resp.is_redirect = False
+    resp.iter_content = MagicMock(return_value=[b"\x00\x00\x00\x18ftypmp42"])
+    resp.close = MagicMock()
+    return resp
+
+
+def _redirect_response(location: str) -> MagicMock:
+    resp = MagicMock()
+    resp.headers = {"Location": location}
+    resp.is_redirect = True
+    resp.close = MagicMock()
+    return resp
+
+
+def test_save_url_video_blocks_loopback():
+    from agent.video_gen_provider import save_url_video
+
+    with pytest.raises(ValueError, match="private or internal"):
+        save_url_video("http://127.0.0.1:8080/clip.mp4")
+
+
+def test_save_url_video_blocks_cloud_metadata():
+    from agent.video_gen_provider import save_url_video
+
+    with pytest.raises(ValueError, match="private or internal"):
+        save_url_video("http://169.254.169.254/latest/meta-data/")
+
+
+def test_save_url_video_blocks_redirect_to_metadata():
+    from agent.video_gen_provider import save_url_video
+
+    public = "https://cdn.example.com/clip.mp4"
+    evil = "http://169.254.169.254/latest/meta-data/"
+
+    with patch("tools.url_safety.is_safe_url", side_effect=lambda u: u == public), patch(
+        "requests.get", return_value=_redirect_response(evil)
+    ) as mock_get:
+        with pytest.raises(ValueError, match="private or internal"):
+            save_url_video(public)
+        mock_get.assert_called()
+
+
+def test_save_url_video_allows_public_url(tmp_path, monkeypatch):
+    from agent.video_gen_provider import save_url_video
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    public = "https://cdn.example.com/clip.mp4"
+
+    with patch("tools.url_safety.is_safe_url", return_value=True), patch(
+        "requests.get", return_value=_final_response()
+    ):
+        path = save_url_video(public, prefix="test")
+    assert path.exists()
+    assert path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- Apply `is_safe_url` and manual redirect re-validation to `save_url_video` (sibling of the image path).
- Prevent cloud-metadata / private-target pivots via redirected CDN URLs when downloading generated video assets.
- Add focused regression tests.

## Salvage / credit
Sibling coverage for the incomplete image-side work tracked around #44743 / #44728 (video download path was still unprotected).

## Test plan
- [x] `pytest tests/agent/test_save_url_video_ssrf.py -q`
