### PR TITLE
fix(qqbot): respect markdown_support config in standalone _send_qqbot

### DIFF
--- a/tests/tools/test_qqbot_payload.py
+++ b/tests/tools/test_qqbot_payload.py
@@ -1,0 +1,216 @@
+"""Tests for the standalone _send_qqbot payload construction.
+
+Verifies that the three endpoint types (channel, C2C, group) receive the
+correct payload format and that msg_seq stays within the 0..65535 range.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# _send_qqbot — standalone QQ Bot HTTP payload
+# ---------------------------------------------------------------------------
+
+class TestSendQqbot:
+    """Verify _send_qqbot builds correct per-endpoint payloads."""
+
+    MARKDOWN_CONTENT = "**bold** and `code`"
+
+    @staticmethod
+    def _mock_token_response():
+        """Return a mock that succeeds on the token endpoint."""
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.return_value = {"access_token": "test_token", "expires_in": 7200}
+        return token_resp
+
+    @staticmethod
+    def _make_channel_success():
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"id": "ch_msg_001"}
+        return resp
+
+    @staticmethod
+    def _make_c2c_success():
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"id": "c2c_msg_001"}
+        return resp
+
+    @staticmethod
+    def _make_failure():
+        resp = MagicMock()
+        resp.status_code = 404
+        resp.json.return_value = {"code": 1003, "message": "not found"}
+        return resp
+
+    # ---------- markdown_enabled=True ----------
+
+    @pytest.mark.asyncio
+    async def test_markdown_enabled_channel(self):
+        """Channel endpoint gets content-only payload regardless of markdown_support."""
+        from gateway.config import PlatformConfig
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = PlatformConfig(enabled=True, extra={
+            "app_id": "app123", "client_secret": "sec456",
+            "markdown_support": True,
+        })
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            # Token succeeds, channel succeeds
+            mock_client.post.side_effect = [
+                self._mock_token_response(),   # token
+                self._make_channel_success(),  # channel → 200
+            ]
+
+            result = await _send_qqbot(pconfig, "123456", self.MARKDOWN_CONTENT)
+
+            calls = mock_client.post.call_args_list
+            assert len(calls) >= 2
+
+            # First POST is token
+            assert "getAppAccessToken" in str(calls[0][0][0])
+
+            # Second POST is channel — must be content-only
+            channel_body = calls[1].kwargs["json"]
+            assert "content" in channel_body
+            assert "msg_seq" not in channel_body
+            assert "msg_type" not in channel_body
+            assert "markdown" not in channel_body
+            assert channel_body["content"] == self.MARKDOWN_CONTENT
+
+            assert result["success"] is True
+            assert result["message_id"] == "ch_msg_001"
+
+    @pytest.mark.asyncio
+    async def test_markdown_enabled_c2c_fallback(self):
+        """When channel fails, C2C endpoint gets markdown payload."""
+        from gateway.config import PlatformConfig
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = PlatformConfig(enabled=True, extra={
+            "app_id": "app123", "client_secret": "sec456",
+            "markdown_support": True,
+        })
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            mock_client.post.side_effect = [
+                self._mock_token_response(),
+                self._make_failure(),
+                self._make_c2c_success(),
+            ]
+
+            result = await _send_qqbot(pconfig, "user_001", self.MARKDOWN_CONTENT)
+
+            calls = mock_client.post.call_args_list
+            c2c_body = calls[2].kwargs["json"]
+
+            assert "markdown" in c2c_body
+            assert c2c_body["markdown"]["content"] == self.MARKDOWN_CONTENT
+            assert c2c_body["msg_type"] == 2
+            assert 0 <= c2c_body["msg_seq"] <= 65535
+
+            assert result["success"] is True
+            assert result["message_id"] == "c2c_msg_001"
+
+    @pytest.mark.asyncio
+    async def test_markdown_disabled_channel(self):
+        """Channel is always content-only, even with markdown_support=False."""
+        from gateway.config import PlatformConfig
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = PlatformConfig(enabled=True, extra={
+            "app_id": "app123", "client_secret": "sec456",
+            "markdown_support": False,
+        })
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+            mock_client.post.side_effect = [
+                self._mock_token_response(),
+                self._make_channel_success(),
+            ]
+
+            result = await _send_qqbot(pconfig, "123456", "plain text")
+
+            calls = mock_client.post.call_args_list
+            channel_body = calls[1].kwargs["json"]
+            assert "content" in channel_body
+            assert "msg_type" not in channel_body
+            assert "markdown" not in channel_body
+            assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_markdown_disabled_c2c(self):
+        """With markdown_support=False, C2C gets text payload + msg_seq."""
+        from gateway.config import PlatformConfig
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = PlatformConfig(enabled=True, extra={
+            "app_id": "app123", "client_secret": "sec456",
+            "markdown_support": False,
+        })
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+            mock_client.post.side_effect = [
+                self._mock_token_response(),
+                self._make_failure(),
+                self._make_c2c_success(),
+            ]
+
+            result = await _send_qqbot(pconfig, "user_001", "plain text")
+
+            calls = mock_client.post.call_args_list
+            c2c_body = calls[2].kwargs["json"]
+
+            assert c2c_body["content"] == "plain text"
+            assert c2c_body["msg_type"] == 0
+            assert 0 <= c2c_body["msg_seq"] <= 65535
+            assert "markdown" not in c2c_body
+
+            assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_msg_seq_range(self):
+        """msg_seq is always in 0..65535 for C2C/group."""
+        from gateway.config import PlatformConfig
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = PlatformConfig(enabled=True, extra={
+            "app_id": "app123", "client_secret": "sec456",
+            "markdown_support": True,
+        })
+
+        seqs = set()
+        for _ in range(20):
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client_cls.return_value.__aenter__.return_value = mock_client
+                mock_client.post.side_effect = [
+                    self._mock_token_response(),
+                    self._make_failure(),
+                    self._make_c2c_success(),
+                ]
+                await _send_qqbot(pconfig, "u", "hello")
+                calls = mock_client.post.call_args_list
+                seq = calls[2].kwargs["json"]["msg_seq"]
+                assert 0 <= seq <= 65535, f"msg_seq {seq} out of range"
+                seqs.add(seq)
+
+        assert len(seqs) > 1, "msg_seq should vary across calls"

--- a/tests/tools/test_qqbot_payload.py
+++ b/tests/tools/test_qqbot_payload.py
@@ -50,6 +50,13 @@ class TestSendQqbot:
         resp.json.return_value = {"code": 1003, "message": "not found"}
         return resp
 
+    @staticmethod
+    def _make_group_success():
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"id": "grp_msg_001"}
+        return resp
+
     # ---------- markdown_enabled=True ----------
 
     @pytest.mark.asyncio
@@ -185,6 +192,82 @@ class TestSendQqbot:
             assert "markdown" not in c2c_body
 
             assert result["success"] is True
+
+    # ---------- group fallback (deepest chain) ----------
+
+    @pytest.mark.asyncio
+    async def test_markdown_enabled_group_fallback(self):
+        """When channel and C2C fail, group endpoint gets markdown payload."""
+        from gateway.config import PlatformConfig
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = PlatformConfig(enabled=True, extra={
+            "app_id": "app123", "client_secret": "sec456",
+            "markdown_support": True,
+        })
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            mock_client.post.side_effect = [
+                self._mock_token_response(),   # token
+                self._make_failure(),           # channel → 404
+                self._make_failure(),           # C2C → 404
+                self._make_group_success(),     # group → 200
+            ]
+
+            result = await _send_qqbot(pconfig, "group_001", self.MARKDOWN_CONTENT)
+
+            calls = mock_client.post.call_args_list
+            assert len(calls) >= 4
+
+            group_body = calls[3].kwargs["json"]
+            assert "markdown" in group_body
+            assert group_body["markdown"]["content"] == self.MARKDOWN_CONTENT
+            assert group_body["msg_type"] == 2
+            assert 0 <= group_body["msg_seq"] <= 65535
+
+            assert result["success"] is True
+            assert result["message_id"] == "grp_msg_001"
+
+    @pytest.mark.asyncio
+    async def test_markdown_disabled_group_fallback(self):
+        """With markdown_support=False and all endpoints tried, group gets text + msg_seq."""
+        from gateway.config import PlatformConfig
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = PlatformConfig(enabled=True, extra={
+            "app_id": "app123", "client_secret": "sec456",
+            "markdown_support": False,
+        })
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            mock_client.post.side_effect = [
+                self._mock_token_response(),   # token
+                self._make_failure(),           # channel → 404
+                self._make_failure(),           # C2C → 404
+                self._make_group_success(),     # group → 200
+            ]
+
+            result = await _send_qqbot(pconfig, "group_001", "plain text")
+
+            calls = mock_client.post.call_args_list
+            assert len(calls) >= 4
+
+            group_body = calls[3].kwargs["json"]
+            assert group_body["content"] == "plain text"
+            assert group_body["msg_type"] == 0
+            assert 0 <= group_body["msg_seq"] <= 65535
+            assert "markdown" not in group_body
+
+            assert result["success"] is True
+            assert result["message_id"] == "grp_msg_001"
+
+    # ---------- msg_seq ----------
 
     @pytest.mark.asyncio
     async def test_msg_seq_range(self):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -12,6 +12,7 @@ import os
 import re
 import ssl
 import time
+import uuid
 from email.utils import formatdate
 
 from agent.redact import redact_sensitive_text
@@ -2028,11 +2029,31 @@ async def _send_qqbot(pconfig, chat_id, message):
                 "Authorization": f"QQBot {access_token}",
                 "Content-Type": "application/json",
             }
-            payload = {"content": message[:4000], "msg_type": 0}
+            # Build payloads.
+            # Channel endpoint: content-only (no markdown, no msg_seq).
+            channel_payload = {"content": message[:4000]}
+            # C2C / group endpoints: respect markdown_support + include msg_seq.
+            markdown_enabled = bool(
+                (pconfig.extra or {}).get("markdown_support", True)
+            )
+            msg_seq = (int(time.time()) % 100000000
+                       ^ int(uuid.uuid4().hex[:4], 16)) % 65536
+            if markdown_enabled:
+                c2c_payload = {
+                    "markdown": {"content": message[:4000]},
+                    "msg_type": 2,
+                    "msg_seq": msg_seq,
+                }
+            else:
+                c2c_payload = {
+                    "content": message[:4000],
+                    "msg_type": 0,
+                    "msg_seq": msg_seq,
+                }
 
             # Try channel endpoint first (works for guild channels)
             url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
-            resp = await client.post(url, json=payload, headers=headers)
+            resp = await client.post(url, json=channel_payload, headers=headers)
             if resp.status_code in {200, 201}:
                 data = resp.json()
                 return {"success": True, "platform": "qqbot", "chat_id": chat_id,
@@ -2040,7 +2061,7 @@ async def _send_qqbot(pconfig, chat_id, message):
 
             # If channel endpoint failed (likely "频道不存在"), try C2C endpoint
             url_c2c = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
-            resp_c2c = await client.post(url_c2c, json=payload, headers=headers)
+            resp_c2c = await client.post(url_c2c, json=c2c_payload, headers=headers)
             if resp_c2c.status_code in {200, 201}:
                 data = resp_c2c.json()
                 return {"success": True, "platform": "qqbot", "chat_id": chat_id,
@@ -2048,7 +2069,7 @@ async def _send_qqbot(pconfig, chat_id, message):
 
             # If C2C also failed, try group endpoint
             url_group = f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages"
-            resp_group = await client.post(url_group, json=payload, headers=headers)
+            resp_group = await client.post(url_group, json=c2c_payload, headers=headers)
             if resp_group.status_code in {200, 201}:
                 data = resp_group.json()
                 return {"success": True, "platform": "qqbot", "chat_id": chat_id,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2029,15 +2029,15 @@ async def _send_qqbot(pconfig, chat_id, message):
                 "Authorization": f"QQBot {access_token}",
                 "Content-Type": "application/json",
             }
-            # Build payloads.
-            # Channel endpoint: content-only (no markdown, no msg_seq).
+            # Build payloads — channel vs C2C/group use different formats.
+            # Channel is content-only (no msg_type / msg_seq / markdown).
             channel_payload = {"content": message[:4000]}
             # C2C / group endpoints: respect markdown_support + include msg_seq.
             markdown_enabled = bool(
                 (pconfig.extra or {}).get("markdown_support", True)
             )
             msg_seq = (int(time.time()) % 100000000
-                       ^ int(uuid.uuid4().hex[:4], 16)) % 65536
+                ^ int(uuid.uuid4().hex[:4], 16)) % 65536
             if markdown_enabled:
                 c2c_payload = {
                     "markdown": {"content": message[:4000]},


### PR DESCRIPTION
## Summary

Fix standalone `_send_qqbot` path (used by cron job manual triggers) to respect the `markdown_support` config flag and match the QQ adapter's endpoint-specific payload contracts.

## Changes

1. **Channel endpoint** — content-only payload (`{"content": ...}`), matching `QQBotAdapter._send_guild_text()`. No msg_type, no msg_seq, no markdown.
2. **C2C/group endpoints** — conditionally uses markdown payload (msg_type=2 + `markdown.content`) when `markdown_support` is enabled, matching `QQBotAdapter._build_text_body()`.
3. **msg_seq** — generated in 0..65535 range, matching `QQBotAdapter._next_msg_seq()`.

## Tests

Adds `tests/tools/test_qqbot_payload.py` with 5 regression tests covering:
- Channel: always content-only payload
- C2C/group with markdown enabled: markdown payload (`markdown.content`, `msg_type=2`, `msg_seq`)
- C2C/group with markdown disabled: text payload (`content`, `msg_type=0`, `msg_seq`)
- msg_seq range: always in 0..65535 and varies across calls

## References

This is a more complete replacement for #49423 (same bug, author unresponsive to review feedback). Key differences:
- Channel requests are content-only (no markdown payload sent to /channels/ endpoint)
- msg_seq respects the 0..65535 contract
- Standalone send path is fully covered with tests

Contributed by Zhao Zuohong (AI-assisted per AGENTS.md).