### PR TITLE
fix(gateway): deduplicate explicit media attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5195,6 +5195,11 @@ class BasePlatformAdapter(ABC):
                     if local_files:
                         logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
 
+                # A response can name an attachment for the user and also
+                # request it with MEDIA:<path>. The explicit directive owns
+                # delivery, so suppress its duplicate bare-path detection.
+                media_paths = {path for path, _ in media_files}
+                local_files = [path for path in local_files if path not in media_paths]
                 # A2 (#29346): extraction can reduce a non-empty response to
                 # empty text with no attachment, and the `if text_content` guard
                 # below then drops it silently. Recover on every platform (#33842

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -82,6 +82,26 @@ async def test_base_adapter_routes_telegram_flac_media_tag_to_document_sender(tm
 
 
 @pytest.mark.asyncio
+async def test_base_adapter_deduplicates_explicit_and_bare_file_paths(tmp_path, monkeypatch):
+    "An explicit MEDIA tag wins over the same path named in report text."
+    adapter = _MediaRoutingAdapter()
+    event = _event()
+    report = _allowed_media_path(tmp_path, monkeypatch, "report.md")
+    adapter._message_handler = AsyncMock(
+        return_value=f"Report saved: {report}\nMEDIA:{report}"
+    )
+    adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc"))
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1",
+        file_path=str(report),
+        metadata={"notify": True},
+    )
+
+
+@pytest.mark.asyncio
 async def test_base_adapter_routes_non_voice_telegram_ogg_media_tag_to_document_sender(tmp_path, monkeypatch):
     adapter = _MediaRoutingAdapter()
     event = _event()


### PR DESCRIPTION
## Summary
- prevent duplicate uploads when a response contains the same report path both as ordinary text and a MEDIA directive
- add regression coverage for report-style Slack responses

## Verification
- python -m py_compile gateway/platforms/base.py tests/gateway/test_tts_media_routing.py`n- ash scripts/run_tests.sh tests/gateway/test_tts_media_routing.py -q *(blocked locally: no development virtualenv with pytest is installed)*