### PR TITLE
fix(cli): prevent duplicate TTS response rendering

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -893,6 +893,14 @@ from rich.markup import escape as _escape
 from rich.panel import Panel
 from rich.text import Text as _RichText
 
+
+def _select_streaming_tts_display_callback(
+    token_streaming_enabled: bool,
+    display_callback,
+):
+    """Avoid rendering the same response from both token and TTS streams."""
+    return None if token_streaming_enabled else display_callback
+
 # Import agent and tool systems lazily. Bare interactive startup only needs the
 # prompt; the full agent/tool registry is initialized on first use.
 def AIAgent(*args, **kwargs):
@@ -12433,7 +12441,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 tts_thread = threading.Thread(
                     target=stream_tts_to_speaker,
                     args=(text_queue, stop_event, self._voice_tts_done),
-                    kwargs={"display_callback": display_callback},
+                    kwargs={
+                        "display_callback": _select_streaming_tts_display_callback(
+                            self.streaming_enabled,
+                            display_callback,
+                        )
+                    },
                     daemon=True,
                 )
                 tts_thread.start()

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -222,6 +222,25 @@ class TestStreamingTTSActivation:
             "_HAS_AUDIO should not exist -- lazy imports replaced it"
 
 
+def test_token_streaming_disables_the_tts_display_callback():
+    from cli import _select_streaming_tts_display_callback
+
+    display_callback = MagicMock()
+
+    assert _select_streaming_tts_display_callback(True, display_callback) is None
+
+
+def test_non_streaming_display_preserves_the_tts_display_callback():
+    from cli import _select_streaming_tts_display_callback
+
+    display_callback = MagicMock()
+
+    assert (
+        _select_streaming_tts_display_callback(False, display_callback)
+        is display_callback
+    )
+
+
 # ============================================================================
 # Voice mode user message prefix (Bug B fix)
 # ============================================================================


### PR DESCRIPTION
## Summary

- avoid installing the TTS sentence display callback when token streaming already renders the response
- preserve sentence-based display when token streaming is disabled
- add regression coverage for both display modes

## Test plan

- `scripts/run_tests.sh tests/tools/test_voice_cli_integration.py` (87 passed)
- `.venv/bin/ruff check cli.py tests/tools/test_voice_cli_integration.py`
- `.venv/bin/python -m py_compile cli.py tests/tools/test_voice_cli_integration.py`
- `git diff --check`