### PR TITLE
fix(shared): await in-flight JsonRpc gateway connect

### DIFF
--- a/apps/shared/src/json-rpc-gateway.test.ts
+++ b/apps/shared/src/json-rpc-gateway.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { JsonRpcGatewayClient } from './json-rpc-gateway'
+
+class FakeSocket {
+  readyState = 0
+  private listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+
+  addEventListener(type: string, handler: (...args: unknown[]) => void) {
+    const set = this.listeners.get(type) ?? new Set()
+    set.add(handler)
+    this.listeners.set(type, set)
+  }
+
+  removeEventListener(type: string, handler: (...args: unknown[]) => void) {
+    this.listeners.get(type)?.delete(handler)
+  }
+
+  close() {
+    this.readyState = 3
+    this.emit('close')
+  }
+
+  openNow() {
+    this.readyState = 1
+    this.emit('open')
+  }
+
+  private emit(type: string) {
+    for (const handler of this.listeners.get(type) ?? []) {
+      handler()
+    }
+  }
+}
+
+describe('JsonRpcGatewayClient.connect', () => {
+  it('shares an in-flight connect promise instead of short-circuiting', async () => {
+    let socket: FakeSocket | null = null
+
+    const client = new JsonRpcGatewayClient({
+      connectTimeoutMs: 5_000,
+      socketFactory: () => {
+        socket = new FakeSocket()
+
+        return socket as unknown as WebSocket
+      }
+    })
+
+    const first = client.connect('ws://127.0.0.1:9/api/ws')
+    const second = client.connect('ws://127.0.0.1:9/api/ws')
+
+    expect(client.connectionState).toBe('connecting')
+    expect(socket).not.toBeNull()
+
+    queueMicrotask(() => socket?.openNow())
+
+    await Promise.all([first, second])
+    expect(client.connectionState).toBe('open')
+  })
+})

--- a/apps/shared/src/json-rpc-gateway.test.ts
+++ b/apps/shared/src/json-rpc-gateway.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import { JsonRpcGatewayClient } from './json-rpc-gateway'
+
+class FakeSocket {
+  readyState = 0
+  private listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+
+  addEventListener(type: string, handler: (...args: unknown[]) => void) {
+    const set = this.listeners.get(type) ?? new Set()
+    set.add(handler)
+    this.listeners.set(type, set)
+  }
+
+  removeEventListener(type: string, handler: (...args: unknown[]) => void) {
+    this.listeners.get(type)?.delete(handler)
+  }
+
+  close() {
+    this.readyState = 3
+    this.emit('close')
+  }
+
+  openNow() {
+    this.readyState = 1
+    this.emit('open')
+  }
+
+  private emit(type: string) {
+    for (const handler of this.listeners.get(type) ?? []) {
+      handler()
+    }
+  }
+}
+
+describe('JsonRpcGatewayClient.connect', () => {
+  it('shares an in-flight connect promise instead of short-circuiting', async () => {
+    let socket: FakeSocket | null = null
+
+    const client = new JsonRpcGatewayClient({
+      connectTimeoutMs: 5_000,
+      socketFactory: () => {
+        socket = new FakeSocket()
+
+        return socket as unknown as WebSocket
+      }
+    })
+
+    const first = client.connect('ws://127.0.0.1:9/api/ws')
+    const second = client.connect('ws://127.0.0.1:9/api/ws')
+
+    expect(client.connectionState).toBe('connecting')
+    expect(socket).not.toBeNull()
+
+    queueMicrotask(() => socket?.openNow())
+
+    await Promise.all([first, second])
+    expect(client.connectionState).toBe('open')
+  })
+
+  it('starts a fresh handshake immediately after close interrupts a connect', async () => {
+    const sockets: FakeSocket[] = []
+
+    const client = new JsonRpcGatewayClient({
+      connectTimeoutMs: 5_000,
+      socketFactory: () => {
+        const socket = new FakeSocket()
+        sockets.push(socket)
+
+        return socket as unknown as WebSocket
+      }
+    })
+
+    const interrupted = client.connect('ws://127.0.0.1:9/api/ws')
+    const interruptedRejection = expect(interrupted).rejects.toThrow('WebSocket closed')
+
+    client.close()
+
+    const replacement = client.connect('ws://127.0.0.1:10/api/ws')
+
+    expect(sockets).toHaveLength(2)
+    expect(client.connectionState).toBe('connecting')
+
+    sockets[0].openNow()
+    expect(client.connectionState).toBe('connecting')
+
+    sockets[1].openNow()
+
+    await interruptedRejection
+    await replacement
+    expect(client.connectionState).toBe('open')
+  })
+})

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -72,6 +72,8 @@ export class JsonRpcGatewayClient {
   private pending = new Map<GatewayRequestId, PendingCall>()
   private socket: WebSocketLike | null = null
   private state: ConnectionState = 'idle'
+  /** Shared in-flight connect so concurrent callers await the same handshake. */
+  private connectPromise: Promise<void> | null = null
   private readonly eventHandlers = new Map<string, Set<(event: GatewayEvent) => void>>()
   private readonly stateHandlers = new Set<(state: ConnectionState) => void>()
   private readonly options: Required<Omit<GatewayClientOptions, 'socketFactory'>> &
@@ -119,8 +121,15 @@ export class JsonRpcGatewayClient {
       throw invalidUrl()
     }
 
-    if (this.socket?.readyState === WebSocket.OPEN || this.state === 'connecting') {
+    if (this.socket?.readyState === WebSocket.OPEN) {
       return
+    }
+
+    // Concurrent connect() during an in-flight handshake must await the same
+    // promise — returning early while state === 'connecting' made callers believe
+    // the socket was ready and immediately hit "gateway not connected".
+    if (this.connectPromise) {
+      return this.connectPromise
     }
 
     this.setState('connecting')
@@ -146,7 +155,7 @@ export class JsonRpcGatewayClient {
       this.rejectAllPending(new Error(this.options.closedErrorMessage))
     })
 
-    await new Promise<void>((resolve, reject) => {
+    this.connectPromise = new Promise<void>((resolve, reject) => {
       let settled = false
       let timer: ReturnType<typeof setTimeout> | undefined
 
@@ -159,26 +168,36 @@ export class JsonRpcGatewayClient {
         socket.removeEventListener('error', onError)
       }
 
-      const onOpen = () => {
-        if (settled || this.socket !== socket) {
+      const finish = (fn: () => void) => {
+        if (settled) {
           return
         }
 
         settled = true
         cleanup()
-        this.setState('open')
-        resolve()
+        fn()
+      }
+
+      const onOpen = () => {
+        if (this.socket !== socket) {
+          return
+        }
+
+        finish(() => {
+          this.setState('open')
+          resolve()
+        })
       }
 
       const onError = () => {
-        if (settled || this.socket !== socket) {
+        if (this.socket !== socket) {
           return
         }
 
-        settled = true
-        cleanup()
-        this.setState('error')
-        reject(new Error(this.options.connectErrorMessage))
+        finish(() => {
+          this.setState('error')
+          reject(new Error(this.options.connectErrorMessage))
+        })
       }
 
       socket.addEventListener('open', onOpen, { once: true })
@@ -186,30 +205,29 @@ export class JsonRpcGatewayClient {
 
       if (this.options.connectTimeoutMs > 0) {
         timer = setTimeout(() => {
-          if (settled) {
-            return
-          }
+          finish(() => {
+            // Drop the half-open socket so the next connect() starts clean
+            // instead of short-circuiting on a zombie 'connecting' state.
+            if (this.socket === socket) {
+              try {
+                socket.close()
+              } catch {
+                // ignore
+              }
 
-          settled = true
-          cleanup()
-
-          // Drop the half-open socket so the next connect() starts clean
-          // instead of short-circuiting on a zombie 'connecting' state.
-          if (this.socket === socket) {
-            try {
-              socket.close()
-            } catch {
-              // ignore
+              this.socket = null
             }
 
-            this.socket = null
-          }
-
-          this.setState('error')
-          reject(new Error(this.options.connectErrorMessage))
+            this.setState('error')
+            reject(new Error(this.options.connectErrorMessage))
+          })
         }, this.options.connectTimeoutMs)
       }
+    }).finally(() => {
+      this.connectPromise = null
     })
+
+    await this.connectPromise
   }
 
   close(): void {

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -74,6 +74,8 @@ export class JsonRpcGatewayClient {
   private state: ConnectionState = 'idle'
   /** Shared in-flight connect so concurrent callers await the same handshake. */
   private connectPromise: Promise<void> | null = null
+  /** Cancels the active handshake when close() interrupts a dial. */
+  private cancelConnect: (() => void) | null = null
   private readonly eventHandlers = new Map<string, Set<(event: GatewayEvent) => void>>()
   private readonly stateHandlers = new Set<(state: ConnectionState) => void>()
   private readonly options: Required<Omit<GatewayClientOptions, 'socketFactory'>> &
@@ -155,7 +157,7 @@ export class JsonRpcGatewayClient {
       this.rejectAllPending(new Error(this.options.closedErrorMessage))
     })
 
-    this.connectPromise = new Promise<void>((resolve, reject) => {
+    const connectPromise = new Promise<void>((resolve, reject) => {
       let settled = false
       let timer: ReturnType<typeof setTimeout> | undefined
 
@@ -200,6 +202,10 @@ export class JsonRpcGatewayClient {
         })
       }
 
+      this.cancelConnect = () => {
+        finish(() => reject(new Error(this.options.closedErrorMessage)))
+      }
+
       socket.addEventListener('open', onOpen, { once: true })
       socket.addEventListener('error', onError, { once: true })
 
@@ -224,14 +230,23 @@ export class JsonRpcGatewayClient {
         }, this.options.connectTimeoutMs)
       }
     }).finally(() => {
-      this.connectPromise = null
-    })
+      if (this.connectPromise === connectPromise) {
+        this.connectPromise = null
+      }
 
-    await this.connectPromise
+      this.cancelConnect = null
+    })
+    this.connectPromise = connectPromise
+
+    await connectPromise
   }
 
   close(): void {
     const socket = this.socket
+
+    this.cancelConnect?.()
+    this.cancelConnect = null
+    this.connectPromise = null
 
     if (!socket) {
       return

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -97,6 +97,10 @@ export class JsonRpcGatewayClient {
   private pending = new Map<GatewayRequestId, PendingCall>()
   private socket: WebSocketLike | null = null
   private state: ConnectionState = 'idle'
+  /** Shared in-flight connect so concurrent callers await the same handshake. */
+  private connectPromise: Promise<void> | null = null
+  /** Cancels the active handshake when close() interrupts a dial. */
+  private cancelConnect: (() => void) | null = null
   private readonly eventHandlers = new Map<string, Set<(event: GatewayEvent) => void>>()
   private readonly stateHandlers = new Set<(state: ConnectionState) => void>()
   private readonly options: Required<Omit<GatewayClientOptions, 'socketFactory'>> &
@@ -145,8 +149,15 @@ export class JsonRpcGatewayClient {
       throw invalidUrl()
     }
 
-    if (this.socket?.readyState === WebSocket.OPEN || this.state === 'connecting') {
+    if (this.socket?.readyState === WebSocket.OPEN) {
       return
+    }
+
+    // Concurrent connect() during an in-flight handshake must await the same
+    // promise — returning early while state === 'connecting' made callers believe
+    // the socket was ready and immediately hit "gateway not connected".
+    if (this.connectPromise) {
+      return this.connectPromise
     }
 
     this.setState('connecting')
@@ -176,7 +187,7 @@ export class JsonRpcGatewayClient {
       this.rejectAllPending(new Error(this.options.closedErrorMessage))
     })
 
-    await new Promise<void>((resolve, reject) => {
+    const connectPromise = new Promise<void>((resolve, reject) => {
       let settled = false
       let timer: ReturnType<typeof setTimeout> | undefined
 
@@ -189,26 +200,40 @@ export class JsonRpcGatewayClient {
         socket.removeEventListener('error', onError)
       }
 
-      const onOpen = () => {
-        if (settled || this.socket !== socket) {
+      const finish = (fn: () => void) => {
+        if (settled) {
           return
         }
 
         settled = true
         cleanup()
-        this.setState('open')
-        resolve()
+        fn()
+      }
+
+      const onOpen = () => {
+        if (this.socket !== socket) {
+          return
+        }
+
+        finish(() => {
+          this.setState('open')
+          resolve()
+        })
       }
 
       const onError = () => {
-        if (settled || this.socket !== socket) {
+        if (this.socket !== socket) {
           return
         }
 
-        settled = true
-        cleanup()
-        this.setState('error')
-        reject(new Error(this.options.connectErrorMessage))
+        finish(() => {
+          this.setState('error')
+          reject(new Error(this.options.connectErrorMessage))
+        })
+      }
+
+      this.cancelConnect = () => {
+        finish(() => reject(new Error(this.options.closedErrorMessage)))
       }
 
       socket.addEventListener('open', onOpen, { once: true })
@@ -216,34 +241,42 @@ export class JsonRpcGatewayClient {
 
       if (this.options.connectTimeoutMs > 0) {
         timer = setTimeout(() => {
-          if (settled) {
-            return
-          }
+          finish(() => {
+            // Drop the half-open socket so the next connect() starts clean
+            // instead of short-circuiting on a zombie 'connecting' state.
+            if (this.socket === socket) {
+              try {
+                socket.close()
+              } catch {
+                // ignore
+              }
 
-          settled = true
-          cleanup()
-
-          // Drop the half-open socket so the next connect() starts clean
-          // instead of short-circuiting on a zombie 'connecting' state.
-          if (this.socket === socket) {
-            try {
-              socket.close()
-            } catch {
-              // ignore
+              this.socket = null
             }
 
-            this.socket = null
-          }
-
-          this.setState('error')
-          reject(new Error(this.options.connectErrorMessage))
+            this.setState('error')
+            reject(new Error(this.options.connectErrorMessage))
+          })
         }, this.options.connectTimeoutMs)
       }
+    }).finally(() => {
+      if (this.connectPromise === connectPromise) {
+        this.connectPromise = null
+        this.cancelConnect = null
+      }
     })
+
+    this.connectPromise = connectPromise
+
+    await connectPromise
   }
 
   close(): void {
     const socket = this.socket
+
+    this.cancelConnect?.()
+    this.cancelConnect = null
+    this.connectPromise = null
 
     if (!socket) {
       return


### PR DESCRIPTION
## Summary
- Share a single in-flight `connect()` promise on `JsonRpcGatewayClient` instead of returning immediately while `state === 'connecting'`.
- Concurrent callers (boot, soft switch, `ensureGatewayOpen`) now wait for the same handshake.

## Why
Returning early during `connecting` made callers believe the socket was ready and immediately hit `gateway not connected`, which presents as a dead composer / Desktop↔backend connection failure after sleep/wake or overlapping reconnects.

## Test plan
- [x] `apps/shared/src/json-rpc-gateway.test.ts` parallel connect shares handshake
- [ ] Manual: interrupt boot mid-connect and confirm soft-switch waits rather than failing open