### PR TITLE
fix(sessions): persist renames on compression tips

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -666,9 +666,11 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
                 status_code=400,
                 detail="Nothing to update; provide 'title', 'archived', and/or 'pinned'.",
             )
+        title_sid = sid
         if body.title is not None:
+            title_sid = db.get_compression_tip(sid) or sid
             try:
-                db.set_session_title(sid, body.title or "")
+                db.set_session_title(title_sid, body.title or "")
             except ValueError as e:
                 # Title too long, invalid characters, or already in use.
                 raise HTTPException(status_code=400, detail=str(e))
@@ -676,7 +678,7 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
             db.set_session_archived(sid, body.archived)
         if body.pinned is not None:
             db.set_session_pinned(sid, body.pinned)
-        result = {"ok": True, "title": db.get_session_title(sid) or ""}
+        result = {"ok": True, "title": db.get_session_title(title_sid) or ""}
         if body.archived is not None:
             result["archived"] = bool(body.archived)
         if body.pinned is not None:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -639,6 +639,79 @@ class TestWebServerEndpoints:
             {"index": 0, "error": "session id is required"}
         ]
 
+    def test_rename_compression_root_updates_visible_tip_only(self):
+        """A title PATCH follows compression continuity, not arbitrary children."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="rename-root", source="desktop")
+            db.set_session_title("rename-root", "Generated root title")
+            db.end_session("rename-root", "compression")
+            db.create_session(
+                session_id="rename-compression-tip",
+                source="desktop",
+                parent_session_id="rename-root",
+            )
+            db.set_session_title("rename-compression-tip", "Generated visible title")
+
+            # A normal descendant must not be treated as part of the
+            # compression lineage, even when it is newer than the tip.
+            db.create_session(
+                session_id="rename-ordinary-child",
+                source="desktop",
+                parent_session_id="rename-compression-tip",
+            )
+            db.set_session_title("rename-ordinary-child", "Ordinary child title")
+        finally:
+            db.close()
+
+        resp = self.client.patch(
+            "/api/sessions/rename-root", json={"title": "Manual session title"}
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "title": "Manual session title"}
+
+        db = SessionDB()
+        try:
+            assert db.get_session_title("rename-root") == "Generated root title"
+            assert db.get_session_title("rename-compression-tip") == "Manual session title"
+            assert db.get_session_title("rename-ordinary-child") == "Ordinary child title"
+        finally:
+            db.close()
+
+    def test_rename_root_does_not_follow_non_compression_child(self):
+        """An ordinary child is not a title-write continuation."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="ordinary-root", source="desktop")
+            db.set_session_title("ordinary-root", "Generated root title")
+            db.create_session(
+                session_id="ordinary-child",
+                source="desktop",
+                parent_session_id="ordinary-root",
+            )
+            db.set_session_title("ordinary-child", "Ordinary child title")
+        finally:
+            db.close()
+
+        resp = self.client.patch(
+            "/api/sessions/ordinary-root", json={"title": "Manual root title"}
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "title": "Manual root title"}
+
+        db = SessionDB()
+        try:
+            assert db.get_session_title("ordinary-root") == "Manual root title"
+            assert db.get_session_title("ordinary-child") == "Ordinary child title"
+        finally:
+            db.close()
+
 
 
 


### PR DESCRIPTION
## Summary

- Resolve title writes from a compression root to its visible compression tip only.
- Preserve archive and pin writes on the supplied session ID; their existing lineage-aware methods retain those semantics.
- Add authenticated PATCH regressions for both a compression continuation and an ordinary child that must not be renamed.

## Problem

Desktop can retain a stable compression-root ID while the session list projects that logical conversation to its latest compression continuation. The PATCH route previously renamed only the hidden root, so the visible continuation retained its generated title after refresh.

## Verification

- `python -m pytest tests/hermes_cli/test_web_server.py -q`
  - 106 passed
- `python -m pytest tests/run_agent/test_in_place_compaction.py tests/test_hermes_state.py -k "compression or title" -q`
  - 20 passed, 125 deselected
- `python -m py_compile hermes_cli/web_routers/sessions.py tests/hermes_cli/test_web_server.py`
- `git diff --check`

## Scope

Two files only:

- `hermes_cli/web_routers/sessions.py`
- `tests/hermes_cli/test_web_server.py