### PR TITLE
fix(desktop): drop unscoped stream events after mid-turn pin clears

### DIFF
--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -96,4 +96,29 @@ describe('gateway event routing', () => {
       sessionId: 'session-a'
     })
   })
+
+  it('drops late unscoped stream events after the pin clears (no active fallback)', () => {
+    const lateDelta = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'message.delta',
+      explicitSessionId: '',
+      unscopedStreamSessionId: null
+    })
+
+    expect(lateDelta).toEqual({
+      drop: true,
+      nextUnscopedStreamSessionId: null,
+      sessionId: null
+    })
+
+    const lateTool = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'tool.start',
+      explicitSessionId: '',
+      unscopedStreamSessionId: null
+    })
+
+    expect(lateTool.drop).toBe(true)
+    expect(lateTool.sessionId).toBeNull()
+  })
 })

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -127,4 +127,29 @@ describe('gateway event routing', () => {
       sessionId: 'session-a'
     })
   })
+
+  it('drops late unscoped stream events after the pin clears (no active fallback)', () => {
+    const lateDelta = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'message.delta',
+      explicitSessionId: '',
+      unscopedStreamSessionId: null
+    })
+
+    expect(lateDelta).toEqual({
+      drop: true,
+      nextUnscopedStreamSessionId: null,
+      sessionId: null
+    })
+
+    const lateTool = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'tool.start',
+      explicitSessionId: '',
+      unscopedStreamSessionId: null
+    })
+
+    expect(lateTool.drop).toBe(true)
+    expect(lateTool.sessionId).toBeNull()
+  })
 })

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -92,11 +92,9 @@ describe('gateway event routing', () => {
     })
   })
 
-  it('attributes an unpinned stream event to the active session without the pin flag', () => {
-    // A late straggler (no pin left after the previous turn completed) falls
-    // back to the active session. The handler drops this case when the target
-    // session has no live turn — the straggler belongs to a turn that already
-    // ended elsewhere (#43142 family).
+  it('drops an unpinned stream event after the previous turn completed', () => {
+    // A late straggler has no pin left after the previous turn completed, so
+    // attributing it to the active session would attach it to the wrong chat.
     const routed = resolveGatewayEventSessionId({
       activeSessionId: 'session-b',
       eventType: 'thinking.delta',
@@ -105,10 +103,10 @@ describe('gateway event routing', () => {
     })
 
     expect(routed).toEqual({
-      drop: false,
+      drop: true,
       nextUnscopedStreamSessionId: null,
       pinned: false,
-      sessionId: 'session-b'
+      sessionId: null
     })
   })
 
@@ -139,6 +137,7 @@ describe('gateway event routing', () => {
     expect(lateDelta).toEqual({
       drop: true,
       nextUnscopedStreamSessionId: null,
+      pinned: false,
       sessionId: null
     })
 

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -105,11 +105,23 @@ export function resolveGatewayEventSessionId({
 
   const streamEvent = eventType ? UNSCOPED_STREAM_EVENT_TYPES.has(eventType) : false
 
+  // Mid-stream unscoped events must stay on the pin from ``message.start``.
+  // After the pin clears (complete/error), do NOT fall back to whatever chat
+  // is focused now — that reattributes late deltas onto the wrong transcript
+  // (#47709 / #48281 remaining gap).
+  if (streamEvent && eventType !== 'message.start' && !unscopedStreamSessionId) {
+    return {
+      drop: true,
+      nextUnscopedStreamSessionId: null,
+      sessionId: null
+    }
+  }
+
   const sessionId =
     eventType === 'message.start'
       ? activeSessionId
       : streamEvent
-        ? unscopedStreamSessionId || activeSessionId
+        ? unscopedStreamSessionId
         : activeSessionId
 
   let nextUnscopedStreamSessionId = unscopedStreamSessionId

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -134,11 +134,23 @@ export function resolveGatewayEventSessionId({
 
   const streamEvent = eventType ? UNSCOPED_STREAM_EVENT_TYPES.has(eventType) : false
 
+  // Mid-stream unscoped events must stay on the pin from ``message.start``.
+  // After the pin clears (complete/error), do NOT fall back to whatever chat
+  // is focused now — that reattributes late deltas onto the wrong transcript
+  // (#47709 / #48281 remaining gap).
+  if (streamEvent && eventType !== 'message.start' && !unscopedStreamSessionId) {
+    return {
+      drop: true,
+      nextUnscopedStreamSessionId: null,
+      sessionId: null
+    }
+  }
+
   const sessionId =
     eventType === 'message.start'
       ? activeSessionId
       : streamEvent
-        ? unscopedStreamSessionId || activeSessionId
+        ? unscopedStreamSessionId
         : activeSessionId
 
   let nextUnscopedStreamSessionId = unscopedStreamSessionId

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -142,6 +142,7 @@ export function resolveGatewayEventSessionId({
     return {
       drop: true,
       nextUnscopedStreamSessionId: null,
+      pinned: false,
       sessionId: null
     }
   }


### PR DESCRIPTION
## Summary
- After an unscoped stream pin is cleared (`message.complete` / `error`), late unscoped stream events are dropped instead of falling back to the currently focused chat.
- `message.start` still pins to the active session; explicit `session_id` routing is unchanged.

## Why
`resolveGatewayEventSessionId` used `unscopedStreamSessionId || activeSessionId` for mid-stream events. Once the pin cleared, a late delta/tool event without `session_id` could paint onto a different conversation — the reported failed-turn / wrong-transcript symptom.

Closes the remaining gap after #47709 / #48281 pinning.

## Test plan
- [x] `gateway-events.test.ts` cases for pin retention and post-clear drop
- [ ] Manual: switch chats mid-turn; confirm late unscoped deltas do not attach to the newly focused transcript