### PR TITLE
docs(feishu): document granular receive scopes for group @mentions

### DIFF
--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -63,11 +63,22 @@ In the Feishu developer console, go to **Permission Management** and add the fol
 
 | Scope | Purpose |
 |-------|---------|
-| `im:message` | Receive and read messages |
+| `im:message` | Base messaging scope (read/send via the API) |
+| `im:message.p2p_msg:readonly` | **Receive direct messages** sent to the bot |
+| `im:message.group_at_msg:readonly` | **Receive group messages that @mention the bot** |
 | `im:message:send_as_bot` | Send messages as the bot |
 | `im:resource` | Access images, files, and audio sent by users |
 | `im:chat` | Access chat/group metadata |
 | `im:chat:readonly` | Read chat list and membership |
+
+:::warning Receive scopes are required for inbound messages
+`im:message` alone does **not** cause inbound messages to be delivered to the `im.message.receive_v1` event. Feishu gates event delivery on the granular *receive* scopes, which are listed under **any one suffices** for that event in the console:
+
+- Grant `im:message.p2p_msg:readonly` so the bot receives **direct messages**.
+- Grant `im:message.group_at_msg:readonly` so the bot receives **group messages that @mention it**.
+
+A bot that is missing `im:message.group_at_msg:readonly` will answer DMs but **silently ignore every group @mention** — the event is never delivered, so nothing appears in the logs.
+:::
 
 **Recommended permissions (for full functionality):**
 
@@ -84,6 +95,10 @@ In **Events and Callbacks**:
 1. Set the connection mode to **Long Connection (WebSocket)** (recommended) or configure a webhook URL
 2. In the **Event Configuration** section, subscribe to:
    - `im.message.receive_v1` — required for receiving messages
+
+:::info
+The `im.message.receive_v1` event only pushes the message types you hold a matching *receive* scope for (the console shows these under **any one suffices**). Grant `im:message.p2p_msg:readonly` to receive DMs and `im:message.group_at_msg:readonly` to receive group @mentions — see [Configure Permissions](#configure-permissions) above. After adding a scope you must publish a new app version, or the change will not take effect.
+:::
 
 ### Publish the App
 
@@ -575,6 +590,7 @@ WebSocket and per-group ACL settings are configured via `config.yaml` under `pla
 | `FEISHU_APP_ID or FEISHU_APP_SECRET not set` | Set both env vars or configure via `hermes gateway setup` |
 | `Another local Hermes gateway is already using this Feishu app_id` | Only one Hermes instance can use the same app_id at a time. Stop the other gateway first. |
 | Bot doesn't respond in groups | Ensure the bot is @mentioned, check `FEISHU_GROUP_POLICY`, and verify the sender is in `FEISHU_ALLOWED_USERS` if policy is `allowlist` |
+| Bot answers DMs but ignores group @mentions | The app is missing the `im:message.group_at_msg:readonly` scope, so Feishu never delivers group @mention events (nothing shows in the logs). Add it under **Permission Management**, then publish a new app version. |
 | `Webhook rejected: invalid verification token` | Ensure `FEISHU_VERIFICATION_TOKEN` matches the token in your Feishu app's Event Subscriptions config |
 | `Webhook rejected: invalid signature` | Ensure `FEISHU_ENCRYPT_KEY` matches the encrypt key in your Feishu app config |
 | Post messages show as plain text | The Feishu API rejected the post payload; this is normal fallback behavior. Check logs for details. |

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -66,6 +66,7 @@ In the Feishu developer console, go to **Permission Management** and add the fol
 | `im:message` | Base messaging scope (read/send via the API) |
 | `im:message.p2p_msg:readonly` | **Receive direct messages** sent to the bot |
 | `im:message.group_at_msg:readonly` | **Receive group messages that @mention the bot** |
+| `im:message.group_msg:readonly` | **Receive all group messages** — only when the @mention requirement is turned off (see [Group Message Policy](#group-message-policy)) |
 | `im:message:send_as_bot` | Send messages as the bot |
 | `im:resource` | Access images, files, and audio sent by users |
 | `im:chat` | Access chat/group metadata |
@@ -76,8 +77,9 @@ In the Feishu developer console, go to **Permission Management** and add the fol
 
 - Grant `im:message.p2p_msg:readonly` so the bot receives **direct messages**.
 - Grant `im:message.group_at_msg:readonly` so the bot receives **group messages that @mention it**.
+- Grant `im:message.group_msg:readonly` so the bot receives **group messages that do not @mention it** — required only if you turn off the @mention requirement with `FEISHU_REQUIRE_MENTION=false` or a per-chat `require_mention: false`.
 
-A bot that is missing `im:message.group_at_msg:readonly` will answer DMs but **silently ignore every group @mention** — the event is never delivered, so nothing appears in the logs.
+A bot that is missing `im:message.group_at_msg:readonly` will answer DMs but **silently ignore every group @mention** — the event is never delivered, so nothing appears in the logs. The same applies to `im:message.group_msg:readonly` and non-mentioned group messages: Hermes will accept them, but Feishu never pushes them.
 :::
 
 **Recommended permissions (for full functionality):**
@@ -97,7 +99,7 @@ In **Events and Callbacks**:
    - `im.message.receive_v1` — required for receiving messages
 
 :::info
-The `im.message.receive_v1` event only pushes the message types you hold a matching *receive* scope for (the console shows these under **any one suffices**). Grant `im:message.p2p_msg:readonly` to receive DMs and `im:message.group_at_msg:readonly` to receive group @mentions — see [Configure Permissions](#configure-permissions) above. After adding a scope you must publish a new app version, or the change will not take effect.
+The `im.message.receive_v1` event only pushes the message types you hold a matching *receive* scope for (the console shows these under **any one suffices**). Grant `im:message.p2p_msg:readonly` to receive DMs, `im:message.group_at_msg:readonly` to receive group @mentions, and `im:message.group_msg:readonly` to receive group messages without an @mention — see [Configure Permissions](#configure-permissions) above. After adding a scope you must publish a new app version, or the change will not take effect.
 :::
 
 ### Publish the App
@@ -257,6 +259,10 @@ Set `FEISHU_REQUIRE_MENTION=false` to let Hermes read all group traffic without 
 ```bash
 FEISHU_REQUIRE_MENTION=false
 ```
+
+:::warning Requires an extra Feishu scope
+`im:message.group_at_msg:readonly` only delivers group messages that @mention the bot. To actually receive non-mentioned group traffic, the app also needs `im:message.group_msg:readonly` — add it under **Permission Management** and publish a new app version, otherwise Hermes will accept the messages but Feishu will never send them. See [Configure Permissions](#configure-permissions).
+:::
 
 For per-chat control, set `require_mention` on a `group_rules` entry — see [Per-Group Access Control](#per-group-access-control) below.
 
@@ -539,7 +545,7 @@ platforms:
 | `admin_only` | Only users in the global `admins` list can use the bot in this group |
 | `disabled` | Bot ignores all messages in this group |
 
-Set `require_mention: false` on a `group_rules` entry to skip the @-mention requirement for that specific chat. When omitted, the chat inherits the global `FEISHU_REQUIRE_MENTION` value.
+Set `require_mention: false` on a `group_rules` entry to skip the @-mention requirement for that specific chat. When omitted, the chat inherits the global `FEISHU_REQUIRE_MENTION` value. This also needs the `im:message.group_msg:readonly` scope — see [Group Message Policy](#group-message-policy).
 
 Groups not listed in `group_rules` fall back to `default_group_policy` (defaults to the value of `FEISHU_GROUP_POLICY`).
 
@@ -591,6 +597,7 @@ WebSocket and per-group ACL settings are configured via `config.yaml` under `pla
 | `Another local Hermes gateway is already using this Feishu app_id` | Only one Hermes instance can use the same app_id at a time. Stop the other gateway first. |
 | Bot doesn't respond in groups | Ensure the bot is @mentioned, check `FEISHU_GROUP_POLICY`, and verify the sender is in `FEISHU_ALLOWED_USERS` if policy is `allowlist` |
 | Bot answers DMs but ignores group @mentions | The app is missing the `im:message.group_at_msg:readonly` scope, so Feishu never delivers group @mention events (nothing shows in the logs). Add it under **Permission Management**, then publish a new app version. |
+| Bot replies to @mentions but ignores other group messages with `FEISHU_REQUIRE_MENTION=false` (or `require_mention: false`) | The app is missing the `im:message.group_msg:readonly` scope, so Feishu only delivers @mention events. Add it under **Permission Management**, then publish a new app version. |
 | `Webhook rejected: invalid verification token` | Ensure `FEISHU_VERIFICATION_TOKEN` matches the token in your Feishu app's Event Subscriptions config |
 | `Webhook rejected: invalid signature` | Ensure `FEISHU_ENCRYPT_KEY` matches the encrypt key in your Feishu app config |
 | Post messages show as plain text | The Feishu API rejected the post payload; this is normal fallback behavior. Check logs for details. |


### PR DESCRIPTION
## What does this PR do?

Fixes a documentation gap that leaves a Feishu/Lark bot unable to receive **group @mentions**.

The setup docs list only `im:message` ("Receive and read messages") as the messaging scope. In practice `im:message` alone does **not** cause inbound messages to be delivered to the `im.message.receive_v1` event. Feishu gates event delivery on the granular *receive* scopes shown under **"any one suffices"** in the console:

- `im:message.p2p_msg:readonly` → direct messages
- `im:message.group_at_msg:readonly` → group messages that @mention the bot

A bot set up per the current docs (with only `im:message`) will answer DMs but **silently ignore every group @mention** — the event is never delivered, so nothing appears in the logs, which makes it hard to diagnose. Neither granular scope is mentioned anywhere in the docs today.

This is docs-only; no code changes.

## Related Issue

No existing issue — this surfaced during a real deployment. A search of open and merged issues/PRs found no prior report of the missing group-receive scope (`im:message.group_at_msg:readonly` / `im:message.p2p_msg:readonly` appear nowhere in the repo).

## Type of Change

- [x] 📝 Documentation update

## Changes Made

All in `website/docs/user-guide/messaging/feishu.md`:

- **Required permissions table:** added `im:message.p2p_msg:readonly` (DMs) and `im:message.group_at_msg:readonly` (group @mentions); reworded `im:message` to "base messaging scope (read/send via the API)".
- **New `:::warning`:** explains that `im:message` alone does not deliver inbound events, and that a bot missing `im:message.group_at_msg:readonly` answers DMs but ignores group @mentions.
- **Configure Events `:::info`:** notes that `im.message.receive_v1` only pushes message types you hold a matching receive scope for, and that a new app version must be published after adding a scope.
- **Troubleshooting row:** "Bot answers DMs but ignores group @mentions" → add `im:message.group_at_msg:readonly`, then publish a new version.

## How to Test

This documents observed real-world behavior:

1. Create a Feishu/Lark app with only `im:message` (+ send/resource/chat scopes) and subscribe to `im.message.receive_v1`, as the current docs describe.
2. DM the bot → it receives and replies. @mention the bot in a group → **nothing arrives** (no inbound event logged).
3. In the console, open the `im.message.receive_v1` event's "any one suffices" scope list and add **"Receive users' mentions"** (`im:message.group_at_msg:readonly`); publish a new app version.
4. @mention the bot in the group again → the event is now delivered and the bot replies. ✅

Docs preview: the two admonitions render with the existing Docusaurus `:::warning` / `:::info` styles already used throughout this file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(feishu): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single file, docs-only)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (docs-only, no code paths touched)
- [ ] I've added tests for my changes — N/A (docs-only)
- [x] I've tested on my platform: Ubuntu (Lark international tenant, WebSocket mode) — verified the reproduction and fix above on a live gateway

### Documentation & Housekeeping

- [x] I've updated relevant documentation (this PR *is* the docs update)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (docs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Symptom before the fix — group @mention produces no inbound event at all (only DMs arrive); after granting `im:message.group_at_msg:readonly` and publishing a new version, group messages are delivered:

```
[Feishu] Inbound group message received: chat_id=oc_… text='…'   ← only appears after the scope is granted
```
