### PR TITLE
fix(plugins): block updates while gateway runs

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -653,6 +653,10 @@ def cmd_update(name: str) -> None:
         )
         sys.exit(1)
 
+    if _gateway_is_running_for_plugin_update():
+        console.print(f"[red]Error:[/red] {_RUNNING_GATEWAY_PLUGIN_UPDATE_ERROR}")
+        sys.exit(1)
+
     console.print(f"[dim]Updating {name}...[/dim]")
 
     ok, output = _git_pull_plugin_dir(target)
@@ -1950,6 +1954,9 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
             "error": f"Plugin '{name}' is not a git checkout; cannot pull updates.",
         }
 
+    if _gateway_is_running_for_plugin_update():
+        return {"ok": False, "error": _RUNNING_GATEWAY_PLUGIN_UPDATE_ERROR}
+
     ok, msg = _git_pull_plugin_dir(target)
     if not ok:
         return {"ok": False, "error": msg}
@@ -1959,6 +1966,20 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
     _copy_example_files(target, Console())
     unchanged = "Already up to date" in msg
     return {"ok": True, "name": name, "output": msg, "unchanged": unchanged}
+
+
+_RUNNING_GATEWAY_PLUGIN_UPDATE_ERROR = (
+    "Cannot update plugin files while the gateway is running because loaded "
+    "plugin callbacks may still import from the installed checkout. Run "
+    "`hermes gateway stop`, update the plugin, then run `hermes gateway start`."
+)
+
+
+def _gateway_is_running_for_plugin_update() -> bool:
+    """Return whether mutating an installed plugin could break a live gateway."""
+    from gateway.status import is_gateway_running
+
+    return is_gateway_running(cleanup_stale=False)
 
 
 def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -469,9 +469,39 @@ class TestCmdUpdate:
 
         mock_run.return_value = MagicMock(returncode=0, stdout="Updated", stderr="")
 
-        cmd_update("test-plugin")
+        with patch(
+            "hermes_cli.plugins_cmd._gateway_is_running_for_plugin_update",
+            return_value=False,
+        ):
+            cmd_update("test-plugin")
 
         mock_run.assert_called_once()
+
+    @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins_cmd.subprocess.run")
+    def test_update_refuses_to_mutate_plugin_while_gateway_runs(
+        self, mock_run, mock_plugins_dir, mock_sanitize
+    ):
+        from hermes_cli.plugins_cmd import cmd_update
+
+        mock_plugins_dir.return_value = MagicMock()
+        mock_target = MagicMock()
+        mock_target.exists.return_value = True
+        mock_target.__truediv__ = lambda self, x: MagicMock(
+            exists=MagicMock(return_value=True)
+        )
+        mock_sanitize.return_value = mock_target
+
+        with patch(
+            "hermes_cli.plugins_cmd._gateway_is_running_for_plugin_update",
+            return_value=True,
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_update("test-plugin")
+
+        assert exc_info.value.code == 1
+        mock_run.assert_not_called()
 
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
@@ -489,6 +519,49 @@ class TestCmdUpdate:
             cmd_update("nonexistent-plugin")
 
         assert exc_info.value.code == 1
+
+
+class TestDashboardPluginUpdate:
+    def test_refuses_to_mutate_plugin_while_gateway_runs(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd as pc
+
+        target = tmp_path / "plugins" / "test-plugin"
+        (target / ".git").mkdir(parents=True)
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: tmp_path / "plugins")
+        monkeypatch.setattr(
+            pc, "_gateway_is_running_for_plugin_update", lambda: True
+        )
+        pull = MagicMock()
+        monkeypatch.setattr(pc, "_git_pull_plugin_dir", pull)
+
+        result = pc.dashboard_update_user_plugin("test-plugin")
+
+        assert result["ok"] is False
+        assert "gateway is running" in result["error"]
+        pull.assert_not_called()
+
+    def test_updates_plugin_when_gateway_is_stopped(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd as pc
+
+        target = tmp_path / "plugins" / "test-plugin"
+        (target / ".git").mkdir(parents=True)
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: tmp_path / "plugins")
+        monkeypatch.setattr(
+            pc, "_gateway_is_running_for_plugin_update", lambda: False
+        )
+        pull = MagicMock(return_value=(True, "Updating old..new"))
+        monkeypatch.setattr(pc, "_git_pull_plugin_dir", pull)
+        monkeypatch.setattr(pc, "_copy_example_files", MagicMock())
+
+        result = pc.dashboard_update_user_plugin("test-plugin")
+
+        assert result == {
+            "ok": True,
+            "name": "test-plugin",
+            "output": "Updating old..new",
+            "unchanged": False,
+        }
+        pull.assert_called_once_with(target)
 
 
 # ── cmd_remove tests ─────────────────────────────────────────────────────────


### PR DESCRIPTION
﻿## What does this PR do?

Prevents Git-installed plugin checkouts from being mutated while the current profile's messaging gateway is running.

A loaded plugin callback may defer a relative import until its first tool invocation. Updating the checkout in place can delete or replace that module before the callback imports it, so the update reports success and the later tool call fails with `ModuleNotFoundError`. The CLI and Dashboard paths now fail before `git pull` and give the operator an explicit stop/update/start sequence.

This is intentionally a guard, not a partial hot-reload implementation. Updates continue unchanged when the gateway is stopped.

## Related Issue

Fixes #70473

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins_cmd.py`: gate both CLI and Dashboard Git update paths on the current profile's live gateway status before mutating files
- `tests/hermes_cli/test_plugins_cmd.py`: cover blocked CLI/Dashboard updates and preserve the stopped-gateway success path

## How to Test

1. Start a gateway with a Git-installed plugin that has a callback containing a deferred relative import.
2. Attempt to update the plugin through `hermes plugins update` or the Dashboard; verify the update is rejected before `git pull` with stop/update/start guidance.
3. Stop the gateway and repeat; verify the plugin fast-forwards normally.

Focused verification:

- `PYTHONUTF8=1 python -m pytest tests/hermes_cli/test_plugins_cmd.py -q -k "TestCmdUpdate or TestDashboardPluginUpdate"` -> 5 passed
- `python -m ruff check hermes_cli/plugins_cmd.py tests/hermes_cli/test_plugins_cmd.py` -> clean
- `git diff --check` -> clean
- `PYTHONUTF8=1 python -m pytest tests/hermes_cli/test_plugins_cmd.py -q` -> 100 passed, 2 environment failures on Windows: symlink creation requires an unavailable privilege; stdlib `_curses` is unavailable

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] Relevant documentation: N/A; the error contains the required recovery sequence
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed
- [x] Cross-platform impact considered: the guard uses the existing profile-aware gateway status helper
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Before the fix, a real minimal plugin update returned success after deleting the deferred module, then the registered callback failed:

```text
update: {"ok": true, "output": "Fast-forward; delete mode 100644 late.py"}
reproduced: ModuleNotFoundError No module named 'hermes_plugins.live_update_plugin.late'
```

After the fix, both update entry points stop before invoking `git pull` while the gateway is live.
