### PR TITLE
fix(tui): keep automatic compaction status visible for the whole operation (#70338)

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -195,6 +195,77 @@ describe('createGatewayEventHandler', () => {
     expect(ctx.system.sys).toHaveBeenCalledWith('compressing 968 messages (~123,400 tok)…')
   })
 
+  it('keeps automatic compaction status pinned beyond 4 seconds (#70338)', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const onEvent = createGatewayEventHandler(ctx)
+    const compactText = '🗜️ Compacting context — summarizing earlier conversation so I can continue...'
+
+    vi.useFakeTimers()
+
+    try {
+      onEvent({
+        payload: { kind: 'compacting', text: compactText },
+        type: 'status.update'
+      } as any)
+
+      expect(getUiState().status).toBe(compactText)
+
+      // Automatic compaction runs for tens of seconds to minutes. The label
+      // must NOT revert to generic activity after the 4s window that other
+      // transient statuses use — otherwise the operation looks frozen.
+      vi.advanceTimersByTime(4001)
+      expect(getUiState().status).toBe(compactText)
+
+      vi.advanceTimersByTime(120_000)
+      expect(getUiState().status).toBe(compactText)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('replaces the compaction status when normal activity resumes (#70338)', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const onEvent = createGatewayEventHandler(ctx)
+
+    vi.useFakeTimers()
+
+    try {
+      onEvent({
+        payload: { kind: 'compacting', text: '🗜️ Compacting context…' },
+        type: 'status.update'
+      } as any)
+      expect(getUiState().status).toBe('🗜️ Compacting context…')
+
+      // A later status event (compaction finished, model resumed) replaces the
+      // pinned label — it must not linger stale.
+      onEvent({
+        payload: { kind: 'status', text: 'thinking…' },
+        type: 'status.update'
+      } as any)
+      expect(getUiState().status).toBe('thinking…')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not add a transcript line for automatic compaction, unlike manual compress (#70338)', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({
+      payload: { kind: 'compacting', text: '🗜️ Compacting context…' },
+      type: 'status.update'
+    } as any)
+
+    // Manual '/compress' (compressing) pushes a transcript line; automatic
+    // compaction can fire every turn on a large session, so it must not.
+    expect(ctx.system.sys).not.toHaveBeenCalled()
+    expect(getUiState().status).toBe('🗜️ Compacting context…')
+  })
+
   it('keeps goal verdict text in transcript but shows a brief idle status (#goal statusbar)', () => {
     const appended: Msg[] = []
     const ctx = buildCtx(appended)

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -793,6 +793,18 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           return
         }
 
+        // Automatic compaction (kind='compacting') runs for tens of seconds to
+        // minutes. Keep its explanatory label pinned for the whole operation
+        // instead of reverting to generic activity after the 4s window other
+        // transient statuses use (#70338) — otherwise a healthy long-running
+        // compaction looks frozen. The next status/content event on resume
+        // replaces it. Unlike manual '/compress' (compressing) we do NOT also
+        // push a transcript line: automatic compaction can fire on many turns
+        // of a large session and would be noisy.
+        if (p.kind === 'compacting') {
+          return
+        }
+
         if (!p.kind || p.kind === 'status') {
           return
         }


### PR DESCRIPTION
## What
During automatic preflight/mid-turn context compaction the Ink TUI briefly shows a useful `🗜️ Compacting context — summarizing…` status, then replaces it with a generic status after ~4s — even though automatic compaction routinely runs for tens of seconds to minutes. A healthy long-running compaction therefore looks frozen, with no persistent indication that Hermes is compacting rather than stalled. Fixes #70338.

## Fix
`createGatewayEventHandler` only pinned `kind='compressing'` (manual `/compress`); an automatic `kind='compacting'` event fell through to the generic activity path and got `restoreStatusAfter(4000)`, reverting the label after four seconds.

Treat `kind='compacting'` as a first-class long-running status: keep its label pinned until the next status/content event on resume replaces it, mirroring `'compressing'`. Unlike manual `/compress` it does **not** also push a transcript line, since automatic compaction can fire on many turns of a large session and would be noisy. Existing `'compressing'` behavior is unchanged.

## Tests
- New event-handler tests (fake timers): `'compacting'` stays pinned past 4s and past 120s; a later status event replaces it on resume; no transcript line is pushed for automatic compaction.
- `vitest run src/__tests__/createGatewayEventHandler.test.ts` -> 92 passed. Mutation check: disabling the new branch makes the >4s test fail (status reverts to `ready`), confirming the fix is exercised.
- Verified on Ubuntu 24.04.
