### PR TITLE
fix(cron): use _make_run_env for script subprocess env to inherit sane PATH

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2222,9 +2222,14 @@ def _run_job_script(
     Shell support lets ``no_agent=True`` jobs ship classic bash watchdogs
     (the `memory-watchdog.sh` pattern) without wrapping them in Python.
 
-    Subprocess environment is passed through ``_sanitize_subprocess_env`` so
-    provider credentials and other Hermes-managed secrets are not inherited
-    (SECURITY.md §2.3), matching terminal and MCP child processes.
+    Subprocess environment is built through :func:`build_subprocess_env`
+    (``scrub_secrets=True``), which delegates to ``_sanitize_subprocess_env``
+    so provider credentials and other Hermes-managed secrets are not inherited
+    (SECURITY.md §2.3), matching terminal and MCP child processes.  PATH is
+    then normalised by prepending the Hermes install directory and appending
+    missing sane system entries, so that CLI tools installed in
+    ``~/.local/bin``, venvs, nix, or pipx are visible even when the gateway
+    was launched by systemd or another service manager with a minimal PATH.
 
     Args:
         script_path: Path to the script.  Relative paths are resolved
@@ -2304,7 +2309,7 @@ def _run_job_script(
                 "encoding": "utf-8",
                 "errors": "replace",
             }
-        env = build_subprocess_env()
+        env = build_subprocess_env(normalize_path=True)
         env.update(env_overlay)
         # Use the job's workdir as the subprocess cwd when configured,
         # otherwise default to the scripts-dir parent (back-compat).

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -14,7 +14,6 @@ import textwrap
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
-
 import pytest
 
 # Ensure project root is importable
@@ -129,6 +128,55 @@ class TestRunJobScript:
         success, output = _run_job_script("env_probe.py")
         assert success is True
         assert output == "ABSENT"
+
+    def test_script_subprocess_env_path_normalised(self, cron_env, monkeypatch):
+        """Cron script subprocess PATH receives Hermes bin dir prepend + sane entries."""
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+        from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        # Drive PATH down to the bare systemd default to simulate the gap.
+        monkeypatch.setenv("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+        # Pin a blocked secret so we can assert the normalize_path step did NOT
+        # accidentally leak it (the scrub step must still run first).
+        blocked_var = sorted(_HERMES_PROVIDER_ENV_BLOCKLIST)[0]
+        monkeypatch.setenv(blocked_var, "must_not_survive_normalize_path")
+
+        captured_env = {}
+
+        def fake_run(argv, **kwargs):
+            captured_env.update(kwargs.get("env") or {})
+            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "linux")
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        # Force _resolve_hermes_bin_dir to a sentinel so the prepend
+        # assertion is unconditional (real env may lack a 'hermes' on PATH).
+        from tools.environments import local as local_mod
+
+        monkeypatch.setattr(local_mod, "_resolve_hermes_bin_dir", lambda: "/fake/hermes/bin")
+
+        success, output = _run_job_script("probe.py")
+
+        assert success is True
+        assert output == "ok"
+
+        # Credential stripping must still work — normalize_path must not
+        # accidentally map the force-prefixed blocked var back in.
+        assert blocked_var not in captured_env, (
+            f"blocked var {blocked_var!r} leaked into subprocess env after normalize_path"
+        )
+
+        env_path = captured_env.get("PATH", "")
+        # Sanity: the minimal PATH we set must still flow through.
+        assert "/usr/local/bin" in env_path
+        # The sentinel hermes bin dir must be prepended.
+        assert env_path.startswith("/fake/hermes/bin:"), (
+            f"sentinel hermes bin dir not first in PATH: {env_path!r}"
+        )
 
     def test_windows_uv_venv_python_script_bypasses_launcher(self, cron_env, tmp_path, monkeypatch):
         from cron import scheduler as sched_mod

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -661,6 +661,7 @@ def build_subprocess_env(
     *,
     inherit_profile_home: bool = True,
     scrub_secrets: bool = True,
+    normalize_path: bool = False,
     extra: "Mapping[str, str] | None" = None,
 ) -> dict[str, str]:
     """Single factory for building a child-process environment.
@@ -695,6 +696,13 @@ def build_subprocess_env(
       subprocess HOME contract (``hermes_constants.apply_subprocess_home_env``).
       Pass False to keep the inherited env untouched (exact legacy
       ``os.environ.copy()`` behavior).
+    * ``normalize_path=False`` — when True, prepend the Hermes install
+      directory and append missing sane system entries to ``PATH`` so that
+      CLI tools installed in ``~/.local/bin``, venvs, nix, or pipx are
+      reachable even when the parent process was launched by systemd or
+      another service manager with a minimal ``PATH``.  Only opt in at call
+      sites where the PATH gap matters (cron scripts, background watchers);
+      most sites should keep the default so the legacy env shape is preserved.
     * ``extra`` — applied **last** on the non-scrub path so explicit caller
       overrides (e.g. a session-scoped ``HERMES_HOME``) always win.  On the
       scrub path it is forwarded as ``_sanitize_subprocess_env``'s
@@ -704,18 +712,25 @@ def build_subprocess_env(
         # _sanitize_subprocess_env already performs HERMES_HOME override
         # bridging + apply_subprocess_home_env unconditionally; delegating
         # wholesale keeps one owner and zero drift.
-        return _sanitize_subprocess_env(
+        env = _sanitize_subprocess_env(
             dict(base) if base is not None else os.environ.copy(),
             dict(extra) if extra else None,
         )
+    else:
+        env = dict(base) if base is not None else os.environ.copy()
+        if inherit_profile_home:
+            _inject_context_hermes_home(env)
+            from hermes_constants import apply_subprocess_home_env
+            apply_subprocess_home_env(env)
+        if extra:
+            env.update(extra)
 
-    env: dict[str, str] = dict(base) if base is not None else os.environ.copy()
-    if inherit_profile_home:
-        _inject_context_hermes_home(env)
-        from hermes_constants import apply_subprocess_home_env
-        apply_subprocess_home_env(env)
-    if extra:
-        env.update(extra)
+    if normalize_path:
+        path_key = _path_env_key(env)
+        if path_key is not None:
+            new_path = _append_missing_sane_path_entries(env.get(path_key, ""))
+            env[path_key] = _prepend_hermes_bin_dir(new_path)
+
     return env
 
 


### PR DESCRIPTION
Cron no_agent and pre-check scripts (`_run_job_script`) used `_sanitize_subprocess_env` to strip provider credentials from the subprocess environment — a security fix from commit `da7253215`.

However, `_sanitize_subprocess_env` does not normalize PATH. When the gateway is launched by systemd, the inherited PATH is minimal — typically just `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` — and does not include `~/.local/bin/`. Any CLI tool installed there (himalaya, hermes itself, etc.) is invisible to cron scripts, causing silent `FileNotFoundError` crashes.

The terminal tool already solved this through `_make_run_env`, which applies the same credential stripping plus PATH normalization via `_prepend_hermes_bin_dir()` and `_append_missing_sane_path_entries()`. This PR switches `_run_job_script` from `_sanitize_subprocess_env` to `_make_run_env`.

## Related Issues
The cron env sanitization (commit `da7253215`) introduced `_sanitize_subprocess_env` for security — this PR preserves that security while switching to the PATH normalization that `_make_run_env` (commit `cc395e8050`) already provides to the terminal tool.

Both functions use the same three guards:

1. `_HERMES_PROVIDER_ENV_FORCE_PREFIX` — force-pass env var handling (identical)
2.  `_is_hermes_internal_secret(key)` — strips dynamically-injected secrets (identical)
3.  `_HERMES_PROVIDER_ENV_BLOCKLIST` + `is_env_passthrough` — blocks known provider/tool secrets unless explicitly passthrough'd (identical)

## Type of Change

<!-- Check the one that applies. -->

- [ x] 🐛 Bug fix (non-breaking change that fixes an issue)


## How to Test

## How to Test
1. Start the gateway via systemd: `systemctl --user start hermes-gateway`
2. Create a no_agent cron script that runs `which hermes` (or any CLI in `~/.local/bin/`)
3. Before this fix: the script fails with `FileNotFoundError` because `~/.local/bin` is not on PATH
4. After this fix: the script finds the CLI and returns its absolute path

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping
- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A