### PR TITLE
fix(approval): recognize the raw temp-dir alias in verification cleanup

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -128,6 +128,32 @@ class TestDetectDangerousRm:
                     None,
                 )
 
+    def test_top_level_temp_dir_alias_is_exempted_via_raw_path(self, tmp_path):
+        """A top-level tempdir alias (e.g. macOS ``/tmp`` -> ``/private/tmp``)
+        must be exempted using the raw, unresolved path, since that's the
+        literal text a real cleanup command carries — realpath() alone would
+        never match it."""
+        real_root_temp = tmp_path / "private_tmp"
+        real_root_temp.mkdir()
+        basename = "hermes-verify-example.py"
+        orig_realpath = os.path.realpath
+
+        def fake_realpath(path):
+            text = str(path)
+            if text == "/tmp":
+                return str(real_root_temp)
+            if text.startswith("/tmp/"):
+                return str(real_root_temp / text[len("/tmp/"):])
+            return orig_realpath(text)
+
+        with mock_patch("tempfile.gettempdir", return_value="/tmp"), \
+                mock_patch("os.path.realpath", side_effect=fake_realpath):
+            assert detect_dangerous_command(f"rm -f /tmp/{basename}") == (
+                False,
+                None,
+                None,
+            )
+
     def test_symlinked_temp_dir_only_exempts_canonical_target(self, tmp_path):
         real_temp = tmp_path / "real-temp"
         real_temp.mkdir()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1974,9 +1974,14 @@ def _is_verification_artifact_cleanup(command: str) -> bool:
         return False
 
     operand = argv[2]
-    temp_dir = os.path.realpath(tempfile.gettempdir())
+    raw_temp_dir = os.path.abspath(tempfile.gettempdir())
+    temp_dir = os.path.realpath(raw_temp_dir)
     basename = os.path.basename(operand)
-    if operand != os.path.join(temp_dir, basename):
+    canonical_operand = os.path.join(temp_dir, basename)
+    raw_operand = os.path.join(raw_temp_dir, basename)
+    if operand != canonical_operand and not (
+        operand == raw_operand and os.path.dirname(raw_temp_dir) == os.path.abspath(os.sep)
+    ):
         return False
 
     target = os.path.realpath(operand)


### PR DESCRIPTION
**Problem:** `_is_verification_artifact_cleanup()` (which lets the agent self-clean its own `hermes-verify-*`/`hermes-ad-hoc-*` temp scripts without an approval prompt) only matched the `realpath()`-resolved temp directory. On systems where `tempfile.gettempdir()` returns a top-level alias — e.g. macOS's `/tmp`, which resolves to `/private/tmp` — a cleanup command using the literal path the shell/OS actually reports (`/tmp/hermes-verify-foo.py`) was never recognized as safe, since it doesn't match the canonical `/private/tmp/...` form.

**Fix:** accept the raw (non-realpath) operand as an alternative match, but only when the raw temp dir's own parent is the filesystem root (`os.path.dirname(raw_temp_dir) == os.path.abspath(os.sep)`). This keeps the exemption narrow: an arbitrary non-root symlinked temp directory (the existing `test_symlinked_temp_dir_only_exempts_canonical_target` regression) still requires the canonical realpath form and is unaffected.

**Testing done:** full `tests/tools/test_approval.py` (313 tests) passes, including the existing symlink-alias regression unchanged, plus one new regression test for the top-level-alias case specifically.
