### PR TITLE
fix: raise image token estimate from 1500/1600 to 4000 for multimodal models (#70328)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -541,8 +541,10 @@ _CHARS_PER_TOKEN = 4
 # dimensions (Anthropic ≈ width×height/750, GPT-4o up to ~1700 for
 # high-detail 2048×2048, Gemini 258/tile), but 1600 is a realistic ceiling
 # that keeps compression budgeting honest for multi-image conversations.
-# Matches Claude Code's IMAGE_TOKEN_ESTIMATE constant.
-_IMAGE_TOKEN_ESTIMATE = 1600
+# Previously matched Claude Code's flat-rate 1600 but underestimated
+# multimodal local models (llama.cpp mmproj) where a 1920x1080 screenshot
+# costs 3000-6000 real prompt tokens.  4000 is the midpoint of that range.
+_IMAGE_TOKEN_ESTIMATE = 4000
 # Same figure expressed in the char-budget currency the rest of the
 # compressor speaks in.  Used when accumulating message "content length"
 # for tail-cut decisions.

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2734,12 +2734,15 @@ def estimate_tokens_rough(text: str) -> int:
 def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     """Rough token estimate for a message list (pre-flight only).
 
-    Image parts (base64 PNG/JPEG) are counted as a flat ~1500 tokens per
-    image — the Anthropic pricing model — instead of counting raw base64
-    character length. Without this, a single ~1MB screenshot would be
-    estimated at ~250K tokens and trigger premature context compression.
+    Image parts (base64 PNG/JPEG) are counted as a flat ~4000 tokens per
+    image instead of counting raw base64 character length. Without this, a
+    single ~1MB screenshot would be estimated at ~250K tokens and trigger
+    premature context compression.  The previous value of 1500 matched
+    Claude Code's flat-rate pricing but underestimated multimodal local
+    models (llama.cpp mmproj) where a 1920x1080 screenshot can cost
+    3000-6000 real prompt tokens.  4000 is the midpoint of that range.
     """
-    _IMAGE_TOKEN_COST = 1500
+    _IMAGE_TOKEN_COST = 4000
     text_tokens = 0
     image_tokens = 0
     for msg in messages:


### PR DESCRIPTION
## Summary

The flat per-image token estimate of 1500/1600 tokens underestimates multimodal local models (llama.cpp mmproj) by 2-4x, causing compression to never fire in vision-heavy sessions. The provider rejects requests with "exceeds context size" while the rough estimator reports a fraction of the real token count.

## Root Cause

Two constants price images at a flat rate based on Anthropic's model:
- `model_metadata.py:2742`: `_IMAGE_TOKEN_COST = 1500`
- `context_compressor.py:545`: `_IMAGE_TOKEN_ESTIMATE = 1600`

For multimodal local models, a 1920x1080 screenshot costs 3000-6000 real prompt tokens. The compression trigger (`should_compress`) runs on the rough estimate, which stays far below the threshold while the real prompt grows past the provider window.

**Real session evidence**: provider reported 80K+ tokens, rough estimate said 18-23K, compression said "Cannot compress further" against a 64K window.

## Fix

Raise both constants to 4000 (midpoint of the 3000-6000 range). Still far below ~250K from raw base64 counting, so no premature compression risk.

Fixes #70328
