### PR TITLE
fix(desktop): redact secrets in local backend log ring

### DIFF
--- a/apps/desktop/electron/desktop-log-redact.test.ts
+++ b/apps/desktop/electron/desktop-log-redact.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { formatDesktopLogChunk } from './desktop-log-redact'
+
+test('formatDesktopLogChunk redacts session tokens before the local log ring', () => {
+  const out = formatDesktopLogChunk('Listening on ws://127.0.0.1:9119/api/ws?token=supersecret')
+
+  assert.match(out, /\?token=<redacted>/)
+  assert.ok(!out.includes('supersecret'))
+})
+
+test('formatDesktopLogChunk leaves non-secret lines intact', () => {
+  assert.equal(formatDesktopLogChunk('Hermes serve ready'), 'Hermes serve ready')
+})

--- a/apps/desktop/electron/desktop-log-redact.test.ts
+++ b/apps/desktop/electron/desktop-log-redact.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest'
+
+import { createDesktopLogFormatter, formatDesktopLogChunk } from './desktop-log-redact'
+
+test('formatDesktopLogChunk redacts session tokens before the local log ring', () => {
+  const out = formatDesktopLogChunk('Listening on ws://127.0.0.1:9119/api/ws?token=supersecret')
+
+  expect(out).toMatch(/\?token=<redacted>/)
+  expect(out).not.toContain('supersecret')
+})
+
+test('formatDesktopLogChunk leaves non-secret lines intact', () => {
+  expect(formatDesktopLogChunk('Hermes serve ready')).toBe('Hermes serve ready')
+})
+
+test('stream formatter redacts prefixes split across chunks', () => {
+  const prefixes = [
+    '?token=',
+    '?ticket=',
+    'HERMES_DASHBOARD_SESSION_TOKEN=',
+    'X-Hermes-Session-Token: ',
+    'Authorization: Bearer '
+  ]
+
+  for (const prefix of prefixes) {
+    const format = createDesktopLogFormatter()
+    expect(format(`stream ${prefix}`)).toBe('')
+    const output = format('split-secret\n')
+    expect(output).toContain('<redacted>')
+    expect(output).not.toContain('split-secret')
+  }
+})
+
+test('stream formatter redacts a value split across chunks on either stream', () => {
+  for (const stream of ['stdout', 'stderr']) {
+    const format = createDesktopLogFormatter()
+    expect(format(`${stream}: ?token=split`)).toBe('')
+    const output = format('-secret\n')
+    expect(output).toContain('<redacted>')
+    expect(output).not.toContain('split-secret')
+  }
+})

--- a/apps/desktop/electron/desktop-log-redact.ts
+++ b/apps/desktop/electron/desktop-log-redact.ts
@@ -1,0 +1,10 @@
+import { redactSecrets } from './ssh-connection'
+
+/**
+ * Format a backend stdout/stderr chunk for the local Desktop log ring.
+ * Secrets that leak into process output must not persist in hermesLog /
+ * desktopLogBuffer (or the on-disk desktop log flush).
+ */
+export function formatDesktopLogChunk(chunk: unknown): string {
+  return redactSecrets(String(chunk || '')).trim()
+}

--- a/apps/desktop/electron/desktop-log-redact.ts
+++ b/apps/desktop/electron/desktop-log-redact.ts
@@ -1,0 +1,47 @@
+import { redactSecrets } from './ssh-connection'
+
+const MAX_CARRY_CHARS = 4096
+
+const SECRET_PREFIX_RE =
+  /(?:[?&](?:token|ticket)=|HERMES_DASHBOARD_SESSION_TOKEN=|X-Hermes-Session-Token["']?\s*[:=]\s*["']?|Authorization["']?\s*:\s*Bearer\s+)/i
+
+export function formatDesktopLogChunk(chunk: unknown): string {
+  return redactSecrets(String(chunk ?? '')).trim()
+}
+
+export function createDesktopLogFormatter(): (chunk: unknown) => string {
+  let carry = ''
+  let suppressSecret = false
+
+  return chunk => {
+    let input = String(chunk ?? '')
+
+    if (suppressSecret) {
+      const boundary = input.search(/\r?\n/)
+
+      if (boundary < 0) {
+        return ''
+      }
+
+      input = input.slice(boundary + (input[boundary] === '\r' ? 2 : 1))
+      suppressSecret = false
+    }
+
+    carry += input
+    const parts = carry.split(/\r?\n/)
+    carry = parts.pop() ?? ''
+    let complete = parts.join('\n')
+
+    if (carry && !SECRET_PREFIX_RE.test(carry)) {
+      complete += `${complete ? '\n' : ''}${carry}`
+      carry = ''
+    }
+
+    if (carry.length > MAX_CARRY_CHARS && SECRET_PREFIX_RE.test(carry)) {
+      carry = ''
+      suppressSecret = true
+    }
+
+    return formatDesktopLogChunk(complete)
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -66,6 +66,7 @@ import {
   tokenPreview
 } from './connection-config'
 import { adoptServedDashboardToken } from './dashboard-token'
+import { formatDesktopLogChunk } from './desktop-log-redact'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import {
   buildPosixCleanupScript,
@@ -1155,7 +1156,7 @@ function scheduleDesktopLogFlush() {
 }
 
 function rememberLog(chunk) {
-  const text = String(chunk || '').trim()
+  const text = formatDesktopLogChunk(chunk)
 
   if (!text) {
     return

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -121,6 +121,7 @@ import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import { formatDesktopLogLine } from './desktop-log-line'
+import { createDesktopLogFormatter } from './desktop-log-redact'
 import { resolveDesktopRemoteRoute } from './desktop-remote-route'
 import {
   buildPosixCleanupScript,
@@ -1364,6 +1365,7 @@ const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
 let desktopLogBuffer = ''
+const desktopLogFormatter = createDesktopLogFormatter()
 let desktopLogFlushTimer = null
 let desktopLogFlushPromise = Promise.resolve()
 let nativeThemeListenerInstalled = false
@@ -1502,7 +1504,7 @@ function scheduleDesktopLogFlush() {
 }
 
 function rememberLog(chunk) {
-  const text = String(chunk || '').trim()
+  const text = desktopLogFormatter(chunk)
 
   if (!text) {
     return


### PR DESCRIPTION
## Summary
- Route local `hermes serve` stdout/stderr through `formatDesktopLogChunk` / `redactSecrets` before appending to the in-memory log ring and on-disk desktop log buffer.
- Align local logging with the existing SSH path, which already redacted secrets.

## Why
Session tokens and `?token=` URL lines from local serve output could previously persist in `hermesLog` / `desktop.log` and be returned via `hermes:logs:recent`. The SSH path already used `redactSecrets`; the local path did not.

## Test plan
- [x] `npx tsx --test apps/desktop/electron/desktop-log-redact.test.ts`
- [ ] Manual: confirm Desktop log panel redacts `?token=` lines from local serve output