### PR TITLE
fix(sessions): repair blank assistant text blocks that wedge a session (#70475)

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1480,15 +1480,53 @@ def _sessions_repair(_engine: HermesConsoleEngine, args: list[str]) -> str:
     parser = _ArgumentParser(prog="sessions repair", add_help=False)
     parser.add_argument("--check-only", action="store_true")
     parser.add_argument("--no-backup", action="store_true")
+    parser.add_argument(
+        "--content",
+        action="store_true",
+        help="Also heal blank assistant text blocks that wedge a session behind "
+        "an HTTP 400 (empty text content block replayed every turn).",
+    )
     ns = parser.parse_args(args)
 
     def _run() -> None:
-        from hermes_state import DEFAULT_DB_PATH, _db_opens_cleanly, repair_state_db_schema
+        from hermes_state import (
+            DEFAULT_DB_PATH,
+            _db_opens_cleanly,
+            repair_blank_message_content,
+            repair_state_db_schema,
+        )
 
         db_path = DEFAULT_DB_PATH
         if not db_path.exists():
             print(f"No session database at {db_path} (nothing to repair).")
             return
+
+        if ns.content:
+            content_report = repair_blank_message_content(
+                db_path, check_only=ns.check_only, backup=not ns.no_backup
+            )
+            if content_report.get("error"):
+                raise ConsoleCommandError(
+                    f"Content repair failed: {content_report['error']}"
+                )
+            affected = content_report.get("affected", 0)
+            sessions = content_report.get("sessions", 0)
+            if affected == 0:
+                print("No blank message content blocks found.")
+            elif ns.check_only:
+                print(
+                    f"Found {affected} blank message content block(s) across "
+                    f"{sessions} session(s) (run without --check-only to repair)."
+                )
+            else:
+                if content_report.get("backup_path"):
+                    print(f"backup: {content_report['backup_path']}")
+                print(
+                    f"Repaired {affected} blank message content block(s) across "
+                    f"{sessions} session(s)."
+                )
+            return
+
         reason = _db_opens_cleanly(db_path)
         if reason is None:
             print(f"{db_path} opens cleanly; no repair needed.")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1048,6 +1048,89 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     return report
 
 
+# Non-whitespace placeholder for a blank assistant text block. Kept in sync with
+# agent.anthropic_adapter._EMPTY_TEXT_PLACEHOLDER in intent (any non-whitespace
+# string satisfies the provider); a distinct value marks a healed row.
+_BLANK_CONTENT_PLACEHOLDER = "(tool call)"
+
+
+def repair_blank_message_content(
+    db_path: Path, *, check_only: bool = False, backup: bool = True
+) -> Dict[str, Any]:
+    """Heal assistant messages whose text content is empty/whitespace-only while
+    they carry tool calls — a content-level poison distinct from the schema
+    corruption ``repair_state_db_schema`` handles.
+
+    Such a row serializes to an empty text content block. The Anthropic Messages
+    API (and Bedrock) reject a request containing a blank text block with HTTP
+    400 ``text content blocks must contain non-whitespace text``, and because the
+    blank is stored in history it replays on every subsequent turn — the session
+    hangs with no output until the block is coerced. The request-path adapters
+    coerce blanks on send, but rows persisted before that coercion existed stay
+    wedged; this repairs them in place so the next turn succeeds.
+
+    Only rows that are BOTH blank-text AND tool-call-bearing are touched, and
+    only their ``content`` is rewritten to a non-whitespace placeholder — the
+    tool_use blocks (the real payload of those turns) are untouched, and no
+    other column or message is modified. A truly empty assistant message with no
+    tool calls is left alone (it is not this poison class).
+
+    Returns ``{repaired: bool, affected: int, sessions: int,
+    backup_path: str|None, error: str|None}``. With ``check_only`` it reports
+    the count without writing.
+    """
+    report: Dict[str, Any] = {
+        "repaired": False,
+        "affected": 0,
+        "sessions": 0,
+        "backup_path": None,
+        "error": None,
+    }
+    if not db_path.exists():
+        return report
+
+    # Blank = NULL or whitespace-only; poison = blank AND has tool_calls.
+    # SQLite trim() strips only ASCII space by default, so pass the full
+    # whitespace set (space, tab, newline, CR) to catch "\n"/"\t"-only content
+    # the way Python str.strip() (used by the request-path coercion) would.
+    _ws = "char(32) || char(9) || char(10) || char(13)"
+    where = (
+        "role = 'assistant' AND active = 1 "
+        f"AND (content IS NULL OR trim(content, {_ws}) = '') "
+        "AND tool_calls IS NOT NULL"
+    )
+    try:
+        conn = sqlite3.connect(str(db_path), isolation_level=None)
+        try:
+            conn.execute("PRAGMA busy_timeout = 30000")
+            row = conn.execute(
+                f"SELECT count(*), count(DISTINCT session_id) FROM messages WHERE {where}"
+            ).fetchone()
+            affected, sessions = (int(row[0]), int(row[1])) if row else (0, 0)
+            report["affected"] = affected
+            report["sessions"] = sessions
+            if affected == 0 or check_only:
+                return report
+
+            if backup:
+                bpath = _backup_db_file(db_path)
+                report["backup_path"] = str(bpath) if bpath else None
+
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                f"UPDATE messages SET content = ? WHERE {where}",
+                (_BLANK_CONTENT_PLACEHOLDER,),
+            )
+            conn.execute("COMMIT")
+            report["repaired"] = True
+            return report
+        finally:
+            conn.close()
+    except Exception as exc:
+        report["error"] = str(exc)
+        return report
+
+
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER NOT NULL

--- a/tests/agent/test_blank_message_content_repair.py
+++ b/tests/agent/test_blank_message_content_repair.py
@@ -1,0 +1,103 @@
+"""Regression: heal blank assistant text blocks that wedge a session.
+
+An assistant message stored with empty/whitespace ``content`` while it carries
+``tool_calls`` serializes to an empty text content block. The Anthropic Messages
+API (and Bedrock) reject a request containing a blank text block with HTTP 400
+``text content blocks must contain non-whitespace text``. Because the blank is
+in stored history it replays every turn, so the session hangs with no output.
+
+The request-path adapters coerce blanks on send, but rows persisted before that
+coercion existed stay wedged. ``repair_blank_message_content`` heals them in
+place. This test uses synthetic rows only.
+"""
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB, repair_blank_message_content
+
+
+def _seed(db_path, rows):
+    """Insert (role, content, tool_calls) rows into a real, initialized DB."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('s1', 'test', 0)"
+        )
+        for i, (role, content, tool_calls) in enumerate(rows):
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, tool_calls, timestamp) "
+                "VALUES ('s1', ?, ?, ?, ?)",
+                (role, content, tool_calls, float(i)),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _contents(db_path):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return [r[0] for r in conn.execute(
+            "SELECT content FROM messages ORDER BY timestamp"
+        ).fetchall()]
+    finally:
+        conn.close()
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    p = tmp_path / "state.db"
+    SessionDB(db_path=p).close()  # initialize schema
+    return p
+
+
+TOOL_CALLS = '[{"id": "call_1", "type": "function", "function": {"name": "read_file", "arguments": "{}"}}]'
+
+
+def test_heals_blank_assistant_toolcall_content(db_path):
+    _seed(db_path, [
+        ("user", "hi", None),
+        ("assistant", "", TOOL_CALLS),        # poison: empty + tool_calls
+        ("assistant", "   \n", TOOL_CALLS),   # poison: whitespace + tool_calls
+        ("assistant", None, TOOL_CALLS),      # poison: NULL + tool_calls
+    ])
+    report = repair_blank_message_content(db_path, backup=False)
+    assert report["repaired"] is True
+    assert report["affected"] == 3
+    assert report["sessions"] == 1
+    contents = _contents(db_path)
+    assert contents[0] == "hi"
+    for healed in contents[1:]:
+        assert healed and healed.strip(), f"blank survived: {healed!r}"
+
+
+def test_leaves_real_content_and_plain_empty_untouched(db_path):
+    _seed(db_path, [
+        ("assistant", "real answer", TOOL_CALLS),  # real text: keep verbatim
+        ("assistant", "", None),                   # empty but NO tool_calls: not this class
+        ("user", "", None),                        # user empty: never touched
+    ])
+    report = repair_blank_message_content(db_path, backup=False)
+    assert report["affected"] == 0
+    assert report["repaired"] is False
+    contents = _contents(db_path)
+    assert contents[0] == "real answer"
+    assert contents[1] == ""  # untouched
+    assert contents[2] == ""  # untouched
+
+
+def test_check_only_reports_without_writing(db_path):
+    _seed(db_path, [("assistant", "", TOOL_CALLS)])
+    report = repair_blank_message_content(db_path, check_only=True, backup=False)
+    assert report["affected"] == 1
+    assert report["repaired"] is False
+    assert _contents(db_path) == [""]  # unchanged
+
+
+def test_missing_db_is_noop(tmp_path):
+    report = repair_blank_message_content(tmp_path / "nope.db")
+    assert report == {
+        "repaired": False, "affected": 0, "sessions": 0,
+        "backup_path": None, "error": None,
+    }


### PR DESCRIPTION
## Summary

Fixes #70475. A session hangs with no output when its stored history contains an assistant message with **empty/whitespace content plus `tool_calls`**: that serializes to a blank text content block, Anthropic/Bedrock reject the request with `HTTP 400: text content blocks must contain non-whitespace text`, and because the block is in stored history it replays every turn — the session stays wedged.

The request-path adapters already coerce blanks on send (#69512), but rows persisted before that coercion existed stay stuck. `hermes sessions repair` only handled schema corruption (`_db_opens_cleanly` / `repair_state_db_schema`), not this content-level poison.

## Changes

- **`hermes_state.py`**: add `repair_blank_message_content(db_path, *, check_only=False, backup=True)`. Heals assistant rows that are **both** blank-text **and** tool-call-bearing, rewriting only their `content` to a non-whitespace placeholder. Tool_use payloads and every other message are left untouched; a truly empty assistant message with no tool calls is not this class and is skipped. Returns a report dict (`repaired/affected/sessions/backup_path/error`), takes a timestamped backup via the existing `_backup_db_file` unless disabled, and uses `BEGIN IMMEDIATE` + a busy timeout so it is safe alongside a live DB.
- **`hermes_cli/console_engine.py`**: wire `hermes sessions repair --content` (honors existing `--check-only` and `--no-backup`).

Whitespace matching passes the full space/tab/newline/CR set to SQLite `trim()` (which strips only ASCII space by default), so `"\n"`/`"\t"`-only content is caught the same way the adapter's `str.strip()` coercion catches it.

## Testing

`tests/agent/test_blank_message_content_repair.py` (synthetic rows, temp DB) — 4 tests:
- heals empty / whitespace / NULL content on tool-call assistant rows
- leaves real content and plain-empty (no tool_calls) rows untouched
- `--check-only` reports without writing
- missing DB is a no-op

```
pytest tests/agent/test_blank_message_content_repair.py -q   # 4 passed
pytest tests/agent/test_anthropic_whitespace_text_blocks.py -q  # 16 passed (unchanged)
```

## Scope

This is the recovery half of the blank-text-block class: #69512 stops new blanks going out; this heals old rows already persisted. It touches only the repair paths and adds one CLI flag; no adapter or send-path behavior changes.

---
*Developed during triage of a real hang; verified against the stored-message shape that caused it.*
