### PR TITLE
fix(gateway): include _pending_native_image_paths_by_session in _CONVERSATION_SCOPED_STATE

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2143,6 +2143,10 @@ _CONVERSATION_SCOPED_STATE: tuple = (
     # and run_sync) must not leak into a future conversation's first user
     # message — session keys are source-derived and REUSED.
     "_pending_turn_sidecar_notes",
+    # Staged-but-never-consumed native image paths (turn aborted or reset
+    # before run_conversation) must not leak into subsequent turns or
+    # new conversations on reused session keys.
+    "_pending_native_image_paths_by_session",
 )
 
 # Sentinel for "caller did not pass metadata" vs "caller passed None".

--- a/tests/gateway/test_conversation_scope_pending_native_images.py
+++ b/tests/gateway/test_conversation_scope_pending_native_images.py
@@ -1,0 +1,28 @@
+"""Regression test for _pending_native_image_paths_by_session conversation scope clearing."""
+
+from unittest.mock import MagicMock
+from gateway.run import GatewayRunner, _CONVERSATION_SCOPED_STATE
+
+
+def test_conversation_scoped_state_contains_pending_native_image_paths():
+    """Verify _pending_native_image_paths_by_session is registered in _CONVERSATION_SCOPED_STATE."""
+    assert "_pending_native_image_paths_by_session" in _CONVERSATION_SCOPED_STATE
+
+
+def test_clear_conversation_scope_clears_pending_native_images():
+    """Verify _clear_conversation_scope purges staged native image paths for session_key."""
+    runner = object.__new__(GatewayRunner)
+    session_key = "test_session_key_123"
+    runner._pending_native_image_paths_by_session = {
+        session_key: ["/tmp/staged_image1.png", "/tmp/staged_image2.jpg"],
+        "other_session": ["/tmp/other.png"],
+    }
+
+    # Mock security boundary helper call inside _clear_conversation_scope
+    runner._clear_session_boundary_security_state = MagicMock()
+
+    runner._clear_conversation_scope(session_key, reason="test_reset")
+
+    assert session_key not in runner._pending_native_image_paths_by_session
+    assert "other_session" in runner._pending_native_image_paths_by_session
+    assert runner._pending_native_image_paths_by_session["other_session"] == ["/tmp/other.png"]


### PR DESCRIPTION
## Summary

Adds `_pending_native_image_paths_by_session` to `_CONVERSATION_SCOPED_STATE` in `gateway/run.py` so staged native image file paths are automatically purged when clearing a conversation scope (`_clear_conversation_scope`).

## Why

When an inbound message containing images is processed, `_prepare_inbound_message_text()` stages native image paths into `self._pending_native_image_paths_by_session[session_key]` for consumption during `run_conversation()`.

If a turn is aborted or fails between staging and execution, or if a conversation boundary reset (`/new`, `/reset`, session reset, compression auto-reset) occurs, `_pending_native_image_paths_by_session` was omitted from `_CONVERSATION_SCOPED_STATE`. Because session keys are source-derived and reused across turns, the staged image paths leaked into subsequent turns or new conversations on that session key, attaching stale/deleted image files to a new user message.

## Key Changes

- **Gateway Scope Registry**: Added `"_pending_native_image_paths_by_session"` to `_CONVERSATION_SCOPED_STATE` in `gateway/run.py`.
- **Tests**: Added `tests/gateway/test_conversation_scope_pending_native_images.py` to assert registration in `_CONVERSATION_SCOPED_STATE` and verify scope clearing behavior.

## Test
```bash
python -m pytest tests/gateway/test_conversation_scope_pending_native_images.py -q --timeout-method=thread