### PR TITLE
fix(providers): classify code-only failover errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -142,6 +142,29 @@ _BILLING_ERROR_CODES = frozenset({
     _XAI_SPENDING_LIMIT_ERROR_CODE,
 })
 
+# Structured codes whose meaning is defined by a specific provider. Keep these
+# scoped so a coincidentally named code from another backend remains unknown.
+_PROVIDER_ERROR_CODE_REASONS = {
+    "openai": {
+        "server_error": FailoverReason.server_error,
+    },
+    "gemini": {
+        "unavailable": FailoverReason.overloaded,
+        "deadline_exceeded": FailoverReason.timeout,
+        "internal": FailoverReason.server_error,
+    },
+    "anthropic": {
+        "rate_limit_error": FailoverReason.rate_limit,
+        "api_error": FailoverReason.timeout,
+    },
+}
+
+_PROVIDER_ERROR_CODE_ALIASES = {
+    "openai-codex": "openai",
+    "google": "gemini",
+    "google-vertex": "gemini",
+}
+
 # Patterns that indicate rate limiting (transient, will resolve)
 _RATE_LIMIT_PATTERNS = [
     "rate limit",
@@ -805,7 +828,12 @@ def classify_api_error(
     # ── 3. Error code classification ────────────────────────────────
 
     if error_code:
-        classified = _classify_by_error_code(error_code, error_msg, _result)
+        classified = _classify_by_error_code(
+            error_code,
+            error_msg,
+            _result,
+            provider=provider_lower,
+        )
         if classified is not None:
             return classified
 
@@ -1357,7 +1385,11 @@ def _classify_400(
 # ── Error code classification ───────────────────────────────────────────
 
 def _classify_by_error_code(
-    error_code: str, error_msg: str, result_fn,
+    error_code: str,
+    error_msg: str,
+    result_fn,
+    *,
+    provider: str = "",
 ) -> Optional[ClassifiedError]:
     """Classify by structured error codes from the response body."""
     code_lower = error_code.lower()
@@ -1397,6 +1429,20 @@ def _classify_by_error_code(
             retryable=True,
             should_fallback=False,
         )
+
+    provider_key = _PROVIDER_ERROR_CODE_ALIASES.get(provider, provider)
+    provider_reason = _PROVIDER_ERROR_CODE_REASONS.get(provider_key, {}).get(
+        code_lower
+    )
+    if provider_reason == FailoverReason.rate_limit:
+        return result_fn(
+            provider_reason,
+            retryable=True,
+            should_rotate_credential=True,
+            should_fallback=True,
+        )
+    if provider_reason is not None:
+        return result_fn(provider_reason, retryable=True)
 
     return None
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -143,6 +143,30 @@ _BILLING_ERROR_CODES = frozenset({
     _XAI_SPENDING_LIMIT_ERROR_CODE,
 })
 
+# Structured codes whose meaning is defined by a specific provider. Keep these
+# scoped so a coincidentally named code from another backend remains unknown.
+_PROVIDER_ERROR_CODE_REASONS = {
+    "openai": {
+        "server_error": FailoverReason.server_error,
+    },
+    "gemini": {
+        "unavailable": FailoverReason.overloaded,
+        "deadline_exceeded": FailoverReason.timeout,
+        "internal": FailoverReason.server_error,
+    },
+    "anthropic": {
+        "rate_limit_error": FailoverReason.rate_limit,
+        "api_error": FailoverReason.server_error,
+    },
+}
+
+_PROVIDER_ERROR_CODE_ALIASES = {
+    "openai-codex": "openai",
+    "google": "gemini",
+    "google-vertex": "gemini",
+    "vertex": "gemini",
+}
+
 # Patterns that indicate rate limiting (transient, will resolve)
 _RATE_LIMIT_PATTERNS = [
     "rate limit",
@@ -914,7 +938,12 @@ def classify_api_error(
     # ── 3. Error code classification ────────────────────────────────
 
     if error_code:
-        classified = _classify_by_error_code(error_code, error_msg, _result)
+        classified = _classify_by_error_code(
+            error_code,
+            error_msg,
+            _result,
+            provider=provider_lower,
+        )
         if classified is not None:
             return classified
 
@@ -1517,7 +1546,11 @@ def _classify_400(
 # ── Error code classification ───────────────────────────────────────────
 
 def _classify_by_error_code(
-    error_code: str, error_msg: str, result_fn,
+    error_code: str,
+    error_msg: str,
+    result_fn,
+    *,
+    provider: str = "",
 ) -> Optional[ClassifiedError]:
     """Classify by structured error codes from the response body."""
     code_lower = error_code.lower()
@@ -1557,6 +1590,20 @@ def _classify_by_error_code(
             retryable=True,
             should_fallback=False,
         )
+
+    provider_key = _PROVIDER_ERROR_CODE_ALIASES.get(provider, provider)
+    provider_reason = _PROVIDER_ERROR_CODE_REASONS.get(provider_key, {}).get(
+        code_lower
+    )
+    if provider_reason == FailoverReason.rate_limit:
+        return result_fn(
+            provider_reason,
+            retryable=True,
+            should_rotate_credential=True,
+            should_fallback=True,
+        )
+    if provider_reason is not None:
+        return result_fn(provider_reason, retryable=True)
 
     return None
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -648,6 +648,7 @@ class TestClassifyApiError:
         assert result.should_fallback is True
         assert result.should_compress is False
 
+
     def test_400_cyber_content_policy_blocked(self):
         # When the SDK does attach a status (e.g. 400), the safety pattern
         # must still beat the format_error fallthrough.
@@ -1092,6 +1093,46 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.billing
 
     # ── Message-only patterns (no status code) ──
+
+    @pytest.mark.parametrize(
+        ("provider", "code", "reason"),
+        [
+            ("openai", "SERVER_ERROR", FailoverReason.server_error),
+            ("openai-codex", "SERVER_ERROR", FailoverReason.server_error),
+            ("gemini", "UNAVAILABLE", FailoverReason.overloaded),
+            ("google", "DEADLINE_EXCEEDED", FailoverReason.timeout),
+            ("google-vertex", "INTERNAL", FailoverReason.server_error),
+            ("anthropic", "RATE_LIMIT_ERROR", FailoverReason.rate_limit),
+            ("anthropic", "API_ERROR", FailoverReason.timeout),
+        ],
+    )
+    def test_provider_code_only_error_classification(
+        self, provider, code, reason
+    ):
+        e = MockAPIError("", body={"error": {"code": code}})
+        result = classify_api_error(e, provider=provider)
+
+        assert result.reason == reason
+        assert result.retryable is True
+        if reason == FailoverReason.rate_limit:
+            assert result.should_rotate_credential is True
+            assert result.should_fallback is True
+
+    @pytest.mark.parametrize(
+        ("provider", "code"),
+        [
+            ("anthropic", "SERVER_ERROR"),
+            ("openai", "API_ERROR"),
+            ("custom", "UNAVAILABLE"),
+        ],
+    )
+    def test_provider_code_only_error_does_not_cross_provider_boundaries(
+        self, provider, code
+    ):
+        e = MockAPIError("", body={"error": {"code": code}})
+        result = classify_api_error(e, provider=provider)
+
+        assert result.reason == FailoverReason.unknown
 
     def test_message_billing_pattern(self):
         e = Exception("insufficient credits to complete this request")
@@ -2169,4 +2210,3 @@ class Test408RequestTimeout:
         assert result.retryable is False
         assert result.should_fallback is True
         assert result.should_compress is False
-

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -611,6 +611,47 @@ class TestClassifyApiError:
 
 
 
+    @pytest.mark.parametrize(
+        ("provider", "code", "reason"),
+        [
+            ("openai", "SERVER_ERROR", FailoverReason.server_error),
+            ("openai-codex", "SERVER_ERROR", FailoverReason.server_error),
+            ("gemini", "UNAVAILABLE", FailoverReason.overloaded),
+            ("google", "DEADLINE_EXCEEDED", FailoverReason.timeout),
+            ("google-vertex", "INTERNAL", FailoverReason.server_error),
+            ("vertex", "INTERNAL", FailoverReason.server_error),
+            ("anthropic", "RATE_LIMIT_ERROR", FailoverReason.rate_limit),
+            ("anthropic", "API_ERROR", FailoverReason.server_error),
+        ],
+    )
+    def test_provider_code_only_error_classification(self, provider, code, reason):
+        result = classify_api_error(
+            MockAPIError("", body={"error": {"code": code}}), provider=provider
+        )
+
+        assert result.reason == reason
+        assert result.retryable is True
+        if reason == FailoverReason.rate_limit:
+            assert result.should_rotate_credential is True
+            assert result.should_fallback is True
+
+    @pytest.mark.parametrize(
+        ("provider", "code"),
+        [
+            ("anthropic", "SERVER_ERROR"),
+            ("openai", "API_ERROR"),
+            ("custom", "UNAVAILABLE"),
+        ],
+    )
+    def test_provider_code_only_error_does_not_cross_provider_boundaries(
+        self, provider, code
+    ):
+        result = classify_api_error(
+            MockAPIError("", body={"error": {"code": code}}), provider=provider
+        )
+
+        assert result.reason == FailoverReason.unknown
+
     def test_400_litellm_invalid_request_body_shape(self, caplog):
         """litellm/Bedrock proxy shape (errorMessage/errorCode) → format_error.
 


### PR DESCRIPTION
Fixes #70414

## Summary

- classify provider-native structured error codes even when an SDK supplies no HTTP status or descriptive message
- keep OpenAI, Gemini/Google/Vertex, and Anthropic mappings provider-scoped so coincidentally named codes from other backends remain unknown
- preserve the existing retry, credential-rotation, and fallback semantics attached to each `FailoverReason`

## Behavior

- OpenAI `SERVER_ERROR` -> `server_error`
- Gemini/Google/Vertex `UNAVAILABLE` -> `overloaded`
- Gemini/Google/Vertex `DEADLINE_EXCEEDED` -> `timeout`
- Gemini/Google/Vertex `INTERNAL` -> `server_error`
- Anthropic `RATE_LIMIT_ERROR` -> `rate_limit`
- Anthropic `API_ERROR` -> `server_error`

Shared codes such as `INSUFFICIENT_QUOTA` continue to use the existing cross-provider classifier.

## Tests

- `bash scripts/run_tests.sh tests/agent/test_error_classifier.py -q` -> 86 passed
- `python -m ruff check agent/error_classifier.py tests/agent/test_error_classifier.py` -> clean
- `git diff --check origin/main...HEAD` -> clean
