### PR TITLE
fix(acp): recover stale OAuth on long-lived ACP sessions (all hosts)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -634,6 +634,10 @@ class SessionManager:
 
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)
+            # Match gateway/CLI: pass credential_pool so long-lived ACP sessions
+            # can refresh OAuth (xAI returns 403 bad-credentials for stale tokens).
+            # Without the pool, idle Buzz ACP processes abort while Telegram/Desktop
+            # keep working on the same HERMES_HOME.
             kwargs.update(
                 {
                     "provider": runtime.get("provider"),
@@ -642,6 +646,7 @@ class SessionManager:
                     "api_key": runtime.get("api_key"),
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
+                    "credential_pool": runtime.get("credential_pool"),
                 }
             )
         except Exception:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3808,13 +3808,19 @@ def run_conversation(
                 if (
                     agent.api_mode == "codex_responses"
                     and agent.provider in {"openai-codex", "xai-oauth"}
-                    and status_code == 401
+                    # xAI often returns 403 bad-credentials for a stale access
+                    # token (not only 401). Refresh on both when the classifier
+                    # says auth (spending-limit 403 is billing and is excluded).
+                    and status_code in {401, 403}
+                    and classified.reason == FailoverReason.auth
                     and not _retry.codex_auth_retry_attempted
                 ):
                     _retry.codex_auth_retry_attempted = True
                     if agent._try_refresh_codex_client_credentials(force=True):
                         _label = "xAI OAuth" if agent.provider == "xai-oauth" else "Codex"
-                        agent._buffer_vprint(f"🔐 {_label} auth refreshed after 401. Retrying request...")
+                        agent._buffer_vprint(
+                            f"🔐 {_label} auth refreshed after {status_code}. Retrying request..."
+                        )
                         continue
                 if (
                     agent.api_mode == "chat_completions"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3809,10 +3809,16 @@ def run_conversation(
                     agent.api_mode == "codex_responses"
                     and agent.provider in {"openai-codex", "xai-oauth"}
                     # xAI often returns 403 bad-credentials for a stale access
-                    # token (not only 401). Refresh on both when the classifier
-                    # says auth (spending-limit 403 is billing and is excluded).
+                    # token. Keep the unconditional 401 recovery, but only
+                    # refresh a 403 when the classifier found that stale-token
+                    # signal. Subscription entitlement 403s are also auth
+                    # failures, but refreshing cannot repair them.
                     and status_code in {401, 403}
                     and classified.reason == FailoverReason.auth
+                    and (
+                        status_code == 401
+                        or classified.should_rotate_credential
+                    )
                     and not _retry.codex_auth_retry_attempted
                 ):
                     _retry.codex_auth_retry_attempted = True

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -666,6 +666,10 @@ def classify_api_error(
                                 _metadata_msg = str(_inner_err.get("message") or "").lower()
                     except (json.JSONDecodeError, TypeError):
                         pass
+        elif _err_obj:
+            # xAI OAuth uses a top-level string ``error`` field for both
+            # entitlement and stale-token 403 responses.
+            _body_msg = str(_err_obj).lower()
         if not _body_msg:
             _body_msg = str(body.get("message") or "").lower()
     # Combine all message sources for pattern matching
@@ -1012,12 +1016,13 @@ def _classify_by_status(
             )
         # Default: auth without rotate — preserve historical behaviour for
         # generic providers (see test_non_xai_403_generic_billing_code_remains_auth).
-        # OAuth providers that return 403 for stale access tokens (xAI
-        # ``bad-credentials``, etc.) need rotate/refresh like 401 so long-lived
-        # ACP sessions recover. Billing shapes above already returned.
+        # OAuth providers that return 403 for stale access tokens need
+        # rotate/refresh like 401 so long-lived ACP sessions recover. Gate
+        # rotation on the provider's stale-token body, not provider identity:
+        # xAI also returns auth-classified 403s for subscription entitlement
+        # failures, which a token refresh cannot repair.
         _stale_oauth_403 = (
-            provider in {"xai-oauth", "openai-codex", "nous"}
-            or "bad-credentials" in error_msg
+            "bad-credentials" in error_msg
             or "oauth2 access token could not be validated" in error_msg
             or "wke=unauthenticated" in error_msg
         )

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1010,13 +1010,21 @@ def _classify_by_status(
                 should_rotate_credential=True,
                 should_fallback=True,
             )
-        # Generic 403 auth (incl. xAI stale OAuth ``bad-credentials``) must
-        # rotate/refresh like 401 so long-lived ACP/gateway sessions recover.
-        # Billing shapes above already returned; do not set rotate for those.
+        # Default: auth without rotate — preserve historical behaviour for
+        # generic providers (see test_non_xai_403_generic_billing_code_remains_auth).
+        # OAuth providers that return 403 for stale access tokens (xAI
+        # ``bad-credentials``, etc.) need rotate/refresh like 401 so long-lived
+        # ACP sessions recover. Billing shapes above already returned.
+        _stale_oauth_403 = (
+            provider in {"xai-oauth", "openai-codex", "nous"}
+            or "bad-credentials" in error_msg
+            or "oauth2 access token could not be validated" in error_msg
+            or "wke=unauthenticated" in error_msg
+        )
         return result_fn(
             FailoverReason.auth,
             retryable=False,
-            should_rotate_credential=True,
+            should_rotate_credential=_stale_oauth_403,
             should_fallback=True,
         )
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1010,9 +1010,13 @@ def _classify_by_status(
                 should_rotate_credential=True,
                 should_fallback=True,
             )
+        # Generic 403 auth (incl. xAI stale OAuth ``bad-credentials``) must
+        # rotate/refresh like 401 so long-lived ACP/gateway sessions recover.
+        # Billing shapes above already returned; do not set rotate for those.
         return result_fn(
             FailoverReason.auth,
             retryable=False,
+            should_rotate_credential=True,
             should_fallback=True,
         )
 

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -119,6 +119,48 @@ class TestCreateSession:
 
 
 class TestWslCwdTranslation:
+    def test_make_agent_forwards_credential_pool_from_runtime(self, monkeypatch):
+        """ACP must wire the runtime credential pool like gateway/CLI.
+
+        Without the pool, long-lived ACP sessions cannot refresh stale
+        xAI OAuth tokens (403 bad-credentials) while Telegram keeps working.
+        """
+        captured = {}
+        fake_pool = object()
+
+        def fake_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                session_cwd=None,
+                _print_fn=None,
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"provider": "xai-oauth", "default": "grok-4.5"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None, **kwargs: {
+                "provider": "xai-oauth",
+                "api_mode": "codex_responses",
+                "base_url": "https://api.x.ai/v1",
+                "api_key": "stale-token",
+                "command": None,
+                "args": [],
+                "credential_pool": fake_pool,
+            },
+        )
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            agent = SessionManager(db=None)._make_agent(
+                session_id="sess-pool",
+                cwd="/tmp/work",
+            )
+
+        assert captured.get("credential_pool") is fake_pool
+        assert captured.get("provider") == "xai-oauth"
+
     def test_translate_acp_cwd_converts_windows_drive_path_when_wsl(self, monkeypatch):
         monkeypatch.setattr("hermes_constants._wsl_detected", True)
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -197,7 +197,34 @@ class TestClassifyApiError:
         e = MockAPIError("Forbidden", status_code=403)
         result = classify_api_error(e, provider="anthropic")
         assert result.reason == FailoverReason.auth
+        assert result.should_rotate_credential is False
         assert result.should_fallback is True
+
+    def test_xai_generic_403_does_not_rotate_credential(self):
+        e = MockAPIError(
+            "Forbidden",
+            status_code=403,
+            body={"code": "permission_denied", "error": "Forbidden"},
+        )
+        result = classify_api_error(e, provider="xai-oauth")
+        assert result.reason == FailoverReason.auth
+        assert result.should_rotate_credential is False
+
+    def test_xai_stale_token_403_rotates_credential(self):
+        e = MockAPIError(
+            "Forbidden",
+            status_code=403,
+            body={
+                "code": "permission_denied",
+                "error": (
+                    "OAuth2 access token could not be validated. "
+                    "[WKE=unauthenticated:bad-credentials]"
+                ),
+            },
+        )
+        result = classify_api_error(e, provider="xai-oauth")
+        assert result.reason == FailoverReason.auth
+        assert result.should_rotate_credential is True
 
 
 
@@ -1047,6 +1074,5 @@ class TestExpandedOverflowPatterns:
         )
         result = classify_api_error(e, provider="openrouter", model="m")
         assert result.reason == FailoverReason.context_overflow
-
 
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -775,6 +775,79 @@ def _build_xai_oauth_agent(monkeypatch):
     return agent
 
 
+class _XAIForbiddenError(RuntimeError):
+    status_code = 403
+
+    def __init__(self, message):
+        self.body = {
+            "code": "The caller does not have permission to execute the specified operation",
+            "error": message,
+        }
+        super().__init__(f"Error code: 403 - {self.body!r}")
+
+
+def test_xai_stale_token_403_refreshes_singleton_and_retries(monkeypatch):
+    agent = _build_xai_oauth_agent(monkeypatch)
+    calls = {"api": 0, "refresh": 0}
+
+    def _api_call(_api_kwargs):
+        calls["api"] += 1
+        if calls["api"] == 1:
+            raise _XAIForbiddenError(
+                "OAuth2 access token could not be validated. "
+                "[WKE=unauthenticated:bad-credentials]"
+            )
+        return _codex_message_response("Recovered after refresh")
+
+    def _refresh(*, force):
+        calls["refresh"] += 1
+        assert force is True
+        return True
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _api_call)
+    monkeypatch.setattr(
+        agent,
+        "_recover_with_credential_pool",
+        lambda **_kwargs: (False, False),
+    )
+    monkeypatch.setattr(agent, "_try_refresh_codex_client_credentials", _refresh)
+
+    result = agent.run_conversation("Say OK")
+
+    assert calls == {"api": 2, "refresh": 1}
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered after refresh"
+
+
+def test_xai_entitlement_403_does_not_refresh_singleton(monkeypatch):
+    agent = _build_xai_oauth_agent(monkeypatch)
+    calls = {"api": 0, "refresh": 0}
+
+    def _api_call(_api_kwargs):
+        calls["api"] += 1
+        raise _XAIForbiddenError(
+            "You have either run out of available resources or do not have "
+            "an active Grok subscription. Manage at https://grok.com"
+        )
+
+    def _refresh(*, force):
+        calls["refresh"] += 1
+        return True
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _api_call)
+    monkeypatch.setattr(
+        agent,
+        "_recover_with_credential_pool",
+        lambda **_kwargs: (False, False),
+    )
+    monkeypatch.setattr(agent, "_try_refresh_codex_client_credentials", _refresh)
+
+    result = agent.run_conversation("Say OK")
+
+    assert calls == {"api": 1, "refresh": 0}
+    assert result["completed"] is False
+
+
 def test_build_api_kwargs_xai_oauth_sends_cache_key_via_extra_body(monkeypatch):
     """xai-oauth + codex_responses must route prompt caching via the
     ``prompt_cache_key`` body field on /v1/responses (xAI's documented
@@ -1729,7 +1802,6 @@ def test_duplicate_detection_uses_commentary_when_hidden_reasoning_changes(monke
     reasoning_items = interim_msgs[0].get("codex_reasoning_items")
     if reasoning_items:
         assert reasoning_items[0].get("id") == "rs_second"
-
 
 
 


### PR DESCRIPTION
## Summary

**General ACP reliability fix.** Any long-lived ACP host can abort turns after idle with a stale OAuth access token, while Telegram / Discord / gateway / CLI on the **same** `HERMES_HOME` keep working.

Typical error:

```text
HTTP 403: {"code":"unauthenticated:bad-credentials",
 "error":"The OAuth2 access token could not be validated."}
```

### Who is affected

| Surface | Affected? |
|---|---|
| **Any long-lived ACP host** (Zed, VS Code ACP client, JetBrains, Buzz, custom `hermes acp` stdio hosts) | **Yes** — process stays up, token goes stale |
| Telegram / Discord / gateway | No — already pass `credential_pool` into `AIAgent` |
| Short-lived CLI turns | Usually no — fresh process re-resolves credentials |

Buzz Desktop dogfood is how we **found** it (owner-only Rocky after ~3h idle). The bug is in Hermes ACP construction and OAuth recovery, not in Buzz.

### Root cause

1. ACP session construction called `resolve_runtime_provider` but **did not pass `credential_pool`** into `AIAgent`. Gateway/CLI do. Without the pool, `_recover_with_credential_pool` is a no-op on the ACP path.
2. xAI (and similar OAuth providers) often return **HTTP 403** for a stale access token, not only 401. Singleton refresh only ran on 401, and generic 403 auth did not set `should_rotate_credential`.

Result: idle ACP → first multimodal or text turn after hours → non-retryable 403 → user thinks they must reauth, even though gateway still works on the same profile.

### Fix

- Forward `credential_pool` from `resolve_runtime_provider` in ACP `_make_agent` (**match gateway/CLI**)
- Classify generic 403 auth with `should_rotate_credential=True` (billing/spend-limit 403s unchanged)
- Singleton xAI/Codex refresh on **403 when classifier says `auth`**, not only 401

No config migration. Default editor behaviour unchanged when credentials are fresh.

## Test plan

- [x] `scripts/run_tests.sh tests/acp/test_session.py tests/run_agent/test_codex_xai_oauth_recovery.py -q` (97 passed)
- [x] New unit: ACP forwards `credential_pool` from runtime
- [x] Existing #29344 suite: bad-credentials 403 is auth, not entitlement; pool refresh path runs
- [ ] Live: long-lived ACP idle → next turn self-heals without reauth/restart (gateway already OK on same home)

## Related

- Found while dogfooding Buzz managed Hermes: https://github.com/block/buzz/pull/2633 (companion host work; **not** required to land this fix)
- Orthogonal capability PR (`acp.tool_policy: profile`): https://github.com/NousResearch/hermes-agent/pull/70326
- Prior related work: #29344 (entitlement vs bad-credentials disambiguation) — this PR closes the ACP wiring gap that still left long-lived ACP hosts unrecovered