### PR TITLE
fix(desktop): ignore EPIPE on standard pipes by error code

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -203,6 +203,13 @@ import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
 import { resolvePickerDefaultPath } from './wsl-path-bridge'
+import { installStdioPipeErrorGuards } from './stdio-pipe-guards'
+
+// ESM evaluates static imports (including electron) before any module body
+// statement, so this cannot run literally before `import 'electron'`. Install
+// as the first body statement — before window/backend work — and ignore only
+// structural pipe error codes (salvage of #61894; code-only, no message match).
+installStdioPipeErrorGuards()
 
 const USER_DATA_OVERRIDE = process.env.HERMES_DESKTOP_USER_DATA_DIR
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -148,6 +148,7 @@ import {
   redactSecrets,
   SshConnection
 } from './ssh-connection'
+import { installStdioPipeErrorGuards } from './stdio-pipe-guards'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
@@ -203,7 +204,6 @@ import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
 import { resolvePickerDefaultPath } from './wsl-path-bridge'
-import { installStdioPipeErrorGuards } from './stdio-pipe-guards'
 
 // ESM evaluates static imports (including electron) before any module body
 // statement, so this cannot run literally before `import 'electron'`. Install

--- a/apps/desktop/electron/stdio-pipe-guards.test.ts
+++ b/apps/desktop/electron/stdio-pipe-guards.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import test from 'node:test'
+
+import { installStdioPipeErrorGuards, isIgnorablePipeError } from './stdio-pipe-guards'
+
+test('isIgnorablePipeError accepts only EPIPE and ERR_STREAM_DESTROYED codes', () => {
+  assert.equal(isIgnorablePipeError(Object.assign(new Error('closed'), { code: 'EPIPE' })), true)
+  assert.equal(
+    isIgnorablePipeError(Object.assign(new Error('gone'), { code: 'ERR_STREAM_DESTROYED' })),
+    true
+  )
+})
+
+test('isIgnorablePipeError rejects message-only broken-pipe errors', () => {
+  assert.equal(isIgnorablePipeError(new Error('broken pipe')), false)
+  assert.equal(isIgnorablePipeError(new Error('EPIPE')), false)
+  assert.equal(isIgnorablePipeError(new Error('ERR_STREAM_DESTROYED')), false)
+  assert.equal(isIgnorablePipeError(Object.assign(new Error('write'), { code: 'EIO' })), false)
+})
+
+test('installStdioPipeErrorGuards swallows coded pipe errors on stdout/stderr', () => {
+  const stdout = new EventEmitter()
+  const stderr = new EventEmitter()
+
+  assert.equal(installStdioPipeErrorGuards({ stdout, stderr }), 2)
+
+  assert.doesNotThrow(() => stdout.emit('error', Object.assign(new Error('closed'), { code: 'EPIPE' })))
+  assert.doesNotThrow(() =>
+    stderr.emit('error', Object.assign(new Error('gone'), { code: 'ERR_STREAM_DESTROYED' }))
+  )
+})

--- a/apps/desktop/electron/stdio-pipe-guards.test.ts
+++ b/apps/desktop/electron/stdio-pipe-guards.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
-import test from 'node:test'
+
+import { test } from 'vitest'
 
 import { installStdioPipeErrorGuards, isIgnorablePipeError } from './stdio-pipe-guards'
 

--- a/apps/desktop/electron/stdio-pipe-guards.ts
+++ b/apps/desktop/electron/stdio-pipe-guards.ts
@@ -1,0 +1,48 @@
+/**
+ * Guard Electron main-process stdout/stderr against broken-pipe crashes.
+ *
+ * When the parent console is closed (Windows updater handoff, detached launch,
+ * redirected stdio), writes to standard pipes raise EPIPE / ERR_STREAM_DESTROYED.
+ * Those are expected and must not take down the Desktop main process.
+ *
+ * Only structural `error.code` values are ignorable — never match on message
+ * text (see review on #61894).
+ */
+
+const INSTALLED_PIPE_GUARD = '__hermesDesktopStdioPipeGuardInstalled'
+
+type ErrorStream = {
+  on: (event: 'error', listener: (error: NodeJS.ErrnoException) => void) => unknown
+  [INSTALLED_PIPE_GUARD]?: boolean
+}
+
+export function isIgnorablePipeError(error: NodeJS.ErrnoException | null | undefined): boolean {
+  const code = error?.code
+
+  return code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED'
+}
+
+function attachPipeGuard(stream: ErrorStream | null | undefined): boolean {
+  if (!stream || stream[INSTALLED_PIPE_GUARD]) {
+    return false
+  }
+
+  stream[INSTALLED_PIPE_GUARD] = true
+  stream.on('error', error => {
+    if (!isIgnorablePipeError(error)) {
+      throw error
+    }
+  })
+
+  return true
+}
+
+export function installStdioPipeErrorGuards({
+  stdout = process.stdout,
+  stderr = process.stderr
+}: {
+  stdout?: ErrorStream | null
+  stderr?: ErrorStream | null
+} = {}): number {
+  return [stdout, stderr].filter(attachPipeGuard).length
+}


### PR DESCRIPTION
## Summary
- Install stdio pipe guards that ignore only `EPIPE` and `ERR_STREAM_DESTROYED` by structural `error.code`.
- Do **not** match on error message text (addresses the #61894 review).

## Why
Open PR #61894 added Desktop stdio guards but broadened suppression via a message regex. That can hide ordinary stream errors whose code is not one of the two allowed values. Current `upstream/main` still has no equivalent guard.

This salvage implements the reviewed contract: code-only ignorable pipe errors, installed early in Electron main so a closed parent console cannot crash Desktop.

## Test plan
- [x] `npx tsx --test apps/desktop/electron/stdio-pipe-guards.test.ts`
- [ ] Confirm CI typecheck includes the new electron test module