### PR TITLE
fix(config): warn on legacy restart drain setting

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4866,6 +4866,38 @@ def clear_model_endpoint_credentials(
 
 
 _MISSING = object()
+_LEGACY_RESTART_DRAIN_TIMEOUT = 180
+_RESTART_DRAIN_TIMEOUT_CONFIG_KEY = "agent.restart_drain_timeout"
+
+
+def _is_exact_legacy_restart_drain_timeout(value: Any) -> bool:
+    """Return True only for the persisted numeric former default."""
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and value == _LEGACY_RESTART_DRAIN_TIMEOUT
+    )
+
+
+def get_legacy_config_warnings(raw_config: Optional[Dict[str, Any]] = None) -> List[str]:
+    """Return read-only warnings for persisted values that shadow safer defaults."""
+    if raw_config is None:
+        raw_config = read_raw_config()
+
+    restart_drain_timeout = _get_nested(raw_config, _RESTART_DRAIN_TIMEOUT_CONFIG_KEY)
+    if not _is_exact_legacy_restart_drain_timeout(restart_drain_timeout):
+        return []
+
+    current_default = DEFAULT_CONFIG["agent"]["restart_drain_timeout"]
+    return [
+        (
+            f"{_RESTART_DRAIN_TIMEOUT_CONFIG_KEY} is explicitly set to "
+            f"{_LEGACY_RESTART_DRAIN_TIMEOUT}, which matches the former default; "
+            f"the current default is {current_default}.\n"
+            "Long drain windows can delay or interfere with supervised gateway restarts.\n"
+            "Run: hermes config set agent.restart_drain_timeout 0"
+        )
+    ]
 
 
 def _get_nested(config, dotted_key: str):
@@ -9254,6 +9286,17 @@ def config_command(args):
             print()
             print(color(f"  {len(missing_config)} new config option(s) available", Colors.YELLOW))
             print("    Run 'hermes config migrate' to add them")
+
+        legacy_warnings = get_legacy_config_warnings()
+        if legacy_warnings:
+            print()
+            for warning in legacy_warnings:
+                lines = warning.splitlines()
+                if not lines:
+                    continue
+                print(color(f"  ⚠️  {lines[0]}", Colors.YELLOW))
+                for line in lines[1:]:
+                    print(color(f"      {line}", Colors.YELLOW))
         
         print()
     

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli configuration management."""
 
+import argparse
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -10,6 +11,7 @@ import yaml
 from hermes_cli.config import (
     DEFAULT_CONFIG,
     check_config_version,
+    config_command,
     get_hermes_home,
     ensure_hermes_home,
     get_compatible_custom_providers,
@@ -127,6 +129,56 @@ class TestLoadConfigDefaults:
             config = load_config()
             assert config["agent"]["max_turns"] == 42
             assert "max_turns" not in config
+
+
+class TestConfigCheckLegacyRestartDrainWarning:
+    """``hermes config check`` warns only for the persisted former default."""
+
+    def _run_check(self, capsys) -> str:
+        args = argparse.Namespace(config_command="check")
+        config_command(args)
+        return capsys.readouterr().out
+
+    @pytest.mark.parametrize("value_yaml", ["180", "180.0"])
+    def test_warns_for_explicit_legacy_restart_drain_timeout(
+        self, tmp_path, capsys, value_yaml
+    ):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(f"agent:\n  restart_drain_timeout: {value_yaml}\n")
+        before = config_path.read_text()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            output = self._run_check(capsys)
+
+        assert "agent.restart_drain_timeout" in output
+        assert "former default" in output
+        assert "current default is 0" in output
+        assert "Long drain windows can delay or interfere with supervised gateway restarts" in output
+        assert "hermes config set agent.restart_drain_timeout 0" in output
+        assert config_path.read_text() == before
+
+    @pytest.mark.parametrize(
+        "config_yaml",
+        [
+            "",
+            "agent:\n  gateway_timeout: 1800\n",
+            "agent:\n  restart_drain_timeout: 0\n",
+            "agent:\n  restart_drain_timeout: 30\n",
+            "agent:\n  restart_drain_timeout: '180'\n",
+            "agent:\n  restart_drain_timeout: true\n",
+            "agent:\n  restart_drain_timeout: null\n",
+        ],
+    )
+    def test_no_legacy_warning_without_explicit_180(self, tmp_path, capsys, config_yaml):
+        if config_yaml:
+            (tmp_path / "config.yaml").write_text(config_yaml)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            output = self._run_check(capsys)
+
+        assert "agent.restart_drain_timeout" not in output
+        assert "former default" not in output
+        assert "supervised gateway restarts" not in output
 
 
 class TestLoadConfigParseFailure:


### PR DESCRIPTION
## What does this PR do?

`hermes config check` now warns when the persisted config explicitly contains numeric `agent.restart_drain_timeout: 180`.

That value matches the former default changed to `0` by #54066 after long drain windows were found to interfere with supervised gateway restarts. Existing config files can still retain the old explicit value, so merging with the current defaults does not help those installations.

The warning is advisory and read-only. It reports the current default and gives the exact remediation command:

```text
hermes config set agent.restart_drain_timeout 0
```

It does **not** rewrite user config because an explicit value may be intentional.

This is intentionally separate from launchd recovery work such as #68238 and #43181: those PRs recover a failed restart, while this change only detects a persisted legacy default during `hermes config check`.

## Related Issue

Follow-up to #31981 and PR #54066. No new issue was filed for this small, self-contained follow-up.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`
  - detect an explicitly persisted numeric legacy value of `180`
  - print a warning and remediation command from `hermes config check`
  - preserve existing output/exit semantics and avoid config mutation
- `tests/hermes_cli/test_config.py`
  - cover integer and float numeric `180`
  - verify no warning for an absent key, current default `0`, another positive value, quoted string, boolean, or null
  - verify `config.yaml` remains unchanged

## How to Test

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_config.py \
  tests/hermes_cli/test_set_config_value.py \
  tests/hermes_cli/test_config_validation.py -q
```

Result: `309 passed, 0 failed`.

A broader restart-related regression selection also passed:

```text
366 passed in 35.18s
```

Additional checks:

```bash
ruff check hermes_cli/config.py tests/hermes_cli/test_config.py
python -m compileall -q hermes_cli/config.py tests/hermes_cli/test_config.py
git diff --check
```

All passed.

Manual smoke with isolated `HERMES_HOME` values confirmed:

```text
# persisted numeric 180
⚠️  agent.restart_drain_timeout is explicitly set to 180, which matches the former default; the current default is 0.
    Long drain windows can delay or interfere with supervised gateway restarts.
    Run: hermes config set agent.restart_drain_timeout 0

# persisted 0
(no legacy warning)
```

The config hashes were unchanged after both checks.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public option or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config key or default changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — config parsing/output is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; CLI output and verification are included above.
