### PR TITLE
fix(security): reject always-blocked Supermemory BASE_URL

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -82,12 +82,27 @@ def _resolve_base_url(config_value: Any = "") -> str:
     """Resolve the API base URL: config > SUPERMEMORY_BASE_URL env var > default.
 
     Supports self-hosted Supermemory servers (e.g. http://localhost:6767).
+    Cloud-metadata / always-blocked targets are rejected so a poisoned config
+    cannot turn memory sync into an SSRF springboard.
     """
     raw = (
         str(config_value or "").strip()
         or os.environ.get("SUPERMEMORY_BASE_URL", "").strip()
     )
-    return (raw or _DEFAULT_BASE_URL).rstrip("/") or _DEFAULT_BASE_URL
+    base = (raw or _DEFAULT_BASE_URL).rstrip("/") or _DEFAULT_BASE_URL
+    try:
+        from tools.url_safety import is_always_blocked_url
+
+        if is_always_blocked_url(base):
+            logger.warning(
+                "SUPERMEMORY_BASE_URL '%s' targets an always-blocked address; "
+                "falling back to the default endpoint.",
+                base,
+            )
+            return _DEFAULT_BASE_URL
+    except Exception:
+        pass
+    return base
 
 
 def _clamp_entity_context(text: str) -> str:

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -100,8 +100,13 @@ def _resolve_base_url(config_value: Any = "") -> str:
                 base,
             )
             return _DEFAULT_BASE_URL
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning(
+            "Supermemory base URL safety check failed; falling back to the "
+            "default endpoint: %s",
+            exc,
+        )
+        return _DEFAULT_BASE_URL
     return base
 
 

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -83,12 +83,27 @@ def _resolve_base_url(config_value: Any = "") -> str:
     """Resolve the API base URL: config > SUPERMEMORY_BASE_URL env var > default.
 
     Supports self-hosted Supermemory servers (e.g. http://localhost:6767).
+    Cloud-metadata / always-blocked targets are rejected so a poisoned config
+    cannot turn memory sync into an SSRF springboard.
     """
     raw = (
         str(config_value or "").strip()
         or os.environ.get("SUPERMEMORY_BASE_URL", "").strip()
     )
-    return (raw or _DEFAULT_BASE_URL).rstrip("/") or _DEFAULT_BASE_URL
+    base = (raw or _DEFAULT_BASE_URL).rstrip("/") or _DEFAULT_BASE_URL
+    try:
+        from tools.url_safety import is_always_blocked_url
+
+        if is_always_blocked_url(base):
+            logger.warning(
+                "SUPERMEMORY_BASE_URL '%s' targets an always-blocked address; "
+                "falling back to the default endpoint.",
+                base,
+            )
+            return _DEFAULT_BASE_URL
+    except Exception:
+        pass
+    return base
 
 
 def _clamp_entity_context(text: str) -> str:

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -101,8 +101,13 @@ def _resolve_base_url(config_value: Any = "") -> str:
                 base,
             )
             return _DEFAULT_BASE_URL
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning(
+            "Supermemory base URL safety check failed; falling back to the "
+            "default endpoint: %s",
+            exc,
+        )
+        return _DEFAULT_BASE_URL
     return base
 
 

--- a/tests/plugins/memory/test_supermemory_base_url_always_blocked.py
+++ b/tests/plugins/memory/test_supermemory_base_url_always_blocked.py
@@ -1,0 +1,18 @@
+"""Supermemory BASE_URL always-blocked floor."""
+
+from plugins.memory.supermemory import _DEFAULT_BASE_URL, _resolve_base_url
+
+
+def test_supermemory_blocks_metadata_base_url(monkeypatch):
+    monkeypatch.delenv("SUPERMEMORY_BASE_URL", raising=False)
+    assert _resolve_base_url("http://169.254.169.254/latest/meta-data/") == _DEFAULT_BASE_URL
+
+
+def test_supermemory_allows_localhost_self_host(monkeypatch):
+    monkeypatch.delenv("SUPERMEMORY_BASE_URL", raising=False)
+    assert _resolve_base_url("http://localhost:6767") == "http://localhost:6767"
+
+
+def test_supermemory_env_poisoning_falls_back(monkeypatch):
+    monkeypatch.setenv("SUPERMEMORY_BASE_URL", "http://metadata.google.internal/")
+    assert _resolve_base_url("") == _DEFAULT_BASE_URL

--- a/tests/plugins/memory/test_supermemory_base_url_always_blocked.py
+++ b/tests/plugins/memory/test_supermemory_base_url_always_blocked.py
@@ -16,3 +16,14 @@ def test_supermemory_allows_localhost_self_host(monkeypatch):
 def test_supermemory_env_poisoning_falls_back(monkeypatch):
     monkeypatch.setenv("SUPERMEMORY_BASE_URL", "http://metadata.google.internal/")
     assert _resolve_base_url("") == _DEFAULT_BASE_URL
+
+
+def test_supermemory_safety_check_failure_falls_back(monkeypatch):
+    def fail_safety_check(_url):
+        raise RuntimeError("safety check unavailable")
+
+    monkeypatch.setattr(
+        "tools.url_safety.is_always_blocked_url",
+        fail_safety_check,
+    )
+    assert _resolve_base_url("http://169.254.169.254/latest/meta-data/") == _DEFAULT_BASE_URL


### PR DESCRIPTION
## Summary
- Teach `_resolve_base_url` to fall back when config/env points at always-blocked hosts.
- Preserve localhost / LAN self-host support while blocking metadata SSRF springboards.
- Add focused unit tests.

## Salvage / credit
Same class as RetainDB always-blocked floor; avoids the over-broad private-IP rejection pattern from #4984 / #4986.

## Test plan
- [x] `pytest tests/plugins/memory/test_supermemory_base_url_always_blocked.py -q`
