### PR TITLE
fix(desktop): show exact timestamps in tooltips

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -4,6 +4,7 @@ import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
+import type * as Time from '@/lib/time'
 import type * as ComposerStatusStore from '@/store/composer-status'
 import type * as SessionStore from '@/store/session'
 import type * as SessionStatesStore from '@/store/session-states'
@@ -28,6 +29,12 @@ vi.mock('@/i18n', () => ({
           sessionRunning: 'Running',
           waitingForAnswer: 'Waiting for answer'
         }
+      },
+      assistant: {
+        thread: {
+          today: (time: string) => `Today at ${time}`,
+          yesterday: (time: string) => `Yesterday at ${time}`
+        }
       }
     }
   })
@@ -47,7 +54,11 @@ vi.mock('@/lib/session-source', () => ({
   handoffOriginSource: (state?: string, platform?: string) => (state && platform ? platform : null),
   sessionSourceLabel: (source: string) => source
 }))
-vi.mock('@/lib/time', () => ({ coarseElapsed: () => ({ unit: 'minute' as const, value: 5 }) }))
+vi.mock('@/lib/time', async importOriginal => {
+  const actual = await importOriginal<typeof Time>()
+
+  return { ...actual, coarseElapsed: () => ({ unit: 'minute' as const, value: 5 }) }
+})
 
 // These mocks use importOriginal rather than replacing the module wholesale:
 // session-row.tsx (and its transitive imports, e.g. session-color.ts) reads
@@ -144,6 +155,31 @@ describe('SidebarSessionRow', () => {
     expect(screen.getByTestId('session-actions-menu').getAttribute('data-tooltip')).toBe(
       'Actions for Hermes doctor health check results'
     )
+  })
+
+  it('exposes the exact session time through a focusable Tip trigger', () => {
+    const startedAt = Math.floor(Date.now() / 1000) - 5 * 60
+
+    render(
+      <SidebarSessionRow
+        isPinned={false}
+        isSelected={false}
+        isWorking={false}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={noop}
+        onResume={noop}
+        session={makeSession({ started_at: startedAt, title: 'Timestamped session' })}
+      />
+    )
+
+    const age = screen.getByText('5m')
+    expect(age.tagName).toBe('TIME')
+    expect(age.getAttribute('datetime')).toBe(new Date(startedAt * 1000).toISOString())
+    expect(age.getAttribute('aria-label')).toMatch(/^5m, Today at /)
+    expect(age.getAttribute('tabindex')).toBe('0')
+    expect(age.getAttribute('title')).toBeNull()
+    expect(tipTrigger(age)).toBeTruthy()
   })
 
   it('does not render a handoff avatar for a locally-started session', () => {

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -4,6 +4,7 @@ import type * as React from 'react'
 import { ProfileTag } from '@/app/chat/profile-tag'
 import { startSessionDrag } from '@/app/chat/session-drag'
 import { PlatformAvatar } from '@/app/messaging/platform-icon'
+import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { Tip } from '@/components/ui/tooltip'
@@ -78,7 +79,10 @@ export function SidebarSessionRow({
   const r = t.sidebar.row
   const { cancelPrewarm, startPrewarm } = useProfilePrewarm(session.profile)
   const title = sessionTitle(session)
-  const age = formatAge(session.last_active || session.started_at, r)
+  const timestamp = session.last_active || session.started_at
+  const age = formatAge(timestamp, r)
+  const timestampDate = new Date(timestamp * 1000)
+  const absoluteAge = formatMessageTimestamp(timestampDate, t.assistant.thread)
   const handleLabel = `Reorder ${title}`
   // A handed-off session's live source is local, but it originated on a
   // messaging platform — surface that origin as a small badge so e.g. a
@@ -103,9 +107,16 @@ export function SidebarSessionRow({
         actions={
           <div className="relative z-2 grid w-[1.375rem] place-items-center" data-row-actions>
             {!isWorking && (
-              <span className="pointer-events-none absolute right-6 top-1/2 min-w-6 -translate-y-1/2 text-right text-[0.625rem] leading-none text-(--ui-text-tertiary) opacity-0 transition-opacity group-hover:opacity-100">
-                {age}
-              </span>
+              <Tip label={absoluteAge} side="top">
+                <time
+                  aria-label={`${age}, ${absoluteAge}`}
+                  className="absolute right-6 top-1/2 min-w-6 -translate-y-1/2 text-right text-[0.625rem] leading-none text-(--ui-text-tertiary) opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+                  dateTime={timestampDate.toISOString()}
+                  tabIndex={0}
+                >
+                  {age}
+                </time>
+              </Tip>
             )}
             <SessionActionsMenu
               onArchive={onArchive}

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -14,9 +14,9 @@ import {
   messageContentText,
   pickPrimaryPreviewTarget
 } from '@/components/assistant-ui/thread/content'
+import { MessageAge as MessageAgeLabel } from '@/components/assistant-ui/thread/message-age'
 import { MESSAGE_PARTS_COMPONENTS } from '@/components/assistant-ui/thread/message-parts'
 import { ResponseLoadingIndicator, StreamStallIndicator } from '@/components/assistant-ui/thread/status'
-import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { Codicon } from '@/components/ui/codicon'
@@ -25,7 +25,6 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { AudioLines, GitForkIcon, Loader2Icon, RefreshCwIcon, VolumeXIcon, XIcon } from '@/lib/icons'
 import { extractPreviewTargets } from '@/lib/preview-targets'
-import { formatAgo } from '@/lib/time'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
@@ -215,23 +214,9 @@ const ReadAloudButton: FC<{ getText: () => string; messageId: string }> = ({ get
 }
 
 const MessageAge: FC = () => {
-  const { t } = useI18n()
   const createdAt = useAuiState(s => s.message.createdAt)
-  const date = createdAt ? new Date(createdAt) : null
 
-  if (!date || Number.isNaN(date.getTime())) {
-    return null
-  }
-
-  // Compact "2h ago" (shared util) with the absolute time on hover.
-  return (
-    <span
-      className="px-0.5 text-[0.6875rem] tabular-nums text-muted-foreground"
-      title={formatMessageTimestamp(date, t.assistant.thread) || undefined}
-    >
-      {formatAgo(date.getTime(), t.agents)}
-    </span>
-  )
+  return <MessageAgeLabel createdAt={createdAt} />
 }
 
 const AssistantFooter: FC<MessageActionProps> = props => (

--- a/apps/desktop/src/components/assistant-ui/thread/message-age.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-age.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MessageAge } from './message-age'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      agents: {
+        ageDays: (days: number) => `${days}d ago`,
+        ageHours: (hours: number) => `${hours}h ago`,
+        ageMinutes: (minutes: number) => `${minutes}m ago`,
+        ageNow: 'now',
+        ageSeconds: (seconds: number) => `${seconds}s ago`
+      },
+      assistant: {
+        thread: {
+          today: (time: string) => `Today at ${time}`,
+          yesterday: (time: string) => `Yesterday at ${time}`
+        }
+      }
+    }
+  })
+}))
+
+const tipTrigger = (el: HTMLElement) => el.closest('[data-slot="tooltip-trigger"]')
+
+describe('MessageAge', () => {
+  it('renders a focusable Tip trigger with relative and exact time', () => {
+    const createdAt = new Date()
+    createdAt.setMinutes(createdAt.getMinutes() - 5)
+
+    render(<MessageAge createdAt={createdAt} />)
+
+    const age = screen.getByText('5m ago')
+    expect(age.tagName).toBe('TIME')
+    expect(age.getAttribute('datetime')).toBe(createdAt.toISOString())
+    expect(age.getAttribute('aria-label')).toMatch(/^5m ago, Today at /)
+    expect(age.getAttribute('tabindex')).toBe('0')
+    expect(age.getAttribute('title')).toBeNull()
+    expect(tipTrigger(age)).toBeTruthy()
+  })
+
+  it('does not render an invalid timestamp', () => {
+    const { container } = render(<MessageAge createdAt="not-a-date" />)
+
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/message-age.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-age.tsx
@@ -1,0 +1,35 @@
+import type { FC } from 'react'
+
+import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { formatAgo } from '@/lib/time'
+
+interface MessageAgeProps {
+  createdAt: Date | string | number | undefined
+}
+
+export const MessageAge: FC<MessageAgeProps> = ({ createdAt }) => {
+  const { t } = useI18n()
+  const date = createdAt instanceof Date ? createdAt : createdAt ? new Date(createdAt) : null
+
+  if (!date || Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  const age = formatAgo(date.getTime(), t.agents)
+  const absoluteAge = formatMessageTimestamp(date, t.assistant.thread)
+
+  return (
+    <Tip label={absoluteAge} side="top">
+      <time
+        aria-label={`${age}, ${absoluteAge}`}
+        className="px-0.5 text-[0.6875rem] tabular-nums text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        dateTime={date.toISOString()}
+        tabIndex={0}
+      >
+        {age}
+      </time>
+    </Tip>
+  )
+}


### PR DESCRIPTION
## Summary

- replace native timestamp titles with the shared Desktop `Tip` component
- expose exact localized timestamps for message ages and sidebar session ages
- keep compact relative labels while supporting both pointer hover and keyboard focus
- use semantic `<time>` elements with accessible labels and machine-readable datetimes

Closes #70450

## Validation

- `npm test -- --run src/app/chat/sidebar/session-row.test.tsx src/components/assistant-ui/thread/message-age.test.tsx` (6 passed)
- `npm run typecheck`
- ESLint and Prettier checks for all changed files
- `npm run build`
- Full Desktop suite on Windows: 2,708 passed; 21 unrelated failures in untouched Billing, SSH/POSIX, relaunch, and packaging suites (including missing Bash/POSIX-only expectations)