### PR TITLE
fix(cron): reconcile external provider after a claimed direct run

### DIFF
--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -32,12 +32,53 @@ class TestCronjobRunExecutesImmediately:
         m_claim.assert_called_once_with("job-run-1")   # at-most-once claim taken
         m_run.assert_called_once()                       # fired via the shared body
 
+    def test_run_reconciles_external_provider_after_claimed_execution(self):
+        """A direct run must re-arm Chronos after it advances next_run_at.
+
+        Otherwise a scheduled Chronos fire that loses its claim to this direct
+        run is consumed without a successor one-shot, permanently stalling the
+        recurring job.
+        """
+        order = []
+        ran = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_one_job",
+                   side_effect=lambda *a, **kw: order.append("run") or True), \
+             patch("tools.cronjob_tools.get_job", return_value=ran), \
+             patch("tools.cronjob_tools._notify_provider_jobs_changed_safe",
+                   side_effect=lambda: order.append("notify")) as m_notify:
+            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+
+        assert out["job"]["executed"] is True
+        m_notify.assert_called_once_with()
+        # Reconcile only AFTER the run persisted its final state (mark_job_run
+        # inside run_one_job), so the provider arms the post-run next_run_at.
+        assert order == ["run", "notify"]
+
+    def test_run_reconciles_external_provider_even_when_claimed_run_fails(self):
+        """A claimed direct run advances next_run_at at claim time, so the
+        provider must be reconciled even when the execution itself fails."""
+        failed = {"id": "job-run-1", "last_status": "error", "last_error": "provider 500"}
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_one_job", side_effect=RuntimeError("boom")), \
+             patch("tools.cronjob_tools.mark_job_run"), \
+             patch("tools.cronjob_tools.get_job", return_value=failed), \
+             patch("tools.cronjob_tools._notify_provider_jobs_changed_safe") as m_notify:
+            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+
+        assert out["job"]["executed"] is True
+        assert out["job"]["execution_success"] is False
+        m_notify.assert_called_once_with()
+
     def test_run_skips_when_claim_lost(self):
         """If the scheduler already holds the fire claim, do NOT double-run."""
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
              patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
              patch("cron.scheduler.run_one_job") as m_run, \
-             patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):
+             patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)), \
+             patch("tools.cronjob_tools._notify_provider_jobs_changed_safe") as m_notify:
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
 
         assert out["success"] is True
@@ -45,6 +86,7 @@ class TestCronjobRunExecutesImmediately:
         assert out["job"]["execution_success"] is False
         assert "execution_skipped" in out["job"]
         m_run.assert_not_called()  # claim lost -> never fired
+        m_notify.assert_not_called()  # the winning scheduler owns the re-arm
 
     def test_run_reports_failure_from_last_status(self):
         """A failed run is reported via the re-read job's last_status/last_error."""

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -842,6 +842,12 @@ def cronjob(
             # _execute_job_now advances next_run_at and blocks a concurrent tick
             # from double-firing.
             exec_result = _execute_job_now(job)
+            # A claimed direct run advances next_run_at and may race the
+            # external one-shot for the same occurrence. If Chronos loses that
+            # claim, its consumed fire cannot re-arm itself; reconcile from the
+            # winning direct path after the run has persisted its final state.
+            if exec_result.get("claimed", False):
+                _notify_provider_jobs_changed_safe()
             # Re-read so the response reflects the post-run last_run_at/last_status.
             result = _format_job(get_job(job_id) or {"id": job_id})
             result["executed"] = exec_result.get("claimed", False)


### PR DESCRIPTION
## Summary

A direct cron run (`cronjob(action='run')` / `hermes cron run` / webhook-triggered manual fire) takes the job's `fire_claim` and advances `next_run_at`. When it races the external provider's scheduled fire for the **same occurrence**, the Chronos fire loses the claim and — correctly — does not re-arm (`test_fire_due_no_rearm_when_claim_lost`: the winner owns the re-arm). But the direct-run winner never notified the provider, so the NAS one-shot for the consumed occurrence stayed stale forever and the recurring managed job silently stopped firing.

This PR makes the winning direct run reconcile the provider after its execution completes: `cronjob(action='run')` now calls `_notify_provider_jobs_changed_safe()` when (and only when) the direct execution actually claimed the job. That routes through the provider's `on_jobs_changed() -> reconcile()`, which re-arms the post-run `next_run_at`. No-op for the built-in ticker provider.

## Production incident this fixes

On a Hermes Cloud instance, a 1-minute managed review cron stalled for ~20 hours while `/api/status` stayed green:

1. `05:37:00Z` — Chronos fire delivered (202), ran, completed `05:37:03`.
2. `05:37:04` — agent provisioned the next NAS one-shot for `05:38:03.586`.
3. `05:38:01` — a GitHub-webhook direct run claimed the job (`fire_claim` taken, `next_run_at` advanced).
4. `05:38:04` — the scheduled Chronos callback arrived, got 202, lost the claim in the background, executed nothing, and (by design) did not re-arm.
5. The direct run completed at `05:38:06` — but never reconciled the provider.
6. The NAS `AgentCronSchedule` row stayed armed at `05:38:03` forever; local `next_run_at` kept advancing with no external fire to consume it. Every subsequent occurrence was orphaned.

Subsequent webhook-triggered direct runs masked the dead managed schedule until webhook traffic stopped.

## Why this shape

- The claim-lost Chronos path must NOT re-arm (existing behavior, kept): when the loser re-arms mid-run it would arm the *pre-completion* `next_run_at` and can double-fire. The winner re-arms after `mark_job_run` persists the final schedule.
- The built-in ticker needs nothing: it re-reads jobs.json every tick.
- The notification fires for claimed runs **even when the execution fails** — `next_run_at` advances at claim time either way, so the successor one-shot must be armed regardless.
- Claim-lost direct runs do not notify: the scheduler that won is mid-run and will re-arm on completion via its own `fire_due` path.

`_notify_provider_jobs_changed_safe()` is already best-effort (never raises into the tool) and `reconcile()` is idempotent per `(job_id, fire_at)` via the NAS dedup key, so a redundant notify while a provider fire is in flight is a no-op.

## Tests

- New: `test_run_reconciles_external_provider_after_claimed_execution` — claimed direct run notifies the provider exactly once, strictly **after** `run_one_job` (order asserted), so the provider arms the post-run `next_run_at`. Written first and verified RED against the unpatched code.
- New: `test_run_reconciles_external_provider_even_when_claimed_run_fails` — a claimed run that raises still notifies.
- Extended: `test_run_skips_when_claim_lost` — now also asserts the notifier is NOT called when the claim is lost.
- `pytest tests/tools/test_cronjob_run_immediate.py tests/plugins/test_chronos_cron.py tests/cron -q` → 764 passed (full `tests/cron` sweep), plus targeted re-run after final test tightening → 31 passed.
- `ruff check` clean on both touched files; `git diff --check` clean.
- Independent reviewer subagent verdict: PASS (no blocking issues).