### PR TITLE
fix(desktop): decode persisted timeline metadata

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -180,15 +180,29 @@ describe('toChatMessages', () => {
         content: 'opaque delegation context payload',
         display_kind: 'async_delegation_complete',
         timestamp: 5
+      },
+      {
+        role: 'user',
+        content: 'serialized delegation context payload',
+        display_kind: 'async_delegation_complete',
+        // SQLite can return persisted JSON metadata as a serialized string.
+        display_metadata: JSON.stringify({
+          delegation_id: 'deleg_f6415f5b',
+          task_count: 1,
+          completed_count: 1,
+          failed_count: 0
+        }) as unknown as { delegation_id: string; task_count: number },
+        timestamp: 6
       }
     ])
 
-    expect(messages.map(message => message.role)).toEqual(['user', 'assistant', 'system', 'system'])
+    expect(messages.map(message => message.role)).toEqual(['user', 'assistant', 'system', 'system', 'system'])
     expect(messages.map(chatMessageText)).toEqual([
       'real user turn',
       'real assistant reply',
       'model changed',
-      'background agent work finished'
+      'background agent work finished',
+      '1 background agent finished'
     ])
   })
 })

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -311,16 +311,30 @@ function transcriptContent(displayKind: SessionMessage['display_kind'], content:
   return displayKind === 'hidden' ? null : content
 }
 
+function timelineDisplayMetadata(value: SessionMessage['display_metadata']): Record<string, unknown> | null {
+  let metadata: unknown = value
+
+  if (typeof metadata === 'string') {
+    try {
+      metadata = JSON.parse(metadata)
+    } catch {
+      return null
+    }
+  }
+
+  return metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+    ? (metadata as Record<string, unknown>)
+    : null
+}
+
 function timelineDisplayContent(message: SessionMessage, content: string): string {
   if (message.display_kind === 'model_switch') {
     return 'model changed'
   }
 
   if (message.display_kind === 'async_delegation_complete') {
-    const count =
-      message.display_metadata && 'task_count' in message.display_metadata
-        ? message.display_metadata.task_count
-        : undefined
+    const metadata = timelineDisplayMetadata(message.display_metadata)
+    const count = typeof metadata?.task_count === 'number' ? metadata.task_count : undefined
 
     return count === undefined
       ? 'background agent work finished'

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -442,7 +442,7 @@ export interface SessionMessage {
   reasoning_content?: null | string
   reasoning_details?: unknown
   display_kind?: 'async_delegation_complete' | 'hidden' | 'model_switch' | string
-  display_metadata?: TimelineDisplayMetadata
+  display_metadata?: string | TimelineDisplayMetadata
   role: 'assistant' | 'system' | 'tool' | 'user'
   text?: unknown
   timestamp?: number

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6169,6 +6169,13 @@ class SessionDB:
                 except (json.JSONDecodeError, TypeError):
                     logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
                     msg["tool_calls"] = []
+            display_metadata = msg.get("display_metadata")
+            if isinstance(display_metadata, str):
+                try:
+                    msg["display_metadata"] = json.loads(display_metadata)
+                except json.JSONDecodeError:
+                    logger.warning("Failed to deserialize display_metadata in get_messages, ignoring it")
+                    msg["display_metadata"] = None
             result.append(msg)
         return result
 
@@ -6238,6 +6245,15 @@ class SessionDB:
                         "Failed to deserialize tool_calls in get_messages_around, falling back to []"
                     )
                     msg["tool_calls"] = []
+            display_metadata = msg.get("display_metadata")
+            if isinstance(display_metadata, str):
+                try:
+                    msg["display_metadata"] = json.loads(display_metadata)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Failed to deserialize display_metadata in get_messages_around, ignoring it"
+                    )
+                    msg["display_metadata"] = None
             result.append(msg)
 
         # before_rows includes the anchor itself; subtract 1 for the count of

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -7199,6 +7199,13 @@ class TestDisplayMetadataPersistence:
             display_kind="async_delegation_complete",
             display_metadata=meta,
         )
+        stored = db.get_messages("s1")
+        assert stored[0]["display_kind"] == "async_delegation_complete"
+        assert stored[0]["display_metadata"] == meta
+
+        around = db.get_messages_around("s1", stored[0]["id"], window=0)
+        assert around["window"][0]["display_metadata"] == meta
+
         conv = db.get_messages_as_conversation("s1")
         assert conv[0]["display_kind"] == "async_delegation_complete"
         assert conv[0]["display_metadata"] == meta


### PR DESCRIPTION
## Summary
- deserialize persisted `display_metadata` in SessionDB message read paths
- tolerate serialized metadata from older backends in Desktop
- prevent resume crashes while preserving async delegation task counts

## Regression
Reproduces the exact failure: `Cannot use 'in' operator to search for 'task_count'` when `display_metadata` is a JSON string.

## Test plan
- `python -m pytest -q tests/test_hermes_state.py::TestDisplayMetadataPersistence`
- `npm exec --workspace apps/desktop -- vitest run --project ui src/lib/chat-messages.test.ts`
- Desktop Prettier + ESLint
- `npm run typecheck --workspace apps/desktop`
- independent read-only review passed