### PR TITLE
fix(desktop): stash HMR gateway survivor while connecting

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/gateway-hmr-survivor.test.ts
+++ b/apps/desktop/src/app/gateway/hooks/gateway-hmr-survivor.test.ts
@@ -51,6 +51,9 @@ describe('gateway HMR survivor cache', () => {
   })
 
   it('treats open / connecting sockets as adoptable', () => {
+    // use-gateway-boot stashes on HMR when !survivorIsStale(survivor). Connecting
+    // must stay non-stale so a mid-dial hot reload parks the socket instead of
+    // closing it.
     expect(survivorIsStale(makeSurvivor('open'))).toBe(false)
     expect(survivorIsStale(makeSurvivor('connecting'))).toBe(false)
   })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -28,15 +28,17 @@ class FakeWebSocket {
   static CLOSED = 3
   // Flipped by the test: 'open' = next socket connects; 'fail' = next socket
   // errors (a dead remote). Mirrors a VPS going away after the first connect.
-  static mode: 'open' | 'fail' = 'open'
+  static mode: 'open' | 'fail' | 'pending' = 'open'
   static instances: FakeWebSocket[] = []
 
   readyState = 0
+  closeCalls = 0
   private listeners: Record<string, Set<Listener>> = {}
 
   constructor(public url: string) {
     FakeWebSocket.instances.push(this)
     const willOpen = FakeWebSocket.mode === 'open'
+    if (FakeWebSocket.mode === 'pending') return
     // Resolve on the next microtask/macrotask so connect()'s promise wiring is
     // in place before open/error fires (matches real async socket handshake).
     setTimeout(() => {
@@ -59,6 +61,7 @@ class FakeWebSocket {
   }
 
   close() {
+    this.closeCalls += 1
     this.readyState = FakeWebSocket.CLOSED
     this.emit('close', {})
   }
@@ -246,6 +249,23 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
     await flushAsync()
     expect($gatewayState.get()).toBe('open')
+  })
+
+  it('HMR cleanup stashes a connecting gateway instead of closing it', async () => {
+    FakeWebSocket.mode = 'pending'
+    render(<Harness />)
+    await flushAsync()
+
+    expect($gatewayState.get()).toBe('connecting')
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    const gateway = FakeWebSocket.instances[0]
+
+    cleanup()
+
+    const survivor = takeGatewaySurvivor()
+    expect(survivor).not.toBeNull()
+    expect(survivor?.gateway).toBeDefined()
+    expect(gateway.closeCalls).toBe(0)
   })
 
   it('a remote that drops post-boot keeps looping with NO boot.error (the dead-end CONNECTING combo)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -31,15 +31,21 @@ class FakeWebSocket {
   static CLOSED = 3
   // Flipped by the test: 'open' = next socket connects; 'fail' = next socket
   // errors (a dead remote). Mirrors a VPS going away after the first connect.
-  static mode: 'open' | 'fail' = 'open'
+  static mode: 'open' | 'fail' | 'pending' = 'open'
   static instances: FakeWebSocket[] = []
 
   readyState = 0
+  closeCalls = 0
   private listeners: Record<string, Set<Listener>> = {}
 
   constructor(public url: string) {
     FakeWebSocket.instances.push(this)
     const willOpen = FakeWebSocket.mode === 'open'
+
+    if (FakeWebSocket.mode === 'pending') {
+      return
+    }
+
     // Resolve on the next microtask/macrotask so connect()'s promise wiring is
     // in place before open/error fires (matches real async socket handshake).
     setTimeout(() => {
@@ -62,6 +68,7 @@ class FakeWebSocket {
   }
 
   close() {
+    this.closeCalls += 1
     this.readyState = FakeWebSocket.CLOSED
     this.emit('close', {})
   }
@@ -323,6 +330,23 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     // Backend B's list replaced A's — the rail survives the switch instead of
     // painting the previous backend's (or an empty) universe.
     expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'cloud-eric'])
+  })
+
+  it('HMR cleanup stashes a connecting gateway instead of closing it', async () => {
+    FakeWebSocket.mode = 'pending'
+    render(<Harness />)
+    await flushAsync()
+
+    expect($gatewayState.get()).toBe('connecting')
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    const gateway = FakeWebSocket.instances[0]
+
+    cleanup()
+
+    const survivor = takeGatewaySurvivor()
+    expect(survivor).not.toBeNull()
+    expect(survivor?.gateway).toBeDefined()
+    expect(gateway.closeCalls).toBe(0)
   })
 
   it('a remote that drops post-boot keeps looping with NO boot.error (the dead-end CONNECTING combo)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -591,17 +591,21 @@ export function useGatewayBoot({
 
       // HMR teardown vs. real unmount. On a hot update we must NOT close the
       // socket — that's the whole bug. Detach this instance's listeners (their
-      // closures capture the disposed module), park the still-open gateway, and
-      // let the freshly loaded effect re-adopt it. Secondaries are owned by the
-      // gateway store (HMR-stable module state), so they survive untouched.
-      // Production: import.meta.hot is undefined, so this branch never runs and
-      // the original destructive teardown below is byte-for-byte preserved.
-      if (import.meta.hot && gateway.connectionState === 'open') {
-        stashGatewaySurvivor({
-          gateway,
-          profile: survivor?.profile ?? $activeGatewayProfile.get(),
-          connection: $connection.get()
-        })
+      // closures capture the disposed module), park the still-open/connecting
+      // gateway, and let the freshly loaded effect re-adopt it. Secondaries are
+      // owned by the gateway store (HMR-stable module state), so they survive
+      // untouched. Production: import.meta.hot is undefined, so this branch
+      // never runs and the original destructive teardown below is preserved.
+      // Stash policy MUST match survivorIsStale: `connecting` is adoptable, so
+      // stashing only on `open` closed mid-dial sockets on Vite HMR.
+      const hmrSurvivor = {
+        gateway,
+        profile: survivor?.profile ?? $activeGatewayProfile.get(),
+        connection: $connection.get()
+      }
+
+      if (import.meta.hot && !survivorIsStale(hmrSurvivor)) {
+        stashGatewaySurvivor(hmrSurvivor)
 
         return
       }

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -808,17 +808,21 @@ export function useGatewayBoot({
 
       // HMR teardown vs. real unmount. On a hot update we must NOT close the
       // socket — that's the whole bug. Detach this instance's listeners (their
-      // closures capture the disposed module), park the still-open gateway, and
-      // let the freshly loaded effect re-adopt it. Secondaries are owned by the
-      // gateway store (HMR-stable module state), so they survive untouched.
-      // Production: import.meta.hot is undefined, so this branch never runs and
-      // the original destructive teardown below is byte-for-byte preserved.
-      if (import.meta.hot && gateway.connectionState === 'open') {
-        stashGatewaySurvivor({
-          gateway,
-          profile: survivor?.profile ?? $activeGatewayProfile.get(),
-          connection: $connection.get()
-        })
+      // closures capture the disposed module), park the still-open/connecting
+      // gateway, and let the freshly loaded effect re-adopt it. Secondaries are
+      // owned by the gateway store (HMR-stable module state), so they survive
+      // untouched. Production: import.meta.hot is undefined, so this branch
+      // never runs and the original destructive teardown below is preserved.
+      // Stash policy MUST match survivorIsStale: `connecting` is adoptable, so
+      // stashing only on `open` closed mid-dial sockets on Vite HMR.
+      const hmrSurvivor = {
+        gateway,
+        profile: survivor?.profile ?? $activeGatewayProfile.get(),
+        connection: $connection.get()
+      }
+
+      if (import.meta.hot && !survivorIsStale(hmrSurvivor)) {
+        stashGatewaySurvivor(hmrSurvivor)
 
         return
       }


### PR DESCRIPTION
## Summary
- Align Vite HMR gateway stash policy with `survivorIsStale`: park `open` **and** `connecting` sockets instead of only `open`.
- Prevents mid-dial hot reload from closing the live socket and forcing a full reboot that drops the session.

## Why
`survivorIsStale` already treated `connecting` as adoptable, but cleanup only stashed when `connectionState === 'open'`. An HMR update during the first dial closed the socket and rebooted, which feels like a flaky Desktop↔backend disconnect in dev.

## Test plan
- [x] `gateway-hmr-survivor.test.ts` documents connecting as adoptable
- [ ] Manual (dev): trigger HMR during gateway connect; confirm socket is re-adopted