### PR TITLE
fix(mcp): skip dynamic tool refresh when session is closed or superseded

### DIFF
--- a/tests/tools/test_mcp_dynamic_discovery.py
+++ b/tests/tools/test_mcp_dynamic_discovery.py
@@ -75,6 +75,20 @@ class TestRefreshTools:
             assert "mcp__live_srv__new_tool" in resolve_toolset("live_srv")
             assert server._registered_tool_names == ["mcp__live_srv__new_tool"]
 
+    @pytest.mark.asyncio
+    async def test_skips_refresh_before_session_ready(self, mock_registry):
+        """Startup notifications can arrive before ClientSession is assigned."""
+        server = MCPServerTask("early_srv")
+        server._refresh_lock = asyncio.Lock()
+        server._config = {}
+        server.session = None
+        server._registered_tool_names = ["mcp_early_srv_old_tool"]
+
+        with patch("tools.registry.registry", mock_registry):
+            await server._refresh_tools()
+
+        assert server._registered_tool_names == ["mcp_early_srv_old_tool"]
+
 
 class TestMessageHandler:
     """Tests for MCPServerTask._make_message_handler dispatch."""

--- a/tests/tools/test_mcp_dynamic_discovery.py
+++ b/tests/tools/test_mcp_dynamic_discovery.py
@@ -75,6 +75,214 @@ class TestRefreshTools:
             assert "mcp__live_srv__new_tool" in resolve_toolset("live_srv")
             assert server._registered_tool_names == ["mcp__live_srv__new_tool"]
 
+    @pytest.mark.asyncio
+    async def test_skips_refresh_before_session_ready(self, mock_registry):
+        """Startup notifications can arrive before ClientSession is assigned."""
+        server = MCPServerTask("early_srv")
+        server._config = {}
+        server.session = None
+        server._registered_tool_names = ["mcp_early_srv_old_tool"]
+
+        with patch("tools.registry.registry", mock_registry):
+            await server._refresh_tools()
+
+        assert server._registered_tool_names == ["mcp_early_srv_old_tool"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_tools_ignores_closed_session(self, mock_registry):
+        """A queued dynamic refresh can race with shutdown/reconnect."""
+        server = MCPServerTask("srv")
+        server.session = None
+        server._registered_tool_names = ["mcp__srv__old"]
+
+        with patch("tools.registry.registry", mock_registry):
+            await server._refresh_tools()
+
+        assert server._registered_tool_names == ["mcp__srv__old"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_resolves_session_after_waiting_for_rpc_lock(self):
+        """A reconnect while queued must query the replacement session."""
+        server = MCPServerTask("srv")
+        old_session = MagicMock()
+        old_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+        new_session = MagicMock()
+        new_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+        server.session = old_session
+
+        await server._rpc_lock.acquire()
+        task = asyncio.create_task(server._refresh_tools())
+        await asyncio.sleep(0)
+        server._adopt_session(new_session)
+        server._rpc_lock.release()
+        await task
+
+        old_session.list_tools.assert_not_awaited()
+        new_session.list_tools.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_discards_response_from_superseded_session(self, mock_registry):
+        """An old in-flight response must not mutate the current registry."""
+        started = asyncio.Event()
+        finish = asyncio.Event()
+        server = MCPServerTask("srv")
+        old_session = MagicMock()
+
+        async def list_tools():
+            started.set()
+            await finish.wait()
+            return SimpleNamespace(tools=[_make_mcp_tool("stale_tool")])
+
+        old_session.list_tools = AsyncMock(side_effect=list_tools)
+        server.session = old_session
+        server._registered_tool_names = ["mcp__srv__old"]
+        mock_registry.register(
+            name="mcp__srv__old", toolset="mcp-srv", schema={},
+            handler=lambda x: x, check_fn=lambda: True, is_async=False,
+            description="", emoji="",
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            task = asyncio.create_task(server._refresh_tools())
+            await started.wait()
+            server._adopt_session(MagicMock())
+            finish.set()
+            await task
+
+        assert server._registered_tool_names == ["mcp__srv__old"]
+        assert "mcp__srv__stale_tool" not in mock_registry.get_all_tool_names()
+
+    @pytest.mark.asyncio
+    async def test_refresh_uses_locked_capability_snapshot(self):
+        """Capability must come from the locked generation, not the old one."""
+        server = MCPServerTask("srv")
+        old_session = MagicMock()
+        old_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+        new_session = MagicMock()
+        new_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+        server.session = old_session
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace(), prompts=None)
+        )
+
+        await server._rpc_lock.acquire()
+        task = asyncio.create_task(server._refresh_tools())
+        await asyncio.sleep(0)
+        server._adopt_session(new_session)
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=None, prompts=SimpleNamespace())
+        )
+        server._rpc_lock.release()
+        await task
+
+        old_session.list_tools.assert_not_awaited()
+        new_session.list_tools.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "config",
+        [{}, {"url": "https://mcp.example.test/mcp"}],
+        ids=["stdio", "streamable-http"],
+    )
+    async def test_refresh_skips_closed_transport_during_teardown(
+        self, mock_registry, caplog, config
+    ):
+        """ClientSession can stay referenced while its transport is dying."""
+        from anyio import ClosedResourceError
+
+        started = asyncio.Event()
+        finish = asyncio.Event()
+        server = MCPServerTask("srv")
+        server._config = config
+        session = MagicMock()
+
+        async def list_tools():
+            started.set()
+            await finish.wait()
+            raise ClosedResourceError()
+
+        session.list_tools = list_tools
+        server.session = session
+        server._registered_tool_names = ["mcp__srv__old"]
+        mock_registry.register(
+            name="mcp__srv__old", toolset="mcp-srv", schema={},
+            handler=lambda x: x, check_fn=lambda: True, is_async=False,
+            description="", emoji="",
+        )
+
+        with patch("tools.registry.registry", mock_registry), caplog.at_level("DEBUG"):
+            task = server._schedule_tools_refresh()
+            await started.wait()
+            # Same interleaving as ClientSession.__aexit__: pointer remains,
+            # transport is invalidated, generation is bumped first.
+            server._invalidate_session_generation()
+            finish.set()
+            await task
+
+        assert server._registered_tool_names == ["mcp__srv__old"]
+        assert "mcp__srv__old" in mock_registry.get_all_tool_names()
+        assert "dynamic tool refresh failed" not in caplog.text
+        assert task not in server._pending_refresh_tasks
+
+    @pytest.mark.asyncio
+    async def test_refresh_propagates_genuine_protocol_errors(self, caplog):
+        """Do not swallow tools/list failures that are not teardown."""
+        server = MCPServerTask("srv")
+        session = MagicMock()
+        session.list_tools = AsyncMock(side_effect=RuntimeError("tools/list exploded"))
+        server.session = session
+
+        with pytest.raises(RuntimeError, match="tools/list exploded"):
+            await server._refresh_tools()
+
+        with caplog.at_level("ERROR"):
+            await server._refresh_tools_task()
+        assert "dynamic tool refresh failed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_refresh_logs_unexpected_closed_transport(self, caplog):
+        """Closed transport is not skipped unless that generation is dying."""
+        from anyio import ClosedResourceError
+
+        server = MCPServerTask("srv")
+        session = MagicMock()
+        session.list_tools = AsyncMock(side_effect=ClosedResourceError())
+        server.session = session
+
+        with pytest.raises(ClosedResourceError):
+            await server._refresh_tools()
+
+        with caplog.at_level("ERROR"):
+            await server._refresh_tools_task()
+        assert "dynamic tool refresh failed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_return_invalidates_generation_before_context_exit(self):
+        """Shutdown/reconnect must bump generation while the pointer is still set."""
+        server = MCPServerTask("srv")
+        live = object()
+        server.session = live
+        generation = server._session_generation
+        server._shutdown_event.set()
+
+        reason = await server._wait_for_lifecycle_event()
+
+        assert reason == "shutdown"
+        assert server.session is live
+        assert server._session_generation != generation
+        assert server._refresh_generation_stale(generation, live)
+
+    @pytest.mark.asyncio
+    async def test_stdio_recycle_invalidates_generation(self):
+        server = MCPServerTask("srv")
+        server.session = object()
+        generation = server._session_generation
+
+        server._mark_stdio_recycled("idle_timeout_seconds")
+
+        assert server.session is None
+        assert server._session_generation != generation
+
 
 class TestMessageHandler:
     """Tests for MCPServerTask._make_message_handler dispatch."""

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1193,6 +1193,70 @@ class TestMCPServerTask:
                 "mcp__srv__get_prompt",
             }
 
+    def test_refresh_tools_ignores_closed_session(self):
+        """A queued dynamic refresh can race with shutdown/reconnect."""
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("srv")
+        server.session = None
+        server._registered_tool_names = ["mcp__srv__old"]
+
+        asyncio.run(server._refresh_tools())
+
+        assert server._registered_tool_names == ["mcp__srv__old"]
+
+    def test_refresh_resolves_session_after_waiting_for_rpc_lock(self):
+        """A reconnect while queued must query the replacement session."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("srv")
+            old_session = MagicMock()
+            old_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+            new_session = MagicMock()
+            new_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+            server.session = old_session
+
+            await server._rpc_lock.acquire()
+            task = asyncio.create_task(server._refresh_tools())
+            await asyncio.sleep(0)
+            server.session = new_session
+            server._rpc_lock.release()
+            await task
+
+            old_session.list_tools.assert_not_awaited()
+            new_session.list_tools.assert_awaited_once()
+
+        asyncio.run(_test())
+
+    def test_refresh_discards_response_from_superseded_session(self):
+        """An old in-flight response must not mutate the current registry."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            started = asyncio.Event()
+            finish = asyncio.Event()
+            server = MCPServerTask("srv")
+            old_session = MagicMock()
+
+            async def list_tools():
+                started.set()
+                await finish.wait()
+                return SimpleNamespace(tools=[])
+
+            old_session.list_tools = AsyncMock(side_effect=list_tools)
+            server.session = old_session
+            server._registered_tool_names = ["mcp__srv__old"]
+            task = asyncio.create_task(server._refresh_tools())
+            await started.wait()
+            server.session = MagicMock()
+            finish.set()
+            await task
+
+            assert server._registered_tool_names == ["mcp__srv__old"]
+
+        asyncio.run(_test())
+
     def test_schedule_tools_refresh_keeps_task_until_done(self):
         """Background refresh tasks are strongly referenced and then discarded."""
         from tools.mcp_tool import MCPServerTask

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2091,11 +2091,29 @@ class MCPServerTask:
             # Capture old tool names for change diff
             old_tool_names = set(self._registered_tool_names)
 
-            # 1. Fetch current tool list from server (follow nextCursor)
+            # 1. Resolve the current session only after entering the RPC lock,
+            # then fetch every page. A refresh can queue behind shutdown or a
+            # reconnect; capturing before the lock would query a stale session.
             async with self._rpc_lock:
+                session = self.session
+                if session is None:
+                    logger.debug(
+                        "MCP server '%s': skipping dynamic tool refresh; session is closed",
+                        self.name,
+                    )
+                    return
                 new_mcp_tools = await _paginate_full_list(
-                    self.session.list_tools, "tools", self.name
+                    session.list_tools, "tools", self.name
                 )
+
+            # Reconnect may replace the session while pagination is in flight.
+            # Never let an old response overwrite the current registry.
+            if self.session is not session:
+                logger.debug(
+                    "MCP server '%s': discarding tool refresh from superseded session",
+                    self.name,
+                )
+                return
 
             # 2. Re-register with fresh tool list. Avoid nuke-and-repave for
             # all names: live agent turns may already have tool-call IDs

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2333,6 +2333,7 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported", "_list_cache_meta",
         "_reconnect_retries", "_session_proven", "_was_parked",
+        "_session_generation",
     )
 
     def __init__(self, name: str):
@@ -2407,12 +2408,17 @@ class MCPServerTask:
         # back to ``list_tools`` (the pre-ping probe) so we neither spam pings
         # nor reconnect-loop. Reset on each fresh transport connection.
         self._ping_unsupported: bool = False
+        # Bumped when a session is adopted or torn down. Teardown is not
+        # serialized by ``_rpc_lock``, so a non-None ``ClientSession`` can
+        # remain assigned after its transport has started closing. Dynamic
+        # refresh binds to this generation, not the pointer alone.
+        self._session_generation: int = 0
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
         return "url" in self._config
 
-    def _advertises_tools(self) -> bool:
+    def _advertises_tools(self, init_result: Optional[Any] = None) -> bool:
         """Whether the server advertises the ``tools`` capability.
 
         Per the MCP spec, ``InitializeResult.capabilities.tools`` is non-None
@@ -2425,8 +2431,12 @@ class MCPServerTask:
         Returns True when no capability info was captured (legacy fallback:
         preserve the old always-call-list_tools behavior rather than regress
         any server that was working before this gate).
+
+        Pass ``init_result`` to evaluate a locked generation snapshot rather
+        than whatever ``self.initialize_result`` is now.
         """
-        init_result = self.initialize_result
+        if init_result is None:
+            init_result = self.initialize_result
         caps = getattr(init_result, "capabilities", None) if init_result is not None else None
         if caps is None:
             return True
@@ -2555,9 +2565,35 @@ class MCPServerTask:
             deadlines.append(self._last_tool_call_at + self._idle_timeout_seconds)
         return min(deadlines) if deadlines else None
 
+    def _invalidate_session_generation(self) -> None:
+        """Mark the current session generation dead for in-flight refreshes.
+
+        Teardown is not serialized by ``_rpc_lock``. The ``ClientSession``
+        object can stay assigned while its transport is already closing, so
+        a non-None pointer is not proof the session is live. Refresh binds
+        to this counter rather than inventing a second ownership model.
+        """
+        self._session_generation += 1
+
+    def _adopt_session(self, session) -> None:
+        """Install a live session and start a new refresh generation."""
+        self.session = session
+        self._session_generation += 1
+
+    def _refresh_generation_stale(self, generation: int, session) -> bool:
+        """True when the snapshotted refresh generation is no longer current."""
+        return (
+            self._session_generation != generation
+            or self.session is not session
+            or self.session is None
+            or self._shutdown_event.is_set()
+            or self._recycled_reason is not None
+        )
+
     def _mark_stdio_recycled(self, reason: str) -> None:
         """Mark a stdio session dormant before its transport finishes closing."""
         self._recycled_reason = reason
+        self._invalidate_session_generation()
         self.session = None
 
     # ----- Dynamic tool discovery (notifications/tools/list_changed) -----
@@ -2670,24 +2706,64 @@ class MCPServerTask:
         The lock prevents overlapping refreshes from rapid-fire notifications.
         After the initial ``await`` (list_tools), all mutations are synchronous
         — atomic from the event loop's perspective.
+
+        Session pointer, generation, and advertised capabilities are
+        snapshotted only after both locks are held. A queued refresh can
+        sit behind shutdown or reconnect; capturing earlier would query a
+        stale or already-dying transport. A superseded or torn-down
+        generation never mutates the registry.
         """
         from tools.registry import registry
-
-        if not self._advertises_tools():
-            # A server that doesn't implement tools/* should never send
-            # tools/list_changed, but guard anyway — calling tools/list
-            # would raise MCPError(-32601).
-            return
 
         async with self._refresh_lock:
             # Capture old tool names for change diff
             old_tool_names = set(self._registered_tool_names)
 
-            # 1. Fetch current tool list from server (follow nextCursor)
+            # 1. Resolve the current generation only after entering the RPC
+            # lock, then fetch every page. Teardown is not under this lock,
+            # so bind the fetch to the snapshotted generation rather than
+            # assuming a non-None ClientSession is still live.
             async with self._rpc_lock:
-                new_mcp_tools = await _paginate_full_list(
-                    self.session.list_tools, "tools", self.name
+                session = self.session
+                generation = self._session_generation
+                init_result = self.initialize_result
+                if session is None:
+                    logger.debug(
+                        "MCP server '%s': skipping dynamic tool refresh; session is closed",
+                        self.name,
+                    )
+                    return
+                if not self._advertises_tools(init_result):
+                    # A server that doesn't implement tools/* should never
+                    # send tools/list_changed, but guard anyway — calling
+                    # tools/list would raise MCPError(-32601).
+                    return
+                try:
+                    new_mcp_tools = await _paginate_full_list(
+                        session.list_tools, "tools", self.name
+                    )
+                except Exception as exc:
+                    if (
+                        _is_session_expired_error(exc)
+                        and self._refresh_generation_stale(generation, session)
+                    ):
+                        logger.debug(
+                            "MCP server '%s': skipping dynamic tool refresh; "
+                            "session transport closed during teardown",
+                            self.name,
+                        )
+                        return
+                    raise
+
+            # Reconnect / shutdown may replace or close the session while
+            # pagination is in flight. Never let that response overwrite
+            # the current registry.
+            if self._refresh_generation_stale(generation, session):
+                logger.debug(
+                    "MCP server '%s': discarding tool refresh from superseded session",
+                    self.name,
                 )
+                return
 
             # 2. Re-register with fresh tool list. Avoid nuke-and-repave for
             # all names: live agent turns may already have tool-call IDs
@@ -2911,8 +2987,13 @@ class MCPServerTask:
                         pass
 
         if self._shutdown_event.is_set():
+            # Invalidate before ClientSession.__aexit__ starts closing the
+            # transport so an in-flight refresh cannot treat the still-assigned
+            # pointer as live.
+            self._invalidate_session_generation()
             return "shutdown"
         self._reconnect_event.clear()
+        self._invalidate_session_generation()
         return "reconnect"
 
     async def _wait_for_reconnect_or_shutdown(
@@ -3116,7 +3197,7 @@ class MCPServerTask:
                     self.initialize_result = await self._negotiate_session(
                         session, connect_timeout
                     )
-                    self.session = session
+                    self._adopt_session(session)
                     self._mark_lifecycle_started()
                     await self._discover_tools()
                     self._ready.set()
@@ -3488,7 +3569,7 @@ class MCPServerTask:
                         self.initialize_result = await self._negotiate_session(
                             session, float(connect_timeout)
                         )
-                        self.session = session
+                        self._adopt_session(session)
                         await self._discover_tools()
                         self._ready.set()
                         # Session is live again: clear any breaker state from a
@@ -3553,7 +3634,7 @@ class MCPServerTask:
                             self.initialize_result = await self._negotiate_session(
                                 session, float(connect_timeout)
                             )
-                            self.session = session
+                            self._adopt_session(session)
                             await self._discover_tools()
                             self._ready.set()
                             # Session is live again: clear any breaker state from
@@ -3600,7 +3681,7 @@ class MCPServerTask:
                         self.initialize_result = await self._negotiate_session(
                             session, float(connect_timeout)
                         )
-                        self.session = session
+                        self._adopt_session(session)
                         await self._discover_tools()
                         self._ready.set()
                         # Session is live again: clear any breaker state from a
@@ -4087,6 +4168,7 @@ class MCPServerTask:
                 if self._shutdown_event.is_set():
                     return
             finally:
+                self._invalidate_session_generation()
                 self.session = None
 
     async def start(self, config: dict):
@@ -4110,6 +4192,7 @@ class MCPServerTask:
 
     async def shutdown(self):
         """Signal the Task to exit and wait for clean resource teardown."""
+        self._invalidate_session_generation()
         self._shutdown_event.set()
         # Defensive: if _wait_for_lifecycle_event is blocking, we need ANY
         # event to unblock it. _shutdown_event alone is sufficient (the


### PR DESCRIPTION
## What does this PR do?

`tools/list_changed` refresh can queue behind shutdown or reconnect. A non-`None` `ClientSession` is not proof the transport is still live: teardown is not serialized by `_rpc_lock`, so a dying connection can still look open and a stale `tools/list` response can land after the session has been replaced or closed.

This PR rebases the original snapshot + superseded-response discard onto current `main`'s collision-safe refresh body, then binds the fetch to a **session generation** snapshotted under `_rpc_lock`.

**This PR now guarantees:**

- Session pointer, generation, and `InitializeResult` capabilities are snapshotted only after `_refresh_lock` + `_rpc_lock`.
- Closed (`session is None`) refreshes are a no-op.
- Capability is taken from the locked generation, so a prompt/resource-only replacement is not asked for `tools/list`.
- Teardown / recycle / reconnect / shutdown bump the generation *before* `ClientSession.__aexit__` starts closing the transport.
- A closed-transport failure (`ClosedResourceError` / session-expired markers) on a **dying** generation is a clean skip: no error log, no registry mutation, no leaked refresh task.
- Genuine `tools/list` protocol/server errors still propagate and still log `dynamic tool refresh failed`.
- A superseded in-flight response is discarded and does not mutate the registry.
- Current `main` collision-safe registry updates are preserved (ownership checks, normalization-ambiguous cleanup).

**This PR does not invent a second ownership / publish model.** Discarding a superseded response does **not** publish the replacement session's tools. That authoritative reconnect / `list_changed` reconciliation belongs to #68808. In-flight RPC cancellation on teardown belongs to #48069. The generation counter is a refresh-liveness signal only and is compatible with both.

## Related Issue

Related to MCP dynamic-refresh races on closed / superseded / dying sessions. Canonical narrow repair after #83354 closed as a duplicate of this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`:
  - `_session_generation` + `_invalidate_session_generation()` / `_adopt_session()` / `_refresh_generation_stale()`
  - `_refresh_tools()` snapshots session/generation/capabilities under the locks; skips closed sessions; treats dying-transport errors as a clean skip; discards superseded responses
  - `_advertises_tools(init_result=...)` can evaluate a locked snapshot
  - generation bump on stdio recycle, lifecycle return (shutdown/reconnect), `shutdown()`, `run()` finally, and new session adopt
  - registry mutation body is current `main`'s collision-safe path
- `tests/tools/test_mcp_dynamic_discovery.py`: closed, queued-reconnect, superseded-discard, locked capability, dying-transport (stdio + HTTP), genuine-error, and generation-invalidation tests

## How to Test

```
scripts/run_tests.sh tests/tools/test_mcp_dynamic_discovery.py tests/tools/test_mcp_capability_gating.py tests/tools/test_mcp_tool.py -q
```

## Checklist

### Code

- [x] Conventional Commits (`fix(mcp):`)
- [x] Only MCP refresh lifecycle changes
- [x] Tests for closed / superseded / dying-transport refresh paths
- [x] Focused MCP suite after rebase: 33/33 on discovery+capability; session-expired / pagination / failure-class / transport-group / reconnect-signal green; `test_mcp_tool.py` 93 passed (4 failures are missing `httpx`/`dotenv` in this environment, unrelated to this diff)
- [x] `ruff check`, `compileall`, `git diff --check`, Windows-footgun scan clean on the touched files

### Documentation & Housekeeping

- [x] N/A for docs / config / AGENTS.md / tool schemas
