### PR TITLE
fix(runtime): harden image and ACP boundaries

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -577,7 +577,12 @@ def init_agent(
     )
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
-    agent.acp_args = list(acp_args or args or [])
+    if acp_args is not None:
+        agent.acp_args = list(acp_args)
+    elif args is not None:
+        agent.acp_args = list(args)
+    else:
+        agent.acp_args = None
     if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -18,6 +18,10 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
+from agent.image_data_url import (
+    INVALID_IMAGE_ATTACHMENT_NOTE,
+    sanitize_image_data_url,
+)
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 
 logger = logging.getLogger(__name__)
@@ -120,7 +124,19 @@ def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> Lis
                 url = image_ref
             if not isinstance(url, str) or not url:
                 continue
-            image_part: Dict[str, Any] = {"type": "input_image", "image_url": url}
+            sanitized_url, removed = sanitize_image_data_url(url)
+            if removed:
+                converted.append({
+                    "type": text_type,
+                    "text": INVALID_IMAGE_ATTACHMENT_NOTE,
+                })
+                continue
+            if not isinstance(sanitized_url, str) or not sanitized_url:
+                continue
+            image_part: Dict[str, Any] = {
+                "type": "input_image",
+                "image_url": sanitized_url,
+            }
             if isinstance(detail, str) and detail.strip():
                 image_part["detail"] = detail.strip()
             converted.append(image_part)
@@ -797,7 +813,19 @@ def _preflight_codex_input_items(
                             url = image_ref
                         if not isinstance(url, str):
                             url = str(url or "")
-                        image_part: Dict[str, Any] = {"type": "input_image", "image_url": url}
+                        sanitized_url, removed = sanitize_image_data_url(url)
+                        if removed:
+                            validated.append({
+                                "type": text_type,
+                                "text": INVALID_IMAGE_ATTACHMENT_NOTE,
+                            })
+                            continue
+                        if not isinstance(sanitized_url, str) or not sanitized_url:
+                            continue
+                        image_part: Dict[str, Any] = {
+                            "type": "input_image",
+                            "image_url": sanitized_url,
+                        }
                         if isinstance(detail, str) and detail.strip():
                             image_part["detail"] = detail.strip()
                         validated.append(image_part)

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -413,7 +413,12 @@ class CopilotACPClient:
         self.base_url = base_url or ACP_MARKER_BASE_URL
         self._default_headers = dict(default_headers or {})
         self._acp_command = acp_command or command or _resolve_command()
-        self._acp_args = list(acp_args or args or _resolve_args())
+        if acp_args is not None:
+            self._acp_args = list(acp_args)
+        elif args is not None:
+            self._acp_args = list(args)
+        else:
+            self._acp_args = _resolve_args()
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False

--- a/agent/image_data_url.py
+++ b/agent/image_data_url.py
@@ -1,0 +1,113 @@
+"""Helpers for validating and sanitizing image data URLs.
+
+Native multimodal routing stores local images as ``data:image/*;base64,...``
+URLs.  Providers validate those payloads strictly; a malformed or truncated
+image in persisted history can make every subsequent turn fail with a
+non-retryable HTTP 400.  Keep this module small and side-effect free so provider
+adapters can sanitize per-call copies without mutating persisted sessions.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+from typing import Optional, Tuple
+
+
+INVALID_IMAGE_ATTACHMENT_NOTE = "[Invalid image attachment removed before API call]"
+
+_DATA_IMAGE_RE = re.compile(r"^data:(image/[A-Za-z0-9.+-]+)(?:;[^,]*)?;base64,", re.IGNORECASE)
+
+
+def detect_image_mime(data: bytes) -> Optional[str]:
+    """Return the MIME type implied by known image magic bytes, if any."""
+    if not isinstance(data, (bytes, bytearray)) or len(data) < 2:
+        return None
+    raw = bytes(data)
+    if raw.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if raw.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if raw.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if len(raw) >= 12 and raw[:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "image/webp"
+    if raw.startswith(b"BM"):
+        return "image/bmp"
+    return None
+
+
+def is_supported_image_bytes(data: bytes) -> bool:
+    """True when *data* starts with a supported image magic-byte sequence."""
+    return detect_image_mime(data) is not None
+
+
+def _decode_base64_payload(payload: str) -> Optional[bytes]:
+    compact = "".join(str(payload or "").split())
+    if not compact:
+        return None
+    # Data URLs in the wild sometimes omit padding.  Accept that while keeping
+    # ``validate=True`` so non-base64 characters do not slip through.
+    compact += "=" * (-len(compact) % 4)
+    try:
+        return base64.b64decode(compact, validate=True)
+    except Exception:
+        return None
+
+
+def parse_image_data_url(url: str) -> Optional[Tuple[str, bytes, str]]:
+    """Parse a base64 image data URL into ``(declared_mime, bytes, payload)``.
+
+    Returns ``None`` when the URL is not a syntactically valid image data URL.
+    """
+    if not isinstance(url, str):
+        return None
+    match = _DATA_IMAGE_RE.match(url.strip())
+    if not match:
+        return None
+    declared_mime = match.group(1).lower()
+    payload = url.strip()[match.end():]
+    decoded = _decode_base64_payload(payload)
+    if decoded is None:
+        return None
+    return declared_mime, decoded, payload
+
+
+def sanitize_image_data_url(url: str) -> Tuple[Optional[str], bool]:
+    """Return ``(sanitized_url, removed)`` for an image URL value.
+
+    - Non-data URLs are returned unchanged.
+    - Valid image data URLs are returned unchanged unless the declared MIME does
+      not match the bytes, in which case only the MIME prefix is normalized.
+    - Malformed/unsupported image data URLs return ``(None, True)`` so callers
+      can replace them with a textual note instead of sending bad payloads to a
+      provider.
+    """
+    if not isinstance(url, str) or not url:
+        return url if isinstance(url, str) else None, False
+
+    stripped = url.strip()
+    if not stripped.lower().startswith("data:image/"):
+        return url, False
+
+    parsed = parse_image_data_url(stripped)
+    if parsed is None:
+        return None, True
+
+    declared_mime, decoded, payload = parsed
+    actual_mime = detect_image_mime(decoded)
+    if actual_mime is None:
+        return None, True
+
+    if declared_mime != actual_mime:
+        return f"data:{actual_mime};base64,{payload}", False
+    return stripped, False
+
+
+__all__ = [
+    "INVALID_IMAGE_ATTACHMENT_NOTE",
+    "detect_image_mime",
+    "is_supported_image_bytes",
+    "parse_image_data_url",
+    "sanitize_image_data_url",
+]

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -684,9 +684,9 @@ def _file_to_data_url(path: Path) -> Optional[str]:
 
     Returns None if the file can't be read OR if the format isn't
     universally supported AND Pillow can't transcode it (Pillow missing,
-    HEIC/AVIF plugin missing, vector format like SVG, corrupt bytes). The
-    caller reports those paths in ``skipped`` and the rest of the turn
-    proceeds.
+    HEIC/AVIF plugin missing, vector format like SVG, corrupt bytes), or if
+    the file does not start with recognized image magic bytes. The caller
+    reports those paths in ``skipped`` and the rest of the turn proceeds.
     """
     try:
         from agent.file_safety import raise_if_read_blocked
@@ -704,7 +704,14 @@ def _file_to_data_url(path: Path) -> Optional[str]:
     except Exception as exc:
         logger.warning("image_routing: failed to read %s — %s", path, exc)
         return None
-    mime = _guess_mime(path, raw=raw)
+    mime = _sniff_mime_from_bytes(raw)
+    if mime is None:
+        logger.warning(
+            "image_routing: skipping invalid image bytes at %s (size=%d)",
+            path,
+            len(raw),
+        )
+        return None
     if mime not in _UNIVERSALLY_SUPPORTED_MIMES:
         transcoded = _transcode_to_png(raw)
         if transcoded is None:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -22,6 +22,27 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
     def setUp(self) -> None:
         self.client = CopilotACPClient(acp_cwd="/tmp")
 
+    def test_empty_acp_args_are_preserved(self) -> None:
+        client = CopilotACPClient(
+            acp_command="custom-acp",
+            acp_args=[],
+            acp_cwd="/tmp",
+        )
+
+        self.assertEqual(client._acp_args, [])
+
+    def test_omitted_acp_args_still_use_resolved_defaults(self) -> None:
+        with patch(
+            "agent.copilot_acp_client._resolve_args",
+            return_value=["--acp", "--stdio"],
+        ):
+            client = CopilotACPClient(
+                acp_command="custom-acp",
+                acp_cwd="/tmp",
+            )
+
+        self.assertEqual(client._acp_args, ["--acp", "--stdio"])
+
     def test_extracted_tool_calls_match_openai_sdk_shape(self) -> None:
         tool_response = (
             "I'll inspect that.\n"

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 
+from agent.image_data_url import detect_image_mime, sanitize_image_data_url
 from agent.image_routing import (
     _coerce_capability_bool,
     _coerce_mode,
@@ -394,6 +395,35 @@ def _png_bytes() -> bytes:
     )
 
 
+def _jpeg_bytes() -> bytes:
+    """Return minimal JPEG-like bytes with a valid magic-byte prefix."""
+    return b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x01" + b"\x00" * 16
+
+
+def test_valid_png_and_jpeg_data_urls_pass_validation():
+    png_url = "data:image/png;base64," + base64.b64encode(
+        _png_bytes()
+    ).decode("ascii")
+    jpeg_url = "data:image/jpeg;base64," + base64.b64encode(
+        _jpeg_bytes()
+    ).decode("ascii")
+
+    assert detect_image_mime(_png_bytes()) == "image/png"
+    assert detect_image_mime(_jpeg_bytes()) == "image/jpeg"
+    assert sanitize_image_data_url(png_url) == (png_url, False)
+    assert sanitize_image_data_url(jpeg_url) == (jpeg_url, False)
+
+
+def test_malformed_jpeg_data_url_is_invalid():
+    bad_bytes = b"\x10JFIF\x00\x01\x01\x01"
+    bad_url = "data:image/jpeg;base64," + base64.b64encode(
+        bad_bytes
+    ).decode("ascii")
+
+    assert bad_url.startswith("data:image/jpeg;base64,EEpGSUY")
+    assert sanitize_image_data_url(bad_url) == (None, True)
+
+
 class TestBuildNativeContentParts:
     def test_text_then_image(self, tmp_path: Path):
         img = tmp_path / "cat.png"
@@ -427,6 +457,14 @@ class TestBuildNativeContentParts:
         assert skipped == [str(tmp_path / "missing.png")]
         # Skipped paths are NOT advertised in the path hints — the model
         # would otherwise be told a non-existent file is attached.
+        assert parts == [{"type": "text", "text": "hi"}]
+
+    def test_invalid_image_file_is_skipped(self, tmp_path: Path):
+        img = tmp_path / "bad.jpg"
+        img.write_bytes(b"\x10JFIF\x00\x01\x01\x01")
+        parts, skipped = build_native_content_parts("hi", [str(img)])
+
+        assert skipped == [str(img)]
         assert parts == [{"type": "text", "text": "hi"}]
 
     def test_path_hint_appended(self, tmp_path: Path):

--- a/tests/run_agent/test_codex_multimodal_tool_result.py
+++ b/tests/run_agent/test_codex_multimodal_tool_result.py
@@ -17,6 +17,12 @@ from agent.codex_responses_adapter import (
     _preflight_codex_input_items,
 )
 
+_VALID_PNG_DATA_URL = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+    "AAAADUlEQVR4nGNgYGBgAAAABQABpfZFQAAAAABJRU5ErkJggg=="
+)
+
 
 def _build_messages_with_multimodal_tool_result():
     return [
@@ -39,7 +45,10 @@ def _build_messages_with_multimodal_tool_result():
             "tool_call_id": "call_abc",
             "content": [
                 {"type": "text", "text": "Image loaded."},
-                {"type": "image_url", "image_url": {"url": "data:image/png;base64,XYZ"}},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": _VALID_PNG_DATA_URL},
+                },
             ],
         },
     ]
@@ -69,7 +78,7 @@ class TestMultimodalToolResultConversion:
         out = next(it for it in items if it.get("type") == "function_call_output")
         image_parts = [p for p in out["output"] if p.get("type") == "input_image"]
         assert len(image_parts) == 1
-        assert image_parts[0]["image_url"] == "data:image/png;base64,XYZ"
+        assert image_parts[0]["image_url"] == _VALID_PNG_DATA_URL
 
     def test_string_tool_content_still_string_output(self):
         msgs = [
@@ -106,7 +115,7 @@ class TestPreflightAcceptsArrayOutput:
                 "call_id": "call_abc",
                 "output": [
                     {"type": "input_text", "text": "Image loaded."},
-                    {"type": "input_image", "image_url": "data:image/png;base64,ABC"},
+                    {"type": "input_image", "image_url": _VALID_PNG_DATA_URL},
                 ],
             },
         ]
@@ -115,7 +124,7 @@ class TestPreflightAcceptsArrayOutput:
         assert isinstance(out["output"], list)
         assert len(out["output"]) == 2
         assert out["output"][1]["type"] == "input_image"
-        assert out["output"][1]["image_url"] == "data:image/png;base64,ABC"
+        assert out["output"][1]["image_url"] == _VALID_PNG_DATA_URL
 
     def test_preflight_drops_unknown_part_types(self):
         raw = [
@@ -129,7 +138,7 @@ class TestPreflightAcceptsArrayOutput:
                 "output": [
                     {"type": "input_text", "text": "ok"},
                     {"type": "garbage", "data": "nope"},  # unknown — should be dropped
-                    {"type": "input_image", "image_url": "data:image/png;base64,ZZ"},
+                    {"type": "input_image", "image_url": _VALID_PNG_DATA_URL},
                 ],
             },
         ]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7411,6 +7411,29 @@ def test_aiagent_uses_copilot_acp_client():
     assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
 
 
+def test_aiagent_preserves_explicit_empty_copilot_acp_args():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp_client,
+    ):
+        mock_acp_client.return_value = MagicMock()
+
+        agent = AIAgent(
+            api_key="copilot-acp",
+            base_url="acp://copilot",
+            provider="copilot-acp",
+            acp_command="/usr/local/bin/copilot",
+            acp_args=[],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.acp_args == []
+    assert mock_acp_client.call_args.kwargs["args"] == []
+
+
 def test_quiet_spinner_allowed_with_explicit_print_fn(agent):
     agent._print_fn = lambda *_a, **_kw: None
     with patch.object(run_agent.sys.stdout, "isatty", return_value=False):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,3 +1,4 @@
+import base64
 import sys
 import types
 from types import SimpleNamespace
@@ -244,6 +245,22 @@ def _codex_request_kwargs():
         "tools": None,
         "store": False,
     }
+
+
+def _valid_png_data_url():
+    png_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGBgAAAABQABpfZFQAAAAABJRU5ErkJggg=="
+    )
+    return "data:image/png;base64," + base64.b64encode(png_bytes).decode(
+        "ascii"
+    )
+
+
+def _invalid_jpeg_data_url():
+    bad_bytes = b"\x10JFIF\x00\x01\x01\x01"
+    return "data:image/jpeg;base64," + base64.b64encode(bad_bytes).decode(
+        "ascii"
+    )
 
 
 def test_api_mode_uses_explicit_provider_when_codex(monkeypatch):
@@ -1671,6 +1688,113 @@ def test_chat_messages_to_responses_input_accepts_call_pipe_fc_ids(monkeypatch):
     assert function_call["call_id"] == "call_pair123"
     assert "id" not in function_call
     assert function_output["call_id"] == "call_pair123"
+
+
+def test_chat_messages_to_responses_input_replaces_invalid_image_data_url(
+    monkeypatch,
+):
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import (
+        _chat_messages_to_responses_input,
+    )
+    from agent.image_data_url import INVALID_IMAGE_ATTACHMENT_NOTE
+
+    bad_url = _invalid_jpeg_data_url()
+    items = _chat_messages_to_responses_input(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "before"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": bad_url},
+                    },
+                    {"type": "text", "text": "after"},
+                ],
+            }
+        ]
+    )
+
+    assert items == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "before"},
+                {
+                    "type": "input_text",
+                    "text": INVALID_IMAGE_ATTACHMENT_NOTE,
+                },
+                {"type": "input_text", "text": "after"},
+            ],
+        }
+    ]
+    assert bad_url not in str(items)
+
+
+def test_preflight_codex_api_kwargs_preserves_valid_image_data_url(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+
+    png_url = _valid_png_data_url()
+    preflight = _preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5-codex",
+            "instructions": "You are Hermes.",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "see"},
+                        {"type": "input_image", "image_url": png_url},
+                    ],
+                }
+            ],
+            "tools": [],
+            "store": False,
+        }
+    )
+
+    assert preflight["input"][0]["content"] == [
+        {"type": "input_text", "text": "see"},
+        {"type": "input_image", "image_url": png_url},
+    ]
+
+
+def test_preflight_codex_api_kwargs_replaces_invalid_image_data_url(
+    monkeypatch,
+):
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+    from agent.image_data_url import INVALID_IMAGE_ATTACHMENT_NOTE
+
+    bad_url = _invalid_jpeg_data_url()
+    preflight = _preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5-codex",
+            "instructions": "You are Hermes.",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "before"},
+                        {"type": "input_image", "image_url": bad_url},
+                        {"type": "input_text", "text": "after"},
+                    ],
+                }
+            ],
+            "tools": [],
+            "store": False,
+        }
+    )
+
+    content = preflight["input"][0]["content"]
+    assert content == [
+        {"type": "input_text", "text": "before"},
+        {"type": "input_text", "text": INVALID_IMAGE_ATTACHMENT_NOTE},
+        {"type": "input_text", "text": "after"},
+    ]
+    assert bad_url not in str(content)
 
 
 def test_preflight_codex_api_kwargs_strips_optional_function_call_id(monkeypatch):


### PR DESCRIPTION
## Summary
- validate image data URLs before Codex Responses conversion
- replace malformed image payloads in per-call copies without mutating shared message state
- skip corrupt local image bytes before native encoding
- preserve an explicitly empty Copilot ACP argv while retaining defaults when omitted

## Verification
- 16 focused regression tests passed
- production modules compile successfully
- `git diff --check` passed