### PR TITLE
fix(gateway): inject work into exact live session

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -780,6 +780,11 @@ def init_agent(
     # existing tool message rather than inserting a new user turn).
     agent._pending_steer: Optional[str] = None
     agent._pending_steer_lock = threading.Lock()
+    # Tracks whether the first text in the pending steer batch came from the
+    # authenticated gateway-session IPC path.  The finalizer carries this bit
+    # back to the gateway so slash-leading task text is not reclassified as a
+    # user command if it arrives after the last tool drain.
+    agent._pending_steer_is_gateway_session_ipc = False
     # Admission is opened by run_conversation() and atomically closed by the
     # finalizer before its last drain.  A surface that races turn completion
     # therefore gets False from steer() and can queue a real follow-up instead

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -780,11 +780,19 @@ def init_agent(
     # existing tool message rather than inserting a new user turn).
     agent._pending_steer: Optional[str] = None
     agent._pending_steer_lock = threading.Lock()
-    # Tracks whether the first text in the pending steer batch came from the
-    # authenticated gateway-session IPC path.  The finalizer carries this bit
-    # back to the gateway so slash-leading task text is not reclassified as a
-    # user command if it arrives after the last tool drain.
+    # Keep provenance per accepted steer. A single bit for a newline-joined
+    # batch lets an ordinary slash command either declassify a trusted
+    # gateway-session IPC task or accidentally confer trust on it, depending
+    # solely on arrival order. ``_pending_steer`` and the legacy bit remain as
+    # compatibility mirrors for lightweight stubs and older callers.
+    agent._pending_steer_chunks: list[tuple[str, bool]] = []
     agent._pending_steer_is_gateway_session_ipc = False
+    # Codex app-server consumes steers natively, outside Hermes' tool-result
+    # drain. Retain accepted requests until that native turn reports success so
+    # a caught runtime failure can hand them back to the gateway.
+    agent._codex_native_pending_steer_chunks: list[
+        tuple[object, str, bool]
+    ] = []
     # Admission is opened by run_conversation() and atomically closed by the
     # finalizer before its last drain.  A surface that races turn completion
     # therefore gets False from steer() and can queue a real follow-up instead

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -780,6 +780,11 @@ def init_agent(
     # existing tool message rather than inserting a new user turn).
     agent._pending_steer: Optional[str] = None
     agent._pending_steer_lock = threading.Lock()
+    # Admission is opened by run_conversation() and atomically closed by the
+    # finalizer before its last drain.  A surface that races turn completion
+    # therefore gets False from steer() and can queue a real follow-up instead
+    # of accepting text that this turn can no longer consume.
+    agent._steer_accepting = False
 
     # Active-turn redirect mechanism. A regular follow-up sent while the model
     # is generating is different from a hard /stop: preserve the valid turn

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3659,7 +3659,14 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
     """
     if num_tool_msgs <= 0 or not messages:
         return
-    steer_text = agent._drain_pending_steer()
+    _drain_with_provenance = getattr(
+        agent, "_drain_pending_steer_with_provenance", None
+    )
+    if callable(_drain_with_provenance):
+        steer_text, steer_is_gateway_session_ipc = _drain_with_provenance()
+    else:
+        steer_text = agent._drain_pending_steer()
+        steer_is_gateway_session_ipc = False
     if not steer_text:
         return
     # Find the last tool-role message in the recent tail. Skipping
@@ -3675,16 +3682,27 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         # No tool result in this batch (e.g. all skipped by interrupt);
         # put the steer back so the caller's fallback path can deliver
         # it as a normal next-turn user message.
-        _lock = getattr(agent, "_pending_steer_lock", None)
-        if _lock is not None:
-            with _lock:
-                if agent._pending_steer:
-                    agent._pending_steer = agent._pending_steer + "\n" + steer_text
-                else:
-                    agent._pending_steer = steer_text
+        _restore_pending_steer = getattr(agent, "_restore_pending_steer", None)
+        if callable(_restore_pending_steer):
+            _restore_pending_steer(
+                steer_text,
+                is_gateway_session_ipc=steer_is_gateway_session_ipc,
+            )
         else:
-            existing = getattr(agent, "_pending_steer", None)
-            agent._pending_steer = (existing + "\n" + steer_text) if existing else steer_text
+            _lock = getattr(agent, "_pending_steer_lock", None)
+            if _lock is not None:
+                with _lock:
+                    if agent._pending_steer:
+                        agent._pending_steer = (
+                            agent._pending_steer + "\n" + steer_text
+                        )
+                    else:
+                        agent._pending_steer = steer_text
+            else:
+                existing = getattr(agent, "_pending_steer", None)
+                agent._pending_steer = (
+                    (existing + "\n" + steer_text) if existing else steer_text
+                )
         return
     marker = format_steer_marker(steer_text)
     existing_content = messages[target_idx].get("content", "")

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3659,14 +3659,24 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
     """
     if num_tool_msgs <= 0 or not messages:
         return
-    _drain_with_provenance = getattr(
-        agent, "_drain_pending_steer_with_provenance", None
-    )
-    if callable(_drain_with_provenance):
-        steer_text, steer_is_gateway_session_ipc = _drain_with_provenance()
+    _drain_chunks = getattr(agent, "_drain_pending_steer_chunks", None)
+    if callable(_drain_chunks):
+        steer_chunks = _drain_chunks()
+        steer_text = "\n".join(text for text, _trusted in steer_chunks) or None
     else:
-        steer_text = agent._drain_pending_steer()
-        steer_is_gateway_session_ipc = False
+        _drain_with_provenance = getattr(
+            agent, "_drain_pending_steer_with_provenance", None
+        )
+        if callable(_drain_with_provenance):
+            steer_text, steer_is_gateway_session_ipc = _drain_with_provenance()
+        else:
+            steer_text = agent._drain_pending_steer()
+            steer_is_gateway_session_ipc = False
+        steer_chunks = (
+            [(steer_text, steer_is_gateway_session_ipc)]
+            if steer_text
+            else []
+        )
     if not steer_text:
         return
     # Find the last tool-role message in the recent tail. Skipping
@@ -3682,13 +3692,19 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         # No tool result in this batch (e.g. all skipped by interrupt);
         # put the steer back so the caller's fallback path can deliver
         # it as a normal next-turn user message.
-        _restore_pending_steer = getattr(agent, "_restore_pending_steer", None)
-        if callable(_restore_pending_steer):
+        _restore_chunks = getattr(agent, "_restore_pending_steer_chunks", None)
+        if callable(_restore_chunks):
+            _restore_chunks(steer_chunks)
+        else:
+            _restore_pending_steer = getattr(
+                agent, "_restore_pending_steer", None
+            )
+        if not callable(_restore_chunks) and callable(_restore_pending_steer):
             _restore_pending_steer(
                 steer_text,
                 is_gateway_session_ipc=steer_is_gateway_session_ipc,
             )
-        else:
+        elif not callable(_restore_chunks):
             _lock = getattr(agent, "_pending_steer_lock", None)
             if _lock is not None:
                 with _lock:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -615,6 +615,34 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
     return on_event
 
 
+def _settle_codex_native_steers(
+    agent: Any,
+    result: Dict[str, Any],
+    *,
+    delivered: bool,
+) -> Dict[str, Any]:
+    """Acknowledge native steers or expose them for next-turn recovery."""
+    drain = getattr(agent, "_drain_codex_native_pending_steer_chunks", None)
+    if not callable(drain):
+        return result
+    chunks = drain()
+    if delivered or not chunks:
+        return result
+    result["pending_steer"] = "\n".join(
+        text for text, _trusted in chunks
+    )
+    result["pending_steer_chunks"] = [
+        {
+            "text": text,
+            "gateway_session_ipc": trusted,
+        }
+        for text, trusted in chunks
+    ]
+    if all(trusted for _text, trusted in chunks):
+        result["pending_steer_is_gateway_session_ipc"] = True
+    return result
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -715,7 +743,7 @@ def run_codex_app_server_turn(
         )
         if _user_interrupted:
             agent.clear_interrupt()
-        return {
+        result = {
             "final_response": (
                 f"Codex app-server turn failed: {exc}. "
                 f"Fall back to default runtime with `/codex-runtime auto`."
@@ -732,6 +760,11 @@ def run_codex_app_server_turn(
             ),
             "error": str(exc),
         }
+        return _settle_codex_native_steers(
+            agent,
+            result,
+            delivered=False,
+        )
 
     # This runtime bypasses the normal conversation-loop finalizer. Mirror its
     # interrupt handoff/cleanup so a hard stop cannot poison the next turn and a
@@ -859,7 +892,7 @@ def run_codex_app_server_turn(
         except Exception:
             logger.debug("background review spawn raised", exc_info=True)
 
-    return {
+    result = {
         "final_response": turn.final_text,
         "messages": messages,
         "api_calls": api_calls,
@@ -888,6 +921,14 @@ def run_codex_app_server_turn(
         "codex_turn_id": turn.turn_id,
         **usage_result,
     }
+    return _settle_codex_native_steers(
+        agent,
+        result,
+        delivered=bool(
+            not turn.interrupted
+            and turn.error is None
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1345,7 +1345,16 @@ def run_conversation(
         # iteration, no tools yet), the steer stays pending for the next
         # tool batch — injecting into a user message would break role
         # alternation, and there's no tool output to piggyback on.
-        _pre_api_steer = agent._drain_pending_steer()
+        _drain_with_provenance = getattr(
+            agent, "_drain_pending_steer_with_provenance", None
+        )
+        if callable(_drain_with_provenance):
+            _pre_api_steer, _pre_api_steer_is_gateway_session_ipc = (
+                _drain_with_provenance()
+            )
+        else:
+            _pre_api_steer = agent._drain_pending_steer()
+            _pre_api_steer_is_gateway_session_ipc = False
         if _pre_api_steer:
             _injected = False
             for _si in range(len(messages) - 1, -1, -1):
@@ -1373,16 +1382,33 @@ def run_conversation(
             if not _injected:
                 # No tool message to inject into — put it back so
                 # the post-tool-execution drain picks it up later.
-                _lock = getattr(agent, "_pending_steer_lock", None)
-                if _lock is not None:
-                    with _lock:
-                        if agent._pending_steer:
-                            agent._pending_steer = agent._pending_steer + "\n" + _pre_api_steer
-                        else:
-                            agent._pending_steer = _pre_api_steer
+                _restore_pending_steer = getattr(
+                    agent, "_restore_pending_steer", None
+                )
+                if callable(_restore_pending_steer):
+                    _restore_pending_steer(
+                        _pre_api_steer,
+                        is_gateway_session_ipc=(
+                            _pre_api_steer_is_gateway_session_ipc
+                        ),
+                    )
                 else:
-                    existing = getattr(agent, "_pending_steer", None)
-                    agent._pending_steer = (existing + "\n" + _pre_api_steer) if existing else _pre_api_steer
+                    _lock = getattr(agent, "_pending_steer_lock", None)
+                    if _lock is not None:
+                        with _lock:
+                            if agent._pending_steer:
+                                agent._pending_steer = (
+                                    agent._pending_steer + "\n" + _pre_api_steer
+                                )
+                            else:
+                                agent._pending_steer = _pre_api_steer
+                    else:
+                        existing = getattr(agent, "_pending_steer", None)
+                        agent._pending_steer = (
+                            (existing + "\n" + _pre_api_steer)
+                            if existing
+                            else _pre_api_steer
+                        )
 
         # Prepare messages for API call
         # If we have an ephemeral system prompt, prepend it to the messages

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1345,16 +1345,34 @@ def run_conversation(
         # iteration, no tools yet), the steer stays pending for the next
         # tool batch — injecting into a user message would break role
         # alternation, and there's no tool output to piggyback on.
-        _drain_with_provenance = getattr(
-            agent, "_drain_pending_steer_with_provenance", None
-        )
-        if callable(_drain_with_provenance):
-            _pre_api_steer, _pre_api_steer_is_gateway_session_ipc = (
-                _drain_with_provenance()
+        _drain_chunks = getattr(agent, "_drain_pending_steer_chunks", None)
+        if callable(_drain_chunks):
+            _pre_api_steer_chunks = _drain_chunks()
+            _pre_api_steer = (
+                "\n".join(text for text, _trusted in _pre_api_steer_chunks)
+                or None
             )
         else:
-            _pre_api_steer = agent._drain_pending_steer()
-            _pre_api_steer_is_gateway_session_ipc = False
+            _drain_with_provenance = getattr(
+                agent, "_drain_pending_steer_with_provenance", None
+            )
+            if callable(_drain_with_provenance):
+                _pre_api_steer, _pre_api_steer_is_gateway_session_ipc = (
+                    _drain_with_provenance()
+                )
+            else:
+                _pre_api_steer = agent._drain_pending_steer()
+                _pre_api_steer_is_gateway_session_ipc = False
+            _pre_api_steer_chunks = (
+                [
+                    (
+                        _pre_api_steer,
+                        _pre_api_steer_is_gateway_session_ipc,
+                    )
+                ]
+                if _pre_api_steer
+                else []
+            )
         if _pre_api_steer:
             _injected = False
             for _si in range(len(messages) - 1, -1, -1):
@@ -1382,17 +1400,26 @@ def run_conversation(
             if not _injected:
                 # No tool message to inject into — put it back so
                 # the post-tool-execution drain picks it up later.
-                _restore_pending_steer = getattr(
-                    agent, "_restore_pending_steer", None
+                _restore_pending_steer_chunks = getattr(
+                    agent, "_restore_pending_steer_chunks", None
                 )
-                if callable(_restore_pending_steer):
+                if callable(_restore_pending_steer_chunks):
+                    _restore_pending_steer_chunks(_pre_api_steer_chunks)
+                else:
+                    _restore_pending_steer = getattr(
+                        agent, "_restore_pending_steer", None
+                    )
+                if (
+                    not callable(_restore_pending_steer_chunks)
+                    and callable(_restore_pending_steer)
+                ):
                     _restore_pending_steer(
                         _pre_api_steer,
                         is_gateway_session_ipc=(
                             _pre_api_steer_is_gateway_session_ipc
                         ),
                     )
-                else:
+                elif not callable(_restore_pending_steer_chunks):
                     _lock = getattr(agent, "_pending_steer_lock", None)
                     if _lock is not None:
                         with _lock:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1135,6 +1135,13 @@ def run_conversation(
         except Exception:
             pass
 
+    # Cached agents are reused across gateway turns.  Open /steer admission
+    # only for the lifetime of this turn; the finalizer closes it atomically
+    # with the last pending-steer drain.
+    _open_steer_admission = getattr(agent, "_open_steer_admission", None)
+    if callable(_open_steer_admission):
+        _open_steer_admission()
+
     # The gateway caches agents across user turns.  Compression state is
     # per-turn: carrying a prior in-place boundary forward would make a later
     # uncompressed result look like a compacted transcript to gateway writers.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -615,24 +615,52 @@ def finalize_turn(
     # If a /steer landed after the final assistant turn (no more tool
     # batches to drain into), hand it back to the caller so it can be
     # delivered as the next user turn instead of being silently lost.
-    _close_with_provenance = getattr(
-        agent, "_close_steer_admission_with_provenance", None
+    _close_with_chunks = getattr(
+        agent, "_close_steer_admission_with_chunks", None
     )
-    if callable(_close_with_provenance):
-        (
-            _leftover_steer,
-            _leftover_steer_is_gateway_session_ipc,
-        ) = _close_with_provenance()
+    if callable(_close_with_chunks):
+        _leftover_steer_chunks = _close_with_chunks()
+        _leftover_steer = (
+            "\n".join(text for text, _trusted in _leftover_steer_chunks)
+            or None
+        )
+        _leftover_steer_is_gateway_session_ipc = bool(
+            _leftover_steer_chunks
+            and all(trusted for _text, trusted in _leftover_steer_chunks)
+        )
     else:
-        _close_steer_admission = getattr(agent, "_close_steer_admission", None)
-        if callable(_close_steer_admission):
-            _leftover_steer = _close_steer_admission()
+        _close_with_provenance = getattr(
+            agent, "_close_steer_admission_with_provenance", None
+        )
+        if callable(_close_with_provenance):
+            (
+                _leftover_steer,
+                _leftover_steer_is_gateway_session_ipc,
+            ) = _close_with_provenance()
         else:
-            # Compatibility for lightweight test/runtime stubs.
-            _leftover_steer = agent._drain_pending_steer()
-        _leftover_steer_is_gateway_session_ipc = False
+            _close_steer_admission = getattr(
+                agent, "_close_steer_admission", None
+            )
+            if callable(_close_steer_admission):
+                _leftover_steer = _close_steer_admission()
+            else:
+                # Compatibility for lightweight test/runtime stubs.
+                _leftover_steer = agent._drain_pending_steer()
+            _leftover_steer_is_gateway_session_ipc = False
+        _leftover_steer_chunks = (
+            [(_leftover_steer, _leftover_steer_is_gateway_session_ipc)]
+            if _leftover_steer
+            else []
+        )
     if _leftover_steer:
         result["pending_steer"] = _leftover_steer
+        result["pending_steer_chunks"] = [
+            {
+                "text": text,
+                "gateway_session_ipc": trusted,
+            }
+            for text, trusted in _leftover_steer_chunks
+        ]
         if _leftover_steer_is_gateway_session_ipc:
             result["pending_steer_is_gateway_session_ipc"] = True
     agent._response_was_previewed = False

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -615,7 +615,12 @@ def finalize_turn(
     # If a /steer landed after the final assistant turn (no more tool
     # batches to drain into), hand it back to the caller so it can be
     # delivered as the next user turn instead of being silently lost.
-    _leftover_steer = agent._drain_pending_steer()
+    _close_steer_admission = getattr(agent, "_close_steer_admission", None)
+    if callable(_close_steer_admission):
+        _leftover_steer = _close_steer_admission()
+    else:
+        # Compatibility for lightweight test/runtime stubs.
+        _leftover_steer = agent._drain_pending_steer()
     if _leftover_steer:
         result["pending_steer"] = _leftover_steer
     agent._response_was_previewed = False

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -615,14 +615,26 @@ def finalize_turn(
     # If a /steer landed after the final assistant turn (no more tool
     # batches to drain into), hand it back to the caller so it can be
     # delivered as the next user turn instead of being silently lost.
-    _close_steer_admission = getattr(agent, "_close_steer_admission", None)
-    if callable(_close_steer_admission):
-        _leftover_steer = _close_steer_admission()
+    _close_with_provenance = getattr(
+        agent, "_close_steer_admission_with_provenance", None
+    )
+    if callable(_close_with_provenance):
+        (
+            _leftover_steer,
+            _leftover_steer_is_gateway_session_ipc,
+        ) = _close_with_provenance()
     else:
-        # Compatibility for lightweight test/runtime stubs.
-        _leftover_steer = agent._drain_pending_steer()
+        _close_steer_admission = getattr(agent, "_close_steer_admission", None)
+        if callable(_close_steer_admission):
+            _leftover_steer = _close_steer_admission()
+        else:
+            # Compatibility for lightweight test/runtime stubs.
+            _leftover_steer = agent._drain_pending_steer()
+        _leftover_steer_is_gateway_session_ipc = False
     if _leftover_steer:
         result["pending_steer"] = _leftover_steer
+        if _leftover_steer_is_gateway_session_ipc:
+            result["pending_steer_is_gateway_session_ipc"] = True
     agent._response_was_previewed = False
 
     # Include interrupt message if one triggered the interrupt

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5407,12 +5407,9 @@ class BasePlatformAdapter(ABC):
 
         if session_key in self._active_sessions:
             runner = getattr(self, "gateway_runner", None)
-            enqueue = getattr(runner, "_queue_or_replace_pending_event", None)
-            depth = getattr(runner, "_queue_depth", None)
-            if callable(enqueue) and callable(depth):
-                before = depth(session_key, adapter=self)
-                enqueue(session_key, event)
-                return depth(session_key, adapter=self) > before
+            enqueue_internal = getattr(runner, "_enqueue_internal_fifo_event", None)
+            if callable(enqueue_internal):
+                return bool(enqueue_internal(session_key, event, self))
             if session_key in self._pending_messages:
                 return False
             self._pending_messages[session_key] = event

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2126,6 +2126,8 @@ class MessageEvent:
     
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
+        if self.internal and self.metadata.get("gateway_session_ipc_task") is True:
+            return False
         return (self.text or "").lstrip().startswith("/")
     
     def get_command(self) -> Optional[str]:
@@ -2196,6 +2198,15 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
                 return
     except Exception:
         return
+
+
+def is_gateway_session_ipc_task(event: "MessageEvent") -> bool:
+    """Return whether *event* is the dedicated non-command IPC task type."""
+    metadata = getattr(event, "metadata", None) or {}
+    return bool(
+        getattr(event, "internal", False)
+        and metadata.get("gateway_session_ipc_task") is True
+    )
 
 
 @dataclass
@@ -5386,6 +5397,29 @@ class BasePlatformAdapter(ABC):
             task.add_done_callback(self._expected_cancelled_tasks.discard)
         return True
 
+    def accept_internal_task(self, event: MessageEvent, session_key: str) -> bool:
+        """Synchronously claim or FIFO-queue a validated non-command IPC task."""
+        if not is_gateway_session_ipc_task(event):
+            return False
+        metadata = event.metadata or {}
+        if metadata.get("gateway_session_key") != session_key:
+            return False
+
+        if session_key in self._active_sessions:
+            runner = getattr(self, "gateway_runner", None)
+            enqueue = getattr(runner, "_queue_or_replace_pending_event", None)
+            depth = getattr(runner, "_queue_depth", None)
+            if callable(enqueue) and callable(depth):
+                before = depth(session_key, adapter=self)
+                enqueue(session_key, event)
+                return depth(session_key, adapter=self) > before
+            if session_key in self._pending_messages:
+                return False
+            self._pending_messages[session_key] = event
+            return True
+
+        return self._start_session_processing(event, session_key)
+
     async def cancel_session_processing(
         self,
         session_key: str,
@@ -5543,7 +5577,9 @@ class BasePlatformAdapter(ABC):
         if not self._message_handler:
             return
 
-        coerce_plaintext_gateway_command(event)
+        trusted_ipc_task = is_gateway_session_ipc_task(event)
+        if not trusted_ipc_task:
+            coerce_plaintext_gateway_command(event)
 
         # Rewrite ``event.source.thread_id`` via the installed recovery hook
         # (Telegram DM topic mode) so the session key, guard checks, and
@@ -5556,6 +5592,14 @@ class BasePlatformAdapter(ABC):
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
+
+        if trusted_ipc_task:
+            # IPC task text is model input, never command/control input.  Keep
+            # all slash/admin/approval/clarify handlers below unreachable.
+            if (event.metadata or {}).get("gateway_session_key") != session_key:
+                return
+            self.accept_internal_task(event, session_key)
+            return
 
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5423,6 +5423,10 @@ class BasePlatformAdapter(ABC):
         if metadata.get("gateway_session_key") != session_key:
             return False
 
+        # Match ordinary inbound dispatch: a completed owner task can leave a
+        # stale active-session guard behind.  Heal it before choosing the busy
+        # queue, otherwise accepted IPC work has no live task to drain it.
+        self._heal_stale_session_lock(session_key)
         if session_key in self._active_sessions:
             runner = getattr(self, "gateway_runner", None)
             enqueue_internal = getattr(runner, "_enqueue_internal_fifo_event", None)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2218,7 +2218,12 @@ def _new_gateway_session_ipc_event(**kwargs: Any) -> MessageEvent:
 
 
 def is_gateway_session_ipc_task(event: "MessageEvent") -> bool:
-    """Return whether *event* carries the unforgeable in-process IPC type."""
+    """Return whether *event* carries the process-private IPC event type.
+
+    This prevents trust forgery through platform payloads or copied metadata. Loaded
+    Python code already executes inside the trusted gateway process and is outside
+    this owner-local IPC threat boundary.
+    """
     return isinstance(event, _GatewaySessionIPCEvent)
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2126,7 +2126,7 @@ class MessageEvent:
     
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
-        if self.internal and self.metadata.get("gateway_session_ipc_task") is True:
+        if is_gateway_session_ipc_task(self):
             return False
         return (self.text or "").lstrip().startswith("/")
     
@@ -2200,13 +2200,26 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
         return
 
 
+_GATEWAY_SESSION_IPC_CAPABILITY = object()
+
+
+class _GatewaySessionIPCEvent(MessageEvent):
+    """Private event subtype constructible only with the in-process capability."""
+
+    def __init__(self, capability: object, **kwargs: Any) -> None:
+        if capability is not _GATEWAY_SESSION_IPC_CAPABILITY:
+            raise TypeError("trusted gateway session IPC events require server capability")
+        super().__init__(**kwargs)
+
+
+def _new_gateway_session_ipc_event(**kwargs: Any) -> MessageEvent:
+    """Create a server-owned IPC event; not part of the adapter/plugin API."""
+    return _GatewaySessionIPCEvent(_GATEWAY_SESSION_IPC_CAPABILITY, **kwargs)
+
+
 def is_gateway_session_ipc_task(event: "MessageEvent") -> bool:
-    """Return whether *event* is the dedicated non-command IPC task type."""
-    metadata = getattr(event, "metadata", None) or {}
-    return bool(
-        getattr(event, "internal", False)
-        and metadata.get("gateway_session_ipc_task") is True
-    )
+    """Return whether *event* carries the unforgeable in-process IPC type."""
+    return isinstance(event, _GatewaySessionIPCEvent)
 
 
 @dataclass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5670,6 +5670,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # inject``.  It is created only after adapters are ready and closed at
         # the start of shutdown so no new internal work can enter a drain.
         self._session_ipc_server = None
+        # Serializes the shared adapter head slot and runner overflow queue.
+        # Construct once so concurrent first-use admissions cannot install
+        # different locks and both pass the queue-depth cap.
+        self._busy_queue_lock = threading.RLock()
         self._executor_lock = threading.Lock()
         self._executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
         # Set on gateway stop so the recreate-on-shutdown path can't resurrect
@@ -10968,9 +10972,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             from gateway.session_ipc import GatewaySessionIPCServer
 
+            ipc_profiles = {self._active_profile_name()}
+            if getattr(self.config, "multiplex_profiles", False):
+                ipc_profiles.update(self._profile_adapters.keys())
             self._session_ipc_server = GatewaySessionIPCServer(
                 self._inject_exact_session,
                 profile=self._active_profile_name(),
+                served_profiles=ipc_profiles,
             )
             await self._session_ipc_server.start()
             logger.info(
@@ -11825,10 +11833,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         active_profile = self._active_profile_name()
-        if profile != active_profile:
+        served_profiles = {active_profile}
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            served_profiles.update(getattr(self, "_profile_adapters", {}).keys())
+        if profile not in served_profiles:
             raise SessionIPCRequestError(
                 "profile_mismatch",
-                f"Gateway serves profile {active_profile!r}, not {profile!r}",
+                f"Gateway does not serve profile {profile!r}",
             )
         if not message.strip():
             raise SessionIPCRequestError("invalid_request", "message is required")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5619,6 +5619,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._booted_from_restart: bool = False
         self._stop_task: Optional[asyncio.Task] = None
         self._restart_task: Optional[asyncio.Task] = None
+        # Owner-only, profile-scoped Unix socket used by ``hermes gateway
+        # inject``.  It is created only after adapters are ready and closed at
+        # the start of shutdown so no new internal work can enter a drain.
+        self._session_ipc_server = None
         self._executor_lock = threading.Lock()
         self._executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
         # Set on gateway stop so the recreate-on-shutdown path can't resurrect
@@ -10868,6 +10872,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running = True
         self._update_runtime_status("running")
 
+        # Local exact-session control plane.  This is deliberately a Unix
+        # socket under the active HERMES_HOME (mode 0600), never a TCP listener.
+        try:
+            from gateway.session_ipc import GatewaySessionIPCServer
+
+            self._session_ipc_server = GatewaySessionIPCServer(
+                self._inject_exact_session,
+                profile=self._active_profile_name(),
+            )
+            await self._session_ipc_server.start()
+            logger.info(
+                "Gateway session IPC listening at %s",
+                self._session_ipc_server.socket_path,
+            )
+        except Exception:
+            self._session_ipc_server = None
+            logger.warning("Gateway session IPC unavailable", exc_info=True)
+
         # Loop-liveness heartbeat (#66892): an asyncio task so a frozen loop
         # stops refreshing ``state/gateway.heartbeat``. Cancelled with the
         # other background tasks during stop(). Best-effort — a liveness probe
@@ -11605,6 +11627,137 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             return "default"
 
+    def _resolve_exact_session_route(self, session_key: str):
+        """Return one exact live routing entry or fail closed.
+
+        The dictionary key and the entry's embedded key must agree.  A mismatch
+        means the durable routing index is corrupt/ambiguous; silently choosing
+        either side could inject work into another conversation.
+        """
+        from gateway.session_ipc import SessionIPCRequestError
+
+        session_store = getattr(self, "session_store", None)
+        if session_store is None:
+            raise SessionIPCRequestError("route_not_found", "Gateway session store is unavailable")
+        with session_store._lock:  # noqa: SLF001 - exact live routing snapshot
+            session_store._ensure_loaded_locked()  # noqa: SLF001
+            entry = session_store._entries.get(session_key)  # noqa: SLF001
+            if entry is None:
+                raise SessionIPCRequestError(
+                    "route_not_found",
+                    f"No live gateway route for exact session_key {session_key!r}",
+                )
+            if getattr(entry, "session_key", None) != session_key:
+                raise SessionIPCRequestError(
+                    "route_ambiguous",
+                    f"Gateway route key disagrees with its stored session_key for {session_key!r}",
+                )
+            return entry
+
+    async def _inject_exact_session(
+        self,
+        *,
+        profile: str,
+        session_key: str,
+        message: str,
+    ) -> Dict[str, Any]:
+        """Queue or safely steer one internal task into an exact live route."""
+        from gateway.session_ipc import SessionIPCRequestError
+
+        active_profile = self._active_profile_name()
+        if profile != active_profile:
+            raise SessionIPCRequestError(
+                "profile_mismatch",
+                f"Gateway serves profile {active_profile!r}, not {profile!r}",
+            )
+        if not message.strip():
+            raise SessionIPCRequestError("invalid_request", "message is required")
+
+        entry = await asyncio.to_thread(self._resolve_exact_session_route, session_key)
+        source = getattr(entry, "origin", None)
+        if source is None:
+            raise SessionIPCRequestError(
+                "route_ambiguous",
+                f"Exact route {session_key!r} has no delivery origin",
+            )
+        source_profile = (getattr(source, "profile", None) or "").strip()
+        if source_profile and source_profile != profile:
+            raise SessionIPCRequestError(
+                "profile_mismatch",
+                f"Exact route belongs to profile {source_profile!r}, not {profile!r}",
+            )
+        if self._session_key_for_source(source) != session_key:
+            raise SessionIPCRequestError(
+                "route_ambiguous",
+                f"Stored route origin does not reproduce exact session_key {session_key!r}",
+            )
+
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            raise SessionIPCRequestError(
+                "route_unavailable",
+                f"No live adapter owns exact route {session_key!r}",
+            )
+
+        session_id = str(getattr(entry, "session_id", "") or "")
+        if not session_id:
+            raise SessionIPCRequestError(
+                "route_ambiguous",
+                f"Exact route {session_key!r} has no session_id",
+            )
+
+        running_agent = getattr(self, "_running_agents", {}).get(session_key)
+        if (
+            running_agent is not None
+            and running_agent is not _AGENT_PENDING_SENTINEL
+            and hasattr(running_agent, "steer")
+        ):
+            try:
+                if running_agent.steer(message.strip()):
+                    return {
+                        "ok": True,
+                        "profile": profile,
+                        "session_key": session_key,
+                        "session_id": session_id,
+                        "disposition": "steered",
+                    }
+            except Exception:
+                logger.warning("Exact-session IPC steer failed; queueing", exc_info=True)
+
+        event = MessageEvent(
+            text=message.strip(),
+            message_type=MessageType.TEXT,
+            source=source,
+            internal=True,
+            metadata={
+                "gateway_session_ipc": True,
+                "gateway_session_id": session_id,
+            },
+        )
+
+        if session_key in getattr(self, "_running_agents", {}):
+            before = self._queue_depth(session_key, adapter=adapter)
+            self._queue_or_replace_pending_event(session_key, event)
+            after = self._queue_depth(session_key, adapter=adapter)
+            if after <= before:
+                raise SessionIPCRequestError(
+                    "queue_full",
+                    f"Pending queue is full for exact route {session_key!r}",
+                )
+        else:
+            # BasePlatformAdapter.handle_message installs its per-session guard
+            # synchronously and starts the normal background turn.  No inbound
+            # bot message or busy acknowledgement is sent for this internal event.
+            await adapter.handle_message(event)
+
+        return {
+            "ok": True,
+            "profile": profile,
+            "session_key": session_key,
+            "session_id": session_id,
+            "disposition": "queued",
+        }
+
     # ── Kanban board watchers ───────────────────────────────────────────
     # The kanban notifier/dispatcher watcher loops + their helpers live in
     # GatewayKanbanWatchersMixin (gateway/kanban_watchers.py). They use only
@@ -12046,6 +12199,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             self._running = False
             self._draining = True
+
+            session_ipc_server = getattr(self, "_session_ipc_server", None)
+            self._session_ipc_server = None
+            if session_ipc_server is not None:
+                try:
+                    await session_ipc_server.stop()
+                except Exception:
+                    logger.warning("Failed to stop gateway session IPC", exc_info=True)
 
             stop_watchdog = getattr(self, "_stop_systemd_watchdog", None)
             if callable(stop_watchdog):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8352,6 +8352,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return text
         return (enriched_text or text).strip()
 
+    def _enqueue_internal_fifo_event(
+        self,
+        session_key: str,
+        event: MessageEvent,
+        adapter: Any,
+    ) -> bool:
+        """Admit one internal IPC task without touching user media merge state."""
+        if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
+            return False
+        before = self._queue_depth(session_key, adapter=adapter)
+        self._enqueue_fifo(session_key, event, adapter)
+        return self._queue_depth(session_key, adapter=adapter) == before + 1
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -11664,8 +11677,75 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         idempotency_key: str,
         message: str,
     ) -> Dict[str, Any]:
+        """Run exact-route validation and acceptance away from the event loop."""
+        cancelled = threading.Event()
+        mutation_gate = threading.Lock()
+        committed = threading.Event()
+        event_loop = asyncio.get_running_loop()
+        worker = asyncio.create_task(
+            asyncio.to_thread(
+                self._inject_exact_session_sync,
+                profile=profile,
+                session_key=session_key,
+                expected_session_id=expected_session_id,
+                idempotency_key=idempotency_key,
+                message=message,
+                cancelled=cancelled,
+                mutation_gate=mutation_gate,
+                committed=committed,
+                event_loop=event_loop,
+            )
+        )
+        try:
+            return await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            while not mutation_gate.acquire(blocking=False):
+                await asyncio.sleep(0.001)
+            try:
+                if not committed.is_set():
+                    cancelled.set()
+                    raise
+            finally:
+                mutation_gate.release()
+            # A synchronous side effect already crossed the commit gate.  Wait
+            # for its definitive result instead of returning a false timeout
+            # that could trigger a duplicate retry.
+            return await asyncio.shield(worker)
+
+    @staticmethod
+    async def _accept_internal_task_on_loop(
+        adapter: Any,
+        event: MessageEvent,
+        session_key: str,
+        cancelled: threading.Event,
+    ) -> bool:
+        """Run adapter task creation on its owning event-loop thread."""
+        if cancelled.is_set():
+            return False
+        return bool(adapter.accept_internal_task(event, session_key))
+
+    def _inject_exact_session_sync(
+        self,
+        *,
+        profile: str,
+        session_key: str,
+        expected_session_id: str,
+        idempotency_key: str,
+        message: str,
+        cancelled: threading.Event,
+        mutation_gate: threading.Lock,
+        committed: threading.Event,
+        event_loop: asyncio.AbstractEventLoop,
+    ) -> Dict[str, Any]:
         """Atomically validate and accept one non-command task on an exact route."""
         from gateway.session_ipc import SessionIPCRequestError
+
+        def ensure_not_cancelled() -> None:
+            if cancelled.is_set():
+                raise SessionIPCRequestError(
+                    "request_timeout",
+                    "Gateway session acceptance timed out before mutation",
+                )
 
         active_profile = self._active_profile_name()
         if profile != active_profile:
@@ -11717,13 +11797,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 raise SessionIPCRequestError("session_ended", "Exact session has ended")
             if self.session_store._is_session_ended_in_db(session_id):
                 raise SessionIPCRequestError("session_ended", "Exact session has ended")
+            ensure_not_cancelled()
             if self.session_store._is_session_expired(entry):
                 raise SessionIPCRequestError("session_expired", "Exact session has expired")
+            ensure_not_cancelled()
             if self.session_store._compression_tip_for_session_id(session_id) != session_id:
                 raise SessionIPCRequestError(
                     "route_rotated",
                     "Expected session is a stale parent of a newer compressed session",
                 )
+            ensure_not_cancelled()
 
             source = getattr(entry, "origin", None)
             if source is None:
@@ -11764,16 +11847,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
             running_agent = getattr(self, "_running_agents", {}).get(session_key)
+            ensure_not_cancelled()
             if (
                 running_agent is not None
                 and running_agent is not _AGENT_PENDING_SENTINEL
                 and hasattr(running_agent, "steer")
             ):
                 try:
-                    if running_agent.steer(event.text):
-                        disposition = "steered"
-                    else:
-                        disposition = ""
+                    with mutation_gate:
+                        ensure_not_cancelled()
+                        if running_agent.steer(event.text):
+                            committed.set()
+                            disposition = "steered"
+                        else:
+                            disposition = ""
                 except Exception:
                     logger.warning("Exact-session IPC steer failed; queueing", exc_info=True)
                     disposition = ""
@@ -11786,19 +11873,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "disposition": disposition,
                     }
 
-            if session_key in getattr(self, "_running_agents", {}):
-                before = self._queue_depth(session_key, adapter=adapter)
-                self._queue_or_replace_pending_event(session_key, event)
-                if self._queue_depth(session_key, adapter=adapter) <= before:
-                    raise SessionIPCRequestError(
-                        "queue_full",
-                        f"Pending queue is full for exact route {session_key!r}",
-                    )
-            elif not adapter.accept_internal_task(event, session_key):
-                raise SessionIPCRequestError(
-                    "acceptance_failed",
-                    f"Exact route {session_key!r} could not be synchronously claimed",
-                )
+            with mutation_gate:
+                ensure_not_cancelled()
+                if session_key in getattr(self, "_running_agents", {}):
+                    if not self._enqueue_internal_fifo_event(session_key, event, adapter):
+                        raise SessionIPCRequestError(
+                            "queue_full",
+                            f"Pending queue is full for exact route {session_key!r}",
+                        )
+                else:
+                    accepted = asyncio.run_coroutine_threadsafe(
+                        self._accept_internal_task_on_loop(
+                            adapter,
+                            event,
+                            session_key,
+                            cancelled,
+                        ),
+                        event_loop,
+                    ).result()
+                    if not accepted:
+                        raise SessionIPCRequestError(
+                            "acceptance_failed",
+                            f"Exact route {session_key!r} could not be synchronously claimed",
+                        )
+                committed.set()
 
             return {
                 "ok": True,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2698,6 +2698,73 @@ def _event_for_leftover_gateway_session_ipc_steer(
     )
 
 
+def _leftover_steer_chunks(
+    result: dict[str, Any],
+) -> list[tuple[str, bool]]:
+    """Decode lossless steer handoff, with legacy single-value fallback."""
+    raw_chunks = result.get("pending_steer_chunks")
+    chunks: list[tuple[str, bool]] = []
+    if isinstance(raw_chunks, list):
+        for raw in raw_chunks:
+            if not isinstance(raw, dict):
+                continue
+            text = str(raw.get("text") or "").strip()
+            if text:
+                chunks.append(
+                    (
+                        text,
+                        bool(raw.get("gateway_session_ipc")),
+                    )
+                )
+    if chunks:
+        return chunks
+    text = str(result.get("pending_steer") or "").strip()
+    return (
+        [
+            (
+                text,
+                bool(result.get("pending_steer_is_gateway_session_ipc")),
+            )
+        ]
+        if text
+        else []
+    )
+
+
+def _event_for_leftover_steer(
+    text: str,
+    *,
+    trusted_session_ipc: bool,
+    source: SessionSource,
+) -> MessageEvent:
+    if trusted_session_ipc:
+        return _new_gateway_session_ipc_event(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            internal=True,
+        )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+
+def _events_for_leftover_steers(
+    result: dict[str, Any],
+    source: SessionSource,
+) -> list[MessageEvent]:
+    return [
+        _event_for_leftover_steer(
+            text,
+            trusted_session_ipc=trusted,
+            source=source,
+        )
+        for text, trusted in _leftover_steer_chunks(result)
+    ]
+
+
 _INTERRUPT_REASON_STOP = "Stop requested"
 _INTERRUPT_REASON_RESET = "Session reset requested"
 _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
@@ -5129,38 +5196,68 @@ class TurnRunner:
             # The normal finalizer closes this at its last steer drain.  Also
             # close here so an exceptional gateway turn cannot leave a cached
             # agent accepting steers that no running loop can consume.
-            _close_with_provenance = getattr(
+            _close_with_chunks = getattr(
                 agent,
-                "_close_steer_admission_with_provenance",
+                "_close_steer_admission_with_chunks",
                 None,
             )
-            if callable(_close_with_provenance):
-                _unconsumed_steer, _steer_is_session_ipc = (
-                    _close_with_provenance()
-                )
+            if callable(_close_with_chunks):
+                _unconsumed_steer_chunks = _close_with_chunks()
             else:
-                _close_steer_admission = getattr(
+                _close_with_provenance = getattr(
                     agent,
-                    "_close_steer_admission",
+                    "_close_steer_admission_with_provenance",
                     None,
                 )
-                _unconsumed_steer = (
-                    _close_steer_admission()
-                    if callable(_close_steer_admission)
-                    else None
+                if callable(_close_with_provenance):
+                    _unconsumed_steer, _steer_is_session_ipc = (
+                        _close_with_provenance()
+                    )
+                else:
+                    _close_steer_admission = getattr(
+                        agent,
+                        "_close_steer_admission",
+                        None,
+                    )
+                    _unconsumed_steer = (
+                        _close_steer_admission()
+                        if callable(_close_steer_admission)
+                        else None
+                    )
+                    _steer_is_session_ipc = False
+                _unconsumed_steer_chunks = (
+                    [
+                        (
+                            str(_unconsumed_steer),
+                            _steer_is_session_ipc,
+                        )
+                    ]
+                    if str(_unconsumed_steer or "").strip()
+                    else []
                 )
-                _steer_is_session_ipc = False
             if (
                 not _conversation_completed
-                and str(_unconsumed_steer or "").strip()
+                and callable(
+                    getattr(
+                        agent,
+                        "_drain_codex_native_pending_steer_chunks",
+                        None,
+                    )
+                )
+            ):
+                _unconsumed_steer_chunks.extend(
+                    agent._drain_codex_native_pending_steer_chunks()
+                )
+            if (
+                not _conversation_completed
+                and _unconsumed_steer_chunks
             ):
                 try:
                     _preserve_future = asyncio.run_coroutine_threadsafe(
-                        self._runner._requeue_failed_turn_steer(
+                        self._runner._requeue_failed_turn_steers(
                             ctx.session_key,
                             ctx.source,
-                            str(_unconsumed_steer),
-                            trusted_session_ipc=_steer_is_session_ipc,
+                            _unconsumed_steer_chunks,
                         ),
                         ctx._loop_for_step,
                     )
@@ -8529,36 +8626,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         trusted_session_ipc: bool,
     ) -> bool:
         """Put an accepted steer first in line when its active turn raises."""
-        adapter = self._adapter_for_source(source)
-        pending_text = str(text or "").strip()
-        if adapter is None or not session_key or not pending_text:
-            return False
-        event = (
-            _new_gateway_session_ipc_event(
-                text=pending_text,
-                message_type=MessageType.TEXT,
-                source=source,
-                internal=True,
-            )
-            if trusted_session_ipc
-            else MessageEvent(
-                text=pending_text,
-                message_type=MessageType.TEXT,
-                source=source,
-            )
+        return await self._requeue_failed_turn_steers(
+            session_key,
+            source,
+            [(text, trusted_session_ipc)],
         )
+
+    async def _requeue_failed_turn_steers(
+        self,
+        session_key: str,
+        source: SessionSource,
+        chunks: list[tuple[str, bool]],
+    ) -> bool:
+        """Put accepted steers first in line without collapsing provenance."""
+        adapter = self._adapter_for_source(source)
+        events = [
+            _event_for_leftover_steer(
+                pending_text,
+                trusted_session_ipc=trusted,
+                source=source,
+            )
+            for text, trusted in chunks
+            if (pending_text := str(text or "").strip())
+        ]
+        if adapter is None or not session_key or not events:
+            return False
         with self._busy_queue_guard():
             pending_slot = getattr(adapter, "_pending_messages", None)
             if pending_slot is None:
                 return False
             existing = pending_slot.get(session_key)
-            if existing is not None:
-                # The accepted steer belonged to the failed active turn, so it
-                # precedes follow-ups already waiting for their own turns.
-                self._session_state(
-                    session_key
-                ).conversation.queued_events.insert(0, existing)
-            pending_slot[session_key] = event
+            queue = self._session_state(
+                session_key
+            ).conversation.queued_events
+            # Accepted steers belonged to the failed active turn, so all of
+            # them precede follow-ups already waiting for their own turns.
+            ordered = events + ([existing] if existing is not None else []) + queue
+            pending_slot[session_key] = ordered[0]
+            self._session_state(
+                session_key
+            ).conversation.queued_events = ordered[1:]
         return True
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
@@ -24780,13 +24887,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # and returned it in result["pending_steer"]. Deliver it as the
             # next user turn so it isn't silently dropped.
             if result and not pending and not pending_event:
-                _leftover_steer = result.get("pending_steer")
-                if _leftover_steer:
-                    pending = _leftover_steer
-                    pending_event = _event_for_leftover_gateway_session_ipc_steer(
-                        result,
-                        source,
-                    )
+                _leftover_events = _events_for_leftover_steers(result, source)
+                if _leftover_events:
+                    pending_event = _leftover_events[0]
+                    pending = pending_event.text
+                    if len(_leftover_events) > 1:
+                        adapter = self._adapter_for_source(source)
+                        with self._busy_queue_guard():
+                            pending_slot = (
+                                getattr(adapter, "_pending_messages", None)
+                                if adapter is not None
+                                else None
+                            )
+                            if pending_slot is not None and session_key:
+                                existing = pending_slot.get(session_key)
+                                queue = self._session_state(
+                                    session_key
+                                ).conversation.queued_events
+                                ordered = (
+                                    _leftover_events[1:]
+                                    + (
+                                        [existing]
+                                        if existing is not None
+                                        else []
+                                    )
+                                    + queue
+                                )
+                                pending_slot[session_key] = ordered[0]
+                                self._session_state(
+                                    session_key
+                                ).conversation.queued_events = ordered[1:]
                     logger.debug("Delivering leftover /steer as next turn: '%s...'", pending[:40])
 
             # Safety net: if the pending text is a slash command (e.g. "/stop",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2765,6 +2765,34 @@ def _events_for_leftover_steers(
     ]
 
 
+def _prioritize_leftover_steers(
+    result: dict[str, Any],
+    source: SessionSource,
+    pending_event: MessageEvent | None,
+    pending_text: str | None,
+) -> tuple[MessageEvent | None, str | None, list[MessageEvent], bool]:
+    """Choose the next recovered steer and defer every later follow-up."""
+    leftovers = [
+        event
+        for event in _events_for_leftover_steers(result, source)
+        if not _pending_slash_is_command_leak(event.text, event)
+    ]
+    if not leftovers:
+        return pending_event, pending_text, [], False
+    deferred = leftovers[1:]
+    if pending_event is not None:
+        deferred.append(pending_event)
+    elif pending_text:
+        deferred.append(
+            MessageEvent(
+                text=pending_text,
+                message_type=MessageType.TEXT,
+                source=source,
+            )
+        )
+    return leftovers[0], leftovers[0].text, deferred, True
+
+
 _INTERRUPT_REASON_STOP = "Stop requested"
 _INTERRUPT_REASON_RESET = "Session reset requested"
 _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
@@ -8617,6 +8645,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # change before a second measurement.
         return True
 
+    def _prepend_pending_events(
+        self,
+        session_key: str,
+        events: list[MessageEvent],
+        adapter: Any,
+    ) -> bool:
+        """Place recovered events ahead of every later queued follow-up."""
+        if adapter is None or not session_key or not events:
+            return False
+        with self._busy_queue_guard():
+            pending_slot = getattr(adapter, "_pending_messages", None)
+            if pending_slot is None:
+                return False
+            existing = pending_slot.get(session_key)
+            queue = self._session_state(
+                session_key
+            ).conversation.queued_events
+            ordered = events + ([existing] if existing is not None else []) + queue
+            pending_slot[session_key] = ordered[0]
+            self._session_state(
+                session_key
+            ).conversation.queued_events = ordered[1:]
+        return True
+
     async def _requeue_failed_turn_steer(
         self,
         session_key: str,
@@ -8651,22 +8703,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ]
         if adapter is None or not session_key or not events:
             return False
-        with self._busy_queue_guard():
-            pending_slot = getattr(adapter, "_pending_messages", None)
-            if pending_slot is None:
-                return False
-            existing = pending_slot.get(session_key)
-            queue = self._session_state(
-                session_key
-            ).conversation.queued_events
-            # Accepted steers belonged to the failed active turn, so all of
-            # them precede follow-ups already waiting for their own turns.
-            ordered = events + ([existing] if existing is not None else []) + queue
-            pending_slot[session_key] = ordered[0]
-            self._session_state(
-                session_key
-            ).conversation.queued_events = ordered[1:]
-        return True
+        # Accepted steers belonged to the failed active turn, so all of them
+        # precede follow-ups already waiting for their own turns.
+        return self._prepend_pending_events(session_key, events, adapter)
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
@@ -24857,67 +24896,63 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                     else:
                         pending = interrupt_message
-                elif pending_event:
-                    # Transcribe audio media on the dequeued event BEFORE it is
-                    # handed back as the next user turn, so queued/interrupting
-                    # voice messages drain with the real transcript instead of
-                    # a file-path placeholder. When configured, echo each
-                    # transcript back to the user in the same 🎙️ format as
-                    # fresh voice messages.
-                    _pending_text = pending_event.text or ""
-                    _media_urls = getattr(pending_event, "media_urls", None) or []
-                    if self._pending_event_audio_paths(pending_event):
-                        pending, _ = await self._transcribe_and_echo_pending_voice(
-                            pending_event,
-                            adapter,
-                            source,
-                            _pending_text,
-                            log_context="Voice-drain",
-                            metadata={"thread_id": source.thread_id} if source.thread_id else None,
-                        )
-                        if not pending:
-                            pending = _build_media_placeholder(pending_event)
-                    else:
-                        pending = _pending_text or _build_media_placeholder(pending_event)
-                    if pending:
-                        logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
 
             # Leftover /steer: if a steer arrived after the last tool batch
             # (e.g. during the final API call), the agent couldn't inject it
-            # and returned it in result["pending_steer"]. Deliver it as the
-            # next user turn so it isn't silently dropped.
-            if result and not pending and not pending_event:
-                _leftover_events = _events_for_leftover_steers(result, source)
-                if _leftover_events:
-                    pending_event = _leftover_events[0]
-                    pending = pending_event.text
-                    if len(_leftover_events) > 1:
-                        adapter = self._adapter_for_source(source)
-                        with self._busy_queue_guard():
-                            pending_slot = (
-                                getattr(adapter, "_pending_messages", None)
-                                if adapter is not None
-                                else None
-                            )
-                            if pending_slot is not None and session_key:
-                                existing = pending_slot.get(session_key)
-                                queue = self._session_state(
-                                    session_key
-                                ).conversation.queued_events
-                                ordered = (
-                                    _leftover_events[1:]
-                                    + (
-                                        [existing]
-                                        if existing is not None
-                                        else []
-                                    )
-                                    + queue
-                                )
-                                pending_slot[session_key] = ordered[0]
-                                self._session_state(
-                                    session_key
-                                ).conversation.queued_events = ordered[1:]
-                    logger.debug("Delivering leftover /steer as next turn: '%s...'", pending[:40])
+            # and returned it in result["pending_steer_chunks"]. It belongs to
+            # the just-finished turn, so deliver it before follow-ups already
+            # waiting in the adapter queue. Keep each recovered event separate
+            # so an ordinary slash command cannot discard a trusted IPC task.
+            pending_event, pending, deferred, _recovered_steer_is_next = (
+                _prioritize_leftover_steers(
+                    result,
+                    source,
+                    pending_event,
+                    pending,
+                )
+                if result
+                else (pending_event, pending, [], False)
+            )
+            if deferred:
+                self._prepend_pending_events(
+                    session_key,
+                    deferred,
+                    adapter,
+                )
+            if _recovered_steer_is_next and pending_event is not None:
+                if deferred:
+                    logger.debug(
+                        "Deferred %d queued follow-up(s) behind recovered steer",
+                        len(deferred),
+                    )
+                logger.debug(
+                    "Delivering leftover /steer as next turn: '%s...'",
+                    pending[:40],
+                )
+            elif pending_event:
+                # Transcribe audio media only after recovered steers have been
+                # prioritized. If the media event is deferred, it stays intact
+                # and is transcribed exactly once when its own turn is next.
+                _pending_text = pending_event.text or ""
+                _media_urls = getattr(pending_event, "media_urls", None) or []
+                if self._pending_event_audio_paths(pending_event):
+                    pending, _ = await self._transcribe_and_echo_pending_voice(
+                        pending_event,
+                        adapter,
+                        source,
+                        _pending_text,
+                        log_context="Voice-drain",
+                        metadata={"thread_id": source.thread_id} if source.thread_id else None,
+                    )
+                    if not pending:
+                        pending = _build_media_placeholder(pending_event)
+                else:
+                    pending = _pending_text or _build_media_placeholder(pending_event)
+                if pending:
+                    logger.debug(
+                        "Processing queued message after agent completion: '%s...'",
+                        pending[:40],
+                    )
 
             # Safety net: if the pending text is a slash command (e.g. "/stop",
             # "/new"), discard it — commands should never be passed to the agent

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8669,6 +8669,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ).conversation.queued_events = ordered[1:]
         return True
 
+    def _queue_pending_at_recursion_cap(
+        self,
+        session_key: str,
+        source: SessionSource,
+        pending_event: MessageEvent | None,
+        pending_text: str | None,
+    ) -> bool:
+        """Queue the current head without replacing already deferred work."""
+        adapter = self._adapter_for_source(source)
+        event = pending_event
+        if event is None and pending_text:
+            event = MessageEvent(
+                text=pending_text,
+                message_type=MessageType.TEXT,
+                source=source,
+            )
+        return bool(
+            event is not None
+            and self._prepend_pending_events(
+                session_key,
+                [event],
+                adapter,
+            )
+        )
+
     async def _requeue_failed_turn_steer(
         self,
         session_key: str,
@@ -24996,15 +25021,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "queueing message instead of recursing.",
                         _interrupt_depth, session_key,
                     )
-                    adapter = self._adapter_for_source(source)
-                    if adapter and pending_event:
-                        self._merge_pending_event(
-                            adapter,
-                            session_key,
-                            pending_event,
-                        )
-                    elif adapter and hasattr(adapter, 'queue_message'):
-                        adapter.queue_message(session_key, pending)
+                    self._queue_pending_at_recursion_cap(
+                        session_key,
+                        source,
+                        pending_event,
+                        pending,
+                    )
                     return result_holder[0] or {"final_response": response, "messages": history}
 
                 was_interrupted = result.get("interrupted")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2215,6 +2215,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    _new_gateway_session_ipc_event,
     _prefix_within_utf16_limit,
     _reply_anchor_for_event,
     build_auto_tts_output_path,
@@ -10161,7 +10162,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Empty-text internal event — the _is_resume_pending branch in
             # _handle_message_with_agent prepends the proper reason-aware
             # system note before the turn runs.
-            event = MessageEvent(
+            event = _new_gateway_session_ipc_event(
                 text="",
                 message_type=MessageType.TEXT,
                 source=source,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -41,6 +41,7 @@ import signal
 import threading
 import time
 from collections import OrderedDict
+from contextlib import nullcontext
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
@@ -11659,9 +11660,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         *,
         profile: str,
         session_key: str,
+        expected_session_id: str,
+        idempotency_key: str,
         message: str,
     ) -> Dict[str, Any]:
-        """Queue or safely steer one internal task into an exact live route."""
+        """Atomically validate and accept one non-command task on an exact route."""
         from gateway.session_ipc import SessionIPCRequestError
 
         active_profile = self._active_profile_name()
@@ -11672,91 +11675,138 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         if not message.strip():
             raise SessionIPCRequestError("invalid_request", "message is required")
-
-        entry = await asyncio.to_thread(self._resolve_exact_session_route, session_key)
-        source = getattr(entry, "origin", None)
-        if source is None:
-            raise SessionIPCRequestError(
-                "route_ambiguous",
-                f"Exact route {session_key!r} has no delivery origin",
-            )
-        source_profile = (getattr(source, "profile", None) or "").strip()
-        if source_profile and source_profile != profile:
-            raise SessionIPCRequestError(
-                "profile_mismatch",
-                f"Exact route belongs to profile {source_profile!r}, not {profile!r}",
-            )
-        if self._session_key_for_source(source) != session_key:
-            raise SessionIPCRequestError(
-                "route_ambiguous",
-                f"Stored route origin does not reproduce exact session_key {session_key!r}",
-            )
-
-        adapter = self._adapter_for_source(source)
-        if adapter is None:
+        if not expected_session_id.strip():
+            raise SessionIPCRequestError("invalid_request", "expected_session_id is required")
+        if not idempotency_key.strip():
+            raise SessionIPCRequestError("invalid_request", "idempotency_key is required")
+        if not getattr(self, "_running", False) or getattr(self, "_draining", False):
             raise SessionIPCRequestError(
                 "route_unavailable",
-                f"No live adapter owns exact route {session_key!r}",
+                "Gateway is not accepting new session tasks",
             )
 
-        session_id = str(getattr(entry, "session_id", "") or "")
-        if not session_id:
-            raise SessionIPCRequestError(
-                "route_ambiguous",
-                f"Exact route {session_key!r} has no session_id",
+        lock = getattr(self.session_store, "_lock", nullcontext())
+        with lock:
+            ensure_loaded = getattr(self.session_store, "_ensure_loaded_locked", None)
+            if callable(ensure_loaded):
+                ensure_loaded()
+            entries = getattr(self.session_store, "_entries", {})
+            entry = entries.get(session_key)
+            if entry is None:
+                raise SessionIPCRequestError(
+                    "route_not_found",
+                    f"No live gateway route for exact session_key {session_key!r}",
+                )
+            if getattr(entry, "session_key", None) != session_key:
+                raise SessionIPCRequestError(
+                    "route_ambiguous",
+                    f"Gateway route key disagrees with stored session_key {session_key!r}",
+                )
+
+            session_id = str(getattr(entry, "session_id", "") or "")
+            if session_id != expected_session_id:
+                raise SessionIPCRequestError(
+                    "route_rotated",
+                    f"Exact route no longer points to expected session {expected_session_id!r}",
+                )
+            if getattr(entry, "suspended", False):
+                raise SessionIPCRequestError("session_suspended", "Exact session is suspended")
+            if getattr(entry, "ended_at", None) or str(
+                getattr(entry, "status", "") or ""
+            ).lower() in {"ended", "closed", "terminated"}:
+                raise SessionIPCRequestError("session_ended", "Exact session has ended")
+            if self.session_store._is_session_ended_in_db(session_id):
+                raise SessionIPCRequestError("session_ended", "Exact session has ended")
+            if self.session_store._is_session_expired(entry):
+                raise SessionIPCRequestError("session_expired", "Exact session has expired")
+            if self.session_store._compression_tip_for_session_id(session_id) != session_id:
+                raise SessionIPCRequestError(
+                    "route_rotated",
+                    "Expected session is a stale parent of a newer compressed session",
+                )
+
+            source = getattr(entry, "origin", None)
+            if source is None:
+                raise SessionIPCRequestError(
+                    "route_ambiguous",
+                    f"Exact route {session_key!r} has no delivery origin",
+                )
+            source_profile = (getattr(source, "profile", None) or "").strip()
+            if source_profile and source_profile != profile:
+                raise SessionIPCRequestError(
+                    "profile_mismatch",
+                    f"Exact route belongs to profile {source_profile!r}, not {profile!r}",
+                )
+            if self._session_key_for_source(source) != session_key:
+                raise SessionIPCRequestError(
+                    "route_ambiguous",
+                    f"Stored route origin does not reproduce exact session_key {session_key!r}",
+                )
+
+            adapter = self._adapter_for_source(source)
+            if adapter is None:
+                raise SessionIPCRequestError(
+                    "route_unavailable",
+                    f"No live adapter owns exact route {session_key!r}",
+                )
+
+            event = MessageEvent(
+                text=message.strip(),
+                message_type=MessageType.TEXT,
+                source=source,
+                internal=True,
+                metadata={
+                    "gateway_session_ipc_task": True,
+                    "gateway_session_key": session_key,
+                    "gateway_session_id": session_id,
+                    "gateway_session_idempotency_key": idempotency_key,
+                },
             )
 
-        running_agent = getattr(self, "_running_agents", {}).get(session_key)
-        if (
-            running_agent is not None
-            and running_agent is not _AGENT_PENDING_SENTINEL
-            and hasattr(running_agent, "steer")
-        ):
-            try:
-                if running_agent.steer(message.strip()):
+            running_agent = getattr(self, "_running_agents", {}).get(session_key)
+            if (
+                running_agent is not None
+                and running_agent is not _AGENT_PENDING_SENTINEL
+                and hasattr(running_agent, "steer")
+            ):
+                try:
+                    if running_agent.steer(event.text):
+                        disposition = "steered"
+                    else:
+                        disposition = ""
+                except Exception:
+                    logger.warning("Exact-session IPC steer failed; queueing", exc_info=True)
+                    disposition = ""
+                if disposition:
                     return {
                         "ok": True,
                         "profile": profile,
                         "session_key": session_key,
                         "session_id": session_id,
-                        "disposition": "steered",
+                        "disposition": disposition,
                     }
-            except Exception:
-                logger.warning("Exact-session IPC steer failed; queueing", exc_info=True)
 
-        event = MessageEvent(
-            text=message.strip(),
-            message_type=MessageType.TEXT,
-            source=source,
-            internal=True,
-            metadata={
-                "gateway_session_ipc": True,
-                "gateway_session_id": session_id,
-            },
-        )
-
-        if session_key in getattr(self, "_running_agents", {}):
-            before = self._queue_depth(session_key, adapter=adapter)
-            self._queue_or_replace_pending_event(session_key, event)
-            after = self._queue_depth(session_key, adapter=adapter)
-            if after <= before:
+            if session_key in getattr(self, "_running_agents", {}):
+                before = self._queue_depth(session_key, adapter=adapter)
+                self._queue_or_replace_pending_event(session_key, event)
+                if self._queue_depth(session_key, adapter=adapter) <= before:
+                    raise SessionIPCRequestError(
+                        "queue_full",
+                        f"Pending queue is full for exact route {session_key!r}",
+                    )
+            elif not adapter.accept_internal_task(event, session_key):
                 raise SessionIPCRequestError(
-                    "queue_full",
-                    f"Pending queue is full for exact route {session_key!r}",
+                    "acceptance_failed",
+                    f"Exact route {session_key!r} could not be synchronously claimed",
                 )
-        else:
-            # BasePlatformAdapter.handle_message installs its per-session guard
-            # synchronously and starts the normal background turn.  No inbound
-            # bot message or busy acknowledgement is sent for this internal event.
-            await adapter.handle_message(event)
 
-        return {
-            "ok": True,
-            "profile": profile,
-            "session_key": session_key,
-            "session_id": session_id,
-            "disposition": "queued",
-        }
+            return {
+                "ok": True,
+                "profile": profile,
+                "session_key": session_key,
+                "session_id": session_id,
+                "disposition": "queued",
+            }
 
     # ── Kanban board watchers ───────────────────────────────────────────
     # The kanban notifier/dispatcher watcher loops + their helpers live in

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5074,6 +5074,7 @@ class TurnRunner:
         _approval_session_key = ctx.session_key or ""
         _approval_session_token = set_current_session_key(_approval_session_key)
         register_gateway_notify(_approval_session_key, _approval_notify_sync)
+        _conversation_completed = False
         try:
             # If _prepare_inbound_message_text buffered image paths for native
             # attachment, wrap the user turn as an OpenAI-style multimodal
@@ -5123,13 +5124,59 @@ class TurnRunner:
             if _persist_user_timestamp_override is not None:
                 _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
             result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+            _conversation_completed = True
         finally:
             # The normal finalizer closes this at its last steer drain.  Also
             # close here so an exceptional gateway turn cannot leave a cached
             # agent accepting steers that no running loop can consume.
-            _close_steer_admission = getattr(agent, "_close_steer_admission", None)
-            if callable(_close_steer_admission):
-                _close_steer_admission()
+            _close_with_provenance = getattr(
+                agent,
+                "_close_steer_admission_with_provenance",
+                None,
+            )
+            if callable(_close_with_provenance):
+                _unconsumed_steer, _steer_is_session_ipc = (
+                    _close_with_provenance()
+                )
+            else:
+                _close_steer_admission = getattr(
+                    agent,
+                    "_close_steer_admission",
+                    None,
+                )
+                _unconsumed_steer = (
+                    _close_steer_admission()
+                    if callable(_close_steer_admission)
+                    else None
+                )
+                _steer_is_session_ipc = False
+            if (
+                not _conversation_completed
+                and str(_unconsumed_steer or "").strip()
+            ):
+                try:
+                    _preserve_future = asyncio.run_coroutine_threadsafe(
+                        self._runner._requeue_failed_turn_steer(
+                            ctx.session_key,
+                            ctx.source,
+                            str(_unconsumed_steer),
+                            trusted_session_ipc=_steer_is_session_ipc,
+                        ),
+                        ctx._loop_for_step,
+                    )
+                    if not _preserve_future.result(timeout=5.0):
+                        logger.error(
+                            "Could not preserve unconsumed steer after failed "
+                            "turn for session %s",
+                            ctx.session_key or "?",
+                        )
+                except Exception:
+                    # Preserve the original turn exception; this recovery path
+                    # must never replace it with a queueing failure.
+                    logger.exception(
+                        "Failed to preserve unconsumed steer for session %s",
+                        ctx.session_key or "?",
+                    )
             unregister_gateway_notify(_approval_session_key)
             # Cancel any pending clarify entries so blocked agent
             # threads don't hang past the end of the run (interrupt,
@@ -8471,6 +8518,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # The caller owns this mutation under _busy_queue_guard; do not infer
         # success from the aggregate depth, which sibling admissions can also
         # change before a second measurement.
+        return True
+
+    async def _requeue_failed_turn_steer(
+        self,
+        session_key: str,
+        source: SessionSource,
+        text: str,
+        *,
+        trusted_session_ipc: bool,
+    ) -> bool:
+        """Put an accepted steer first in line when its active turn raises."""
+        adapter = self._adapter_for_source(source)
+        pending_text = str(text or "").strip()
+        if adapter is None or not session_key or not pending_text:
+            return False
+        event = (
+            _new_gateway_session_ipc_event(
+                text=pending_text,
+                message_type=MessageType.TEXT,
+                source=source,
+                internal=True,
+            )
+            if trusted_session_ipc
+            else MessageEvent(
+                text=pending_text,
+                message_type=MessageType.TEXT,
+                source=source,
+            )
+        )
+        with self._busy_queue_guard():
+            pending_slot = getattr(adapter, "_pending_messages", None)
+            if pending_slot is None:
+                return False
+            existing = pending_slot.get(session_key)
+            if existing is not None:
+                # The accepted steer belonged to the failed active turn, so it
+                # precedes follow-ups already waiting for their own turns.
+                self._session_state(
+                    session_key
+                ).conversation.queued_events.insert(0, existing)
+            pending_slot[session_key] = event
         return True
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
@@ -13970,7 +14058,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if accepted:
                 preview = steer_text[:60] + ("..." if len(steer_text) > 60 else "")
                 return f"⏩ Steer queued — arrives after the next tool call: '{preview}'"
-            return "Steer rejected (empty payload)."
+            # Admission can close between the state lookup and steer().  The
+            # payload is known nonempty here, so preserve it as a next-turn
+            # event instead of misreporting an empty-payload rejection.
         # Running agent is missing or lacks steer() — fall back to queue.
         adapter = self._adapter_for_source(source)
         if adapter:
@@ -13983,6 +14073,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_context=event.channel_context,
             )
             self._enqueue_fifo(quick_key, queued_event, adapter)
+        if running_agent:
+            return "Steer admission closed — /steer queued for the next turn."
         return "No active agent — /steer queued for the next turn."
 
     async def _busy_goal_command(self, event: MessageEvent, quick_key: str, source):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2731,6 +2731,16 @@ def _leftover_steer_chunks(
     )
 
 
+def _conversation_result_completed(result: dict[str, Any]) -> bool:
+    """Whether a returned agent result completed its logical turn.
+
+    ``run_conversation()`` returning is not enough: retry/backoff interrupt
+    paths return early with ``completed=False`` and bypass the normal turn
+    finalizer. Those results still need the failed-turn steer recovery handoff.
+    """
+    return bool(result.get("completed", True))
+
+
 def _event_for_leftover_steer(
     text: str,
     *,
@@ -5219,7 +5229,7 @@ class TurnRunner:
             if _persist_user_timestamp_override is not None:
                 _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
             result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
-            _conversation_completed = True
+            _conversation_completed = _conversation_result_completed(result)
         finally:
             # The normal finalizer closes this at its last steer drain.  Also
             # close here so an exceptional gateway turn cannot leave a cached

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7387,6 +7387,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else:
                 pending_slot[session_key] = queued_event
 
+    def _merge_pending_event(
+        self,
+        adapter: Any,
+        session_key: str,
+        event: "MessageEvent",
+        *,
+        merge_text: bool = False,
+    ) -> None:
+        """Merge a user/media follow-up under the shared pending-slot lock."""
+        with self._busy_queue_guard():
+            merge_pending_message_event(
+                adapter._pending_messages,
+                session_key,
+                event,
+                merge_text=merge_text,
+            )
+
     def _promote_queued_event(
         self,
         session_key: str,
@@ -8442,9 +8459,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> bool:
         if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
             return False
-        before = self._queue_depth(session_key, adapter=adapter)
-        self._enqueue_fifo(session_key, event, adapter)
-        return self._queue_depth(session_key, adapter=adapter) == before + 1
+        pending_slot = getattr(adapter, "_pending_messages", None)
+        if pending_slot is None:
+            return False
+        if session_key in pending_slot:
+            self._session_state(
+                session_key
+            ).conversation.queued_events.append(event)
+        else:
+            pending_slot[session_key] = event
+        # The caller owns this mutation under _busy_queue_guard; do not infer
+        # success from the aggregate depth, which sibling admissions can also
+        # change before a second measurement.
+        return True
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
@@ -11809,6 +11836,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
         return bool(adapter.accept_internal_task(event, session_key))
 
+    async def _enqueue_internal_task_on_loop(
+        self,
+        adapter: Any,
+        event: MessageEvent,
+        session_key: str,
+        cancelled: threading.Event,
+    ) -> bool:
+        """Serialize the busy-queue mutation with ordinary gateway dispatch."""
+        if cancelled.is_set():
+            return False
+        return self._enqueue_internal_fifo_event(
+            session_key,
+            event,
+            adapter,
+        )
+
     def _inject_exact_session_sync(
         self,
         *,
@@ -11967,7 +12010,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             with mutation_gate:
                 ensure_not_cancelled()
                 if session_key in getattr(self, "_running_agents", {}):
-                    if not self._enqueue_internal_fifo_event(session_key, event, adapter):
+                    accepted = asyncio.run_coroutine_threadsafe(
+                        self._enqueue_internal_task_on_loop(
+                            adapter,
+                            event,
+                            session_key,
+                            cancelled,
+                        ),
+                        event_loop,
+                    ).result()
+                    if not accepted:
                         raise SessionIPCRequestError(
                             "queue_full",
                             f"Pending queue is full for exact route {session_key!r}",
@@ -13907,7 +13959,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     channel_prompt=event.channel_prompt,
                     channel_context=event.channel_context,
                 )
-                adapter._pending_messages[quick_key] = queued_event
+                self._enqueue_fifo(quick_key, queued_event, adapter)
             return "Agent still starting — /steer queued for the next turn."
         if running_agent and hasattr(running_agent, "steer"):
             try:
@@ -13930,7 +13982,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=event.channel_prompt,
                 channel_context=event.channel_context,
             )
-            adapter._pending_messages[quick_key] = queued_event
+            self._enqueue_fifo(quick_key, queued_event, adapter)
         return "No active agent — /steer queued for the next turn."
 
     async def _busy_goal_command(self, event: MessageEvent, quick_key: str, source):
@@ -14422,7 +14474,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
                 adapter = self._adapter_for_source(source)
                 if adapter:
-                    merge_pending_message_event(adapter._pending_messages, _quick_key, event)
+                    self._merge_pending_event(adapter, _quick_key, event)
                 return None
 
             _telegram_followup_grace = float(
@@ -14447,8 +14499,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if self._busy_input_mode == "queue":
                         self._enqueue_fifo(_quick_key, event, adapter)
                     else:
-                        merge_pending_message_event(
-                            adapter._pending_messages,
+                        self._merge_pending_event(
+                            adapter,
                             _quick_key,
                             event,
                             merge_text=True,
@@ -14468,8 +14520,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # agent starts.
                 adapter = self._adapter_for_source(source)
                 if adapter:
-                    merge_pending_message_event(
-                        adapter._pending_messages,
+                    self._merge_pending_event(
+                        adapter,
                         _quick_key,
                         event,
                         merge_text=True,
@@ -24689,7 +24741,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     adapter = self._adapter_for_source(source)
                     if adapter and pending_event:
-                        merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
+                        self._merge_pending_event(
+                            adapter,
+                            session_key,
+                            pending_event,
+                        )
                     elif adapter and hasattr(adapter, 'queue_message'):
                         adapter.queue_message(session_key, pending)
                     return result_holder[0] or {"final_response": response, "messages": history}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2218,6 +2218,7 @@ from gateway.platforms.base import (
     _prefix_within_utf16_limit,
     _reply_anchor_for_event,
     build_auto_tts_output_path,
+    is_gateway_session_ipc_task,
     merge_pending_message_event,
     utf16_len,
 )
@@ -2656,6 +2657,28 @@ def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:
     to a placeholder string.
     """
     return adapter.get_pending_message(session_key)
+
+
+def _pending_slash_is_command_leak(
+    pending: str | None, pending_event: MessageEvent | None
+) -> bool:
+    """Whether pending text is a user command that must not reach the agent.
+
+    Trusted session-IPC tasks may intentionally have slash-leading text, so
+    retain those events even when the textual fallback resembles a command.
+    """
+    text = str(pending or "").strip()
+    if not text.startswith("/") or is_gateway_session_ipc_task(pending_event):
+        return False
+    command_word = text.split(None, 1)[0][1:].lower()
+    if not command_word:
+        return False
+    try:
+        from hermes_cli.commands import resolve_command
+
+        return resolve_command(command_word) is not None
+    except Exception:
+        return False
 
 
 _INTERRUPT_REASON_STOP = "Stop requested"
@@ -7326,17 +7349,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _enqueue_fifo(self, session_key: str, queued_event: "MessageEvent", adapter: Any) -> None:
         """Append a /queue event to the FIFO chain for a session."""
-        if adapter is None:
-            return
-        pending_slot = getattr(adapter, "_pending_messages", None)
-        if pending_slot is None:
-            return
-        if session_key in pending_slot:
-            self._session_state(session_key).conversation.queued_events.append(
-                queued_event
-            )
-        else:
-            pending_slot[session_key] = queued_event
+        with self._busy_queue_guard():
+            if adapter is None:
+                return
+            pending_slot = getattr(adapter, "_pending_messages", None)
+            if pending_slot is None:
+                return
+            if session_key in pending_slot:
+                self._session_state(session_key).conversation.queued_events.append(queued_event)
+            else:
+                pending_slot[session_key] = queued_event
 
     def _promote_queued_event(
         self,
@@ -7355,27 +7377,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             the slot so the NEXT recursion picks it up.
         Returns the (possibly updated) pending_event for drain to use.
         """
-        _q_state = self._peek_session_state(session_key)
-        overflow = _q_state.conversation.queued_events if _q_state else None
-        if not overflow:
+        with self._busy_queue_guard():
+            _q_state = self._peek_session_state(session_key)
+            overflow = _q_state.conversation.queued_events if _q_state else None
+            if not overflow:
+                return pending_event
+            next_queued = overflow.pop(0)
+            if pending_event is None:
+                return next_queued
+            if adapter is not None and hasattr(adapter, "_pending_messages"):
+                adapter._pending_messages[session_key] = next_queued
+            else:
+                # No adapter — push back so we don't silently drop the item.
+                overflow.insert(0, next_queued)
             return pending_event
-        next_queued = overflow.pop(0)
-        if pending_event is None:
-            return next_queued
-        if adapter is not None and hasattr(adapter, "_pending_messages"):
-            adapter._pending_messages[session_key] = next_queued
-        else:
-            # No adapter — push back so we don't silently drop the item.
-            overflow.insert(0, next_queued)
-        return pending_event
 
     def _queue_depth(self, session_key: str, *, adapter: Any = None) -> int:
         """Total pending /queue items for a session — slot + overflow."""
-        _q_state = self._peek_session_state(session_key)
-        depth = len(_q_state.conversation.queued_events) if _q_state else 0
-        if adapter is not None and session_key in getattr(adapter, "_pending_messages", {}):
-            depth += 1
-        return depth
+        with self._busy_queue_guard():
+            _q_state = self._peek_session_state(session_key)
+            depth = len(_q_state.conversation.queued_events) if _q_state else 0
+            if adapter is not None and session_key in getattr(adapter, "_pending_messages", {}):
+                depth += 1
+            return depth
+
+    def _dequeue_and_promote_queued_event(
+        self, session_key: str, adapter: Any
+    ) -> Optional["MessageEvent"]:
+        """Atomically consume the queue head and promote its successor."""
+        with self._busy_queue_guard():
+            pending_event = _dequeue_pending_event(adapter, session_key)
+            return self._promote_queued_event(session_key, adapter, pending_event)
 
     @staticmethod
     def _is_goal_continuation_event(event_or_text: Any) -> bool:
@@ -7395,6 +7427,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         queued by the judge.  Remove only synthetic goal continuations while
         preserving normal /queue and user follow-up events.
         """
+        with self._busy_queue_guard():
+            return self._clear_goal_pending_continuations_locked(session_key, adapter)
+
+    def _clear_goal_pending_continuations_locked(self, session_key: str, adapter: Any) -> int:
         removed = 0
         pending_slot = getattr(adapter, "_pending_messages", None) if adapter is not None else None
         if isinstance(pending_slot, dict):
@@ -8276,7 +8312,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # still small enough to never threaten memory.
     _BUSY_QUEUE_MAX_PENDING = 32
 
+    def _busy_queue_guard(self):
+        """Return the re-entrant lock protecting one gateway's busy queues."""
+        guard = getattr(self, "_busy_queue_lock", None)
+        if guard is None:
+            guard = threading.RLock()
+            self._busy_queue_lock = guard
+        return guard
+
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
+        with self._busy_queue_guard():
+            self._queue_or_replace_pending_event_locked(session_key, event)
+
+    def _queue_or_replace_pending_event_locked(self, session_key: str, event: MessageEvent) -> None:
         adapter = self._adapter_for_source(event.source)
         if not adapter:
             return
@@ -8359,6 +8407,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter: Any,
     ) -> bool:
         """Admit one internal IPC task without touching user media merge state."""
+        with self._busy_queue_guard():
+            return self._enqueue_internal_fifo_event_locked(session_key, event, adapter)
+
+    def _enqueue_internal_fifo_event_locked(
+        self, session_key: str, event: MessageEvent, adapter: Any
+    ) -> bool:
         if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
             return False
         before = self._queue_depth(session_key, adapter=adapter)
@@ -22153,20 +22207,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not session_key:
             return
-        # Structural clear: every conversation-scoped field resets in one
-        # call — no per-attribute pop-list to drift.
-        state = self._peek_session_state(session_key)
-        if state is not None:
-            state.conversation.clear()
-        # Legacy plain-dict stores still registered in
-        # _CONVERSATION_SCOPED_STATE (not yet folded into SessionState),
-        # e.g. _pending_model_notes.  SessionState-backed names resolve to
-        # MutableMapping views (not dict), so the isinstance(dict) guard
-        # skips them — already handled above.
-        for attr in _CONVERSATION_SCOPED_STATE:
-            store = getattr(self, attr, None)
-            if isinstance(store, dict):
-                store.pop(session_key, None)
+        with self._busy_queue_guard():
+            # Structural clear: every conversation-scoped field resets in one
+            # call — no per-attribute pop-list to drift.
+            state = self._peek_session_state(session_key)
+            if state is not None:
+                state.conversation.clear()
+            # Legacy plain-dict stores still registered in
+            # _CONVERSATION_SCOPED_STATE (not yet folded into SessionState),
+            # e.g. _pending_model_notes.  SessionState-backed names resolve to
+            # MutableMapping views (not dict), so the isinstance(dict) guard
+            # skips them — already handled above.
+            for attr in _CONVERSATION_SCOPED_STATE:
+                store = getattr(self, attr, None)
+                if isinstance(store, dict):
+                    store.pop(session_key, None)
         self._clear_session_boundary_security_state(session_key)
         logger.debug(
             "Cleared conversation scope for %s (%s)", session_key, reason
@@ -24497,14 +24552,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pending_event = None
             pending = None
             if result and adapter and session_key:
-                pending_event = _dequeue_pending_event(adapter, session_key)
+                pending_event = self._dequeue_and_promote_queued_event(session_key, adapter)
                 # /queue overflow: after consuming the adapter's "next-up"
                 # slot, promote the next queued event into it so the
                 # recursive run's drain will see it.  This keeps the slot
                 # occupied for the full FIFO chain, which (a) preserves
                 # order, and (b) causes any mid-chain /queue to correctly
                 # route to overflow rather than jumping the queue.
-                pending_event = self._promote_queued_event(session_key, adapter, pending_event)
                 if result.get("interrupted") and not pending_event and result.get("interrupt_message"):
                     interrupt_message = result.get("interrupt_message")
                     if _is_control_interrupt_message(interrupt_message):
@@ -24555,22 +24609,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # as user input.  The primary fix is in base.py (commands bypass the
             # active-session guard), but this catches edge cases where command
             # text leaks through the interrupt_message fallback.
-            if pending and pending.strip().startswith("/"):
+            if _pending_slash_is_command_leak(pending, pending_event):
                 _pending_parts = pending.strip().split(None, 1)
                 _pending_cmd_word = _pending_parts[0][1:].lower() if _pending_parts else ""
-                if _pending_cmd_word:
-                    try:
-                        from hermes_cli.commands import resolve_command as _rc_pending
-                        if _rc_pending(_pending_cmd_word):
-                            logger.info(
-                                "Discarding command '/%s' from pending queue — "
-                                "commands must not be passed as agent input",
-                                _pending_cmd_word,
-                            )
-                            pending_event = None
-                            pending = None
-                    except Exception:
-                        pass
+                logger.info(
+                    "Discarding command '/%s' from pending queue — "
+                    "commands must not be passed as agent input",
+                    _pending_cmd_word,
+                )
+                pending_event = None
+                pending = None
 
             if self._draining and (pending_event or pending):
                 logger.info(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5108,6 +5108,12 @@ class TurnRunner:
                 _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
             result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
         finally:
+            # The normal finalizer closes this at its last steer drain.  Also
+            # close here so an exceptional gateway turn cannot leave a cached
+            # agent accepting steers that no running loop can consume.
+            _close_steer_admission = getattr(agent, "_close_steer_admission", None)
+            if callable(_close_steer_admission):
+                _close_steer_admission()
             unregister_gateway_notify(_approval_session_key)
             # Cancel any pending clarify entries so blocked agent
             # threads don't hang past the end of the run (interrupt,
@@ -10162,7 +10168,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Empty-text internal event — the _is_resume_pending branch in
             # _handle_message_with_agent prepends the proper reason-aware
             # system note before the turn runs.
-            event = _new_gateway_session_ipc_event(
+            event = MessageEvent(
                 text="",
                 message_type=MessageType.TEXT,
                 source=source,
@@ -11888,7 +11894,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"No live adapter owns exact route {session_key!r}",
                 )
 
-            event = MessageEvent(
+            event = _new_gateway_session_ipc_event(
                 text=message.strip(),
                 message_type=MessageType.TEXT,
                 source=source,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2682,6 +2682,22 @@ def _pending_slash_is_command_leak(
         return False
 
 
+def _event_for_leftover_gateway_session_ipc_steer(
+    result: dict[str, Any],
+    source: SessionSource,
+) -> MessageEvent | None:
+    """Rebuild the protected event for a trusted steer handed to a new turn."""
+    text = str(result.get("pending_steer") or "").strip()
+    if not text or not result.get("pending_steer_is_gateway_session_ipc"):
+        return None
+    return _new_gateway_session_ipc_event(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+    )
+
+
 _INTERRUPT_REASON_STOP = "Stop requested"
 _INTERRUPT_REASON_RESET = "Session reset requested"
 _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
@@ -11917,7 +11933,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     with mutation_gate:
                         ensure_not_cancelled()
-                        if running_agent.steer(event.text):
+                        if running_agent.steer(
+                            event.text,
+                            _gateway_session_ipc=True,
+                        ):
                             committed.set()
                             disposition = "steered"
                         else:
@@ -24609,6 +24628,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _leftover_steer = result.get("pending_steer")
                 if _leftover_steer:
                     pending = _leftover_steer
+                    pending_event = _event_for_leftover_gateway_session_ipc_steer(
+                        result,
+                        source,
+                    )
                     logger.debug("Delivering leftover /steer as next turn: '%s...'", pending[:40])
 
             # Safety net: if the pending text is a slash command (e.g. "/stop",

--- a/gateway/session_ipc.py
+++ b/gateway/session_ipc.py
@@ -100,22 +100,40 @@ def inject_gateway_session(
     if len(request) > _MAX_REQUEST_BYTES:
         raise SessionIPCRequestError("request_too_large", "Gateway injection request is too large")
 
-    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
-        client.settimeout(timeout)
-        client.connect(str(path))
-        client.sendall(request)
-        chunks: list[bytes] = []
-        total = 0
-        while True:
-            chunk = client.recv(min(8192, _MAX_REQUEST_BYTES + 1 - total))
-            if not chunk:
-                break
-            chunks.append(chunk)
-            total += len(chunk)
-            if total > _MAX_REQUEST_BYTES:
-                raise SessionIPCRequestError("invalid_response", "Gateway IPC response is too large")
-            if b"\n" in chunk:
-                break
+    phase = "connect"
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(timeout)
+            client.connect(str(path))
+            phase = "send"
+            client.sendall(request)
+            phase = "receive"
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                chunk = client.recv(min(8192, _MAX_REQUEST_BYTES + 1 - total))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                total += len(chunk)
+                if total > _MAX_REQUEST_BYTES:
+                    raise SessionIPCRequestError(
+                        "invalid_response",
+                        "Gateway IPC response is too large",
+                    )
+                if b"\n" in chunk:
+                    break
+    except socket.timeout as exc:
+        raise SessionIPCRequestError(
+            "request_timeout",
+            f"Gateway IPC {phase} timed out",
+        ) from exc
+    except OSError as exc:
+        code = "gateway_unavailable" if phase == "connect" else "transport_error"
+        raise SessionIPCRequestError(
+            code,
+            f"Gateway IPC {phase} failed: {exc}",
+        ) from exc
     raw = b"".join(chunks).split(b"\n", 1)[0]
     try:
         response = json.loads(raw.decode("utf-8"))
@@ -143,6 +161,7 @@ class GatewaySessionIPCServer:
         self._bound_identity: tuple[int, int] | None = None
         self._idempotency_lock = asyncio.Lock()
         self._idempotency_tasks: OrderedDict[str, asyncio.Task[dict[str, Any]]] = OrderedDict()
+        self._idempotency_results: OrderedDict[str, dict[str, Any]] = OrderedDict()
         self._idempotency_fingerprints: dict[str, str] = {}
 
     def _prepare_socket_directory(self) -> None:
@@ -292,6 +311,34 @@ class GatewaySessionIPCServer:
                 str(exc) or type(exc).__name__,
             ).to_response()
 
+    async def _finalize_idempotency_task(
+        self,
+        idempotency_key: str,
+        task: asyncio.Task[dict[str, Any]],
+    ) -> None:
+        """Move a completed task out of the pending map without a new request."""
+        async with self._idempotency_lock:
+            if self._idempotency_tasks.get(idempotency_key) is not task:
+                return
+            self._idempotency_tasks.pop(idempotency_key, None)
+            if task.cancelled():
+                self._idempotency_fingerprints.pop(idempotency_key, None)
+                return
+            try:
+                result = task.result()
+            except Exception:
+                self._idempotency_fingerprints.pop(idempotency_key, None)
+                return
+            self._idempotency_results[idempotency_key] = result
+            self._idempotency_results.move_to_end(idempotency_key)
+
+            while (
+                len(self._idempotency_tasks) + len(self._idempotency_results)
+                > _MAX_IDEMPOTENCY_RECORDS
+            ):
+                oldest_key, _ = self._idempotency_results.popitem(last=False)
+                self._idempotency_fingerprints.pop(oldest_key, None)
+
     async def _dispatch_idempotent(
         self,
         idempotency_key: str,
@@ -305,20 +352,39 @@ class GatewaySessionIPCServer:
                     "idempotency_conflict",
                     "Idempotency key was already used for a different request",
                 )
+
+            prior_result = self._idempotency_results.get(idempotency_key)
+            if prior_result is not None:
+                self._idempotency_results.move_to_end(idempotency_key)
+                return prior_result
+
             task = self._idempotency_tasks.get(idempotency_key)
             if task is None:
+                while (
+                    len(self._idempotency_tasks) + len(self._idempotency_results)
+                    >= _MAX_IDEMPOTENCY_RECORDS
+                    and self._idempotency_results
+                ):
+                    oldest_key, _ = self._idempotency_results.popitem(last=False)
+                    self._idempotency_fingerprints.pop(oldest_key, None)
+                if (
+                    len(self._idempotency_tasks) + len(self._idempotency_results)
+                    >= _MAX_IDEMPOTENCY_RECORDS
+                ):
+                    raise SessionIPCRequestError(
+                        "server_busy",
+                        "Gateway session idempotency capacity is full",
+                    )
                 task = asyncio.create_task(self._run_handler(request))
                 self._idempotency_tasks[idempotency_key] = task
                 self._idempotency_fingerprints[idempotency_key] = fingerprint
+                task.add_done_callback(
+                    lambda completed, key=idempotency_key: asyncio.create_task(
+                        self._finalize_idempotency_task(key, completed)
+                    )
+                )
             else:
                 self._idempotency_tasks.move_to_end(idempotency_key)
-
-            while len(self._idempotency_tasks) > _MAX_IDEMPOTENCY_RECORDS:
-                oldest_key, oldest_task = next(iter(self._idempotency_tasks.items()))
-                if not oldest_task.done():
-                    break
-                self._idempotency_tasks.pop(oldest_key, None)
-                self._idempotency_fingerprints.pop(oldest_key, None)
 
         # Shield the shared task: a client disconnect/cancel must not cancel an
         # acceptance that a retry will join by idempotency key.

--- a/gateway/session_ipc.py
+++ b/gateway/session_ipc.py
@@ -1,18 +1,25 @@
-"""Owner-only local IPC for injecting work into an exact gateway session.
+"""Owner-local IPC for injecting work into an exact gateway session.
 
 The socket is scoped to the active ``HERMES_HOME``.  It is intentionally a
 Unix-domain socket rather than an HTTP endpoint: session injection is an
 operator-local control-plane operation and must never be network reachable.
+
+This boundary prevents accidental cross-profile and cross-session delivery by
+requiring the target profile socket plus exact routing key and session id.  It
+is owner-local, not hostile same-UID isolation: another process running as the
+same OS user can access the profile's owner-only runtime directory.
 """
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import socket
 import stat
 import struct
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
@@ -20,6 +27,9 @@ from hermes_constants import get_hermes_home
 
 _MAX_REQUEST_BYTES = 64 * 1024
 _SOCKET_NAME = "gateway-session.sock"
+_MAX_IDEMPOTENCY_KEY_BYTES = 256
+_MAX_IDEMPOTENCY_RECORDS = 1024
+_HANDLER_TIMEOUT_SECONDS = 5.0
 
 
 class SessionIPCRequestError(RuntimeError):
@@ -67,6 +77,8 @@ def inject_gateway_session(
     *,
     profile: str,
     session_key: str,
+    expected_session_id: str,
+    idempotency_key: str,
     message: str,
     hermes_home: Path | str | None = None,
     timeout: float = 5.0,
@@ -79,6 +91,8 @@ def inject_gateway_session(
             "operation": "inject",
             "profile": profile,
             "session_key": session_key,
+            "expected_session_id": expected_session_id,
+            "idempotency_key": idempotency_key,
             "message": message,
         },
         separators=(",", ":"),
@@ -126,6 +140,10 @@ class GatewaySessionIPCServer:
         self.profile = str(profile or "default")
         self.socket_path = gateway_session_socket_path(hermes_home)
         self._server: asyncio.AbstractServer | None = None
+        self._bound_identity: tuple[int, int] | None = None
+        self._idempotency_lock = asyncio.Lock()
+        self._idempotency_tasks: OrderedDict[str, asyncio.Task[dict[str, Any]]] = OrderedDict()
+        self._idempotency_fingerprints: dict[str, str] = {}
 
     def _prepare_socket_directory(self) -> None:
         runtime_dir = self.socket_path.parent
@@ -171,6 +189,15 @@ class GatewaySessionIPCServer:
                     "gateway_already_running",
                     f"A live gateway already owns the profile IPC socket: {self.socket_path}",
                 )
+        try:
+            current = self.socket_path.lstat()
+        except FileNotFoundError:
+            return
+        if (current.st_dev, current.st_ino) != (existing.st_dev, existing.st_ino):
+            raise SessionIPCRequestError(
+                "socket_replaced",
+                f"Gateway IPC socket changed during stale-socket inspection: {self.socket_path}",
+            )
         self.socket_path.unlink()
 
     async def start(self) -> None:
@@ -185,6 +212,13 @@ class GatewaySessionIPCServer:
             limit=_MAX_REQUEST_BYTES,
         )
         os.chmod(self.socket_path, 0o600)
+        bound = self.socket_path.lstat()
+        if not stat.S_ISSOCK(bound.st_mode):
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+            raise SessionIPCRequestError("unsafe_socket", "Gateway IPC bind did not create a socket")
+        self._bound_identity = (bound.st_dev, bound.st_ino)
 
     async def stop(self) -> None:
         server = self._server
@@ -192,14 +226,21 @@ class GatewaySessionIPCServer:
         if server is not None:
             server.close()
             await server.wait_closed()
+        pending = [task for task in self._idempotency_tasks.values() if not task.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
         try:
             info = self.socket_path.lstat()
         except FileNotFoundError:
+            self._bound_identity = None
             return
-        if stat.S_ISSOCK(info.st_mode) and (
+        if (info.st_dev, info.st_ino) == self._bound_identity and stat.S_ISSOCK(info.st_mode) and (
             not hasattr(os, "geteuid") or info.st_uid == os.geteuid()
         ):
             self.socket_path.unlink()
+        self._bound_identity = None
 
     @staticmethod
     def _peer_uid(writer: asyncio.StreamWriter) -> int | None:
@@ -225,13 +266,76 @@ class GatewaySessionIPCServer:
                 return None
         return None
 
+    @staticmethod
+    def _request_fingerprint(request: dict[str, Any]) -> str:
+        canonical = json.dumps(request, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(canonical).hexdigest()
+
+    async def _run_handler(self, request: dict[str, str]) -> dict[str, Any]:
+        try:
+            return await asyncio.wait_for(
+                self._handler(**request),
+                timeout=_HANDLER_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            return SessionIPCRequestError(
+                "request_timeout",
+                "Gateway session acceptance timed out and was cancelled",
+            ).to_response()
+        except SessionIPCRequestError as exc:
+            return exc.to_response()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SessionIPCRequestError(
+                "internal_error",
+                str(exc) or type(exc).__name__,
+            ).to_response()
+
+    async def _dispatch_idempotent(
+        self,
+        idempotency_key: str,
+        request: dict[str, str],
+    ) -> dict[str, Any]:
+        fingerprint = self._request_fingerprint(request)
+        async with self._idempotency_lock:
+            prior_fingerprint = self._idempotency_fingerprints.get(idempotency_key)
+            if prior_fingerprint is not None and prior_fingerprint != fingerprint:
+                raise SessionIPCRequestError(
+                    "idempotency_conflict",
+                    "Idempotency key was already used for a different request",
+                )
+            task = self._idempotency_tasks.get(idempotency_key)
+            if task is None:
+                task = asyncio.create_task(self._run_handler(request))
+                self._idempotency_tasks[idempotency_key] = task
+                self._idempotency_fingerprints[idempotency_key] = fingerprint
+            else:
+                self._idempotency_tasks.move_to_end(idempotency_key)
+
+            while len(self._idempotency_tasks) > _MAX_IDEMPOTENCY_RECORDS:
+                oldest_key, oldest_task = next(iter(self._idempotency_tasks.items()))
+                if not oldest_task.done():
+                    break
+                self._idempotency_tasks.pop(oldest_key, None)
+                self._idempotency_fingerprints.pop(oldest_key, None)
+
+        # Shield the shared task: a client disconnect/cancel must not cancel an
+        # acceptance that a retry will join by idempotency key.
+        return await asyncio.shield(task)
+
     async def _handle_connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
         response: dict[str, Any]
         try:
             peer_uid = self._peer_uid(writer)
-            if peer_uid is not None and hasattr(os, "geteuid") and peer_uid != os.geteuid():
+            if peer_uid is None or not hasattr(os, "geteuid"):
+                raise SessionIPCRequestError(
+                    "peer_credentials_unavailable",
+                    "Gateway IPC peer credentials could not be established",
+                )
+            if peer_uid != os.geteuid():
                 raise SessionIPCRequestError("permission_denied", "Gateway IPC peer user mismatch")
             try:
                 raw = await asyncio.wait_for(reader.readline(), timeout=5.0)
@@ -247,6 +351,8 @@ class GatewaySessionIPCServer:
                 raise SessionIPCRequestError("invalid_request", "Unsupported gateway IPC operation")
             profile = request.get("profile")
             session_key = request.get("session_key")
+            expected_session_id = request.get("expected_session_id")
+            idempotency_key = request.get("idempotency_key")
             message = request.get("message")
             if profile != self.profile:
                 raise SessionIPCRequestError(
@@ -255,21 +361,37 @@ class GatewaySessionIPCServer:
                 )
             if not isinstance(session_key, str) or not session_key.strip():
                 raise SessionIPCRequestError("invalid_request", "session_key is required")
+            if not isinstance(expected_session_id, str) or not expected_session_id.strip():
+                raise SessionIPCRequestError("invalid_request", "expected_session_id is required")
+            if not isinstance(idempotency_key, str) or not idempotency_key.strip():
+                raise SessionIPCRequestError("invalid_request", "idempotency_key is required")
+            if len(idempotency_key.encode("utf-8")) > _MAX_IDEMPOTENCY_KEY_BYTES:
+                raise SessionIPCRequestError("invalid_request", "idempotency_key is too large")
             if not isinstance(message, str) or not message.strip():
                 raise SessionIPCRequestError("invalid_request", "message is required")
-            response = await self._handler(
-                profile=profile,
-                session_key=session_key.strip(),
-                message=message.strip(),
+            response = await self._dispatch_idempotent(
+                idempotency_key.strip(),
+                {
+                    "profile": profile,
+                    "session_key": session_key.strip(),
+                    "expected_session_id": expected_session_id.strip(),
+                    "idempotency_key": idempotency_key.strip(),
+                    "message": message.strip(),
+                },
             )
         except SessionIPCRequestError as exc:
             response = exc.to_response()
-        except (asyncio.TimeoutError, Exception) as exc:
+        except asyncio.CancelledError:
+            response = SessionIPCRequestError("request_cancelled", "Gateway IPC request cancelled").to_response()
+        except Exception as exc:
             response = SessionIPCRequestError("internal_error", str(exc) or type(exc).__name__).to_response()
 
-        writer.write(json.dumps(response, separators=(",", ":")).encode("utf-8") + b"\n")
         try:
+            writer.write(json.dumps(response, separators=(",", ":")).encode("utf-8") + b"\n")
             await writer.drain()
+        except (BrokenPipeError, ConnectionError, OSError):
+            # The request result remains in the idempotency cache for a retry.
+            pass
         finally:
             writer.close()
             try:

--- a/gateway/session_ipc.py
+++ b/gateway/session_ipc.py
@@ -1,0 +1,278 @@
+"""Owner-only local IPC for injecting work into an exact gateway session.
+
+The socket is scoped to the active ``HERMES_HOME``.  It is intentionally a
+Unix-domain socket rather than an HTTP endpoint: session injection is an
+operator-local control-plane operation and must never be network reachable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+import stat
+import struct
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from hermes_constants import get_hermes_home
+
+_MAX_REQUEST_BYTES = 64 * 1024
+_SOCKET_NAME = "gateway-session.sock"
+
+
+class SessionIPCRequestError(RuntimeError):
+    """A fail-closed session IPC request error with a stable machine code."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+    def to_response(self) -> dict[str, Any]:
+        return {"ok": False, "error": {"code": self.code, "message": str(self)}}
+
+
+def gateway_session_socket_path(hermes_home: Path | str | None = None) -> Path:
+    home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
+    return home.resolve() / "run" / _SOCKET_NAME
+
+
+def _validate_owner_only_socket(path: Path) -> None:
+    try:
+        info = path.lstat()
+    except FileNotFoundError as exc:
+        raise SessionIPCRequestError(
+            "gateway_unavailable",
+            f"No live gateway session socket for this profile: {path}",
+        ) from exc
+    if not stat.S_ISSOCK(info.st_mode):
+        raise SessionIPCRequestError(
+            "unsafe_socket",
+            f"Refusing non-socket gateway IPC path: {path}",
+        )
+    if hasattr(os, "geteuid") and info.st_uid != os.geteuid():
+        raise SessionIPCRequestError(
+            "unsafe_socket",
+            f"Gateway IPC socket is not owned by the current user: {path}",
+        )
+    if stat.S_IMODE(info.st_mode) & 0o077:
+        raise SessionIPCRequestError(
+            "unsafe_socket",
+            f"Gateway IPC socket must be owner-only (mode 0600): {path}",
+        )
+
+
+def inject_gateway_session(
+    *,
+    profile: str,
+    session_key: str,
+    message: str,
+    hermes_home: Path | str | None = None,
+    timeout: float = 5.0,
+) -> dict[str, Any]:
+    """Send one exact-session injection request to the profile-local gateway."""
+    path = gateway_session_socket_path(hermes_home)
+    _validate_owner_only_socket(path)
+    request = json.dumps(
+        {
+            "operation": "inject",
+            "profile": profile,
+            "session_key": session_key,
+            "message": message,
+        },
+        separators=(",", ":"),
+    ).encode("utf-8") + b"\n"
+    if len(request) > _MAX_REQUEST_BYTES:
+        raise SessionIPCRequestError("request_too_large", "Gateway injection request is too large")
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(timeout)
+        client.connect(str(path))
+        client.sendall(request)
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = client.recv(min(8192, _MAX_REQUEST_BYTES + 1 - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > _MAX_REQUEST_BYTES:
+                raise SessionIPCRequestError("invalid_response", "Gateway IPC response is too large")
+            if b"\n" in chunk:
+                break
+    raw = b"".join(chunks).split(b"\n", 1)[0]
+    try:
+        response = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SessionIPCRequestError("invalid_response", "Gateway returned invalid JSON") from exc
+    if not isinstance(response, dict):
+        raise SessionIPCRequestError("invalid_response", "Gateway returned a non-object response")
+    return response
+
+
+class GatewaySessionIPCServer:
+    """Single-request NDJSON server bound to one profile's Hermes home."""
+
+    def __init__(
+        self,
+        handler: Callable[..., Awaitable[dict[str, Any]]],
+        *,
+        profile: str,
+        hermes_home: Path | str | None = None,
+    ) -> None:
+        self._handler = handler
+        self.profile = str(profile or "default")
+        self.socket_path = gateway_session_socket_path(hermes_home)
+        self._server: asyncio.AbstractServer | None = None
+
+    def _prepare_socket_directory(self) -> None:
+        runtime_dir = self.socket_path.parent
+        runtime_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
+        info = runtime_dir.lstat()
+        if not stat.S_ISDIR(info.st_mode) or runtime_dir.is_symlink():
+            raise SessionIPCRequestError("unsafe_socket", f"Unsafe gateway IPC directory: {runtime_dir}")
+        if hasattr(os, "geteuid") and info.st_uid != os.geteuid():
+            raise SessionIPCRequestError(
+                "unsafe_socket", f"Gateway IPC directory is not owned by the current user: {runtime_dir}"
+            )
+        os.chmod(runtime_dir, 0o700)
+
+        try:
+            existing = self.socket_path.lstat()
+        except FileNotFoundError:
+            return
+        if not stat.S_ISSOCK(existing.st_mode):
+            raise SessionIPCRequestError(
+                "unsafe_socket", f"Refusing to replace non-socket IPC path: {self.socket_path}"
+            )
+        if hasattr(os, "geteuid") and existing.st_uid != os.geteuid():
+            raise SessionIPCRequestError(
+                "unsafe_socket", f"Refusing socket owned by another user: {self.socket_path}"
+            )
+        # Never unlink a live listener.  That would let a second gateway bind
+        # the same pathname while the first keeps serving through its orphaned
+        # inode, defeating the one-gateway/profile invariant.  Only a refused
+        # connect proves this is crash-stale and safe to remove.
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+            probe.settimeout(0.25)
+            try:
+                probe.connect(str(self.socket_path))
+            except (ConnectionRefusedError, FileNotFoundError):
+                pass
+            except OSError as exc:
+                raise SessionIPCRequestError(
+                    "gateway_unavailable",
+                    f"Cannot safely inspect existing gateway IPC socket: {exc}",
+                ) from exc
+            else:
+                raise SessionIPCRequestError(
+                    "gateway_already_running",
+                    f"A live gateway already owns the profile IPC socket: {self.socket_path}",
+                )
+        self.socket_path.unlink()
+
+    async def start(self) -> None:
+        if not hasattr(socket, "AF_UNIX"):
+            raise SessionIPCRequestError("unsupported", "Gateway session IPC requires Unix sockets")
+        if self._server is not None:
+            return
+        self._prepare_socket_directory()
+        self._server = await asyncio.start_unix_server(
+            self._handle_connection,
+            path=str(self.socket_path),
+            limit=_MAX_REQUEST_BYTES,
+        )
+        os.chmod(self.socket_path, 0o600)
+
+    async def stop(self) -> None:
+        server = self._server
+        self._server = None
+        if server is not None:
+            server.close()
+            await server.wait_closed()
+        try:
+            info = self.socket_path.lstat()
+        except FileNotFoundError:
+            return
+        if stat.S_ISSOCK(info.st_mode) and (
+            not hasattr(os, "geteuid") or info.st_uid == os.geteuid()
+        ):
+            self.socket_path.unlink()
+
+    @staticmethod
+    def _peer_uid(writer: asyncio.StreamWriter) -> int | None:
+        transport_socket = writer.get_extra_info("socket")
+        if transport_socket is None:
+            return None
+        if hasattr(socket, "SO_PEERCRED"):
+            try:
+                raw = transport_socket.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, 12)
+                _pid, uid, _gid = struct.unpack("3i", raw)
+                return uid
+            except (OSError, struct.error):
+                return None
+        getpeereid = getattr(transport_socket, "getpeereid", None)
+        if callable(getpeereid):
+            try:
+                peer_ids = getpeereid()
+                if not isinstance(peer_ids, tuple) or len(peer_ids) != 2:
+                    return None
+                uid, _gid = peer_ids
+                return int(uid)
+            except OSError:
+                return None
+        return None
+
+    async def _handle_connection(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        response: dict[str, Any]
+        try:
+            peer_uid = self._peer_uid(writer)
+            if peer_uid is not None and hasattr(os, "geteuid") and peer_uid != os.geteuid():
+                raise SessionIPCRequestError("permission_denied", "Gateway IPC peer user mismatch")
+            try:
+                raw = await asyncio.wait_for(reader.readline(), timeout=5.0)
+            except (asyncio.LimitOverrunError, ValueError) as exc:
+                raise SessionIPCRequestError("request_too_large", "Gateway IPC request is too large") from exc
+            if not raw or len(raw) > _MAX_REQUEST_BYTES or not raw.endswith(b"\n"):
+                raise SessionIPCRequestError("invalid_request", "Expected one bounded JSON request line")
+            try:
+                request = json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise SessionIPCRequestError("invalid_request", "Request must be valid UTF-8 JSON") from exc
+            if not isinstance(request, dict) or request.get("operation") != "inject":
+                raise SessionIPCRequestError("invalid_request", "Unsupported gateway IPC operation")
+            profile = request.get("profile")
+            session_key = request.get("session_key")
+            message = request.get("message")
+            if profile != self.profile:
+                raise SessionIPCRequestError(
+                    "profile_mismatch",
+                    f"Socket serves profile {self.profile!r}, not {profile!r}",
+                )
+            if not isinstance(session_key, str) or not session_key.strip():
+                raise SessionIPCRequestError("invalid_request", "session_key is required")
+            if not isinstance(message, str) or not message.strip():
+                raise SessionIPCRequestError("invalid_request", "message is required")
+            response = await self._handler(
+                profile=profile,
+                session_key=session_key.strip(),
+                message=message.strip(),
+            )
+        except SessionIPCRequestError as exc:
+            response = exc.to_response()
+        except (asyncio.TimeoutError, Exception) as exc:
+            response = SessionIPCRequestError("internal_error", str(exc) or type(exc).__name__).to_response()
+
+        writer.write(json.dumps(response, separators=(",", ":")).encode("utf-8") + b"\n")
+        try:
+            await writer.drain()
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass

--- a/gateway/session_ipc.py
+++ b/gateway/session_ipc.py
@@ -220,36 +220,48 @@ class GatewaySessionIPCServer:
                 f"Gateway IPC socket changed during stale-socket inspection: {self.socket_path}",
             )
 
-        # POSIX/Python has no atomic "unlink this pathname only if it still
-        # names inode X" operation. Move the pathname to a private unique
-        # quarantine first, then inspect the inode that was actually moved.
-        # A replacement racing the move is preserved and restored (or left at
-        # the quarantine path if another socket already reclaimed the public
-        # name); it is never path-unlinked as stale.
+        self._quarantine_socket_path(expected_identity, label="stale")
+
+    def _quarantine_socket_path(
+        self,
+        expected_identity: tuple[int, int],
+        *,
+        label: str,
+    ) -> None:
+        """Atomically move the canonical path, then delete only the moved inode."""
         quarantine = self.socket_path.with_name(
-            f".{self.socket_path.name}.stale-{os.getpid()}-{uuid.uuid4().hex}"
+            f".{self.socket_path.name}.{label}-{os.getpid()}-{uuid.uuid4().hex}"
         )
         try:
             os.replace(self.socket_path, quarantine)
         except FileNotFoundError:
             return
+
         moved = quarantine.lstat()
         moved_identity = (moved.st_dev, moved.st_ino)
-        if moved_identity != expected_identity:
-            try:
-                os.link(quarantine, self.socket_path, follow_symlinks=False)
-            except FileExistsError:
-                pass
-            except OSError as exc:
-                raise SessionIPCRequestError(
-                    "socket_replaced",
-                    f"Gateway IPC replacement was quarantined and could not be restored: {exc}",
-                ) from exc
+        if moved_identity == expected_identity:
+            quarantine.unlink()
+            return
+
+        # The atomic move captured a replacement. Restore it only if the
+        # canonical name is still vacant; hard-link creation is no-clobber.
+        # If another actor reclaimed the canonical path, leave the replacement
+        # quarantined rather than deleting either inode.
+        try:
+            os.link(quarantine, self.socket_path, follow_symlinks=False)
+        except FileExistsError:
+            pass
+        except OSError as exc:
             raise SessionIPCRequestError(
                 "socket_replaced",
-                f"Gateway IPC socket changed during stale-socket cleanup: {self.socket_path}",
-            )
-        quarantine.unlink()
+                f"Gateway IPC replacement was quarantined and could not be restored: {exc}",
+            ) from exc
+        else:
+            quarantine.unlink()
+        raise SessionIPCRequestError(
+            "socket_replaced",
+            f"Gateway IPC socket changed during {label} cleanup: {self.socket_path}",
+        )
 
     async def start(self) -> None:
         if not hasattr(socket, "AF_UNIX"):
@@ -282,16 +294,10 @@ class GatewaySessionIPCServer:
             task.cancel()
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
-        try:
-            info = self.socket_path.lstat()
-        except FileNotFoundError:
-            self._bound_identity = None
-            return
-        if (info.st_dev, info.st_ino) == self._bound_identity and stat.S_ISSOCK(info.st_mode) and (
-            not hasattr(os, "geteuid") or info.st_uid == os.geteuid()
-        ):
-            self.socket_path.unlink()
+        bound_identity = self._bound_identity
         self._bound_identity = None
+        if bound_identity is not None:
+            self._quarantine_socket_path(bound_identity, label="stop")
 
     @staticmethod
     def _peer_uid(writer: asyncio.StreamWriter) -> int | None:

--- a/gateway/session_ipc.py
+++ b/gateway/session_ipc.py
@@ -19,6 +19,7 @@ import os
 import socket
 import stat
 import struct
+import uuid
 from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Awaitable, Callable
@@ -208,16 +209,47 @@ class GatewaySessionIPCServer:
                     "gateway_already_running",
                     f"A live gateway already owns the profile IPC socket: {self.socket_path}",
                 )
+        expected_identity = (existing.st_dev, existing.st_ino)
         try:
             current = self.socket_path.lstat()
         except FileNotFoundError:
             return
-        if (current.st_dev, current.st_ino) != (existing.st_dev, existing.st_ino):
+        if (current.st_dev, current.st_ino) != expected_identity:
             raise SessionIPCRequestError(
                 "socket_replaced",
                 f"Gateway IPC socket changed during stale-socket inspection: {self.socket_path}",
             )
-        self.socket_path.unlink()
+
+        # POSIX/Python has no atomic "unlink this pathname only if it still
+        # names inode X" operation. Move the pathname to a private unique
+        # quarantine first, then inspect the inode that was actually moved.
+        # A replacement racing the move is preserved and restored (or left at
+        # the quarantine path if another socket already reclaimed the public
+        # name); it is never path-unlinked as stale.
+        quarantine = self.socket_path.with_name(
+            f".{self.socket_path.name}.stale-{os.getpid()}-{uuid.uuid4().hex}"
+        )
+        try:
+            os.replace(self.socket_path, quarantine)
+        except FileNotFoundError:
+            return
+        moved = quarantine.lstat()
+        moved_identity = (moved.st_dev, moved.st_ino)
+        if moved_identity != expected_identity:
+            try:
+                os.link(quarantine, self.socket_path, follow_symlinks=False)
+            except FileExistsError:
+                pass
+            except OSError as exc:
+                raise SessionIPCRequestError(
+                    "socket_replaced",
+                    f"Gateway IPC replacement was quarantined and could not be restored: {exc}",
+                ) from exc
+            raise SessionIPCRequestError(
+                "socket_replaced",
+                f"Gateway IPC socket changed during stale-socket cleanup: {self.socket_path}",
+            )
+        quarantine.unlink()
 
     async def start(self) -> None:
         if not hasattr(socket, "AF_UNIX"):

--- a/gateway/session_ipc.py
+++ b/gateway/session_ipc.py
@@ -380,6 +380,14 @@ class GatewaySessionIPCServer:
             except Exception:
                 self._idempotency_fingerprints.pop(idempotency_key, None)
                 return
+            # A failed handler result did not accept a task.  Release both the
+            # result and fingerprint so a caller can retry the same operation
+            # with the same required idempotency key after a transient failure
+            # (for example queue_full, acceptance_failed, or request_timeout).
+            # Successful results remain cached and exactly-once.
+            if result.get("ok") is not True:
+                self._idempotency_fingerprints.pop(idempotency_key, None)
+                return
             self._idempotency_results[idempotency_key] = result
             self._idempotency_results.move_to_end(idempotency_key)
 

--- a/gateway/session_ipc.py
+++ b/gateway/session_ipc.py
@@ -155,9 +155,13 @@ class GatewaySessionIPCServer:
         *,
         profile: str,
         hermes_home: Path | str | None = None,
+        served_profiles: set[str] | frozenset[str] | None = None,
     ) -> None:
         self._handler = handler
         self.profile = str(profile or "default")
+        self.served_profiles = frozenset(
+            {self.profile, *(str(item) for item in (served_profiles or ()))}
+        )
         self.socket_path = gateway_session_socket_path(hermes_home)
         self._server: asyncio.AbstractServer | None = None
         self._bound_identity: tuple[int, int] | None = None
@@ -480,10 +484,10 @@ class GatewaySessionIPCServer:
             expected_session_id = request.get("expected_session_id")
             idempotency_key = request.get("idempotency_key")
             message = request.get("message")
-            if profile != self.profile:
+            if profile not in self.served_profiles:
                 raise SessionIPCRequestError(
                     "profile_mismatch",
-                    f"Socket serves profile {self.profile!r}, not {profile!r}",
+                    f"Socket does not serve profile {profile!r}",
                 )
             if not isinstance(session_key, str) or not session_key.strip():
                 raise SessionIPCRequestError("invalid_request", "session_key is required")

--- a/gateway/session_ipc.py
+++ b/gateway/session_ipc.py
@@ -19,6 +19,7 @@ import os
 import socket
 import stat
 import struct
+import sys
 import uuid
 from collections import OrderedDict
 from pathlib import Path
@@ -311,6 +312,18 @@ class GatewaySessionIPCServer:
                 return uid
             except (OSError, struct.error):
                 return None
+        if sys.platform == "darwin" and hasattr(socket, "LOCAL_PEERCRED"):
+            try:
+                # Darwin exposes xucred through LOCAL_PEERCRED at SOL_LOCAL
+                # (level 0).  xucr_uid is the second uint32 field.
+                raw = transport_socket.getsockopt(
+                    0,
+                    socket.LOCAL_PEERCRED,
+                    128,
+                )
+                return int(struct.unpack_from("=I", raw, 4)[0])
+            except (OSError, struct.error):
+                return None
         getpeereid = getattr(transport_socket, "getpeereid", None)
         if callable(getpeereid):
             try:
@@ -434,12 +447,13 @@ class GatewaySessionIPCServer:
         response: dict[str, Any]
         try:
             peer_uid = self._peer_uid(writer)
-            if peer_uid is None or not hasattr(os, "geteuid"):
+            get_euid = getattr(os, "geteuid", None)
+            if peer_uid is None or not callable(get_euid):
                 raise SessionIPCRequestError(
                     "peer_credentials_unavailable",
                     "Gateway IPC peer credentials could not be established",
                 )
-            if peer_uid != os.geteuid():
+            if peer_uid != get_euid():
                 raise SessionIPCRequestError("permission_denied", "Gateway IPC peer user mismatch")
             try:
                 raw = await asyncio.wait_for(reader.readline(), timeout=5.0)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6790,6 +6790,8 @@ def _gateway_command_inner(args):
             response = inject_gateway_session(
                 profile=profile,
                 session_key=args.session_key,
+                expected_session_id=args.expected_session_id,
+                idempotency_key=args.idempotency_key,
                 message=args.message,
             )
         except SessionIPCRequestError as exc:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1,7 +1,7 @@
 """
 Gateway subcommand for hermes CLI.
 
-Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
+Handles: hermes gateway [run|start|stop|restart|status|inject|install|uninstall|setup]
 """
 
 import asyncio
@@ -6779,6 +6779,24 @@ def _gateway_command_inner(args):
 
     if subcmd == "setup":
         gateway_setup()
+        return
+
+    if subcmd == "inject":
+        from gateway.session_ipc import SessionIPCRequestError, inject_gateway_session
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile = get_active_profile_name() or "default"
+        try:
+            response = inject_gateway_session(
+                profile=profile,
+                session_key=args.session_key,
+                message=args.message,
+            )
+        except SessionIPCRequestError as exc:
+            response = exc.to_response()
+        print(json.dumps(response, sort_keys=True))
+        if not response.get("ok"):
+            raise SystemExit(1)
         return
 
     # Service management commands

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6782,10 +6782,22 @@ def _gateway_command_inner(args):
         return
 
     if subcmd == "inject":
-        from gateway.session_ipc import SessionIPCRequestError, inject_gateway_session
+        from gateway.session_ipc import (
+            SessionIPCRequestError,
+            gateway_session_socket_path,
+            inject_gateway_session,
+        )
+        from hermes_constants import get_default_hermes_root
         from hermes_cli.profiles import get_active_profile_name
 
         profile = get_active_profile_name() or "default"
+        ipc_home = None
+        if profile != "default" and not gateway_session_socket_path().exists():
+            # A default-profile multiplexer owns the only IPC socket while
+            # retaining the named profile in the request for exact routing.
+            default_home = get_default_hermes_root()
+            if gateway_session_socket_path(default_home).exists():
+                ipc_home = default_home
         try:
             response = inject_gateway_session(
                 profile=profile,
@@ -6793,6 +6805,7 @@ def _gateway_command_inner(args):
                 expected_session_id=args.expected_session_id,
                 idempotency_key=args.idempotency_key,
                 message=args.message,
+                hermes_home=ipc_home,
             )
         except SessionIPCRequestError as exc:
             response = exc.to_response()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6792,21 +6792,45 @@ def _gateway_command_inner(args):
 
         profile = get_active_profile_name() or "default"
         ipc_home = None
-        if profile != "default" and not gateway_session_socket_path().exists():
+        default_home = None
+        if profile != "default":
             # A default-profile multiplexer owns the only IPC socket while
             # retaining the named profile in the request for exact routing.
             default_home = get_default_hermes_root()
-            if gateway_session_socket_path(default_home).exists():
+            if (
+                not gateway_session_socket_path().exists()
+                and gateway_session_socket_path(default_home).exists()
+            ):
                 ipc_home = default_home
         try:
-            response = inject_gateway_session(
-                profile=profile,
-                session_key=args.session_key,
-                expected_session_id=args.expected_session_id,
-                idempotency_key=args.idempotency_key,
-                message=args.message,
-                hermes_home=ipc_home,
-            )
+            try:
+                response = inject_gateway_session(
+                    profile=profile,
+                    session_key=args.session_key,
+                    expected_session_id=args.expected_session_id,
+                    idempotency_key=args.idempotency_key,
+                    message=args.message,
+                    hermes_home=ipc_home,
+                )
+            except SessionIPCRequestError as exc:
+                if (
+                    profile == "default"
+                    or ipc_home is not None
+                    or exc.code != "gateway_unavailable"
+                ):
+                    raise
+                # A crash-stale named-profile socket can exist but refuse the
+                # connection. That failure occurs before any bytes are sent,
+                # so the same idempotent request can safely retry against the
+                # default multiplexer socket.
+                response = inject_gateway_session(
+                    profile=profile,
+                    session_key=args.session_key,
+                    expected_session_id=args.expected_session_id,
+                    idempotency_key=args.idempotency_key,
+                    message=args.message,
+                    hermes_home=default_home,
+                )
         except SessionIPCRequestError as exc:
             response = exc.to_response()
         print(json.dumps(response, sort_keys=True))

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -159,6 +159,26 @@ def build_gateway_parser(
     )
     _add_compat_platform_flag(gateway_status)
 
+    # gateway inject — owner-local exact-session control plane
+    gateway_inject = gateway_subparsers.add_parser(
+        "inject",
+        help="Queue or steer an internal task into an exact live gateway session",
+        description=(
+            "Send an internal task through the selected profile's owner-only Unix "
+            "socket. Use global --profile/-p to select the target profile."
+        ),
+    )
+    gateway_inject.add_argument(
+        "--session-key",
+        required=True,
+        help="Exact live gateway routing key (no fuzzy or latest-session lookup)",
+    )
+    gateway_inject.add_argument(
+        "--message",
+        required=True,
+        help="Internal task text to queue or steer",
+    )
+
     # gateway install
     gateway_install = gateway_subparsers.add_parser(
         "install", help="Install gateway as a systemd/launchd background service"

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -174,6 +174,16 @@ def build_gateway_parser(
         help="Exact live gateway routing key (no fuzzy or latest-session lookup)",
     )
     gateway_inject.add_argument(
+        "--expected-session-id",
+        required=True,
+        help="Exact session id currently expected at the routing key",
+    )
+    gateway_inject.add_argument(
+        "--idempotency-key",
+        required=True,
+        help="Stable unique key reused only when retrying this exact task",
+    )
+    gateway_inject.add_argument(
         "--message",
         required=True,
         help="Internal task text to queue or steer",

--- a/run_agent.py
+++ b/run_agent.py
@@ -3116,10 +3116,14 @@ class AIAgent:
             # Test stubs that built AIAgent via object.__new__ skip __init__.
             # Fall back to direct attribute set; no concurrent callers expected
             # in those stubs.
+            if not getattr(self, "_steer_accepting", True):
+                return False
             existing = getattr(self, "_pending_steer", None)
             self._pending_steer = (existing + "\n" + cleaned) if existing else cleaned
             return True
         with _lock:
+            if not getattr(self, "_steer_accepting", True):
+                return False
             if self._pending_steer:
                 self._pending_steer = self._pending_steer + "\n" + cleaned
             else:
@@ -3250,6 +3254,34 @@ class AIAgent:
             self._pending_steer = None
             return text
         with _lock:
+            text = self._pending_steer
+            self._pending_steer = None
+        return text
+
+    def _open_steer_admission(self) -> None:
+        """Allow steer() calls for the current conversation turn."""
+        _lock = getattr(self, "_pending_steer_lock", None)
+        if _lock is None:
+            self._steer_accepting = True
+            return
+        with _lock:
+            self._steer_accepting = True
+
+    def _close_steer_admission(self) -> Optional[str]:
+        """Atomically reject future steers and drain the final pending text.
+
+        The close and drain share steer()'s lock.  Once this returns, a
+        concurrent surface cannot report a steer as accepted unless it was
+        included in the returned text.
+        """
+        _lock = getattr(self, "_pending_steer_lock", None)
+        if _lock is None:
+            self._steer_accepting = False
+            text = getattr(self, "_pending_steer", None)
+            self._pending_steer = None
+            return text
+        with _lock:
+            self._steer_accepting = False
             text = self._pending_steer
             self._pending_steer = None
         return text

--- a/run_agent.py
+++ b/run_agent.py
@@ -3088,7 +3088,9 @@ class AIAgent:
         if _steer_lock is not None:
             with _steer_lock:
                 self._pending_steer = None
+                self._pending_steer_chunks = []
                 self._pending_steer_is_gateway_session_ipc = False
+                self._codex_native_pending_steer_chunks = []
         return True
 
     def steer(self, text: str, *, _gateway_session_ipc: bool = False) -> bool:
@@ -3116,7 +3118,10 @@ class AIAgent:
             # Codex owns its internal tool loop. Its native turn/steer request
             # is the only live-turn admission path; the Hermes pending-tool
             # slot below is never drained by this runtime.
-            return self.redirect(cleaned)
+            return self._request_codex_native_steer(
+                cleaned,
+                is_gateway_session_ipc=_gateway_session_ipc,
+            )
         _lock = getattr(self, "_pending_steer_lock", None)
         if _lock is None:
             # Test stubs that built AIAgent via object.__new__ skip __init__.
@@ -3124,20 +3129,157 @@ class AIAgent:
             # in those stubs.
             if not getattr(self, "_steer_accepting", True):
                 return False
-            existing = getattr(self, "_pending_steer", None)
-            self._pending_steer = (existing + "\n" + cleaned) if existing else cleaned
-            if not existing:
-                self._pending_steer_is_gateway_session_ipc = bool(_gateway_session_ipc)
+            self._append_pending_steer_locked(
+                cleaned,
+                is_gateway_session_ipc=_gateway_session_ipc,
+            )
             return True
         with _lock:
             if not getattr(self, "_steer_accepting", True):
                 return False
-            if self._pending_steer:
-                self._pending_steer = self._pending_steer + "\n" + cleaned
-            else:
-                self._pending_steer = cleaned
-                self._pending_steer_is_gateway_session_ipc = bool(_gateway_session_ipc)
+            self._append_pending_steer_locked(
+                cleaned,
+                is_gateway_session_ipc=_gateway_session_ipc,
+            )
         return True
+
+    def _pending_steer_chunks_locked(self) -> list[tuple[str, bool]]:
+        """Return the lossless pending-steer state while its lock is held."""
+        chunks = getattr(self, "_pending_steer_chunks", None)
+        if chunks is None:
+            text = getattr(self, "_pending_steer", None)
+            chunks = (
+                [
+                    (
+                        str(text),
+                        bool(
+                            getattr(
+                                self,
+                                "_pending_steer_is_gateway_session_ipc",
+                                False,
+                            )
+                        ),
+                    )
+                ]
+                if text
+                else []
+            )
+            self._pending_steer_chunks = chunks
+        return chunks
+
+    def _sync_pending_steer_compat_locked(self) -> None:
+        """Refresh the legacy aggregate fields from per-steer chunks."""
+        chunks = self._pending_steer_chunks_locked()
+        self._pending_steer = "\n".join(text for text, _trusted in chunks) or None
+        self._pending_steer_is_gateway_session_ipc = bool(
+            chunks and all(trusted for _text, trusted in chunks)
+        )
+
+    def _append_pending_steer_locked(
+        self,
+        text: str,
+        *,
+        is_gateway_session_ipc: bool,
+    ) -> None:
+        self._pending_steer_chunks_locked().append(
+            (text, bool(is_gateway_session_ipc))
+        )
+        self._sync_pending_steer_compat_locked()
+
+    def _request_codex_native_steer(
+        self,
+        text: str,
+        *,
+        is_gateway_session_ipc: bool,
+    ) -> bool:
+        """Send a native Codex steer and retain it until turn success.
+
+        Stage the entry before the cross-thread request. If the native turn
+        completes concurrently, its success drain sees and acknowledges the
+        staged entry. A rejected request removes only its own opaque token.
+        """
+        _codex_session = getattr(self, "_codex_session", None)
+        _native_steer = getattr(_codex_session, "request_steer", None)
+        if not callable(_native_steer):
+            return False
+        _redirect_lock = getattr(self, "_pending_redirect_lock", None)
+        if _redirect_lock is not None:
+            with _redirect_lock:
+                if self._interrupt_requested:
+                    return False
+        elif self._interrupt_requested:
+            return False
+
+        token = object()
+        _steer_lock = getattr(self, "_pending_steer_lock", None)
+        if _steer_lock is None:
+            pending = getattr(
+                self, "_codex_native_pending_steer_chunks", None
+            )
+            if pending is None:
+                pending = []
+                self._codex_native_pending_steer_chunks = pending
+            pending.append((token, text, bool(is_gateway_session_ipc)))
+        else:
+            with _steer_lock:
+                pending = getattr(
+                    self, "_codex_native_pending_steer_chunks", None
+                )
+                if pending is None:
+                    pending = []
+                    self._codex_native_pending_steer_chunks = pending
+                pending.append(
+                    (token, text, bool(is_gateway_session_ipc))
+                )
+
+        try:
+            accepted = bool(_native_steer(text))
+        except Exception:
+            logger.debug("Codex app-server turn/steer failed", exc_info=True)
+            accepted = False
+        if not accepted:
+            self._discard_codex_native_pending_steer(token)
+        return accepted
+
+    def _discard_codex_native_pending_steer(self, token: object) -> None:
+        _lock = getattr(self, "_pending_steer_lock", None)
+        if _lock is None:
+            self._codex_native_pending_steer_chunks = [
+                item
+                for item in getattr(
+                    self, "_codex_native_pending_steer_chunks", []
+                )
+                if item[0] is not token
+            ]
+            return
+        with _lock:
+            self._codex_native_pending_steer_chunks = [
+                item
+                for item in getattr(
+                    self, "_codex_native_pending_steer_chunks", []
+                )
+                if item[0] is not token
+            ]
+
+    def _drain_codex_native_pending_steer_chunks(
+        self,
+    ) -> list[tuple[str, bool]]:
+        """Acknowledge or recover all native steers for the current turn."""
+        _lock = getattr(self, "_pending_steer_lock", None)
+        if _lock is None:
+            pending = list(
+                getattr(self, "_codex_native_pending_steer_chunks", [])
+            )
+            self._codex_native_pending_steer_chunks = []
+        else:
+            with _lock:
+                pending = list(
+                    getattr(
+                        self, "_codex_native_pending_steer_chunks", []
+                    )
+                )
+                self._codex_native_pending_steer_chunks = []
+        return [(text, trusted) for _token, text, trusted in pending]
 
     def redirect(self, text: str) -> bool:
         """Redirect the active turn without converting it into a new task.
@@ -3160,21 +3302,10 @@ class AIAgent:
         # Codex owns its internal reasoning/tool loop, so use its first-class
         # active-turn steering protocol rather than interrupting the subprocess.
         if getattr(self, "api_mode", None) == "codex_app_server":
-            _codex_session = getattr(self, "_codex_session", None)
-            _native_steer = getattr(_codex_session, "request_steer", None)
-            if callable(_native_steer):
-                _redirect_lock = getattr(self, "_pending_redirect_lock", None)
-                if _redirect_lock is not None:
-                    with _redirect_lock:
-                        if self._interrupt_requested:
-                            return False
-                elif self._interrupt_requested:
-                    return False
-                try:
-                    return bool(_native_steer(cleaned))
-                except Exception:
-                    logger.debug("Codex app-server turn/steer failed", exc_info=True)
-                    return False
+            return self._request_codex_native_steer(
+                cleaned,
+                is_gateway_session_ipc=False,
+            )
 
         # Never kill a tool merely to deliver conversational guidance. The
         # existing steer drain puts it on the final tool result before the next
@@ -3261,24 +3392,26 @@ class AIAgent:
         return text
 
     def _drain_pending_steer_with_provenance(self) -> tuple[Optional[str], bool]:
-        """Return and clear pending steer text together with trust provenance."""
+        """Compatibility wrapper for callers that can represent one trust bit."""
+        chunks = self._drain_pending_steer_chunks()
+        text = "\n".join(chunk for chunk, _trusted in chunks) or None
+        return text, bool(chunks and all(trusted for _text, trusted in chunks))
+
+    def _drain_pending_steer_chunks(self) -> list[tuple[str, bool]]:
+        """Return and clear pending steers without collapsing provenance."""
         _lock = getattr(self, "_pending_steer_lock", None)
         if _lock is None:
-            text = getattr(self, "_pending_steer", None)
-            is_gateway_session_ipc = bool(
-                getattr(self, "_pending_steer_is_gateway_session_ipc", False)
-            )
+            chunks = list(self._pending_steer_chunks_locked())
+            self._pending_steer_chunks = []
             self._pending_steer = None
             self._pending_steer_is_gateway_session_ipc = False
-            return text, is_gateway_session_ipc
+            return chunks
         with _lock:
-            text = self._pending_steer
-            is_gateway_session_ipc = bool(
-                getattr(self, "_pending_steer_is_gateway_session_ipc", False)
-            )
+            chunks = list(self._pending_steer_chunks_locked())
+            self._pending_steer_chunks = []
             self._pending_steer = None
             self._pending_steer_is_gateway_session_ipc = False
-        return text, is_gateway_session_ipc
+        return chunks
 
     def _restore_pending_steer(
         self,
@@ -3287,23 +3420,25 @@ class AIAgent:
         is_gateway_session_ipc: bool = False,
     ) -> None:
         """Put a temporarily drained steer back without losing provenance."""
+        self._restore_pending_steer_chunks(
+            [(text, bool(is_gateway_session_ipc))]
+        )
+
+    def _restore_pending_steer_chunks(
+        self,
+        chunks: list[tuple[str, bool]],
+    ) -> None:
+        """Restore an ordered steer batch without merging trust domains."""
+        if not chunks:
+            return
         _lock = getattr(self, "_pending_steer_lock", None)
         if _lock is None:
-            existing = getattr(self, "_pending_steer", None)
-            self._pending_steer = (existing + "\n" + text) if existing else text
-            if not existing:
-                self._pending_steer_is_gateway_session_ipc = bool(
-                    is_gateway_session_ipc
-                )
+            self._pending_steer_chunks_locked().extend(chunks)
+            self._sync_pending_steer_compat_locked()
             return
         with _lock:
-            if self._pending_steer:
-                self._pending_steer = self._pending_steer + "\n" + text
-            else:
-                self._pending_steer = text
-                self._pending_steer_is_gateway_session_ipc = bool(
-                    is_gateway_session_ipc
-                )
+            self._pending_steer_chunks_locked().extend(chunks)
+            self._sync_pending_steer_compat_locked()
 
     def _open_steer_admission(self) -> None:
         """Allow steer() calls for the current conversation turn."""
@@ -3327,26 +3462,28 @@ class AIAgent:
         return text
 
     def _close_steer_admission_with_provenance(self) -> tuple[Optional[str], bool]:
-        """Atomically close steer admission and return text plus provenance."""
+        """Compatibility wrapper for callers that can represent one trust bit."""
+        chunks = self._close_steer_admission_with_chunks()
+        text = "\n".join(chunk for chunk, _trusted in chunks) or None
+        return text, bool(chunks and all(trusted for _text, trusted in chunks))
+
+    def _close_steer_admission_with_chunks(self) -> list[tuple[str, bool]]:
+        """Atomically close admission and retain each steer's provenance."""
         _lock = getattr(self, "_pending_steer_lock", None)
         if _lock is None:
             self._steer_accepting = False
-            text = getattr(self, "_pending_steer", None)
-            is_gateway_session_ipc = bool(
-                getattr(self, "_pending_steer_is_gateway_session_ipc", False)
-            )
+            chunks = list(self._pending_steer_chunks_locked())
+            self._pending_steer_chunks = []
             self._pending_steer = None
             self._pending_steer_is_gateway_session_ipc = False
-            return text, is_gateway_session_ipc
+            return chunks
         with _lock:
             self._steer_accepting = False
-            text = self._pending_steer
-            is_gateway_session_ipc = bool(
-                getattr(self, "_pending_steer_is_gateway_session_ipc", False)
-            )
+            chunks = list(self._pending_steer_chunks_locked())
+            self._pending_steer_chunks = []
             self._pending_steer = None
             self._pending_steer_is_gateway_session_ipc = False
-        return text, is_gateway_session_ipc
+        return chunks
 
     def _record_file_mutation_result(
         self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3080,17 +3080,28 @@ class AIAgent:
                     _set_interrupt(False, _wtid)
                 except Exception:
                     pass
-        # A hard interrupt supersedes any pending /steer — the steer was
-        # meant for the agent's next tool-call iteration, which will no
-        # longer happen. Drop it instead of surprising the user with a
-        # late injection on the post-interrupt turn.
+        # A hard interrupt supersedes an ordinary user /steer — the steer was
+        # meant for the agent's next tool-call iteration, which will no longer
+        # happen. A trusted gateway-session IPC steer is different: its caller
+        # has already received ``disposition: steered``, so dropping it here
+        # would lose an acknowledged task. Retain trusted chunks for the failed
+        # turn recovery path (or the next turn) while discarding user steers.
         _steer_lock = getattr(self, "_pending_steer_lock", None)
         if _steer_lock is not None:
             with _steer_lock:
-                self._pending_steer = None
-                self._pending_steer_chunks = []
-                self._pending_steer_is_gateway_session_ipc = False
-                self._codex_native_pending_steer_chunks = []
+                self._pending_steer_chunks = [
+                    (text, trusted)
+                    for text, trusted in self._pending_steer_chunks_locked()
+                    if trusted
+                ]
+                self._sync_pending_steer_compat_locked()
+                self._codex_native_pending_steer_chunks = [
+                    item
+                    for item in getattr(
+                        self, "_codex_native_pending_steer_chunks", []
+                    )
+                    if len(item) >= 3 and item[2]
+                ]
         return True
 
     def steer(self, text: str, *, _gateway_session_ipc: bool = False) -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3088,9 +3088,10 @@ class AIAgent:
         if _steer_lock is not None:
             with _steer_lock:
                 self._pending_steer = None
+                self._pending_steer_is_gateway_session_ipc = False
         return True
 
-    def steer(self, text: str) -> bool:
+    def steer(self, text: str, *, _gateway_session_ipc: bool = False) -> bool:
         """
         Inject a user message into the next tool result without interrupting.
 
@@ -3120,6 +3121,8 @@ class AIAgent:
                 return False
             existing = getattr(self, "_pending_steer", None)
             self._pending_steer = (existing + "\n" + cleaned) if existing else cleaned
+            if not existing:
+                self._pending_steer_is_gateway_session_ipc = bool(_gateway_session_ipc)
             return True
         with _lock:
             if not getattr(self, "_steer_accepting", True):
@@ -3128,6 +3131,7 @@ class AIAgent:
                 self._pending_steer = self._pending_steer + "\n" + cleaned
             else:
                 self._pending_steer = cleaned
+                self._pending_steer_is_gateway_session_ipc = bool(_gateway_session_ipc)
         return True
 
     def redirect(self, text: str) -> bool:
@@ -3248,15 +3252,53 @@ class AIAgent:
         Safe to call from the agent execution thread after appending tool
         results. Returns None when no steer is pending.
         """
+        text, _is_gateway_session_ipc = self._drain_pending_steer_with_provenance()
+        return text
+
+    def _drain_pending_steer_with_provenance(self) -> tuple[Optional[str], bool]:
+        """Return and clear pending steer text together with trust provenance."""
         _lock = getattr(self, "_pending_steer_lock", None)
         if _lock is None:
             text = getattr(self, "_pending_steer", None)
+            is_gateway_session_ipc = bool(
+                getattr(self, "_pending_steer_is_gateway_session_ipc", False)
+            )
             self._pending_steer = None
-            return text
+            self._pending_steer_is_gateway_session_ipc = False
+            return text, is_gateway_session_ipc
         with _lock:
             text = self._pending_steer
+            is_gateway_session_ipc = bool(
+                getattr(self, "_pending_steer_is_gateway_session_ipc", False)
+            )
             self._pending_steer = None
-        return text
+            self._pending_steer_is_gateway_session_ipc = False
+        return text, is_gateway_session_ipc
+
+    def _restore_pending_steer(
+        self,
+        text: str,
+        *,
+        is_gateway_session_ipc: bool = False,
+    ) -> None:
+        """Put a temporarily drained steer back without losing provenance."""
+        _lock = getattr(self, "_pending_steer_lock", None)
+        if _lock is None:
+            existing = getattr(self, "_pending_steer", None)
+            self._pending_steer = (existing + "\n" + text) if existing else text
+            if not existing:
+                self._pending_steer_is_gateway_session_ipc = bool(
+                    is_gateway_session_ipc
+                )
+            return
+        with _lock:
+            if self._pending_steer:
+                self._pending_steer = self._pending_steer + "\n" + text
+            else:
+                self._pending_steer = text
+                self._pending_steer_is_gateway_session_ipc = bool(
+                    is_gateway_session_ipc
+                )
 
     def _open_steer_admission(self) -> None:
         """Allow steer() calls for the current conversation turn."""
@@ -3274,17 +3316,32 @@ class AIAgent:
         concurrent surface cannot report a steer as accepted unless it was
         included in the returned text.
         """
+        text, _is_gateway_session_ipc = (
+            self._close_steer_admission_with_provenance()
+        )
+        return text
+
+    def _close_steer_admission_with_provenance(self) -> tuple[Optional[str], bool]:
+        """Atomically close steer admission and return text plus provenance."""
         _lock = getattr(self, "_pending_steer_lock", None)
         if _lock is None:
             self._steer_accepting = False
             text = getattr(self, "_pending_steer", None)
+            is_gateway_session_ipc = bool(
+                getattr(self, "_pending_steer_is_gateway_session_ipc", False)
+            )
             self._pending_steer = None
-            return text
+            self._pending_steer_is_gateway_session_ipc = False
+            return text, is_gateway_session_ipc
         with _lock:
             self._steer_accepting = False
             text = self._pending_steer
+            is_gateway_session_ipc = bool(
+                getattr(self, "_pending_steer_is_gateway_session_ipc", False)
+            )
             self._pending_steer = None
-        return text
+            self._pending_steer_is_gateway_session_ipc = False
+        return text, is_gateway_session_ipc
 
     def _record_file_mutation_result(
         self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3112,6 +3112,11 @@ class AIAgent:
         if not text or not text.strip():
             return False
         cleaned = text.strip()
+        if getattr(self, "api_mode", None) == "codex_app_server":
+            # Codex owns its internal tool loop. Its native turn/steer request
+            # is the only live-turn admission path; the Hermes pending-tool
+            # slot below is never drained by this runtime.
+            return self.redirect(cleaned)
         _lock = getattr(self, "_pending_steer_lock", None)
         if _lock is None:
             # Test stubs that built AIAgent via object.__new__ skip __init__.

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import socket
+import stat
+import threading
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from gateway import session_ipc
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import Platform, SessionEntry, SessionSource, build_session_key
+from gateway.session_ipc import (
+    GatewaySessionIPCServer,
+    SessionIPCRequestError,
+    inject_gateway_session,
+)
+from hermes_cli.subcommands.gateway import build_gateway_parser
+
+
+SESSION_KEY = "agent:jasper:telegram:dm:7873700813"
+SESSION_ID = "20260723_201200_deadbeef"
+
+
+def _source(*, profile: str = "jasper") -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="7873700813",
+        chat_type="dm",
+        user_id="7873700813",
+        user_name="Tyler",
+        profile=profile,
+    )
+
+
+def _entry(*, key: str = SESSION_KEY, profile: str = "jasper") -> SessionEntry:
+    now = datetime.now(timezone.utc)
+    return SessionEntry(
+        session_key=key,
+        session_id=SESSION_ID,
+        created_at=now,
+        updated_at=now,
+        origin=_source(profile=profile),
+        platform=Platform.TELEGRAM,
+    )
+
+
+def _runner(entry: SessionEntry | None = None):
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = SimpleNamespace(
+        _lock=threading.Lock(),
+        _loaded=True,
+        _entries={} if entry is None else {SESSION_KEY: entry},
+        _ensure_loaded_locked=lambda: None,
+        _generate_session_key=lambda source: build_session_key(
+            source,
+            profile=source.profile,
+        ),
+    )
+    runner._running_agents = {}
+    runner._queued_events = {}
+    runner._active_profile_name = lambda: "jasper"
+    adapter = SimpleNamespace(
+        _pending_messages={},
+        _active_sessions={},
+        handle_message=AsyncMock(),
+    )
+    runner._adapter_for_source = lambda source: adapter
+    return runner, adapter
+
+
+def _raw_request(socket_path, payload: bytes) -> dict:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(2.0)
+        client.connect(str(socket_path))
+        client.sendall(payload)
+        raw = b""
+        while b"\n" not in raw:
+            chunk = client.recv(8192)
+            if not chunk:
+                break
+            raw += chunk
+    return json.loads(raw.split(b"\n", 1)[0].decode("utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_exact_profile_local_idle_route_returns_session_proof_and_dispatches_in_order():
+    runner, adapter = _runner(_entry())
+
+    first = await runner._inject_exact_session(
+        profile="jasper",
+        session_key=SESSION_KEY,
+        message="Inspect WORK-8491 and report status.",
+    )
+    second = await runner._inject_exact_session(
+        profile="jasper",
+        session_key=SESSION_KEY,
+        message="Then preserve FIFO order.",
+    )
+
+    assert first == {
+        "ok": True,
+        "profile": "jasper",
+        "session_key": SESSION_KEY,
+        "session_id": SESSION_ID,
+        "disposition": "queued",
+    }
+    assert second["session_id"] == SESSION_ID
+    assert second["disposition"] == "queued"
+    events = [call.args[0] for call in adapter.handle_message.await_args_list]
+    assert [event.text for event in events] == [
+        "Inspect WORK-8491 and report status.",
+        "Then preserve FIFO order.",
+    ]
+    assert all(isinstance(event, MessageEvent) for event in events)
+    assert all(event.internal is True for event in events)
+    assert all(event.source.profile == "jasper" for event in events)
+    assert all(event.metadata["gateway_session_id"] == SESSION_ID for event in events)
+
+
+@pytest.mark.asyncio
+async def test_active_exact_route_steers_without_platform_send_or_queue():
+    runner, adapter = _runner(_entry())
+    agent = SimpleNamespace(steer=Mock(return_value=True))
+    runner._running_agents[SESSION_KEY] = agent
+
+    proof = await runner._inject_exact_session(
+        profile="jasper",
+        session_key=SESSION_KEY,
+        message="Use the corrected constraint.",
+    )
+
+    assert proof["disposition"] == "steered"
+    assert proof["session_id"] == SESSION_ID
+    agent.steer.assert_called_once_with("Use the corrected constraint.")
+    adapter.handle_message.assert_not_awaited()
+    assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_active_route_steer_fallback_uses_bounded_fifo_queue():
+    runner, adapter = _runner(_entry())
+    agent = SimpleNamespace(steer=Mock(return_value=False))
+    runner._running_agents[SESSION_KEY] = agent
+
+    for message in ("First queued task.", "Second queued task."):
+        proof = await runner._inject_exact_session(
+            profile="jasper",
+            session_key=SESSION_KEY,
+            message=message,
+        )
+        assert proof["disposition"] == "queued"
+
+    assert [call.args for call in agent.steer.call_args_list] == [
+        ("First queued task.",),
+        ("Second queued task.",),
+    ]
+    adapter.handle_message.assert_not_awaited()
+    assert adapter._pending_messages[SESSION_KEY].text == "First queued task."
+    assert [event.text for event in runner._queued_events[SESSION_KEY]] == [
+        "Second queued task."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_missing_exact_route_fails_closed():
+    runner, adapter = _runner()
+
+    with pytest.raises(SessionIPCRequestError, match="No live gateway route") as exc_info:
+        await runner._inject_exact_session(
+            profile="jasper",
+            session_key=SESSION_KEY,
+            message="Do not create a session.",
+        )
+
+    assert exc_info.value.code == "route_not_found"
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_malformed_route_with_mismatched_embedded_key_fails_closed():
+    runner, adapter = _runner(_entry(key="agent:other:telegram:dm:7873700813"))
+
+    with pytest.raises(SessionIPCRequestError) as exc_info:
+        await runner._inject_exact_session(
+            profile="jasper",
+            session_key=SESSION_KEY,
+            message="Do not guess the route.",
+        )
+
+    assert exc_info.value.code == "route_ambiguous"
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cross_profile_route_is_rejected_before_dispatch():
+    runner, adapter = _runner(_entry())
+
+    with pytest.raises(SessionIPCRequestError) as exc_info:
+        await runner._inject_exact_session(
+            profile="cleo",
+            session_key=SESSION_KEY,
+            message="Do not cross profile boundaries.",
+        )
+
+    assert exc_info.value.code == "profile_mismatch"
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+@pytest.mark.asyncio
+async def test_profile_socket_and_runtime_directory_are_owner_only_and_unix_only(tmp_path):
+    home = tmp_path / "profiles" / "jasper"
+
+    async def handler(**request):
+        return {
+            "ok": True,
+            "profile": "jasper",
+            "session_key": request["session_key"],
+            "session_id": SESSION_ID,
+            "disposition": "queued",
+        }
+
+    server = GatewaySessionIPCServer(handler, profile="jasper", hermes_home=home)
+    await server.start()
+    try:
+        assert server.socket_path == home.resolve() / "run" / "gateway-session.sock"
+        assert stat.S_IMODE(server.socket_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(server.socket_path.parent.stat().st_mode) == 0o700
+        assert server._server is not None
+        assert server._server.sockets
+        assert {sock.family for sock in server._server.sockets} == {socket.AF_UNIX}
+
+        proof = await asyncio.to_thread(
+            inject_gateway_session,
+            profile="jasper",
+            session_key=SESSION_KEY,
+            message="Exact local task",
+            hermes_home=home,
+        )
+        assert proof["session_id"] == SESSION_ID
+    finally:
+        await server.stop()
+
+    assert not server.socket_path.exists()
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+def test_client_rejects_permissive_profile_socket(tmp_path):
+    home = tmp_path / "profiles" / "jasper"
+    socket_path = home / "run" / "gateway-session.sock"
+    socket_path.parent.mkdir(parents=True)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(socket_path))
+    listener.listen(1)
+    socket_path.chmod(0o666)
+    try:
+        with pytest.raises(SessionIPCRequestError) as exc_info:
+            inject_gateway_session(
+                profile="jasper",
+                session_key=SESSION_KEY,
+                message="Unsafe socket must be rejected",
+                hermes_home=home,
+            )
+    finally:
+        listener.close()
+
+    assert exc_info.value.code == "unsafe_socket"
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+@pytest.mark.asyncio
+async def test_socket_rejects_cross_profile_and_malformed_json(tmp_path):
+    calls = []
+
+    async def handler(**request):
+        calls.append(request)
+        return {"ok": True}
+
+    server = GatewaySessionIPCServer(handler, profile="jasper", hermes_home=tmp_path)
+    await server.start()
+    try:
+        malformed = await asyncio.to_thread(_raw_request, server.socket_path, b"{not-json}\n")
+        assert malformed["ok"] is False
+        assert malformed["error"]["code"] == "invalid_request"
+
+        cross_profile = await asyncio.to_thread(
+            _raw_request,
+            server.socket_path,
+            json.dumps(
+                {
+                    "operation": "inject",
+                    "profile": "cleo",
+                    "session_key": SESSION_KEY,
+                    "message": "Cross-profile attempt",
+                }
+            ).encode("utf-8")
+            + b"\n",
+        )
+        assert cross_profile["ok"] is False
+        assert cross_profile["error"]["code"] == "profile_mismatch"
+        assert calls == []
+    finally:
+        await server.stop()
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+@pytest.mark.asyncio
+async def test_socket_rejects_json_beyond_request_bound_without_dispatch(tmp_path):
+    calls = []
+
+    async def handler(**request):
+        calls.append(request)
+        return {"ok": True}
+
+    server = GatewaySessionIPCServer(handler, profile="jasper", hermes_home=tmp_path)
+    await server.start()
+    try:
+        oversized = b"{" + b"x" * session_ipc._MAX_REQUEST_BYTES + b"}\n"
+        response = await asyncio.to_thread(_raw_request, server.socket_path, oversized)
+        assert response["ok"] is False
+        assert response["error"]["code"] == "request_too_large"
+        assert calls == []
+    finally:
+        await server.stop()
+
+
+def test_gateway_inject_cli_parser_requires_exact_session_and_message():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_gateway_parser(
+        subparsers,
+        cmd_gateway=lambda _args: None,
+        cmd_proxy=lambda _args: None,
+        cmd_gateway_enroll=lambda _args: None,
+    )
+
+    args = parser.parse_args(
+        ["gateway", "inject", "--session-key", SESSION_KEY, "--message", "Do the task"]
+    )
+
+    assert args.gateway_command == "inject"
+    assert args.session_key == SESSION_KEY
+    assert args.message == "Do the task"

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -6,14 +6,17 @@ import json
 import socket
 import stat
 import threading
+import time
+import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from gateway import session_ipc
-from gateway.platforms.base import MessageEvent
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
 from gateway.run import GatewayRunner
 from gateway.session import Platform, SessionEntry, SessionSource, build_session_key
 from gateway.session_ipc import (
@@ -26,6 +29,20 @@ from hermes_cli.subcommands.gateway import build_gateway_parser
 
 SESSION_KEY = "agent:jasper:telegram:dm:7873700813"
 SESSION_ID = "20260723_201200_deadbeef"
+
+
+class _TestAdapter(BasePlatformAdapter):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, *args, **kwargs):
+        return None
+
+    async def get_chat_info(self, *args, **kwargs):
+        return {}
 
 
 def _source(*, profile: str = "jasper") -> SessionSource:
@@ -51,10 +68,27 @@ def _entry(*, key: str = SESSION_KEY, profile: str = "jasper") -> SessionEntry:
     )
 
 
+async def _inject(
+    runner,
+    message: str,
+    *,
+    expected_session_id: str = SESSION_ID,
+    idempotency_key: str | None = None,
+):
+    return await runner._inject_exact_session(
+        profile="jasper",
+        session_key=SESSION_KEY,
+        expected_session_id=expected_session_id,
+        idempotency_key=idempotency_key or str(uuid.uuid4()),
+        message=message,
+    )
+
+
 def _runner(entry: SessionEntry | None = None):
     runner = object.__new__(GatewayRunner)
     runner.session_store = SimpleNamespace(
-        _lock=threading.Lock(),
+        _lock=threading.RLock(),
+        resolve_session_entry=Mock(return_value=entry),
         _loaded=True,
         _entries={} if entry is None else {SESSION_KEY: entry},
         _ensure_loaded_locked=lambda: None,
@@ -62,14 +96,21 @@ def _runner(entry: SessionEntry | None = None):
             source,
             profile=source.profile,
         ),
+        _is_session_expired=Mock(return_value=False),
+        _is_session_ended_in_db=Mock(return_value=False),
+        _compression_tip_for_session_id=Mock(side_effect=lambda value: value),
     )
     runner._running_agents = {}
+    runner._running_agents_ts = {}
     runner._queued_events = {}
+    runner._session_run_generation = {}
+    runner._draining = False
+    runner._running = True
     runner._active_profile_name = lambda: "jasper"
     adapter = SimpleNamespace(
         _pending_messages={},
         _active_sessions={},
-        handle_message=AsyncMock(),
+        accept_internal_task=Mock(return_value=True),
     )
     runner._adapter_for_source = lambda source: adapter
     return runner, adapter
@@ -89,20 +130,35 @@ def _raw_request(socket_path, payload: bytes) -> dict:
     return json.loads(raw.split(b"\n", 1)[0].decode("utf-8"))
 
 
+def _request_payload(
+    *,
+    profile: str = "jasper",
+    session_key: str = SESSION_KEY,
+    expected_session_id: str = SESSION_ID,
+    idempotency_key: str | None = None,
+    message: str = "Exact local task",
+) -> bytes:
+    return (
+        json.dumps(
+            {
+                "operation": "inject",
+                "profile": profile,
+                "session_key": session_key,
+                "expected_session_id": expected_session_id,
+                "idempotency_key": idempotency_key or str(uuid.uuid4()),
+                "message": message,
+            }
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
 @pytest.mark.asyncio
 async def test_exact_profile_local_idle_route_returns_session_proof_and_dispatches_in_order():
     runner, adapter = _runner(_entry())
 
-    first = await runner._inject_exact_session(
-        profile="jasper",
-        session_key=SESSION_KEY,
-        message="Inspect WORK-8491 and report status.",
-    )
-    second = await runner._inject_exact_session(
-        profile="jasper",
-        session_key=SESSION_KEY,
-        message="Then preserve FIFO order.",
-    )
+    first = await _inject(runner, "Inspect WORK-8491 and report status.")
+    second = await _inject(runner, "Then preserve FIFO order.")
 
     assert first == {
         "ok": True,
@@ -113,7 +169,7 @@ async def test_exact_profile_local_idle_route_returns_session_proof_and_dispatch
     }
     assert second["session_id"] == SESSION_ID
     assert second["disposition"] == "queued"
-    events = [call.args[0] for call in adapter.handle_message.await_args_list]
+    events = [call.args[0] for call in adapter.accept_internal_task.call_args_list]
     assert [event.text for event in events] == [
         "Inspect WORK-8491 and report status.",
         "Then preserve FIFO order.",
@@ -130,16 +186,12 @@ async def test_active_exact_route_steers_without_platform_send_or_queue():
     agent = SimpleNamespace(steer=Mock(return_value=True))
     runner._running_agents[SESSION_KEY] = agent
 
-    proof = await runner._inject_exact_session(
-        profile="jasper",
-        session_key=SESSION_KEY,
-        message="Use the corrected constraint.",
-    )
+    proof = await _inject(runner, "Use the corrected constraint.")
 
     assert proof["disposition"] == "steered"
     assert proof["session_id"] == SESSION_ID
     agent.steer.assert_called_once_with("Use the corrected constraint.")
-    adapter.handle_message.assert_not_awaited()
+    adapter.accept_internal_task.assert_not_called()
     assert adapter._pending_messages == {}
 
 
@@ -150,18 +202,14 @@ async def test_active_route_steer_fallback_uses_bounded_fifo_queue():
     runner._running_agents[SESSION_KEY] = agent
 
     for message in ("First queued task.", "Second queued task."):
-        proof = await runner._inject_exact_session(
-            profile="jasper",
-            session_key=SESSION_KEY,
-            message=message,
-        )
+        proof = await _inject(runner, message)
         assert proof["disposition"] == "queued"
 
     assert [call.args for call in agent.steer.call_args_list] == [
         ("First queued task.",),
         ("Second queued task.",),
     ]
-    adapter.handle_message.assert_not_awaited()
+    adapter.accept_internal_task.assert_not_called()
     assert adapter._pending_messages[SESSION_KEY].text == "First queued task."
     assert [event.text for event in runner._queued_events[SESSION_KEY]] == [
         "Second queued task."
@@ -173,14 +221,10 @@ async def test_missing_exact_route_fails_closed():
     runner, adapter = _runner()
 
     with pytest.raises(SessionIPCRequestError, match="No live gateway route") as exc_info:
-        await runner._inject_exact_session(
-            profile="jasper",
-            session_key=SESSION_KEY,
-            message="Do not create a session.",
-        )
+        await _inject(runner, "Do not create a session.")
 
     assert exc_info.value.code == "route_not_found"
-    adapter.handle_message.assert_not_awaited()
+    adapter.accept_internal_task.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -188,14 +232,10 @@ async def test_malformed_route_with_mismatched_embedded_key_fails_closed():
     runner, adapter = _runner(_entry(key="agent:other:telegram:dm:7873700813"))
 
     with pytest.raises(SessionIPCRequestError) as exc_info:
-        await runner._inject_exact_session(
-            profile="jasper",
-            session_key=SESSION_KEY,
-            message="Do not guess the route.",
-        )
+        await _inject(runner, "Do not guess the route.")
 
     assert exc_info.value.code == "route_ambiguous"
-    adapter.handle_message.assert_not_awaited()
+    adapter.accept_internal_task.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -206,11 +246,108 @@ async def test_cross_profile_route_is_rejected_before_dispatch():
         await runner._inject_exact_session(
             profile="cleo",
             session_key=SESSION_KEY,
+            expected_session_id=SESSION_ID,
+            idempotency_key=str(uuid.uuid4()),
             message="Do not cross profile boundaries.",
         )
 
     assert exc_info.value.code == "profile_mismatch"
-    adapter.handle_message.assert_not_awaited()
+    adapter.accept_internal_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task_text", ["restart gateway", "/restart", "/approve always"])
+async def test_trusted_internal_task_is_never_command_coerced_or_dispatched_as_control(task_text):
+    adapter = _TestAdapter(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+    adapter._message_handler = AsyncMock(return_value="must not run inline")
+    adapter._busy_session_handler = AsyncMock(return_value=False)
+    adapter._active_sessions = {SESSION_KEY: asyncio.Event()}
+    adapter._pending_messages = {}
+    adapter._session_tasks = {}
+    adapter._background_tasks = set()
+    adapter._expected_cancelled_tasks = set()
+    adapter._text_debounce = {}
+    adapter._busy_text_mode = "interrupt"
+    adapter._busy_text_debounce_seconds = 0.0
+    adapter._busy_text_hard_cap_seconds = 0.0
+    adapter._topic_recovery_fn = None
+
+    event = MessageEvent(
+        text=task_text,
+        message_type=MessageType.TEXT,
+        source=_source(),
+        internal=True,
+        metadata={
+            "gateway_session_ipc_task": True,
+            "gateway_session_key": SESSION_KEY,
+            "gateway_session_id": SESSION_ID,
+        },
+    )
+
+    with (
+        patch("gateway.platforms.base.coerce_plaintext_gateway_command") as coerce,
+        patch("gateway.platforms.base.build_session_key", return_value=SESSION_KEY),
+    ):
+        await adapter.handle_message(event)
+
+    coerce.assert_not_called()
+    adapter._message_handler.assert_not_awaited()
+    adapter._busy_session_handler.assert_not_awaited()
+    assert adapter._pending_messages[SESSION_KEY].text == task_text
+
+
+@pytest.mark.asyncio
+async def test_expected_session_rotation_is_rejected_before_steer_or_queue():
+    runner, adapter = _runner(_entry())
+    runner._running_agents[SESSION_KEY] = SimpleNamespace(steer=Mock(return_value=True))
+
+    with pytest.raises(SessionIPCRequestError) as exc_info:
+        await _inject(runner, "Must not land", expected_session_id="rotated-session")
+
+    assert exc_info.value.code == "route_rotated"
+    runner._running_agents[SESSION_KEY].steer.assert_not_called()
+    adapter.accept_internal_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("route_state", "expected_code"),
+    [
+        ("suspended", "session_suspended"),
+        ("expired", "session_expired"),
+        ("ended", "session_ended"),
+        ("stale_parent", "route_rotated"),
+    ],
+)
+async def test_inactive_or_stale_routes_are_rejected_before_acceptance(route_state, expected_code):
+    entry = _entry()
+    runner, adapter = _runner(entry)
+    if route_state == "suspended":
+        entry.suspended = True
+    elif route_state == "expired":
+        runner.session_store._is_session_expired.return_value = True
+    elif route_state == "ended":
+        runner.session_store._is_session_ended_in_db.return_value = True
+    elif route_state == "stale_parent":
+        runner.session_store._compression_tip_for_session_id.side_effect = None
+        runner.session_store._compression_tip_for_session_id.return_value = "compressed-child"
+
+    with pytest.raises(SessionIPCRequestError) as exc_info:
+        await _inject(runner, "Must not land")
+
+    assert exc_info.value.code == expected_code
+    adapter.accept_internal_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_idle_route_does_not_report_queued_when_adapter_claim_fails():
+    runner, adapter = _runner(_entry())
+    adapter.accept_internal_task.return_value = False
+
+    with pytest.raises(SessionIPCRequestError) as exc_info:
+        await _inject(runner, "Claim must be synchronous")
+
+    assert exc_info.value.code == "acceptance_failed"
 
 
 @pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
@@ -241,6 +378,8 @@ async def test_profile_socket_and_runtime_directory_are_owner_only_and_unix_only
             inject_gateway_session,
             profile="jasper",
             session_key=SESSION_KEY,
+            expected_session_id=SESSION_ID,
+            idempotency_key=str(uuid.uuid4()),
             message="Exact local task",
             hermes_home=home,
         )
@@ -265,6 +404,8 @@ def test_client_rejects_permissive_profile_socket(tmp_path):
             inject_gateway_session(
                 profile="jasper",
                 session_key=SESSION_KEY,
+                expected_session_id=SESSION_ID,
+                idempotency_key=str(uuid.uuid4()),
                 message="Unsafe socket must be rejected",
                 hermes_home=home,
             )
@@ -293,15 +434,7 @@ async def test_socket_rejects_cross_profile_and_malformed_json(tmp_path):
         cross_profile = await asyncio.to_thread(
             _raw_request,
             server.socket_path,
-            json.dumps(
-                {
-                    "operation": "inject",
-                    "profile": "cleo",
-                    "session_key": SESSION_KEY,
-                    "message": "Cross-profile attempt",
-                }
-            ).encode("utf-8")
-            + b"\n",
+            _request_payload(profile="cleo", message="Cross-profile attempt"),
         )
         assert cross_profile["ok"] is False
         assert cross_profile["error"]["code"] == "profile_mismatch"
@@ -331,6 +464,172 @@ async def test_socket_rejects_json_beyond_request_bound_without_dispatch(tmp_pat
         await server.stop()
 
 
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+@pytest.mark.asyncio
+async def test_unknown_peer_uid_fails_closed_without_dispatch(tmp_path, monkeypatch):
+    handler = AsyncMock(return_value={"ok": True})
+    server = GatewaySessionIPCServer(handler, profile="jasper", hermes_home=tmp_path)
+    monkeypatch.setattr(server, "_peer_uid", lambda _writer: None)
+    await server.start()
+    try:
+        response = await asyncio.to_thread(
+            _raw_request,
+            server.socket_path,
+            _request_payload(),
+        )
+    finally:
+        await server.stop()
+
+    assert response["ok"] is False
+    assert response["error"]["code"] == "peer_credentials_unavailable"
+    handler.assert_not_awaited()
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+@pytest.mark.asyncio
+async def test_client_timeout_retry_with_same_key_delivers_once(tmp_path):
+    calls = 0
+
+    async def handler(**request):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.05)
+        return {
+            "ok": True,
+            "profile": request["profile"],
+            "session_key": request["session_key"],
+            "session_id": request["expected_session_id"],
+            "disposition": "queued",
+        }
+
+    server = GatewaySessionIPCServer(handler, profile="jasper", hermes_home=tmp_path)
+    await server.start()
+    key = "timeout-retry-same-task"
+    try:
+        with pytest.raises((TimeoutError, socket.timeout, SessionIPCRequestError)):
+            await asyncio.to_thread(
+                inject_gateway_session,
+                profile="jasper",
+                session_key=SESSION_KEY,
+                expected_session_id=SESSION_ID,
+                idempotency_key=key,
+                message="Deliver exactly once",
+                hermes_home=tmp_path,
+                timeout=0.01,
+            )
+        await asyncio.sleep(0.08)
+        proof = await asyncio.to_thread(
+            inject_gateway_session,
+            profile="jasper",
+            session_key=SESSION_KEY,
+            expected_session_id=SESSION_ID,
+            idempotency_key=key,
+            message="Deliver exactly once",
+            hermes_home=tmp_path,
+        )
+    finally:
+        await server.stop()
+
+    assert proof["disposition"] == "queued"
+    assert calls == 1
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+@pytest.mark.asyncio
+async def test_server_timeout_cancels_handler_and_returns_closed_failure(tmp_path, monkeypatch):
+    cancelled = asyncio.Event()
+
+    async def handler(**_request):
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    monkeypatch.setattr(session_ipc, "_HANDLER_TIMEOUT_SECONDS", 0.01)
+    server = GatewaySessionIPCServer(handler, profile="jasper", hermes_home=tmp_path)
+    await server.start()
+    try:
+        response = await asyncio.to_thread(
+            _raw_request,
+            server.socket_path,
+            _request_payload(idempotency_key="server-timeout"),
+        )
+    finally:
+        await server.stop()
+
+    assert response["ok"] is False
+    assert response["error"]["code"] == "request_timeout"
+    assert cancelled.is_set()
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+@pytest.mark.asyncio
+async def test_reused_idempotency_key_with_different_payload_is_rejected(tmp_path):
+    handler = AsyncMock(
+        return_value={
+            "ok": True,
+            "profile": "jasper",
+            "session_key": SESSION_KEY,
+            "session_id": SESSION_ID,
+            "disposition": "queued",
+        }
+    )
+    server = GatewaySessionIPCServer(handler, profile="jasper", hermes_home=tmp_path)
+    await server.start()
+    try:
+        first = await asyncio.to_thread(
+            _raw_request,
+            server.socket_path,
+            _request_payload(idempotency_key="conflict", message="first"),
+        )
+        second = await asyncio.to_thread(
+            _raw_request,
+            server.socket_path,
+            _request_payload(idempotency_key="conflict", message="different"),
+        )
+    finally:
+        await server.stop()
+
+    assert first["ok"] is True
+    assert second["ok"] is False
+    assert second["error"]["code"] == "idempotency_conflict"
+    handler.assert_awaited_once()
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+@pytest.mark.asyncio
+async def test_stop_does_not_unlink_replacement_socket(tmp_path):
+    server = GatewaySessionIPCServer(
+        AsyncMock(return_value={"ok": True}),
+        profile="jasper",
+        hermes_home=tmp_path,
+    )
+    await server.start()
+    original = server.socket_path.lstat()
+    server.socket_path.unlink()
+
+    replacement = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    replacement.bind(str(server.socket_path))
+    replacement.listen(1)
+    replacement_stat = server.socket_path.lstat()
+    try:
+        assert (replacement_stat.st_dev, replacement_stat.st_ino) != (
+            original.st_dev,
+            original.st_ino,
+        )
+        await server.stop()
+        assert server.socket_path.exists()
+        current = server.socket_path.lstat()
+        assert (current.st_dev, current.st_ino) == (
+            replacement_stat.st_dev,
+            replacement_stat.st_ino,
+        )
+    finally:
+        replacement.close()
+        server.socket_path.unlink(missing_ok=True)
+
+
 def test_gateway_inject_cli_parser_requires_exact_session_and_message():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
@@ -342,9 +641,22 @@ def test_gateway_inject_cli_parser_requires_exact_session_and_message():
     )
 
     args = parser.parse_args(
-        ["gateway", "inject", "--session-key", SESSION_KEY, "--message", "Do the task"]
+        [
+            "gateway",
+            "inject",
+            "--session-key",
+            SESSION_KEY,
+            "--expected-session-id",
+            SESSION_ID,
+            "--idempotency-key",
+            "work-8491-message-1",
+            "--message",
+            "Do the task",
+        ]
     )
 
     assert args.gateway_command == "inject"
     assert args.session_key == SESSION_KEY
+    assert args.expected_session_id == SESSION_ID
+    assert args.idempotency_key == "work-8491-message-1"
     assert args.message == "Do the task"

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from gateway import run as gateway_run
 from gateway import session_ipc
 from gateway.config import PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
@@ -105,6 +106,7 @@ def _runner(entry: SessionEntry | None = None):
     runner._running_agents = {}
     runner._running_agents_ts = {}
     runner._queued_events = {}
+    runner._busy_queue_lock = threading.RLock()
     runner._session_run_generation = {}
     runner._draining = False
     runner._running = True
@@ -114,6 +116,7 @@ def _runner(entry: SessionEntry | None = None):
         _active_sessions={},
         accept_internal_task=Mock(return_value=True),
     )
+    adapter.get_pending_message = lambda key: adapter._pending_messages.pop(key, None)
     runner._adapter_for_source = lambda source: adapter
     return runner, adapter
 
@@ -252,6 +255,95 @@ async def test_internal_task_uses_separate_fifo_and_queue_full_preserves_user_me
         event.text != "Rejected internal FIFO task"
         for event in runner._queued_events[SESSION_KEY]
     )
+
+
+def test_concurrent_user_and_ipc_admission_never_exceeds_busy_queue_cap(monkeypatch):
+    runner, adapter = _runner(_entry())
+    monkeypatch.setattr(runner, "_BUSY_QUEUE_MAX_PENDING", 2)
+    adapter._pending_messages[SESSION_KEY] = MessageEvent(
+        text="already queued",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+    user_event = MessageEvent(
+        text="concurrent user follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+    ipc_event = MessageEvent(
+        text="concurrent IPC follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        internal=True,
+        metadata={"gateway_session_ipc_task": True},
+    )
+    admission_barrier = threading.Barrier(2)
+    original_depth = runner._queue_depth
+    first_depth_call = threading.local()
+
+    def synchronized_depth(session_key, *, adapter=None):
+        depth = original_depth(session_key, adapter=adapter)
+        if not getattr(first_depth_call, "seen", False):
+            first_depth_call.seen = True
+            try:
+                admission_barrier.wait(timeout=0.2)
+            except threading.BrokenBarrierError:
+                pass
+        return depth
+
+    monkeypatch.setattr(runner, "_queue_depth", synchronized_depth)
+    ipc_result = []
+    user_thread = threading.Thread(
+        target=runner._queue_or_replace_pending_event,
+        args=(SESSION_KEY, user_event),
+    )
+    ipc_thread = threading.Thread(
+        target=lambda: ipc_result.append(
+            runner._enqueue_internal_fifo_event(SESSION_KEY, ipc_event, adapter)
+        )
+    )
+
+    user_thread.start()
+    ipc_thread.start()
+    user_thread.join(timeout=1.0)
+    ipc_thread.join(timeout=1.0)
+
+    assert not user_thread.is_alive()
+    assert not ipc_thread.is_alive()
+    assert original_depth(SESSION_KEY, adapter=adapter) <= runner._BUSY_QUEUE_MAX_PENDING
+    assert len(ipc_result) == 1
+
+
+def test_trusted_slash_task_survives_drain_as_inert_text_while_user_slash_is_blocked():
+    runner, adapter = _runner(_entry())
+    trusted = MessageEvent(
+        text="/restart trusted task",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        internal=True,
+        metadata={"gateway_session_ipc_task": True},
+    )
+    user = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+
+    runner._enqueue_fifo(SESSION_KEY, trusted, adapter)
+    drained_trusted = runner._dequeue_and_promote_queued_event(SESSION_KEY, adapter)
+    assert drained_trusted is trusted
+    assert gateway_run._pending_slash_is_command_leak(
+        drained_trusted.text, drained_trusted
+    ) is False
+    assert drained_trusted.is_command() is False
+
+    runner._enqueue_fifo(SESSION_KEY, user, adapter)
+    drained_user = runner._dequeue_and_promote_queued_event(SESSION_KEY, adapter)
+    assert drained_user is user
+    assert gateway_run._pending_slash_is_command_leak(
+        drained_user.text, drained_user
+    ) is True
+    assert drained_user.is_command() is True
 
 
 @pytest.mark.asyncio
@@ -822,6 +914,56 @@ async def test_stop_does_not_unlink_replacement_socket(tmp_path):
     finally:
         replacement.close()
         server.socket_path.unlink(missing_ok=True)
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+def test_startup_stale_cleanup_never_unlinks_replacement_between_check_and_cleanup(
+    tmp_path, monkeypatch
+):
+    server = GatewaySessionIPCServer(
+        AsyncMock(return_value={"ok": True}),
+        profile="jasper",
+        hermes_home=tmp_path,
+    )
+    server.socket_path.parent.mkdir(parents=True)
+    stale = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    stale.bind(str(server.socket_path))
+    stale.close()
+    replacement = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    replacement_path = server.socket_path.with_name("replacement.sock")
+    replacement.bind(str(replacement_path))
+    replacement.listen(1)
+    replacement_identity = replacement_path.lstat().st_dev, replacement_path.lstat().st_ino
+    original_replace = session_ipc.os.replace
+    replaced = False
+
+    def replace_before_quarantine(source, destination):
+        nonlocal replaced
+        if source == server.socket_path and not replaced:
+            replaced = True
+            server.socket_path.unlink()
+            original_replace(replacement_path, server.socket_path)
+        return original_replace(source, destination)
+
+    monkeypatch.setattr(session_ipc.os, "replace", replace_before_quarantine)
+    try:
+        with pytest.raises(SessionIPCRequestError):
+            server._prepare_socket_directory()
+        assert replaced is True
+        assert server.socket_path.exists()
+        assert stat.S_ISSOCK(server.socket_path.lstat().st_mode)
+        current = server.socket_path.lstat()
+        assert (current.st_dev, current.st_ino) == replacement_identity
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(0.5)
+            client.connect(str(server.socket_path))
+    finally:
+        replacement.close()
+        server.socket_path.unlink(missing_ok=True)
+        for quarantined in server.socket_path.parent.glob(
+            f".{server.socket_path.name}.stale-*"
+        ):
+            quarantined.unlink(missing_ok=True)
 
 
 def test_gateway_inject_cli_parser_requires_exact_session_and_message():

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import pickle
 import socket
 import stat
 import threading
@@ -24,6 +25,7 @@ from gateway.session_ipc import (
     SessionIPCRequestError,
     inject_gateway_session,
 )
+from hermes_cli.gateway import _gateway_command_inner
 from hermes_cli.subcommands.gateway import build_gateway_parser
 
 
@@ -214,6 +216,42 @@ async def test_active_route_steer_fallback_uses_bounded_fifo_queue():
     assert [event.text for event in runner._queued_events[SESSION_KEY]] == [
         "Second queued task."
     ]
+
+
+@pytest.mark.asyncio
+async def test_internal_task_uses_separate_fifo_and_queue_full_preserves_user_media():
+    runner, adapter = _runner(_entry())
+    runner._running_agents[SESSION_KEY] = SimpleNamespace(steer=Mock(return_value=False))
+    pending_user_event = MessageEvent(
+        text="Original user caption",
+        message_type=MessageType.PHOTO,
+        source=_source(),
+        media_urls=["https://example.invalid/original.jpg"],
+        media_types=["image/jpeg"],
+    )
+    adapter._pending_messages[SESSION_KEY] = pending_user_event
+    runner._queued_events[SESSION_KEY] = [
+        MessageEvent(text=f"queued-{index}", message_type=MessageType.TEXT, source=_source())
+        for index in range(runner._BUSY_QUEUE_MAX_PENDING - 2)
+    ]
+    before = pickle.dumps(pending_user_event, protocol=pickle.HIGHEST_PROTOCOL)
+
+    accepted = await _inject(runner, "Separate internal FIFO task")
+
+    assert accepted["disposition"] == "queued"
+    assert pickle.dumps(pending_user_event, protocol=pickle.HIGHEST_PROTOCOL) == before
+    assert runner._queued_events[SESSION_KEY][-1].text == "Separate internal FIFO task"
+    full_before = pickle.dumps(pending_user_event, protocol=pickle.HIGHEST_PROTOCOL)
+
+    with pytest.raises(SessionIPCRequestError) as exc_info:
+        await _inject(runner, "Rejected internal FIFO task")
+
+    assert exc_info.value.code == "queue_full"
+    assert pickle.dumps(pending_user_event, protocol=pickle.HIGHEST_PROTOCOL) == full_before
+    assert all(
+        event.text != "Rejected internal FIFO task"
+        for event in runner._queued_events[SESSION_KEY]
+    )
 
 
 @pytest.mark.asyncio
@@ -565,6 +603,46 @@ async def test_server_timeout_cancels_handler_and_returns_closed_failure(tmp_pat
 
 @pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
 @pytest.mark.asyncio
+async def test_blocking_production_lookup_times_out_without_later_injection(tmp_path, monkeypatch):
+    runner, adapter = _runner(_entry())
+    lookup_started = threading.Event()
+
+    def blocking_lookup(_session_id):
+        lookup_started.set()
+        time.sleep(0.2)
+        return False
+
+    runner.session_store._is_session_ended_in_db = Mock(side_effect=blocking_lookup)
+    monkeypatch.setattr(session_ipc, "_HANDLER_TIMEOUT_SECONDS", 0.01)
+    server = GatewaySessionIPCServer(
+        runner._inject_exact_session,
+        profile="jasper",
+        hermes_home=tmp_path,
+    )
+    await server.start()
+    try:
+        started = time.monotonic()
+        response = await asyncio.to_thread(
+            _raw_request,
+            server.socket_path,
+            _request_payload(idempotency_key="blocking-production-lookup"),
+        )
+        elapsed = time.monotonic() - started
+        assert lookup_started.is_set()
+        assert response["ok"] is False
+        assert response["error"]["code"] == "request_timeout"
+        assert elapsed < 0.1
+        await asyncio.sleep(0.25)
+    finally:
+        await server.stop()
+
+    adapter.accept_internal_task.assert_not_called()
+    assert adapter._pending_messages == {}
+    assert runner._queued_events == {}
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+@pytest.mark.asyncio
 async def test_reused_idempotency_key_with_different_payload_is_rejected(tmp_path):
     handler = AsyncMock(
         return_value={
@@ -595,6 +673,122 @@ async def test_reused_idempotency_key_with_different_payload_is_rejected(tmp_pat
     assert second["ok"] is False
     assert second["error"]["code"] == "idempotency_conflict"
     handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_unique_idempotency_admission_never_exceeds_hard_cap(monkeypatch):
+    release = asyncio.Event()
+
+    async def handler(**request):
+        await release.wait()
+        return {"ok": True, "idempotency_key": request["idempotency_key"]}
+
+    monkeypatch.setattr(session_ipc, "_MAX_IDEMPOTENCY_RECORDS", 3)
+    server = GatewaySessionIPCServer(handler, profile="jasper")
+    tasks = [
+        asyncio.create_task(
+            server._dispatch_idempotent(
+                f"concurrent-{index}",
+                {
+                    "profile": "jasper",
+                    "session_key": SESSION_KEY,
+                    "expected_session_id": SESSION_ID,
+                    "idempotency_key": f"concurrent-{index}",
+                    "message": f"task-{index}",
+                },
+            )
+        )
+        for index in range(5)
+    ]
+    try:
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert len(server._idempotency_tasks) <= session_ipc._MAX_IDEMPOTENCY_RECORDS
+        assert (
+            len(server._idempotency_tasks) + len(server._idempotency_results)
+            <= session_ipc._MAX_IDEMPOTENCY_RECORDS
+        )
+        assert len(server._idempotency_fingerprints) <= session_ipc._MAX_IDEMPOTENCY_RECORDS
+    finally:
+        release.set()
+        outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+
+    await asyncio.sleep(0)
+    assert server._idempotency_tasks == {}
+    assert (
+        len(server._idempotency_tasks) + len(server._idempotency_results)
+        <= session_ipc._MAX_IDEMPOTENCY_RECORDS
+    )
+    assert len(server._idempotency_fingerprints) <= session_ipc._MAX_IDEMPOTENCY_RECORDS
+    assert sum(
+        isinstance(outcome, SessionIPCRequestError) and outcome.code == "server_busy"
+        for outcome in outcomes
+    ) == 2
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_code"),
+    [
+        (ConnectionRefusedError("connect rejected"), "gateway_unavailable"),
+        (BrokenPipeError("peer rejected before send"), "transport_error"),
+        (socket.timeout("response deadline"), "request_timeout"),
+    ],
+)
+def test_client_socket_failures_are_normalized_and_cli_exits_nonzero(
+    tmp_path, monkeypatch, capsys, failure, expected_code
+):
+    socket_path = session_ipc.gateway_session_socket_path(tmp_path)
+    socket_path.parent.mkdir(parents=True)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(socket_path))
+    listener.listen(1)
+    socket_path.chmod(0o600)
+    try:
+        client = Mock()
+        client.__enter__ = Mock(return_value=client)
+        client.__exit__ = Mock(return_value=False)
+        if isinstance(failure, ConnectionRefusedError):
+            client.connect.side_effect = failure
+        elif isinstance(failure, BrokenPipeError):
+            client.sendall.side_effect = failure
+        else:
+            client.recv.side_effect = failure
+        monkeypatch.setattr(session_ipc.socket, "socket", Mock(return_value=client))
+
+        with pytest.raises(SessionIPCRequestError) as exc_info:
+            inject_gateway_session(
+                profile="jasper",
+                session_key=SESSION_KEY,
+                expected_session_id=SESSION_ID,
+                idempotency_key="stable-client-error",
+                message="Must fail stably",
+                hermes_home=tmp_path,
+            )
+        assert exc_info.value.code == expected_code
+
+        monkeypatch.setattr(
+            session_ipc,
+            "inject_gateway_session",
+            Mock(side_effect=exc_info.value),
+        )
+        with (
+            patch("hermes_cli.profiles.get_active_profile_name", return_value="jasper"),
+            pytest.raises(SystemExit) as cli_exit,
+        ):
+            _gateway_command_inner(
+                SimpleNamespace(
+                    gateway_command="inject",
+                    session_key=SESSION_KEY,
+                    expected_session_id=SESSION_ID,
+                    idempotency_key="stable-client-error",
+                    message="Must fail stably",
+                )
+            )
+        assert cli_exit.value.code == 1
+        assert json.loads(capsys.readouterr().out)["error"]["code"] == expected_code
+    finally:
+        listener.close()
+        socket_path.unlink(missing_ok=True)
 
 
 @pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -17,7 +17,7 @@ import pytest
 
 from gateway import run as gateway_run
 from gateway import session_ipc
-from gateway.config import PlatformConfig
+from gateway.config import GatewayConfig, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -229,6 +229,51 @@ async def test_idle_exact_route_uses_real_adapter_protected_acceptance_path():
     assert is_gateway_session_ipc_task(accepted_event)
     assert accepted_event.is_command() is False
     assert accepted_event.metadata["gateway_session_id"] == SESSION_ID
+
+
+@pytest.mark.asyncio
+async def test_idle_exact_route_heals_stale_adapter_guard_before_acceptance():
+    runner, _ = _runner(_entry())
+    adapter = _TestAdapter(
+        PlatformConfig(enabled=True, token="test"),
+        Platform.TELEGRAM,
+    )
+    runner._adapter_for_source = lambda source: adapter
+    adapter._start_session_processing = Mock(return_value=True)
+
+    async def _done():
+        return None
+
+    stale_task = asyncio.create_task(_done())
+    await stale_task
+    adapter._active_sessions[SESSION_KEY] = asyncio.Event()
+    adapter._session_tasks[SESSION_KEY] = stale_task
+
+    proof = await _inject(runner, "Do not strand this task")
+
+    assert proof["disposition"] == "queued"
+    adapter._start_session_processing.assert_called_once()
+    assert SESSION_KEY not in adapter._session_tasks
+
+
+@pytest.mark.asyncio
+async def test_multiplexer_accepts_exact_route_for_served_named_profile():
+    runner, adapter = _runner(_entry(profile="jasper"))
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+    runner._active_profile_name = lambda: "default"
+    runner._profile_adapters = {"jasper": {Platform.TELEGRAM: adapter}}
+
+    proof = await _inject(runner, "Route through the default multiplexer")
+
+    assert proof["profile"] == "jasper"
+    assert proof["disposition"] == "queued"
+    adapter.accept_internal_task.assert_called_once()
+
+
+def test_gateway_runner_constructs_one_busy_queue_lock():
+    runner = GatewayRunner(GatewayConfig())
+
+    assert runner._busy_queue_guard() is runner._busy_queue_lock
 
 
 @pytest.mark.asyncio
@@ -619,6 +664,43 @@ async def test_socket_rejects_cross_profile_and_malformed_json(tmp_path):
         assert calls == []
     finally:
         await server.stop()
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+@pytest.mark.asyncio
+async def test_multiplexer_socket_dispatches_served_named_profile(tmp_path):
+    handler = AsyncMock(
+        return_value={
+            "ok": True,
+            "profile": "jasper",
+            "session_key": SESSION_KEY,
+            "session_id": SESSION_ID,
+            "disposition": "queued",
+        }
+    )
+    server = GatewaySessionIPCServer(
+        handler,
+        profile="default",
+        served_profiles={"default", "jasper"},
+        hermes_home=tmp_path,
+    )
+    await server.start()
+    try:
+        response = await asyncio.to_thread(
+            inject_gateway_session,
+            profile="jasper",
+            session_key=SESSION_KEY,
+            expected_session_id=SESSION_ID,
+            idempotency_key="multiplex-server-1",
+            message="Route through one socket",
+            hermes_home=tmp_path,
+        )
+    finally:
+        await server.stop()
+
+    assert response["ok"] is True
+    assert response["profile"] == "jasper"
+    handler.assert_awaited_once()
 
 
 @pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
@@ -1085,3 +1167,49 @@ def test_gateway_inject_cli_parser_requires_exact_session_and_message():
     assert args.expected_session_id == SESSION_ID
     assert args.idempotency_key == "work-8491-message-1"
     assert args.message == "Do the task"
+
+
+def test_named_profile_inject_uses_default_multiplexer_socket(tmp_path, capsys):
+    active_socket = tmp_path / "named" / "run" / "gateway-session.sock"
+    default_home = tmp_path / "default"
+    default_socket = default_home / "run" / "gateway-session.sock"
+    default_socket.parent.mkdir(parents=True)
+    default_socket.touch()
+    inject_mock = Mock(
+        return_value={
+            "ok": True,
+            "profile": "jasper",
+            "session_key": SESSION_KEY,
+            "session_id": SESSION_ID,
+            "disposition": "queued",
+        }
+    )
+
+    def socket_path(home=None):
+        return default_socket if home == default_home else active_socket
+
+    with (
+        patch("hermes_cli.profiles.get_active_profile_name", return_value="jasper"),
+        patch("hermes_constants.get_default_hermes_root", return_value=default_home),
+        patch("gateway.session_ipc.gateway_session_socket_path", side_effect=socket_path),
+        patch("gateway.session_ipc.inject_gateway_session", inject_mock),
+    ):
+        _gateway_command_inner(
+            SimpleNamespace(
+                gateway_command="inject",
+                session_key=SESSION_KEY,
+                expected_session_id=SESSION_ID,
+                idempotency_key="multiplex-task-1",
+                message="Route this exactly",
+            )
+        )
+
+    inject_mock.assert_called_once_with(
+        profile="jasper",
+        session_key=SESSION_KEY,
+        expected_session_id=SESSION_ID,
+        idempotency_key="multiplex-task-1",
+        message="Route this exactly",
+        hermes_home=default_home,
+    )
+    assert json.loads(capsys.readouterr().out)["ok"] is True

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -23,6 +23,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     _new_gateway_session_ipc_event,
+    is_gateway_session_ipc_task,
 )
 from gateway.run import GatewayRunner
 from gateway.session import Platform, SessionEntry, SessionSource, build_session_key
@@ -185,6 +186,7 @@ async def test_exact_profile_local_idle_route_returns_session_proof_and_dispatch
         "Then preserve FIFO order.",
     ]
     assert all(isinstance(event, MessageEvent) for event in events)
+    assert all(is_gateway_session_ipc_task(event) for event in events)
     assert all(event.internal is True for event in events)
     assert all(event.source.profile == "jasper" for event in events)
     assert all(event.metadata["gateway_session_id"] == SESSION_ID for event in events)
@@ -203,6 +205,27 @@ async def test_active_exact_route_steers_without_platform_send_or_queue():
     agent.steer.assert_called_once_with("Use the corrected constraint.")
     adapter.accept_internal_task.assert_not_called()
     assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_idle_exact_route_uses_real_adapter_protected_acceptance_path():
+    runner, _ = _runner(_entry())
+    adapter = _TestAdapter(
+        PlatformConfig(enabled=True, token="test"),
+        Platform.TELEGRAM,
+    )
+    adapter._start_session_processing = Mock(return_value=True)
+    runner._adapter_for_source = lambda source: adapter
+
+    proof = await _inject(runner, "/restart is task text")
+
+    assert proof["disposition"] == "queued"
+    adapter._start_session_processing.assert_called_once()
+    accepted_event, accepted_key = adapter._start_session_processing.call_args.args
+    assert accepted_key == SESSION_KEY
+    assert is_gateway_session_ipc_task(accepted_event)
+    assert accepted_event.is_command() is False
+    assert accepted_event.metadata["gateway_session_id"] == SESSION_ID
 
 
 @pytest.mark.asyncio
@@ -906,7 +929,9 @@ async def test_stop_does_not_unlink_replacement_socket(tmp_path):
             original.st_dev,
             original.st_ino,
         )
-        await server.stop()
+        with pytest.raises(SessionIPCRequestError) as exc_info:
+            await server.stop()
+        assert exc_info.value.code == "socket_replaced"
         assert server.socket_path.exists()
         current = server.socket_path.lstat()
         assert (current.st_dev, current.st_ino) == (

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -500,6 +500,39 @@ async def test_failed_turn_requeues_mixed_steers_with_independent_trust():
     assert followup is existing
 
 
+def test_recursion_cap_preserves_deferred_head_behind_recovered_steer():
+    runner, adapter = _runner(_entry())
+    deferred = MessageEvent(
+        text="already deferred",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+    tail = MessageEvent(
+        text="later tail",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+    recovered = _new_gateway_session_ipc_event(
+        text="/restart trusted recovery",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        internal=True,
+    )
+    adapter._pending_messages[SESSION_KEY] = deferred
+    runner._queued_events[SESSION_KEY] = [tail]
+
+    queued = runner._queue_pending_at_recursion_cap(
+        SESSION_KEY,
+        _source(),
+        recovered,
+        recovered.text,
+    )
+
+    assert queued is True
+    assert adapter._pending_messages[SESSION_KEY] is recovered
+    assert runner._queued_events[SESSION_KEY] == [deferred, tail]
+
+
 @pytest.mark.asyncio
 async def test_busy_steer_queues_nonempty_text_when_admission_closed():
     runner, adapter = _runner(_entry())

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -202,7 +202,10 @@ async def test_active_exact_route_steers_without_platform_send_or_queue():
 
     assert proof["disposition"] == "steered"
     assert proof["session_id"] == SESSION_ID
-    agent.steer.assert_called_once_with("Use the corrected constraint.")
+    agent.steer.assert_called_once_with(
+        "Use the corrected constraint.",
+        _gateway_session_ipc=True,
+    )
     adapter.accept_internal_task.assert_not_called()
     assert adapter._pending_messages == {}
 
@@ -241,6 +244,10 @@ async def test_active_route_steer_fallback_uses_bounded_fifo_queue():
     assert [call.args for call in agent.steer.call_args_list] == [
         ("First queued task.",),
         ("Second queued task.",),
+    ]
+    assert [call.kwargs for call in agent.steer.call_args_list] == [
+        {"_gateway_session_ipc": True},
+        {"_gateway_session_ipc": True},
     ]
     adapter.accept_internal_task.assert_not_called()
     assert adapter._pending_messages[SESSION_KEY].text == "First queued task."
@@ -370,6 +377,22 @@ def test_trusted_slash_task_survives_drain_as_inert_text_while_user_slash_is_blo
         drained_user.text, drained_user
     ) is True
     assert drained_user.is_command() is True
+
+
+def test_leftover_gateway_ipc_steer_rebuilds_protected_event():
+    event = gateway_run._event_for_leftover_gateway_session_ipc_steer(
+        {
+            "pending_steer": "/restart trusted task",
+            "pending_steer_is_gateway_session_ipc": True,
+        },
+        _source(),
+    )
+
+    assert event is not None
+    assert event.text == "/restart trusted task"
+    assert is_gateway_session_ipc_task(event)
+    assert event.is_command() is False
+    assert gateway_run._pending_slash_is_command_leak(event.text, event) is False
 
 
 @pytest.mark.asyncio
@@ -687,6 +710,45 @@ async def test_client_timeout_retry_with_same_key_delivers_once(tmp_path):
 
     assert proof["disposition"] == "queued"
     assert calls == 1
+
+
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")
+@pytest.mark.asyncio
+async def test_uncommitted_failure_releases_idempotency_key_for_retry(tmp_path):
+    calls = 0
+
+    async def handler(**request):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return SessionIPCRequestError(
+                "queue_full",
+                "Pending queue is full",
+            ).to_response()
+        return {
+            "ok": True,
+            "profile": request["profile"],
+            "session_key": request["session_key"],
+            "session_id": request["expected_session_id"],
+            "disposition": "queued",
+        }
+
+    server = GatewaySessionIPCServer(handler, profile="jasper", hermes_home=tmp_path)
+    await server.start()
+    key = "retry-after-uncommitted-failure"
+    payload = _request_payload(idempotency_key=key)
+    try:
+        first = await asyncio.to_thread(_raw_request, server.socket_path, payload)
+        await asyncio.sleep(0)
+        second = await asyncio.to_thread(_raw_request, server.socket_path, payload)
+    finally:
+        await server.stop()
+
+    assert first["ok"] is False
+    assert first["error"]["code"] == "queue_full"
+    assert second["ok"] is True
+    assert second["disposition"] == "queued"
+    assert calls == 2
 
 
 @pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets unavailable")

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -302,6 +302,34 @@ async def test_active_route_steer_fallback_uses_bounded_fifo_queue():
 
 
 @pytest.mark.asyncio
+async def test_active_route_queue_mutation_runs_on_gateway_event_loop(
+    monkeypatch,
+):
+    runner, adapter = _runner(_entry())
+    runner._running_agents[SESSION_KEY] = SimpleNamespace(
+        steer=Mock(return_value=False)
+    )
+    event_loop_thread = threading.get_ident()
+    mutation_threads = []
+    original_enqueue = runner._enqueue_internal_fifo_event
+
+    def record_enqueue(*args, **kwargs):
+        mutation_threads.append(threading.get_ident())
+        return original_enqueue(*args, **kwargs)
+
+    monkeypatch.setattr(
+        runner,
+        "_enqueue_internal_fifo_event",
+        record_enqueue,
+    )
+
+    proof = await _inject(runner, "Queue on the owning loop")
+
+    assert proof["disposition"] == "queued"
+    assert mutation_threads == [event_loop_thread]
+
+
+@pytest.mark.asyncio
 async def test_internal_task_uses_separate_fifo_and_queue_full_preserves_user_media():
     runner, adapter = _runner(_entry())
     runner._running_agents[SESSION_KEY] = SimpleNamespace(steer=Mock(return_value=False))
@@ -391,6 +419,26 @@ def test_concurrent_user_and_ipc_admission_never_exceeds_busy_queue_cap(monkeypa
     assert not ipc_thread.is_alive()
     assert original_depth(SESSION_KEY, adapter=adapter) <= runner._BUSY_QUEUE_MAX_PENDING
     assert len(ipc_result) == 1
+
+
+def test_internal_enqueue_reports_its_own_committed_mutation(monkeypatch):
+    runner, adapter = _runner(_entry())
+    event = _new_gateway_session_ipc_event(
+        text="exact internal task",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        internal=True,
+    )
+    monkeypatch.setattr(runner, "_queue_depth", Mock(return_value=0))
+
+    accepted = runner._enqueue_internal_fifo_event(
+        SESSION_KEY,
+        event,
+        adapter,
+    )
+
+    assert accepted is True
+    assert adapter._pending_messages[SESSION_KEY] is event
 
 
 def test_trusted_slash_task_survives_drain_as_inert_text_while_user_slash_is_blocked():
@@ -1212,4 +1260,69 @@ def test_named_profile_inject_uses_default_multiplexer_socket(tmp_path, capsys):
         message="Route this exactly",
         hermes_home=default_home,
     )
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+
+
+def test_stale_named_profile_socket_falls_back_to_default_multiplexer(
+    tmp_path, capsys
+):
+    active_socket = tmp_path / "named" / "run" / "gateway-session.sock"
+    active_socket.parent.mkdir(parents=True)
+    active_socket.touch()
+    default_home = tmp_path / "default"
+    default_socket = default_home / "run" / "gateway-session.sock"
+    default_socket.parent.mkdir(parents=True)
+    default_socket.touch()
+    success = {
+        "ok": True,
+        "profile": "jasper",
+        "session_key": SESSION_KEY,
+        "session_id": SESSION_ID,
+        "disposition": "queued",
+    }
+    inject_mock = Mock(
+        side_effect=[
+            SessionIPCRequestError(
+                "gateway_unavailable",
+                "named socket refused connection",
+            ),
+            success,
+        ]
+    )
+
+    def socket_path(home=None):
+        return default_socket if home == default_home else active_socket
+
+    with (
+        patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="jasper",
+        ),
+        patch(
+            "hermes_constants.get_default_hermes_root",
+            return_value=default_home,
+        ),
+        patch(
+            "gateway.session_ipc.gateway_session_socket_path",
+            side_effect=socket_path,
+        ),
+        patch(
+            "gateway.session_ipc.inject_gateway_session",
+            inject_mock,
+        ),
+    ):
+        _gateway_command_inner(
+            SimpleNamespace(
+                gateway_command="inject",
+                session_key=SESSION_KEY,
+                expected_session_id=SESSION_ID,
+                idempotency_key="multiplex-task-stale-socket",
+                message="Route this exactly",
+            )
+        )
+
+    assert [call.kwargs["hermes_home"] for call in inject_mock.call_args_list] == [
+        None,
+        default_home,
+    ]
     assert json.loads(capsys.readouterr().out)["ok"] is True

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -18,7 +18,12 @@ import pytest
 from gateway import run as gateway_run
 from gateway import session_ipc
 from gateway.config import PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    _new_gateway_session_ipc_event,
+)
 from gateway.run import GatewayRunner
 from gateway.session import Platform, SessionEntry, SessionSource, build_session_key
 from gateway.session_ipc import (
@@ -270,12 +275,11 @@ def test_concurrent_user_and_ipc_admission_never_exceeds_busy_queue_cap(monkeypa
         message_type=MessageType.TEXT,
         source=_source(),
     )
-    ipc_event = MessageEvent(
+    ipc_event = _new_gateway_session_ipc_event(
         text="concurrent IPC follow-up",
         message_type=MessageType.TEXT,
         source=_source(),
         internal=True,
-        metadata={"gateway_session_ipc_task": True},
     )
     admission_barrier = threading.Barrier(2)
     original_depth = runner._queue_depth
@@ -316,12 +320,11 @@ def test_concurrent_user_and_ipc_admission_never_exceeds_busy_queue_cap(monkeypa
 
 def test_trusted_slash_task_survives_drain_as_inert_text_while_user_slash_is_blocked():
     runner, adapter = _runner(_entry())
-    trusted = MessageEvent(
+    trusted = _new_gateway_session_ipc_event(
         text="/restart trusted task",
         message_type=MessageType.TEXT,
         source=_source(),
         internal=True,
-        metadata={"gateway_session_ipc_task": True},
     )
     user = MessageEvent(
         text="/restart",
@@ -402,13 +405,12 @@ async def test_trusted_internal_task_is_never_command_coerced_or_dispatched_as_c
     adapter._busy_text_hard_cap_seconds = 0.0
     adapter._topic_recovery_fn = None
 
-    event = MessageEvent(
+    event = _new_gateway_session_ipc_event(
         text=task_text,
         message_type=MessageType.TEXT,
         source=_source(),
         internal=True,
         metadata={
-            "gateway_session_ipc_task": True,
             "gateway_session_key": SESSION_KEY,
             "gateway_session_id": SESSION_ID,
         },

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -533,6 +533,22 @@ def test_recursion_cap_preserves_deferred_head_behind_recovered_steer():
     assert runner._queued_events[SESSION_KEY] == [deferred, tail]
 
 
+def test_early_interrupt_result_requires_failed_turn_steer_recovery():
+    assert gateway_run._conversation_result_completed(
+        {
+            "completed": False,
+            "interrupted": True,
+            "final_response": "Operation interrupted during retry.",
+        }
+    ) is False
+    assert gateway_run._conversation_result_completed(
+        {
+            "completed": True,
+            "final_response": "Done.",
+        }
+    ) is True
+
+
 @pytest.mark.asyncio
 async def test_busy_steer_queues_nonempty_text_when_admission_closed():
     runner, adapter = _runner(_entry())

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -597,6 +597,65 @@ def test_mixed_leftover_steers_rebuild_separate_trust_domains():
     ) is False
 
 
+def test_recovered_ipc_steer_precedes_already_pending_followup():
+    followup = MessageEvent(
+        text="later follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+
+    next_event, next_text, deferred, recovered = (
+        gateway_run._prioritize_leftover_steers(
+            {
+                "pending_steer_chunks": [
+                    {
+                        "text": "/restart trusted task",
+                        "gateway_session_ipc": True,
+                    }
+                ]
+            },
+            _source(),
+            followup,
+            followup.text,
+        )
+    )
+
+    assert recovered is True
+    assert is_gateway_session_ipc_task(next_event)
+    assert next_text == "/restart trusted task"
+    assert deferred == [followup]
+
+
+def test_dropped_user_command_does_not_strand_recovered_ipc_steer():
+    followup = MessageEvent(
+        text="later follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+
+    next_event, next_text, deferred, recovered = (
+        gateway_run._prioritize_leftover_steers(
+            {
+                "pending_steer_chunks": [
+                    {"text": "/stop", "gateway_session_ipc": False},
+                    {
+                        "text": "/restart trusted task",
+                        "gateway_session_ipc": True,
+                    },
+                ]
+            },
+            _source(),
+            followup,
+            followup.text,
+        )
+    )
+
+    assert recovered is True
+    assert is_gateway_session_ipc_task(next_event)
+    assert next_text == "/restart trusted task"
+    assert deferred == [followup]
+
+
 @pytest.mark.asyncio
 async def test_missing_exact_route_fails_closed():
     runner, adapter = _runner()

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -470,6 +470,35 @@ async def test_failed_turn_requeues_accepted_ipc_steer_before_followups():
     assert recovered.text == "/restart trusted recovery task"
     assert runner._queued_events[SESSION_KEY] == [existing, tail]
 
+@pytest.mark.asyncio
+async def test_failed_turn_requeues_mixed_steers_with_independent_trust():
+    runner, adapter = _runner(_entry())
+    existing = MessageEvent(
+        text="already waiting",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+    adapter._pending_messages[SESSION_KEY] = existing
+
+    preserved = await runner._requeue_failed_turn_steers(
+        SESSION_KEY,
+        _source(),
+        [
+            ("/stop", False),
+            ("/restart trusted recovery task", True),
+        ],
+    )
+
+    user_command = adapter._pending_messages[SESSION_KEY]
+    trusted_task, followup = runner._queued_events[SESSION_KEY]
+    assert preserved is True
+    assert gateway_run._pending_slash_is_command_leak(
+        user_command.text, user_command
+    ) is True
+    assert is_gateway_session_ipc_task(trusted_task)
+    assert trusted_task.text == "/restart trusted recovery task"
+    assert followup is existing
+
 
 @pytest.mark.asyncio
 async def test_busy_steer_queues_nonempty_text_when_admission_closed():
@@ -539,6 +568,33 @@ def test_leftover_gateway_ipc_steer_rebuilds_protected_event():
     assert is_gateway_session_ipc_task(event)
     assert event.is_command() is False
     assert gateway_run._pending_slash_is_command_leak(event.text, event) is False
+
+def test_mixed_leftover_steers_rebuild_separate_trust_domains():
+    events = gateway_run._events_for_leftover_steers(
+        {
+            "pending_steer": "/stop\n/restart trusted task",
+            "pending_steer_chunks": [
+                {"text": "/stop", "gateway_session_ipc": False},
+                {
+                    "text": "/restart trusted task",
+                    "gateway_session_ipc": True,
+                },
+            ],
+        },
+        _source(),
+    )
+
+    assert [event.text for event in events] == [
+        "/stop",
+        "/restart trusted task",
+    ]
+    assert gateway_run._pending_slash_is_command_leak(
+        events[0].text, events[0]
+    ) is True
+    assert is_gateway_session_ipc_task(events[1])
+    assert gateway_run._pending_slash_is_command_leak(
+        events[1].text, events[1]
+    ) is False
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_ipc.py
+++ b/tests/gateway/test_session_ipc.py
@@ -441,6 +441,59 @@ def test_internal_enqueue_reports_its_own_committed_mutation(monkeypatch):
     assert adapter._pending_messages[SESSION_KEY] is event
 
 
+@pytest.mark.asyncio
+async def test_failed_turn_requeues_accepted_ipc_steer_before_followups():
+    runner, adapter = _runner(_entry())
+    existing = MessageEvent(
+        text="already waiting",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+    tail = MessageEvent(
+        text="later follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+    adapter._pending_messages[SESSION_KEY] = existing
+    runner._queued_events[SESSION_KEY] = [tail]
+
+    preserved = await runner._requeue_failed_turn_steer(
+        SESSION_KEY,
+        _source(),
+        "/restart trusted recovery task",
+        trusted_session_ipc=True,
+    )
+
+    recovered = adapter._pending_messages[SESSION_KEY]
+    assert preserved is True
+    assert is_gateway_session_ipc_task(recovered)
+    assert recovered.text == "/restart trusted recovery task"
+    assert runner._queued_events[SESSION_KEY] == [existing, tail]
+
+
+@pytest.mark.asyncio
+async def test_busy_steer_queues_nonempty_text_when_admission_closed():
+    runner, adapter = _runner(_entry())
+    runner._running_agents[SESSION_KEY] = SimpleNamespace(
+        steer=Mock(return_value=False)
+    )
+    event = MessageEvent(
+        text="/steer keep this guidance",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+
+    response = await runner._busy_steer_command(
+        event,
+        SESSION_KEY,
+        event.source,
+    )
+
+    assert response == "Steer admission closed — /steer queued for the next turn."
+    queued = adapter._pending_messages[SESSION_KEY]
+    assert queued.text == "keep this guidance"
+
+
 def test_trusted_slash_task_survives_drain_as_inert_text_while_user_slash_is_blocked():
     runner, adapter = _runner(_entry())
     trusted = _new_gateway_session_ipc_event(

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -86,6 +86,66 @@ class TestRunConversationCodexPath:
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
 
+    def test_failed_native_turn_returns_accepted_ipc_steer(self):
+        class FailedSession:
+            def request_steer(self, text):
+                return True
+
+            def run_turn(self, user_input):
+                raise RuntimeError("native turn failed")
+
+            def close(self):
+                return None
+
+        agent = _make_codex_agent()
+        agent._codex_session = FailedSession()
+        agent._open_steer_admission()
+        assert agent.steer(
+            "/restart trusted recovery",
+            _gateway_session_ipc=True,
+        )
+
+        result = agent.run_conversation("start")
+
+        assert result["completed"] is False
+        assert result["pending_steer_chunks"] == [
+            {
+                "text": "/restart trusted recovery",
+                "gateway_session_ipc": True,
+            }
+        ]
+        assert agent._codex_native_pending_steer_chunks == []
+
+    def test_successful_native_turn_acknowledges_accepted_steer(
+        self,
+    ):
+        class SuccessfulSession:
+            def request_steer(self, text):
+                return True
+
+            def run_turn(self, user_input):
+                return TurnResult(
+                    final_text="done",
+                    projected_messages=[
+                        {"role": "assistant", "content": "done"}
+                    ],
+                    interrupted=False,
+                    error=None,
+                    turn_id="turn-success",
+                    thread_id="thread-success",
+                )
+
+        agent = _make_codex_agent()
+        agent._codex_session = SuccessfulSession()
+        agent._open_steer_admission()
+        assert agent.steer("continue with tests")
+
+        result = agent.run_conversation("start")
+
+        assert result["completed"] is True
+        assert "pending_steer_chunks" not in result
+        assert agent._codex_native_pending_steer_chunks == []
+
     def test_codex_app_server_token_usage_updates_session_accounting(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
             return TurnResult(

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -23,6 +23,7 @@ def _bare_agent() -> AIAgent:
     agent = object.__new__(AIAgent)
     agent._pending_steer = None
     agent._pending_steer_lock = threading.Lock()
+    agent._steer_accepting = True
     agent._pending_redirect = None
     agent._pending_redirect_lock = threading.Lock()
     agent._model_request_active = threading.Event()
@@ -61,6 +62,23 @@ class TestSteerDrain:
         agent.steer("hello")
         assert agent._drain_pending_steer() == "hello"
         assert agent._pending_steer is None
+
+    def test_close_atomically_drains_and_rejects_late_steer(self):
+        agent = _bare_agent()
+        assert agent.steer("before close") is True
+
+        assert agent._close_steer_admission() == "before close"
+        assert agent.steer("too late") is False
+        assert agent._pending_steer is None
+
+    def test_new_turn_reopens_admission(self):
+        agent = _bare_agent()
+        agent._close_steer_admission()
+
+        agent._open_steer_admission()
+
+        assert agent.steer("new turn") is True
+        assert agent._drain_pending_steer() == "new turn"
 
 
 

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -211,6 +211,28 @@ class TestActiveTurnRedirect:
 
         assert calls == ["interrupt"]
 
+    def test_codex_app_server_steer_reaches_native_session(self):
+        agent = _bare_agent()
+        calls = []
+        agent.api_mode = "codex_app_server"
+        agent._codex_session = type(
+            "_CodexSession",
+            (),
+            {
+                "request_steer": (
+                    lambda self, text: calls.append(text) or True
+                )
+            },
+        )()
+        agent._open_steer_admission()
+
+        assert agent.steer(
+            "/restart trusted task",
+            _gateway_session_ipc=True,
+        )
+        assert calls == ["/restart trusted task"]
+        assert agent._pending_steer is None
+
 
     def test_redirect_during_tool_execution_uses_safe_steer_boundary(self):
         agent = _bare_agent()

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -514,6 +514,29 @@ class TestSteerClearedOnInterrupt:
         assert agent._pending_steer is None
         assert agent._pending_redirect is None
 
+    def test_clear_interrupt_retains_acknowledged_ipc_steers(self):
+        agent = _bare_agent()
+        agent._interrupt_requested = True
+        agent.steer("ordinary steer")
+        agent.steer(
+            "/restart acknowledged task",
+            _gateway_session_ipc=True,
+        )
+        native_token = object()
+        agent._codex_native_pending_steer_chunks = [
+            (object(), "ordinary native steer", False),
+            (native_token, "/status acknowledged task", True),
+        ]
+
+        agent.clear_interrupt()
+
+        assert agent._drain_pending_steer_chunks() == [
+            ("/restart acknowledged task", True),
+        ]
+        assert agent._codex_native_pending_steer_chunks == [
+            (native_token, "/status acknowledged task", True),
+        ]
+
 
 class TestPreApiCallSteerDrain:
     """Test that steers arriving during an API call are drained before the

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -23,6 +23,7 @@ def _bare_agent() -> AIAgent:
     agent = object.__new__(AIAgent)
     agent._pending_steer = None
     agent._pending_steer_lock = threading.Lock()
+    agent._pending_steer_is_gateway_session_ipc = False
     agent._steer_accepting = True
     agent._pending_redirect = None
     agent._pending_redirect_lock = threading.Lock()
@@ -79,6 +80,20 @@ class TestSteerDrain:
 
         assert agent.steer("new turn") is True
         assert agent._drain_pending_steer() == "new turn"
+
+    def test_close_preserves_gateway_session_ipc_provenance(self):
+        agent = _bare_agent()
+        assert agent.steer(
+            "/restart trusted task",
+            _gateway_session_ipc=True,
+        ) is True
+
+        text, trusted = agent._close_steer_admission_with_provenance()
+
+        assert text == "/restart trusted task"
+        assert trusted is True
+        assert agent._pending_steer is None
+        assert agent._pending_steer_is_gateway_session_ipc is False
 
 
 

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -23,7 +23,9 @@ def _bare_agent() -> AIAgent:
     agent = object.__new__(AIAgent)
     agent._pending_steer = None
     agent._pending_steer_lock = threading.Lock()
+    agent._pending_steer_chunks = []
     agent._pending_steer_is_gateway_session_ipc = False
+    agent._codex_native_pending_steer_chunks = []
     agent._steer_accepting = True
     agent._pending_redirect = None
     agent._pending_redirect_lock = threading.Lock()
@@ -94,6 +96,20 @@ class TestSteerDrain:
         assert trusted is True
         assert agent._pending_steer is None
         assert agent._pending_steer_is_gateway_session_ipc is False
+
+    def test_mixed_steers_retain_independent_provenance(self):
+        agent = _bare_agent()
+        assert agent.steer("/stop") is True
+        assert agent.steer(
+            "/restart trusted task",
+            _gateway_session_ipc=True,
+        ) is True
+
+        assert agent._close_steer_admission_with_chunks() == [
+            ("/stop", False),
+            ("/restart trusted task", True),
+        ]
+        assert agent._pending_steer is None
 
 
 
@@ -232,6 +248,24 @@ class TestActiveTurnRedirect:
         )
         assert calls == ["/restart trusted task"]
         assert agent._pending_steer is None
+        assert [
+            (text, trusted)
+            for _token, text, trusted in (
+                agent._codex_native_pending_steer_chunks
+            )
+        ] == [("/restart trusted task", True)]
+
+    def test_rejected_codex_native_steer_is_not_retained(self):
+        agent = _bare_agent()
+        agent.api_mode = "codex_app_server"
+        agent._codex_session = type(
+            "_CodexSession",
+            (),
+            {"request_steer": lambda self, text: False},
+        )()
+
+        assert agent.steer("too late") is False
+        assert agent._codex_native_pending_steer_chunks == []
 
 
     def test_redirect_during_tool_execution_uses_safe_steer_boundary(self):

--- a/tests/run_agent/test_tool_batch_segmentation.py
+++ b/tests/run_agent/test_tool_batch_segmentation.py
@@ -327,6 +327,9 @@ class TestSegmentedDispatchIntegration:
         def fake_handle(name, args, task_id, **kwargs):
             return json.dumps({"ok": True})
 
+        # This direct dispatcher test bypasses run_conversation(), which opens
+        # steer admission for a live turn in production.
+        agent._open_steer_admission()
         agent.steer("focus on the tests")
         with patch("run_agent.handle_function_call", side_effect=fake_handle):
             agent._execute_tool_calls(msg, messages, "task-1")


### PR DESCRIPTION
## Motivation

Hermes currently has no supported way for trusted local tooling to submit a task to one exact live gateway session while preserving that gateway's own active-turn, queue, and steer state. Starting a separate resumed process can race the gateway and does not share the live session's execution surface.

This PR adds a narrow, owner-local gateway control-plane primitive for that use case.

Related upstream requests:

- #51079 — local IPC/API messaging into a running Hermes session
- #65448 — gateway-session message injection
- #17415 — trusted internal triggers between gateway role sessions

This PR implements the gateway-focused local IPC primitive. It does not claim to fully close the broader CLI, plugin, authorization, or role-routing requirements in those issues.

## Summary

- add owner-local Unix IPC for exact live gateway-session injection
- atomically validate profile, route, expected session ID, lifecycle, and idempotency before acceptance
- use the protected `_new_gateway_session_ipc_event(...)` contract for idle and queued delivery
- preserve trusted IPC tasks across turn completion, exceptions, hard interrupts, Codex-native steering, recursion caps, and existing queued follow-ups
- serialize busy-queue admission and heal stale adapter guards before accepting work
- support multiplexed profiles with stale named-socket fallback
- keep slash-leading injected task text inert rather than coercing it into a platform command
- return structured acceptance proof containing the exact profile, session key, session ID, and disposition

## Scope and non-goals

- gateway sessions only; this is not a general network API
- owner-local Unix-domain transport only; no TCP listener or public exposure
- fail closed on missing, stale, ambiguous, cross-profile, or mismatched routes
- no replacement for Hermes Kanban or `delegate_task`
- no claim that this alone completes every workflow described by the linked issues

## Security boundary

Platform and user input remains untrusted. The Unix-domain endpoint is owner-local and rejects unknown or different peer UIDs. The gateway validates the exact expected route and session before accepting work. Loaded Python code already executing inside the trusted gateway process is outside this control-plane boundary.

## Verification

- exact head: `e090c251ee3a8af8e45d70c84e69501ee86d17dd`
- 149 affected tests passed in a valid short-path Unix-socket environment
- full fork GitHub Actions workflow passed on the exact head
- fresh exact-head Codex review found no major issues
- real-adapter idle injection and slash-leading queued-task regressions included
- deterministic socket, queue, trust, timeout, recovery, and idempotency regressions passed
- Ruff and `git diff --check` passed
