### PR TITLE
fix(gemini): bump native provider aux default to gemini-3.6-flash

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -293,7 +293,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "gemini": [
         "gemini-3.1-pro-preview",
         "gemini-3-pro-preview",
-        "gemini-3.5-flash",
+        "gemini-3.6-flash",
         "gemini-3.1-flash-lite-preview",
     ],
     "zai": [

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -55,7 +55,7 @@ gemini = GeminiProfile(
     env_vars=("GOOGLE_API_KEY", "GEMINI_API_KEY"),
     base_url="https://generativelanguage.googleapis.com/v1beta",
     auth_type="api_key",
-    default_aux_model="gemini-3.5-flash",
+    default_aux_model="gemini-3.6-flash",
 )
 
 register_provider(gemini)

--- a/tests/plugins/model_providers/test_gemini_profile.py
+++ b/tests/plugins/model_providers/test_gemini_profile.py
@@ -1,0 +1,27 @@
+"""Contract tests for the native Google Gemini provider profile."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def gemini_profile():
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("gemini")
+    assert profile is not None, "gemini provider profile must be registered"
+    return profile
+
+
+def test_native_gemini_auxiliary_default_is_in_curated_catalog(gemini_profile):
+    """The profile's default_aux_model must stay in lockstep with the curated
+    model picker catalog — whatever model the default points at has to be
+    one the picker can actually offer. Deliberately durable against future
+    model-generation bumps: it does not pin either side to a frozen
+    model-name string, only to the invariant that they never drift apart.
+    """
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    assert gemini_profile.default_aux_model in _PROVIDER_MODELS["gemini"]


### PR DESCRIPTION
**Problem:** the native Gemini provider profile's `default_aux_model` and the curated model-picker catalog (`hermes_cli/models.py`, `_PROVIDER_MODELS["gemini"]`) were both still pinned to `gemini-3.5-flash`, superseded by `gemini-3.6-flash` — the documented, stable model code for the current generation.

**Fix:** bump both in lockstep so the auxiliary-task default and the picker's offered model stay consistent.

**Testing done:** contract test (`tests/plugins/model_providers/test_gemini_profile.py`) asserts the durable lockstep invariant — `default_aux_model` is always a member of `_PROVIDER_MODELS["gemini"]` — rather than pinning either side to a frozen model string, so it won't need updating on the next model-generation bump. Confirmed `tests/agent/test_auxiliary_client.py`'s existing gemini reasoning-wire-shape tests are unaffected (they pass an explicit literal model string, not the default).

Other `gemini-3.5-flash` references elsewhere in `hermes_cli/models.py` are intentionally left untouched as out of scope for this minimal fix.
