### PR TITLE
fix: quote $UV_CMD in bootstrap installer for paths with spaces (#70402)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -554,7 +554,7 @@ install_uv() {
 
     if [ -x "$_managed_uv" ]; then
         UV_CMD="$_managed_uv"
-        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        UV_VERSION=$("$UV_CMD" --version 2>/dev/null)
         log_success "Managed uv found ($UV_VERSION)"
         return 0
     fi
@@ -590,7 +590,7 @@ install_uv() {
             exit 1
         fi
         rm -f "$_uv_install_log"
-        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        UV_VERSION=$("$UV_CMD" --version 2>/dev/null)
         log_success "Managed uv installed ($UV_VERSION)"
     else
         log_error "Failed to install uv"
@@ -1346,7 +1346,7 @@ setup_venv() {
     fi
 
     # uv creates the venv and pins the Python version in one step
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    "$UV_CMD" venv venv --python "$PYTHON_VERSION"
 
     # Neutralize any inherited UV_PYTHON (e.g. UV_PYTHON=3.14 left in the
     # user's shell env). uv honours UV_PYTHON over an existing venv for the
@@ -1500,7 +1500,7 @@ install_deps() {
         #                  This respects the curation in pyproject.toml.
         # uv's own progress UI handles TTY detection and downgrades
         # gracefully when stdout/stderr aren't terminals.
-        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra all --locked; then
+        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" "$UV_CMD" sync --extra all --locked; then
             log_success "Main package installed (hash-verified via uv.lock)"
             log_success "All dependencies installed"
             return 0
@@ -1581,7 +1581,7 @@ PY
     install_tier() {
         local name="$1"; local spec="$2"
         log_info "Trying tier: $name ..."
-        if $UV_CMD pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then
+        if "$UV_CMD" pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then
             log_success "Main package installed ($name)"
             _installed=true
             _tier_name="$name"
@@ -1608,7 +1608,7 @@ PY
     if [ "$_tier_name" != "all (with RL/matrix extras)" ]; then
         log_warn "Note: installed via fallback tier ($_tier_name)."
         log_info "Some optional features may be missing. After resolving any"
-        log_info "PyPI/network issue, re-run: $UV_CMD pip install -e '.[all]'"
+        log_info "PyPI/network issue, re-run: \"$UV_CMD\" pip install -e '.[all]'"
     fi
 
     log_success "Main package installed"


### PR DESCRIPTION
## Summary

The bootstrap installer fails on paths with spaces (common on macOS with external volumes at `/Volumes/Volume Name/` or `/Users/First Last/`). Unquoted `$UV_CMD` causes bash word-splitting — the path `/Users/My User/.hermes/bin/uv` splits into `"/Users/My"` and `"User/.hermes/bin/uv"`, failing with "No such file or directory".

The script treats this as a dependency installation failure, exits non-zero, and **destroys the existing venv** — leaving Hermes completely unusable.

## Changes

Quote all 6 remaining `$UV_CMD` references in `scripts/install.sh` to match the 3 already-quoted uses on lines 629, 637, 638:

| Line | Before | After |
|------|--------|-------|
| 557 | `$($UV_CMD --version)` | `$("$UV_CMD" --version)` |
| 593 | `$($UV_CMD --version)` | `$("$UV_CMD" --version)` |
| 1349 | `$UV_CMD venv venv` | `"$UV_CMD" venv venv` |
| 1503 | `$UV_CMD sync --extra` | `"$UV_CMD" sync --extra` |
| 1584 | `$UV_CMD pip install` | `"$UV_CMD" pip install` |
| 1611 | `re-run: $UV_CMD pip` | `re-run: "$UV_CMD" pip` |

Fixes #70402
