### PR TITLE
fix(hooks): make doctor honest about runtime registration

### DIFF
--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -320,7 +320,26 @@ def _cmd_doctor(_args) -> None:
     if problems:
         print(f"{problems} issue(s) found.  Fix before relying on these hooks.")
     else:
-        print("All shell hooks look healthy.")
+        print("All shell hooks look healthy (config, allowlist, synthetic run).")
+
+    # #69836: a ✓ above must not read as "hooks will fire".  Doctor runs in
+    # its own short-lived process and registration state is in-process
+    # (agent/shell_hooks.py), so it genuinely cannot see whether any live
+    # agent process registered these hooks.  Say so, and name the
+    # entrypoints that do register — the #69825 failure mode was a launch
+    # path that never reached the registration call while doctor kept
+    # reporting healthy.
+    print(
+        "\nNote: doctor validates config, allowlist, and script behavior\n"
+        "from this process only — it cannot verify that a live agent\n"
+        "process actually registered these hooks.  Hooks fire only in\n"
+        "processes that call agent.shell_hooks.register_from_config() at\n"
+        "startup: `hermes` agent entrypoints (bare `hermes`, chat, acp,\n"
+        "rl, cron run/tick, gateway run, mcp serve), the interactive\n"
+        "cli.py REPL, and gateway boot.  If your agent runs behind an\n"
+        "entrypoint that skips that call, hooks pass every check above\n"
+        "yet never fire in that process (the #69825 bug class)."
+    )
 
 
 def _doctor_one(spec, shell_hooks) -> int:

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -243,6 +243,31 @@ class TestHooksDoctor:
             out = _run(SimpleNamespace(hooks_action="doctor"))
         assert "All shell hooks look healthy" in out
 
+    def test_states_runtime_registration_limits(self, tmp_path):
+        """#69836: a healthy verdict must not read as "hooks will fire".
+        Registration state is in-process, so doctor cannot verify that any
+        live agent process registered the hooks — it has to say so and name
+        the entrypoints that do register (the #69825 failure mode was a
+        launch path that never reached the registration call while doctor
+        kept reporting ✓ healthy)."""
+        script = _hook_script(tmp_path, "#!/usr/bin/env bash\nprintf '{}\\n'\n")
+        shell_hooks._record_approval("on_session_start", str(script))
+        cfg = {"hooks": {"on_session_start": [{"command": str(script)}]}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = _run(SimpleNamespace(hooks_action="doctor"))
+        assert "cannot verify" in out
+        assert "register_from_config" in out
+        # The verdict itself is scoped to what doctor actually checked.
+        assert "All shell hooks look healthy (config, allowlist, synthetic run)" in out
+
+    def test_no_hooks_configured_skips_scope_note(self):
+        """With nothing configured there is no ✓ to over-trust; the early
+        return stays terse."""
+        with patch("hermes_cli.config.load_config", return_value={}):
+            out = _run(SimpleNamespace(hooks_action="doctor"))
+        assert "nothing to check" in out
+        assert "register_from_config" not in out
+
     def test_unallowlisted_script_is_not_executed(self, tmp_path):
         """Regression for M4: `hermes hooks doctor` used to run every
         listed script against a synthetic payload as part of its JSON


### PR DESCRIPTION
Fixes #69836 (the **minimal/honest variant** — option 2 in the issue).

## Problem

`hermes hooks doctor` answers "will my hooks fire?" while reading only the config and the allowlist. It never verifies that an agent-hosting process actually reached `agent.shell_hooks.register_from_config()` — registration state lives in-process, so doctor genuinely cannot see it. That made the #69825 failure mode (a launch path that never runs the registration call) invisible: doctor printed an unqualified ✓ all-healthy for hooks that would never fire in the process the user cared about.

## Change

1. **Scope the verdict**: `All shell hooks look healthy (config, allowlist, synthetic run).` — ✓ no longer reads as "it works at runtime".
2. **Print the limitation + expected entrypoints** after every non-empty doctor run:

```
Note: doctor validates config, allowlist, and script behavior
from this process only — it cannot verify that a live agent
process actually registered these hooks.  Hooks fire only in
processes that call agent.shell_hooks.register_from_config() at
startup: `hermes` agent entrypoints (bare `hermes`, chat, acp,
rl, cron run/tick, gateway run, mcp serve), the interactive
cli.py REPL, and gateway boot.  If your agent runs behind an
entrypoint that skips that call, hooks pass every check above
yet never fire in that process (the #69825 bug class).
```

The entrypoint list is verified against the actual call sites: `_prepare_agent_startup()` (`_AGENT_COMMANDS` = bare/chat/acp/rl + `_AGENT_SUBCOMMANDS` = cron run/tick, gateway run, mcp serve), `cli.py`'s deferred startup, and `gateway/run.py` boot. `dashboard`/`serve` are deliberately not named — #69832 (open) adds their registration; this note stays true either way since it describes the class, not a snapshot.

## Tests

- `test_states_runtime_registration_limits` — pins the note + scoped verdict on the healthy path
- `test_no_hooks_configured_skips_scope_note` — empty-config early return stays terse
- Existing `test_clean_script_runs` passes unchanged (substring still present)

95 passed (`tests/hermes_cli/test_hooks_cli.py` + `tests/agent/test_shell_hooks*.py`), `ruff check` clean.

Option 1 from the issue (persisted per-process registration evidence under `HERMES_HOME`) remains available as a follow-up if you want the stronger signal — happy to implement it.
