### PR TITLE
fix(cron): release in-flight job ID claim when create_execution fails

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4104,31 +4104,33 @@ def tick(
                     logger.info("Job '%s' already running — skipping", job.get("name", job_id))
                     return None
                 _running_job_ids.add(job_id)
-            # Record the attempt before executor dispatch. Recovery classifies
-            # abandoned records as unknown; it never automatically retries them.
-            execution = create_execution(job_id, source="builtin")
-            dispatched_job = dict(job, execution_id=execution["id"])
-            _ctx = contextvars.copy_context()
-
-            def _run_and_release(j=dispatched_job, ctx=_ctx):
-                try:
-                    return ctx.run(_process_job, j)
-                finally:
-                    with _running_lock:
-                        _running_job_ids.discard(j["id"])
-
             try:
+                # Record the attempt before executor dispatch. Recovery classifies
+                # abandoned records as unknown; it never automatically retries them.
+                execution = create_execution(job_id, source="builtin")
+                dispatched_job = dict(job, execution_id=execution["id"])
+                _ctx = contextvars.copy_context()
+
+                def _run_and_release(j=dispatched_job, ctx=_ctx):
+                    try:
+                        return ctx.run(_process_job, j)
+                    finally:
+                        with _running_lock:
+                            _running_job_ids.discard(j["id"])
+
                 return pool.submit(_run_and_release)
             except Exception as submit_err:
                 with _running_lock:
                     _running_job_ids.discard(job_id)
-                finish_execution(
-                    execution["id"],
-                    success=False,
-                    error=f"Executor dispatch failed: {submit_err}",
-                )
-                # Interpreter began finalizing between the guard above and the
-                # submit — release the in-flight claim we just took and skip.
+                if "execution" in locals() and isinstance(execution, dict) and execution.get("id"):
+                    try:
+                        finish_execution(
+                            execution["id"],
+                            success=False,
+                            error=f"Executor dispatch failed: {submit_err}",
+                        )
+                    except Exception:
+                        pass
                 if isinstance(submit_err, RuntimeError) and _interpreter_shutting_down(submit_err):
                     logger.warning(
                         "Job '%s' not dispatched — interpreter is shutting down",

--- a/tests/cron/test_cron_create_execution_wedge.py
+++ b/tests/cron/test_cron_create_execution_wedge.py
@@ -1,0 +1,53 @@
+"""Regression tests verifying create_execution failure does not wedge _running_job_ids."""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from cron.scheduler import tick, get_running_job_ids, _running_job_ids, _running_lock
+
+
+class TestCronCreateExecutionWedge:
+    """Verify _running_job_ids is cleared if create_execution raises an exception in _tick_impl."""
+
+    def test_create_execution_failure_cleans_running_job_ids(self):
+        job = {"id": "test_wedge_job_1", "name": "Test Wedge Job"}
+
+        with patch("cron.scheduler.open", MagicMock()), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.create_execution", side_effect=RuntimeError("DB Lock Error")):
+            tick(verbose=False)
+
+        assert "test_wedge_job_1" not in get_running_job_ids()
+
+        with _running_lock:
+            assert "test_wedge_job_1" not in _running_job_ids
+
+    def test_subsequent_tick_succeeds_after_create_execution_error(self):
+        job = {"id": "test_wedge_job_2", "name": "Test Wedge Job 2"}
+
+        # First tick attempt fails at create_execution
+        with patch("cron.scheduler.open", MagicMock()), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.create_execution", side_effect=RuntimeError("DB Lock Error")):
+            tick(verbose=False)
+
+        assert "test_wedge_job_2" not in get_running_job_ids()
+
+        # Second tick attempt succeeds at create_execution
+        mock_exec = {"id": "exec_123"}
+        mock_pool = MagicMock()
+
+        with patch("cron.scheduler.open", MagicMock()), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.create_execution", return_value=mock_exec), \
+             patch("cron.scheduler._get_parallel_pool", return_value=mock_pool):
+            tick(verbose=False)
+
+        mock_pool.submit.assert_called_once()
+
+        # Clean up running state after mock submit
+        with _running_lock:
+            _running_job_ids.discard("test_wedge_job_2")


### PR DESCRIPTION
## Summary

Fixes a scheduler reliability bug in `cron/scheduler.py` where an exception during `create_execution()` left the job ID permanently in `_running_job_ids`.

## Why

In `_submit_with_guard()`, `_running_job_ids.add(job_id)` is called to acquire the in-flight claim before invoking `create_execution(job_id)`. If `create_execution()` raises an exception (e.g. SQLite database lock, busy error, or I/O failure), execution unwound past the helper without reaching the worker thread's `finally` block or the `submit_err` catch handler.

As a result, `job_id` remained stuck in `_running_job_ids`. On every subsequent tick, `if job_id in _running_job_ids:` evaluated to `True` and logged `"Job 'X' already running — skipping"`, permanently preventing the scheduled job from executing until the gateway or daemon process was restarted.

## Key Changes

- **Scheduler Cleanup**: Wrapped `create_execution()` inside the `try...except` block in `_submit_with_guard()` to ensure `_running_job_ids.discard(job_id)` is called under `_running_lock` upon any dispatch or execution creation error.
- **Tests**: Added `tests/cron/test_cron_create_execution_wedge.py` to verify that `_running_job_ids` is properly cleared when `create_execution()` fails and that subsequent ticks can dispatch the job normally.

## Test
```bash
python -m pytest tests/cron/test_cron_create_execution_wedge.py -q --timeout-method=thread