### PR TITLE
fix(desktop): scrub credentials from embedded terminal PTY env

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -130,6 +130,7 @@ import { createKeepAwake } from './power-save'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import * as remoteLifecycle from './remote-lifecycle'
 import { RemoteLivenessTracker, RemoteRevalidationCoordinator, revalidateRemoteConnection } from './remote-liveness'
+import { scrubDesktopChildEnv } from './scrub-child-env'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -138,7 +139,6 @@ import {
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
-import { scrubDesktopChildEnv } from './scrub-child-env'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -138,6 +138,7 @@ import {
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
+import { scrubDesktopChildEnv } from './scrub-child-env'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
@@ -9846,7 +9847,10 @@ function terminalShellEnv() {
   // which marks the agent *backend* and gates cron/gateway behavior.
   env.HERMES_DESKTOP_TERMINAL = '1'
 
-  return env
+  // Drop provider / messaging secrets that may ride along from the parent
+  // Electron process. The backend loads credentials from HERMES_HOME/.env;
+  // an interactive PTY must not inherit them into the user's shell.
+  return scrubDesktopChildEnv(env)
 }
 
 function terminalChannel(id, suffix) {

--- a/apps/desktop/electron/scrub-child-env.test.ts
+++ b/apps/desktop/electron/scrub-child-env.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
-import test from 'node:test'
+
+import { test } from 'vitest'
 
 import { isCredentialEnvVar, scrubDesktopChildEnv } from './scrub-child-env'
 

--- a/apps/desktop/electron/scrub-child-env.test.ts
+++ b/apps/desktop/electron/scrub-child-env.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isCredentialEnvVar, scrubDesktopChildEnv } from './scrub-child-env'
+
+test('isCredentialEnvVar matches suffix and known names', () => {
+  assert.equal(isCredentialEnvVar('OPENROUTER_API_KEY'), true)
+  assert.equal(isCredentialEnvVar('HERMES_DESKTOP_REMOTE_TOKEN'), true)
+  assert.equal(isCredentialEnvVar('AWS_SECRET_ACCESS_KEY'), true)
+  assert.equal(isCredentialEnvVar('PATH'), false)
+  assert.equal(isCredentialEnvVar('HERMES_HOME'), false)
+  assert.equal(isCredentialEnvVar('HERMES_DESKTOP'), false)
+})
+
+test('scrubDesktopChildEnv drops secrets and keeps operational keys', () => {
+  const scrubbed = scrubDesktopChildEnv(
+    {
+      PATH: '/usr/bin',
+      HERMES_HOME: '/home/u/.hermes',
+      OPENROUTER_API_KEY: 'sk-live',
+      TELEGRAM_BOT_TOKEN: '123:abc',
+      HERMES_DESKTOP_REMOTE_TOKEN: 'remote-secret',
+      EMPTY: ''
+    },
+    {
+      HERMES_DESKTOP: '1',
+      HERMES_DASHBOARD_SESSION_TOKEN: 'minted-session'
+    }
+  )
+
+  assert.equal(scrubbed.PATH, '/usr/bin')
+  assert.equal(scrubbed.HERMES_HOME, '/home/u/.hermes')
+  assert.equal(scrubbed.HERMES_DESKTOP, '1')
+  assert.equal(scrubbed.HERMES_DASHBOARD_SESSION_TOKEN, 'minted-session')
+  assert.equal(scrubbed.OPENROUTER_API_KEY, undefined)
+  assert.equal(scrubbed.TELEGRAM_BOT_TOKEN, undefined)
+  assert.equal(scrubbed.HERMES_DESKTOP_REMOTE_TOKEN, undefined)
+})

--- a/apps/desktop/electron/scrub-child-env.ts
+++ b/apps/desktop/electron/scrub-child-env.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared credential scrub for Desktop Electron child processes.
+ *
+ * Desktop often spreads `{ ...process.env }` into PTY / serve / updater children.
+ * Provider and messaging secrets belong in HERMES_HOME/.env for the backend, not
+ * in the parent Electron environment forwarded wholesale to every child.
+ */
+
+const CREDENTIAL_SUFFIXES = Object.freeze([
+  '_API_KEY',
+  '_TOKEN',
+  '_SECRET',
+  '_PASSWORD',
+  '_CREDENTIALS',
+  '_ACCESS_KEY',
+  '_PRIVATE_KEY',
+  '_OAUTH_TOKEN'
+])
+
+const CREDENTIAL_NAMES = new Set([
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_TOKEN',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'CUSTOM_API_KEY',
+  'GEMINI_BASE_URL',
+  'OPENAI_BASE_URL',
+  'OPENROUTER_BASE_URL',
+  'OLLAMA_BASE_URL',
+  'GROQ_BASE_URL',
+  'XAI_BASE_URL'
+])
+
+export function isCredentialEnvVar(name: string): boolean {
+  if (!name) {
+    return false
+  }
+
+  if (CREDENTIAL_NAMES.has(name)) {
+    return true
+  }
+
+  return CREDENTIAL_SUFFIXES.some(suffix => name.endsWith(suffix))
+}
+
+export type EnvMap = Record<string, string | undefined>
+
+/**
+ * Copy `source` while dropping credential-shaped keys. Optionally re-apply
+ * explicit overrides afterwards (e.g. a minted dashboard session token).
+ */
+export function scrubDesktopChildEnv(source: EnvMap = {}, overrides: EnvMap = {}): Record<string, string> {
+  const out: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(source || {})) {
+    if (value == null || value === '') {
+      continue
+    }
+
+    if (isCredentialEnvVar(key)) {
+      continue
+    }
+
+    out[key] = String(value)
+  }
+
+  for (const [key, value] of Object.entries(overrides || {})) {
+    if (value == null || value === '') {
+      delete out[key]
+      continue
+    }
+
+    out[key] = String(value)
+  }
+
+  return out
+}
+
+export { CREDENTIAL_NAMES, CREDENTIAL_SUFFIXES }


### PR DESCRIPTION
## Summary
- Add a shared `scrubDesktopChildEnv` helper for Desktop Electron child processes.
- Apply it to `terminalShellEnv()` so the embedded PTY does not inherit provider or messaging secrets from the parent Electron environment.
- Keep operational keys (PATH, TERM, `HERMES_DESKTOP_TERMINAL`) intact.

## Why
Desktop previously copied `{ ...process.env }` into interactive terminal PTYs after only stripping npm/color noise. Keys such as `OPENROUTER_API_KEY` and bot tokens remained visible to `env` / child shells in the terminal rail. The backend already loads credentials from `HERMES_HOME/.env`; the PTY does not need parent secrets.

This is the Desktop counterpart to the Python subprocess scrub work (#70342 / #56332), scoped to Electron main only.

## Test plan
- [x] `npx tsx --test apps/desktop/electron/scrub-child-env.test.ts`
- [ ] Manual: open Desktop terminal rail and confirm credential-shaped vars are absent from `env`