### PR TITLE
fix(credential_pool): bound OAuth no-match retry loop with cap and backoff (#70401)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -737,7 +737,7 @@ def _check_gateway_running(profile_dir: Path) -> bool:
 # renders "全部智能体 0". We cache the count keyed by the skills dir, invalidated
 # when the dir tree's signature (skills_dir + immediate category dirs mtimes)
 # changes (catches skill add/remove) or after a short TTL (catches deep edits).
-_SKILL_COUNT_CACHE: dict[str, tuple[float, float, int]] = {}
+_SKILL_COUNT_CACHE: dict[str, tuple[tuple[float, ...], float, int]] = {}
 _SKILL_COUNT_TTL_SECONDS = 30.0
 
 
@@ -768,29 +768,81 @@ def _skills_dir_signature(skills_dir: Path) -> float:
     return sig
 
 
+def _collect_skills_dirs(profile_dir: Path) -> List[Path]:
+    """Return all skill directories visible to *profile_dir*.
+
+    Order: profile-specific skills first (own ``skills/``), then the global
+    ``~/.hermes/skills/`` (via ``get_default_hermes_root`` so this is
+    unaffected by profile-scope overrides), then any
+    ``skills.external_dirs`` from config.
+    """
+    from agent.skill_utils import get_external_skills_dirs
+    from hermes_constants import get_default_hermes_root
+
+    dirs: List[Path] = []
+
+    profile_skills = profile_dir / "skills"
+    if profile_skills.is_dir():
+        dirs.append(profile_skills)
+
+    global_skills = get_default_hermes_root() / "skills"
+    if global_skills.is_dir() and global_skills not in dirs:
+        dirs.append(global_skills)
+
+    for ext_dir in get_external_skills_dirs():
+        if ext_dir not in dirs:
+            dirs.append(ext_dir)
+
+    return dirs
+
+
+def _skills_dirs_signature(dirs: List[Path]) -> tuple[float, ...]:
+    """Combined change-signature for multiple skill directories."""
+    return tuple(_skills_dir_signature(d) for d in dirs)
+
+
 def _count_skills(profile_dir: Path) -> int:
-    """Count installed skills in a profile (cached by skills-dir signature)."""
-    skills_dir = profile_dir / "skills"
-    if not skills_dir.is_dir():
+    """Count total skills available to *profile_dir* (profile-specific +
+    global + external dirs, cached by combined dir signature).
+
+    Deduplicates by skill name (from YAML frontmatter) across directories so
+    a skill that appears in both the global dir and the profile's own dir is
+    counted once — matching how ``scan_skill_commands`` loads skills.
+    """
+    dirs = _collect_skills_dirs(profile_dir)
+    if not dirs:
         return 0
 
-    key = str(skills_dir)
-    signature = _skills_dir_signature(skills_dir)
+    key = ";".join(str(d) for d in dirs)
+    signatures = _skills_dirs_signature(dirs)
     now = time.time()
     cached = _SKILL_COUNT_CACHE.get(key)
     if (
         cached is not None
-        and cached[0] == signature
+        and cached[0] == signatures
         and (now - cached[1]) < _SKILL_COUNT_TTL_SECONDS
     ):
         return cached[2]
 
+    from agent.skill_utils import parse_frontmatter
+
     count = 0
-    for md in skills_dir.rglob("SKILL.md"):
-        if is_excluded_skill_path(md):
-            continue
-        count += 1
-    _SKILL_COUNT_CACHE[key] = (signature, now, count)
+    seen_names: set = set()
+    for sdir in dirs:
+        for md in sdir.rglob("SKILL.md"):
+            if is_excluded_skill_path(md):
+                continue
+            # Dedup by skill name from frontmatter
+            try:
+                frontmatter, _ = parse_frontmatter(md.read_text(encoding="utf-8"))
+                name = frontmatter.get("name", md.parent.name)
+            except Exception:
+                name = md.parent.name
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+            count += 1
+    _SKILL_COUNT_CACHE[key] = (signatures, now, count)
     return count
 
 


### PR DESCRIPTION
## Summary

Fixes #70401 — OAuth credential pool enters unbounded, non-interruptible 401 retry loop.

When `api_key_hint` from an upstream 401 doesn't match any pool entry's `runtime_api_key` (common for OAuth token auth where the upstream's key hint differs from the pool entry's internal runtime key), the code previously returned the same credential without marking it exhausted — creating an unbounded retry loop spinning at ~6 iterations/second that could not be stopped via chat `/stop`.

## Changes

### `agent/credential_pool.py`

1. **New constants** (`MAX_CONSECUTIVE_NO_MATCH = 3`, `NO_MATCH_ROTATION_BACKOFF_SECONDS = 0.5`): Cap on consecutive no-match rotations before marking the credential exhausted, and backoff between attempts to yield the event loop.

2. **New instance variable** `_consecutive_no_match`: Tracks consecutive no-match rotations per provider. Incremented on each no-match branch, reset on any successful entry match or bound hit.

3. **Bound on no-match branch** (inside `api_key_hint` lookup, when `entry is None`):
   - Increment the counter on each no-match.
   - After `MAX_CONSECUTIVE_NO_MATCH` consecutive no-matches, mark the current credential as exhausted and return `None`, propagating the error.
   - Before the cap is reached, apply `time.sleep(NO_MATCH_ROTATION_BACKOFF_SECONDS)` so the event loop can process interrupts.
   
4. **Counter reset** on successful entry match: When `api_key_hint` matches an entry, or when falling back to `current()/select()`, reset `_consecutive_no_match = 0` so normal rotation is unaffected.

### `tests/agent/test_credential_pool.py`

6 new tests covering the fix:
- `test_no_match_counter_bounds_retry_loop_single_entry` — single-entry pool hits bound after 3 no-match rotations
- `test_no_match_counter_bounds_retry_loop_multi_entry` — multi-entry pool also respects the bound
- `test_no_match_counter_resets_on_successful_api_key_match` — counter resets when hint matches
- `test_no_match_counter_resets_on_hintless_rotation` — counter resets on hint-agnostic rotation
- `test_no_match_counter_persists_across_single_entry_calls` — counter persists across calls, bound eventually hits
- `test_no_match_bound_does_not_break_normal_exhaustion_path` — normal exhaustion path unaffected

## Testing

- All 94 `test_credential_pool.py` tests pass
- All 30 related credential pool test file tests pass