### PR TITLE
fix(security): Mattermost media redirect SSRF hardening

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -50,6 +50,14 @@ _MATTERMOST_DISABLE_MENTIONS_PROPS = {"disable_mentions": True}
 _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
+_MEDIA_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+_MAX_MEDIA_REDIRECTS = 5
+
+
+class _MattermostDownloadHTTPError(Exception):
+    def __init__(self, status: int):
+        super().__init__(f"HTTP {status}")
+        self.status = status
 
 
 def _with_mentions_disabled(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -528,18 +536,27 @@ class MattermostAdapter(BasePlatformAdapter):
 
         for attempt in range(3):
             try:
-                async with self._session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
-                    if resp.status >= 500 or resp.status == 429:
-                        if attempt < 2:
-                            logger.debug("Mattermost download retry %d/2 for %s (status %d)",
-                                         attempt + 1, url[:80], resp.status)
-                            await asyncio.sleep(1.5 * (attempt + 1))
-                            continue
-                    if resp.status >= 400:
-                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
-                    file_data = await resp.read()
-                    ct = resp.content_type or "application/octet-stream"
-                    break
+                file_data, ct, _final_url = await self._download_media_url(url)
+                break
+            except _MattermostDownloadHTTPError as exc:
+                if exc.status >= 500 or exc.status == 429:
+                    if attempt < 2:
+                        logger.debug(
+                            "Mattermost download retry %d/2 for %s (status %d)",
+                            attempt + 1,
+                            url[:80],
+                            exc.status,
+                        )
+                        await asyncio.sleep(1.5 * (attempt + 1))
+                        continue
+                return await self.send(
+                    chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata
+                )
+            except ValueError as exc:
+                logger.warning("Mattermost: blocked unsafe media URL: %s", exc)
+                return await self.send(
+                    chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata
+                )
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
                 if attempt < 2:
                     await asyncio.sleep(1.5 * (attempt + 1))
@@ -568,6 +585,43 @@ class MattermostAdapter(BasePlatformAdapter):
         if not data or "id" not in data:
             return SendResult(success=False, error="Failed to post with file")
         return SendResult(success=True, message_id=data["id"])
+
+    async def _download_media_url(self, url: str) -> Tuple[bytes, str, str]:
+        """Download public media while re-validating every redirect hop.
+
+        Salvages the incomplete pre-check-only posture (aiohttp follows
+        redirects by default) tracked by draft #24831 against the pre-move
+        ``gateway/platforms/mattermost.py`` path.
+        """
+        import aiohttp
+        from urllib.parse import urljoin
+
+        from tools.url_safety import is_safe_url
+
+        current_url = url
+        for _redirect_count in range(_MAX_MEDIA_REDIRECTS + 1):
+            if not is_safe_url(current_url):
+                raise ValueError(f"blocked unsafe URL: {current_url[:80]}")
+
+            async with self._session.get(
+                current_url,
+                timeout=aiohttp.ClientTimeout(total=30),
+                allow_redirects=False,
+            ) as resp:
+                if resp.status in _MEDIA_REDIRECT_STATUSES:
+                    location = resp.headers.get("Location")
+                    if not location:
+                        raise ValueError("redirect response missing Location header")
+                    base_url = str(getattr(resp, "url", None) or current_url)
+                    current_url = urljoin(base_url, location)
+                    continue
+                if resp.status >= 400:
+                    raise _MattermostDownloadHTTPError(resp.status)
+                data = await resp.read()
+                content_type = resp.content_type or "application/octet-stream"
+                return data, content_type, current_url
+
+        raise ValueError(f"too many redirects fetching media URL: {url[:80]}")
 
     async def _send_local_file(
         self,
@@ -656,22 +710,18 @@ class MattermostAdapter(BasePlatformAdapter):
                         ct = mimetypes.guess_type(fname)[0] or "image/png"
                         file_data = p.read_bytes()
                     else:
-                        from tools.url_safety import is_safe_url
-                        if not is_safe_url(image_url):
-                            logger.warning("Mattermost: blocked unsafe image URL in batch")
-                            continue
                         try:
-                            async with self._session.get(
-                                image_url, timeout=aiohttp.ClientTimeout(total=30)
-                            ) as resp:
-                                if resp.status >= 400:
-                                    logger.warning(
-                                        "Mattermost: failed to download image (HTTP %d): %s",
-                                        resp.status, image_url[:80],
-                                    )
-                                    continue
-                                file_data = await resp.read()
-                                ct = resp.content_type or "image/png"
+                            file_data, ct, _final = await self._download_media_url(image_url)
+                        except _MattermostDownloadHTTPError as http_err:
+                            logger.warning(
+                                "Mattermost: failed to download image (HTTP %d): %s",
+                                http_err.status,
+                                image_url[:80],
+                            )
+                            continue
+                        except ValueError as blocked:
+                            logger.warning("Mattermost: blocked unsafe image URL in batch: %s", blocked)
+                            continue
                         except Exception as dl_err:
                             logger.warning("Mattermost: download failed for %s: %s", image_url[:80], dl_err)
                             continue

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -596,11 +596,11 @@ class MattermostAdapter(BasePlatformAdapter):
         import aiohttp
         from urllib.parse import urljoin
 
-        from tools.url_safety import is_safe_url
+        from tools.url_safety import async_is_safe_url
 
         current_url = url
         for _redirect_count in range(_MAX_MEDIA_REDIRECTS + 1):
-            if not is_safe_url(current_url):
+            if not await async_is_safe_url(current_url):
                 raise ValueError(f"blocked unsafe URL: {current_url[:80]}")
 
             async with self._session.get(

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -620,11 +620,11 @@ class MattermostAdapter(BasePlatformAdapter):
         import aiohttp
         from urllib.parse import urljoin
 
-        from tools.url_safety import is_safe_url
+        from tools.url_safety import async_is_safe_url
 
         current_url = url
         for _redirect_count in range(_MAX_MEDIA_REDIRECTS + 1):
-            if not is_safe_url(current_url):
+            if not await async_is_safe_url(current_url):
                 raise ValueError(f"blocked unsafe URL: {current_url[:80]}")
 
             async with self._session.get(

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -547,11 +547,6 @@ class MattermostAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Download a URL and upload it as a file attachment."""
-        from tools.url_safety import is_safe_url
-        if not is_safe_url(url):
-            logger.warning("Mattermost: blocked unsafe URL (SSRF protection)")
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
-
         import aiohttp
 
         file_data = None
@@ -707,7 +702,6 @@ class MattermostAdapter(BasePlatformAdapter):
             return
 
         import mimetypes
-        import aiohttp
         from urllib.parse import unquote as _unquote
 
         CHUNK = 5  # Mattermost post file_ids cap

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -74,6 +74,14 @@ _MATTERMOST_DISABLE_MENTIONS_PROPS = {"disable_mentions": True}
 _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
+_MEDIA_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+_MAX_MEDIA_REDIRECTS = 5
+
+
+class _MattermostDownloadHTTPError(Exception):
+    def __init__(self, status: int):
+        super().__init__(f"HTTP {status}")
+        self.status = status
 
 
 def _with_mentions_disabled(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -552,18 +560,27 @@ class MattermostAdapter(BasePlatformAdapter):
 
         for attempt in range(3):
             try:
-                async with self._session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
-                    if resp.status >= 500 or resp.status == 429:
-                        if attempt < 2:
-                            logger.debug("Mattermost download retry %d/2 for %s (status %d)",
-                                         attempt + 1, url[:80], resp.status)
-                            await asyncio.sleep(1.5 * (attempt + 1))
-                            continue
-                    if resp.status >= 400:
-                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
-                    file_data = await resp.read()
-                    ct = resp.content_type or "application/octet-stream"
-                    break
+                file_data, ct, _final_url = await self._download_media_url(url)
+                break
+            except _MattermostDownloadHTTPError as exc:
+                if exc.status >= 500 or exc.status == 429:
+                    if attempt < 2:
+                        logger.debug(
+                            "Mattermost download retry %d/2 for %s (status %d)",
+                            attempt + 1,
+                            url[:80],
+                            exc.status,
+                        )
+                        await asyncio.sleep(1.5 * (attempt + 1))
+                        continue
+                return await self.send(
+                    chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata
+                )
+            except ValueError as exc:
+                logger.warning("Mattermost: blocked unsafe media URL: %s", exc)
+                return await self.send(
+                    chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata
+                )
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
                 if attempt < 2:
                     await asyncio.sleep(1.5 * (attempt + 1))
@@ -592,6 +609,43 @@ class MattermostAdapter(BasePlatformAdapter):
         if not data or "id" not in data:
             return SendResult(success=False, error="Failed to post with file")
         return SendResult(success=True, message_id=data["id"])
+
+    async def _download_media_url(self, url: str) -> Tuple[bytes, str, str]:
+        """Download public media while re-validating every redirect hop.
+
+        Salvages the incomplete pre-check-only posture (aiohttp follows
+        redirects by default) tracked by draft #24831 against the pre-move
+        ``gateway/platforms/mattermost.py`` path.
+        """
+        import aiohttp
+        from urllib.parse import urljoin
+
+        from tools.url_safety import is_safe_url
+
+        current_url = url
+        for _redirect_count in range(_MAX_MEDIA_REDIRECTS + 1):
+            if not is_safe_url(current_url):
+                raise ValueError(f"blocked unsafe URL: {current_url[:80]}")
+
+            async with self._session.get(
+                current_url,
+                timeout=aiohttp.ClientTimeout(total=30),
+                allow_redirects=False,
+            ) as resp:
+                if resp.status in _MEDIA_REDIRECT_STATUSES:
+                    location = resp.headers.get("Location")
+                    if not location:
+                        raise ValueError("redirect response missing Location header")
+                    base_url = str(getattr(resp, "url", None) or current_url)
+                    current_url = urljoin(base_url, location)
+                    continue
+                if resp.status >= 400:
+                    raise _MattermostDownloadHTTPError(resp.status)
+                data = await resp.read()
+                content_type = resp.content_type or "application/octet-stream"
+                return data, content_type, current_url
+
+        raise ValueError(f"too many redirects fetching media URL: {url[:80]}")
 
     async def _send_local_file(
         self,
@@ -680,22 +734,18 @@ class MattermostAdapter(BasePlatformAdapter):
                         ct = mimetypes.guess_type(fname)[0] or "image/png"
                         file_data = p.read_bytes()
                     else:
-                        from tools.url_safety import is_safe_url
-                        if not is_safe_url(image_url):
-                            logger.warning("Mattermost: blocked unsafe image URL in batch")
-                            continue
                         try:
-                            async with self._session.get(
-                                image_url, timeout=aiohttp.ClientTimeout(total=30)
-                            ) as resp:
-                                if resp.status >= 400:
-                                    logger.warning(
-                                        "Mattermost: failed to download image (HTTP %d): %s",
-                                        resp.status, image_url[:80],
-                                    )
-                                    continue
-                                file_data = await resp.read()
-                                ct = resp.content_type or "image/png"
+                            file_data, ct, _final = await self._download_media_url(image_url)
+                        except _MattermostDownloadHTTPError as http_err:
+                            logger.warning(
+                                "Mattermost: failed to download image (HTTP %d): %s",
+                                http_err.status,
+                                image_url[:80],
+                            )
+                            continue
+                        except ValueError as blocked:
+                            logger.warning("Mattermost: blocked unsafe image URL in batch: %s", blocked)
+                            continue
                         except Exception as dl_err:
                             logger.warning("Mattermost: download failed for %s: %s", image_url[:80], dl_err)
                             continue

--- a/tests/plugins/platforms/test_mattermost_media_redirect_ssrf.py
+++ b/tests/plugins/platforms/test_mattermost_media_redirect_ssrf.py
@@ -1,0 +1,30 @@
+"""Mattermost media download redirect SSRF invariants (salvage of #24831)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def test_download_media_url_blocks_redirect_to_metadata():
+    from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+    adapter = object.__new__(MattermostAdapter)
+
+    public = "https://cdn.example.com/a.png"
+    evil = "http://169.254.169.254/latest/meta-data/"
+
+    redirect_resp = MagicMock()
+    redirect_resp.status = 302
+    redirect_resp.headers = {"Location": evil}
+    redirect_resp.url = public
+    redirect_resp.__aenter__ = AsyncMock(return_value=redirect_resp)
+    redirect_resp.__aexit__ = AsyncMock(return_value=False)
+
+    session = MagicMock()
+    session.get = MagicMock(return_value=redirect_resp)
+    adapter._session = session
+
+    with patch("tools.url_safety.is_safe_url", side_effect=lambda u: u == public):
+        with pytest.raises(ValueError, match="blocked unsafe"):
+            asyncio.run(adapter._download_media_url(public))

--- a/tests/plugins/platforms/test_mattermost_media_redirect_ssrf.py
+++ b/tests/plugins/platforms/test_mattermost_media_redirect_ssrf.py
@@ -25,6 +25,6 @@ def test_download_media_url_blocks_redirect_to_metadata():
     session.get = MagicMock(return_value=redirect_resp)
     adapter._session = session
 
-    with patch("tools.url_safety.is_safe_url", side_effect=lambda u: u == public):
+    with patch("tools.url_safety.async_is_safe_url", new=AsyncMock(side_effect=lambda u: u == public)):
         with pytest.raises(ValueError, match="blocked unsafe"):
             asyncio.run(adapter._download_media_url(public))

--- a/tests/plugins/platforms/test_mattermost_media_redirect_ssrf.py
+++ b/tests/plugins/platforms/test_mattermost_media_redirect_ssrf.py
@@ -3,17 +3,13 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 
-
-def test_download_media_url_blocks_redirect_to_metadata():
+def _redirecting_adapter():
     from plugins.platforms.mattermost.adapter import MattermostAdapter
 
     adapter = object.__new__(MattermostAdapter)
-
     public = "https://cdn.example.com/a.png"
     evil = "http://169.254.169.254/latest/meta-data/"
-
     redirect_resp = MagicMock()
     redirect_resp.status = 302
     redirect_resp.headers = {"Location": evil}
@@ -24,7 +20,32 @@ def test_download_media_url_blocks_redirect_to_metadata():
     session = MagicMock()
     session.get = MagicMock(return_value=redirect_resp)
     adapter._session = session
+    adapter.send = AsyncMock()
+    adapter._upload_file = AsyncMock()
+    return adapter, session, public, evil
 
-    with patch("tools.url_safety.async_is_safe_url", new=AsyncMock(side_effect=lambda u: u == public)):
-        with pytest.raises(ValueError, match="blocked unsafe"):
-            asyncio.run(adapter._download_media_url(public))
+
+def test_send_image_blocks_redirect_to_metadata():
+    adapter, session, public, _evil = _redirecting_adapter()
+
+    with patch(
+        "tools.url_safety.async_is_safe_url",
+        new=AsyncMock(side_effect=lambda url: url == public),
+    ):
+        asyncio.run(adapter.send_image("channel-1", public))
+
+    assert session.get.call_args.kwargs["allow_redirects"] is False
+    adapter.send.assert_awaited_once()
+
+
+def test_send_multiple_images_blocks_redirect_to_metadata():
+    adapter, session, public, _evil = _redirecting_adapter()
+
+    with patch(
+        "tools.url_safety.async_is_safe_url",
+        new=AsyncMock(side_effect=lambda url: url == public),
+    ):
+        asyncio.run(adapter.send_multiple_images("channel-1", [(public, "alt")]))
+
+    assert session.get.call_args.kwargs["allow_redirects"] is False
+    adapter._upload_file.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Download Mattermost public media with `allow_redirects=False` and re-validate every hop via `is_safe_url`.
- Cover both single-URL send and multi-image batch download paths.
- Add a redirect-to-metadata regression test.

## Salvage / credit
Draft #24831 (pre-move `gateway/platforms/mattermost.py`); code now lives under `plugins/platforms/mattermost/`.

## Test plan
- [x] `pytest tests/plugins/platforms/test_mattermost_media_redirect_ssrf.py -q`
