### PR TITLE
fix(feishu): fail-closed approval card operator authorization

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2722,7 +2722,10 @@ class FeishuAdapter(BasePlatformAdapter):
             return False
         allowed_ids = set(self._admins) | set(self._allowed_group_users)
         if not allowed_ids:
-            return True
+            return (
+                os.getenv("FEISHU_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}
+                or os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}
+            )
         return "*" in allowed_ids or normalized in allowed_ids
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:

--- a/tests/gateway/test_feishu_approval_card_fail_closed.py
+++ b/tests/gateway/test_feishu_approval_card_fail_closed.py
@@ -1,0 +1,48 @@
+"""Unit tests verifying Feishu card action approval operator authorization fail-closed behavior."""
+
+import os
+from unittest.mock import MagicMock
+from plugins.platforms.feishu.adapter import FeishuAdapter
+
+
+def _make_feishu_adapter(admins=None, allowed_group_users=None):
+    adapter = object.__new__(FeishuAdapter)
+    adapter._admins = set(admins) if admins else set()
+    adapter._allowed_group_users = set(allowed_group_users) if allowed_group_users else set()
+    return adapter
+
+
+def test_feishu_approval_operator_authorized_with_explicit_allowlist():
+    adapter = _make_feishu_adapter(admins=["ou_admin_123"])
+
+    # Authorized admin user
+    assert adapter._is_interactive_operator_authorized("ou_admin_123") is True
+    # Unauthorized user
+    assert adapter._is_interactive_operator_authorized("ou_stranger_999") is False
+
+
+def test_feishu_approval_operator_fail_closed_when_no_allowlist_configured(monkeypatch):
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    adapter = _make_feishu_adapter(admins=None, allowed_group_users=None)
+
+    # Empty allowlist + no opt-in → FAIL CLOSED (False)
+    assert adapter._is_interactive_operator_authorized("ou_user_123") is False
+
+
+def test_feishu_approval_operator_allowed_with_feishu_allow_all_env(monkeypatch):
+    monkeypatch.setenv("FEISHU_ALLOW_ALL_USERS", "true")
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    adapter = _make_feishu_adapter(admins=None, allowed_group_users=None)
+
+    # Empty allowlist + FEISHU_ALLOW_ALL_USERS=true → True
+    assert adapter._is_interactive_operator_authorized("ou_user_123") is True
+
+
+def test_feishu_approval_operator_allowed_with_gateway_allow_all_env(monkeypatch):
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    adapter = _make_feishu_adapter(admins=None, allowed_group_users=None)
+
+    # Empty allowlist + GATEWAY_ALLOW_ALL_USERS=true → True
+    assert adapter._is_interactive_operator_authorized("ou_user_123") is True


### PR DESCRIPTION
## Summary

Enforces fail-closed authorization in `plugins/platforms/feishu/adapter.py::_is_interactive_operator_authorized()`. When no explicit allowlist (`self._admins` or `self._allowed_group_users`) is configured, interactive card approval clicks now fail closed by default unless `FEISHU_ALLOW_ALL_USERS=true` or `GATEWAY_ALLOW_ALL_USERS=true` is set.

## Why

When an agent turn encounters a dangerous command, the Feishu adapter emits an interactive approval card with buttons ("Approve Once", "Approve for Session", "Approve Always", "Deny").

`_handle_approval_card_action()` checks `_is_interactive_operator_authorized()` to authorize button clicks. When no explicit admin or group allowlist was configured, `allowed_ids` evaluated to `set()`. The implementation previously contained `if not allowed_ids: return True`, returning `True` (fail-open) for any clicker.

As a result, unlisted users in Feishu channels or DMs could click approval card buttons and unblock dangerous command execution on the host machine without admin authorization.

This brings Feishu into exact parity with the fail-closed approval fixes in Telegram (PR #28494), Teams (PR #27290), and Matrix (PR #34567 / #33328 / #30062).

## Key Changes

- **Feishu Operator Authorization**: Updated `_is_interactive_operator_authorized()` in `plugins/platforms/feishu/adapter.py` to require `FEISHU_ALLOW_ALL_USERS` or `GATEWAY_ALLOW_ALL_USERS` when `allowed_ids` is empty, failing closed by default.
- **Tests**: Added `tests/gateway/test_feishu_approval_card_fail_closed.py` with 4 test cases verifying authorized, unauthorized, empty-allowlist fail-closed, and env-opt-in behaviors.

## Test

```bash
python -m pytest tests/gateway/test_feishu_approval_card_fail_closed.py -q --timeout-method=thread