### PR TITLE
fix(security): stop host_supervisor undoing env scrub

### DIFF
--- a/tests/tui_gateway/test_host_supervisor_env_scrub.py
+++ b/tests/tui_gateway/test_host_supervisor_env_scrub.py
@@ -1,0 +1,50 @@
+"""Compute-host spawn must not undo hermes_subprocess_env scrubbing."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tui_gateway.host_supervisor import HostSupervisor
+
+
+def test_spawn_does_not_remerge_full_os_environ(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-should-not-leak-via-update")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tg-should-not-leak-via-update")
+
+    captured = {}
+
+    def fake_popen(*args, **kwargs):
+        captured["env"] = dict(kwargs.get("env") or {})
+        proc = MagicMock()
+        proc.pid = 4242
+        proc.poll.return_value = None
+        proc.stdin = MagicMock()
+        proc.stdout = MagicMock()
+        proc.stderr = MagicMock()
+        return proc
+
+    registry = tmp_path / "registry.json"
+    supervisor = HostSupervisor(
+        registry_path=registry,
+        argv=["python", "-c", "pass"],
+        cwd=Path(tmp_path),
+        autostart=False,
+    )
+
+    def _fake_wait(timeout=None):
+        supervisor._hello = {
+            "hermes_home": supervisor.expected_hermes_home,
+            "build_sha": "unknown",
+        }
+        return True
+
+    with patch("tui_gateway.host_supervisor.subprocess.Popen", side_effect=fake_popen), patch(
+        "tui_gateway.host_supervisor._Thread"
+    ), patch.object(supervisor._hello_event, "wait", side_effect=_fake_wait), patch.object(
+        supervisor, "_persist_registry"
+    ):
+        with supervisor._lock:
+            supervisor._spawn_locked(reason="test")
+
+    env = captured["env"]
+    # Tier-1 always-strip keys must stay absent even when inherit_credentials=True.
+    assert "TELEGRAM_BOT_TOKEN" not in env

--- a/tests/tui_gateway/test_host_supervisor_env_scrub.py
+++ b/tests/tui_gateway/test_host_supervisor_env_scrub.py
@@ -7,7 +7,7 @@ from tui_gateway.host_supervisor import HostSupervisor
 
 
 def test_spawn_does_not_remerge_full_os_environ(tmp_path, monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-should-not-leak-via-update")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-retained-for-model-child")
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tg-should-not-leak-via-update")
 
     captured = {}
@@ -46,5 +46,7 @@ def test_spawn_does_not_remerge_full_os_environ(tmp_path, monkeypatch):
             supervisor._spawn_locked(reason="test")
 
     env = captured["env"]
+    # Provider credentials remain available to the model-driving child by design.
+    assert env["OPENAI_API_KEY"] == "sk-retained-for-model-child"
     # Tier-1 always-strip keys must stay absent even when inherit_credentials=True.
     assert "TELEGRAM_BOT_TOKEN" not in env

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -312,7 +312,10 @@ class HostSupervisor:
         self._hello_event.clear()
         self._hello = {}
         env = hermes_subprocess_env(inherit_credentials=True)
-        env.update(os.environ)
+        # Do NOT re-merge os.environ here: hermes_subprocess_env already starts
+        # from the process environment and strips Hermes secrets. Calling
+        # env.update(os.environ) re-injects gateway tokens / API keys into the
+        # compute-host child and undoes the scrub.
         if self.env:
             env.update(self.env)
         env["HERMES_COMPUTE_HOST_HEARTBEAT_SECS"] = str(self.heartbeat_secs)

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -312,10 +312,10 @@ class HostSupervisor:
         self._hello_event.clear()
         self._hello = {}
         env = hermes_subprocess_env(inherit_credentials=True)
-        # Do NOT re-merge os.environ here: hermes_subprocess_env already starts
-        # from the process environment and strips Hermes secrets. Calling
-        # env.update(os.environ) re-injects gateway tokens / API keys into the
-        # compute-host child and undoes the scrub.
+        # Do NOT re-merge os.environ here: inherit_credentials=True intentionally
+        # preserves provider credentials, while hermes_subprocess_env still
+        # strips gateway/runtime secrets. Calling env.update(os.environ) would
+        # restore those stripped values, such as gateway tokens.
         if self.env:
             env.update(self.env)
         env["HERMES_COMPUTE_HOST_HEARTBEAT_SECS"] = str(self.heartbeat_secs)

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -316,10 +316,10 @@ class HostSupervisor:
         self._hello_event.clear()
         self._hello = {}
         env = hermes_subprocess_env(inherit_credentials=True)
-        # Do NOT re-merge os.environ here: hermes_subprocess_env already starts
-        # from the process environment and strips Hermes secrets. Calling
-        # env.update(os.environ) re-injects gateway tokens / API keys into the
-        # compute-host child and undoes the scrub.
+        # Do NOT re-merge os.environ here: inherit_credentials=True intentionally
+        # preserves provider credentials, while hermes_subprocess_env still
+        # strips gateway/runtime secrets. Calling env.update(os.environ) would
+        # restore those stripped values, such as gateway tokens.
         if self.env:
             env.update(self.env)
         env["HERMES_COMPUTE_HOST_HEARTBEAT_SECS"] = str(self.heartbeat_secs)

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -316,7 +316,10 @@ class HostSupervisor:
         self._hello_event.clear()
         self._hello = {}
         env = hermes_subprocess_env(inherit_credentials=True)
-        env.update(os.environ)
+        # Do NOT re-merge os.environ here: hermes_subprocess_env already starts
+        # from the process environment and strips Hermes secrets. Calling
+        # env.update(os.environ) re-injects gateway tokens / API keys into the
+        # compute-host child and undoes the scrub.
         if self.env:
             env.update(self.env)
         env["HERMES_COMPUTE_HOST_HEARTBEAT_SECS"] = str(self.heartbeat_secs)


### PR DESCRIPTION
## Summary
- Remove `env.update(os.environ)` after `hermes_subprocess_env(...)` in the TUI compute-host supervisor.
- That re-merge re-injected gateway tokens / API keys into the child process and undid scrubbing.
- Add a spawn-path regression test asserting messaging tokens stay absent.

## Salvage / credit
Sibling of voice/TTS credential scrub (#70342 / incomplete #56332) on the TUI host spawn surface.

## Test plan
- [x] `pytest tests/tui_gateway/test_host_supervisor_env_scrub.py -q`
