### PR TITLE
feat(voice): add realtime provider architecture

### DIFF
--- a/agent/realtime_voice_provider.py
+++ b/agent/realtime_voice_provider.py
@@ -1,0 +1,201 @@
+"""
+Realtime Voice Provider ABC
+===========================
+
+Defines the provider-neutral contract for low-latency, bidirectional voice
+sessions. Realtime voice is intentionally separate from
+:mod:`agent.transports`: model transports execute one request/response turn,
+while a realtime session is a long-lived async channel carrying audio, text,
+tool calls, interruptions, and lifecycle events.
+
+Providers own their wire protocol and SDK. OpenAI Realtime, Gemini Live, and
+future backends translate native events into the small event envelope below;
+provider-specific state stays under ``provider_data`` instead of leaking into
+Hermes callers.
+
+Event contract
+--------------
+:meth:`RealtimeVoiceSession.events` yields dictionaries with a required
+``type`` string. Shared event names are:
+
+``session.started`` / ``session.updated`` / ``session.closed``
+    Session lifecycle.
+``input.transcript.delta`` / ``input.transcript.done``
+    User speech transcription in ``text``.
+``output.text.delta`` / ``output.text.done``
+    Assistant text in ``text``.
+``output.audio.delta`` / ``output.audio.done``
+    Assistant audio bytes in ``audio``.
+``tool.call``
+    Tool request in ``tool_call`` with ``id``, ``name``, and ``arguments``.
+``turn.done`` / ``interrupted`` / ``error``
+    Turn completion, barge-in, and failure signals.
+
+Unknown provider-native fields belong in ``provider_data``. New normalized
+event names may be added without changing the provider API version.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+REALTIME_VOICE_PROVIDER_API_VERSION = 1
+
+RealtimeVoiceEvent = Dict[str, Any]
+
+
+class RealtimeVoiceSession(abc.ABC):
+    """One connected bidirectional voice session.
+
+    Implementations may use WebSocket, WebRTC, an SDK-managed connection, or
+    another transport. Callers interact only through normalized methods and
+    events, so transport changes remain provider-local.
+    """
+
+    async def __aenter__(self) -> "RealtimeVoiceSession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        await self.close()
+
+    @abc.abstractmethod
+    async def send_audio(
+        self,
+        audio: bytes,
+        *,
+        mime_type: Optional[str] = None,
+    ) -> None:
+        """Send one audio chunk.
+
+        ``mime_type`` describes the chunk when the provider needs an explicit
+        format (for example ``audio/pcm;rate=16000``). Providers with a
+        session-level or negotiated format may ignore it.
+        """
+
+    @abc.abstractmethod
+    async def send_text(self, text: str, *, end_of_turn: bool = True) -> None:
+        """Send text input, optionally marking the end of the user turn."""
+
+    async def commit_audio(self) -> None:
+        """Commit buffered audio when the provider requires it.
+
+        Default is a no-op for server-VAD and continuously streamed sessions.
+        """
+
+    @abc.abstractmethod
+    async def send_tool_result(
+        self,
+        call_id: str,
+        output: Any,
+        *,
+        name: Optional[str] = None,
+    ) -> None:
+        """Return a tool result to the active realtime conversation."""
+
+    async def interrupt(self) -> None:
+        """Cancel current assistant output when explicit cancellation exists.
+
+        Providers that only support automatic voice-activity interruption may
+        keep the default and let incoming audio trigger barge-in.
+        """
+        raise NotImplementedError(
+            f"Realtime voice session {type(self).__name__!r} does not support "
+            "explicit interruption"
+        )
+
+    @abc.abstractmethod
+    def events(self) -> AsyncIterator[RealtimeVoiceEvent]:
+        """Return the normalized async event stream for this session."""
+
+    @abc.abstractmethod
+    async def close(self) -> None:
+        """Close the session and release all transport resources."""
+
+
+class RealtimeVoiceProvider(abc.ABC):
+    """Abstract factory and metadata surface for realtime voice sessions."""
+
+    api_version: int = REALTIME_VOICE_PROVIDER_API_VERSION
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Stable short identifier used by the realtime voice registry."""
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable provider label."""
+        return self.name.title()
+
+    def is_available(self) -> bool:
+        """Return whether credentials and optional dependencies are ready.
+
+        Must not raise; setup and picker surfaces call this for diagnostics.
+        """
+        return True
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        """Return model catalog entries; each entry requires an ``id``."""
+        return []
+
+    def list_voices(self) -> List[Dict[str, Any]]:
+        """Return voice catalog entries; each entry requires an ``id``."""
+        return []
+
+    def default_model(self) -> Optional[str]:
+        """Return the default model id, or ``None`` when provider-defined."""
+        models = self.list_models()
+        if models:
+            return models[0].get("id")
+        return None
+
+    def default_voice(self) -> Optional[str]:
+        """Return the default voice id, or ``None`` when provider-defined."""
+        voices = self.list_voices()
+        if voices:
+            return voices[0].get("id")
+        return None
+
+    def get_capabilities(self) -> Dict[str, Any]:
+        """Return stable feature metadata for host capability negotiation.
+
+        Providers override only supported features. ``transports`` describes
+        provider-owned wire transports, not Hermes model transports.
+        """
+        return {
+            "input_modalities": [],
+            "output_modalities": [],
+            "transports": [],
+            "tool_calling": False,
+            "input_transcription": False,
+            "output_transcription": False,
+            "interruption": False,
+            "session_resumption": False,
+        }
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        """Return provider metadata for a future setup/picker surface."""
+        return {
+            "name": self.display_name,
+            "badge": "",
+            "tag": "",
+            "env_vars": [],
+        }
+
+    @abc.abstractmethod
+    async def open_session(
+        self,
+        *,
+        model: Optional[str] = None,
+        voice: Optional[str] = None,
+        instructions: Optional[str] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        **extra: Any,
+    ) -> RealtimeVoiceSession:
+        """Open and return a connected realtime voice session.
+
+        Providers translate host tool definitions and session options into
+        their native protocol. Provider-specific options travel through
+        ``extra`` so adding a vendor feature does not widen the shared ABC.
+        """

--- a/agent/realtime_voice_registry.py
+++ b/agent/realtime_voice_registry.py
@@ -1,0 +1,117 @@
+"""
+Realtime Voice Provider Registry
+================================
+
+Central registry for :class:`agent.realtime_voice_provider.RealtimeVoiceProvider`.
+Built-in providers and plugin providers use the same contract. A built-in
+registration always wins its name; plugins may replace other plugin providers
+to keep development reloads predictable.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Dict, List, Optional, Set
+
+from agent.realtime_voice_provider import (
+    REALTIME_VOICE_PROVIDER_API_VERSION,
+    RealtimeVoiceProvider,
+)
+
+logger = logging.getLogger(__name__)
+
+_providers: Dict[str, RealtimeVoiceProvider] = {}
+_built_in_names: Set[str] = set()
+_lock = threading.Lock()
+
+
+def register_provider(
+    provider: RealtimeVoiceProvider,
+    *,
+    built_in: bool = False,
+) -> bool:
+    """Register a realtime voice provider.
+
+    Returns ``True`` when accepted. Built-ins replace an earlier plugin with
+    the same normalized name. Plugin registrations cannot replace a built-in.
+    """
+    if not isinstance(provider, RealtimeVoiceProvider):
+        raise TypeError(
+            "register_provider() expects a RealtimeVoiceProvider instance, "
+            f"got {type(provider).__name__}"
+        )
+
+    name = provider.name
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("Realtime voice provider .name must be a non-empty string")
+    key = name.strip().lower()
+
+    api_version = getattr(provider, "api_version", None)
+    if api_version != REALTIME_VOICE_PROVIDER_API_VERSION:
+        logger.warning(
+            "Realtime voice provider '%s' targets API v%s; Hermes supports v%s. "
+            "Registration ignored.",
+            key,
+            api_version,
+            REALTIME_VOICE_PROVIDER_API_VERSION,
+        )
+        return False
+
+    with _lock:
+        if not built_in and key in _built_in_names:
+            logger.warning(
+                "Realtime voice provider '%s' shadows a built-in name; "
+                "registration ignored. Built-in providers always win.",
+                key,
+            )
+            return False
+
+        existing = _providers.get(key)
+        if built_in:
+            _built_in_names.add(key)
+        _providers[key] = provider
+
+    if existing is not None:
+        logger.debug(
+            "Realtime voice provider '%s' re-registered (was %r)",
+            key,
+            type(existing).__name__,
+        )
+    else:
+        logger.debug(
+            "Registered realtime voice provider '%s' (%s)",
+            key,
+            type(provider).__name__,
+        )
+    return True
+
+
+def list_providers() -> List[RealtimeVoiceProvider]:
+    """Return registered providers sorted by normalized name."""
+    with _lock:
+        items = list(_providers.items())
+    return [provider for _, provider in sorted(items)]
+
+
+def get_provider(name: str) -> Optional[RealtimeVoiceProvider]:
+    """Return a provider by case-insensitive, whitespace-tolerant name."""
+    if not isinstance(name, str):
+        return None
+    with _lock:
+        return _providers.get(name.strip().lower())
+
+
+def is_builtin_provider(name: str) -> bool:
+    """Return whether *name* is reserved by an active built-in provider."""
+    if not isinstance(name, str):
+        return False
+    with _lock:
+        return name.strip().lower() in _built_in_names
+
+
+def _reset_for_tests() -> None:
+    """Clear all providers and built-in reservations. Test-only."""
+    with _lock:
+        _providers.clear()
+        _built_in_names.clear()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -926,6 +926,38 @@ class PluginContext:
             self.manifest.name, provider.name,
         )
 
+    # -- realtime voice provider registration -------------------------------
+
+    def register_realtime_voice_provider(self, provider) -> None:
+        """Register a bidirectional realtime voice backend.
+
+        ``provider`` must inherit from
+        :class:`agent.realtime_voice_provider.RealtimeVoiceProvider` and match
+        the host provider API version. The provider owns its SDK, wire
+        protocol, and session lifecycle; Hermes consumes only normalized
+        audio, text, tool-call, interruption, and lifecycle events.
+
+        Built-in providers always win name collisions. This keeps OpenAI
+        Realtime and future first-party integrations stable while allowing
+        Gemini Live and other engines to use the same extension surface.
+        """
+        from agent.realtime_voice_provider import RealtimeVoiceProvider
+        from agent.realtime_voice_registry import register_provider
+
+        if not isinstance(provider, RealtimeVoiceProvider):
+            logger.warning(
+                "Plugin '%s' tried to register a realtime voice provider that "
+                "does not inherit from RealtimeVoiceProvider. Ignoring.",
+                self.manifest.name,
+            )
+            return
+        if register_provider(provider):
+            logger.info(
+                "Plugin '%s' registered realtime voice provider: %s",
+                self.manifest.name,
+                provider.name,
+            )
+
     # -- platform adapter registration ---------------------------------------
 
     def register_platform(

--- a/tests/agent/test_realtime_voice_registry.py
+++ b/tests/agent/test_realtime_voice_registry.py
@@ -1,0 +1,209 @@
+"""Behavior tests for the realtime voice provider contract and registry."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agent import realtime_voice_registry
+from agent.realtime_voice_provider import (
+    RealtimeVoiceProvider,
+    RealtimeVoiceSession,
+)
+
+
+class _FakeSession(RealtimeVoiceSession):
+    def __init__(self):
+        self.closed = False
+
+    async def send_audio(self, audio, *, mime_type=None):
+        return None
+
+    async def send_text(self, text, *, end_of_turn=True):
+        return None
+
+    async def send_tool_result(self, call_id, output, *, name=None):
+        return None
+
+    def events(self):
+        async def _stream():
+            yield {"type": "session.started"}
+
+        return _stream()
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeProvider(RealtimeVoiceProvider):
+    def __init__(self, name="fake", display=None):
+        self._name = name
+        self._display = display
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def display_name(self):
+        return self._display or super().display_name
+
+    async def open_session(self, **kwargs):
+        return _FakeSession()
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    realtime_voice_registry._reset_for_tests()
+    yield
+    realtime_voice_registry._reset_for_tests()
+
+
+class TestRegistration:
+    def test_rejects_non_provider_type(self):
+        with pytest.raises(TypeError, match="RealtimeVoiceProvider"):
+            realtime_voice_registry.register_provider(object())  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("name", ["", " ", "\t"])
+    def test_rejects_empty_name(self, name):
+        with pytest.raises(ValueError, match="non-empty"):
+            realtime_voice_registry.register_provider(_FakeProvider(name=name))
+
+    def test_rejects_incompatible_api_version(self, caplog):
+        provider = _FakeProvider(name="future")
+        provider.api_version = 999
+
+        with caplog.at_level(logging.WARNING, logger="agent.realtime_voice_registry"):
+            accepted = realtime_voice_registry.register_provider(provider)
+
+        assert accepted is False
+        assert realtime_voice_registry.get_provider("future") is None
+        assert "targets API v999" in caplog.text
+
+    def test_plugin_reregistration_replaces_plugin(self):
+        first = _FakeProvider(name="custom")
+        second = _FakeProvider(name="custom")
+
+        assert realtime_voice_registry.register_provider(first) is True
+        assert realtime_voice_registry.register_provider(second) is True
+        assert realtime_voice_registry.get_provider("custom") is second
+
+    def test_builtin_replaces_plugin_and_cannot_be_shadowed(self, caplog):
+        plugin = _FakeProvider(name="openai")
+        built_in = _FakeProvider(name="openai")
+        shadow = _FakeProvider(name=" OPENAI ")
+
+        assert realtime_voice_registry.register_provider(plugin) is True
+        assert realtime_voice_registry.register_provider(built_in, built_in=True) is True
+        assert realtime_voice_registry.get_provider("openai") is built_in
+        assert realtime_voice_registry.is_builtin_provider(" OpenAI ") is True
+
+        with caplog.at_level(logging.WARNING, logger="agent.realtime_voice_registry"):
+            accepted = realtime_voice_registry.register_provider(shadow)
+
+        assert accepted is False
+        assert realtime_voice_registry.get_provider("openai") is built_in
+        assert "Built-in providers always win" in caplog.text
+
+
+class TestLookup:
+    def test_lookup_normalizes_case_and_whitespace(self):
+        provider = _FakeProvider(name="gemini")
+        realtime_voice_registry.register_provider(provider)
+
+        assert realtime_voice_registry.get_provider(" GEMINI ") is provider
+
+    def test_non_string_lookup_is_missing(self):
+        assert realtime_voice_registry.get_provider(None) is None  # type: ignore[arg-type]
+        assert realtime_voice_registry.is_builtin_provider(None) is False  # type: ignore[arg-type]
+
+    def test_list_is_sorted_by_normalized_registry_name(self):
+        realtime_voice_registry.register_provider(_FakeProvider(name="zylo"))
+        realtime_voice_registry.register_provider(_FakeProvider(name="Alpha"))
+        realtime_voice_registry.register_provider(_FakeProvider(name="middle"))
+
+        assert [provider.name for provider in realtime_voice_registry.list_providers()] == [
+            "Alpha",
+            "middle",
+            "zylo",
+        ]
+
+
+class TestProviderContract:
+    def test_requires_name(self):
+        class Incomplete(RealtimeVoiceProvider):
+            async def open_session(self, **kwargs):
+                return _FakeSession()
+
+        with pytest.raises(TypeError, match="abstract"):
+            Incomplete()  # type: ignore[abstract]
+
+    def test_requires_open_session(self):
+        class Incomplete(RealtimeVoiceProvider):
+            @property
+            def name(self):
+                return "incomplete"
+
+        with pytest.raises(TypeError, match="abstract"):
+            Incomplete()  # type: ignore[abstract]
+
+    def test_defaults_are_safe_and_provider_neutral(self):
+        provider = _FakeProvider(name="openai-realtime")
+
+        assert provider.display_name == "Openai-Realtime"
+        assert provider.is_available() is True
+        assert provider.default_model() is None
+        assert provider.default_voice() is None
+        assert provider.get_capabilities()["tool_calling"] is False
+        assert provider.get_capabilities()["transports"] == []
+        assert provider.get_setup_schema()["env_vars"] == []
+
+    def test_defaults_follow_provider_catalog_order(self):
+        class CatalogProvider(_FakeProvider):
+            def list_models(self):
+                return [{"id": "primary"}, {"id": "fallback"}]
+
+            def list_voices(self):
+                return [{"id": "alloy"}, {"id": "verse"}]
+
+        provider = CatalogProvider()
+        assert provider.default_model() == "primary"
+        assert provider.default_voice() == "alloy"
+
+
+class TestSessionContract:
+    def test_requires_core_lifecycle_methods(self):
+        class Incomplete(RealtimeVoiceSession):
+            pass
+
+        with pytest.raises(TypeError, match="abstract"):
+            Incomplete()  # type: ignore[abstract]
+
+    @pytest.mark.asyncio
+    async def test_async_context_closes_session(self):
+        session = _FakeSession()
+
+        async with session as active:
+            assert active is session
+
+        assert session.closed is True
+
+    @pytest.mark.asyncio
+    async def test_optional_audio_commit_is_noop(self):
+        session = _FakeSession()
+        assert await session.commit_audio() is None
+
+    @pytest.mark.asyncio
+    async def test_explicit_interruption_is_opt_in(self):
+        session = _FakeSession()
+
+        with pytest.raises(NotImplementedError, match="explicit interruption"):
+            await session.interrupt()
+
+    @pytest.mark.asyncio
+    async def test_event_stream_uses_normalized_envelope(self):
+        session = _FakeSession()
+        events = [event async for event in session.events()]
+
+        assert events == [{"type": "session.started"}]

--- a/tests/hermes_cli/test_plugins_realtime_voice_registration.py
+++ b/tests/hermes_cli/test_plugins_realtime_voice_registration.py
@@ -1,0 +1,154 @@
+"""End-to-end tests for PluginContext.register_realtime_voice_provider()."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def _write_plugin(
+    root: Path,
+    name: str,
+    *,
+    manifest_extra: Dict[str, Any] | None = None,
+    register_body: str = "pass",
+) -> Path:
+    plugin_dir = root / name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "name": name,
+        "version": "0.1.0",
+        "description": f"Test plugin {name}",
+    }
+    if manifest_extra:
+        manifest.update(manifest_extra)
+    (plugin_dir / "plugin.yaml").write_text(yaml.dump(manifest))
+    (plugin_dir / "__init__.py").write_text(
+        f"def register(ctx):\n    {register_body}\n"
+    )
+    return plugin_dir
+
+
+def _enable(hermes_home: Path, name: str) -> None:
+    cfg_path = hermes_home / "config.yaml"
+    cfg: dict = {}
+    if cfg_path.exists():
+        try:
+            cfg = yaml.safe_load(cfg_path.read_text()) or {}
+        except Exception:
+            cfg = {}
+    plugins_cfg = cfg.setdefault("plugins", {})
+    enabled = plugins_cfg.setdefault("enabled", [])
+    if isinstance(enabled, list) and name not in enabled:
+        enabled.append(name)
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+
+class TestRegisterRealtimeVoiceProvider:
+    def test_accepts_valid_provider(self):
+        from hermes_cli.plugins import PluginManager
+
+        from agent import realtime_voice_registry
+
+        realtime_voice_registry._reset_for_tests()
+        hermes_home = Path(os.environ["HERMES_HOME"])
+        _write_plugin(
+            hermes_home / "plugins",
+            "my-realtime-plugin",
+            register_body=(
+                "from agent.realtime_voice_provider import RealtimeVoiceProvider, RealtimeVoiceSession\n"
+                "    class S(RealtimeVoiceSession):\n"
+                "        async def send_audio(self, audio, **kw): pass\n"
+                "        async def send_text(self, text, **kw): pass\n"
+                "        async def send_tool_result(self, call_id, output, **kw): pass\n"
+                "        def events(self):\n"
+                "            async def stream():\n"
+                "                if False: yield {}\n"
+                "            return stream()\n"
+                "        async def close(self): pass\n"
+                "    class P(RealtimeVoiceProvider):\n"
+                "        @property\n"
+                "        def name(self): return 'fake-realtime'\n"
+                "        async def open_session(self, **kw): return S()\n"
+                "    ctx.register_realtime_voice_provider(P())"
+            ),
+        )
+        _enable(hermes_home, "my-realtime-plugin")
+
+        manager = PluginManager()
+        manager.discover_and_load()
+
+        assert manager._plugins["my-realtime-plugin"].enabled is True, (
+            f"Plugin failed to load: {manager._plugins['my-realtime-plugin'].error}"
+        )
+        assert realtime_voice_registry.get_provider("fake-realtime") is not None
+
+        realtime_voice_registry._reset_for_tests()
+
+    def test_rejects_non_provider(self, caplog):
+        from hermes_cli.plugins import PluginManager
+
+        from agent import realtime_voice_registry
+
+        realtime_voice_registry._reset_for_tests()
+        hermes_home = Path(os.environ["HERMES_HOME"])
+        _write_plugin(
+            hermes_home / "plugins",
+            "bad-realtime-plugin",
+            register_body="ctx.register_realtime_voice_provider('not a provider')",
+        )
+        _enable(hermes_home, "bad-realtime-plugin")
+
+        with caplog.at_level("WARNING"):
+            manager = PluginManager()
+            manager.discover_and_load()
+
+        assert manager._plugins["bad-realtime-plugin"].enabled is True
+        assert realtime_voice_registry.list_providers() == []
+        assert "does not inherit from RealtimeVoiceProvider" in caplog.text
+
+        realtime_voice_registry._reset_for_tests()
+
+    def test_rejects_incompatible_provider_api(self, caplog):
+        from hermes_cli.plugins import PluginManager
+
+        from agent import realtime_voice_registry
+
+        realtime_voice_registry._reset_for_tests()
+        hermes_home = Path(os.environ["HERMES_HOME"])
+        _write_plugin(
+            hermes_home / "plugins",
+            "old-realtime-plugin",
+            register_body=(
+                "from agent.realtime_voice_provider import RealtimeVoiceProvider, RealtimeVoiceSession\n"
+                "    class S(RealtimeVoiceSession):\n"
+                "        async def send_audio(self, audio, **kw): pass\n"
+                "        async def send_text(self, text, **kw): pass\n"
+                "        async def send_tool_result(self, call_id, output, **kw): pass\n"
+                "        def events(self):\n"
+                "            async def stream():\n"
+                "                if False: yield {}\n"
+                "            return stream()\n"
+                "        async def close(self): pass\n"
+                "    class P(RealtimeVoiceProvider):\n"
+                "        api_version = 0\n"
+                "        @property\n"
+                "        def name(self): return 'old-realtime'\n"
+                "        async def open_session(self, **kw): return S()\n"
+                "    ctx.register_realtime_voice_provider(P())"
+            ),
+        )
+        _enable(hermes_home, "old-realtime-plugin")
+
+        with caplog.at_level("WARNING"):
+            manager = PluginManager()
+            manager.discover_and_load()
+
+        assert manager._plugins["old-realtime-plugin"].enabled is True
+        assert realtime_voice_registry.get_provider("old-realtime") is None
+        assert "targets API v0" in caplog.text
+
+        realtime_voice_registry._reset_for_tests()


### PR DESCRIPTION
## Summary

- add a versioned `RealtimeVoiceProvider` / `RealtimeVoiceSession` contract for long-lived bidirectional audio sessions
- add a thread-safe registry with deterministic built-in-over-plugin precedence
- expose `PluginContext.register_realtime_voice_provider()` for provider extensions
- cover registry invariants, async session lifecycle, API compatibility, and real plugin discovery

## Architecture

Realtime voice is intentionally separate from `ProviderTransport`: current transports model one request/response turn, while Realtime/Live APIs maintain an async session carrying audio, text, tool calls, interruptions, and lifecycle events.

Provider SDK and wire details stay behind the provider/session ABC. Hermes receives normalized event envelopes; provider-native data remains under `provider_data`. This avoids adding `api_mode="realtime"`, changing the core agent loop, growing the model tool schema, or invalidating conversation prompt caches.

The registry already supports built-in name precedence so the planned OpenAI Realtime implementation can claim `openai` without creating a second dispatch path. Gemini Live and later providers can implement the same session contract without widening the shared surface.

## Non-goals

- no concrete provider implementation yet
- no `config.yaml`, setup UI, or credential changes
- no desktop/avatar integration
- no changes to `run_agent.py`, `model_tools.py`, or `toolsets.py`

## Follow-ups

1. OpenAI Realtime provider implementation
2. desktop/gateway realtime session orchestration
3. Gemini Live provider implementation
4. avatar surface integration

## Validation

- `104 passed` across realtime, TTS, STT, and plugin registration suites
- `ruff check` passed for changed files
- `ty check agent/realtime_voice_provider.py agent/realtime_voice_registry.py` passed
- `git diff --check` passed