### PR TITLE
feat(telegram): auto-discover group forum topic names + optional context field

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -581,6 +581,11 @@ class TelegramAdapter(BasePlatformAdapter):
         self._general_request_drain_lock = asyncio.Lock()
         # DM Topics: map of topic_name -> message_thread_id (populated at startup)
         self._dm_topics: Dict[str, int] = {}
+        # Group/supergroup forum topic cache: {(chat_id, thread_id): topic_name}
+        # Populated from forum_topic_created/forum_topic_edited service messages
+        # so topics created after bot setup (or not in static config) still get
+        # their names injected into the session context. Mirrors _dm_topics.
+        self._group_topics_cache: Dict[tuple, str] = {}
         # Track forum chats where we've already registered bot commands
         self._forum_command_registered: set[int] = set()
         # Lock per la registrazione sicura dei comandi nei forum supergroup
@@ -8110,6 +8115,40 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, cache_key, thread_id,
             )
 
+    def _cache_group_topic_from_message(
+        self, chat_id: str, thread_id: str, topic_name: str
+    ) -> None:
+        """Cache a group forum topic name discovered from a service message.
+
+        Mirrors _cache_dm_topic_from_message but keyed on (chat_id, thread_id)
+        for group/supergroup forum topics. Populated from
+        forum_topic_created/forum_topic_edited service messages so topics
+        created after bot setup (or absent from static config) still get their
+        names injected into the session context.
+        """
+        cache_key = (str(chat_id), str(thread_id))
+        if cache_key not in self._group_topics_cache:
+            self._group_topics_cache[cache_key] = topic_name
+            logger.info(
+                "[%s] Cached group forum topic from message: chat=%s thread_id=%s -> %s",
+                self.name, chat_id, thread_id, topic_name,
+            )
+        elif self._group_topics_cache[cache_key] != topic_name:
+            # Topic was renamed — update the cache.
+            self._group_topics_cache[cache_key] = topic_name
+            logger.info(
+                "[%s] Updated group forum topic name: chat=%s thread_id=%s -> %s",
+                self.name, chat_id, thread_id, topic_name,
+            )
+
+    def _get_cached_group_topic_name(
+        self, chat_id: str, thread_id: Optional[str]
+    ) -> Optional[str]:
+        """Look up a cached group forum topic name by (chat_id, thread_id)."""
+        if not thread_id:
+            return None
+        return self._group_topics_cache.get((str(chat_id), str(thread_id)))
+
     @classmethod
     def _flatten_rich_inline_text(cls, value: Any) -> str:
         """Best-effort plaintext flattener for Bot API rich-message inline nodes."""
@@ -8250,6 +8289,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 ]
             else:
                 group_topics_iter = []
+            topic_context: Optional[str] = None
             for chat_entry in group_topics_iter:
                 if str(chat_entry.get("chat_id", "")) == str(chat.id):
                     topics = chat_entry.get("topics", [])
@@ -8262,8 +8302,39 @@ class TelegramAdapter(BasePlatformAdapter):
                         if tid is not None and str(tid) == thread_id_str:
                             chat_topic = topic.get("name")
                             topic_skill = topic.get("skill")
+                            topic_context = topic.get("context")
                             break
                     break
+
+            # Auto-discovery: if config didn't resolve a topic name, check the
+            # cache populated from forum_topic_created/forum_topic_edited service
+            # messages. This covers topics created after bot setup or absent
+            # from static config.
+            if not chat_topic:
+                cached_name = self._get_cached_group_topic_name(str(chat.id), thread_id_str)
+                if cached_name:
+                    chat_topic = cached_name
+
+            # Capture forum_topic_created / forum_topic_edited service messages
+            # to keep the cache current. These are service messages Telegram
+            # delivers when a topic is created or renamed.
+            ftc = getattr(message, "forum_topic_created", None)
+            if ftc and getattr(ftc, "name", None):
+                self._cache_group_topic_from_message(str(chat.id), thread_id_str, ftc.name)
+                if not chat_topic:
+                    chat_topic = ftc.name
+            fte = getattr(message, "forum_topic_edited", None)
+            if fte and getattr(fte, "name", None):
+                self._cache_group_topic_from_message(str(chat.id), thread_id_str, fte.name)
+                # Always prefer the freshest name on rename.
+                chat_topic = fte.name
+
+            # Compose topic with optional context suffix. When a `context` field
+            # is present in config (or a future backfill source), append it to the
+            # topic name so the session prompt carries both — e.g.
+            #   "SystemA (thread 86) — system admin thread for Hermes infrastructure"
+            if chat_topic and topic_context:
+                chat_topic = f"{chat_topic} — {topic_context}"
 
         # Build source
         source = self.build_source(

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -542,6 +542,7 @@ def test_cache_dm_topic_from_message_no_overwrite():
 
 def _make_mock_message(chat_id=111, chat_type="private", text="hello", thread_id=None,
                        user_id=42, user_name="Test User", forum_topic_created=None,
+                       forum_topic_edited=None,
                        is_topic_message=None, is_forum=None):
     """Create a mock Telegram Message for _build_message_event tests."""
     chat = SimpleNamespace(
@@ -573,6 +574,7 @@ def _make_mock_message(chat_id=111, chat_type="private", text="hello", thread_id
         reply_to_message=None,
         date=None,
         forum_topic_created=forum_topic_created,
+        forum_topic_edited=forum_topic_edited,
     )
     return msg
 
@@ -996,3 +998,188 @@ def test_build_message_event_dm_from_user_present_uses_user():
     # Normal case — from_user is used directly
     assert event.source.user_id == "99999"
     assert event.source.user_name == "Bob"
+
+
+# ── _build_message_event: group forum topic auto-discovery ──
+
+
+def test_group_topic_auto_discovery_from_service_message():
+    """A forum_topic_created service message should cache the topic name."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()  # no group_topics config
+
+    ftc = SimpleNamespace(name="SystemA")
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=86,
+        text="someone created a topic",
+        is_topic_message=True,
+        is_forum=True,
+        forum_topic_created=ftc,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    # The topic name should be injected from the service message
+    assert event.source.chat_topic == "SystemA"
+    # And it should be cached for future messages in this topic
+    assert adapter._group_topics_cache.get(("-1001234567890", "86")) == "SystemA"
+
+
+def test_group_topic_auto_discovery_serves_subsequent_messages():
+    """After caching, a subsequent normal message should resolve the name from cache."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()  # no group_topics config
+
+    # Prime the cache as if a forum_topic_created had been seen earlier
+    adapter._cache_group_topic_from_message("-1001234567890", "86", "SystemA")
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=86,
+        text="get me a report",
+        is_topic_message=True,
+        is_forum=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.source.chat_topic == "SystemA"
+
+
+def test_group_topic_rename_updates_cache():
+    """A forum_topic_edited service message should update the cached name."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    adapter._cache_group_topic_from_message("-1001234567890", "86", "OldName")
+
+    fte = SimpleNamespace(name="NewName")
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=86,
+        text="topic renamed",
+        is_topic_message=True,
+        is_forum=True,
+        forum_topic_edited=fte,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    # The freshest name should win
+    assert event.source.chat_topic == "NewName"
+    assert adapter._group_topics_cache.get(("-1001234567890", "86")) == "NewName"
+
+
+def test_group_topic_config_overrides_cache():
+    """Static config should take precedence over the auto-discovery cache."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {"name": "ConfigName", "thread_id": 86},
+            ],
+        }
+    ])
+    # Cache has a different name — config should win
+    adapter._cache_group_topic_from_message("-1001234567890", "86", "CachedName")
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=86,
+        text="hi",
+        is_topic_message=True,
+        is_forum=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.source.chat_topic == "ConfigName"
+
+
+def test_group_topic_context_field_appended():
+    """A `context` field in config should be appended to the topic name."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {
+                    "name": "SystemA",
+                    "thread_id": 86,
+                    "context": "system admin thread for Hermes infrastructure",
+                },
+            ],
+        }
+    ])
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=86,
+        text="get me a report",
+        is_topic_message=True,
+        is_forum=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert (
+        event.source.chat_topic
+        == "SystemA — system admin thread for Hermes infrastructure"
+    )
+
+
+def test_group_topic_context_field_without_name_falls_through():
+    """A context field without a name should not produce a topic."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {"thread_id": 86, "context": "context without a name"},
+            ],
+        }
+    ])
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=86,
+        text="hi",
+        is_topic_message=True,
+        is_forum=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    # No name -> no chat_topic, and the context shouldn't leak in alone
+    assert event.source.chat_topic is None
+
+
+def test_group_topic_auto_discovery_does_not_affect_dm_topics():
+    """Group auto-discovery should not pollute the DM topics cache."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+
+    ftc = SimpleNamespace(name="SystemA")
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=86,
+        text="new topic",
+        is_topic_message=True,
+        is_forum=True,
+        forum_topic_created=ftc,
+    )
+    adapter._build_message_event(msg, MessageType.TEXT)
+
+    # DM topics cache should be untouched
+    assert adapter._dm_topics == {}
+    assert adapter._group_topics_cache.get(("-1001234567890", "86")) == "SystemA"
+


### PR DESCRIPTION
## Problem

Group/supergroup forum topics in Telegram only resolved their names from static `config.extra['group_topics']`. Topics created after bot setup — or absent from config — showed as bare `thread N` in the session context block, losing useful context for the agent on session reset.

This meant a user sending `"get me a report"` in a topic called `SystemA` would land in a session with no idea what `SystemA` is, unless the operator had manually configured a static mapping.

## Solution

Mirror the existing DM topic auto-discovery pattern for group/supergroup forum topics:

1. **Auto-discovery from service messages** — `forum_topic_created` and `forum_topic_edited` service messages now cache `(chat_id, thread_id) → topic_name` so subsequent messages in that topic resolve the name without config. Renames update the cache.

2. **Cache fallback after config lookup** — if static `group_topics` config doesn't match, fall back to the auto-discovery cache. Config takes precedence (operators can override auto-discovered names).

3. **Optional `context` field** — `group_topics` entries can now carry a `context` string that is appended to the topic name in `chat_topic`, flowing through to the existing `**Topic:**` line in the session prompt:
   ```yaml
   group_topics:
     - chat_id: "-100..."
       topics:
         - thread_id: 86
           name: "SystemA"
           context: "system admin thread for Hermes infrastructure"
   ```
   Renders as: `**Topic:** SystemA (thread 86) — system admin thread for Hermes infrastructure`

The context field is purely additive — existing config entries work unchanged.

## Why

Telegram topic names provide durable context that survives session resets. The bot already caches DM topic names from service messages; groups were an asymmetry — same problem, no auto-discovery. This closes the gap so any Hermes user with a Telegram forum setup gets topic-name injection for free, without maintaining a static config.

## Backward compatibility

- Existing `group_topics` config entries (with `name`, `skill`, `thread_id`) work unchanged.
- The `context` field is optional and additive.
- No changes to `SessionSource` schema, `session.py`, or the prompt builder — the existing `chat_topic` field already flows through to the `**Topic:**` line.
- DM topic discovery is untouched — separate cache, separate code path.

## Testing

7 new tests in `tests/gateway/test_dm_topics.py`:

| Test | Covers |
|---|---|
| `test_group_topic_auto_discovery_from_service_message` | forum_topic_created caches name + injects into chat_topic |
| `test_group_topic_auto_discovery_serves_subsequent_messages` | cache serves subsequent normal messages |
| `test_group_topic_rename_updates_cache` | forum_topic_edited updates cache, freshest name wins |
| `test_group_topic_config_overrides_cache` | static config takes precedence over cache |
| `test_group_topic_context_field_appended` | context field appended to name with em-dash separator |
| `test_group_topic_context_field_without_name_falls_through` | context alone doesn't produce a topic |
| `test_group_topic_auto_discovery_does_not_affect_dm_topics` | group cache doesn't pollute DM cache |

All 47 tests in `test_dm_topics.py` pass. No regressions in related gateway test files (`test_session.py`, `test_telegram_bot_auth_bypass.py`, `test_telegram_channel_posts.py`, `test_telegram_reply_quote.py` — 161 tests total pass).

The 8 failures in the broader `tests/ -k telegram` run are pre-existing on `main` (verified by stashing this branch's changes and re-running) — unrelated to this PR.

## Cost impact

Negligible. The context line adds ~24 input tokens per session in a topic with name + context. At GLM 5.2 pricing that's ~$0.000019/session, or under $0.003/month for typical usage. Cache behaviour unchanged — the line is structurally identical to the existing `**Topic:**` injection.