### PR TITLE
feat(api): expose Codex account usage

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7,6 +7,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent and any configured model_routes aliases
+- GET  /v1/account/usage           — normalized OpenAI/ChatGPT OAuth quota windows
 - GET  /v1/capabilities            — machine-readable API capabilities for external UIs
 - GET  /api/sessions               — list client-visible Hermes sessions
 - POST /api/sessions               — create an empty Hermes session
@@ -129,6 +130,7 @@ MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+ACCOUNT_USAGE_CACHE_TTL_SECONDS = 300
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -1041,6 +1043,11 @@ class APIServerAdapter(BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
+        # Profile-scoped normalized quota snapshots. External clients may poll
+        # this endpoint frequently; caching avoids repeatedly hitting ChatGPT's
+        # private usage API while keeping clients free of OAuth credentials.
+        self._account_usage_cache: Dict[str, tuple[float, Dict[str, Any]]] = {}
+        self._account_usage_lock: Optional[asyncio.Lock] = None
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
         # Creation timestamps for orphaned-run TTL sweep
@@ -1558,6 +1565,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/health/detailed", self._handle_health_detailed),
             ("GET", "/v1/health", self._handle_health),
             ("GET", "/v1/models", self._handle_models),
+            ("GET", "/v1/account/usage", self._handle_account_usage),
             ("GET", "/v1/capabilities", self._handle_capabilities),
             ("GET", "/v1/skills", self._handle_skills),
             ("GET", "/v1/toolsets", self._handle_toolsets),
@@ -2070,6 +2078,97 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return web.json_response({"object": "list", "data": models})
 
+    @staticmethod
+    def _account_usage_payload(snapshot: Any) -> Dict[str, Any]:
+        """Return the stable, credential-free account-usage API envelope."""
+        if snapshot is None:
+            return {
+                "ok": True,
+                "available": False,
+                "provider": "openai-codex",
+                "plan": None,
+                "source": None,
+                "fetched_at": None,
+                "windows": [],
+                "details": [],
+                "unavailable_reason": (
+                    "OpenAI/ChatGPT OAuth usage is unavailable. Verify "
+                    "openai-codex authentication on the Hermes API server and try again."
+                ),
+            }
+
+        windows = []
+        for window in snapshot.windows:
+            used_percent = (
+                None
+                if window.used_percent is None
+                else max(0.0, min(100.0, float(window.used_percent)))
+            )
+            windows.append({
+                "label": window.label,
+                "used_percent": used_percent,
+                "remaining_percent": (
+                    None if used_percent is None else max(0.0, 100.0 - used_percent)
+                ),
+                "reset_at": window.reset_at.isoformat() if window.reset_at else None,
+                "detail": window.detail,
+            })
+
+        return {
+            "ok": True,
+            "available": snapshot.available,
+            "provider": snapshot.provider,
+            "plan": snapshot.plan,
+            "source": snapshot.source,
+            "fetched_at": snapshot.fetched_at.isoformat(),
+            "windows": windows,
+            "details": list(snapshot.details),
+            "unavailable_reason": snapshot.unavailable_reason,
+        }
+
+    async def _handle_account_usage(self, request: "web.Request") -> "web.Response":
+        """GET /v1/account/usage — expose server-side Codex OAuth quota safely.
+
+        OAuth access/refresh tokens and account identifiers stay inside Hermes.
+        The normalized response is cached per served profile because desktop
+        clients poll this route and ChatGPT's upstream usage endpoint is private.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        profile_key = _api_request_profile.get() or "__default__"
+
+        def cached_payload() -> Optional[Dict[str, Any]]:
+            cached = self._account_usage_cache.get(profile_key)
+            if cached and time.monotonic() - cached[0] < ACCOUNT_USAGE_CACHE_TTL_SECONDS:
+                return cached[1]
+            return None
+
+        payload = cached_payload()
+        if payload is not None:
+            return web.json_response(payload)
+
+        if self._account_usage_lock is None:
+            self._account_usage_lock = asyncio.Lock()
+        async with self._account_usage_lock:
+            payload = cached_payload()
+            if payload is None:
+                try:
+                    from agent.account_usage import fetch_account_usage
+
+                    snapshot = await asyncio.to_thread(
+                        fetch_account_usage,
+                        "openai-codex",
+                    )
+                except Exception:
+                    logger.exception("GET /v1/account/usage failed")
+                    snapshot = None
+                payload = self._account_usage_payload(snapshot)
+                self._account_usage_cache[profile_key] = (time.monotonic(), payload)
+
+        return web.json_response(payload)
+
     async def _handle_capabilities(self, request: "web.Request") -> "web.Response":
         """GET /v1/capabilities — advertise the stable API surface.
 
@@ -2102,6 +2201,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "features": {
                 "chat_completions": True,
                 "chat_completions_streaming": True,
+                "account_usage": True,
                 "responses_api": True,
                 "responses_streaming": True,
                 "run_submission": True,
@@ -2129,6 +2229,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "health": {"method": "GET", "path": "/health"},
                 "health_detailed": {"method": "GET", "path": "/health/detailed"},
                 "models": {"method": "GET", "path": "/v1/models"},
+                "account_usage": {"method": "GET", "path": "/v1/account/usage"},
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
                 "responses": {"method": "POST", "path": "/v1/responses"},
                 "runs": {"method": "POST", "path": "/v1/runs"},

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -18,17 +18,20 @@ import os
 import stat
 import time
 import uuid
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
     _IdempotencyCache,
+    _api_request_profile,
     _derive_chat_session_id,
     _hermes_version,
     _redact_api_error_text,
@@ -658,6 +661,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)
     app.router.add_get("/v1/models", adapter._handle_models)
+    app.router.add_get("/v1/account/usage", adapter._handle_account_usage)
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
     app.router.add_get("/v1/skills", adapter._handle_skills)
     app.router.add_get("/v1/toolsets", adapter._handle_toolsets)
@@ -1018,6 +1022,219 @@ class TestModelsEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# /v1/account/usage endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestAccountUsageEndpoint:
+    @staticmethod
+    def _snapshot() -> AccountUsageSnapshot:
+        return AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime(2026, 7, 24, 1, 30, tzinfo=timezone.utc),
+            plan="Pro",
+            windows=(
+                AccountUsageWindow(
+                    label="Session",
+                    used_percent=25.0,
+                    reset_at=datetime(2026, 7, 24, 6, 30, tzinfo=timezone.utc),
+                ),
+                AccountUsageWindow(
+                    label="Weekly",
+                    used_percent=40.0,
+                    reset_at=datetime(2026, 7, 28, 1, 30, tzinfo=timezone.utc),
+                    detail="Account-wide Codex allowance",
+                ),
+            ),
+            details=("You have 1 reset banked",),
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_normalized_codex_oauth_usage_without_credentials(self, auth_adapter):
+        snapshot = self._snapshot()
+        with patch("agent.account_usage.fetch_account_usage", return_value=snapshot):
+            app = _create_app(auth_adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get(
+                    "/v1/account/usage",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data == {
+            "ok": True,
+            "available": True,
+            "provider": "openai-codex",
+            "plan": "Pro",
+            "source": "usage_api",
+            "fetched_at": "2026-07-24T01:30:00+00:00",
+            "windows": [
+                {
+                    "label": "Session",
+                    "used_percent": 25.0,
+                    "remaining_percent": 75.0,
+                    "reset_at": "2026-07-24T06:30:00+00:00",
+                    "detail": None,
+                },
+                {
+                    "label": "Weekly",
+                    "used_percent": 40.0,
+                    "remaining_percent": 60.0,
+                    "reset_at": "2026-07-28T01:30:00+00:00",
+                    "detail": "Account-wide Codex allowance",
+                },
+            ],
+            "details": ["You have 1 reset banked"],
+            "unavailable_reason": None,
+        }
+        serialized = json.dumps(data)
+        assert "Bearer " not in serialized
+        assert "ChatGPT-Account-Id" not in serialized
+
+    @pytest.mark.asyncio
+    async def test_requires_the_hermes_api_key(self, auth_adapter):
+        fetch = MagicMock(return_value=self._snapshot())
+        with patch("agent.account_usage.fetch_account_usage", fetch):
+            app = _create_app(auth_adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/account/usage")
+
+        assert resp.status == 401
+        fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_a_safe_unavailable_envelope_when_usage_cannot_be_fetched(self, auth_adapter):
+        with patch("agent.account_usage.fetch_account_usage", return_value=None):
+            app = _create_app(auth_adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get(
+                    "/v1/account/usage",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["ok"] is True
+        assert data["available"] is False
+        assert data["provider"] == "openai-codex"
+        assert data["windows"] == []
+        assert data["details"] == []
+        assert "OAuth usage is unavailable" in data["unavailable_reason"]
+
+    @pytest.mark.asyncio
+    async def test_preserves_details_only_usage_snapshots(self, auth_adapter):
+        snapshot = AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime(2026, 7, 24, 1, 30, tzinfo=timezone.utc),
+            plan="Pro",
+            windows=(),
+            details=("Credits balance: $1.00",),
+        )
+        with patch("agent.account_usage.fetch_account_usage", return_value=snapshot):
+            app = _create_app(auth_adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get(
+                    "/v1/account/usage",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["available"] is True
+        assert data["windows"] == []
+        assert data["details"] == ["Credits balance: $1.00"]
+        assert data["unavailable_reason"] is None
+
+    @pytest.mark.asyncio
+    async def test_serializes_unavailable_windows_and_the_provider_reason(self, auth_adapter):
+        snapshot = AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime(2026, 7, 24, 1, 30, tzinfo=timezone.utc),
+            plan="Pro",
+            windows=(AccountUsageWindow(label="Session", detail="Not reported"),),
+            unavailable_reason="Provider did not return a usable quota percentage.",
+        )
+        with patch("agent.account_usage.fetch_account_usage", return_value=snapshot):
+            app = _create_app(auth_adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get(
+                    "/v1/account/usage",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["available"] is False
+        assert data["windows"] == [{
+            "label": "Session",
+            "used_percent": None,
+            "remaining_percent": None,
+            "reset_at": None,
+            "detail": "Not reported",
+        }]
+        assert data["unavailable_reason"] == snapshot.unavailable_reason
+
+    @pytest.mark.asyncio
+    async def test_caches_the_upstream_usage_read_for_repeated_client_polls(self, auth_adapter):
+        fetch = MagicMock(return_value=self._snapshot())
+        with patch("agent.account_usage.fetch_account_usage", fetch):
+            app = _create_app(auth_adapter)
+            async with TestClient(TestServer(app)) as cli:
+                first = await cli.get(
+                    "/v1/account/usage",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                second = await cli.get(
+                    "/v1/account/usage",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert first.status == second.status == 200
+                first_data = await first.json()
+                second_data = await second.json()
+
+        assert first_data == second_data
+        fetch.assert_called_once_with("openai-codex")
+
+    @pytest.mark.asyncio
+    async def test_cache_is_isolated_between_multiplexed_profiles(self, auth_adapter):
+        first_snapshot = self._snapshot()
+        second_snapshot = AccountUsageSnapshot(
+            provider=first_snapshot.provider,
+            source=first_snapshot.source,
+            fetched_at=first_snapshot.fetched_at,
+            plan="Team",
+            windows=first_snapshot.windows,
+            details=first_snapshot.details,
+        )
+        request = MagicMock()
+        request.headers = {"Authorization": "Bearer sk-secret"}
+
+        with patch(
+            "agent.account_usage.fetch_account_usage",
+            side_effect=[first_snapshot, second_snapshot],
+        ) as fetch:
+            first_token = _api_request_profile.set("first")
+            try:
+                first_response = await auth_adapter._handle_account_usage(request)
+            finally:
+                _api_request_profile.reset(first_token)
+
+            second_token = _api_request_profile.set("second")
+            try:
+                second_response = await auth_adapter._handle_account_usage(request)
+            finally:
+                _api_request_profile.reset(second_token)
+
+        assert json.loads(first_response.text)["plan"] == "Pro"
+        assert json.loads(second_response.text)["plan"] == "Team"
+        assert fetch.call_count == 2
+
+
+# ---------------------------------------------------------------------------
 # /v1/capabilities endpoint
 # ---------------------------------------------------------------------------
 
@@ -1040,10 +1257,15 @@ class TestCapabilitiesEndpoint:
             assert data["runtime"]["split_runtime"] is False
             assert "API-server host" in data["runtime"]["description"]
             assert data["features"]["chat_completions"] is True
+            assert data["features"]["account_usage"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
+            assert data["endpoints"]["account_usage"] == {
+                "method": "GET",
+                "path": "/v1/account/usage",
+            }
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
 


### PR DESCRIPTION
## Summary

- expose the existing `openai-codex` account-usage snapshot through authenticated `GET /v1/account/usage`
- return normalized, nullable quota-window fields without exposing OAuth credentials or ChatGPT account identifiers
- cache upstream reads for five minutes with profile-scoped keys and a single-flight lock
- advertise the feature and endpoint through `/v1/capabilities`
- cover authentication, serialization, unavailable/details-only snapshots, caching, and profile isolation

## Why

Hermes already knows how to refresh the OpenAI Codex OAuth credential and obtain account-wide quota windows, but API clients cannot access that normalized snapshot. This endpoint lets authenticated desktop and dashboard clients display the same limits without duplicating OAuth storage or refresh logic outside Hermes.

## Security

- requires the existing Hermes API bearer key
- returns only the normalized `AccountUsageSnapshot` fields
- does not return access tokens, refresh tokens, credential-pool entries, email addresses, or ChatGPT account IDs
- scopes cached snapshots by multiplex profile

## Verification

- `python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py`
- `python -m pytest -q tests/gateway/test_api_server.py tests/gateway/test_multiplex_api_server_routing.py tests/test_account_usage.py` — 243 passed
- live authenticated request against the deployed gateway returned HTTP 200 with a current `openai-codex` Pro quota window
