### PR TITLE
fix(tools): normalize Unicode space family and minus sign in patch fuzzy matching (port opencode#38133)

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -320,6 +320,58 @@ class TestUnicodeNormalized:
         assert new == "plain text there"
 
 
+class TestUnicodeSpaceAndMinusNormalized:
+    """Space-separator family + Unicode minus normalization.
+
+    Port of the anomalyco/opencode#38133 patch-matching corpus: files with
+    typographic spacing (en/em/thin spaces, narrow NBSP, CJK ideographic
+    space) or the Unicode minus sign must match a model's ASCII old_string
+    at the precise unicode_normalized strategy — not fall through to the
+    similarity-based context_aware fallback.
+    """
+
+    def test_unicode_minus_matched_and_preserved(self):
+        content = "offset = value \u2212 1\nprint(offset)\n"
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, "offset = value - 1", "offset = delta - 1"
+        )
+        assert count == 1, f"Expected match, got err={err}"
+        assert strategy == "unicode_normalized"
+        # The untouched minus keeps its Unicode form
+        assert "delta \u2212 1" in new, f"Got {new!r}"
+
+    def test_space_variants_match_at_unicode_strategy(self):
+        # en space, em space, thin space, narrow NBSP, medium math space,
+        # ideographic space, figure space, hair space
+        for space in ["\u2002", "\u2003", "\u2009", "\u202f",
+                      "\u205f", "\u3000", "\u2007", "\u200a"]:
+            content = f"# wait{space}30{space}seconds\nrun()\n"
+            new, count, strategy, err = fuzzy_find_and_replace(
+                content, "# wait 30 seconds", "# wait 60 seconds"
+            )
+            assert count == 1, (
+                f"space U+{ord(space):04X}: expected match, err={err}"
+            )
+            assert strategy == "unicode_normalized", (
+                f"space U+{ord(space):04X}: matched via {strategy}, "
+                "expected unicode_normalized"
+            )
+            # Unchanged spaces keep their typographic form; only the
+            # digits change.
+            assert f"60{space}seconds" in new, (
+                f"space U+{ord(space):04X}: got {new!r}"
+            )
+
+    def test_ideographic_space_cjk_line(self):
+        content = "標題\u3000第一章\nbody text\n"
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, "標題 第一章", "標題 第二章"
+        )
+        assert count == 1, f"Expected match, got err={err}"
+        assert strategy == "unicode_normalized"
+        assert "標題\u3000第二章" in new, f"Got {new!r}"
+
+
 class TestBlockAnchorThreshold:
     """Tests for the raised block_anchor threshold (Bug 4)."""
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -38,6 +38,23 @@ UNICODE_MAP = {
     "\u2018": "'", "\u2019": "'",  # smart single quotes
     "\u2014": "--", "\u2013": "-", # em/en dashes
     "\u2026": "...", "\u00a0": " ", # ellipsis and non-breaking space
+    # Unicode minus sign — models type ASCII '-' for file content that uses
+    # the typographic minus (math/scientific docs).
+    "\u2212": "-",
+    # Space-separator family (Zs) beyond NBSP.  Files with typographic
+    # spacing (en/em/thin spaces, narrow NBSP in French text, ideographic
+    # space in CJK text) never match a model's ASCII-space old_string via
+    # the precise strategies, falling through to the similarity-based
+    # context_aware fallback — which can pick the wrong region and flattens
+    # the file's Unicode on replacement.  (anomalyco/opencode#38133 corpus)
+    "\u2000": " ", "\u2001": " ",  # en/em quad
+    "\u2002": " ", "\u2003": " ",  # en/em space
+    "\u2004": " ", "\u2005": " ", "\u2006": " ",  # three/four/six-per-em
+    "\u2007": " ", "\u2008": " ",  # figure/punctuation space
+    "\u2009": " ", "\u200a": " ",  # thin/hair space
+    "\u202f": " ",  # narrow no-break space
+    "\u205f": " ",  # medium mathematical space
+    "\u3000": " ",  # ideographic (CJK full-width) space
 }
 
 def _unicode_normalize(text: str) -> str:


### PR DESCRIPTION
## Summary

The `patch` tool's fuzzy matcher now normalizes the full Unicode space-separator family and the Unicode minus sign, so edits against files with typographic spacing (French narrow NBSP, CJK ideographic spaces, en/em/thin spaces, math minus) match at the precise `unicode_normalized` strategy instead of falling through to the similarity-based `context_aware` fallback. Ported from the matching corpus of [anomalyco/opencode#38133](https://github.com/anomalyco/opencode/pull/38133) / [#38134](https://github.com/anomalyco/opencode/pull/38134) ("expand patch Unicode matching").

Root cause: `UNICODE_MAP` covered only NBSP (U+00A0) among the Zs space family and had no minus-sign entry. A model's ASCII-space `old_string` against a file line containing U+2002/U+3000/U+202F/etc. failed every precise strategy; the edit only succeeded via `context_aware` — which (a) carries the wrong-region risk (#54572 family) and (b) silently flattens the file's typographic characters to ASCII on replacement.

## Changes

- `tools/fuzzy_match.py`: `UNICODE_MAP` += U+2212 (minus sign) and the Zs family — U+2000–U+200A (en/em quad, en/em/three-per-em/four-per-em/six-per-em/figure/punctuation/thin/hair spaces), U+202F (narrow NBSP), U+205F (medium mathematical space), U+3000 (CJK ideographic space). All 1:1 mappings, so the existing position-mapping (`_build_orig_to_norm_map`) and Unicode-preservation (`_preserve_unicode_in_replacement`) logic apply unchanged.
- `tests/tools/test_fuzzy_match.py`: new `TestUnicodeSpaceAndMinusNormalized` class — per-variant strategy assertion + preservation checks, including a CJK ideographic-space line.

Adaptation note: OpenCode fixed this inside their line-derivation matcher (`Patch.derive` canonicalization). Hermes's equivalent surface is the `UNICODE_MAP`-driven `unicode_normalized` strategy shared by `patch` replace-mode and `skill_manage` patching — extending the map fixes both consumers at once and additionally gains Unicode *preservation* (their fix normalizes; ours keeps the file's typography in unchanged spans).

## Validation

Multi-line E2E probe (real `fuzzy_find_and_replace` calls), before → after:

| File line contains | Before | After |
|---|---|---|
| en-space + U+2212 minus | `context_aware`, Unicode flattened to ASCII | `unicode_normalized`, "value␣−␣2" keeps en-spaces + minus |
| U+3000 ideographic spaces | `context_aware`, flattened | `unicode_normalized`, spaces preserved |
| U+202F narrow NBSP | `context_aware`, flattened | `unicode_normalized`, preserved |
| U+2009 thin space | `context_aware`, flattened | `unicode_normalized`, preserved |

Tests: 59 passed (`test_fuzzy_match.py`), 188 passed sibling (`test_file_tools.py`, `test_patch_parser.py`, `test_skill_manager_tool.py`).

## Infographic

![unicode-space-fuzzy-match](https://v3b.fal.media/files/b/0aa377df/2p775LpQ4MvxX44H0RAV0_k0UZ1bZi.png)
