### PR TITLE
fix(cron): allow successful silent runs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3907,8 +3907,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             # output is already saved above).  Failed jobs always deliver.
             deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
             # Treat whitespace-only final responses the same as empty
-            # responses: do not deliver a blank message, and let the
-            # empty-response guard below mark the run as a soft failure.
+            # responses: a successful quiet run has nothing to deliver.
             should_deliver = bool(deliver_content.strip())
             # Cron silence suppression — see _is_cron_silence_response.  Replaces the
             # old `SILENT_MARKER in ...upper()` substring check, which both leaked
@@ -3932,13 +3931,6 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             # their subprocesses/clients (#10200).
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
-
-        # Treat empty final_response as a soft failure so last_status
-        # is not "ok" — the agent ran but produced nothing useful.
-        # (issue #8585)
-        if success and not final_response.strip():
-            success = False
-            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
         if not _consume_interrupted_flag(job["id"]):
             mark_job_run(job["id"], success, error, delivery_error=delivery_error)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4727,8 +4727,7 @@ def run_one_job(
             else:
                 deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
             # Treat whitespace-only final responses the same as empty
-            # responses: do not deliver a blank message, and let the
-            # empty-response guard below mark the run as a soft failure.
+            # responses: a successful quiet run has nothing to deliver.
             should_deliver = bool(deliver_content.strip())
             if blocked_config_silent:
                 should_deliver = False
@@ -4759,13 +4758,6 @@ def run_one_job(
             # their subprocesses/clients (#10200).
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
-
-        # Treat empty final_response as a soft failure so last_status
-        # is not "ok" — the agent ran but produced nothing useful.
-        # (issue #8585)
-        if success and not final_response.strip():
-            success = False
-            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
         if not _consume_interrupted_flag(job["id"]):
             if blocked_config:

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -78,14 +78,16 @@ def test_run_one_job_silent_skips_delivery(monkeypatch):
     assert "deliver" not in kinds
 
 
-def test_run_one_job_empty_response_is_soft_failure(monkeypatch):
-    """An empty final response marks the run as NOT ok (issue #8585)."""
+def test_run_one_job_empty_response_is_silent_success(monkeypatch):
+    """A successful empty final response skips delivery and remains successful."""
     calls = _patch_pipeline(monkeypatch, final="   ")
 
     s.run_one_job({"id": "j4", "name": "t"})
 
+    kinds = [c[0] for c in calls]
+    assert "deliver" not in kinds
     mark = [c for c in calls if c[0] == "mark"][0]
-    assert mark == ("mark", "j4", False)
+    assert mark == ("mark", "j4", True)
 
 
 def test_run_one_job_failed_job_delivers_error(monkeypatch):

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -66,6 +66,15 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j2", True)
 
 
+def test_run_one_job_empty_response_is_silent_success(monkeypatch):
+    calls = _patch_pipeline(monkeypatch, final="   ")
+
+    s.run_one_job({"id": "j4", "name": "t"})
+
+    assert "deliver" not in [call[0] for call in calls]
+    assert ("mark", "j4", True) in calls
+
+
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):
     """Regression: under profile isolation (multiplex active), run_one_job must
     execute run_job inside a profile secret scope so credential reads

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1765,11 +1765,8 @@ class TestRunJobSessionPersistence:
         advance.assert_not_called()
         run_one.assert_not_called()
 
-    def test_tick_marks_empty_response_as_error(self, tmp_path):
-        """When run_job returns success=True but final_response is empty,
-        tick() should mark the job as error so last_status != 'ok'.
-        (issue #8585)
-        """
+    def test_tick_marks_successful_empty_response_as_ok(self, tmp_path):
+        """A successful empty response is a quiet run, not a model failure."""
         from cron.scheduler import tick
 
         job = {
@@ -1794,12 +1791,11 @@ class TestRunJobSessionPersistence:
              patch("cron.scheduler.run_job", return_value=(True, "output", "", None)):
             tick(verbose=False)
 
-        # Should be called with success=False because final_response is empty
         mock_mark.assert_called_once()
         call_args = mock_mark.call_args
         assert call_args[0][0] == "empty-job"
-        assert call_args[0][1] is False  # success should be False
-        assert "empty" in call_args[0][2].lower()  # error should mention empty
+        assert call_args[0][1] is True
+        assert call_args[0][2] is None
 
     def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(self, tmp_path, monkeypatch):
         job = {
@@ -2956,8 +2952,8 @@ class TestSilentDelivery:
         save_mock.assert_called_once_with("monitor-job", "# full output")
         deliver_mock.assert_not_called()
 
-    def test_whitespace_only_response_is_marked_failed_not_delivered(self):
-        """Whitespace-only final responses should behave like empty responses."""
+    def test_whitespace_only_response_is_successful_not_delivered(self):
+        """Whitespace-only successful responses are quiet completed runs."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "   \n\t  ", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
@@ -2969,8 +2965,8 @@ class TestSilentDelivery:
         deliver_mock.assert_not_called()
         mark_mock.assert_called_once_with(
             "monitor-job",
-            False,
-            "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
+            True,
+            None,
             delivery_error=None,
         )
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -595,6 +595,24 @@ class TestRunJobSessionPersistence:
         advance.assert_not_called()
         run_one.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "result",
+        [
+            {"failed": True, "error": "provider retries exhausted"},
+            {"completed": False, "error": "incomplete turn"},
+        ],
+    )
+    def test_run_job_preserves_structured_failures(self, tmp_path, result):
+        with self._run_job_patches(tmp_path) as (_, mock_agent_cls):
+            mock_agent_cls.return_value.run_conversation.return_value = result
+            success, _, final_response, error = run_job(
+                {"id": "failed-job", "name": "test", "prompt": "hello"}
+            )
+
+        assert success is False
+        assert final_response == ""
+        assert result["error"] in error
+
 
 class TestRunJobConfigLogging:
     """Verify that config.yaml parse failures are logged, not silently swallowed."""
@@ -991,8 +1009,8 @@ class TestSilentDelivery:
         deliver_mock.assert_called_once()
 
 
-    def test_whitespace_only_response_is_marked_failed_not_delivered(self):
-        """Whitespace-only final responses should behave like empty responses."""
+    def test_whitespace_only_response_is_successful_not_delivered(self):
+        """Whitespace-only successful responses are quiet completed runs."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "   \n\t  ", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
@@ -1004,8 +1022,8 @@ class TestSilentDelivery:
         deliver_mock.assert_not_called()
         mark_mock.assert_called_once_with(
             "monitor-job",
-            False,
-            "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
+            True,
+            None,
             delivery_error=None,
         )
 


### PR DESCRIPTION
﻿Fixes #70427

## Summary

- keep successful empty/whitespace-only cron results as successful quiet runs
- continue saving their output while skipping blank delivery
- rely on `run_job()`'s existing structured failure checks so provider, model, tool, and incomplete-turn failures remain failures

## Why this is safe

The old blanket empty-response guard covered a time when an API failure could return an empty final response with a successful scheduler status. The execution path now rejects `failed=True` and incomplete conversation results before returning its success tuple. `run_one_job()` can therefore preserve the success result without hiding backend failures.

Explicit silence markers and visible responses retain their existing behavior, and failed jobs still deliver their compact failure notice.

## Tests

- `python -m pytest tests/cron/test_scheduler.py tests/cron/test_run_one_job.py -q` -> 247 passed
- `python -m ruff check cron/scheduler.py tests/cron/test_scheduler.py tests/cron/test_run_one_job.py` -> clean
- `git diff --check origin/main...HEAD` -> clean
