### PR TITLE
fix(desktop): fall through to create when branch draft resume fails (#70360)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -346,37 +346,44 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // swap/reconnect left its volatile session binding incomplete or
         // cross-wired. Run the full profile-aware resume path. Creating here
         // would fork a contextless chat against whichever profile is active.
+        let resumeSucceeded = false
         try {
           await resumeStoredSession(routedStoredSessionId)
+          resumeSucceeded = true
         } catch {
-          return abortForSessionSwitch(null)
+          // Branch drafts have no persisted row until their first turn, so
+          // resumeStoredSession always throws for them.  Log and fall through
+          // to the create path below instead of silently dropping the message.
+          console.warn('[submit-resume-fallback] stored session resume failed, will attempt create', { routedStoredSessionId })
         }
 
-        const routedResumeDrift = sessionDriftReason()
+        if (resumeSucceeded) {
+          const routedResumeDrift = sessionDriftReason()
 
-        if (routedResumeDrift) {
-          console.warn('[submit-drift-abort]', routedResumeDrift, { phase: 'post-routed-resume' })
+          if (routedResumeDrift) {
+            console.warn('[submit-drift-abort]', routedResumeDrift, { phase: 'post-routed-resume' })
 
-          return abortForSessionSwitch(null)
+            return abortForSessionSwitch(null)
+          }
+
+          const recoveredRuntimeId = activeSessionIdRef.current
+          const validatedRuntimeId = getRuntimeIdForStoredSession(routedStoredSessionId)
+
+          // Recovery only succeeded when both sides of the cache agree that the
+          // live runtime belongs to the durable routed session. A failed profile
+          // swap may leave the previous profile's runtime active, while a recycled
+          // runtime id may leave a cross-wired stored-session mapping.
+          if (
+            !recoveredRuntimeId ||
+            recoveredRuntimeId !== validatedRuntimeId ||
+            selectedStoredSessionIdRef.current !== routedStoredSessionId
+          ) {
+            return abortForSessionSwitch(null)
+          }
+
+          sessionId = recoveredRuntimeId
+          seedOptimistic(sessionId)
         }
-
-        const recoveredRuntimeId = activeSessionIdRef.current
-        const validatedRuntimeId = getRuntimeIdForStoredSession(routedStoredSessionId)
-
-        // Recovery only succeeded when both sides of the cache agree that the
-        // live runtime belongs to the durable routed session. A failed profile
-        // swap may leave the previous profile's runtime active, while a recycled
-        // runtime id may leave a cross-wired stored-session mapping.
-        if (
-          !recoveredRuntimeId ||
-          recoveredRuntimeId !== validatedRuntimeId ||
-          selectedStoredSessionIdRef.current !== routedStoredSessionId
-        ) {
-          return abortForSessionSwitch(null)
-        }
-
-        sessionId = recoveredRuntimeId
-        seedOptimistic(sessionId)
       }
 
       if (!sessionId && targetStoredSessionId) {


### PR DESCRIPTION
## Summary

Submitting the first message into a branched session silently drops the message — the branch goes blank, no session is created, no backend log, no console output. The user's message is lost.

## Root Cause

In `submit.ts` L344-353, branch drafts have no persisted DB row until their first turn. When `resumeStoredSession(routedStoredSessionId)` is called, it throws because there's no row to resume. The catch block does `return abortForSessionSwitch(null)` which silently drops the message and exits.

## Fix

Wrap the post-resume validation in a `resumeSucceeded` flag:
- **Resume succeeds**: proceed with drift check + runtime validation (existing behavior)
- **Resume fails**: log `[submit-resume-fallback]` warning and let `sessionId` remain null, falling through to `createBackendSessionForSend()` which correctly creates a new session

This matches the issue's suggested fix #2: "the catch at L352 should fall through to create rather than abortForSessionSwitch(null)."

Fixes #70360
