### PR TITLE
fix(security): reject always-blocked RetainDB BASE_URL

### DIFF
--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -491,6 +491,23 @@ class RetainDBMemoryProvider(MemoryProvider):
         api_key = os.environ.get("RETAINDB_API_KEY", "")
         base_url = re.sub(r"/+$", "", os.environ.get("RETAINDB_BASE_URL", _DEFAULT_BASE_URL))
 
+        # Self-hosted RetainDB is allowed on LAN/loopback, but cloud-metadata
+        # and other always-blocked targets must never become the API base
+        # (salvage of incomplete #4984 which incorrectly used full is_safe_url
+        # and would break intentional private deployments).
+        try:
+            from tools.url_safety import is_always_blocked_url
+
+            if is_always_blocked_url(base_url):
+                logger.warning(
+                    "RETAINDB_BASE_URL '%s' targets an always-blocked address; "
+                    "resetting to the default endpoint.",
+                    base_url,
+                )
+                base_url = _DEFAULT_BASE_URL
+        except Exception as exc:
+            logger.debug("RetainDB base URL always-blocked check skipped: %s", exc)
+
         # Project resolution: RETAINDB_PROJECT > hermes-<profile> > "default"
         # If unset, the API auto-creates and uses the "default" project — no config required.
         explicit = os.environ.get("RETAINDB_PROJECT")

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -573,6 +573,23 @@ class RetainDBMemoryProvider(MemoryProvider):
         )
         base_url = re.sub(r"/+$", "", base_url_raw)
 
+        # Self-hosted RetainDB is allowed on LAN/loopback, but cloud-metadata
+        # and other always-blocked targets must never become the API base
+        # (salvage of incomplete #4984 which incorrectly used full is_safe_url
+        # and would break intentional private deployments).
+        try:
+            from tools.url_safety import is_always_blocked_url
+
+            if is_always_blocked_url(base_url):
+                logger.warning(
+                    "RETAINDB_BASE_URL '%s' targets an always-blocked address; "
+                    "resetting to the default endpoint.",
+                    base_url,
+                )
+                base_url = _DEFAULT_BASE_URL
+        except Exception as exc:
+            logger.debug("RetainDB base URL always-blocked check skipped: %s", exc)
+
         # Project resolution: RETAINDB_PROJECT > config.yaml project > hermes-<profile> > "default"
         # If unset, the API auto-creates and uses the "default" project — no config required.
         explicit = os.environ.get("RETAINDB_PROJECT") or _config_str(provider_config.get("project"))

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -31,7 +31,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
-from urllib.parse import quote
+from urllib.parse import quote, urljoin
 
 from agent.memory_provider import MemoryProvider
 from agent.secret_scope import get_secret
@@ -333,9 +333,31 @@ class _Client:
         import requests
         token = self.api_key.replace("Bearer ", "").strip()
         url = f"{self.base_url}/v1/files/{quote(file_id, safe='')}/content"
-        resp = requests.get(url, headers={"Authorization": f"Bearer {token}", "x-sdk-runtime": "hermes-plugin"}, timeout=30, allow_redirects=True)
-        resp.raise_for_status()
-        return resp.content
+        headers = {"Authorization": f"Bearer {token}", "x-sdk-runtime": "hermes-plugin"}
+        # Follow redirects manually so every Location is subject to the same
+        # metadata/SSRF floor as the configured base URL.
+        for _ in range(10):
+            resp = requests.get(url, headers=headers, timeout=30, allow_redirects=False)
+            if not resp.is_redirect:
+                resp.raise_for_status()
+                return resp.content
+
+            location = resp.headers.get("Location")
+            resp.close()
+            if not location:
+                raise RuntimeError("RetainDB file response redirected without a Location header")
+            url = urljoin(url, location)
+            try:
+                from tools.url_safety import is_always_blocked_url
+
+                if is_always_blocked_url(url):
+                    raise RuntimeError("RetainDB redirect target is always blocked")
+            except RuntimeError:
+                raise
+            except Exception as exc:
+                raise RuntimeError("RetainDB redirect safety check failed") from exc
+
+        raise RuntimeError("RetainDB file response exceeded the redirect limit")
 
     def ingest_file(self, file_id: str, user_id: str | None = None, agent_id: str | None = None) -> dict:
         body: dict = {}

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -31,7 +31,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
-from urllib.parse import quote, urljoin
+from urllib.parse import quote
 
 from agent.memory_provider import MemoryProvider
 from agent.secret_scope import get_secret
@@ -42,6 +42,22 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_BASE_URL = "https://api.retaindb.com"
 _ASYNC_SHUTDOWN = object()
+
+
+def _guard_redirect(response, *args, **kwargs) -> None:
+    """Reject metadata redirects before requests follows them."""
+    try:
+        from tools.url_safety import is_always_blocked_url, redirect_target_from_response
+
+        target = redirect_target_from_response(response)
+        if target and is_always_blocked_url(target):
+            response.close()
+            raise RuntimeError("RetainDB redirect target is always blocked")
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        response.close()
+        raise RuntimeError("RetainDB redirect safety check failed") from exc
 
 
 def _load_retaindb_config() -> Dict[str, Any]:
@@ -228,6 +244,7 @@ class _Client:
             json=json_body if method.upper() not in {"GET", "DELETE"} else None,
             headers=self._headers(path),
             timeout=timeout,
+            hooks={"response": [_guard_redirect]},
         )
         try:
             payload = resp.json()
@@ -316,7 +333,14 @@ class _Client:
         fields = {"path": remote_path, "scope": scope.upper()}
         if project_id:
             fields["project_id"] = project_id
-        resp = requests.post(url, files={"file": (filename, io.BytesIO(data), mime_type)}, data=fields, headers=headers, timeout=30)
+        resp = requests.post(
+            url,
+            files={"file": (filename, io.BytesIO(data), mime_type)},
+            data=fields,
+            headers=headers,
+            timeout=30,
+            hooks={"response": [_guard_redirect]},
+        )
         resp.raise_for_status()
         return resp.json()
 
@@ -334,30 +358,14 @@ class _Client:
         token = self.api_key.replace("Bearer ", "").strip()
         url = f"{self.base_url}/v1/files/{quote(file_id, safe='')}/content"
         headers = {"Authorization": f"Bearer {token}", "x-sdk-runtime": "hermes-plugin"}
-        # Follow redirects manually so every Location is subject to the same
-        # metadata/SSRF floor as the configured base URL.
-        for _ in range(10):
-            resp = requests.get(url, headers=headers, timeout=30, allow_redirects=False)
-            if not resp.is_redirect:
-                resp.raise_for_status()
-                return resp.content
-
-            location = resp.headers.get("Location")
-            resp.close()
-            if not location:
-                raise RuntimeError("RetainDB file response redirected without a Location header")
-            url = urljoin(url, location)
-            try:
-                from tools.url_safety import is_always_blocked_url
-
-                if is_always_blocked_url(url):
-                    raise RuntimeError("RetainDB redirect target is always blocked")
-            except RuntimeError:
-                raise
-            except Exception as exc:
-                raise RuntimeError("RetainDB redirect safety check failed") from exc
-
-        raise RuntimeError("RetainDB file response exceeded the redirect limit")
+        resp = requests.get(
+            url,
+            headers=headers,
+            timeout=30,
+            hooks={"response": [_guard_redirect]},
+        )
+        resp.raise_for_status()
+        return resp.content
 
     def ingest_file(self, file_id: str, user_id: str | None = None, agent_id: str | None = None) -> dict:
         body: dict = {}

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -31,7 +31,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
-from urllib.parse import quote
+from urllib.parse import quote, urljoin
 
 from agent.memory_provider import MemoryProvider
 from agent.file_safety import raise_if_read_blocked
@@ -308,9 +308,31 @@ class _Client:
         import requests
         token = self.api_key.replace("Bearer ", "").strip()
         url = f"{self.base_url}/v1/files/{quote(file_id, safe='')}/content"
-        resp = requests.get(url, headers={"Authorization": f"Bearer {token}", "x-sdk-runtime": "hermes-plugin"}, timeout=30, allow_redirects=True)
-        resp.raise_for_status()
-        return resp.content
+        headers = {"Authorization": f"Bearer {token}", "x-sdk-runtime": "hermes-plugin"}
+        # Follow redirects manually so every Location is subject to the same
+        # metadata/SSRF floor as the configured base URL.
+        for _ in range(10):
+            resp = requests.get(url, headers=headers, timeout=30, allow_redirects=False)
+            if not resp.is_redirect:
+                resp.raise_for_status()
+                return resp.content
+
+            location = resp.headers.get("Location")
+            resp.close()
+            if not location:
+                raise RuntimeError("RetainDB file response redirected without a Location header")
+            url = urljoin(url, location)
+            try:
+                from tools.url_safety import is_always_blocked_url
+
+                if is_always_blocked_url(url):
+                    raise RuntimeError("RetainDB redirect target is always blocked")
+            except RuntimeError:
+                raise
+            except Exception as exc:
+                raise RuntimeError("RetainDB redirect safety check failed") from exc
+
+        raise RuntimeError("RetainDB file response exceeded the redirect limit")
 
     def ingest_file(self, file_id: str, user_id: str | None = None, agent_id: str | None = None) -> dict:
         body: dict = {}

--- a/tests/plugins/memory/test_retaindb_base_url_always_blocked.py
+++ b/tests/plugins/memory/test_retaindb_base_url_always_blocked.py
@@ -1,0 +1,28 @@
+"""RetainDB BASE_URL always-blocked floor (salvage of incomplete #4984)."""
+
+from unittest.mock import MagicMock, patch
+
+import plugins.memory.retaindb as mod
+
+
+def test_retaindb_initialize_resets_metadata_base_url(monkeypatch, tmp_path):
+    monkeypatch.setenv("RETAINDB_API_KEY", "test-key")
+    monkeypatch.setenv("RETAINDB_BASE_URL", "http://169.254.169.254/latest/")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    provider = mod.RetainDBMemoryProvider()
+    fake_client = MagicMock()
+    with patch.object(mod, "_Client", return_value=fake_client) as client_cls, patch.object(
+        mod, "_WriteQueue", return_value=MagicMock()
+    ):
+        provider.initialize(session_id="s1", hermes_home=str(tmp_path))
+
+    assert client_cls.call_args.args[1] == mod._DEFAULT_BASE_URL
+
+
+def test_retaindb_allows_private_self_host_url():
+    """Full is_safe_url would wrongly reject LAN; always-blocked must not."""
+    from tools.url_safety import is_always_blocked_url
+
+    assert not is_always_blocked_url("http://192.168.1.50:8080")
+    assert not is_always_blocked_url("http://127.0.0.1:8080")

--- a/tests/plugins/memory/test_retaindb_base_url_always_blocked.py
+++ b/tests/plugins/memory/test_retaindb_base_url_always_blocked.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import plugins.memory.retaindb as mod
 
 
@@ -26,3 +28,22 @@ def test_retaindb_allows_private_self_host_url():
 
     assert not is_always_blocked_url("http://192.168.1.50:8080")
     assert not is_always_blocked_url("http://127.0.0.1:8080")
+
+
+def test_retaindb_file_read_rejects_public_to_metadata_redirect(monkeypatch):
+    response = MagicMock(
+        is_redirect=True,
+        headers={"location": "http://169.254.169.254/latest/meta-data/"},
+        url="https://api.retaindb.com/v1/files/file-1/content",
+    )
+
+    def redirecting_get(*args, **kwargs):
+        for hook in kwargs["hooks"]["response"]:
+            hook(response)
+        return response
+
+    monkeypatch.setattr("requests.get", redirecting_get)
+    client = mod._Client("test-key", "https://api.retaindb.com", "default")
+
+    with pytest.raises(RuntimeError, match="redirect target is always blocked"):
+        client.read_file_content("file-1")


### PR DESCRIPTION
## Summary
- Reset `RETAINDB_BASE_URL` when it targets the always-blocked floor (cloud metadata, etc.).
- Intentionally use `is_always_blocked_url` rather than full `is_safe_url` so self-hosted LAN deployments keep working.
- Add regression tests for metadata rejection and LAN allowance.

## Salvage / credit
Incomplete / incorrect #4984 (used full private-IP blocking and would break legitimate self-host).

## Test plan
- [x] `pytest tests/plugins/memory/test_retaindb_base_url_always_blocked.py -q`
