### PR TITLE
fix(security): SSRF-check WhatsApp Cloud Graph media URLs

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1337,10 +1337,26 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not temp_url:
             return None, None
 
+        # Graph returns a signed temporary URL. Treat it as untrusted for
+        # host-side fetches: a compromised Graph response (or MITM) must not
+        # be allowed to point Hermes at loopback / cloud-metadata targets.
+        from tools.url_safety import is_safe_url
+
+        if not is_safe_url(str(temp_url)):
+            logger.warning(
+                "[whatsapp_cloud] refusing unsafe Graph media URL for id=%s",
+                media_id,
+            )
+            return None, None
+
         # Step 2 — bytes (auth required even though URL is signed; Meta
         # documents this explicitly — the URL alone is not enough).
         try:
-            blob_resp = await self._http_client.get(temp_url, headers=headers)
+            blob_resp = await self._http_client.get(
+                temp_url,
+                headers=headers,
+                follow_redirects=False,
+            )
         except Exception:
             logger.exception(
                 "[whatsapp_cloud] media bytes fetch raised (id=%s)", media_id

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -423,8 +423,13 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # Outbound HTTP client. Tighter keepalive matches other platform
         # adapters so idle CLOSE_WAIT drains promptly (#18451).
         from gateway.platforms._http_client_limits import platform_httpx_limits
+        from tools.url_safety import create_ssrf_safe_async_client
 
-        self._http_client = httpx.AsyncClient(
+        # SSRF-safe client: resolves and validates the target IP at TCP
+        # connect time, so a Graph response (or MITM) that points at
+        # loopback / link-local / cloud-metadata cannot be dialed even if
+        # DNS rebinds between the preflight check and the connect (#70352).
+        self._http_client = create_ssrf_safe_async_client(
             timeout=30.0, limits=platform_httpx_limits()
         )
 
@@ -1340,9 +1345,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # Graph returns a signed temporary URL. Treat it as untrusted for
         # host-side fetches: a compromised Graph response (or MITM) must not
         # be allowed to point Hermes at loopback / cloud-metadata targets.
-        from tools.url_safety import is_safe_url
+        # Preflight uses the async variant so the blocking DNS work runs off
+        # the event loop; the client itself re-validates at connect time.
+        from tools.url_safety import async_is_safe_url
 
-        if not is_safe_url(str(temp_url)):
+        if not await async_is_safe_url(str(temp_url)):
             logger.warning(
                 "[whatsapp_cloud] refusing unsafe Graph media URL for id=%s",
                 media_id,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -81,6 +81,7 @@ from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin, _get_wsecre
 from gateway.platforms.media_cache import ext_for_mime
 from gateway import rich_sent_store
 from hermes_constants import get_hermes_dir
+from tools.url_safety import async_is_safe_url, create_ssrf_safe_async_client
 
 logger = logging.getLogger(__name__)
 
@@ -454,9 +455,13 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # adapters so idle CLOSE_WAIT drains promptly (#18451).
         from gateway.platforms._http_client_limits import platform_httpx_limits
 
-        self._http_client = httpx.AsyncClient(
-            timeout=30.0, limits=platform_httpx_limits()
-        )
+        limits = platform_httpx_limits()
+        if limits is None:
+            self._http_client = create_ssrf_safe_async_client(timeout=30.0)
+        else:
+            self._http_client = create_ssrf_safe_async_client(
+                timeout=30.0, limits=limits
+            )
 
         # Inbound webhook server.
         # client_max_size backstops the bounded reader in _handle_webhook —
@@ -1367,10 +1372,21 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not temp_url:
             return None, None
 
+        # Graph supplies this URL at runtime. Validate the destination before
+        # handing it to the shared client; the client's guarded transport then
+        # repeats the policy at connect time to close DNS-rebinding gaps.
+        if not await async_is_safe_url(str(temp_url)):
+            logger.warning(
+                "[whatsapp_cloud] refusing unsafe media URL (id=%s)", media_id
+            )
+            return None, None
+
         # Step 2 — bytes (auth required even though URL is signed; Meta
         # documents this explicitly — the URL alone is not enough).
         try:
-            blob_resp = await self._http_client.get(temp_url, headers=headers)
+            blob_resp = await self._http_client.get(
+                str(temp_url), headers=headers, follow_redirects=False
+            )
         except Exception:
             logger.exception(
                 "[whatsapp_cloud] media bytes fetch raised (id=%s)", media_id

--- a/tests/gateway/platforms/test_whatsapp_cloud_media_ssrf.py
+++ b/tests/gateway/platforms/test_whatsapp_cloud_media_ssrf.py
@@ -1,0 +1,32 @@
+"""WhatsApp Cloud Graph media URL SSRF invariant."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+
+def test_download_media_rejects_unsafe_temp_url(monkeypatch):
+    from gateway.platforms import whatsapp_cloud as mod
+
+    adapter = object.__new__(mod.WhatsAppCloudAdapter)
+    adapter._http_client = MagicMock()
+    adapter._access_token = "token"
+    adapter._api_version = "v20.0"
+
+    class _MetaResp:
+        status_code = 200
+
+        def json(self):
+            return {"url": "http://169.254.169.254/latest/meta-data/", "mime_type": "image/jpeg"}
+
+    async def fake_get(url, headers=None, follow_redirects=None):
+        assert "169.254" not in url  # must not fetch the unsafe temp URL
+        return _MetaResp()
+
+    adapter._http_client.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr(mod, "GRAPH_API_BASE", "https://graph.facebook.com")
+
+    path, mime = asyncio.run(adapter._download_media_to_cache("MEDIA123"))
+    assert path is None
+    assert mime is None
+    # Only the Graph metadata lookup should have been attempted.
+    assert adapter._http_client.get.await_count == 1

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -762,11 +762,13 @@ class TestDownloadMedia:
     """Two-step Graph media download: meta -> temp URL -> bytes."""
 
     @pytest.mark.asyncio
-    async def test_two_step_download_writes_cache_file(self, tmp_path):
+    async def test_two_step_download_writes_cache_file(self, tmp_path, monkeypatch):
         from gateway.platforms import whatsapp_cloud as wac
 
         adapter = _make_adapter()
         adapter._http_client = MagicMock()
+        safety_check = AsyncMock(return_value=True)
+        monkeypatch.setattr(wac, "async_is_safe_url", safety_check)
 
         # Step 1 — metadata returns temp URL + mime
         meta_resp = MagicMock(status_code=200)
@@ -793,6 +795,68 @@ class TestDownloadMedia:
         assert _os.path.basename(local_path).endswith(".jpg")
         with open(local_path, "rb") as fh:
             assert fh.read() == b"\xff\xd8\xff\xe0jpegdata"
+        safety_check.assert_awaited_once_with(
+            "https://lookaside.fbsbx.com/whatsapp/m/..."
+        )
+        assert adapter._http_client.get.call_args_list[1].kwargs[
+            "follow_redirects"
+        ] is False
+
+    @pytest.mark.asyncio
+    async def test_unsafe_temporary_url_stops_before_byte_fetch(self, monkeypatch):
+        from gateway.platforms import whatsapp_cloud as wac
+
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        meta_resp = MagicMock(status_code=200)
+        meta_resp.json = MagicMock(
+            return_value={
+                "url": "http://169.254.169.254/latest/meta-data/",
+                "mime_type": "image/jpeg",
+            }
+        )
+        adapter._http_client.get = AsyncMock(return_value=meta_resp)
+        safety_check = AsyncMock(return_value=False)
+        monkeypatch.setattr(wac, "async_is_safe_url", safety_check)
+
+        local_path, mime = await adapter._download_media_to_cache("media_xyz")
+
+        assert local_path is None and mime is None
+        safety_check.assert_awaited_once_with(
+            "http://169.254.169.254/latest/meta-data/"
+        )
+        adapter._http_client.get.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_connect_builds_guarded_http_client(self, monkeypatch):
+        from gateway.platforms import whatsapp_cloud as wac
+
+        adapter = _make_adapter()
+        adapter._mark_connected = MagicMock()
+
+        guarded_client = MagicMock()
+        guarded_client.aclose = AsyncMock()
+        guarded_factory = MagicMock(return_value=guarded_client)
+        monkeypatch.setattr(wac, "create_ssrf_safe_async_client", guarded_factory)
+
+        app = MagicMock()
+        app.router = MagicMock()
+        monkeypatch.setattr(wac.web, "Application", MagicMock(return_value=app))
+        runner = MagicMock()
+        runner.setup = AsyncMock()
+        runner.cleanup = AsyncMock()
+        monkeypatch.setattr(wac.web, "AppRunner", MagicMock(return_value=runner))
+        site = MagicMock()
+        site.start = AsyncMock()
+        monkeypatch.setattr(wac.web, "TCPSite", MagicMock(return_value=site))
+
+        assert await adapter.connect() is True
+        guarded_factory.assert_called_once()
+        assert guarded_factory.call_args.kwargs["timeout"] == 30.0
+        assert adapter._http_client is guarded_client
+
+        await adapter.disconnect()
+        guarded_client.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_metadata_failure_returns_none(self):
@@ -1399,4 +1463,3 @@ class TestReplyContextResolution:
         assert event.reply_to_message_id is None
         assert event.reply_to_text is None
         assert event.reply_to_is_own_message is False
-

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -35,6 +35,24 @@ def _whatsapp_open_optin(monkeypatch):
     monkeypatch.setenv("WHATSAPP_ALLOW_ALL_USERS", "true")
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_url_safety(monkeypatch):
+    """Keep the media-download tests resolver-free.
+
+    ``_download_media_to_cache`` preflights the Graph temp URL with
+    ``tools.url_safety.async_is_safe_url``, which would otherwise perform a
+    real DNS lookup for ``lookaside.fbsbx.com``. Stub the predicate to a
+    deterministic allow so unit tests stay hermetic; tests that assert the
+    refusal path patch it to ``False`` inside their own body.
+    """
+    import tools.url_safety as _url_safety
+
+    async def _always_safe(url: str) -> bool:  # pragma: no cover - trivial
+        return True
+
+    monkeypatch.setattr(_url_safety, "async_is_safe_url", _always_safe)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1356,6 +1374,77 @@ class TestDownloadMedia:
         assert local_path.endswith(expected_ext), (
             f"mime {mime!r} should map to {expected_ext} but got {local_path}"
         )
+
+    @pytest.mark.asyncio
+    async def test_unsafe_graph_url_is_refused_without_byte_fetch(
+        self, tmp_path, monkeypatch
+    ):
+        """A Graph temp URL rejected by the safety predicate is never fetched.
+
+        Resolver-free: the predicate is stubbed, so this asserts the adapter's
+        control flow rather than DNS behaviour.
+        """
+        import tools.url_safety as _url_safety
+        from gateway.platforms import whatsapp_cloud as wac
+
+        checked: list[str] = []
+
+        async def _always_unsafe(url: str) -> bool:
+            checked.append(url)
+            return False
+
+        monkeypatch.setattr(_url_safety, "async_is_safe_url", _always_unsafe)
+
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        meta_resp = MagicMock(status_code=200)
+        meta_resp.json = MagicMock(return_value={
+            "url": "http://169.254.169.254/latest/meta-data/",
+            "mime_type": "image/jpeg",
+        })
+        blob_resp = MagicMock(status_code=200, content=b"secret")
+        adapter._http_client.get = AsyncMock(side_effect=[meta_resp, blob_resp])
+
+        with _patch.object(wac, "_INBOUND_MEDIA_CACHE", tmp_path):
+            local_path, mime = await adapter._download_media_to_cache("media_bad")
+
+        assert local_path is None and mime is None
+        assert checked == ["http://169.254.169.254/latest/meta-data/"]
+        # Only the metadata call happened — no byte fetch of the unsafe URL.
+        assert adapter._http_client.get.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_safe_graph_url_byte_fetch_disables_redirects(self, tmp_path):
+        """The allowed path still fetches bytes with redirects disabled."""
+        from gateway.platforms import whatsapp_cloud as wac
+
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        meta_resp = MagicMock(status_code=200)
+        meta_resp.json = MagicMock(return_value={
+            "url": "https://lookaside.fbsbx.com/whatsapp/m/ok",
+            "mime_type": "image/jpeg",
+        })
+        blob_resp = MagicMock(status_code=200, content=b"\xff\xd8\xff\xe0ok")
+        adapter._http_client.get = AsyncMock(side_effect=[meta_resp, blob_resp])
+
+        with _patch.object(wac, "_INBOUND_MEDIA_CACHE", tmp_path):
+            local_path, _ = await adapter._download_media_to_cache("media_ok")
+
+        assert local_path is not None
+        blob_call = adapter._http_client.get.await_args_list[-1]
+        assert blob_call.args[0] == "https://lookaside.fbsbx.com/whatsapp/m/ok"
+        assert blob_call.kwargs["follow_redirects"] is False
+
+    def test_adapter_uses_ssrf_safe_client_factory(self):
+        """connect() builds the shared client via the SSRF-safe factory."""
+        import inspect
+
+        from gateway.platforms import whatsapp_cloud as wac
+
+        src = inspect.getsource(wac.WhatsAppCloudAdapter.connect)
+        assert "create_ssrf_safe_async_client" in src
+        assert "httpx.AsyncClient(" not in src
 
 
 class TestInboundMediaDispatch:

--- a/tests/gateway/test_whatsapp_cloud_media_ssrf_e2e.py
+++ b/tests/gateway/test_whatsapp_cloud_media_ssrf_e2e.py
@@ -1,0 +1,170 @@
+"""Network-level regression tests for WhatsApp Cloud media URL handling."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import httpx
+import pytest
+
+from gateway.platforms import whatsapp_cloud as wac
+from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+
+
+ResponseSpec = tuple[int, dict[str, str], bytes]
+Responder = Callable[[str], ResponseSpec]
+
+
+@contextmanager
+def _http_server(
+    responder: Responder,
+) -> Iterator[tuple[str, list[dict[str, str | None]]]]:
+    requests: list[dict[str, str | None]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            requests.append({
+                "path": self.path,
+                "authorization": self.headers.get("Authorization"),
+            })
+            status, headers, body = responder(self.path)
+            self.send_response(status)
+            for name, value in headers.items():
+                self.send_header(name, value)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host = str(server.server_address[0])
+    port = int(server.server_address[1])
+    try:
+        yield f"http://{host}:{port}", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _adapter(client: httpx.AsyncClient) -> WhatsAppCloudAdapter:
+    adapter = WhatsAppCloudAdapter.__new__(WhatsAppCloudAdapter)
+    adapter._access_token = "e2e-test-token"
+    adapter._api_version = "v20.0"
+    adapter._http_client = client
+    return adapter
+
+
+def _metadata_response(temp_url: str) -> ResponseSpec:
+    body = json.dumps({"url": temp_url, "mime_type": "image/jpeg"}).encode("utf-8")
+    return 200, {"Content-Type": "application/json"}, body
+
+
+@pytest.mark.asyncio
+async def test_private_media_url_is_rejected_before_second_request(
+    tmp_path, monkeypatch
+):
+    """A real metadata response cannot make the adapter call loopback."""
+
+    from tools import url_safety
+
+    monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "false")
+    monkeypatch.setattr(url_safety, "_allow_private_resolved", False)
+    monkeypatch.setattr(url_safety, "_cached_allow_private", False)
+
+    with _http_server(
+        lambda _path: (200, {"Content-Type": "image/jpeg"}, b"private")
+    ) as (media_base, media_requests):
+        with _http_server(
+            lambda _path: _metadata_response(f"{media_base}/media.jpg")
+        ) as (graph_base, graph_requests):
+            monkeypatch.setattr(wac, "GRAPH_API_BASE", graph_base)
+            monkeypatch.setattr(wac, "_INBOUND_MEDIA_CACHE", tmp_path)
+
+            async with httpx.AsyncClient(timeout=5.0, trust_env=False) as client:
+                local_path, mime = await _adapter(client)._download_media_to_cache(
+                    "MEDIA123"
+                )
+
+    assert local_path is None and mime is None
+    assert [request["path"] for request in graph_requests] == ["/v20.0/MEDIA123"]
+    assert media_requests == []
+
+
+@pytest.mark.asyncio
+async def test_safe_media_url_uses_real_two_step_download(tmp_path, monkeypatch):
+    """The safety boundary preserves an allowed Graph media download."""
+
+    async def allow_test_server(_url: str) -> bool:
+        return True
+
+    monkeypatch.setattr(wac, "async_is_safe_url", allow_test_server)
+    image = b"\xff\xd8\xff\xe0e2e-jpeg"
+
+    with _http_server(lambda _path: (200, {"Content-Type": "image/jpeg"}, image)) as (
+        media_base,
+        media_requests,
+    ):
+        with _http_server(
+            lambda _path: _metadata_response(f"{media_base}/media.jpg")
+        ) as (graph_base, graph_requests):
+            monkeypatch.setattr(wac, "GRAPH_API_BASE", graph_base)
+            monkeypatch.setattr(wac, "_INBOUND_MEDIA_CACHE", tmp_path)
+
+            async with httpx.AsyncClient(timeout=5.0, trust_env=False) as client:
+                local_path, mime = await _adapter(client)._download_media_to_cache(
+                    "MEDIA123"
+                )
+
+    assert local_path is not None
+    assert mime == "image/jpeg"
+    assert (tmp_path / "MEDIA123.jpg").read_bytes() == image
+    assert [request["path"] for request in graph_requests] == ["/v20.0/MEDIA123"]
+    assert [request["path"] for request in media_requests] == ["/media.jpg"]
+    assert media_requests[0]["authorization"] == "Bearer e2e-test-token"
+
+
+@pytest.mark.asyncio
+async def test_media_redirect_is_not_followed_with_bearer_token(tmp_path, monkeypatch):
+    """A media redirect cannot carry Meta credentials to another origin."""
+
+    async def allow_test_server(_url: str) -> bool:
+        return True
+
+    monkeypatch.setattr(wac, "async_is_safe_url", allow_test_server)
+
+    with _http_server(
+        lambda _path: (200, {"Content-Type": "text/plain"}, b"capture")
+    ) as (capture_base, capture_requests):
+        with _http_server(
+            lambda _path: (
+                302,
+                {"Location": f"{capture_base}/capture"},
+                b"",
+            )
+        ) as (media_base, media_requests):
+            with _http_server(
+                lambda _path: _metadata_response(f"{media_base}/redirect")
+            ) as (graph_base, _graph_requests):
+                monkeypatch.setattr(wac, "GRAPH_API_BASE", graph_base)
+                monkeypatch.setattr(wac, "_INBOUND_MEDIA_CACHE", tmp_path)
+
+                async with httpx.AsyncClient(
+                    timeout=5.0, trust_env=False, follow_redirects=True
+                ) as client:
+                    local_path, mime = await _adapter(client)._download_media_to_cache(
+                        "MEDIA123"
+                    )
+
+    assert local_path is None and mime is None
+    assert media_requests[0]["authorization"] == "Bearer e2e-test-token"
+    assert capture_requests == []


### PR DESCRIPTION
## Summary
- Validate Graph-returned temporary media URLs with `is_safe_url` before fetching bytes.
- Disable automatic redirects on the byte fetch so a malicious `Location` cannot pivot to metadata.
- Add a focused regression test.

## Salvage / credit
BlueBubbles / Weixin-class media redirect theme (batch-1 #70341 / #70331) applied to WhatsApp Cloud.

## Test plan
- [x] `pytest tests/gateway/platforms/test_whatsapp_cloud_media_ssrf.py -q`
