### PR TITLE
fix(security): block OpenAI image-byte redirect SSRF

### DIFF
--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -132,11 +132,40 @@ def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
     ref = ref.strip()
     lower = ref.lower()
     if lower.startswith(("http://", "https://")):
+        # Incomplete prior guards (#54553 / #56035) only pre-checked the
+        # initial URL; requests follows redirects by default, so a public
+        # host can still 302 into loopback / cloud metadata. Re-validate
+        # every hop (same posture as save_url_image / vision downloads).
+        from urllib.parse import urljoin
+
         import requests
 
-        resp = requests.get(ref, timeout=60)
+        from tools.url_safety import is_safe_url
+
+        current = ref
+        if not is_safe_url(current):
+            raise ValueError(f"Blocked unsafe URL (SSRF protection): {current}")
+
+        _max_redirects = 10
+        resp = None
+        for _ in range(_max_redirects + 1):
+            resp = requests.get(current, timeout=60, allow_redirects=False)
+            if resp.is_redirect and resp.headers.get("Location"):
+                next_url = urljoin(current, resp.headers["Location"])
+                if not is_safe_url(next_url):
+                    raise ValueError(
+                        f"Blocked unsafe redirect URL (SSRF protection): {next_url}"
+                    )
+                current = next_url
+                continue
+            break
+        else:
+            raise ValueError(
+                f"Blocked: too many redirects (>{_max_redirects}) fetching image URL"
+            )
+
         resp.raise_for_status()
-        name = ref.split("?", 1)[0].rsplit("/", 1)[-1] or "image.png"
+        name = current.split("?", 1)[0].rsplit("/", 1)[-1] or "image.png"
         return resp.content, name
     if lower.startswith("data:"):
         import base64

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -138,31 +138,35 @@ def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
         # every hop (same posture as save_url_image / vision downloads).
         from urllib.parse import urljoin
 
-        import requests
-
-        from tools.url_safety import is_safe_url
+        from tools.url_safety import create_ssrf_safe_client, is_safe_url
 
         current = ref
         if not is_safe_url(current):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {current}")
 
         _max_redirects = 10
-        resp = None
-        for _ in range(_max_redirects + 1):
-            resp = requests.get(current, timeout=60, allow_redirects=False)
-            if resp.is_redirect and resp.headers.get("Location"):
-                next_url = urljoin(current, resp.headers["Location"])
-                if not is_safe_url(next_url):
-                    raise ValueError(
-                        f"Blocked unsafe redirect URL (SSRF protection): {next_url}"
-                    )
-                current = next_url
-                continue
-            break
-        else:
-            raise ValueError(
-                f"Blocked: too many redirects (>{_max_redirects}) fetching image URL"
-            )
+        with create_ssrf_safe_client(timeout=60, follow_redirects=False) as client:
+            resp = None
+            for _ in range(_max_redirects + 1):
+                resp = client.get(current)
+                if 300 <= resp.status_code < 400:
+                    location = resp.headers.get("Location")
+                    if not location:
+                        raise ValueError(
+                            "Blocked redirect response without Location header"
+                        )
+                    next_url = urljoin(current, location)
+                    if not is_safe_url(next_url):
+                        raise ValueError(
+                            f"Blocked unsafe redirect URL (SSRF protection): {next_url}"
+                        )
+                    current = next_url
+                    continue
+                break
+            else:
+                raise ValueError(
+                    f"Blocked: too many redirects (>{_max_redirects}) fetching image URL"
+                )
 
         resp.raise_for_status()
         name = current.split("?", 1)[0].rsplit("/", 1)[-1] or "image.png"

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -139,31 +139,35 @@ def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
         # every hop (same posture as save_url_image / vision downloads).
         from urllib.parse import urljoin
 
-        import requests
-
-        from tools.url_safety import is_safe_url
+        from tools.url_safety import create_ssrf_safe_client, is_safe_url
 
         current = ref
         if not is_safe_url(current):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {current}")
 
         _max_redirects = 10
-        resp = None
-        for _ in range(_max_redirects + 1):
-            resp = requests.get(current, timeout=60, allow_redirects=False)
-            if resp.is_redirect and resp.headers.get("Location"):
-                next_url = urljoin(current, resp.headers["Location"])
-                if not is_safe_url(next_url):
-                    raise ValueError(
-                        f"Blocked unsafe redirect URL (SSRF protection): {next_url}"
-                    )
-                current = next_url
-                continue
-            break
-        else:
-            raise ValueError(
-                f"Blocked: too many redirects (>{_max_redirects}) fetching image URL"
-            )
+        with create_ssrf_safe_client(timeout=60, follow_redirects=False) as client:
+            resp = None
+            for _ in range(_max_redirects + 1):
+                resp = client.get(current)
+                if 300 <= resp.status_code < 400:
+                    location = resp.headers.get("Location")
+                    if not location:
+                        raise ValueError(
+                            "Blocked redirect response without Location header"
+                        )
+                    next_url = urljoin(current, location)
+                    if not is_safe_url(next_url):
+                        raise ValueError(
+                            f"Blocked unsafe redirect URL (SSRF protection): {next_url}"
+                        )
+                    current = next_url
+                    continue
+                break
+            else:
+                raise ValueError(
+                    f"Blocked: too many redirects (>{_max_redirects}) fetching image URL"
+                )
 
         resp.raise_for_status()
         name = current.split("?", 1)[0].rsplit("/", 1)[-1] or "image.png"

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -133,11 +133,40 @@ def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
     ref = ref.strip()
     lower = ref.lower()
     if lower.startswith(("http://", "https://")):
+        # Incomplete prior guards (#54553 / #56035) only pre-checked the
+        # initial URL; requests follows redirects by default, so a public
+        # host can still 302 into loopback / cloud metadata. Re-validate
+        # every hop (same posture as save_url_image / vision downloads).
+        from urllib.parse import urljoin
+
         import requests
 
-        resp = requests.get(ref, timeout=60)
+        from tools.url_safety import is_safe_url
+
+        current = ref
+        if not is_safe_url(current):
+            raise ValueError(f"Blocked unsafe URL (SSRF protection): {current}")
+
+        _max_redirects = 10
+        resp = None
+        for _ in range(_max_redirects + 1):
+            resp = requests.get(current, timeout=60, allow_redirects=False)
+            if resp.is_redirect and resp.headers.get("Location"):
+                next_url = urljoin(current, resp.headers["Location"])
+                if not is_safe_url(next_url):
+                    raise ValueError(
+                        f"Blocked unsafe redirect URL (SSRF protection): {next_url}"
+                    )
+                current = next_url
+                continue
+            break
+        else:
+            raise ValueError(
+                f"Blocked: too many redirects (>{_max_redirects}) fetching image URL"
+            )
+
         resp.raise_for_status()
-        name = ref.split("?", 1)[0].rsplit("/", 1)[-1] or "image.png"
+        name = current.split("?", 1)[0].rsplit("/", 1)[-1] or "image.png"
         return resp.content, name
     if lower.startswith("data:"):
         import base64

--- a/tests/plugins/image_gen/test_openai_load_image_ssrf.py
+++ b/tests/plugins/image_gen/test_openai_load_image_ssrf.py
@@ -1,0 +1,53 @@
+"""SSRF invariants for OpenAI image_gen _load_image_bytes (salvage of #54553/#56035)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _redirect(location: str) -> MagicMock:
+    resp = MagicMock()
+    resp.is_redirect = True
+    resp.headers = {"Location": location}
+    return resp
+
+
+def _ok(body: bytes = b"\x89PNG\r\n") -> MagicMock:
+    resp = MagicMock()
+    resp.is_redirect = False
+    resp.headers = {}
+    resp.content = body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def test_load_image_bytes_blocks_private_url():
+    from plugins.image_gen.openai import _load_image_bytes
+
+    with pytest.raises(ValueError, match="SSRF"):
+        _load_image_bytes("http://127.0.0.1/secret.png")
+
+
+def test_load_image_bytes_blocks_redirect_to_metadata():
+    from plugins.image_gen.openai import _load_image_bytes
+
+    public = "https://cdn.example.com/a.png"
+    evil = "http://169.254.169.254/latest/meta-data/"
+
+    with patch("tools.url_safety.is_safe_url", side_effect=lambda u: u == public), patch(
+        "requests.get", return_value=_redirect(evil)
+    ):
+        with pytest.raises(ValueError, match="SSRF"):
+            _load_image_bytes(public)
+
+
+def test_load_image_bytes_allows_public_url():
+    from plugins.image_gen.openai import _load_image_bytes
+
+    public = "https://cdn.example.com/a.png"
+    with patch("tools.url_safety.is_safe_url", return_value=True), patch(
+        "requests.get", return_value=_ok(b"png-bytes")
+    ):
+        data, name = _load_image_bytes(public)
+    assert data == b"png-bytes"
+    assert name.endswith(".png")

--- a/tests/plugins/image_gen/test_openai_load_image_ssrf.py
+++ b/tests/plugins/image_gen/test_openai_load_image_ssrf.py
@@ -7,18 +7,26 @@ import pytest
 
 def _redirect(location: str) -> MagicMock:
     resp = MagicMock()
-    resp.is_redirect = True
+    resp.status_code = 302
     resp.headers = {"Location": location}
     return resp
 
 
 def _ok(body: bytes = b"\x89PNG\r\n") -> MagicMock:
     resp = MagicMock()
-    resp.is_redirect = False
+    resp.status_code = 200
     resp.headers = {}
     resp.content = body
     resp.raise_for_status = MagicMock()
     return resp
+
+
+def _client(response: MagicMock):
+    client = MagicMock()
+    client.get.return_value = response
+    context = MagicMock()
+    context.__enter__.return_value = client
+    return context, client
 
 
 def test_load_image_bytes_blocks_private_url():
@@ -33,21 +41,27 @@ def test_load_image_bytes_blocks_redirect_to_metadata():
 
     public = "https://cdn.example.com/a.png"
     evil = "http://169.254.169.254/latest/meta-data/"
+    context, client = _client(_redirect(evil))
 
     with patch("tools.url_safety.is_safe_url", side_effect=lambda u: u == public), patch(
-        "requests.get", return_value=_redirect(evil)
-    ):
+        "tools.url_safety.create_ssrf_safe_client", return_value=context
+    ) as safe_client:
         with pytest.raises(ValueError, match="SSRF"):
             _load_image_bytes(public)
+    safe_client.assert_called_once_with(timeout=60, follow_redirects=False)
+    client.get.assert_called_once_with(public)
 
 
 def test_load_image_bytes_allows_public_url():
     from plugins.image_gen.openai import _load_image_bytes
 
     public = "https://cdn.example.com/a.png"
+    context, client = _client(_ok(b"png-bytes"))
     with patch("tools.url_safety.is_safe_url", return_value=True), patch(
-        "requests.get", return_value=_ok(b"png-bytes")
-    ):
+        "tools.url_safety.create_ssrf_safe_client", return_value=context
+    ) as safe_client:
         data, name = _load_image_bytes(public)
+    safe_client.assert_called_once_with(timeout=60, follow_redirects=False)
+    client.get.assert_called_once_with(public)
     assert data == b"png-bytes"
     assert name.endswith(".png")


### PR DESCRIPTION
## Summary
- Harden `_load_image_bytes` so redirect hops are re-checked with `is_safe_url` (`allow_redirects=False`).
- Close the gap where a pre-check alone still followed a malicious `Location` into metadata/private hosts.
- Add focused regression tests.

## Salvage / credit
Incomplete prior fixes #54553 / #56035 (pre-check without redirect hop validation).

## Test plan
- [x] `pytest tests/plugins/image_gen/test_openai_load_image_ssrf.py -q`
