### PR TITLE
fix(copilot): drop connection-bound reasoning replay

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -339,15 +339,14 @@ def _chat_messages_to_responses_input(
     items from the conversation history and threads ``replay_enabled=False``
     through this converter so subsequent turns send no reasoning items.
 
-    ``is_github_responses`` drops the ``id`` field from replayed
-    ``codex_message_items`` regardless of length. The Copilot backend
-    (api.githubcopilot.com/responses) binds these ids to a specific
-    backend "connection" — credential-pool rotation, a gateway restart,
-    or routine load-balancer churn between turns all invalidate it — and
-    rejects a stale id with HTTP 401 "input item ID does not belong to
-    this connection" even for short ids (see #32716). ``phase``/
-    ``status``/``content`` are still replayed; only ``id`` is unsafe to
-    reuse across a Copilot connection.
+    ``is_github_responses`` drops connection-bound replay state. The
+    Copilot backend (api.githubcopilot.com/responses) binds message ids
+    and encrypted reasoning to a specific backend "connection" —
+    credential-pool rotation, a gateway restart, or routine load-balancer
+    churn between turns all invalidate them. Replaying a stale message id
+    gets HTTP 401 "input item ID does not belong to this connection" (see
+    #32716), while stale reasoning gets ``invalid_encrypted_content``.
+    Visible assistant content, ``phase``, and ``status`` are still replayed.
 
     ``current_issuer_kind`` enables a per-item cross-issuer guard. The
     Responses API's ``encrypted_content`` blob is decryptable only by the
@@ -392,7 +391,7 @@ def _chat_messages_to_responses_input(
                 # for the May 2026 reversal of the earlier xAI gate.
                 codex_reasoning = (
                     msg.get("codex_reasoning_items")
-                    if replay_encrypted_reasoning
+                    if replay_encrypted_reasoning and not is_github_responses
                     else None
                 )
                 has_codex_reasoning = False
@@ -692,6 +691,12 @@ def _preflight_codex_input_items(
             continue
 
         if item_type == "reasoning":
+            # Copilot Responses credentials rotate between requests, so
+            # encrypted reasoning from a previous backend connection cannot
+            # be replayed safely. Keep this final guard after request
+            # overrides so callers cannot reintroduce stale ciphertext.
+            if is_github_responses:
+                continue
             encrypted = item.get("encrypted_content")
             if isinstance(encrypted, str) and encrypted:
                 item_id = item.get("id")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -191,6 +191,31 @@ class TestCodexBuildKwargs:
         message_item = next(item for item in kw["input"] if item.get("type") == "message")
         assert message_item["id"] == "msg_short_id"
 
+    def test_github_responses_drops_connection_bound_reasoning(self, transport):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "done",
+                "codex_reasoning_items": [
+                    {
+                        "type": "reasoning",
+                        "encrypted_content": "copilot-connection-bound-ciphertext",
+                        "summary": [{"type": "summary_text", "text": "analysis"}],
+                    }
+                ],
+            },
+        ]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            is_github_responses=True,
+        )
+
+        assert all(item.get("type") != "reasoning" for item in kw["input"])
+        assert any(item.get("content") == "done" for item in kw["input"])
+
     def test_github_preflight_drops_id_reintroduced_by_request_override(self, transport):
         injected = {
             "type": "message",
@@ -219,6 +244,33 @@ class TestCodexBuildKwargs:
         assert message_item["phase"] == "final_answer"
         assert message_item["content"] == [{"type": "output_text", "text": "pong"}]
 
+    def test_github_preflight_drops_reasoning_reintroduced_by_request_override(self, transport):
+        injected_reasoning = {
+            "type": "reasoning",
+            "encrypted_content": "copilot-connection-bound-ciphertext",
+            "summary": [{"type": "summary_text", "text": "analysis"}],
+        }
+        injected_message = {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "done"}],
+        }
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "continue"}],
+            tools=[],
+            is_github_responses=True,
+            request_overrides={"input": [injected_reasoning, injected_message]},
+        )
+
+        preflight = transport.preflight_kwargs(
+            kw,
+            is_github_responses=True,
+        )
+
+        assert preflight["input"] == [injected_message]
+
     def test_non_github_responses_keeps_message_item_id_end_to_end(self, transport):
         messages = [
             {"role": "system", "content": "You are Hermes."},
@@ -242,6 +294,31 @@ class TestCodexBuildKwargs:
         )
         message_item = next(item for item in kw["input"] if item.get("type") == "message")
         assert message_item["id"] == "msg_short_id"
+
+    def test_non_github_responses_keeps_encrypted_reasoning(self, transport):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "done",
+                "codex_reasoning_items": [
+                    {
+                        "type": "reasoning",
+                        "encrypted_content": "portable-ciphertext",
+                        "summary": [{"type": "summary_text", "text": "analysis"}],
+                    }
+                ],
+            },
+        ]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            is_codex_backend=True,
+        )
+
+        reasoning = next(item for item in kw["input"] if item.get("type") == "reasoning")
+        assert reasoning["encrypted_content"] == "portable-ciphertext"
 
     def test_xai_responses_sends_cache_key_via_extra_body(self, transport):
         """xAI's Responses API documents ``prompt_cache_key`` as the


### PR DESCRIPTION
## What does this PR do?

Prevents GitHub Copilot Responses requests from replaying encrypted reasoning from an earlier backend connection. Stale connection-bound items can be rejected with a connection-ownership error or `invalid_encrypted_content`.

Visible assistant content is retained, and stored history is not mutated. Only the GitHub Copilot request path drops encrypted reasoning; native Codex, xAI, and other Responses routes keep their existing replay behavior.

Fixes #70481.

## Changes

- Skip cached reasoning during GitHub Copilot history conversion.
- Drop reasoning again in final GitHub preflight, including both `input` and `extra_body.input` request overrides, so neither can reintroduce stale ciphertext.
- Preserve the current shared replay helpers, issuer guards, and native-compaction handling; no old inline implementation is restored.

## Validation

Refreshed onto main at `6c27a289c3f57839a97f5709edb089b202ee6d82` on 2026-09-14.

- RED: the normal-history and request-override GitHub cases fail on main; non-GitHub control cases pass.
- GREEN: `bash scripts/run_tests.sh tests/agent/transports/test_codex_transport.py -j 1 -q` — **129 passed**.
- Ruff and `git diff --check` passed.
- Scoped Codex AutoReview identified the `extra_body.input` bypass; its added case failed before the fix. After the narrow fix and regression rerun, the same reviewer returned no actionable findings.

The new coverage uses the real transport conversion and preflight paths with synthetic history. No new live provider test was performed for this refreshed head; the entire repository suite was not run.

Earlier independent live A/B evidence for the prior revision remains available in [Wenfengcheng's report](https://github.com/NousResearch/hermes-agent/pull/70486#issuecomment-5437794230). That report is supporting evidence, not a claim that this refreshed head was tested against a live account.

## Scope / compatibility

This is a provider-specific request serialization fix, not a change to model selection, persisted session format, visible reasoning output, or other providers' continuity behavior. Only the adapter and its transport regression tests change.
