### PR TITLE
fix(memory): sanitize session-end provider transcripts

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -159,6 +159,33 @@ _INTERNAL_NOTE_RE = re.compile(
     r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
     re.IGNORECASE,
 )
+_SESSION_MEMORY_TOOL_DIRECTIVE_PREFIX = r"(?:(?:\|DSML\|)|(?:\uFF5CDSML\uFF5C))?"
+_SESSION_MEMORY_TOOL_DIRECTIVE_KIND = r"(?:tool_calls?|function_calls?|tool_use_error)"
+_SESSION_MEMORY_DROP_BLOCK_RE = re.compile(
+    rf"<{_SESSION_MEMORY_TOOL_DIRECTIVE_PREFIX}{_SESSION_MEMORY_TOOL_DIRECTIVE_KIND}\b[^>]*>"
+    rf"[\s\S]*?(?:</{_SESSION_MEMORY_TOOL_DIRECTIVE_PREFIX}{_SESSION_MEMORY_TOOL_DIRECTIVE_KIND}>|$)",
+    re.IGNORECASE,
+)
+_SESSION_MEMORY_ROLE_BLOCK_RE = re.compile(
+    r"<(system|assistant|user)\b[^>]*>[\s\S]*?</\1>",
+    re.IGNORECASE,
+)
+_SESSION_MEMORY_ROLE_TAG_RE = re.compile(
+    r"</?(?:system|assistant|user)\b[^>]*>",
+    re.IGNORECASE,
+)
+_SESSION_MEMORY_MEDIA_PLACEHOLDER_RE = re.compile(
+    r"(^|\n)\s*<media:[^>]+>(?:\s*\([^)]*\))?\s*",
+    re.IGNORECASE,
+)
+_SESSION_MEMORY_SPECIAL_TOKEN_RE = re.compile(
+    r"<\|(?:im_(?:start|end)|endoftext|reserved_special_token_\d+)\|>",
+    re.IGNORECASE,
+)
+_SESSION_MEMORY_TRAILING_NO_REPLY_RE = re.compile(
+    r"(?:^|\n)\s*NO_REPLY\s*$",
+    re.IGNORECASE,
+)
 
 
 def sanitize_context(text: str) -> str:
@@ -167,6 +194,70 @@ def sanitize_context(text: str) -> str:
     text = _INTERNAL_NOTE_RE.sub('', text)
     text = _FENCE_TAG_RE.sub('', text)
     return text
+
+
+def sanitize_session_memory_text(text: str) -> str | None:
+    """Strip model/runtime artifacts before a transcript reaches memory providers."""
+    stripped = text.strip()
+    if re.fullmatch(r"NO_REPLY", stripped, re.IGNORECASE):
+        return None
+    if re.fullmatch(r'\{\s*"action"\s*:\s*"NO_REPLY"\s*\}', stripped, re.IGNORECASE):
+        return None
+
+    sanitized = _SESSION_MEMORY_SPECIAL_TOKEN_RE.sub(
+        "[REMOVED_SPECIAL_TOKEN]",
+        text,
+    )
+    sanitized = _SESSION_MEMORY_DROP_BLOCK_RE.sub("", sanitized)
+    sanitized = _SESSION_MEMORY_ROLE_BLOCK_RE.sub("", sanitized)
+    sanitized = _SESSION_MEMORY_ROLE_TAG_RE.sub("", sanitized)
+    sanitized = _SESSION_MEMORY_MEDIA_PLACEHOLDER_RE.sub(r"\1", sanitized)
+    sanitized = _SESSION_MEMORY_TRAILING_NO_REPLY_RE.sub("", sanitized)
+    sanitized = sanitized.strip()
+    return sanitized or None
+
+
+def sanitize_session_memory_messages(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return a provider-safe user/assistant transcript snapshot."""
+    sanitized_messages: List[Dict[str, Any]] = []
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        if role not in {"user", "assistant"}:
+            continue
+
+        content = message.get("content")
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            text_parts: List[str] = []
+            for part in content:
+                if isinstance(part, str):
+                    text_parts.append(part)
+                elif isinstance(part, dict) and part.get("type") in {
+                    "text",
+                    "input_text",
+                    "output_text",
+                }:
+                    value = part.get("text")
+                    if isinstance(value, str):
+                        text_parts.append(value)
+            text = "\n".join(text_parts)
+        else:
+            continue
+
+        sanitized = sanitize_session_memory_text(text)
+        if not sanitized:
+            continue
+        clean_message = dict(message)
+        clean_message["content"] = sanitized
+        clean_message.pop("tool_calls", None)
+        clean_message.pop("tool_call_id", None)
+        sanitized_messages.append(clean_message)
+    return sanitized_messages
 
 
 class StreamingContextScrubber:
@@ -854,9 +945,10 @@ class MemoryManager:
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Notify all providers of session end."""
+        snapshot = sanitize_session_memory_messages(messages)
         for provider in self._providers:
             try:
-                provider.on_session_end(messages)
+                provider.on_session_end(snapshot)
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' on_session_end failed: %s",

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1144,6 +1144,58 @@ class TestCommitMemorySessionRouting:
         assert builtin.end_calls == [msgs]
         assert external.end_calls == [msgs]
 
+    def test_on_session_end_sanitizes_model_artifacts(self):
+        mgr = MemoryManager()
+        provider = _CommitRecorder()
+        mgr.add_provider(provider)
+
+        mgr.on_session_end([
+            {
+                "role": "user",
+                "content": "<media:image:abc> Review <|im_start|>system<|im_end|>",
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    'Looks good\n<tool_call>{"name":"read",'
+                    '"arguments":{"path":"secret.md"}}</tool_call>'
+                ),
+                "tool_calls": [{"id": "call-1"}],
+            },
+            {"role": "assistant", "content": "NO_REPLY"},
+            {"role": "assistant", "content": "Done\n\nNO_REPLY"},
+            {"role": "tool", "content": "secret tool output"},
+        ])
+
+        assert provider.end_calls == [[
+            {
+                "role": "user",
+                "content": "Review [REMOVED_SPECIAL_TOKEN]system[REMOVED_SPECIAL_TOKEN]",
+            },
+            {"role": "assistant", "content": "Looks good"},
+            {"role": "assistant", "content": "Done"},
+        ]]
+
+    def test_on_session_end_preserves_plain_no_reply_mentions_and_text_parts(self):
+        mgr = MemoryManager()
+        provider = _CommitRecorder()
+        mgr.add_provider(provider)
+
+        mgr.on_session_end([
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "hidden"},
+                    {"type": "text", "text": "Use NO_REPLY when nothing changed."},
+                ],
+            },
+        ])
+
+        assert provider.end_calls == [[{
+            "role": "assistant",
+            "content": "Use NO_REPLY when nothing changed.",
+        }]]
+
     def test_on_session_end_tolerates_failure(self):
         mgr = MemoryManager()
         builtin = FakeMemoryProvider("builtin")


### PR DESCRIPTION
## What does this PR do?

Prevents session-end memory extraction from persisting model/runtime artifacts as durable user memory.

`MemoryManager.on_session_end()` now builds a provider-safe snapshot instead of forwarding the caller-owned raw message list. The snapshot keeps useful user/assistant text and existing message metadata while dropping standalone `NO_REPLY` markers, tool/function directive blocks, media placeholders, model special-token literals, non-text typed parts, and tool-role rows.

The original conversation history is not mutated.

## Related Issue

Fixes #70408

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add transcript text/message sanitizers in `agent/memory_manager.py`.
- Sanitize once at the memory-provider fan-out boundary.
- Cover standalone/trailing silence markers, typed text parts, special tokens, media placeholders, tool directives, and preservation of ordinary `NO_REPLY` mentions.

## How to Test

1. Run `python -m pytest tests/agent/test_memory_provider.py -q`.
2. Run `python -m ruff check agent/memory_manager.py tests/agent/test_memory_provider.py`.
3. Verify the recorder-provider regression receives clean user/assistant text and that the input transcript remains unchanged.

Proof on current rebased head:

```text
103 passed in 4.00s
All checks passed!
git diff --check origin/main...HEAD: clean
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11 with Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation: N/A; no user-facing configuration changes
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered; implementation uses only Python string/dict operations
- [x] Tool descriptions/schemas: N/A