### PR TITLE
fix(auxiliary): treat capability-404 (vision) as model-not-found so router fallback engages

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3348,7 +3348,7 @@ def _is_unsupported_temperature_error(exc: Exception) -> bool:
 
 
 def _is_model_not_found_error(exc: Exception) -> bool:
-    """Detect "the requested model doesn't exist" errors (404 / invalid model).
+    """Detect "the requested model/route cannot serve this request" errors.
 
     This fires when a resolved model name is no longer served by the endpoint
     — most commonly when a long-lived process pinned a Portal-recommended model
@@ -3358,10 +3358,22 @@ def _is_model_not_found_error(exc: Exception) -> bool:
         Model 'gpt-5.4-mini' not found. The requested model does not exist
         in our configuration or OpenRouter catalog.
 
+    It ALSO fires for capability 404s where the route exists but cannot accept
+    the request shape — e.g. a text-only model (or a LiteLLM router proxying
+    only text models) handed an image, which OpenRouter/LiteLLM reject with::
+
+        No endpoints found that support image input
+
+    or ``this model does not support vision`` / ``image input is not supported``.
+    Treating these as model-not-found (not a transient error) lets the auxiliary
+    fallback chain move to a working vision/aux backend instead of surfacing a
+    cryptic 404. See #vision-404.
+
     Distinct from :func:`_is_payment_error` (which also matches some 404s for
     free-tier/credit language) — this one keys on "does not exist / not found /
-    not a valid model" phrasing, and explicitly excludes the billing keywords
-    that the payment path already owns so the two predicates don't overlap.
+    not a valid model / cannot serve image input" phrasing, and explicitly
+    excludes the billing keywords that the payment path already owns so the two
+    predicates don't overlap.
     """
     status = getattr(exc, "status_code", None)
     err_lower = str(exc).lower()
@@ -3384,6 +3396,14 @@ def _is_model_not_found_error(exc: Exception) -> bool:
         "the model `",            # OpenAI-style: "The model `X` does not exist"
         "model_not_found",
         "unknown model",
+        # Capability 404s: route exists but cannot serve the request shape.
+        "no endpoints found",             # OpenRouter/LiteLLM: no vision endpoint
+        "support image input",            # "...that support image input"
+        "does not support image",         # "...does not support image input"
+        "image input is not supported",   # Anthropic-style wording
+        "does not support vision",        # "...does not support vision"
+        "model does not support vision",  # OpenAI-style wording
+        "vision is not supported",        # generic vision-capability gate
     ))
 
 
@@ -7606,6 +7626,7 @@ def call_llm(
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
+            or _is_model_not_found_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
         # Respect explicit provider choice for transient errors (auth, request
@@ -7629,6 +7650,7 @@ def call_llm(
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
+            or _is_model_not_found_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
         if should_fallback and (is_auto or is_capacity_error):
@@ -7649,6 +7671,16 @@ def call_llm(
                 reason = "model incompatible with route"
             elif _is_invalid_aux_response_error(first_err):
                 reason = "invalid provider response"
+            elif _is_model_not_found_error(first_err):
+                reason = "model not found"
+                # The configured model/route 404s (e.g. a text-only backend
+                # like a LiteLLM router proxying non-vision models, or a
+                # dropped catalog model). Skip it for the unhealthy TTL so the
+                # fallthrough to a working vision/aux backend doesn't pay a
+                # doomed 404 RTT on every subsequent call.  #vision-404
+                _mark_provider_unhealthy(
+                    _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime) or resolved_provider
+                )
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
@@ -8136,6 +8168,7 @@ async def async_call_llm(
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
+            or _is_model_not_found_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
         # Capacity errors (payment/quota/connection/rate-limit) bypass the
@@ -8151,6 +8184,7 @@ async def async_call_llm(
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
+            or _is_model_not_found_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
         if should_fallback and (is_auto or is_capacity_error):
@@ -8167,6 +8201,16 @@ async def async_call_llm(
                 reason = "model incompatible with route"
             elif _is_invalid_aux_response_error(first_err):
                 reason = "invalid provider response"
+            elif _is_model_not_found_error(first_err):
+                reason = "model not found"
+                # The configured model/route 404s (e.g. a text-only backend
+                # like a LiteLLM router proxying non-vision models, or a
+                # dropped catalog model). Skip it for the unhealthy TTL so the
+                # fallthrough to a working vision/aux backend doesn't pay a
+                # doomed 404 RTT on every subsequent call.  #vision-404
+                _mark_provider_unhealthy(
+                    _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime) or resolved_provider
+                )
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",

--- a/test_vision_404_fallback.py
+++ b/test_vision_404_fallback.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""E2E test: vision_analyze 404 must fall through to a working aux backend.
+
+Reproduces the user's exact failure -- a LiteLLM router proxying only TEXT
+models returns 404 "No endpoints found that support image input" on any
+image payload -- and asserts the patched call_llm/async_call_llm fall back
+to the next available backend instead of raising.
+
+This validates the fix landed in agent/auxiliary_client.py (session 20260723):
+`_is_model_not_found_error` now matches capability-404s ("no endpoints found
+that support image input", "does not support vision", ...) and `call_llm`
+includes it in `should_fallback`, so the fallback chain engages.
+
+No network: we stub the vision client to raise the router's 404 and stub the
+fallback chain to return a sentinel "working" client.
+"""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import agent.auxiliary_client as ac
+
+
+class Router404(Exception):
+    status_code = 404
+
+    def __str__(self):
+        return ('litellm.NotFoundError: OpenrouterException - '
+                '{"error":{"message":"No endpoints found that support image input","code":404}}')
+
+
+def _msg(content):
+    return SimpleNamespace(content=content, reasoning_content=None, refusal=None)
+
+
+def _choices(content):
+    return SimpleNamespace(choices=[SimpleNamespace(message=_msg(content), finish_reason="stop", index=0)], usage=None)
+
+
+def _boom_client():
+    """A fake OpenAI client whose create() raises the router vision-404."""
+    class _Create:
+        def __call__(self, **kw):
+            raise Router404()
+
+    class _Completions:
+        create = _Create()
+
+    class _Chat:
+        completions = _Completions()
+
+    class _Client:
+        base_url = SimpleNamespace(host="router")
+        api_key = "fake-router-key"
+        chat = _Chat()
+
+    return _Client()
+
+
+def _ok_sync_client():
+    """A fake SYNC OpenAI client whose create() returns FALLBACK_OK."""
+    class _Create:
+        def __call__(self, **kw):
+            return _choices("FALLBACK_OK")
+
+    class _Completions:
+        create = _Create()
+
+    class _Chat:
+        completions = _Completions()
+
+    class _Client:
+        base_url = SimpleNamespace(host="fallback")
+        api_key = "fake-fallback-key"
+        chat = _Chat()
+
+    return _Client()
+
+
+def _ok_async_client():
+    """A fake ASYNC OpenAI client whose create() returns FALLBACK_OK."""
+    class _Create:
+        async def __call__(self, **kw):
+            return _choices("FALLBACK_OK")
+
+    class _Completions:
+        create = _Create()
+
+    class _Chat:
+        completions = _Completions()
+
+    class _Client:
+        base_url = SimpleNamespace(host="fallback")
+        api_key = "fake-fallback-key"
+        chat = _Chat()
+
+    return _Client()
+
+
+def _make_fake_vision_provider_client(provider=None, model=None, *a, **k):
+    """Stand-in for resolve_vision_provider_client: returns the boom client."""
+    return (provider or "auto"), _boom_client(), (model or "auto")
+
+
+def _fake_payment_fallback(failed_provider, task=None, reason=None):
+    return _ok_sync_client(), "fallback-model", "openrouter"
+
+
+def _fake_main_fallback_chain(task, failed_provider="", reason=None):
+    return None, None, ""
+
+
+def _fake_configured_fallback_chain(task, failed_provider="", reason=None):
+    return None, None, ""
+
+
+VISION_MSGS = [{"role": "user", "content": [
+    {"type": "text", "text": "describe"},
+    {"type": "image_url", "image_url": {"url": "data:image/png;base64,xxx"}}]}]
+
+
+def _run_sync():
+    with patch.object(ac, "resolve_vision_provider_client", _make_fake_vision_provider_client) as p1, \
+         patch.object(ac, "_try_payment_fallback", _fake_payment_fallback) as p2, \
+         patch.object(ac, "_try_main_fallback_chain", _fake_main_fallback_chain) as p3, \
+         patch.object(ac, "_try_configured_fallback_chain", _fake_configured_fallback_chain) as p4:
+        resp = ac.call_llm(
+            task="vision", messages=VISION_MSGS, max_tokens=200,
+            main_runtime={"provider": "custom:litellm-router", "model": "auto"})
+    content = getattr(getattr(resp, "choices", [None])[0].message, "content", None)
+    assert content == "FALLBACK_OK", f"unexpected content: {content!r}"
+    print("SYNC E2E PASS -> fallback returned:", content)
+
+
+def _run_async():
+    # async_call_llm wraps the fallback sync client into an async client via
+    # _to_async_client (which builds a real AsyncOpenAI and would hit the net).
+    # Stub it to return our offline async fake so the test stays network-free
+    # while still exercising the vision-404 -> fallback decision in call_llm.
+    with patch.object(ac, "resolve_vision_provider_client", _make_fake_vision_provider_client) as p1, \
+         patch.object(ac, "_try_payment_fallback", _fake_payment_fallback) as p2, \
+         patch.object(ac, "_try_main_fallback_chain", _fake_main_fallback_chain) as p3, \
+         patch.object(ac, "_try_configured_fallback_chain", _fake_configured_fallback_chain) as p4, \
+         patch.object(ac, "_to_async_client", lambda c, m, **k: (_ok_async_client(), m)) as p5:
+        resp = asyncio.run(
+            ac.async_call_llm(
+                task="vision", messages=VISION_MSGS, max_tokens=200,
+                main_runtime={"provider": "custom:litellm-router", "model": "auto"}))
+    content = getattr(getattr(resp, "choices", [None])[0].message, "content", None)
+    assert content == "FALLBACK_OK", f"unexpected content: {content!r}"
+    print("ASYNC E2E PASS -> fallback returned:", content)
+
+
+def test_sync():
+    _run_sync()
+
+
+def test_async():
+    _run_async()
+
+
+if __name__ == "__main__":
+    _run_sync()
+    _run_async()
+    print("\nALL E2E TESTS PASSED")


### PR DESCRIPTION
## Summary
A local LiteLLM router proxying only **text** models returns `404 No endpoints found that support image input` (or `...does not support vision`) on any image payload. The previous `_is_model_not_found_error` only matched 404s for genuinely missing models, so this capability-404 was treated as a transient error and retried against the same doomed route instead of falling through to a working vision/aux backend.

- Extend `_is_model_not_found_error` to also match capability-404 wording (`no endpoints found`, `support image input`, `does not support vision`, `vision is not supported`, ...).
- Include it in `call_llm`/`async_call_llm` `should_fallback` so the fallback chain engages and marks the route unhealthy (skips the doomed RTT on subsequent calls).

## Test plan
- Added `test_vision_404_fallback.py` (E2E, no network): stubs the vision client to raise the router's capability-404 and asserts the fallback returns a working aux backend — covers both `call_llm` (sync) and `async_call_llm` (async).
- `pytest test_vision_404_fallback.py` → 2 passed.

## Notes
This only changes fallback *trigger* classification; it does not alter prompt caching, tool schemas, or any core model config. Regression-safe: genuine model-not-found 404s still match; billing 402/quota 429 paths are untouched.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)