### PR TITLE
fix(desktop): honor lineage when gating background queue drain

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -10,10 +10,32 @@ import {
   getQueuedPrompts,
   parkQueuedPrompts
 } from '@/store/composer-queue'
+import { $sessions, setSessions } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
 
 import { useBackgroundQueueDrain } from './use-background-queue-drain'
 import type { SubmitTextOptions } from './use-prompt-actions/utils'
+
+const lineageSession = (over: Partial<SessionInfo>): SessionInfo =>
+  ({
+    archived: false,
+    cwd: null,
+    ended_at: null,
+    id: 'live',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 0,
+    message_count: 0,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: null,
+    started_at: 0,
+    title: null,
+    tool_call_count: 0,
+    ...over
+  }) as SessionInfo
 
 function Harness({
   enabled = true,
@@ -48,6 +70,7 @@ describe('useBackgroundQueueDrain', () => {
     vi.useRealTimers()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    $sessions.set([])
     clearAllSessionStates()
   })
 
@@ -101,6 +124,40 @@ describe('useBackgroundQueueDrain', () => {
 
     expect(submitText).not.toHaveBeenCalled()
     expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
+  })
+
+  it('treats a tip working id as busy for a root queue key via lineage', async () => {
+    // Queue keys use the lineage root (resolveComposerSessionKey) while
+    // $workingSessionIds may hold the compression tip — strict equality misses.
+    const runtimeMap = { current: new Map([['root-a', 'rt-tip-a']]) }
+    const submitText = vi.fn(async () => true)
+
+    setSessions([lineageSession({ id: 'tip-a', _lineage_root_id: 'root-a' })])
+    enqueueQueuedPrompt('root-a', { text: 'wait for tip turn', attachments: [] })
+    publishSessionState('rt-tip-a', { ...createClientSessionState('tip-a'), busy: true })
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+
+    expect(submitText).not.toHaveBeenCalled()
+    expect(getQueuedPrompts('root-a')).toHaveLength(1)
+  })
+
+  it('leaves a root queue to ChatBar when the selected id is the compression tip', async () => {
+    const runtimeMap = { current: new Map([['root-a', 'rt-tip-a']]) }
+    const submitText = vi.fn(async () => true)
+
+    setSessions([lineageSession({ id: 'tip-a', _lineage_root_id: 'root-a' })])
+    enqueueQueuedPrompt('root-a', { text: 'visible after tip select', attachments: [] })
+    clearAllSessionStates()
+
+    render(<Harness runtimeMap={runtimeMap} selectedStoredSessionId="tip-a" submitText={submitText} />)
+
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+
+    expect(submitText).not.toHaveBeenCalled()
+    expect(getQueuedPrompts('root-a')).toHaveLength(1)
   })
 
   it('does not drain a parked background session, even when idle', async () => {

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -13,7 +13,9 @@ import {
   shouldAutoDrain
 } from '@/store/composer-queue'
 import { notify } from '@/store/notifications'
+import { $sessions, sessionMatchesStoredId } from '@/store/session'
 import { $workingSessionIds } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
 
 import type { SubmitTextOptions } from './use-prompt-actions/utils'
 
@@ -27,6 +29,15 @@ interface BackgroundQueueDrainOptions {
 }
 
 const BACKGROUND_DRAIN_RETRY_MS = 750
+
+/** True when two ids name the same conversation across compression tip rotation. */
+export function idsShareLineage(a: string, b: string, sessions: readonly Pick<SessionInfo, '_lineage_root_id' | 'id'>[]): boolean {
+  if (a === b) {
+    return true
+  }
+
+  return sessions.some(session => sessionMatchesStoredId(session, a) && sessionMatchesStoredId(session, b))
+}
 
 /**
  * Drain queued prompts for sessions that are not currently rendered by ChatBar.
@@ -153,14 +164,19 @@ export function useBackgroundQueueDrain({
       return
     }
 
-    const working = new Set(workingSessionIds)
+    const sessions = $sessions.get()
+    const working = [...workingSessionIds]
 
     for (const [sessionKey, entries] of Object.entries(queuedPromptsBySession)) {
+      const isSelected =
+        Boolean(selectedStoredSessionId) && idsShareLineage(sessionKey, selectedStoredSessionId!, sessions)
+      const isBusy = working.some(workingId => idsShareLineage(sessionKey, workingId, sessions))
+
       if (
-        sessionKey === selectedStoredSessionId ||
+        isSelected ||
         drainingSessionIdsRef.current.has(sessionKey) ||
         !shouldAutoDrain({
-          isBusy: working.has(sessionKey),
+          isBusy,
           parked: Boolean(parkedQueueSessions[sessionKey]),
           queueLength: entries.length
         })


### PR DESCRIPTION
## Summary
- Treat compression lineage root and tip as the same conversation when deciding whether a background queue may auto-drain.
- Skip drain when the selected or busy stored id shares lineage with the queue key, not only on exact string equality.

## Why
Composer/queue keys prefer the durable lineage root (`resolveComposerSessionKey`), while `` / selected session may hold the live compression tip. Strict equality then mis-classified a busy or selected chat as idle/offscreen, allowing double drain or drain during an active tip turn — a session-bleed / wrong-transcript class bug.

Complements merged #66001 (originating-session drain) and lineage work around #43483. Deliberately does **not** duplicate open #66240 (restored-queue manual send).

## Test plan
- [x] `use-background-queue-drain.test.tsx` lineage busy + tip-selected cases
- [ ] Manual: compress a session with a queued follow-up; confirm background drain waits for the tip turn