### PR TITLE
fix(desktop): guard display_metadata 'in' operator against JSON string

### DIFF
--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -307,15 +307,33 @@ function transcriptContent(displayKind: SessionMessage['display_kind'], content:
   return displayKind === 'hidden' ? null : content
 }
 
+/** Defensive: display_metadata may arrive as a JSON string from the backend. */
+function normalizeDisplayMetadata(
+  meta: unknown
+): Record<string, unknown> | null {
+  if (!meta) return null
+  if (typeof meta === 'object') return meta as Record<string, unknown>
+  if (typeof meta === 'string') {
+    try {
+      const parsed = JSON.parse(meta)
+      return typeof parsed === 'object' && parsed !== null ? parsed : null
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
 function timelineDisplayContent(message: SessionMessage, content: string): string {
   if (message.display_kind === 'model_switch') {
     return 'model changed'
   }
 
   if (message.display_kind === 'async_delegation_complete') {
+    const meta = normalizeDisplayMetadata(message.display_metadata)
     const count =
-      message.display_metadata && 'task_count' in message.display_metadata
-        ? message.display_metadata.task_count
+      meta && 'task_count' in meta
+        ? meta.task_count
         : undefined
 
     return count === undefined


### PR DESCRIPTION
## Problem

`timelineDisplayContent()` in `chat-messages.ts` crashes when `display_metadata` arrives as a JSON string instead of a parsed object during session recovery:

```
TypeError: Cannot use 'in' operator to search for 'task_count' in
{delegation_id:deleg_287d801e,task_count:1,completed_count:1,...}
```

This prevents loading any session containing an `async_delegation_complete` message — the Desktop app shows "无法加载此会话" (Unable to load session).

## Root Cause

Line 317: `message.display_metadata && 'task_count' in message.display_metadata`

When the backend sends `display_metadata` as a JSON string (observed during session recovery), JavaScript's `in` operator throws because it expects an object on the right side.

## Fix

Added `normalizeDisplayMetadata()` helper that safely handles:
- Already-parsed objects (common case)
- JSON strings (session recovery edge case)
- null/undefined/other types (defensive)

## Testing

- All 41 existing tests pass (`chat-messages.test.ts`)
- Manually verified: sessions with delegation completion messages now load correctly