### PR TITLE
fix(security): reject always-blocked OpenViking endpoints

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -784,11 +784,31 @@ def _normalize_openviking_url(url: str) -> str:
     if lower.startswith("::1:"):
         return f"http://[::1]:{trimmed.rsplit(':', 1)[1]}"
     if "://" in trimmed:
-        return trimmed
-    host, _sep, port = trimmed.partition(":")
-    if host.lower() in {"localhost", "127.0.0.1"}:
-        return f"http://{host}:{port or '1933'}"
-    return trimmed
+        candidate = trimmed
+    else:
+        host, _sep, port = trimmed.partition(":")
+        if host.lower() in {"localhost", "127.0.0.1"}:
+            candidate = f"http://{host}:{port or '1933'}"
+        else:
+            candidate = trimmed
+
+    # Local / LAN self-host remains allowed; reject cloud-metadata and other
+    # always-blocked floors so a poisoned endpoint cannot SSRF via memory sync.
+    try:
+        from tools.url_safety import is_always_blocked_url
+
+        check_url = candidate if "://" in candidate else f"http://{candidate}"
+        if is_always_blocked_url(check_url):
+            logger.warning(
+                "OpenViking endpoint '%s' targets an always-blocked address; "
+                "falling back to the default local endpoint.",
+                candidate,
+            )
+            return _DEFAULT_ENDPOINT
+    except Exception as exc:
+        logger.debug("OpenViking always-blocked endpoint check skipped: %s", exc)
+
+    return candidate
 
 
 def _load_profile(path: Path, *, source: str, name: str) -> Optional[_OvcliProfile]:

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -806,7 +806,12 @@ def _normalize_openviking_url(url: str) -> str:
             )
             return _DEFAULT_ENDPOINT
     except Exception as exc:
-        logger.debug("OpenViking always-blocked endpoint check skipped: %s", exc)
+        logger.warning(
+            "OpenViking always-blocked endpoint check failed; "
+            "falling back to the default local endpoint: %s",
+            exc,
+        )
+        return _DEFAULT_ENDPOINT
 
     return candidate
 
@@ -934,8 +939,9 @@ def _resolve_connection_settings(provider_config: Optional[dict] = None) -> dict
     user_env = _env_value("OPENVIKING_USER")
     agent_env = _env_value("OPENVIKING_AGENT")
 
+    endpoint = _first_nonempty(endpoint_env, ovcli_values.get("endpoint"), default=_DEFAULT_ENDPOINT)
     return {
-        "endpoint": _first_nonempty(endpoint_env, ovcli_values.get("endpoint"), default=_DEFAULT_ENDPOINT),
+        "endpoint": _normalize_openviking_url(endpoint),
         "api_key": api_key_env if api_key_env is not None else ovcli_values.get("api_key", ""),
         "account": account_env if account_env is not None else ovcli_values.get("account", ""),
         "user": user_env if user_env is not None else ovcli_values.get("user", ""),

--- a/tests/plugins/memory/test_openviking_endpoint_always_blocked.py
+++ b/tests/plugins/memory/test_openviking_endpoint_always_blocked.py
@@ -1,0 +1,18 @@
+"""OpenViking endpoint always-blocked floor."""
+
+from plugins.memory.openviking import _DEFAULT_ENDPOINT, _normalize_openviking_url
+
+
+def test_openviking_blocks_metadata_endpoint():
+    assert _normalize_openviking_url("http://169.254.169.254/") == _DEFAULT_ENDPOINT
+
+
+def test_openviking_keeps_default_loopback():
+    assert _normalize_openviking_url("http://127.0.0.1:1933") == "http://127.0.0.1:1933"
+
+
+def test_openviking_blocks_ecs_metadata_hostname():
+    assert (
+        _normalize_openviking_url("http://metadata.google.internal/computeMetadata/v1/")
+        == _DEFAULT_ENDPOINT
+    )


### PR DESCRIPTION
## Summary
- Normalize OpenViking endpoints through `is_always_blocked_url` and fall back to the default local endpoint when poisoned.
- Keep intentional loopback / LAN self-host working.
- Add focused unit tests.

## Salvage / credit
Memory-provider endpoint floor sibling of RetainDB/Supermemory always-blocked hardening (avoids over-broad #4984-style private-IP bans).

## Test plan
- [x] `pytest tests/plugins/memory/test_openviking_endpoint_always_blocked.py -q`
