### PR TITLE
docs(skills): clarify xurl search returns raw, engageable posts

### DIFF
--- a/skills/social-media/xurl/SKILL.md
+++ b/skills/social-media/xurl/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: xurl
-description: "X/Twitter via xurl CLI: post, search, DM, media, v2 API."
-version: 1.1.1
+description: "X/Twitter via xurl CLI: raw post search, posting, DM, media."
+version: 1.1.2
 author: xdevplatform + openclaw + Hermes Agent
 license: MIT
 platforms: [linux, macos]
@@ -20,7 +20,7 @@ metadata:
 
 Use this skill for:
 - posting, replying, quoting, deleting posts
-- searching posts and reading timelines/mentions
+- searching for raw posts (actual post JSON with IDs you can engage with) and reading timelines/mentions
 - liking, reposting, bookmarking
 - following, unfollowing, blocking, muting
 - direct messages
@@ -182,6 +182,8 @@ xurl delete 1234567890
 ```
 
 ### Reading & Search
+
+`xurl search` queries the X index as your authenticated account and returns raw post objects — IDs, authors, full text — so results can be immediately engaged with (reply, like, repost, quote). Use it when you need the actual posts rather than a summarized answer about a topic.
 
 ```bash
 xurl read 1234567890


### PR DESCRIPTION
## Summary
The xurl skill now distinguishes its search (raw, engageable post objects as the authenticated account) from LLM-synthesized X search answers — described entirely in the skill's own terms, with no reference to any other tool.

With the built-in `x_search` tool landed (#26763/#27376), an agent holding both surfaces had two things claiming "search X" and nothing steering the choice. The skill can't name the tool (it's credential-gated and may not exist), so the search bullets now describe what makes xurl search distinct standalone: it queries the X index as your authenticated account and returns raw post JSON with IDs you can immediately reply to, like, or repost — vs a summarized answer about a topic.

## Changes
- `skills/social-media/xurl/SKILL.md`:
  - description: "post, search" → "raw post search, posting" (still exactly 60 chars)
  - "Use this skill for" bullet: search now says "raw posts (actual post JSON with IDs you can engage with)"
  - Reading & Search section: one-paragraph note on what `xurl search` returns and when to prefer it
  - version 1.1.1 → 1.1.2

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/skills/test_xurl_article_ingestion_docs.py -q` | pass |
| description length ≤ 60 | 60 |

## Infographic

![xurl-search-clarity](https://v3b.fal.media/files/b/0aa379e1/PoS6h4sLNlfYzBERc0hK1_Lul8WDXU.png)
