### PR TITLE
fix: break unbounded 401 retry loop in credential pool OAuth path (#70401)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1778,17 +1778,14 @@ class CredentialPool:
                 if entry is None:
                     # The failed key is identifiable but matches no entry
                     # (rotated away, or a wrapper whose runtime key differs).
-                    # Falling through to current()/_select_unlocked() would
-                    # mark an INNOCENT healthy key exhausted for the full
-                    # cooldown TTL.  Don't guess — just hand back a fresh
-                    # selection so the caller can retry.
+                    # Fall through to mark the current entry exhausted so
+                    # the pool can reach "no available entries" and surface
+                    # the error instead of retrying the same token forever.
                     logger.info(
                         "credential pool: failed key hint matched no %s entry; "
-                        "rotating without marking any credential exhausted",
+                        "marking current credential exhausted to break retry loop",
                         self.provider,
                     )
-                    self._current_id = None
-                    return self._select_unlocked()
             if entry is None:
                 entry = self._current_unlocked() or self._select_unlocked()
             if entry is None:


### PR DESCRIPTION
## Summary

When `api_key_hint` from a 401 response doesn't match any pool entry (common with OAuth tokens where `runtime_api_key` rotates), the code returns `_select_unlocked()` without marking anything exhausted. With a single-credential pool (typical OAuth setup), this returns the **same token**, causing an infinite retry loop (~6 attempts/sec) that ignores `/stop` commands and can only be killed by externally killing the gateway process.

## Root Cause

In `mark_exhausted_and_rotate()` (`agent/credential_pool.py:1778`), when `api_key_hint` doesn't match any entry:

```python
if entry is None:
    # "Don't guess — just hand back a fresh selection"
    self._current_id = None
    return self._select_unlocked()  # Returns the SAME token!
```

For OAuth tokens, the hint never matches because `runtime_api_key` rotates. With only 1 pool entry, `_select_unlocked()` returns that same entry. Caller retries → same 401 → same branch → infinite loop. No backoff, no cap, no user interrupt possible.

## Fix

Remove the early return and fall through to the normal path that marks the current entry exhausted. This allows the pool to reach "no available entries" and surface the error to the user.

**Before**: `return self._select_unlocked()` (infinite loop)
**After**: Falls through to `_mark_exhausted(entry)` → error propagates

Fixes #70401
