### PR TITLE
fix(desktop): show exact timestamps in tooltips

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -1,13 +1,15 @@
-import { act, cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { atom } from 'nanostores'
 import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { openSession } from '@/app/open-session'
 import type { SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as Time from '@/lib/time'
 import type * as ComposerStatusStore from '@/store/composer-status'
+import { $sidebarRowMeta } from '@/store/layout'
 import type * as SessionStore from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type * as SessionStatesStore from '@/store/session-states'
@@ -15,7 +17,11 @@ import type * as WindowsStore from '@/store/windows'
 
 import { SidebarSessionRow } from './session-row'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  $sidebarRowMeta.set(['updated'])
+})
 
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
@@ -45,6 +51,7 @@ vi.mock('@/i18n', () => ({
 
 vi.mock('@/app/chat/profile-tag', () => ({ ProfileTag: () => null }))
 vi.mock('@/app/chat/session-drag', () => ({ startSessionDrag: vi.fn() }))
+vi.mock('@/app/open-session', () => ({ openSession: vi.fn() }))
 // PlatformAvatar is intentionally NOT mocked (do not reintroduce this — see
 // #67500, Gille's third pass): it's a forwardRef component that spreads its
 // props onto the rendered span, and mocking it with a stand-in that spreads
@@ -236,7 +243,7 @@ describe('SidebarSessionRow', () => {
     expect(tipTrigger(kebab)).toBeNull()
   })
 
-  it('exposes the exact session time through a focusable Tip trigger', () => {
+  it('exposes the exact session time through a focusable Tip trigger', async () => {
     const startedAt = Math.floor(Date.now() / 1000) - 5 * 60
 
     render(
@@ -258,6 +265,156 @@ describe('SidebarSessionRow', () => {
     expect(age.getAttribute('tabindex')).toBe('0')
     expect(age.getAttribute('title')).toBeNull()
     expect(tipTrigger(age)).toBeTruthy()
+
+    fireEvent.pointerMove(age, { pointerType: 'mouse' })
+    expect((await screen.findByRole('tooltip')).textContent).toMatch(/^Today at /)
+  })
+
+  it('keeps the session row action when the timestamp is clicked', () => {
+    const onResume = vi.fn()
+
+    render(
+      <SidebarSessionRow
+        isPinned={false}
+        isSelected={false}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={noop}
+        onResume={onResume}
+        session={makeSession({
+          started_at: Math.floor(Date.now() / 1000) - 5 * 60,
+          title: 'Timestamped session'
+        })}
+      />
+    )
+
+    fireEvent.click(screen.getByText('5m'))
+
+    expect(onResume).toHaveBeenCalledOnce()
+    expect(openSession).not.toHaveBeenCalled()
+  })
+
+  it('keeps the session pin action when the timestamp is shift-clicked', () => {
+    const onPin = vi.fn()
+
+    render(
+      <SidebarSessionRow
+        isPinned={false}
+        isSelected={false}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={onPin}
+        onResume={noop}
+        session={makeSession({
+          started_at: Math.floor(Date.now() / 1000) - 5 * 60,
+          title: 'Timestamped session'
+        })}
+      />
+    )
+
+    fireEvent.click(screen.getByText('5m'), { shiftKey: true })
+
+    expect(onPin).toHaveBeenCalledOnce()
+    expect(openSession).not.toHaveBeenCalled()
+  })
+
+  it('hides the timestamp when updated metadata is disabled', () => {
+    $sidebarRowMeta.set([])
+
+    render(
+      <SidebarSessionRow
+        isPinned={false}
+        isSelected={false}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={noop}
+        onResume={noop}
+        session={makeSession({
+          started_at: Math.floor(Date.now() / 1000) - 5 * 60,
+          title: 'Timestamped session'
+        })}
+      />
+    )
+
+    expect(screen.queryByText('5m')).toBeNull()
+  })
+
+  it('opens the timestamp target in a tab for a modifier click', () => {
+    const onResume = vi.fn()
+
+    render(
+      <SidebarSessionRow
+        isPinned={false}
+        isSelected={false}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={noop}
+        onResume={onResume}
+        session={makeSession({
+          started_at: Math.floor(Date.now() / 1000) - 5 * 60,
+          title: 'Timestamped session'
+        })}
+      />
+    )
+
+    fireEvent.click(screen.getByText('5m'), { metaKey: true })
+
+    expect(openSession).toHaveBeenCalledOnce()
+    expect(openSession).toHaveBeenCalledWith('s1', expect.any(Function), 'tab')
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it('opens the timestamp target in a window for a shifted modifier click', () => {
+    const onResume = vi.fn()
+
+    render(
+      <SidebarSessionRow
+        isPinned={false}
+        isSelected={false}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={noop}
+        onResume={onResume}
+        session={makeSession({
+          started_at: Math.floor(Date.now() / 1000) - 5 * 60,
+          title: 'Timestamped session'
+        })}
+      />
+    )
+
+    fireEvent.click(screen.getByText('5m'), { ctrlKey: true, shiftKey: true })
+
+    expect(openSession).toHaveBeenCalledOnce()
+    expect(openSession).toHaveBeenCalledWith('s1', expect.any(Function), 'window')
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it('opens the timestamp target in a tab for a middle click', () => {
+    const onResume = vi.fn()
+
+    render(
+      <SidebarSessionRow
+        isPinned={false}
+        isSelected={false}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={noop}
+        onResume={onResume}
+        session={makeSession({
+          started_at: Math.floor(Date.now() / 1000) - 5 * 60,
+          title: 'Timestamped session'
+        })}
+      />
+    )
+
+    const age = screen.getByText('5m')
+    fireEvent.mouseDown(age, { button: 1 })
+    fireEvent.pointerDown(age, { button: 1 })
+    fireEvent.pointerUp(age, { button: 1 })
+
+    expect(openSession).toHaveBeenCalledOnce()
+    expect(openSession).toHaveBeenCalledWith('s1', expect.any(Function), 'tab')
+    expect(onResume).not.toHaveBeenCalled()
   })
 
   it('does not render a handoff avatar for a locally-started session', () => {

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
+import type * as Time from '@/lib/time'
 import type * as ComposerStatusStore from '@/store/composer-status'
 import type * as SessionStore from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
@@ -30,6 +31,12 @@ vi.mock('@/i18n', () => ({
           sessionActions: 'Session actions',
           sessionRunning: 'Running',
           waitingForAnswer: 'Waiting for answer'
+        }
+      },
+      assistant: {
+        thread: {
+          today: (time: string) => `Today at ${time}`,
+          yesterday: (time: string) => `Yesterday at ${time}`
         }
       }
     }
@@ -61,7 +68,11 @@ vi.mock('@/lib/session-source', () => ({
   handoffOriginSource: (state?: string, platform?: string) => (state && platform ? platform : null),
   sessionSourceLabel: (source: string) => source
 }))
-vi.mock('@/lib/time', () => ({ coarseElapsed: () => ({ unit: 'minute' as const, value: 5 }) }))
+vi.mock('@/lib/time', async importOriginal => {
+  const actual = await importOriginal<typeof Time>()
+
+  return { ...actual, coarseElapsed: () => ({ unit: 'minute' as const, value: 5 }) }
+})
 
 // These mocks use importOriginal rather than replacing the module wholesale:
 // session-row.tsx (and its transitive imports, e.g. session-color.ts) reads
@@ -223,6 +234,30 @@ describe('SidebarSessionRow', () => {
 
     const kebab = screen.getByRole('button', { name: 'Session actions' })
     expect(tipTrigger(kebab)).toBeNull()
+  })
+
+  it('exposes the exact session time through a focusable Tip trigger', () => {
+    const startedAt = Math.floor(Date.now() / 1000) - 5 * 60
+
+    render(
+      <SidebarSessionRow
+        isPinned={false}
+        isSelected={false}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={noop}
+        onResume={noop}
+        session={makeSession({ started_at: startedAt, title: 'Timestamped session' })}
+      />
+    )
+
+    const age = screen.getByText('5m')
+    expect(age.tagName).toBe('TIME')
+    expect(age.getAttribute('datetime')).toBe(new Date(startedAt * 1000).toISOString())
+    expect(age.getAttribute('aria-label')).toMatch(/^5m, Today at /)
+    expect(age.getAttribute('tabindex')).toBe('0')
+    expect(age.getAttribute('title')).toBeNull()
+    expect(tipTrigger(age)).toBeTruthy()
   })
 
   it('does not render a handoff avatar for a locally-started session', () => {

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -7,6 +7,7 @@ import { ProfileTag } from '@/app/chat/profile-tag'
 import { startSessionDrag } from '@/app/chat/session-drag'
 import { PlatformAvatar } from '@/app/messaging/platform-icon'
 import { openSession } from '@/app/open-session'
+import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { Tip } from '@/components/ui/tooltip'
@@ -98,7 +99,10 @@ function SidebarSessionRowImpl({
   const r = t.sidebar.row
   const { cancelPrewarm, startPrewarm } = useProfilePrewarm(session.profile)
   const title = sessionTitle(session)
-  const age = formatAge(session.last_active || session.started_at, r)
+  const timestamp = session.last_active || session.started_at
+  const age = formatAge(timestamp, r)
+  const timestampDate = new Date(timestamp * 1000)
+  const absoluteAge = formatMessageTimestamp(timestampDate, t.assistant.thread)
   const handleLabel = `Reorder ${title}`
   // Opt-in row metadata from the sidebar's filter menu. Read from the store
   // rather than threaded as props: the subscription re-renders past the memo
@@ -125,8 +129,7 @@ function SidebarSessionRowImpl({
     rowMeta.includes('tokens') && totalTokens > 0 ? compactNumber(totalTokens) : null,
     // Sub-cent spend rounds to "$0.00", which reads as a bug rather than as a
     // cheap session — below a cent the row says nothing at all.
-    rowMeta.includes('cost') && cost >= 0.01 ? `$${cost.toFixed(2)}` : null,
-    pinnedAge ? age : null
+    rowMeta.includes('cost') && cost >= 0.01 ? `$${cost.toFixed(2)}` : null
   ].filter(Boolean) as string[]
 
   // Everything the Show menu puts after the title shares ONE right-aligned
@@ -146,8 +149,8 @@ function SidebarSessionRowImpl({
     trailing.push({ key: 'pr', node: <PrTag pr={pr} /> })
   }
 
-  if (figures.length) {
-    const head = figures.slice(0, -1).join(' · ')
+  if (figures.length || pinnedAge) {
+    const head = (pinnedAge ? figures : figures.slice(0, -1)).join(' · ')
 
     trailing.push({
       key: 'figures',
@@ -157,7 +160,20 @@ function SidebarSessionRowImpl({
           {/* The figures own their tail: the separator goes with it. */}
           <span className={cn('inline-block text-right', TAIL_HIDES)}>
             {head && ' · '}
-            {figures.at(-1)}
+            {pinnedAge ? (
+              <Tip label={absoluteAge} side="top">
+                <time
+                  aria-label={`${age}, ${absoluteAge}`}
+                  className="pointer-events-auto focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+                  dateTime={timestampDate.toISOString()}
+                  tabIndex={0}
+                >
+                  {age}
+                </time>
+              </Tip>
+            ) : (
+              figures.at(-1)
+            )}
           </span>
         </span>
       )
@@ -165,7 +181,7 @@ function SidebarSessionRowImpl({
   }
 
   // A chip that ends the slot hides whole; the figures handle their own tail.
-  const chipEndsSlot = trailing.length > 0 && !figures.length
+  const chipEndsSlot = trailing.length > 0 && !figures.length && !pinnedAge
   // A handed-off session's live source is local, but it originated on a
   // messaging platform — surface that origin as a small badge so e.g. a
   // Telegram thread continued here still reads as Telegram.

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -139,6 +139,47 @@ function SidebarSessionRowImpl({
   // switched on, and a PR keeps its place (and its click) unless it IS the last
   // thing. Chips used to render in the body instead, which left them stranded
   // to the left of the kebab's own column: never flush right, never swapping.
+  const sessionMiddleClickHandlers = middleClickHandlers(() => {
+    triggerHaptic('selection')
+    openSession(session.id, () => undefined, 'tab')
+  })
+
+  const handleSessionClick = (event: React.MouseEvent<HTMLElement>) => {
+    const mod = event.metaKey || event.ctrlKey
+
+    // ⇧⌘-click → pop into its own window (needs standalone windows).
+    if (mod && event.shiftKey) {
+      event.preventDefault()
+      event.stopPropagation()
+      triggerHaptic('selection')
+      openSession(session.id, () => undefined, 'window')
+
+      return
+    }
+
+    // ⌘/⌃-click → open in a new tab (stack into main).
+    if (mod) {
+      event.preventDefault()
+      event.stopPropagation()
+      triggerHaptic('selection')
+      openSession(session.id, () => undefined, 'tab')
+
+      return
+    }
+
+    // ⇧-click → pin.
+    if (event.shiftKey) {
+      event.preventDefault()
+      event.stopPropagation()
+      triggerHaptic('selection')
+      onPin()
+
+      return
+    }
+
+    onResume()
+  }
+
   const trailing: { key: string; node: React.ReactNode }[] = []
 
   if ((showProfile || pinnedProfile) && hasProfileTag) {
@@ -166,6 +207,8 @@ function SidebarSessionRowImpl({
                   aria-label={`${age}, ${absoluteAge}`}
                   className="pointer-events-auto focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
                   dateTime={timestampDate.toISOString()}
+                  {...sessionMiddleClickHandlers}
+                  onClick={handleSessionClick}
                   tabIndex={0}
                 >
                   {age}
@@ -303,46 +346,8 @@ function SidebarSessionRowImpl({
           // measures — so the title needs a gap from it and nothing else. Hover
           // changes what you can see in that slot, never how wide it is.
           className={cn('z-0 pr-2', branchStem && 'pl-3.5')}
-          // Middle-click = open in a new tab (browser muscle memory).
-          {...middleClickHandlers(() => {
-            triggerHaptic('selection')
-            openSession(session.id, () => undefined, 'tab')
-          })}
-          onClick={event => {
-            const mod = event.metaKey || event.ctrlKey
-
-            // ⇧⌘-click → pop into its own window (needs standalone windows).
-            if (mod && event.shiftKey) {
-              event.preventDefault()
-              event.stopPropagation()
-              triggerHaptic('selection')
-              openSession(session.id, () => undefined, 'window')
-
-              return
-            }
-
-            // ⌘/⌃-click → open in a new tab (stack into main).
-            if (mod) {
-              event.preventDefault()
-              event.stopPropagation()
-              triggerHaptic('selection')
-              openSession(session.id, () => undefined, 'tab')
-
-              return
-            }
-
-            // ⇧-click → pin.
-            if (event.shiftKey) {
-              event.preventDefault()
-              event.stopPropagation()
-              triggerHaptic('selection')
-              onPin()
-
-              return
-            }
-
-            onResume()
-          }}
+          {...sessionMiddleClickHandlers}
+          onClick={handleSessionClick}
         >
           {reorderable ? (
             <SidebarRowGrab ariaLabel={handleLabel} dragging={dragging} dragHandleProps={dragHandleProps}>

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -15,10 +15,10 @@ import {
   messageContentText,
   pickPrimaryPreviewTarget
 } from '@/components/assistant-ui/thread/content'
+import { MessageAge as MessageAgeLabel } from '@/components/assistant-ui/thread/message-age'
 import { MESSAGE_PARTS_COMPONENTS } from '@/components/assistant-ui/thread/message-parts'
 import { ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
 import { ResponseLoadingIndicator, StreamStallIndicator } from '@/components/assistant-ui/thread/status'
-import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
 import { useMessageReactions, useTapbackDoubleClick } from '@/components/assistant-ui/thread/use-message-reactions'
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
@@ -28,7 +28,6 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { AudioLines, GitForkIcon, Loader2Icon, RefreshCwIcon, SmilePlusIcon, VolumeXIcon, XIcon } from '@/lib/icons'
 import { extractPreviewTargets } from '@/lib/preview-targets'
-import { formatAgo } from '@/lib/time'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
@@ -301,23 +300,9 @@ const ReadAloudButton: FC<{ getText: () => string; messageId: string }> = ({ get
 }
 
 const MessageAge: FC = () => {
-  const { t } = useI18n()
   const createdAt = useAuiState(s => s.message.createdAt)
-  const date = createdAt ? new Date(createdAt) : null
 
-  if (!date || Number.isNaN(date.getTime())) {
-    return null
-  }
-
-  // Compact "2h ago" (shared util) with the absolute time on hover.
-  return (
-    <span
-      className="px-0.5 text-[0.6875rem] tabular-nums text-muted-foreground"
-      title={formatMessageTimestamp(date, t.assistant.thread) || undefined}
-    >
-      {formatAgo(date.getTime(), t.agents)}
-    </span>
-  )
+  return <MessageAgeLabel createdAt={createdAt} />
 }
 
 const AssistantFooter: FC<MessageActionProps> = props => (

--- a/apps/desktop/src/components/assistant-ui/thread/message-age.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-age.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MessageAge } from './message-age'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      agents: {
+        ageDays: (days: number) => `${days}d ago`,
+        ageHours: (hours: number) => `${hours}h ago`,
+        ageMinutes: (minutes: number) => `${minutes}m ago`,
+        ageNow: 'now',
+        ageSeconds: (seconds: number) => `${seconds}s ago`
+      },
+      assistant: {
+        thread: {
+          today: (time: string) => `Today at ${time}`,
+          yesterday: (time: string) => `Yesterday at ${time}`
+        }
+      }
+    }
+  })
+}))
+
+const tipTrigger = (el: HTMLElement) => el.closest('[data-slot="tooltip-trigger"]')
+
+describe('MessageAge', () => {
+  it('renders a focusable Tip trigger with relative and exact time', () => {
+    const createdAt = new Date()
+    createdAt.setMinutes(createdAt.getMinutes() - 5)
+
+    render(<MessageAge createdAt={createdAt} />)
+
+    const age = screen.getByText('5m ago')
+    expect(age.tagName).toBe('TIME')
+    expect(age.getAttribute('datetime')).toBe(createdAt.toISOString())
+    expect(age.getAttribute('aria-label')).toMatch(/^5m ago, Today at /)
+    expect(age.getAttribute('tabindex')).toBe('0')
+    expect(age.getAttribute('title')).toBeNull()
+    expect(tipTrigger(age)).toBeTruthy()
+  })
+
+  it('does not render an invalid timestamp', () => {
+    const { container } = render(<MessageAge createdAt="not-a-date" />)
+
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/message-age.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-age.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { MessageAge } from './message-age'
@@ -28,7 +28,7 @@ vi.mock('@/i18n', () => ({
 const tipTrigger = (el: HTMLElement) => el.closest('[data-slot="tooltip-trigger"]')
 
 describe('MessageAge', () => {
-  it('renders a focusable Tip trigger with relative and exact time', () => {
+  it('renders a focusable Tip trigger with relative and exact time', async () => {
     const createdAt = new Date()
     createdAt.setMinutes(createdAt.getMinutes() - 5)
 
@@ -41,6 +41,9 @@ describe('MessageAge', () => {
     expect(age.getAttribute('tabindex')).toBe('0')
     expect(age.getAttribute('title')).toBeNull()
     expect(tipTrigger(age)).toBeTruthy()
+
+    fireEvent.pointerMove(age, { pointerType: 'mouse' })
+    expect((await screen.findByRole('tooltip')).textContent).toMatch(/^Today at /)
   })
 
   it('does not render an invalid timestamp', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/message-age.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-age.tsx
@@ -1,0 +1,35 @@
+import type { FC } from 'react'
+
+import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { formatAgo } from '@/lib/time'
+
+interface MessageAgeProps {
+  createdAt: Date | string | number | undefined
+}
+
+export const MessageAge: FC<MessageAgeProps> = ({ createdAt }) => {
+  const { t } = useI18n()
+  const date = createdAt instanceof Date ? createdAt : createdAt ? new Date(createdAt) : null
+
+  if (!date || Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  const age = formatAgo(date.getTime(), t.agents)
+  const absoluteAge = formatMessageTimestamp(date, t.assistant.thread)
+
+  return (
+    <Tip label={absoluteAge} side="top">
+      <time
+        aria-label={`${age}, ${absoluteAge}`}
+        className="px-0.5 text-[0.6875rem] tabular-nums text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        dateTime={date.toISOString()}
+        tabIndex={0}
+      >
+        {age}
+      </time>
+    </Tip>
+  )
+}


### PR DESCRIPTION
## Summary

- replace native timestamp titles with the shared Desktop `Tip` component
- expose exact localized timestamps for message ages and sidebar session ages
- keep compact relative labels while supporting both pointer hover and keyboard focus
- use semantic `<time>` elements with accessible labels and machine-readable datetimes
- preserve the sidebar row's normal, modifier-key, and middle-click actions when the timestamp is targeted

Closes #70450

## Validation

- `npm test -- --run src/app/chat/sidebar/session-row.test.tsx src/components/assistant-ui/thread/message-age.test.tsx` (7 passed)
- tests exercise real tooltip hover on both surfaces and session activation through the sidebar timestamp
- `npm run typecheck`
- ESLint and Prettier checks for all changed files
- `npm run build`
- Full Desktop suite on Windows: 2,708 passed; 21 unrelated failures in untouched Billing, SSH/POSIX, relaunch, and packaging suites (including missing Bash/POSIX-only expectations)