### PR TITLE
fix(desktop): omit remote tokens from Linux update relaunch scripts

### DIFF
--- a/apps/desktop/electron/update-relaunch.test.ts
+++ b/apps/desktop/electron/update-relaunch.test.ts
@@ -23,7 +23,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { test } from 'vitest'
+import test from 'node:test'
 
 import {
   buildRelaunchScript,
@@ -173,11 +173,11 @@ test('collectRelaunchEnv preserves HERMES_HOME + HERMES_DESKTOP_* + sandbox opt-
   assert.deepEqual(collectRelaunchEnv(env), {
     HERMES_HOME: '/home/u/.hermes',
     HERMES_DESKTOP_REMOTE_URL: 'http://box:9119',
-    HERMES_DESKTOP_REMOTE_TOKEN: 'secret',
     HERMES_DESKTOP_HERMES_ROOT: '/home/u/dev/hermes',
     HERMES_DESKTOP_APP_NAME: 'HermesSandbox',
     ELECTRON_DISABLE_SANDBOX: '1'
   })
+  assert.equal(collectRelaunchEnv(env).HERMES_DESKTOP_REMOTE_TOKEN, undefined)
   assert.deepEqual(collectRelaunchEnv(null), {})
 })
 

--- a/apps/desktop/electron/update-relaunch.test.ts
+++ b/apps/desktop/electron/update-relaunch.test.ts
@@ -2,7 +2,7 @@
  * Tests for electron/update-relaunch.ts — the pure decision + script helpers
  * behind the Linux in-app update relaunch (#45205).
  *
- * Run with: node --test electron/update-relaunch.test.ts
+ * Run with: npx vitest run --project electron electron/update-relaunch.test.ts
  * (Wired into npm test:desktop:platforms in package.json.)
  *
  * What this locks (review acceptance criteria for PR #45205):
@@ -23,7 +23,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import test from 'node:test'
+import { test } from 'vitest'
 
 import {
   buildRelaunchScript,

--- a/apps/desktop/electron/update-relaunch.test.ts
+++ b/apps/desktop/electron/update-relaunch.test.ts
@@ -177,7 +177,7 @@ test('collectRelaunchEnv preserves HERMES_HOME + HERMES_DESKTOP_* + sandbox opt-
     HERMES_DESKTOP_APP_NAME: 'HermesSandbox',
     ELECTRON_DISABLE_SANDBOX: '1'
   })
-  assert.equal(collectRelaunchEnv(env).HERMES_DESKTOP_REMOTE_TOKEN, undefined)
+  assert.equal('HERMES_DESKTOP_REMOTE_TOKEN' in collectRelaunchEnv(env), false)
   assert.deepEqual(collectRelaunchEnv(null), {})
 })
 

--- a/apps/desktop/electron/update-relaunch.ts
+++ b/apps/desktop/electron/update-relaunch.ts
@@ -233,6 +233,13 @@ function collectRelaunchArgs(argv) {
 // the SUID sandbox, the relaunched instance must inherit that opt-out too.
 const PRESERVED_ENV_KEYS = ['HERMES_HOME', 'ELECTRON_DISABLE_SANDBOX']
 const PRESERVED_ENV_PREFIXES = ['HERMES_DESKTOP_']
+// HERMES_DESKTOP_* is snapshotted into a world-readable temp relaunch script.
+// Never export credential-shaped values (remote tokens, passwords, API keys).
+const RELAUNCH_ENV_SECRET_SUFFIXES = ['_TOKEN', '_SECRET', '_PASSWORD', '_API_KEY', '_CREDENTIALS']
+
+function isRelaunchEnvSecretKey(key) {
+  return RELAUNCH_ENV_SECRET_SUFFIXES.some(suffix => key.endsWith(suffix))
+}
 
 function collectRelaunchEnv(env) {
   const out = {}
@@ -243,6 +250,10 @@ function collectRelaunchEnv(env) {
 
   for (const [key, value] of Object.entries(env)) {
     if (value == null) {
+      continue
+    }
+
+    if (isRelaunchEnvSecretKey(key)) {
       continue
     }
 


### PR DESCRIPTION
## Summary
- Stop exporting credential-shaped `HERMES_DESKTOP_*` values (notably `HERMES_DESKTOP_REMOTE_TOKEN`) into the world-readable Linux update relaunch temp script.
- Preserve non-secret relaunch context such as `HERMES_HOME`, `HERMES_DESKTOP_REMOTE_URL`, and sandbox opt-out.

## Why
`collectRelaunchEnv` snapshotted every `HERMES_DESKTOP_*` key into a temp bash script under the system temp directory. A remote gateway token therefore landed on disk in plaintext. Remote auth should be re-read from the connection store after relaunch, not written into the watcher script.

Extends the #45205 relaunch env snapshot without weakening relaunch correctness.

## Test plan
- [x] Focused `collectRelaunchEnv` assertion: remote token absent, remote URL retained
- [ ] Manual on Linux: in-app update relaunch still restores profile/root context