### PR TITLE
fix(ui): roll compact token counts across units

### DIFF
--- a/agent/rate_limit_tracker.py
+++ b/agent/rate_limit_tracker.py
@@ -136,6 +136,8 @@ def _fmt_count(n: int) -> str:
     """Human-friendly number: 7999856 -> '8.0M', 33599 -> '33.6K', 799 -> '799'."""
     if n >= 1_000_000:
         return f"{n / 1_000_000:.1f}M"
+    if float(f"{n / 1_000:.1f}") >= 1_000:
+        return f"{n / 1_000_000:.1f}M"
     if n >= 10_000:
         return f"{n / 1_000:.1f}K"
     if n >= 1_000:

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1317,18 +1317,22 @@ def format_token_count_compact(value: int) -> str:
         return str(int(value))
 
     sign = "-" if value < 0 else ""
-    units = ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K"))
-    for threshold, suffix in units:
-        if abs_value >= threshold:
-            scaled = abs_value / threshold
-            if scaled < 10:
-                text = f"{scaled:.2f}"
-            elif scaled < 100:
-                text = f"{scaled:.1f}"
-            else:
-                text = f"{scaled:.0f}"
-            if "." in text:
-                text = text.rstrip("0").rstrip(".")
+    units = ((1_000, "K"), (1_000_000, "M"), (1_000_000_000, "B"))
+    unit_index = max(
+        index for index, (threshold, _suffix) in enumerate(units)
+        if abs_value >= threshold
+    )
+    while True:
+        threshold, suffix = units[unit_index]
+        scaled = abs_value / threshold
+        if scaled < 10:
+            text = f"{scaled:.2f}"
+        elif scaled < 100:
+            text = f"{scaled:.1f}"
+        else:
+            text = f"{scaled:.0f}"
+        if "." in text:
+            text = text.rstrip("0").rstrip(".")
+        if float(text) < 1_000 or unit_index == len(units) - 1:
             return f"{sign}{text}{suffix}"
-
-    return f"{value:,}"
+        unit_index += 1

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -504,7 +504,9 @@ def get_update_result(timeout: float = 0.5) -> Optional[int]:
 
 def _format_context_length(tokens: int) -> str:
     """Format a token count for display (e.g. 128000 → '128K', 1048576 → '1M')."""
-    if tokens >= 1_000_000:
+    if tokens >= 1_000_000 or (
+        tokens >= 1_000 and float(f"{tokens / 1_000:.1f}") >= 1_000
+    ):
         val = tokens / 1_000_000
         rounded = round(val)
         if abs(val - rounded) < 0.05:

--- a/tests/agent/test_rate_limit_tracker.py
+++ b/tests/agent/test_rate_limit_tracker.py
@@ -123,6 +123,11 @@ class TestFormatting:
         assert _fmt_count(33600) == "33.6K"
         assert _fmt_count(1500) == "1.5K"
 
+    def test_fmt_count_rolls_rounded_thousands_into_millions(self):
+        assert _fmt_count(999_949) == "999.9K"
+        assert _fmt_count(999_950) == "1.0M"
+        assert _fmt_count(999_999) == "1.0M"
+
     def test_fmt_count_small(self):
         assert _fmt_count(800) == "800"
         assert _fmt_count(0) == "0"

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -3,9 +3,17 @@ from types import SimpleNamespace
 from agent.usage_pricing import (
     CanonicalUsage,
     estimate_usage_cost,
+    format_token_count_compact,
     get_pricing_entry,
     normalize_usage,
 )
+
+
+def test_format_token_count_compact_rolls_over_rounded_units():
+    assert format_token_count_compact(999_499) == "999K"
+    assert format_token_count_compact(999_500) == "1M"
+    assert format_token_count_compact(999_999_999) == "1B"
+    assert format_token_count_compact(-999_999) == "-1M"
 
 
 def test_normalize_usage_anthropic_keeps_cache_buckets_separate():

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -26,6 +26,12 @@ def test_display_toolset_name_handles_empty():
     assert banner._display_toolset_name(None) == "unknown"
 
 
+def test_format_context_length_rolls_rounded_thousands_into_millions():
+    assert banner._format_context_length(999_949) == "999.9K"
+    assert banner._format_context_length(999_950) == "1M"
+    assert banner._format_context_length(999_999) == "1M"
+
+
 def test_build_welcome_banner_uses_normalized_toolset_names():
     """Unavailable toolsets should not have '_tools' appended in banner output."""
     with (


### PR DESCRIPTION
﻿## What does this PR do?

Prevents Hermes compact token-count displays from showing `1000K` or `1000.0K` when a value just below one million rounds across the unit boundary.

Each display keeps its existing precision policy. The shared usage formatter also handles the same rollover from millions to billions.

## Related Issue

Fixes #70489

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Make `format_token_count_compact` advance to the next unit when its rendered value reaches 1000.
- Apply the same `K` to `M` rollover to rate-limit and banner displays.
- Add boundary tests immediately before and after the rendered rollover.

## How to Test

1. Run `python -m pytest tests/agent/test_usage_pricing.py tests/agent/test_rate_limit_tracker.py tests/hermes_cli/test_banner.py -q -k "not title_is_hyperlinked_to_release"`.
2. Run the reproduction from #70489 and confirm the output is `1M`, `1.0M`, `1M`.
3. Run Ruff on the six touched files.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused files: 70 passed, 1 unrelated test deselected)
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered; pure numeric formatting
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Before:

```text
1000K
1000.0K
1000K
```

After:

```text
1M
1.0M
1M
```

Focused test result:

```text
70 passed, 1 deselected in 6.75s
All checks passed!
```

The deselected pre-existing banner test checks OSC-8 hyperlink emission and fails independently on this Windows/Rich environment; it is unrelated to token formatting.
