### PR TITLE
fix: remove DASHSCOPE_API_KEY fallback from alibaba-coding-plan

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -330,7 +330,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="Alibaba Cloud (Coding Plan)",
         auth_type="api_key",
         inference_base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
-        api_key_env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY"),
+        api_key_env_vars=("ALIBABA_CODING_PLAN_API_KEY",),
         base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
     ),
     "minimax-cn": ProviderConfig(

--- a/plugins/model-providers/alibaba-coding-plan/__init__.py
+++ b/plugins/model-providers/alibaba-coding-plan/__init__.py
@@ -13,7 +13,7 @@ alibaba_coding_plan = ProviderProfile(
     display_name="Alibaba Cloud (Coding Plan)",
     description="Alibaba Cloud Coding Plan (Dedicated coding tier)",
     signup_url="https://help.aliyun.com/zh/model-studio/",
-    env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY", "ALIBABA_CODING_PLAN_BASE_URL"),
+    env_vars=("ALIBABA_CODING_PLAN_API_KEY", "ALIBABA_CODING_PLAN_BASE_URL"),
     base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
     auth_type="api_key",
 )

--- a/tests/hermes_cli/test_alibaba_coding_plan_provider_listing.py
+++ b/tests/hermes_cli/test_alibaba_coding_plan_provider_listing.py
@@ -1,0 +1,49 @@
+"""Test that alibaba-coding-plan requires its own key and does not fall back
+to DASHSCOPE_API_KEY.
+
+Regression for #70361: alibaba-coding-plan previously accepted
+DASHSCOPE_API_KEY as a valid credential (both in the plugin env_vars and the
+static auth.py registry), so it appeared as configured for users who only
+held a generic DashScope key. Coding Plan is a separate billing SKU with its
+own endpoint and must require ALIBABA_CODING_PLAN_API_KEY.
+"""
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+# -- Only DASHSCOPE_API_KEY set ---------------------------------------------
+
+
+@patch.dict(os.environ, {"DASHSCOPE_API_KEY": "sk-dashscope-fake"}, clear=False)
+def test_alibaba_coding_plan_hidden_when_only_dashscope_key_set():
+    """alibaba-coding-plan must NOT appear when only DASHSCOPE_API_KEY is set."""
+    providers = list_authenticated_providers(current_provider="alibaba")
+
+    # alibaba-coding-plan must NOT be listed (no dedicated key)
+    cp = next((p for p in providers if p["slug"] == "alibaba-coding-plan"), None)
+    assert cp is None, (
+        "alibaba-coding-plan should NOT appear when only DASHSCOPE_API_KEY is set"
+    )
+
+    # alibaba itself must still appear (DASHSCOPE_API_KEY belongs to it)
+    alibaba = next((p for p in providers if p["slug"] == "alibaba"), None)
+    assert alibaba is not None, (
+        "alibaba should appear when DASHSCOPE_API_KEY is set"
+    )
+
+
+# -- Only ALIBABA_CODING_PLAN_API_KEY set -----------------------------------
+
+
+@patch.dict(os.environ, {"ALIBABA_CODING_PLAN_API_KEY": "sk-cp-fake"}, clear=False)
+def test_alibaba_coding_plan_appears_when_own_key_set():
+    """alibaba-coding-plan should appear when ALIBABA_CODING_PLAN_API_KEY is set."""
+    providers = list_authenticated_providers(current_provider="alibaba-coding-plan")
+
+    cp = next((p for p in providers if p["slug"] == "alibaba-coding-plan"), None)
+    assert cp is not None, (
+        "alibaba-coding-plan should appear when ALIBABA_CODING_PLAN_API_KEY is set"
+    )

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -32,7 +32,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
 | **xAI Grok OAuth (SuperGrok)** | `hermes model` → "xAI Grok OAuth (SuperGrok / Premium+)" — browser login, no API key. See [guide](../guides/xai-grok-oauth.md) |
 | **Qwen Cloud (Alibaba DashScope)** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`) |
-| **Alibaba Cloud (Coding Plan)** | `DASHSCOPE_API_KEY` (provider: `alibaba-coding-plan`, alias: `alibaba_coding`) — separate billing SKU, different endpoint |
+| **Alibaba Cloud (Coding Plan)** | `ALIBABA_CODING_PLAN_API_KEY` in `~/.hermes/.env` (provider: `alibaba-coding-plan`, alias: `alibaba_coding`) — separate billing SKU, different endpoint |
 | **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |
 | **Xiaomi MiMo** | `XIAOMI_API_KEY` in `~/.hermes/.env` (provider: `xiaomi`, aliases: `mimo`, `xiaomi-mimo`) |
 | **Tencent TokenHub** | `TOKENHUB_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenhub`, aliases: `tencent`, `tokenhub`, `tencentmaas`) |
@@ -447,7 +447,7 @@ Or from the CLI:
 hermes chat --provider alibaba_coding --model qwen3-coder-plus
 ```
 
-`alibaba_coding` uses the same `DASHSCOPE_API_KEY` your `alibaba` entry already uses — no separate key needed, just a different routing target. Before this provider was registered, users who set `provider: alibaba_coding` in `config.yaml` silently fell through to OpenRouter routing.
+`alibaba_coding` uses its own `ALIBABA_CODING_PLAN_API_KEY` — Coding Plan is a separate billing SKU and does not accept the generic DashScope key. Before this provider was registered, users who set `provider: alibaba_coding` in `config.yaml` silently fell through to OpenRouter routing.
 
 ### MiniMax (OAuth)
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -76,7 +76,7 @@ Each entry requires both `provider` and `model`. Entries missing either field ar
 | Arcee AI | `arcee` | `ARCEEAI_API_KEY` |
 | GMI Cloud | `gmi` | `GMI_API_KEY` |
 | Alibaba / DashScope | `alibaba` | `DASHSCOPE_API_KEY` |
-| Alibaba Coding Plan | `alibaba-coding-plan` | `ALIBABA_CODING_PLAN_API_KEY` (falls back to `DASHSCOPE_API_KEY`) |
+| Alibaba Coding Plan | `alibaba-coding-plan` | `ALIBABA_CODING_PLAN_API_KEY` |
 | Kimi / Moonshot (China) | `kimi-coding-cn` | `KIMI_CN_API_KEY` |
 | StepFun | `stepfun` | `STEPFUN_API_KEY` |
 | Tencent TokenHub | `tencent-tokenhub` | `TOKENHUB_API_KEY` |


### PR DESCRIPTION
The alibaba-coding-plan provider incorrectly fell back to DASHSCOPE_API_KEY, causing it to appear as configured even when the user only has a generic DashScope key. Coding Plan is a separate billing product on Alibaba Cloud and requires its own API key.

This aligns alibaba-coding-plan with other isolated provider pairs like kimi-coding/kimi-coding-cn and minimax/minimax-cn.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)


## Changes Made

- `plugins/model-providers/alibaba-coding-plan/__init__.py`: remove `DASHSCOPE_API_KEY` from `env_vars`

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
