### PR TITLE
feat(state): indexed sessions.last_active for recents ordering + legacy trigram opt-out

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -26,6 +26,8 @@ import threading
 import time
 from pathlib import Path
 
+import yaml
+
 from agent.memory_manager import sanitize_context
 from agent.message_sanitization import _sanitize_surrogates
 from hermes_constants import get_hermes_home
@@ -210,7 +212,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 23
+SCHEMA_VERSION = 24
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
 # state_meta key ``fts_storage_version``. The main schema version advances
@@ -277,14 +279,68 @@ _wal_fallback_warned_lock = threading.Lock()
 _wal_reset_bug_warned_paths: set[str] = set()
 _wal_reset_bug_warned_lock = threading.Lock()
 
-_FTS_TRIGGERS = (
+_FTS_BASE_TRIGGERS = (
     "messages_fts_insert",
     "messages_fts_delete",
     "messages_fts_update",
+)
+
+_FTS_TRIGRAM_TRIGGERS = (
     "messages_fts_trigram_insert",
     "messages_fts_trigram_delete",
     "messages_fts_trigram_update",
 )
+
+_FTS_TRIGGERS = _FTS_BASE_TRIGGERS + _FTS_TRIGRAM_TRIGGERS
+
+
+def _truthy_config_value(value: Any) -> bool:
+    """Parse config/env booleans without treating "false" as truthy."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _config_disables_fts_trigram(db_path: Optional[Path] = None) -> bool:
+    """Return the config-backed legacy trigram disable flag.
+
+    ``sessions.disable_fts_trigram`` is the documented surface. The env var is
+    kept as a process-transport fallback for entry points that set it before
+    importing storage code. Schema-v23 databases always keep the compact,
+    tool-row-free trigram index; this switch only prevents an old inline
+    trigram from being recreated while a legacy database awaits explicit
+    ``optimize-storage`` migration.
+    """
+    env_value = os.getenv("HERMES_DISABLE_FTS_TRIGRAM")
+    if env_value is not None:
+        return _truthy_config_value(env_value)
+    target_config = Path(db_path).parent / "config.yaml" if db_path else None
+    if target_config and target_config.is_file():
+        try:
+            with target_config.open("r", encoding="utf-8") as fh:
+                target_cfg = yaml.safe_load(fh) or {}
+            sessions_cfg = target_cfg.get("sessions") or {}
+            if isinstance(sessions_cfg, dict):
+                return _truthy_config_value(sessions_cfg.get("disable_fts_trigram"))
+        except Exception as exc:
+            logger.debug(
+                "Could not read sessions.disable_fts_trigram from %s: %s",
+                target_config,
+                exc,
+            )
+    try:
+        from hermes_cli.config import load_config
+
+        sessions_cfg = (load_config().get("sessions") or {})
+        if isinstance(sessions_cfg, dict):
+            return _truthy_config_value(sessions_cfg.get("disable_fts_trigram"))
+    except Exception as exc:
+        logger.debug("Could not read sessions.disable_fts_trigram: %s", exc)
+    return False
 
 
 def _set_last_init_error(msg: Optional[str]) -> None:
@@ -1071,6 +1127,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     started_at REAL NOT NULL,
     ended_at REAL,
     end_reason TEXT,
+    last_active REAL,
     message_count INTEGER DEFAULT 0,
     tool_call_count INTEGER DEFAULT 0,
     input_tokens INTEGER DEFAULT 0,
@@ -1220,6 +1277,59 @@ CREATE INDEX IF NOT EXISTS idx_sessions_gateway_peer
     ON sessions(source, user_id, chat_id, chat_type, thread_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state
     ON sessions(handoff_state, started_at);
+CREATE INDEX IF NOT EXISTS idx_sessions_last_active
+    ON sessions(last_active DESC, started_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_session_active_id
+    ON messages(session_id, active, id DESC);
+"""
+
+LAST_ACTIVE_REPAIR_TRIGGER_SQL = """
+CREATE TRIGGER IF NOT EXISTS messages_last_active_timestamp_update
+AFTER UPDATE OF timestamp ON messages
+BEGIN
+    UPDATE sessions
+    SET last_active = (
+        WITH RECURSIVE chain(cur_id) AS (
+            SELECT sessions.id
+            UNION ALL
+            SELECT child.id
+            FROM chain c
+            JOIN sessions parent ON parent.id = c.cur_id
+            JOIN sessions child ON child.parent_session_id = c.cur_id
+            WHERE parent.end_reason = 'compression'
+              AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+              AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+              AND COALESCE(child.source, '') != 'tool'
+        )
+        SELECT MAX(COALESCE(
+            (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = chain.cur_id),
+            (SELECT ss.started_at FROM sessions ss WHERE ss.id = chain.cur_id)
+        ))
+        FROM chain
+    )
+    WHERE id IN (
+        WITH RECURSIVE affected(id) AS (
+            SELECT NEW.session_id
+            UNION
+            SELECT parent.id
+            FROM affected a
+            JOIN sessions child ON child.id = a.id
+            JOIN sessions parent ON parent.id = child.parent_session_id
+            WHERE parent.end_reason = 'compression'
+              AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+              AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+              AND COALESCE(child.source, '') != 'tool'
+        )
+        SELECT id FROM affected
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS sessions_last_active_started_at_update
+AFTER UPDATE OF started_at ON sessions
+WHEN OLD.last_active IS NULL OR OLD.last_active = OLD.started_at
+BEGIN
+    UPDATE sessions SET last_active = NEW.started_at WHERE id = NEW.id;
+END;
 """
 
 # ── Deferred FTS rebuild bookkeeping (schema v23) ──
@@ -1620,6 +1730,7 @@ class SessionDB:
         # unrecoverable database can't put writers into a rebuild loop.
         self._fts_runtime_rebuild_attempted = False
         self._fts_enabled = False
+        self._fts_trigram_disabled = _config_disables_fts_trigram(self.db_path)
         self._trigram_available = False
         # CJK-bigram index (cjk_unicode61 loadable tokenizer). _fts_cjk_loaded:
         # extension present on the writer connection; _fts_cjk_available: the
@@ -1628,6 +1739,7 @@ class SessionDB:
         self._fts_cjk_loaded = False
         self._fts_cjk_available = False
         self._fts_unavailable_warned = False
+        self._has_sessions_last_active = True
         self._conn = None
         try:
             if read_only:
@@ -1647,6 +1759,9 @@ class SessionDB:
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                self._has_sessions_last_active = self._table_has_column(
+                    self._conn, "sessions", "last_active"
+                )
                 return
 
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1935,6 +2050,22 @@ class SessionDB:
             self._fts_cjk_available = False
 
     @staticmethod
+    def _table_has_column(
+        conn: sqlite3.Connection,
+        table_name: str,
+        column_name: str,
+    ) -> bool:
+        try:
+            rows = conn.execute(f'PRAGMA table_info("{table_name}")').fetchall()
+        except sqlite3.OperationalError:
+            return False
+        for row in rows:
+            name = row["name"] if isinstance(row, sqlite3.Row) else row[1]
+            if name == column_name:
+                return True
+        return False
+
+    @staticmethod
     def _drop_fts_triggers(cursor: sqlite3.Cursor) -> None:
         for trigger in _FTS_TRIGGERS:
             try:
@@ -1943,12 +2074,64 @@ class SessionDB:
                 pass
 
     @staticmethod
-    def _fts_trigger_count(cursor: sqlite3.Cursor) -> int:
-        placeholders = ",".join("?" for _ in _FTS_TRIGGERS)
+    def _drop_fts_trigram_objects(cursor: sqlite3.Cursor) -> bool:
+        """Drop trigram FTS objects only. Returns true when anything existed."""
+        placeholders = ",".join("?" for _ in _FTS_TRIGRAM_TRIGGERS)
+        trigger_count = cursor.execute(
+            f"SELECT COUNT(*) FROM sqlite_master "
+            f"WHERE type = 'trigger' AND name IN ({placeholders})",
+            _FTS_TRIGRAM_TRIGGERS,
+        ).fetchone()[0]
+        table_count = cursor.execute(
+            "SELECT COUNT(*) FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'messages_fts_trigram'"
+        ).fetchone()[0]
+        for trigger in _FTS_TRIGRAM_TRIGGERS:
+            try:
+                cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            except sqlite3.OperationalError:
+                pass
+        try:
+            cursor.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+        except sqlite3.OperationalError as exc:
+            if not table_count or not SessionDB._is_fts5_unavailable_error(exc):
+                raise
+            # If this SQLite runtime cannot load the FTS5 module, dropping an
+            # existing virtual table can fail before SQLite reaches the shadow
+            # tables. Disabled mode still needs the heavyweight trigram schema
+            # gone, so use the same writable-schema escape hatch as the state.db
+            # repair path, scoped only to messages_fts_trigram* objects.
+            conn = cursor.connection
+            try:
+                conn.execute("PRAGMA writable_schema=ON")
+                conn.execute(
+                    "DELETE FROM sqlite_master "
+                    "WHERE name = 'messages_fts_trigram' "
+                    "OR name LIKE 'messages_fts_trigram_%' "
+                    "OR tbl_name = 'messages_fts_trigram'"
+                )
+                conn.execute("PRAGMA writable_schema=OFF")
+                conn.commit()
+                conn.execute("VACUUM")
+            finally:
+                try:
+                    conn.execute("PRAGMA writable_schema=OFF")
+                except sqlite3.OperationalError:
+                    pass
+        return bool(trigger_count or table_count)
+
+    @staticmethod
+    def _fts_trigger_count(
+        cursor: sqlite3.Cursor,
+        *,
+        include_trigram: bool = True,
+    ) -> int:
+        triggers = _FTS_TRIGGERS if include_trigram else _FTS_BASE_TRIGGERS
+        placeholders = ",".join("?" for _ in triggers)
         row = cursor.execute(
             f"SELECT COUNT(*) FROM sqlite_master "
             f"WHERE type = 'trigger' AND name IN ({placeholders})",
-            _FTS_TRIGGERS,
+            triggers,
         ).fetchone()
         return int(row[0] if not isinstance(row, sqlite3.Row) else row[0])
 
@@ -2718,6 +2901,18 @@ class SessionDB:
         pending = self.get_meta("fts_rebuild_high_water") is not None
         if legacy and not pending:
             self._demote_legacy_fts_to_trash()
+            # A legacy database may have deliberately omitted its heavyweight
+            # inline trigram index via sessions.disable_fts_trigram. The v23
+            # replacement is compact and excludes tool rows, so the explicit
+            # optimizer must still backfill it. Refresh the capability flag
+            # after the demotion created the new external-content table.
+            with self._lock:
+                self._trigram_available = (
+                    self._fts_table_probe(
+                        self._conn, "messages_fts_trigram"
+                    )
+                    is True
+                )
 
         # A stale CJK index (triggers dropped by a tokenizer-less process)
         # can only be recovered from scratch — reset it now so the cjk
@@ -2912,6 +3107,181 @@ class SessionDB:
                             "reconcile %s.%s: %s", table_name, col_name, exc,
                         )
 
+    @staticmethod
+    def _backfill_session_last_active(cursor: sqlite3.Cursor) -> None:
+        """Populate sessions.last_active from message timestamps and compression chains."""
+        cursor.execute(
+            """
+            WITH RECURSIVE chain(root_id, cur_id) AS (
+                SELECT id, id FROM sessions
+                UNION ALL
+                SELECT c.root_id, child.id
+                FROM chain c
+                JOIN sessions parent ON parent.id = c.cur_id
+                JOIN sessions child ON child.parent_session_id = c.cur_id
+                WHERE parent.end_reason = 'compression'
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+                  AND COALESCE(child.source, '') != 'tool'
+            ),
+            activity AS (
+                SELECT
+                    c.root_id AS id,
+                    MAX(COALESCE(
+                        (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = c.cur_id),
+                        s.started_at
+                    )) AS last_active
+                FROM chain c
+                JOIN sessions s ON s.id = c.cur_id
+                GROUP BY c.root_id
+            )
+            UPDATE sessions
+            SET last_active = activity.last_active
+            FROM activity
+            WHERE sessions.id = activity.id
+              AND (
+                  sessions.last_active IS NULL
+                  OR sessions.last_active != activity.last_active
+              )
+            """
+        )
+
+    @staticmethod
+    def _touch_session_last_active(
+        conn: sqlite3.Connection,
+        session_id: str,
+        timestamp: float,
+    ) -> None:
+        """Advance a session and its compression ancestors to *timestamp*."""
+        conn.execute(
+            """
+            UPDATE sessions
+            SET last_active = CASE
+                WHEN last_active IS NULL OR last_active < ? THEN ?
+                ELSE last_active
+            END
+            WHERE id = ?
+            """,
+            (timestamp, timestamp, session_id),
+        )
+        conn.execute(
+            """
+            WITH RECURSIVE ancestors(id) AS (
+                SELECT parent.id
+                FROM sessions child
+                JOIN sessions parent ON parent.id = child.parent_session_id
+                WHERE child.id = ?
+                  AND parent.end_reason = 'compression'
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+                  AND COALESCE(child.source, '') != 'tool'
+                UNION
+                SELECT parent.id
+                FROM ancestors a
+                JOIN sessions child ON child.id = a.id
+                JOIN sessions parent ON parent.id = child.parent_session_id
+                WHERE parent.end_reason = 'compression'
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+                  AND COALESCE(child.source, '') != 'tool'
+            )
+            UPDATE sessions
+            SET last_active = CASE
+                WHEN last_active IS NULL OR last_active < ? THEN ?
+                ELSE last_active
+            END
+            WHERE id IN (SELECT id FROM ancestors)
+            """,
+            (session_id, timestamp, timestamp),
+        )
+
+    @staticmethod
+    def _refresh_session_last_active(
+        conn: sqlite3.Connection,
+        session_id: str,
+    ) -> None:
+        """Recompute exact last_active for a session and compression ancestors."""
+        conn.execute(
+            """
+            WITH RECURSIVE affected(id) AS (
+                SELECT ?
+                UNION
+                SELECT parent.id
+                FROM affected a
+                JOIN sessions child ON child.id = a.id
+                JOIN sessions parent ON parent.id = child.parent_session_id
+                WHERE parent.end_reason = 'compression'
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+                  AND COALESCE(child.source, '') != 'tool'
+            ),
+            chain(root_id, cur_id) AS (
+                SELECT id, id FROM affected
+                UNION ALL
+                SELECT c.root_id, child.id
+                FROM chain c
+                JOIN sessions parent ON parent.id = c.cur_id
+                JOIN sessions child ON child.parent_session_id = c.cur_id
+                WHERE parent.end_reason = 'compression'
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+                  AND COALESCE(child.source, '') != 'tool'
+            ),
+            activity AS (
+                SELECT
+                    c.root_id AS id,
+                    MAX(COALESCE(
+                        (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = c.cur_id),
+                        s.started_at
+                    )) AS last_active
+                FROM chain c
+                JOIN sessions s ON s.id = c.cur_id
+                GROUP BY c.root_id
+            )
+            UPDATE sessions
+            SET last_active = (SELECT activity.last_active FROM activity WHERE activity.id = sessions.id)
+            WHERE id IN (SELECT id FROM affected)
+            """,
+            (session_id,),
+        )
+
+    @staticmethod
+    def _compression_ancestor_ids(
+        conn: sqlite3.Connection,
+        session_ids: List[str],
+    ) -> List[str]:
+        """Return compression ancestors of the given sessions before mutation."""
+        ids = [sid for sid in session_ids if sid]
+        if not ids:
+            return []
+        placeholders = ",".join("?" * len(ids))
+        rows = conn.execute(
+            f"""
+            WITH RECURSIVE ancestors(id) AS (
+                SELECT parent.id
+                FROM sessions child
+                JOIN sessions parent ON parent.id = child.parent_session_id
+                WHERE child.id IN ({placeholders})
+                  AND parent.end_reason = 'compression'
+                  AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                  AND COALESCE(child.source, '') != 'tool'
+                UNION
+                SELECT parent.id
+                FROM ancestors a
+                JOIN sessions child ON child.id = a.id
+                JOIN sessions parent ON parent.id = child.parent_session_id
+                WHERE parent.end_reason = 'compression'
+                  AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                  AND COALESCE(child.source, '') != 'tool'
+            )
+            SELECT DISTINCT id FROM ancestors
+            """,
+            ids,
+        ).fetchall()
+        return [row["id"] if isinstance(row, sqlite3.Row) else row[0] for row in rows]
+
     def _init_schema(self):
         """Create tables and FTS if they don't exist, reconcile columns.
 
@@ -2952,6 +3322,7 @@ class SessionDB:
         # Deferred indexes that reference the reconciler-added ``active``
         # column (idx_messages_session_active) — same ordering constraint.
         cursor.executescript(DEFERRED_INDEX_SQL)
+        cursor.executescript(LAST_ACTIVE_REPAIR_TRIGGER_SQL)
 
         # Heal NULL ``active`` rows unconditionally on every startup.
         # On real-world DBs the reconciler-added ``active`` column can lack
@@ -2972,6 +3343,16 @@ class SessionDB:
 
         fts5_available = self._sqlite_supports_fts5(cursor)
         fts_migrations_complete = True
+        legacy_fts_layout = self._db_has_legacy_inline_fts(cursor)
+        legacy_trigram_disabled = (
+            self._fts_trigram_disabled and legacy_fts_layout
+        )
+        if legacy_trigram_disabled:
+            if self._drop_fts_trigram_objects(cursor):
+                logger.info(
+                    "Dropped disabled legacy messages_fts_trigram index for %s",
+                    self.db_path,
+                )
         if not fts5_available:
             # Existing FTS triggers can still fire on messages INSERT/UPDATE
             # even though the current sqlite runtime cannot read the virtual
@@ -2986,6 +3367,13 @@ class SessionDB:
         cursor.execute("SELECT version FROM schema_version LIMIT 1")
         row = cursor.fetchone()
         if row is None:
+            # No schema_version row at all predates that table's introduction
+            # — an old DB, not necessarily an empty one. Backfill last_active
+            # for whatever sessions/messages it already has before stamping
+            # it straight to the current version.
+            self._execute_write(
+                lambda conn: self._backfill_session_last_active(conn.cursor())
+            )
             cursor.execute(
                 "INSERT INTO schema_version (version) VALUES (?)",
                 (SCHEMA_VERSION,),
@@ -3214,6 +3602,16 @@ class SessionDB:
                 # users too. Only the FTS *layout* waits for opt-in.
                 if fts5_available and self._db_has_legacy_inline_fts(cursor):
                     self.set_meta("fts_optimize_available", "1", cursor=cursor)
+            if current_version < 24:
+                # v24: sessions.last_active (issue #59912). Backfill the new
+                # denormalized column for every existing session so
+                # list_sessions_rich's indexed recents path (idx_sessions_
+                # last_active) has correct data from the first read — the
+                # column reconciler above only adds the column, it doesn't
+                # populate historical rows.
+                self._execute_write(
+                    lambda conn: self._backfill_session_last_active(conn.cursor())
+                )
 
             # The FTS storage layout is versioned independently of the main
             # schema (see the v23 note above). Stamp the current layout so the
@@ -3304,16 +3702,24 @@ class SessionDB:
             # v23 view/external tables entirely. Fresh installs and opted-in
             # DBs have no legacy inline FTS, so they get the v23 DDL.
             if self._db_has_legacy_inline_fts(cursor):
+                include_trigram = not legacy_trigram_disabled
                 triggers_need_repair = (
-                    self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+                    self._fts_trigger_count(
+                        cursor, include_trigram=include_trigram
+                    )
+                    < len(_FTS_TRIGGERS if include_trigram else _FTS_BASE_TRIGGERS)
                 )
                 self._fts_enabled = self._ensure_fts_schema(
                     cursor, "messages_fts", LEGACY_FTS_SQL
                 )
                 if self._fts_enabled:
-                    trigram_enabled = self._ensure_fts_schema(
-                        cursor, "messages_fts_trigram", LEGACY_FTS_TRIGRAM_SQL
-                    )
+                    trigram_enabled = False
+                    if include_trigram:
+                        trigram_enabled = self._ensure_fts_schema(
+                            cursor,
+                            "messages_fts_trigram",
+                            LEGACY_FTS_TRIGRAM_SQL,
+                        )
                     self._trigram_available = trigram_enabled
                     if triggers_need_repair:
                         self._rebuild_legacy_fts_indexes(
@@ -3401,13 +3807,14 @@ class SessionDB:
         without a recoverable routing mapping (#59527).
         """
         def _do(conn):
+            now = time.time()
             conn.execute(
                 """INSERT INTO sessions (
                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
                    model, model_config, system_prompt, parent_session_id, cwd,
-                   profile_name, git_repo_root, started_at
+                   profile_name, git_repo_root, started_at, last_active
                 )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(id) DO UPDATE SET
                        model = COALESCE(sessions.model, excluded.model),
                        model_config = COALESCE(sessions.model_config, excluded.model_config),
@@ -3419,7 +3826,8 @@ class SessionDB:
                        parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id),
                        cwd = COALESCE(sessions.cwd, excluded.cwd),
                        profile_name = COALESCE(sessions.profile_name, excluded.profile_name),
-                       git_repo_root = COALESCE(sessions.git_repo_root, excluded.git_repo_root)""",
+                       git_repo_root = COALESCE(sessions.git_repo_root, excluded.git_repo_root),
+                       last_active = COALESCE(sessions.last_active, excluded.last_active)""",
                 (
                     session_id,
                     source,
@@ -3435,9 +3843,11 @@ class SessionDB:
                     cwd,
                     profile_name,
                     git_repo_root,
-                    time.time(),
+                    now,
+                    now,
                 ),
             )
+            self._refresh_session_last_active(conn, session_id)
             if parent_session_id:
                 conn.execute(
                     """UPDATE sessions
@@ -3856,20 +4266,38 @@ class SessionDB:
         intentionally need to re-end a closed session with a new reason.
         """
         def _do(conn):
-            conn.execute(
+            row = conn.execute(
+                "SELECT end_reason FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            previous_reason = row["end_reason"] if row is not None else None
+            result = conn.execute(
                 "UPDATE sessions SET ended_at = ?, end_reason = ? "
                 "WHERE id = ? AND ended_at IS NULL",
                 (time.time(), end_reason, session_id),
             )
+            if (
+                result.rowcount
+                and end_reason == "compression"
+                and previous_reason != "compression"
+            ):
+                self._refresh_session_last_active(conn, session_id)
         self._execute_write(_do)
 
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed."""
         def _do(conn):
-            conn.execute(
+            row = conn.execute(
+                "SELECT end_reason FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            previous_reason = row["end_reason"] if row is not None else None
+            result = conn.execute(
                 "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
                 (session_id,),
             )
+            if result.rowcount and previous_reason == "compression":
+                self._refresh_session_last_active(conn, session_id)
         self._execute_write(_do)
 
     def promote_to_session_reset(
@@ -5215,17 +5643,27 @@ class SessionDB:
     _session_compact_cols_sql: Optional[str] = None
 
     @classmethod
-    def _compact_session_cols(cls) -> str:
+    def _compact_session_cols(cls, include_last_active: bool = True) -> str:
         """SELECT list for compact_rows: every ``sessions`` column declared in
         SCHEMA_SQL except the ``system_prompt`` blob, aliased with the ``s``
-        prefix used by list_sessions_rich/_get_session_rich_row queries."""
+        prefix used by list_sessions_rich/_get_session_rich_row queries.
+
+        Read-only legacy databases can predate ``sessions.last_active``. Exclude
+        that physical column there so the query-level fallback can provide the
+        same public ``last_active`` field without attempting a migration.
+        """
         if cls._session_compact_cols_sql is None:
             declared = cls._parse_schema_columns(SCHEMA_SQL)["sessions"]
             cls._session_compact_cols_sql = ", ".join(
                 f"s.{name}" for name in declared
                 if name not in cls._SESSION_COMPACT_EXCLUDED
             )
-        return cls._session_compact_cols_sql
+        if include_last_active:
+            return cls._session_compact_cols_sql
+        return ", ".join(
+            column for column in cls._session_compact_cols_sql.split(", ")
+            if column != "s.last_active"
+        )
 
     def distinct_session_cwds(self, include_archived: bool = False) -> List[Dict[str, Any]]:
         """Distinct non-empty session cwds with usage stats, for repo discovery.
@@ -5291,11 +5729,10 @@ class SessionDB:
 
         Pass ``order_by_last_active=True`` to sort by most-recent activity
         instead of original conversation start time. For compression chains,
-        the "most-recent activity" is taken from the live tip (not the root),
-        so an old conversation that was compressed and continued recently
-        surfaces in the correct slot. Ordering is computed at SQL level via
-        a recursive CTE that walks compression-continuation edges, so LIMIT
-        and OFFSET still apply efficiently.
+        the root row's denormalized ``last_active`` is kept in sync with the
+        live tip, so an old conversation that was compressed and continued
+        recently surfaces in the correct slot without walking every chain
+        before LIMIT.
 
         ``search_query`` matches case-insensitive substrings against each
         surfaced row's title and id (and, like ``id_query``, every title/id in
@@ -5350,6 +5787,15 @@ class SessionDB:
             where_clauses.append("s.archived = 0")
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+        has_last_active = getattr(self, "_has_sessions_last_active", True)
+        fallback_last_active_select = """
+                    ,
+                    COALESCE(
+                        (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
+                        s.started_at
+                    ) AS last_active
+        """
+        last_active_select = "" if has_last_active else fallback_last_active_select
 
         # Optional session-id filter, pushed into SQL so callers (Desktop
         # session-id search) don't have to fetch every row and filter in
@@ -5361,7 +5807,9 @@ class SessionDB:
         # pass id_query=None.
         id_needle = (id_query or "").strip().lower()
         search_needle = (search_query or "").strip().lower()
-        if order_by_last_active:
+        if order_by_last_active and (not has_last_active or id_needle or search_needle):
+            # Legacy read-only DBs and filtered searches retain the recursive
+            # fallback; writable unfiltered recents use the indexed branch below.
             # Compute effective_last_active by walking each surfaced session's
             # compression-continuation chain forward in SQL and taking the MAX
             # timestamp across the chain. This lets us ORDER BY + LIMIT at SQL
@@ -5425,7 +5873,7 @@ class SessionDB:
                 outer_where = (
                     f"{where_sql} AND {combined}" if where_sql else f"WHERE {combined}"
                 )
-            _sel = self._compact_session_cols() if compact_rows else "s.*"
+            _sel = self._compact_session_cols(include_last_active=has_last_active) if compact_rows else "s.*"
             query = f"""
                 WITH RECURSIVE chain(root_id, cur_id) AS (
                     SELECT s.id, s.id FROM sessions s {where_sql}
@@ -5471,8 +5919,8 @@ class SessionDB:
             # WHERE params apply twice (CTE seed + outer select); the id filter
             # only applies to the outer select.
             params = params + params + id_params + [limit, offset]
-        else:
-            _sel = self._compact_session_cols() if compact_rows else "s.*"
+        elif order_by_last_active:
+            _sel = self._compact_session_cols(include_last_active=has_last_active) if compact_rows else "s.*"
             query = f"""
                 SELECT {_sel},
                     COALESCE(
@@ -5481,14 +5929,28 @@ class SessionDB:
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
-                    ) AS _preview_raw,
-                    COALESCE(
-                        (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
-                        s.started_at
-                    ) AS last_active
+                    ) AS _preview_raw
                 FROM sessions s
                 {where_sql}
-                ORDER BY s.started_at DESC
+                ORDER BY s.last_active DESC, s.started_at DESC, s.id DESC
+                LIMIT ? OFFSET ?
+            """
+            params.extend([limit, offset])
+        else:
+            _sel = self._compact_session_cols(include_last_active=has_last_active) if compact_rows else "s.*"
+            query = f"""
+                SELECT {_sel},
+                    COALESCE(
+                        (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                         FROM messages m
+                         WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                         ORDER BY m.timestamp, m.id LIMIT 1),
+                        ''
+                    ) AS _preview_raw
+                    {last_active_select}
+                FROM sessions s
+                {where_sql}
+                ORDER BY s.started_at DESC, s.id DESC
                 LIMIT ? OFFSET ?
             """
             params.extend([limit, offset])
@@ -5619,7 +6081,16 @@ class SessionDB:
         Pass ``compact_rows=True`` to omit the ``system_prompt`` blob (see
         ``list_sessions_rich`` for details).
         """
-        _sel = self._compact_session_cols() if compact_rows else "s.*"
+        has_last_active = getattr(self, "_has_sessions_last_active", True)
+        _sel = self._compact_session_cols(include_last_active=has_last_active) if compact_rows else "s.*"
+        last_active_select = ""
+        if not has_last_active:
+            last_active_select = """
+                , COALESCE(
+                    (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
+                    s.started_at
+                ) AS last_active
+            """
         query = f"""
             SELECT {_sel},
                 COALESCE(
@@ -5628,11 +6099,8 @@ class SessionDB:
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
-                ) AS _preview_raw,
-                COALESCE(
-                    (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
-                    s.started_at
-                ) AS last_active
+                ) AS _preview_raw
+                {last_active_select}
             FROM sessions s
             WHERE s.id = ?
         """
@@ -5841,6 +6309,7 @@ class SessionDB:
                     "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
                     (session_id,),
                 )
+            self._touch_session_last_active(conn, session_id, message_timestamp)
             return msg_id
 
         return self._execute_write(_do)
@@ -5973,6 +6442,7 @@ class SessionDB:
                 tool_calls_total += (
                     len(tool_calls) if isinstance(tool_calls, list) else 1
                 )
+            self._touch_session_last_active(conn, session_id, message_timestamp)
             now_ts = max(now_ts + 1e-6, message_timestamp + 1e-6)
         return inserted, tool_calls_total
 
@@ -6021,6 +6491,7 @@ class SessionDB:
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
                 (total_messages, total_tool_calls, session_id),
             )
+            self._refresh_session_last_active(conn, session_id)
 
         self._execute_write(_do)
 
@@ -8544,6 +9015,18 @@ class SessionDB:
                     parent_by_child.pop(session_id, None)
                     detached += 1
 
+            # Every imported session was inserted with parent_session_id=NULL
+            # (wired up above, after all messages were already written), so
+            # _insert_message_rows' per-message _touch_session_last_active
+            # calls ran when the compression-chain walk had nothing to climb
+            # — a compression parent's last_active never learned about its
+            # continuation's activity. Settle the whole chain now that
+            # parent edges are final. This also gives an empty imported
+            # session (zero messages, so _touch_session_last_active never
+            # ran for it) a real last_active instead of leaving it NULL.
+            for session_id in imported_ids:
+                self._refresh_session_last_active(conn, session_id)
+
             return {
                 "ok": True,
                 "imported": len(imported_ids),
@@ -8566,6 +9049,11 @@ class SessionDB:
                 "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
                 (session_id,),
             )
+            # The session row itself survives (only its messages are gone),
+            # so its parent_session_id linkage is still live — recompute
+            # last_active for it and any compression ancestors now that its
+            # own activity has dropped to (at most) started_at.
+            self._refresh_session_last_active(conn, session_id)
         self._execute_write(_do)
 
     @staticmethod
@@ -8618,7 +9106,11 @@ class SessionDB:
             )
             if cursor.fetchone()[0] == 0:
                 return False
+            affected_ancestors = set(self._compression_ancestor_ids(conn, [session_id]))
             removed_delegate_ids.extend(_delete_delegate_children(conn, [session_id]))
+            affected_ancestors.update(
+                self._compression_ancestor_ids(conn, removed_delegate_ids)
+            )
             # Orphan remaining child sessions (branches, etc.) so FK is satisfied.
             conn.execute(
                 "UPDATE sessions SET parent_session_id = NULL "
@@ -8627,6 +9119,8 @@ class SessionDB:
             )
             conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
             conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+            for ancestor_id in affected_ancestors:
+                self._refresh_session_last_active(conn, ancestor_id)
             return True
 
         deleted = self._execute_write(_do)
@@ -8656,6 +9150,7 @@ class SessionDB:
         flushed. Returns True if the session was deleted.
         """
         def _do(conn):
+            affected_ancestors = set(self._compression_ancestor_ids(conn, [session_id]))
             cursor = conn.execute(
                 """
                 DELETE FROM sessions
@@ -8671,7 +9166,11 @@ class SessionDB:
                 """,
                 (session_id,),
             )
-            return cursor.rowcount > 0
+            deleted = cursor.rowcount > 0
+            if deleted:
+                for ancestor_id in affected_ancestors:
+                    self._refresh_session_last_active(conn, ancestor_id)
+            return deleted
 
         deleted = self._execute_write(_do)
         if deleted:
@@ -8732,7 +9231,11 @@ class SessionDB:
                 return 0
 
             existing_placeholders = ",".join("?" * len(existing))
+            affected_ancestors = set(self._compression_ancestor_ids(conn, existing))
             removed_delegate_ids.extend(_delete_delegate_children(conn, existing))
+            affected_ancestors.update(
+                self._compression_ancestor_ids(conn, removed_delegate_ids)
+            )
             # Orphan remaining children whose parent is in the kill list so the
             # FK constraint stays satisfied. Pin children whose parent
             # is itself in the kill list rather than NULL-ing parents
@@ -8751,6 +9254,8 @@ class SessionDB:
                 f"DELETE FROM sessions WHERE id IN ({existing_placeholders})",
                 existing,
             )
+            for ancestor_id in affected_ancestors:
+                self._refresh_session_last_active(conn, ancestor_id)
             removed_ids.extend(existing)
             return len(existing)
 
@@ -8829,6 +9334,9 @@ class SessionDB:
             if not session_ids:
                 return 0
 
+            affected_ancestors = set(
+                self._compression_ancestor_ids(conn, list(session_ids))
+            )
             placeholders = ",".join("?" * len(session_ids))
             conn.execute(
                 f"UPDATE sessions SET parent_session_id = NULL "
@@ -8846,6 +9354,8 @@ class SessionDB:
                 )
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
                 removed_ids.append(sid)
+            for ancestor_id in affected_ancestors:
+                self._refresh_session_last_active(conn, ancestor_id)
             return len(session_ids)
 
         count = self._execute_write(_do)
@@ -9082,6 +9592,9 @@ class SessionDB:
 
             # Orphan any sessions whose parent is about to be deleted
             placeholders = ",".join("?" * len(session_ids))
+            affected_ancestors = set(
+                self._compression_ancestor_ids(conn, list(session_ids))
+            )
             conn.execute(
                 f"UPDATE sessions SET parent_session_id = NULL "
                 f"WHERE parent_session_id IN ({placeholders})",
@@ -9092,6 +9605,8 @@ class SessionDB:
                 conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
                 removed_ids.append(sid)
+            for ancestor_id in affected_ancestors:
+                self._refresh_session_last_active(conn, ancestor_id)
             return len(session_ids)
 
         count = self._execute_write(_do)

--- a/tests/hermes_state/test_fts_trigram_disable.py
+++ b/tests/hermes_state/test_fts_trigram_disable.py
@@ -1,0 +1,289 @@
+"""Config-backed disable/reenable behavior for the trigram FTS index."""
+
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _sqlite_supports_trigram() -> bool:
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute(
+            "CREATE VIRTUAL TABLE t USING fts5(content, tokenize='trigram')"
+        )
+        return True
+    except sqlite3.OperationalError:
+        return False
+    finally:
+        conn.close()
+
+
+pytestmark = pytest.mark.skipif(
+    not _sqlite_supports_trigram(),
+    reason="SQLite FTS5 trigram tokenizer is not available",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_disable_env(monkeypatch):
+    monkeypatch.delenv("HERMES_DISABLE_FTS_TRIGRAM", raising=False)
+
+
+def _write_config(home, *, disabled: bool) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    home.joinpath("config.yaml").write_text(
+        "sessions:\n"
+        f"  disable_fts_trigram: {'true' if disabled else 'false'}\n",
+        encoding="utf-8",
+    )
+
+
+def _objects(conn):
+    rows = conn.execute(
+        "SELECT type, name FROM sqlite_master "
+        "WHERE name = 'messages_fts_trigram' "
+        "OR name IN ("
+        "'messages_fts_trigram_insert',"
+        "'messages_fts_trigram_delete',"
+        "'messages_fts_trigram_update'"
+        ")"
+    ).fetchall()
+    return {(row[0], row[1]) for row in rows}
+
+
+def _seed_message(db: SessionDB, content: str) -> None:
+    db.create_session(session_id="s1", source="cli")
+    db.append_message("s1", role="user", content=content)
+
+
+class _DropTrigramFailsCursor(sqlite3.Cursor):
+    def execute(self, sql, parameters=()):
+        if sql.strip() == "DROP TABLE IF EXISTS messages_fts_trigram":
+            raise sqlite3.OperationalError("no such module: fts5")
+        return super().execute(sql, parameters)
+
+
+class _DropTrigramFailsConnection(sqlite3.Connection):
+    def cursor(self, factory=None):
+        return super().cursor(factory or _DropTrigramFailsCursor)
+
+
+def test_default_config_creates_trigram_and_triggers_write(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        assert db._fts_trigram_disabled is False
+        assert db._trigram_available is True
+        _seed_message(db, "hello unicode 大别山项目")
+
+        assert (
+            db._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
+            == 1
+        )
+        assert (
+            db._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts_trigram"
+            ).fetchone()[0]
+            == 1
+        )
+        assert ("table", "messages_fts_trigram") in _objects(db._conn)
+        assert {
+            ("trigger", "messages_fts_trigram_insert"),
+            ("trigger", "messages_fts_trigram_delete"),
+            ("trigger", "messages_fts_trigram_update"),
+        }.issubset(_objects(db._conn))
+    finally:
+        db.close()
+
+
+def test_disabled_fresh_v23_db_keeps_compact_trigram_and_search_works(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_config(home, disabled=True)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        assert db._fts_enabled is True
+        assert db._fts_trigram_disabled is True
+        assert db._trigram_available is True
+        assert ("table", "messages_fts_trigram") in _objects(db._conn)
+
+        _seed_message(db, "hello unicode 大别山项目")
+        assert len(db.search_messages("hello")) == 1
+        assert len(db.search_messages("大别山项目")) == 1
+        assert db._conn.execute(
+            "SELECT COUNT(*) FROM messages_fts_trigram"
+        ).fetchone()[0] == 1
+    finally:
+        db.close()
+
+
+def test_explicit_profile_v23_db_keeps_compact_trigram_despite_legacy_flag(
+    tmp_path, monkeypatch
+):
+    process_home = tmp_path / "profiles" / "gpt"
+    target_home = tmp_path / "profiles" / "coding"
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    _write_config(process_home, disabled=False)
+    _write_config(target_home, disabled=True)
+
+    db = SessionDB(db_path=target_home / "state.db")
+    try:
+        assert db._fts_trigram_disabled is True
+        assert db._trigram_available is True
+        assert ("table", "messages_fts_trigram") in _objects(db._conn)
+    finally:
+        db.close()
+
+
+def test_disabled_existing_v23_trigram_is_not_dropped_or_backfilled(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        _seed_message(seeded, "before disable 大别山项目")
+        assert ("table", "messages_fts_trigram") in _objects(seeded._conn)
+    finally:
+        seeded.close()
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_config(home, disabled=True)
+
+    traced_sql = []
+    real_connect = sqlite3.connect
+
+    def connect_with_trace(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+
+        def trace(sql):
+            text = " ".join(str(sql).split())
+            if "messages_fts_trigram" in text:
+                traced_sql.append(text)
+
+        conn.set_trace_callback(trace)
+        return conn
+
+    monkeypatch.setattr("hermes_state.sqlite3.connect", connect_with_trace)
+
+    db = SessionDB(db_path=db_path)
+    try:
+        assert db._fts_trigram_disabled is True
+        assert db._trigram_available is True
+        assert ("table", "messages_fts_trigram") in _objects(db._conn)
+        assert not any(
+            "messages_fts_trigram(messages_fts_trigram) VALUES('rebuild')" in sql
+            for sql in traced_sql
+        )
+
+        db.append_message("s1", role="assistant", content="after disable")
+        assert len(db.search_messages("after")) == 1
+    finally:
+        db.close()
+
+
+def test_disabled_existing_v23_trigram_is_preserved_when_fts5_probe_fails(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        _seed_message(seeded, "before no fts5 runtime")
+        assert ("table", "messages_fts_trigram") in _objects(seeded._conn)
+    finally:
+        seeded.close()
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_config(home, disabled=True)
+    monkeypatch.setattr(
+        SessionDB,
+        "_sqlite_supports_fts5",
+        lambda self, cursor: False,
+    )
+
+    db = SessionDB(db_path=db_path)
+    try:
+        assert db._fts_enabled is False
+        assert _objects(db._conn) == {("table", "messages_fts_trigram")}
+        db.append_message("s1", role="assistant", content="writes still work")
+    finally:
+        db.close()
+
+
+def test_disabled_existing_v23_trigram_never_attempts_legacy_drop(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    seeded = SessionDB(db_path=db_path)
+    try:
+        _seed_message(seeded, "before drop failure")
+        assert ("table", "messages_fts_trigram") in _objects(seeded._conn)
+    finally:
+        seeded.close()
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_config(home, disabled=True)
+    monkeypatch.setattr(
+        SessionDB,
+        "_sqlite_supports_fts5",
+        lambda self, cursor: False,
+    )
+    real_connect = sqlite3.connect
+
+    def connect_with_drop_failure(*args, **kwargs):
+        kwargs["factory"] = _DropTrigramFailsConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr("hermes_state.sqlite3.connect", connect_with_drop_failure)
+
+    db = SessionDB(db_path=db_path)
+    try:
+        assert ("table", "messages_fts_trigram") in _objects(db._conn)
+        remaining_shadow_rows = db._conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master "
+            "WHERE name LIKE 'messages_fts_trigram_%'"
+        ).fetchone()[0]
+        assert remaining_shadow_rows > 0
+    finally:
+        db.close()
+
+
+def test_legacy_disable_flag_does_not_remove_v23_trigram(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db_path = tmp_path / "state.db"
+
+    _write_config(home, disabled=False)
+    seeded = SessionDB(db_path=db_path)
+    try:
+        _seed_message(seeded, "reenable needle 大别山项目")
+    finally:
+        seeded.close()
+
+    _write_config(home, disabled=True)
+    disabled = SessionDB(db_path=db_path)
+    try:
+        assert ("table", "messages_fts_trigram") in _objects(disabled._conn)
+    finally:
+        disabled.close()
+
+    _write_config(home, disabled=False)
+    restored = SessionDB(db_path=db_path)
+    try:
+        assert restored._trigram_available is True
+        assert ("table", "messages_fts_trigram") in _objects(restored._conn)
+        assert (
+            restored._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts_trigram"
+            ).fetchone()[0]
+            == 1
+        )
+        assert len(restored.search_messages("大别山项目")) == 1
+    finally:
+        restored.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2919,6 +2919,61 @@ class TestDeleteAndExport:
         assert result["errors"][0]["error"] == "messages exceeds the per-session import limit"
         assert db.get_session("too-many-messages") is None
 
+    def test_import_sessions_settles_compression_chain_last_active(self, db):
+        """Import wires parent_session_id only after every session's messages
+        are already inserted, so the per-message _touch_session_last_active
+        calls run before there's any chain to climb. The parent must still
+        end up reflecting its continuation child's activity once import
+        finishes, and an empty imported session must not retain a NULL
+        last_active.
+        """
+        t_parent_start = 1000.0
+        t_child_start = 2000.0
+        t_child_msg = 5000.0
+        t_empty_start = 3000.0
+        result = db.import_sessions(
+            [
+                {
+                    "id": "parent",
+                    "source": "cli",
+                    "started_at": t_parent_start,
+                    "end_reason": "compression",
+                    "messages": [],
+                },
+                {
+                    "id": "child",
+                    "source": "cli",
+                    "parent_session_id": "parent",
+                    "started_at": t_child_start,
+                    "messages": [
+                        {"role": "user", "content": "hi", "timestamp": t_child_msg},
+                    ],
+                },
+                {
+                    "id": "empty",
+                    "source": "cli",
+                    "started_at": t_empty_start,
+                    "messages": [],
+                },
+            ]
+        )
+
+        assert result["ok"] is True
+        assert result["imported"] == 3
+
+        child = db.get_session("child")
+        parent = db.get_session("parent")
+        empty = db.get_session("empty")
+
+        assert child["last_active"] == t_child_msg
+        # The compression parent's last_active must have learned about the
+        # child's activity even though parent_session_id was only wired up
+        # after every session's messages were already inserted.
+        assert parent["last_active"] == t_child_msg
+        # An empty imported session (no messages, so the per-message touch
+        # never ran for it) must fall back to started_at, not stay NULL.
+        assert empty["last_active"] == t_empty_start
+
 
 # =========================================================================
 # Prune
@@ -3860,6 +3915,176 @@ class TestSchemaInit:
         version = cursor.fetchone()[0]
         assert version == SCHEMA_VERSION
 
+    @pytest.mark.parametrize("legacy_version", [17, 19, 23])
+    def test_last_active_migration_backfills_and_indexes_legacy_db(self, tmp_path, legacy_version):
+        """Writable pre-v24 databases gain indexed chain activity without changing
+        their existing message history.
+        """
+        db_path = tmp_path / f"legacy-v{legacy_version}.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(SCHEMA_SQL.replace("    last_active REAL,\n", ""))
+        conn.execute("DELETE FROM schema_version")
+        conn.execute("INSERT INTO schema_version VALUES (?)", (legacy_version,))
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at, end_reason) VALUES (?, ?, ?, ?)",
+            ("root", "cli", 100.0, "compression"),
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, source, parent_session_id, started_at) VALUES (?, ?, ?, ?)",
+            ("tip", "cli", "root", 110.0),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            ("tip", "user", "fresh continuation", 200.0),
+        )
+        conn.commit()
+        conn.close()
+
+        migrated = SessionDB(db_path=db_path)
+        try:
+            columns = {
+                row[1] for row in migrated._conn.execute("PRAGMA table_info(sessions)")
+            }
+            assert "last_active" in columns
+            assert migrated._conn.execute(
+                "SELECT version FROM schema_version"
+            ).fetchone()[0] == SCHEMA_VERSION
+            assert migrated._conn.execute(
+                "SELECT last_active FROM sessions WHERE id = 'root'"
+            ).fetchone()[0] == 200.0
+            indexes = {
+                row[1] for row in migrated._conn.execute("PRAGMA index_list(sessions)")
+            }
+            assert "idx_sessions_last_active" in indexes
+        finally:
+            migrated.close()
+
+    def test_read_only_legacy_db_uses_last_active_fallback_without_writes(self, tmp_path):
+        """Cross-profile aggregation must not migrate a v19 DB it only reads."""
+        db_path = tmp_path / "legacy-read-only.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(SCHEMA_SQL.replace("    last_active REAL,\n", ""))
+        conn.execute("DELETE FROM schema_version")
+        conn.execute("INSERT INTO schema_version VALUES (19)")
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("old", "cli", 100.0),
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("new", "cli", 110.0),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            ("old", "user", "most recent", 300.0),
+        )
+        conn.commit()
+        conn.close()
+        before = db_path.read_bytes()
+
+        readonly = SessionDB(db_path=db_path, read_only=True)
+        try:
+            assert readonly._has_sessions_last_active is False
+            assert [row["id"] for row in readonly.list_sessions_rich(
+                order_by_last_active=True
+            )] == ["old", "new"]
+        finally:
+            readonly.close()
+
+        assert db_path.read_bytes() == before
+
+    def test_read_only_legacy_db_compact_rows_uses_last_active_fallback_without_writes(self, tmp_path):
+        """Compact cross-profile aggregation must not select a missing legacy column."""
+        db_path = tmp_path / "legacy-read-only-compact.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(SCHEMA_SQL.replace("    last_active REAL,\n", ""))
+        conn.execute("DELETE FROM schema_version")
+        conn.execute("INSERT INTO schema_version VALUES (19)")
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("old", "cli", 100.0),
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("new", "cli", 110.0),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            ("old", "user", "most recent", 300.0),
+        )
+        conn.commit()
+        conn.close()
+        before = db_path.read_bytes()
+
+        readonly = SessionDB(db_path=db_path, read_only=True)
+        try:
+            assert readonly._has_sessions_last_active is False
+            rows = readonly.list_sessions_rich(
+                compact_rows=True, order_by_last_active=True
+            )
+            assert [row["id"] for row in rows] == ["old", "new"]
+            assert [row["last_active"] for row in rows] == [300.0, 110.0]
+            assert all("system_prompt" not in row for row in rows)
+        finally:
+            readonly.close()
+
+        assert db_path.read_bytes() == before
+
+    def test_stale_write_from_bypassing_writer_self_heals_on_next_write(self, db):
+        """Documented contract: a writer that mutates ``messages`` without
+        going through ``_touch_session_last_active``/
+        ``_refresh_session_last_active`` (an older process version sharing
+        this state.db during a rolling upgrade, a different language
+        binding, an ad hoc SQL script) leaves that session's ``last_active``
+        stale — behind its true message activity — until the next
+        helper-mediated write on that session. There is no on-open or
+        background reconciliation for this: it is a recents-ORDERING
+        staleness only (no data loss), and it self-heals the moment normal
+        traffic resumes on the session. This test proves the self-heal half
+        of that contract actually happens, not just that the touch/refresh
+        helpers exist.
+        """
+        db.create_session("root", "cli")
+        db.create_session("solo", "cli")
+        # Pin both sessions' last_active to a known baseline — a fresh
+        # create_session() stamps "now", which a later append_message with
+        # an explicit older timestamp would (correctly) never move
+        # backward, so an artificial baseline is needed to simulate
+        # "activity happened, but nothing told last_active about it".
+        with db._lock:
+            db._conn.execute(
+                "UPDATE sessions SET last_active=? WHERE id=?", (1000.0, "root"),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET last_active=? WHERE id=?", (2000.0, "solo"),
+            )
+            db._conn.commit()
+
+        # Simulate a writer that bypasses every last_active-aware helper:
+        # insert a message directly with raw SQL.
+        with db._lock:
+            db._conn.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp, active) "
+                "VALUES (?, 'user', 'raw insert', ?, 1)",
+                ("root", 9000.0),
+            )
+            db._conn.commit()
+        # last_active is now stale: the bypassing insert never touched it,
+        # and nothing repairs it just from sitting there.
+        assert db.get_session("root")["last_active"] == 1000.0
+        assert [
+            s["id"] for s in db.list_sessions_rich(limit=2, order_by_last_active=True)
+        ] == ["solo", "root"]
+
+        # The next helper-mediated write on "root" — a normal append_message
+        # call, same as any real turn — heals it via _touch_session_last_active.
+        db.append_message("root", "user", "normal turn", timestamp=9500.0)
+
+        assert db.get_session("root")["last_active"] == 9500.0
+        assert [
+            s["id"] for s in db.list_sessions_rich(limit=2, order_by_last_active=True)
+        ] == ["root", "solo"]
+
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
         cursor = db._conn.execute("PRAGMA table_info(sessions)")
@@ -4677,6 +4902,163 @@ class TestListSessionsRich:
         # Projection surfaces the tip's id in the root's slot.
         assert top[0]["id"] == "tip1"
         assert top[0]["_lineage_root_id"] == "root1"
+
+    def test_last_active_refreshes_when_compression_edge_changes(self, db):
+        """A child with existing messages becomes/removes chain activity when
+        the parent transitions into/out of ``end_reason='compression'``.
+        """
+        t0 = 1709500000.0
+        db.create_session("root", "cli")
+        db.create_session("tip", "cli", parent_session_id="root")
+        db.create_session("solo", "cli")
+        with db._lock:
+            db._conn.execute(
+                "UPDATE sessions SET started_at=?, last_active=? WHERE id=?",
+                (t0, t0, "root"),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at=?, last_active=? WHERE id=?",
+                (t0 + 10, t0 + 10, "tip"),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at=?, last_active=? WHERE id=?",
+                (t0 + 20, t0 + 20, "solo"),
+            )
+            db._conn.commit()
+        db.append_message("root", "user", "old root", timestamp=t0 + 1)
+        db.append_message("tip", "user", "new child", timestamp=t0 + 1000)
+        db.append_message("solo", "user", "middle", timestamp=t0 + 500)
+
+        assert [
+            s["id"] for s in db.list_sessions_rich(limit=2, order_by_last_active=True)
+        ] == ["solo", "root"]
+
+        db.end_session("root", "compression")
+        assert [
+            s["id"] for s in db.list_sessions_rich(limit=2, order_by_last_active=True)
+        ] == ["tip", "solo"]
+
+        db.reopen_session("root")
+        assert [
+            s["id"] for s in db.list_sessions_rich(limit=2, order_by_last_active=True)
+        ] == ["solo", "root"]
+
+    def test_last_active_refreshes_when_compression_descendant_removed(self, tmp_path):
+        """Deleting/pruning a compression tip must not leave ancestors sorted
+        by the removed descendant's activity.
+        """
+
+        def build_db(name: str) -> SessionDB:
+            db = SessionDB(db_path=tmp_path / f"{name}.db")
+            t0 = 1709500000.0
+            db.create_session("root", "cli")
+            with db._lock:
+                db._conn.execute(
+                    "UPDATE sessions SET started_at=?, last_active=? WHERE id=?",
+                    (t0, t0, "root"),
+                )
+                db._conn.commit()
+            db.append_message("root", "user", "old root", timestamp=t0 + 1)
+            db.end_session("root", "compression")
+            db.create_session("tip", "cli", parent_session_id="root")
+            with db._lock:
+                db._conn.execute(
+                    "UPDATE sessions SET started_at=?, last_active=? WHERE id=?",
+                    (t0 + 10, t0 + 10, "tip"),
+                )
+                db._conn.commit()
+            db.append_message("tip", "user", "new tip", timestamp=t0 + 1000)
+            db.create_session("solo", "cli")
+            with db._lock:
+                db._conn.execute(
+                    "UPDATE sessions SET started_at=?, last_active=? WHERE id=?",
+                    (t0 + 20, t0 + 20, "solo"),
+                )
+                db._conn.commit()
+            db.append_message("solo", "user", "middle", timestamp=t0 + 500)
+            assert [
+                s["id"] for s in db.list_sessions_rich(limit=2, order_by_last_active=True)
+            ] == ["tip", "solo"]
+            return db
+
+        db = build_db("single")
+        try:
+            assert db.delete_session("tip") is True
+            assert [
+                s["id"] for s in db.list_sessions_rich(limit=2, order_by_last_active=True)
+            ] == ["solo", "root"]
+        finally:
+            db.close()
+
+        db = build_db("bulk")
+        try:
+            assert db.delete_sessions(["tip"]) == 1
+            assert [
+                s["id"] for s in db.list_sessions_rich(limit=2, order_by_last_active=True)
+            ] == ["solo", "root"]
+        finally:
+            db.close()
+
+        db = build_db("prune")
+        try:
+            with db._lock:
+                db._conn.execute(
+                    "UPDATE sessions SET ended_at=?, end_reason=? WHERE id=?",
+                    (1709500100.0, "delete_me", "tip"),
+                )
+                db._conn.commit()
+            assert db.prune_sessions(
+                older_than_days=None,
+                end_reason="delete_me",
+                started_before=1709500200.0,
+            ) == 1
+            assert [
+                s["id"] for s in db.list_sessions_rich(limit=2, order_by_last_active=True)
+            ] == ["solo", "root"]
+        finally:
+            db.close()
+
+    def test_clear_messages_refreshes_compression_ancestor_last_active(self, db):
+        """clear_messages() only deletes the session's own message rows and
+        never touches its parent_session_id — but a compression parent's
+        (and the cleared session's own) last_active must still drop back
+        down once the activity is wiped, instead of staying pinned to the
+        now-deleted messages' timestamps forever.
+
+        Checked directly via get_session() rather than list_sessions_rich(),
+        since the compression-tip display projection would keep showing
+        "tip" as the surfaced id regardless of its message content (the
+        session row and parent link are untouched by clear_messages) — the
+        thing actually at risk here is the last_active *value*, not which
+        id gets displayed.
+        """
+        t0 = 1709500000.0
+        db.create_session("root", "cli")
+        db.create_session("tip", "cli", parent_session_id="root")
+        with db._lock:
+            db._conn.execute(
+                "UPDATE sessions SET started_at=?, last_active=? WHERE id=?",
+                (t0, t0, "root"),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at=?, last_active=? WHERE id=?",
+                (t0 + 10, t0 + 10, "tip"),
+            )
+            db._conn.commit()
+        db.end_session("root", "compression")
+        db.append_message("tip", "user", "new child", timestamp=t0 + 1000)
+
+        # The touch on append propagates up through the compression edge.
+        assert db.get_session("root")["last_active"] == t0 + 1000
+        assert db.get_session("tip")["last_active"] == t0 + 1000
+
+        db.clear_messages("tip")
+
+        # Both the cleared tip and its compression-ancestor root must fall
+        # back to the tip's started_at now that its only message is gone —
+        # neither may stay pinned to the deleted message's timestamp.
+        assert db.get_session("tip")["last_active"] == t0 + 10
+        assert db.get_session("root")["last_active"] == t0 + 10
 
     def test_rich_list_includes_title(self, db):
         db.create_session("s1", "cli")
@@ -5830,6 +6212,40 @@ class TestFTSExternalContentMigration:
                 ).fetchone()[0] == 1
             db._conn.execute(
                 "INSERT INTO messages_fts(messages_fts, rank) VALUES('integrity-check', 1)"
+            )
+        finally:
+            db.close()
+
+    def test_optimize_builds_compact_trigram_when_legacy_disable_is_set(
+        self, tmp_path
+    ):
+        """The old space-saving flag must suppress only the legacy inline
+        trigram, not the compact v23 replacement built by the explicit CLI."""
+        db_path = tmp_path / "v22.db"
+        self._build_v22_db(db_path)
+        (tmp_path / "config.yaml").write_text(
+            "sessions:\n  disable_fts_trigram: true\n",
+            encoding="utf-8",
+        )
+
+        db = SessionDB(db_path=db_path)
+        try:
+            assert db._fts_trigram_disabled is True
+            assert db._trigram_available is False
+            assert db._conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE name = 'messages_fts_trigram'"
+            ).fetchone() is None
+
+            result = db.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True
+            assert db._trigram_available is True
+            assert db._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts_trigram"
+            ).fetchone()[0] == 2
+            db._conn.execute(
+                "INSERT INTO messages_fts_trigram"
+                "(messages_fts_trigram, rank) VALUES('integrity-check', 1)"
             )
         finally:
             db.close()


### PR DESCRIPTION
**Part 1 — sessions.last_active (schema v24).** `list_sessions_rich(order_by_last_active=True)` currently computes "most recent activity, walking compression-continuation chains forward" via a recursive CTE over every WHERE-admitted row on *every call*. This adds a denormalized `sessions.last_active REAL` column plus `idx_sessions_last_active (last_active DESC, started_at DESC, id DESC)`, so the common unfiltered-recents case can `ORDER BY s.last_active` directly against the index instead. The column is kept live by a SQL trigger pair (message timestamp updates and session `started_at` changes propagate up through compression chains) plus two write-path helpers: `_touch_session_last_active` (monotonic advance — append_message, bulk insert) and `_refresh_session_last_active` (authoritative recompute — session create, end/reopen across a compression boundary, message replace/clear, single/bulk/pruned/empty-session delete, import), used wherever a naive "touch" could leave a stale ancestor last_active pointing at removed or not-yet-linked activity. A new `current_version < 24` migration backfills every existing session on next open; read-only cross-profile DB handles (which never run migrations) detect the missing physical column via `_has_sessions_last_active` and fall back to the original computed-subquery SELECT, so aggregating another profile's not-yet-migrated DB never raises "no such column".

Also fixed three destructive/import paths that mutated messages without refreshing affected compression ancestors: `clear_messages` and `delete_empty_sessions` (capturing ancestor ids *before* deletion, matching the pattern already used in `delete_session`/`delete_sessions`/`prune_sessions`), and `import_sessions` — which wires `parent_session_id` only *after* all messages are already inserted, so the per-message touch calls ran before there was any chain to climb. The chain is now explicitly settled via `_refresh_session_last_active` once every parent edge is final, which also gives an empty imported session a real `last_active` instead of leaving it `NULL`.

**Known limitation, left to maintainer discretion.** Every write path *this PR controls* (the triggers plus the touch/refresh helpers above) keeps `last_active` correct. But a writer that mutates `messages` *without* going through those helpers — an older hermes-agent version sharing this `state.db` mid-rolling-upgrade, a different language binding, an ad hoc SQL script — will leave that session's `last_active` stale (behind its true activity) until the *next* helper-mediated write on that session. This is strictly a **recents-ordering staleness**, never data loss: the message itself is intact and searchable, only its position in "most recently active" sorting can lag. It self-heals the moment normal traffic resumes on the session (proven by `test_stale_write_from_bypassing_writer_self_heals_on_next_write`).

We looked at closing this gap and rejected two approaches, in case a maintainer wants to revisit:
- **Mirror `AFTER INSERT`/`AFTER DELETE` triggers on `messages`**, matching the existing `AFTER UPDATE OF timestamp` trigger. Rejected: SQLite fires `AFTER INSERT` *before* the Python-level `_touch_session_last_active` call that follows the same `INSERT` statement in `append_message`/`_insert_message_rows`, so a naive mirror trigger would run its recursive-CTE chain-walk body on *every single message write* — including the ones the Python helpers already handle correctly with an O(1) monotonic touch — defeating the point of adding an index in the first place.
- **An unconditional on-open reconciliation pass** (an earlier revision of this PR shipped exactly this: `_find_stale_last_active_session_ids`, wired into `_init_schema`). A focused second review found it insufficient on its own terms: it missed delete-drift and fresh-descendant/stale-ancestor shapes (only compared each session's *own* message max against its *own* last_active, not the fuller set of ways a chain can drift); read-only cross-profile handles never call `_init_schema` at all, so they'd trust stale data indefinitely regardless; the per-open scan is unbounded (~40ms measured at 25k messages, and the web-server paths open a writable `SessionDB` per request, making this a per-request cost); and — critically — it could move a compression ancestor's `last_active` *backward* relative to what a live process had already correctly advanced it to, which is exactly the invariant the monotonic-touch design is built to prevent. Patching all of that felt like the wrong shape for this PR, so it's removed rather than iterated further here.

If maintainers want a stronger, operator-triggered guarantee here, the natural home looks like wiring a reconciliation pass into an existing maintenance entrypoint — `hermes sessions optimize-storage` already exists as a deliberate, foreground, disk-checked operation for exactly this class of "occasionally necessary, not safe to run silently on every request" repair. We're leaving that choice (and the shape of the fix) to the maintainers rather than including it in this PR.

**Part 2 — sessions.disable_fts_trigram.** A legacy (pre-v23, inline-FTS) install can set this config key (or `HERMES_DISABLE_FTS_TRIGRAM` env var, as a process-transport fallback) to skip recreating its old heavyweight trigram index — which, unlike the v23 external-content trigram table, duplicates full message content including large tool-call payloads. The flag is a no-op on v23-shape databases (they always get the compact trigram index); the explicit `hermes sessions optimize-storage` migration still backfills the compact trigram table for a disabled legacy DB once it's opted in, refreshing `_trigram_available` after the demote step. Config surface/user-facing docs for this flag are intentionally deferred, not part of this PR.

**Testing done:** `tests/test_hermes_state.py` (424 passed, including regression tests for: legacy-version migration backfill parametrized over `[17,19,23]`, two read-only-fallback tests, two compression-chain last_active-refresh tests covering end/reopen and delete/bulk-delete/prune, `clear_messages` ancestor refresh, import chain settle, and the bypassing-writer self-heal contract) and `tests/hermes_state/test_fts_trigram_disable.py` (7 passed) both pass in the PR worktree venv. Also ran the broader session-listing/gateway/web-server suites with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
