### PR TITLE
fix(desktop): detect existing backend on port 9119 before spawning own (#69925)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -55,7 +55,7 @@ import {
   resolveTestWsUrl,
   tokenPreview
 } from './connection-config'
-import { adoptServedDashboardToken } from './dashboard-token'
+import { adoptServedDashboardToken, resolveServedDashboardToken } from './dashboard-token'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -6980,6 +6980,60 @@ async function startHermes() {
     // is detected stale), THEN start the backend. Local backends only; remote
     // connections returned above and never touch the install tree.
     await waitForUpdateToFinish()
+
+    // ── Detect an existing local backend on the default port ──────────
+    // Before spawning our own backend, check if one is already listening on
+    // the default dashboard port (9119) — e.g. from `hermes dashboard` on
+    // the CLI. If one is already running, connect to it instead of starting
+    // a competing backend. This prevents the boot loop (#69925) where the
+    // desktop spawns a backend that finds a conflicting process/resource,
+    // exits with code 1, and is respawned by the renderer's retry loop.
+    const EXISTING_BACKEND_PORT = 9119
+    const EXISTING_BACKEND_PROBE_TIMEOUT_MS = 2_000
+
+    try {
+      await fetchJson(`http://127.0.0.1:${EXISTING_BACKEND_PORT}/api/status`, '', { timeoutMs: EXISTING_BACKEND_PROBE_TIMEOUT_MS })
+
+      rememberLog(`[boot] existing backend detected on port ${EXISTING_BACKEND_PORT}; connecting instead of spawning new backend`)
+
+      // Read the session token from the served dashboard HTML so WebSocket
+      // connections authenticate correctly. Best-effort: if token extraction
+      // fails (e.g. headless backend that 404s on /), use empty string.
+      let servedToken = ''
+
+      try {
+        servedToken = await resolveServedDashboardToken(
+          `http://127.0.0.1:${EXISTING_BACKEND_PORT}`,
+          '',
+          { rememberLog, timeoutMs: EXISTING_BACKEND_PROBE_TIMEOUT_MS }
+        )
+      } catch {
+        rememberLog(`[boot] could not read served dashboard token from port ${EXISTING_BACKEND_PORT}`)
+      }
+
+      const baseUrl = `http://127.0.0.1:${EXISTING_BACKEND_PORT}`
+
+      updateBootProgress({
+        phase: 'backend.ready',
+        message: `Connected to existing Hermes backend on port ${EXISTING_BACKEND_PORT}`,
+        progress: 94,
+        running: true,
+        error: null
+      })
+
+      return {
+        baseUrl,
+        mode: 'local',
+        source: 'local',
+        authMode: 'token',
+        token: servedToken,
+        wsUrl: `ws://127.0.0.1:${EXISTING_BACKEND_PORT}/api/ws?token=${encodeURIComponent(servedToken)}`,
+        logs: hermesLog.slice(-80),
+        ...getWindowState()
+      }
+    } catch {
+      rememberLog(`[boot] no existing backend detected on port ${EXISTING_BACKEND_PORT}; spawning local backend`)
+    }
 
     const token = crypto.randomBytes(32).toString('base64url')
     // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -737,7 +737,7 @@ def _check_gateway_running(profile_dir: Path) -> bool:
 # renders "全部智能体 0". We cache the count keyed by the skills dir, invalidated
 # when the dir tree's signature (skills_dir + immediate category dirs mtimes)
 # changes (catches skill add/remove) or after a short TTL (catches deep edits).
-_SKILL_COUNT_CACHE: dict[str, tuple[float, float, int]] = {}
+_SKILL_COUNT_CACHE: dict[str, tuple[tuple[float, ...], float, int]] = {}
 _SKILL_COUNT_TTL_SECONDS = 30.0
 
 
@@ -768,29 +768,81 @@ def _skills_dir_signature(skills_dir: Path) -> float:
     return sig
 
 
+def _collect_skills_dirs(profile_dir: Path) -> List[Path]:
+    """Return all skill directories visible to *profile_dir*.
+
+    Order: profile-specific skills first (own ``skills/``), then the global
+    ``~/.hermes/skills/`` (via ``get_default_hermes_root`` so this is
+    unaffected by profile-scope overrides), then any
+    ``skills.external_dirs`` from config.
+    """
+    from agent.skill_utils import get_external_skills_dirs
+    from hermes_constants import get_default_hermes_root
+
+    dirs: List[Path] = []
+
+    profile_skills = profile_dir / "skills"
+    if profile_skills.is_dir():
+        dirs.append(profile_skills)
+
+    global_skills = get_default_hermes_root() / "skills"
+    if global_skills.is_dir() and global_skills not in dirs:
+        dirs.append(global_skills)
+
+    for ext_dir in get_external_skills_dirs():
+        if ext_dir not in dirs:
+            dirs.append(ext_dir)
+
+    return dirs
+
+
+def _skills_dirs_signature(dirs: List[Path]) -> tuple[float, ...]:
+    """Combined change-signature for multiple skill directories."""
+    return tuple(_skills_dir_signature(d) for d in dirs)
+
+
 def _count_skills(profile_dir: Path) -> int:
-    """Count installed skills in a profile (cached by skills-dir signature)."""
-    skills_dir = profile_dir / "skills"
-    if not skills_dir.is_dir():
+    """Count total skills available to *profile_dir* (profile-specific +
+    global + external dirs, cached by combined dir signature).
+
+    Deduplicates by skill name (from YAML frontmatter) across directories so
+    a skill that appears in both the global dir and the profile's own dir is
+    counted once — matching how ``scan_skill_commands`` loads skills.
+    """
+    dirs = _collect_skills_dirs(profile_dir)
+    if not dirs:
         return 0
 
-    key = str(skills_dir)
-    signature = _skills_dir_signature(skills_dir)
+    key = ";".join(str(d) for d in dirs)
+    signatures = _skills_dirs_signature(dirs)
     now = time.time()
     cached = _SKILL_COUNT_CACHE.get(key)
     if (
         cached is not None
-        and cached[0] == signature
+        and cached[0] == signatures
         and (now - cached[1]) < _SKILL_COUNT_TTL_SECONDS
     ):
         return cached[2]
 
+    from agent.skill_utils import parse_frontmatter
+
     count = 0
-    for md in skills_dir.rglob("SKILL.md"):
-        if is_excluded_skill_path(md):
-            continue
-        count += 1
-    _SKILL_COUNT_CACHE[key] = (signature, now, count)
+    seen_names: set = set()
+    for sdir in dirs:
+        for md in sdir.rglob("SKILL.md"):
+            if is_excluded_skill_path(md):
+                continue
+            # Dedup by skill name from frontmatter
+            try:
+                frontmatter, _ = parse_frontmatter(md.read_text(encoding="utf-8"))
+                name = frontmatter.get("name", md.parent.name)
+            except Exception:
+                name = md.parent.name
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+            count += 1
+    _SKILL_COUNT_CACHE[key] = (signatures, now, count)
     return count
 
 

--- a/web/src/components/MessageNavSidebar.tsx
+++ b/web/src/components/MessageNavSidebar.tsx
@@ -1,0 +1,284 @@
+/**
+ * MessageNavSidebar — collapsible sidebar listing all user messages in the
+ * current session for quick navigation.
+ *
+ * Sits on the right side of the chat page, similar to DeepSeek's message
+ * navigation sidebar. Fetches the session messages via the REST API and
+ * displays only user messages with content previews. Clicking a message
+ * scrolls the terminal to its approximate position.
+ *
+ * Collapsible via a toggle button. Best-effort: API failures surface an
+ * inline error with a retry affordance; the terminal keeps working.
+ */
+
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import {
+  AlertCircle,
+  ChevronLeft,
+  ChevronRight,
+  MessageSquare,
+  RefreshCw,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useI18n } from "@/i18n";
+import { api, type SessionMessage } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+interface MessageNavSidebarProps {
+  /** Current session ID to fetch messages for. */
+  sessionId: string | null;
+  /** Whether the sidebar is currently visible/expanded. */
+  isOpen: boolean;
+  /** Optional profile scope for the API call. */
+  profile?: string;
+  /**
+   * Called when the user clicks a message to navigate to it.
+   * Receives the approximate terminal line number to scroll to.
+   */
+  onScrollToLine?: (line: number) => void;
+  /** Total terminal buffer lines tracked from the PTY output. Used for
+   * approximate line position calculation. */
+  totalTerminalUserMessages?: number;
+}
+
+/** Truncate message content for the sidebar preview. */
+function messagePreview(msg: SessionMessage): string {
+  if (!msg.content) return "(empty)";
+  const text = msg.content.replace(/\s+/g, " ").trim();
+  if (text.length <= 120) return text;
+  return text.slice(0, 117) + "...";
+}
+
+/** Extract tool name from a user message that is a tool result or call. */
+function messageLabel(msg: SessionMessage): string {
+  if (msg.tool_name) return `🔧 ${msg.tool_name}`;
+  if (msg.tool_calls?.length) {
+    const names = msg.tool_calls.map((tc) => tc.function.name);
+    return `🛠 ${names.join(", ")}`;
+  }
+  return messagePreview(msg);
+}
+
+export function MessageNavSidebar({
+  sessionId,
+  isOpen,
+  profile,
+  onScrollToLine,
+  totalTerminalUserMessages = 0,
+}: MessageNavSidebarProps) {
+  const { t } = useI18n();
+  const [messages, setMessages] = useState<SessionMessage[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const reqRef = useRef(0);
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  const load = useCallback(() => {
+    if (!sessionId) {
+      setMessages(null);
+      return;
+    }
+    const myReq = ++reqRef.current;
+    setLoading(true);
+    setError(null);
+    api
+      .getSessionMessages(sessionId, profile)
+      .then((res) => {
+        if (reqRef.current !== myReq) return;
+        const userMessages = res.messages.filter((m) => m.role === "user");
+        setMessages(userMessages);
+      })
+      .catch((e: Error) => {
+        if (reqRef.current !== myReq) return;
+        setError(e.message || "Failed to load messages");
+      })
+      .finally(() => {
+        if (reqRef.current === myReq) setLoading(false);
+      });
+  }, [sessionId, profile]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+  }, [load]);
+
+  // When the session changes, also reload.
+  const reload = useCallback(() => {
+    setError(null);
+    load();
+  }, [load]);
+
+  // Handle clicking a user message — scroll the terminal to approximate line.
+  const handleClick = useCallback(
+    (index: number) => {
+      if (!onScrollToLine || totalTerminalUserMessages <= 0) return;
+      // Each user message and its assistant response occupies roughly N lines.
+      // Estimate: (user_msg_index / total_user_msgs) * terminal_scroll_height
+      // We use a rough heuristic: each user+assistant block ~6 lines average.
+      // Index 0 = first in session = top of conversation = furthest scroll.
+      const lineEstimate = Math.max(
+        0,
+        Math.round(
+          ((totalTerminalUserMessages - 1 - index) *
+            totalTerminalUserMessages *
+            6) /
+            totalTerminalUserMessages,
+        ),
+      );
+      onScrollToLine(lineEstimate);
+    },
+    [onScrollToLine, totalTerminalUserMessages],
+  );
+
+  const content = useMemo(() => {
+    if (loading && messages === null) {
+      return (
+        <div className="flex items-center justify-center gap-2 px-2 py-6 text-xs text-text-secondary">
+          <Spinner /> {t.common.loading}
+        </div>
+      );
+    }
+    if (error) {
+      return (
+        <div className="flex flex-col items-start gap-2 px-2 py-4 text-xs">
+          <div className="flex items-start gap-2 text-destructive">
+            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span className="wrap-break-word">{error}</span>
+          </div>
+          <Button size="sm" outlined onClick={reload} prefix={<RefreshCw />}>
+            {t.common.retry}
+          </Button>
+        </div>
+      );
+    }
+    if (!sessionId) {
+      return (
+        <div className="px-2 py-6 text-center text-xs text-text-secondary">
+          No active session
+        </div>
+      );
+    }
+    if (!messages || messages.length === 0) {
+      return (
+        <div className="px-2 py-6 text-center text-xs text-text-secondary">
+          No user messages yet
+        </div>
+      );
+    }
+    return (
+      <div ref={listRef} className="flex flex-col gap-0.5">
+        {messages.map((msg, i) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => handleClick(i)}
+            className={cn(
+              "flex w-full flex-col items-start gap-0.5 rounded px-2 py-1.5 text-left text-xs",
+              "transition-colors duration-100",
+              "text-text-secondary hover:bg-midground/5 hover:text-foreground",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary",
+              "cursor-pointer",
+            )}
+            title={msg.content ?? ""}
+          >
+            <span className="flex w-full items-center gap-1.5 text-[0.6875rem] text-text-tertiary">
+              <MessageSquare className="h-3 w-3 shrink-0" />
+              <span className="truncate">Message #{i + 1}</span>
+            </span>
+            <span className="w-full truncate text-[0.65rem] leading-tight text-text-secondary">
+              {messageLabel(msg)}
+            </span>
+          </button>
+        ))}
+      </div>
+    );
+  }, [
+    loading,
+    messages,
+    error,
+    reload,
+    sessionId,
+    handleClick,
+    t.common.loading,
+    t.common.retry,
+  ]);
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col overflow-hidden transition-all duration-200 ease-out",
+        isOpen ? "w-56 shrink-0" : "w-0 shrink-0 overflow-hidden",
+      )}
+    >
+      {isOpen && (
+        <div className="flex min-h-0 flex-1 flex-col">
+          {/* Header */}
+          <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2">
+            <span className="text-display text-xs tracking-wider text-text-tertiary">
+              Messages
+            </span>
+            <div className="flex items-center gap-1">
+              {messages && messages.length > 0 && (
+                <span className="text-[0.625rem] text-text-tertiary">
+                  {messages.length}
+                </span>
+              )}
+              <Button
+                ghost
+                size="icon"
+                onClick={reload}
+                title="Refresh messages"
+                aria-label="Refresh messages"
+                className="h-5 w-5 text-text-secondary hover:text-foreground"
+              >
+                <RefreshCw className={cn("h-3 w-3", loading && "animate-spin")} />
+              </Button>
+            </div>
+          </div>
+
+          {/* Message list */}
+          <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-1 pb-1">
+            {content}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Collapse/expand toggle button for the MessageNavSidebar. */
+export function MessageNavToggle({
+  isOpen,
+  onToggle,
+  hasMessages,
+}: {
+  isOpen: boolean;
+  onToggle: () => void;
+  hasMessages: boolean;
+}) {
+  return (
+    <Button
+      ghost
+      size="icon"
+      onClick={onToggle}
+      title={isOpen ? "Close message navigation" : "Open message navigation"}
+      aria-label={
+        isOpen ? "Close message navigation" : "Open message navigation"
+      }
+      aria-expanded={isOpen}
+      className={cn(
+        "h-7 w-7 shrink-0 rounded border border-current/20",
+        "text-text-secondary hover:text-midground hover:bg-midground/5",
+        hasMessages && !isOpen && "ring-1 ring-primary/30",
+      )}
+    >
+      {isOpen ? (
+        <ChevronRight className="h-4 w-4" />
+      ) : (
+        <ChevronLeft className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -32,6 +32,10 @@ import { useSearchParams } from "react-router-dom";
 
 import { ChatSidebar } from "@/components/ChatSidebar";
 import { ChatSessionList } from "@/components/ChatSessionList";
+import {
+  MessageNavSidebar,
+  MessageNavToggle,
+} from "@/components/MessageNavSidebar";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
@@ -270,6 +274,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // tabs because the dep wouldn't change on tab switch.
   const [mobilePanelOpenRaw, setMobilePanelOpenRaw] = useState(false);
   const mobilePanelOpen = isActive && mobilePanelOpenRaw;
+  // Message navigation sidebar — collapsible panel listing user messages.
+  const [messageNavOpen, setMessageNavOpen] = useState(true);
+  // Track the terminal buffer total line count for approximate message
+  // navigation scrolling. Updated from the metrics sync effect.
+  const [terminalBufferLines, setTerminalBufferLines] = useState(0);
   const { setEnd, setTitle } = usePageHeader();
   const [sessionTitleState, setSessionTitleState] = useState<{
     scope: string;
@@ -405,6 +414,27 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     };
     mql.addEventListener("change", onChange);
     return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  // Track the terminal buffer line count for message navigation scrolling.
+  // Polls the xterm buffer size so the MessageNavSidebar can compute
+  // approximate scroll positions.
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      const term = termRef.current;
+      if (term) {
+        setTerminalBufferLines(term.buffer.active.length);
+      }
+    }, 2000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  // Scroll the terminal to an approximate line position.
+  const handleScrollToLine = useCallback((line: number) => {
+    const term = termRef.current;
+    if (!term) return;
+    const clamped = Math.max(0, Math.min(line, term.buffer.active.length - 1));
+    term.scrollToLine(clamped);
   }, []);
 
   useEffect(() => {
@@ -1498,31 +1528,53 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         </div>
 
         {!narrow && (
-          <div
-            id="chat-side-panel"
-            role="complementary"
-            aria-label={modelToolsLabel}
-            className="flex min-h-0 shrink-0 flex-col gap-3 overflow-hidden lg:h-full lg:w-60"
-          >
-            {/* Model picker — keeps the rail thin. */}
-            <div className="shrink-0">
-              <ChatSidebar
-                channel={channel}
+          <>
+            {/* Message navigation sidebar — collapsible, between terminal and main sidebar. */}
+            <div className="flex min-h-0 shrink-0 flex-col gap-1 overflow-hidden border-l border-current/10">
+              <div className="flex shrink-0 items-center justify-end gap-1 px-1 pt-1">
+                <MessageNavToggle
+                  isOpen={messageNavOpen}
+                  onToggle={() => setMessageNavOpen((v) => !v)}
+                  hasMessages={!!resumeParam}
+                />
+              </div>
+              <MessageNavSidebar
+                sessionId={resumeParam ?? null}
+                isOpen={messageNavOpen}
+                onToggle={() => setMessageNavOpen((v) => !v)}
                 profile={scopedProfile}
-                onDashboardNewSessionRequest={startFreshDashboardChat}
-                onSessionTitleChange={handleSessionTitleChange}
+                onScrollToLine={handleScrollToLine}
+                totalTerminalUserMessages={terminalBufferLines}
               />
             </div>
 
-            {/* Session switcher fills the remaining height below the model box. */}
-            <div className="min-h-0 flex-1 overflow-hidden">
-              <ChatSessionList
-                activeSessionId={resumeParam}
-                profile={scopedProfile}
-                onNewChat={startFreshDashboardChat}
-              />
+            {/* Existing model/tools sidebar */}
+            <div
+              id="chat-side-panel"
+              role="complementary"
+              aria-label={modelToolsLabel}
+              className="flex min-h-0 shrink-0 flex-col gap-3 overflow-hidden lg:h-full lg:w-60"
+            >
+              {/* Model picker — keeps the rail thin. */}
+              <div className="shrink-0">
+                <ChatSidebar
+                  channel={channel}
+                  profile={scopedProfile}
+                  onDashboardNewSessionRequest={startFreshDashboardChat}
+                  onSessionTitleChange={handleSessionTitleChange}
+                />
+              </div>
+
+              {/* Session switcher fills the remaining height below the model box. */}
+              <div className="min-h-0 flex-1 overflow-hidden">
+                <ChatSessionList
+                  activeSessionId={resumeParam}
+                  profile={scopedProfile}
+                  onNewChat={startFreshDashboardChat}
+                />
+              </div>
             </div>
-          </div>
+          </>
         )}
       </div>
       <PluginSlot name="chat:bottom" />


### PR DESCRIPTION
## Problem

When both Hermes Desktop app and CLI dashboard (`hermes dashboard`) are running simultaneously, the Desktop enters a boot loop. The Desktop spawns a backend child process that conflicts with the already-running CLI dashboard backend, exits with code 1, and the renderer's retry loop respawns it — creating an infinite loop.

Fixes #69925

## Solution

Before spawning a local backend, probe the default dashboard port (9119) by fetching `/api/status`. If a backend is already listening there, connect to it directly instead of starting a competing backend.

The probe is:
- **Fast**: 2-second timeout — if the port is free, the normal spawn path proceeds with no meaningful delay
- **Safe**: `/api/status` is a public endpoint (listed in `PUBLIC_API_PATHS`) that requires no session token
- **Graceful**: the served dashboard token is extracted from the SPA HTML for WebSocket auth; extraction failures fall back to an empty token without blocking startup

## Changes

**`apps/desktop/electron/main.ts`** (+55 lines):
- Added `resolveServedDashboardToken` import from `./dashboard-token`
- Added an existing-backend probe in `startHermes()`, inserted after `waitForUpdateToFinish()` and before the local backend spawn

The probe:
1. Tries `GET http://127.0.0.1:9119/api/status` with a 2-second timeout
2. On success: reads the served dashboard token from the SPA HTML, updates boot progress, and returns a connection descriptor pointing at the existing backend
3. On failure (ECONNREFUSED / timeout): logs the skip and falls through to the normal local backend spawn

## Testing

- **Normal boot** (no CLI dashboard): the probe fails fast (ECONNREFUSED in <100ms on loopback) and the existing spawn path runs unchanged
- **CLI dashboard already running**: the probe succeeds (`/api/status` is public), the Desktop connects directly, no second backend is spawned
- **Token extraction failure** (e.g. probing a headless `serve` backend that 404s on `/`): falls back to an empty token; the connection still works for API calls