### PR TITLE
fix(dashboard): refresh chat session switcher

### DIFF
--- a/web/src/components/ChatSessionList.test.tsx
+++ b/web/src/components/ChatSessionList.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ChatSessionList } from './ChatSessionList'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const { getSessions } = vi.hoisted(() => ({ getSessions: vi.fn() }))
+
+vi.mock('@nous-research/ui/ui/components/button', () => ({
+  Button: ({
+    children,
+    ghost,
+    onClick,
+    outlined,
+    prefix,
+    size,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+    void ghost
+    void outlined
+    void prefix
+    void size
+    return (
+      <button type="button" onClick={onClick} {...props}>
+        {children}
+      </button>
+    )
+  }
+}))
+
+vi.mock('@nous-research/ui/ui/components/list-item', () => ({
+  ListItem: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" onClick={onClick} {...props}>
+      {children}
+    </button>
+  )
+}))
+
+vi.mock('@nous-research/ui/ui/components/spinner', () => ({
+  Spinner: () => <span>Loading</span>
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { loading: 'Loading', refresh: 'Refresh', retry: 'Retry' },
+      sessions: {
+        newChat: 'New chat',
+        noSessions: 'No sessions',
+        title: 'Sessions',
+        untitledSession: 'Untitled session'
+      }
+    }
+  })
+}))
+
+vi.mock('@/lib/api', () => ({ api: { getSessions } }))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
+  timeAgo: () => 'just now'
+}))
+
+function session(id: string, title: string) {
+  return {
+    id,
+    source: 'cli',
+    model: null,
+    title,
+    started_at: 0,
+    ended_at: null,
+    last_active: 0,
+    is_active: false,
+    message_count: 0,
+    tool_call_count: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    preview: null
+  }
+}
+
+function response(id: string, title: string) {
+  return { sessions: [session(id, title)], total: 1, limit: 30, offset: 0 }
+}
+
+describe('ChatSessionList', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    getSessions.mockReset()
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible'
+    })
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    container.remove()
+    vi.useRealTimers()
+  })
+
+  it('renders sessions returned by an automatic refresh', async () => {
+    getSessions
+      .mockResolvedValueOnce(response('first', 'First session'))
+      .mockResolvedValueOnce(response('second', 'Newly created session'))
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <ChatSessionList activeSessionId={null} />
+        </MemoryRouter>
+      )
+    })
+
+    expect(container.textContent).toContain('First session')
+    expect(getSessions).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    expect(getSessions).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('Newly created session')
+  })
+
+  it('refreshes immediately when the tab becomes visible', async () => {
+    getSessions
+      .mockResolvedValueOnce(response('first', 'First session'))
+      .mockResolvedValueOnce(response('second', 'Newly created session'))
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <ChatSessionList activeSessionId={null} />
+        </MemoryRouter>
+      )
+    })
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible'
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(getSessions).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('Newly created session')
+  })
+})

--- a/web/src/components/ChatSessionList.test.tsx
+++ b/web/src/components/ChatSessionList.test.tsx
@@ -158,4 +158,41 @@ describe('ChatSessionList', () => {
     expect(getSessions).toHaveBeenCalledTimes(2)
     expect(container.textContent).toContain('Newly created session')
   })
+
+  it('waits for the Chat tab to become active before loading or polling', async () => {
+    getSessions
+      .mockResolvedValueOnce(response('first', 'First session'))
+      .mockResolvedValueOnce(response('second', 'Newly created session'))
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <ChatSessionList activeSessionId={null} isActive={false} />
+        </MemoryRouter>
+      )
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+    expect(getSessions).not.toHaveBeenCalled()
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <ChatSessionList activeSessionId={null} isActive />
+        </MemoryRouter>
+      )
+    })
+
+    expect(getSessions).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('First session')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    expect(getSessions).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('Newly created session')
+  })
 })

--- a/web/src/components/ChatSessionList.tsx
+++ b/web/src/components/ChatSessionList.tsx
@@ -30,6 +30,7 @@ import { api, type SessionInfo } from "@/lib/api";
 import { cn, timeAgo } from "@/lib/utils";
 
 const SESSION_LIMIT = 30;
+const SESSION_REFRESH_MS = 20_000;
 interface ChatSessionListProps {
   /** Active resume target (the session currently shown in the terminal). */
   activeSessionId: string | null;
@@ -99,6 +100,8 @@ export function ChatSessionList({
       });
   }, [scopeKey]);
 
+  const reload = useCallback(() => setReloadNonce((n) => n + 1), []);
+
   useEffect(() => {
     // Dashboard data surfaces fetch from an effect on mount + scope change;
     // keep this local and explicit until the shared lint profile is updated
@@ -108,7 +111,17 @@ export function ChatSessionList({
     // `reloadNonce` is a manual refetch trigger (Refresh button / row pick).
   }, [load, reloadNonce]);
 
-  const reload = useCallback(() => setReloadNonce((n) => n + 1), []);
+  useEffect(() => {
+    const interval = window.setInterval(reload, SESSION_REFRESH_MS);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") reload();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [reload]);
 
   // Picking a row sets `/chat?resume=<id>`. Re-picking the row already in
   // the terminal is a no-op (avoids a needless PTY teardown).

--- a/web/src/components/ChatSessionList.tsx
+++ b/web/src/components/ChatSessionList.tsx
@@ -34,6 +34,8 @@ const SESSION_REFRESH_MS = 20_000;
 interface ChatSessionListProps {
   /** Active resume target (the session currently shown in the terminal). */
   activeSessionId: string | null;
+  /** Whether the Chat route is visible and should refresh its session list. */
+  isActive?: boolean;
   /** Management profile from the dashboard switcher — scopes the listing. */
   profile?: string;
   className?: string;
@@ -58,6 +60,7 @@ function rowLabel(session: SessionInfo, untitled: string): string {
 
 export function ChatSessionList({
   activeSessionId,
+  isActive = true,
   profile,
   className,
   onPicked,
@@ -103,15 +106,17 @@ export function ChatSessionList({
   const reload = useCallback(() => setReloadNonce((n) => n + 1), []);
 
   useEffect(() => {
+    if (!isActive) return;
     // Dashboard data surfaces fetch from an effect on mount + scope change;
     // keep this local and explicit until the shared lint profile is updated
     // for async loaders (matches FilesPage).
     // eslint-disable-next-line react-hooks/set-state-in-effect
     load();
     // `reloadNonce` is a manual refetch trigger (Refresh button / row pick).
-  }, [load, reloadNonce]);
+  }, [isActive, load, reloadNonce]);
 
   useEffect(() => {
+    if (!isActive) return;
     const interval = window.setInterval(reload, SESSION_REFRESH_MS);
     const onVisibilityChange = () => {
       if (document.visibilityState === "visible") reload();
@@ -121,7 +126,7 @@ export function ChatSessionList({
       window.clearInterval(interval);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [reload]);
+  }, [isActive, reload]);
 
   // Picking a row sets `/chat?resume=<id>`. Re-picking the row already in
   // the terminal is a no-op (avoids a needless PTY teardown).

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1430,6 +1430,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             </div>
             <ChatSessionList
               activeSessionId={resumeParam}
+              isActive={isActive}
               profile={scopedProfile}
               onPicked={closeMobilePanel}
               onNewChat={startFreshDashboardChat}
@@ -1553,6 +1554,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             <div className="min-h-0 flex-1 overflow-hidden">
               <ChatSessionList
                 activeSessionId={resumeParam}
+                isActive={isActive}
                 profile={scopedProfile}
                 onNewChat={startFreshDashboardChat}
               />


### PR DESCRIPTION
## Summary

- Refresh the Chat session switcher every 20 seconds while it remains open.
- Refetch immediately when the browser tab becomes visible again.
- Add regression coverage that verifies newly returned sessions render after each refresh path.

Fixes #70346

## Testing

- `npm --prefix web test`
- `npm --prefix web run typecheck`
- `npx eslint src/components/ChatSessionList.tsx src/components/ChatSessionList.test.tsx`

Tested locally on Windows with Vitest/jsdom. Full browser and repository CI remain for GitHub Actions.