### PR TITLE
fix(desktop): scrub credentials from hermes serve spawn env

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -38,6 +38,7 @@ import fsp from 'node:fs/promises'
 import https from 'node:https'
 import path from 'node:path'
 
+import { scrubDesktopChildEnv } from './scrub-child-env'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 
 const IS_WINDOWS = process.platform === 'win32'
@@ -466,12 +467,11 @@ function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, herme
       fullArgs,
       hiddenWindowsChildOptions({
         stdio: ['ignore', 'pipe', 'pipe'],
-        env: {
-          ...process.env,
+        env: scrubDesktopChildEnv(process.env, {
           // Pass HERMES_HOME through so install.ps1 respects the caller's
           // choice rather than re-computing the default.
           HERMES_HOME: hermesHome || process.env.HERMES_HOME || ''
-        }
+        })
       })
     )
 
@@ -564,10 +564,9 @@ function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome 
   return new Promise<any>((resolve, reject) => {
     const child = spawn('bash', [scriptPath, ...args], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
+      env: scrubDesktopChildEnv(process.env, {
         HERMES_HOME: hermesHome || process.env.HERMES_HOME || ''
-      }
+      })
     })
 
     let stdout = ''

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -138,6 +138,7 @@ import {
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
+import { scrubDesktopChildEnv } from './scrub-child-env'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
@@ -1677,7 +1678,7 @@ function backendSupportsServe(backend) {
       const prefix = backend.args && backend.args[0] === '-m' ? backend.args.slice(0, 2) : []
       execFileSync(backend.command, [...prefix, 'serve', '--help'], {
         cwd: backend.root || undefined,
-        env: { ...process.env, HERMES_HOME, ...(backend.env || {}) },
+        env: scrubDesktopChildEnv(process.env, { HERMES_HOME, ...(backend.env || {}) }),
         timeout: 15000,
         stdio: 'ignore',
         windowsHide: true
@@ -7611,8 +7612,7 @@ async function spawnPoolBackend(profile, entry) {
     backend.args,
     hiddenWindowsChildOptions({
       cwd: hermesCwd,
-      env: {
-        ...process.env,
+      env: scrubDesktopChildEnv(process.env, {
         HERMES_HOME,
         ...backend.env,
         // Pin the gateway's tool/terminal cwd to the same directory we chose for
@@ -7625,7 +7625,7 @@ async function spawnPoolBackend(profile, entry) {
         HERMES_DESKTOP: '1',
         HERMES_WEB_DIST: webDist,
         ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
-      },
+      }),
       shell: backend.shell,
       stdio: ['ignore', 'pipe', 'pipe']
     })
@@ -7869,8 +7869,7 @@ async function startHermes() {
       backend.args,
       hiddenWindowsChildOptions({
         cwd: hermesCwd,
-        env: {
-          ...process.env,
+        env: scrubDesktopChildEnv(process.env, {
           // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
           // resolves to the SAME location our resolveHermesHome() picked. Without
           // this pin, Python falls back to ~/.hermes on every platform — fine on
@@ -7888,7 +7887,7 @@ async function startHermes() {
           HERMES_DESKTOP: '1',
           HERMES_WEB_DIST: webDist,
           ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
-        },
+        }),
         shell: backend.shell,
         stdio: ['ignore', 'pipe', 'pipe']
       })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -130,6 +130,7 @@ import { createKeepAwake } from './power-save'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import * as remoteLifecycle from './remote-lifecycle'
 import { RemoteLivenessTracker, RemoteRevalidationCoordinator, revalidateRemoteConnection } from './remote-liveness'
+import { scrubDesktopChildEnv } from './scrub-child-env'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -138,7 +139,6 @@ import {
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
-import { scrubDesktopChildEnv } from './scrub-child-env'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3686,12 +3686,11 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
 
       child = spawnUpdaterProcess(wrapped.command, wrapped.args, {
         cwd: HERMES_HOME,
-        env: {
-          ...process.env,
+        env: scrubDesktopChildEnv(process.env, {
           HERMES_HOME,
           HERMES_UPDATE_STARTED_AT: String(updateStartedAt),
           PATH: pathWithHermesManagedNode(venvBin)
-        },
+        }),
         detached: true,
         stdio: 'ignore'
       })
@@ -3713,11 +3712,10 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     } else {
       child = spawnUpdaterProcess(updater, updaterArgs, {
         cwd: HERMES_HOME,
-        env: {
-          ...process.env,
+        env: scrubDesktopChildEnv(process.env, {
           HERMES_HOME,
           PATH: pathWithHermesManagedNode(venvBin)
-        },
+        }),
         detached: true,
         stdio: 'ignore'
       })
@@ -3848,11 +3846,10 @@ async function handOffWindowsBootstrapRecovery(reason) {
 
   const child = spawnUpdaterProcess(updater, updaterArgs, {
     cwd: HERMES_HOME,
-    env: {
-      ...process.env,
+    env: scrubDesktopChildEnv(process.env, {
       HERMES_HOME,
       PATH: pathWithHermesManagedNode(venvBin)
-    },
+    }),
     detached: true,
     stdio: 'ignore'
   })
@@ -4077,12 +4074,11 @@ async function applyUpdatesPosixHandoff(opts: any) {
 
   const child = spawnUpdaterProcess(handoff.command, args, {
     cwd: HERMES_HOME,
-    env: {
-      ...process.env,
+    env: scrubDesktopChildEnv(process.env, {
       HERMES_HOME,
       HERMES_UPDATE_STARTED_AT: String(updateStartedAt),
       PATH: pathWithHermesManagedNode(path.join(updateRoot, 'venv', 'bin'))
-    },
+    }),
     detached: true,
     stdio: 'ignore'
   })
@@ -14706,7 +14702,7 @@ async function getUninstallSummary() {
         ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary'],
         hiddenWindowsChildOptions({
           cwd: agentRoot,
-          env: { ...process.env, HERMES_HOME, NO_COLOR: '1' },
+          env: scrubDesktopChildEnv(process.env, { HERMES_HOME, NO_COLOR: '1' }),
           stdio: ['ignore', 'pipe', 'ignore']
         })
       )

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -258,6 +258,7 @@ import {
 } from './remote-liveness'
 import { missingRendererAssets } from './renderer-bundle'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { buildDesktopServeChildEnv, scrubDesktopChildEnv } from './scrub-child-env'
 import {
   buildInstanceWindowUrl,
   buildSessionWindowUrl,
@@ -2212,7 +2213,7 @@ function backendSupportsServe(backend) {
       // and its timeout-only retry instead of a thinner local bound.
       execProbeSync(backend.command, [...prefix, 'serve', '--help'], {
         cwd: backend.root || undefined,
-        env: { ...process.env, HERMES_HOME, ...(backend.env || {}) },
+        env: scrubDesktopChildEnv(process.env, { HERMES_HOME }, backend.env),
         timeout: PROBE_TIMEOUT_MS,
         stdio: 'ignore',
         // `.cmd`/`.bat` shim backends carry shell: true in their descriptor
@@ -10354,25 +10355,16 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
     backend.args,
     hiddenWindowsChildOptions({
       cwd: hermesCwd,
-      env: {
-        ...process.env,
-        HERMES_HOME,
-        ...backend.env,
-        // Pin the gateway's tool/terminal cwd to the same directory we chose for
-        // the child process. Inherited TERMINAL_CWD (or a stale config bridge)
-        // can still point at the install dir even when spawn cwd is home.
-        TERMINAL_CWD: hermesCwd,
-        HERMES_DASHBOARD_SESSION_TOKEN: token,
-        // Marks this dashboard backend as desktop-spawned so it runs the cron
-        // scheduler tick loop (the gateway isn't running under the app).
-        HERMES_DESKTOP: '1',
-        // Exact parent identity lets the backend self-exit after an unclean
-        // Desktop death without mistaking a reused PID for its owner. If the
-        // optional marker probe fails, retain legacy PID-only tracking.
-        ...parentIdentityEnv,
-        HERMES_WEB_DIST: webDist,
-        ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
-      },
+      env: buildDesktopServeChildEnv({
+        source: process.env,
+        backendEnv: backend.env,
+        hermesHome: HERMES_HOME,
+        terminalCwd: hermesCwd,
+        dashboardSessionToken: token,
+        parentIdentityEnv,
+        webDist,
+        readyFile
+      }),
       shell: backend.shell,
       stdio: ['ignore', 'pipe', 'pipe']
     })
@@ -10727,30 +10719,18 @@ async function startHermes() {
       backend.args,
       hiddenWindowsChildOptions({
         cwd: hermesCwd,
-        env: {
-          ...process.env,
-          // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
-          // resolves to the SAME location our resolveHermesHome() picked. Without
-          // this pin, Python falls back to ~/.hermes on every platform — fine on
-          // mac/linux (where our default matches), but on Windows our default is
-          // %LOCALAPPDATA%\hermes, which differs from C:\Users\<u>\.hermes.
-          // Mismatch would split config / sessions / .env / logs across two
-          // directories. install.ps1 sets HERMES_HOME via setx; the desktop
-          // can't reliably do that, so we set it inline for every spawn.
-          HERMES_HOME,
-          ...backend.env,
-          TERMINAL_CWD: hermesCwd,
-          HERMES_DASHBOARD_SESSION_TOKEN: token,
-          // Marks this dashboard backend as desktop-spawned so it runs the cron
-          // scheduler tick loop (the gateway isn't running under the app).
-          HERMES_DESKTOP: '1',
-          // Exact parent identity lets the backend self-exit after an unclean
-          // Desktop death without mistaking a reused PID for its owner. If the
-          // optional marker probe fails, retain legacy PID-only tracking.
-          ...parentIdentityEnv,
-          HERMES_WEB_DIST: webDist,
-          ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
-        },
+        // Pin HERMES_HOME so the child uses the Desktop's config/session root,
+        // and admit only the freshly minted dashboard session token.
+        env: buildDesktopServeChildEnv({
+          source: process.env,
+          backendEnv: backend.env,
+          hermesHome: HERMES_HOME,
+          terminalCwd: hermesCwd,
+          dashboardSessionToken: token,
+          parentIdentityEnv,
+          webDist,
+          readyFile
+        }),
         shell: backend.shell,
         stdio: ['ignore', 'pipe', 'pipe']
       })

--- a/apps/desktop/electron/scrub-child-env.test.ts
+++ b/apps/desktop/electron/scrub-child-env.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
-import test from 'node:test'
+
+import { test } from 'vitest'
 
 import { isCredentialEnvVar, scrubDesktopChildEnv } from './scrub-child-env'
 

--- a/apps/desktop/electron/scrub-child-env.test.ts
+++ b/apps/desktop/electron/scrub-child-env.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isCredentialEnvVar, scrubDesktopChildEnv } from './scrub-child-env'
+
+test('isCredentialEnvVar matches suffix and known names', () => {
+  assert.equal(isCredentialEnvVar('OPENROUTER_API_KEY'), true)
+  assert.equal(isCredentialEnvVar('HERMES_DESKTOP_REMOTE_TOKEN'), true)
+  assert.equal(isCredentialEnvVar('AWS_SECRET_ACCESS_KEY'), true)
+  assert.equal(isCredentialEnvVar('PATH'), false)
+  assert.equal(isCredentialEnvVar('HERMES_HOME'), false)
+  assert.equal(isCredentialEnvVar('HERMES_DESKTOP'), false)
+})
+
+test('scrubDesktopChildEnv drops secrets and keeps operational keys', () => {
+  const scrubbed = scrubDesktopChildEnv(
+    {
+      PATH: '/usr/bin',
+      HERMES_HOME: '/home/u/.hermes',
+      OPENROUTER_API_KEY: 'sk-live',
+      TELEGRAM_BOT_TOKEN: '123:abc',
+      HERMES_DESKTOP_REMOTE_TOKEN: 'remote-secret',
+      EMPTY: ''
+    },
+    {
+      HERMES_DESKTOP: '1',
+      HERMES_DASHBOARD_SESSION_TOKEN: 'minted-session'
+    }
+  )
+
+  assert.equal(scrubbed.PATH, '/usr/bin')
+  assert.equal(scrubbed.HERMES_HOME, '/home/u/.hermes')
+  assert.equal(scrubbed.HERMES_DESKTOP, '1')
+  assert.equal(scrubbed.HERMES_DASHBOARD_SESSION_TOKEN, 'minted-session')
+  assert.equal(scrubbed.OPENROUTER_API_KEY, undefined)
+  assert.equal(scrubbed.TELEGRAM_BOT_TOKEN, undefined)
+  assert.equal(scrubbed.HERMES_DESKTOP_REMOTE_TOKEN, undefined)
+})

--- a/apps/desktop/electron/scrub-child-env.test.ts
+++ b/apps/desktop/electron/scrub-child-env.test.ts
@@ -13,6 +13,22 @@ test('isCredentialEnvVar matches suffix and known names', () => {
   assert.equal(isCredentialEnvVar('HERMES_DESKTOP'), false)
 })
 
+test('isCredentialEnvVar normalizes case and preserves endpoint overrides', () => {
+  assert.equal(isCredentialEnvVar('openrouter_api_key'), true)
+  assert.equal(isCredentialEnvVar('Anthropic_Token'), true)
+  assert.equal(isCredentialEnvVar('OPENROUTER_BASE_URL'), false)
+})
+
+test('scrubDesktopChildEnv keeps OPENROUTER_BASE_URL and drops lower-case secrets', () => {
+  const scrubbed = scrubDesktopChildEnv({
+    OPENROUTER_BASE_URL: 'https://openrouter.ai/api/v1',
+    openrouter_api_key: 'sk-live'
+  })
+
+  assert.equal(scrubbed.OPENROUTER_BASE_URL, 'https://openrouter.ai/api/v1')
+  assert.equal(scrubbed.openrouter_api_key, undefined)
+})
+
 test('scrubDesktopChildEnv drops secrets and keeps operational keys', () => {
   const scrubbed = scrubDesktopChildEnv(
     {

--- a/apps/desktop/electron/scrub-child-env.test.ts
+++ b/apps/desktop/electron/scrub-child-env.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { buildDesktopServeChildEnv, isHermesCredentialEnvVar, scrubDesktopChildEnv } from './scrub-child-env'
+
+test('matches Hermes-owned credentials case-insensitively', () => {
+  assert.equal(isHermesCredentialEnvVar('OPENROUTER_API_KEY'), true)
+  assert.equal(isHermesCredentialEnvVar('openrouter_api_key'), true)
+  assert.equal(isHermesCredentialEnvVar('FAL_KEY'), true)
+  assert.equal(isHermesCredentialEnvVar('CUSTOM_API_KEY'), true)
+  assert.equal(isHermesCredentialEnvVar('GATEWAY_RELAY_DELIVERY_KEY'), true)
+  assert.equal(isHermesCredentialEnvVar('AUXILIARY_VISION_BASE_URL'), true)
+  assert.equal(isHermesCredentialEnvVar('HERMES_CUSTOM_LOCAL_API_KEY'), true)
+  assert.equal(isHermesCredentialEnvVar('HERMES_DESKTOP_REMOTE_TOKEN'), true)
+})
+
+test('closes Apptainer and Singularity effective-name tunnelling', () => {
+  assert.equal(isHermesCredentialEnvVar('APPTAINERENV_OPENAI_API_KEY'), true)
+  assert.equal(isHermesCredentialEnvVar('singularityenv_FAL_KEY'), true)
+  assert.equal(isHermesCredentialEnvVar('APPTAINERENV_SINGULARITYENV_OPENROUTER_API_KEY'), true)
+})
+
+test('preserves non-secret endpoints and operator-owned credentials', () => {
+  for (const name of [
+    'OPENROUTER_BASE_URL',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'NPM_TOKEN'
+  ]) {
+    assert.equal(isHermesCredentialEnvVar(name), false, name)
+  }
+})
+
+test('scrubs every source map without deleting empty non-secret values', () => {
+  const scrubbed = scrubDesktopChildEnv(
+    {
+      PATH: '/usr/bin',
+      EMPTY: '',
+      OPENAI_API_KEY: 'source-secret',
+      NPM_TOKEN: 'operator-secret'
+    },
+    {
+      OPENAI_API_KEY: 'override-secret',
+      openrouter_api_key: 'mixed-case-secret',
+      HERMES_HOME: '/home/u/.hermes'
+    }
+  )
+
+  assert.equal(scrubbed.PATH, '/usr/bin')
+  assert.equal(scrubbed.EMPTY, '')
+  assert.equal(scrubbed.NPM_TOKEN, 'operator-secret')
+  assert.equal(scrubbed.HERMES_HOME, '/home/u/.hermes')
+  assert.equal(scrubbed.OPENAI_API_KEY, undefined)
+  assert.equal(scrubbed.openrouter_api_key, undefined)
+})
+
+test('serve env admits only its freshly minted dashboard token', () => {
+  const env = buildDesktopServeChildEnv({
+    source: {
+      PATH: '/usr/bin',
+      HERMES_DASHBOARD_SESSION_TOKEN: 'inherited-token',
+      FAL_KEY: 'inherited-fal'
+    },
+    backendEnv: {
+      PYTHONPATH: '/app',
+      OPENAI_API_KEY: 'backend-override-secret'
+    },
+    hermesHome: '/home/u/.hermes',
+    terminalCwd: '/work',
+    dashboardSessionToken: 'minted-token',
+    parentIdentityEnv: {
+      HERMES_DESKTOP_PARENT_PID: '42',
+      GATEWAY_RELAY_SECRET: 'relay-secret'
+    },
+    webDist: '/app/web_dist',
+    readyFile: '/tmp/ready.json'
+  })
+
+  assert.equal(env.PATH, '/usr/bin')
+  assert.equal(env.PYTHONPATH, '/app')
+  assert.equal(env.HERMES_HOME, '/home/u/.hermes')
+  assert.equal(env.TERMINAL_CWD, '/work')
+  assert.equal(env.HERMES_DASHBOARD_SESSION_TOKEN, 'minted-token')
+  assert.equal(env.HERMES_DESKTOP, '1')
+  assert.equal(env.HERMES_DESKTOP_PARENT_PID, '42')
+  assert.equal(env.HERMES_WEB_DIST, '/app/web_dist')
+  assert.equal(env.HERMES_DESKTOP_READY_FILE, '/tmp/ready.json')
+  assert.equal(env.FAL_KEY, undefined)
+  assert.equal(env.OPENAI_API_KEY, undefined)
+  assert.equal(env.GATEWAY_RELAY_SECRET, undefined)
+})

--- a/apps/desktop/electron/scrub-child-env.test.ts
+++ b/apps/desktop/electron/scrub-child-env.test.ts
@@ -2,7 +2,12 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { buildDesktopServeChildEnv, isHermesCredentialEnvVar, scrubDesktopChildEnv } from './scrub-child-env'
+import {
+  buildDesktopServeChildEnv,
+  buildDesktopTerminalEnv,
+  isHermesCredentialEnvVar,
+  scrubDesktopChildEnv
+} from './scrub-child-env'
 
 test('matches Hermes-owned credentials case-insensitively', () => {
   assert.equal(isHermesCredentialEnvVar('OPENROUTER_API_KEY'), true)
@@ -91,4 +96,31 @@ test('serve env admits only its freshly minted dashboard token', () => {
   assert.equal(env.FAL_KEY, undefined)
   assert.equal(env.OPENAI_API_KEY, undefined)
   assert.equal(env.GATEWAY_RELAY_SECRET, undefined)
+})
+
+test('terminal env scrubs Hermes credentials and retains the operator shell contract', () => {
+  const env = buildDesktopTerminalEnv(
+    {
+      PATH: '/usr/bin',
+      OPENROUTER_API_KEY: 'provider-secret',
+      NPM_TOKEN: 'operator-secret',
+      AWS_ACCESS_KEY_ID: 'operator-aws',
+      npm_config_prefix: '/npm',
+      NO_COLOR: '1',
+      LC_CTYPE: 'ja_JP.UTF-8'
+    },
+    '0.17.0'
+  )
+
+  assert.equal(env.OPENROUTER_API_KEY, undefined)
+  assert.equal(env.NPM_TOKEN, 'operator-secret')
+  assert.equal(env.AWS_ACCESS_KEY_ID, 'operator-aws')
+  assert.equal(env.npm_config_prefix, undefined)
+  assert.equal(env.NO_COLOR, undefined)
+  assert.equal(env.LC_CTYPE, 'ja_JP.UTF-8')
+  assert.equal(env.COLORTERM, 'truecolor')
+  assert.equal(env.TERM, 'xterm-256color')
+  assert.equal(env.TERM_PROGRAM, 'Hermes')
+  assert.equal(env.TERM_PROGRAM_VERSION, '0.17.0')
+  assert.equal(env.HERMES_DESKTOP_TERMINAL, '1')
 })

--- a/apps/desktop/electron/scrub-child-env.ts
+++ b/apps/desktop/electron/scrub-child-env.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared credential scrub for Desktop Electron child processes.
+ *
+ * Desktop often spreads `{ ...process.env }` into PTY / serve / updater children.
+ * Provider and messaging secrets belong in HERMES_HOME/.env for the backend, not
+ * in the parent Electron environment forwarded wholesale to every child.
+ */
+
+const CREDENTIAL_SUFFIXES = Object.freeze([
+  '_API_KEY',
+  '_TOKEN',
+  '_SECRET',
+  '_PASSWORD',
+  '_CREDENTIALS',
+  '_ACCESS_KEY',
+  '_PRIVATE_KEY',
+  '_OAUTH_TOKEN'
+])
+
+const CREDENTIAL_NAMES = new Set([
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_TOKEN',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'CUSTOM_API_KEY',
+  'GEMINI_BASE_URL',
+  'OPENAI_BASE_URL',
+  'OPENROUTER_BASE_URL',
+  'OLLAMA_BASE_URL',
+  'GROQ_BASE_URL',
+  'XAI_BASE_URL'
+])
+
+export function isCredentialEnvVar(name: string): boolean {
+  if (!name) {
+    return false
+  }
+
+  if (CREDENTIAL_NAMES.has(name)) {
+    return true
+  }
+
+  return CREDENTIAL_SUFFIXES.some(suffix => name.endsWith(suffix))
+}
+
+export type EnvMap = Record<string, string | undefined>
+
+/**
+ * Copy `source` while dropping credential-shaped keys. Optionally re-apply
+ * explicit overrides afterwards (e.g. a minted dashboard session token).
+ */
+export function scrubDesktopChildEnv(source: EnvMap = {}, overrides: EnvMap = {}): Record<string, string> {
+  const out: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(source || {})) {
+    if (value == null || value === '') {
+      continue
+    }
+
+    if (isCredentialEnvVar(key)) {
+      continue
+    }
+
+    out[key] = String(value)
+  }
+
+  for (const [key, value] of Object.entries(overrides || {})) {
+    if (value == null || value === '') {
+      delete out[key]
+      continue
+    }
+
+    out[key] = String(value)
+  }
+
+  return out
+}
+
+export { CREDENTIAL_NAMES, CREDENTIAL_SUFFIXES }

--- a/apps/desktop/electron/scrub-child-env.ts
+++ b/apps/desktop/electron/scrub-child-env.ts
@@ -26,7 +26,6 @@ const CREDENTIAL_NAMES = new Set([
   'CUSTOM_API_KEY',
   'GEMINI_BASE_URL',
   'OPENAI_BASE_URL',
-  'OPENROUTER_BASE_URL',
   'OLLAMA_BASE_URL',
   'GROQ_BASE_URL',
   'XAI_BASE_URL'
@@ -37,11 +36,13 @@ export function isCredentialEnvVar(name: string): boolean {
     return false
   }
 
-  if (CREDENTIAL_NAMES.has(name)) {
+  const normalized = name.toUpperCase()
+
+  if (CREDENTIAL_NAMES.has(normalized)) {
     return true
   }
 
-  return CREDENTIAL_SUFFIXES.some(suffix => name.endsWith(suffix))
+  return CREDENTIAL_SUFFIXES.some(suffix => normalized.endsWith(suffix))
 }
 
 export type EnvMap = Record<string, string | undefined>

--- a/apps/desktop/electron/scrub-child-env.ts
+++ b/apps/desktop/electron/scrub-child-env.ts
@@ -199,6 +199,29 @@ export function scrubDesktopChildEnv(...sources: Array<EnvMap | null | undefined
   return out
 }
 
+export function buildDesktopTerminalEnv(source: EnvMap, appVersion: string): Record<string, string> {
+  const env = scrubDesktopChildEnv(source)
+
+  for (const key of Object.keys(env)) {
+    if (key === 'npm_config_prefix' || key.startsWith('npm_config_') || key.startsWith('npm_package_')) {
+      delete env[key]
+    }
+  }
+
+  delete env.NO_COLOR
+  delete env.FORCE_COLOR
+  delete env.COLORFGBG
+
+  env.COLORTERM = 'truecolor'
+  env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'
+  env.TERM = 'xterm-256color'
+  env.TERM_PROGRAM = 'Hermes'
+  env.TERM_PROGRAM_VERSION = appVersion
+  env.HERMES_DESKTOP_TERMINAL = '1'
+
+  return env
+}
+
 export interface DesktopServeChildEnvOptions {
   source?: EnvMap
   backendEnv?: EnvMap

--- a/apps/desktop/electron/scrub-child-env.ts
+++ b/apps/desktop/electron/scrub-child-env.ts
@@ -1,0 +1,237 @@
+/** Environment maps accepted by Node child-process APIs. */
+export type EnvMap = Record<string, string | undefined>
+
+// Mirrors the credential entries owned by Hermes' provider/tool/messaging
+// registries. Keep unrelated operator credentials (for example NPM_TOKEN),
+// the general AWS chain, and CLAUDE_CODE_OAUTH_TOKEN available to the user's
+// shell; Python applies the same ownership boundary in environments/local.py.
+const HERMES_CREDENTIAL_NAMES = new Set([
+  'A2A_BEARER_TOKEN',
+  'A2A_PEER_TOKENS',
+  'ACTUAL_API_KEY',
+  'AIRTABLE_API_KEY',
+  'AI_GATEWAY_API_KEY',
+  'ALIBABA_CODING_PLAN_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_TOKEN',
+  'API_SERVER_KEY',
+  'ARCEEAI_API_KEY',
+  'AZURE_FOUNDRY_API_KEY',
+  'BLUEBUBBLES_PASSWORD',
+  'BRAVE_SEARCH_API_KEY',
+  'BROWSERBASE_API_KEY',
+  'BROWSER_USE_API_KEY',
+  'BRV_API_KEY',
+  'BUZZ_PRIVATE_KEY',
+  'CAMOFOX_API_KEY',
+  'CLOAKBROWSER_PROXY',
+  'COMMANDCODE_API_KEY',
+  'COPILOT_GITHUB_TOKEN',
+  'CUSTOM_API_KEY',
+  'DASHSCOPE_API_KEY',
+  'DAYTONA_API_KEY',
+  'DEEPINFRA_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'DINGTALK_CLIENT_SECRET',
+  'DISCORD_BOT_TOKEN',
+  'ELEVENLABS_API_KEY',
+  'EMAIL_PASSWORD',
+  'EXA_API_KEY',
+  'FAL_KEY',
+  'FEISHU_APP_SECRET',
+  'FIRECRAWL_API_KEY',
+  'FIREWORKS_API_KEY',
+  'FREEBUFF_PROXY_API_KEY',
+  'FREEBUFF_TOKEN',
+  'FREELLMAPI_API_KEY',
+  'GATEWAY_PROXY_KEY',
+  'GATEWAY_RELAY_DELIVERY_KEY',
+  'GATEWAY_RELAY_ID',
+  'GATEWAY_RELAY_SECRET',
+  'GEMINI_API_KEY',
+  'GH_TOKEN',
+  'GITHUB_APP_ID',
+  'GITHUB_APP_INSTALLATION_ID',
+  'GITHUB_APP_PRIVATE_KEY_PATH',
+  'GITHUB_TOKEN',
+  'GLM_API_KEY',
+  'GMI_API_KEY',
+  'GOOGLE_API_KEY',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'GOOGLE_CHAT_SERVICE_ACCOUNT_JSON',
+  'HASS_TOKEN',
+  'HERMES_LANGFUSE_SECRET_KEY',
+  'HF_TOKEN',
+  'HINDSIGHT_API_KEY',
+  'HONCHO_API_KEY',
+  'IRC_NICKSERV_PASSWORD',
+  'IRC_SERVER_PASSWORD',
+  'KILOCODE_API_KEY',
+  'KIMI_API_KEY',
+  'KIMI_CN_API_KEY',
+  'KIMI_CODING_API_KEY',
+  'KREA_API_KEY',
+  'LANGFUSE_SECRET_KEY',
+  'LINEAR_API_KEY',
+  'LINE_CHANNEL_ACCESS_TOKEN',
+  'LINE_CHANNEL_SECRET',
+  'LM_API_KEY',
+  'MATTERMOST_TOKEN',
+  'MATRIX_ACCESS_TOKEN',
+  'MATRIX_PASSWORD',
+  'MATRIX_RECOVERY_KEY',
+  'MEM0_API_KEY',
+  'META_API_KEY',
+  'META_MODEL_API_KEY',
+  'MINIMAX_API_KEY',
+  'MINIMAX_CN_API_KEY',
+  'MISTRAL_API_KEY',
+  'MODAL_TOKEN_ID',
+  'MODAL_TOKEN_SECRET',
+  'MODEL_API_KEY',
+  'NOTION_API_KEY',
+  'NOVITA_API_KEY',
+  'NTFY_TOKEN',
+  'NVIDIA_API_KEY',
+  'OLLAMA_API_KEY',
+  'OPENCODE_API_KEY',
+  'OPENCODE_GO_API_KEY',
+  'OPENCODE_ZEN_API_KEY',
+  'OPENAI_API_KEY',
+  'OPENROUTER_API_KEY',
+  'OPENVIKING_API_KEY',
+  'PARALLEL_API_KEY',
+  'PHOTON_PROJECT_SECRET',
+  'PORCUPINE_ACCESS_KEY',
+  'QQ_CLIENT_SECRET',
+  'RETAINDB_API_KEY',
+  'SITDECK_PASSWORD',
+  'SLACK_APP_TOKEN',
+  'SLACK_BOT_TOKEN',
+  'STEPFUN_API_KEY',
+  'SUDO_PASSWORD',
+  'SUPERMEMORY_API_KEY',
+  'TAVILY_API_KEY',
+  'TEAMS_CLIENT_SECRET',
+  'TELEGRAM_BOT_TOKEN',
+  'TENOR_API_KEY',
+  'TERMINAL_SSH_KEY',
+  'TOGETHER_API_KEY',
+  'TOOL_GATEWAY_USER_TOKEN',
+  'TWILIO_AUTH_TOKEN',
+  'UPSTAGE_API_KEY',
+  'VERCEL_OIDC_TOKEN',
+  'VERCEL_TOKEN',
+  'VERTEX_CREDENTIALS_PATH',
+  'VOICE_TOOLS_OPENAI_KEY',
+  'WEBHOOK_SECRET',
+  'WECOM_CALLBACK_CORP_SECRET',
+  'WECOM_CALLBACK_ENCODING_AES_KEY',
+  'WECOM_CALLBACK_TOKEN',
+  'WECOM_SECRET',
+  'WORLDMONITOR_API_KEY',
+  'XAI_API_KEY',
+  'XIAOMI_API_KEY',
+  'ZAI_API_KEY',
+  'Z_AI_API_KEY'
+])
+
+const FORWARDED_ENV_PREFIXES = ['APPTAINERENV_', 'SINGULARITYENV_']
+
+function effectiveEnvName(name: string): string {
+  let normalized = name.trim().toUpperCase()
+  let changed = true
+
+  while (changed) {
+    changed = false
+
+    for (const prefix of FORWARDED_ENV_PREFIXES) {
+      if (normalized.startsWith(prefix)) {
+        normalized = normalized.slice(prefix.length)
+        changed = true
+      }
+    }
+  }
+
+  return normalized
+}
+
+export function isHermesCredentialEnvVar(name: string): boolean {
+  const normalized = effectiveEnvName(name)
+
+  if (!normalized) {
+    return false
+  }
+
+  if (normalized.startsWith('_HERMES_FORCE_')) {
+    return true
+  }
+
+  if (HERMES_CREDENTIAL_NAMES.has(normalized)) {
+    return true
+  }
+
+  if (/^HERMES_[A-Z0-9_]+_(?:API_KEY|TOKEN|SECRET|PASSWORD|PRIVATE_KEY)$/.test(normalized)) {
+    return true
+  }
+
+  if (/^AUXILIARY_[A-Z0-9_]+_(?:API_KEY|BASE_URL)$/.test(normalized)) {
+    return true
+  }
+
+  return /^GATEWAY_RELAY_[A-Z0-9_]+_(?:SECRET|KEY|TOKEN)$/.test(normalized)
+}
+
+/** Merge sources while removing only credentials owned by Hermes. */
+export function scrubDesktopChildEnv(...sources: Array<EnvMap | null | undefined>): Record<string, string> {
+  const out: Record<string, string> = {}
+
+  for (const source of sources) {
+    for (const [key, value] of Object.entries(source || {})) {
+      if (value == null || isHermesCredentialEnvVar(key)) {
+        continue
+      }
+
+      out[key] = String(value)
+    }
+  }
+
+  return out
+}
+
+export interface DesktopServeChildEnvOptions {
+  source?: EnvMap
+  backendEnv?: EnvMap
+  hermesHome: string
+  terminalCwd: string
+  dashboardSessionToken: string
+  parentIdentityEnv?: EnvMap
+  webDist: string
+  readyFile?: string | null
+}
+
+/** Build the local Desktop backend env and re-add only its freshly minted token. */
+export function buildDesktopServeChildEnv({
+  source,
+  backendEnv,
+  hermesHome,
+  terminalCwd,
+  dashboardSessionToken,
+  parentIdentityEnv,
+  webDist,
+  readyFile
+}: DesktopServeChildEnvOptions): Record<string, string> {
+  const env = scrubDesktopChildEnv(source, backendEnv, parentIdentityEnv)
+
+  env.HERMES_HOME = hermesHome
+  env.TERMINAL_CWD = terminalCwd
+  env.HERMES_DASHBOARD_SESSION_TOKEN = dashboardSessionToken
+  env.HERMES_DESKTOP = '1'
+  env.HERMES_WEB_DIST = webDist
+
+  if (readyFile) {
+    env.HERMES_DESKTOP_READY_FILE = readyFile
+  }
+
+  return env
+}

--- a/apps/desktop/electron/terminal-ipc.ts
+++ b/apps/desktop/electron/terminal-ipc.ts
@@ -11,6 +11,7 @@ import { app, ipcMain } from 'electron'
 import nodePty from 'node-pty'
 
 import { resolveTerminalConnection } from './connection-apply'
+import { buildDesktopTerminalEnv } from './scrub-child-env'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { buildInteractiveSshArgs } from './ssh-connection'
 import { buildWindowsInteractiveCommand } from './windows-remote-lifecycle'
@@ -136,36 +137,7 @@ export function registerTerminalIpc({
   }
 
   function terminalShellEnv() {
-    const env = { ...process.env }
-
-    // Electron is commonly launched through `npm run dev`; do not leak npm's
-    // managed prefix into a user's interactive shell (nvm/proto warn loudly).
-    for (const key of Object.keys(env)) {
-      if (key === 'npm_config_prefix' || key.startsWith('npm_config_') || key.startsWith('npm_package_')) {
-        delete env[key]
-      }
-    }
-
-    // Strip color/theme-detection vars that ride along when Electron is launched
-    // from a non-tty agent shell (Cursor's runner sets NO_COLOR/FORCE_COLOR=0
-    // /TERM=dumb; some terminals set COLORFGBG which would flip Hermes' TUI into
-    // light-mode). Our PTY is a real xterm-compat terminal — force truecolor.
-    delete env.NO_COLOR
-    delete env.FORCE_COLOR
-    delete env.COLORFGBG
-
-    env.COLORTERM = 'truecolor'
-    env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'
-    env.TERM = 'xterm-256color'
-    env.TERM_PROGRAM = 'Hermes'
-    env.TERM_PROGRAM_VERSION = app.getVersion()
-
-    // Let a hermes/--tui launched in this pane know it's embedded in the desktop
-    // GUI (build_environment_hints surfaces this). Distinct from HERMES_DESKTOP,
-    // which marks the agent *backend* and gates cron/gateway behavior.
-    env.HERMES_DESKTOP_TERMINAL = '1'
-
-    return env
+    return buildDesktopTerminalEnv(process.env, app.getVersion())
   }
 
   function terminalChannel(id, suffix) {


### PR DESCRIPTION
## Summary
- Scrub credential-shaped keys from the environment passed to `hermes serve` / pool backend children and the `serve --help` capability probe.
- Re-inject only intentional overrides (`HERMES_HOME`, minted `HERMES_DASHBOARD_SESSION_TOKEN`, `HERMES_DESKTOP`, web dist, ready file, PATH/PYTHONPATH overlays).

## Why
Long-lived Desktop backends inherited the full parent Electron env, including messaging tokens and provider keys that belong in `HERMES_HOME/.env`. Capability probes also do not need secrets.

## Test plan
- [x] `npx tsx --test apps/desktop/electron/scrub-child-env.test.ts`
- [ ] Manual: start Desktop local backend and confirm serve still boots with a minted session token