### PR TITLE
fix(cron): allow Python scripts to use an external interpreter

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1793,6 +1793,7 @@ def create_job(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    interpreter: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
@@ -1854,6 +1855,16 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
+        interpreter: Optional Python interpreter for ``script`` and
+                ``monitor_script`` — an absolute or ``~``-prefixed path to a
+                Python executable in a user-owned venv. Lets a script import
+                packages the Hermes-managed venv does not carry (e.g.
+                openpyxl, a DB driver) without polluting the runtime
+                environment. Applies only to Python scripts; ``.sh`` /
+                ``.bash`` always run under bash. When unset, scripts run under
+                Hermes' own Python (``sys.executable``), preserving the
+                original behaviour. The path is validated at run time, not
+                here.
 
     Returns:
         The created job dict
@@ -1884,6 +1895,12 @@ def create_job(
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
+    # Trim whitespace; an absent/empty value stays absent so existing records
+    # remain byte-identical. The path itself is validated at run time — cron
+    # jobs are long-lived and the configured venv may be rebuilt or moved
+    # after the job is created.
+    normalized_interpreter = str(interpreter).strip() if isinstance(interpreter, str) else None
+    normalized_interpreter = normalized_interpreter or None
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
     normalized_monitor_script = str(monitor_script).strip() if isinstance(monitor_script, str) else None
@@ -1990,6 +2007,10 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    # Only persist interpreter when explicitly set, so existing jobs and the
+    # common case stay byte-identical (absent key => Hermes Python at run time).
+    if normalized_interpreter is not None:
+        job["interpreter"] = normalized_interpreter
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).
@@ -2092,6 +2113,21 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+            # Normalize interpreter if present in updates. Empty string or
+            # None both mean "clear the field" (revert to Hermes Python). The
+            # path is validated at run time, not here — the configured venv may
+            # not exist yet, or may be rebuilt/moved between create and fire.
+            if "interpreter" in updates:
+                _interp = updates["interpreter"]
+                _normalized_interp = str(_interp).strip() if isinstance(_interp, str) else None
+                if _normalized_interp:
+                    updates["interpreter"] = _normalized_interp
+                else:
+                    # Clear: drop the key entirely so the record stays
+                    # byte-identical to one that never had it (the absence IS
+                    # the "use Hermes Python" default, same as attach_to_session).
+                    updates.pop("interpreter", None)
+                    job.pop("interpreter", None)
 
             # Normalize monitor fields the same way create_job does (empty
             # string clears the field).

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1793,11 +1793,11 @@ def create_job(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
-    interpreter: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    interpreter: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1582,11 +1582,11 @@ def create_job(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
-    interpreter: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    interpreter: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1582,6 +1582,7 @@ def create_job(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    interpreter: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
@@ -1643,6 +1644,16 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
+        interpreter: Optional Python interpreter for ``script`` and
+                ``monitor_script`` — an absolute or ``~``-prefixed path to a
+                Python executable in a user-owned venv. Lets a script import
+                packages the Hermes-managed venv does not carry (e.g.
+                openpyxl, a DB driver) without polluting the runtime
+                environment. Applies only to Python scripts; ``.sh`` /
+                ``.bash`` always run under bash. When unset, scripts run under
+                Hermes' own Python (``sys.executable``), preserving the
+                original behaviour. The path is validated at run time, not
+                here.
 
     Returns:
         The created job dict
@@ -1673,6 +1684,12 @@ def create_job(
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
+    # Trim whitespace; an absent/empty value stays absent so existing records
+    # remain byte-identical. The path itself is validated at run time — cron
+    # jobs are long-lived and the configured venv may be rebuilt or moved
+    # after the job is created.
+    normalized_interpreter = str(interpreter).strip() if isinstance(interpreter, str) else None
+    normalized_interpreter = normalized_interpreter or None
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
     normalized_monitor_script = str(monitor_script).strip() if isinstance(monitor_script, str) else None
@@ -1778,6 +1795,10 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    # Only persist interpreter when explicitly set, so existing jobs and the
+    # common case stay byte-identical (absent key => Hermes Python at run time).
+    if normalized_interpreter is not None:
+        job["interpreter"] = normalized_interpreter
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).
@@ -1880,6 +1901,21 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+            # Normalize interpreter if present in updates. Empty string or
+            # None both mean "clear the field" (revert to Hermes Python). The
+            # path is validated at run time, not here — the configured venv may
+            # not exist yet, or may be rebuilt/moved between create and fire.
+            if "interpreter" in updates:
+                _interp = updates["interpreter"]
+                _normalized_interp = str(_interp).strip() if isinstance(_interp, str) else None
+                if _normalized_interp:
+                    updates["interpreter"] = _normalized_interp
+                else:
+                    # Clear: drop the key entirely so the record stays
+                    # byte-identical to one that never had it (the absence IS
+                    # the "use Hermes Python" default, same as attach_to_session).
+                    updates.pop("interpreter", None)
+                    job.pop("interpreter", None)
 
             # Normalize monitor fields the same way create_job does (empty
             # string clears the field).

--- a/cron/monitor.py
+++ b/cron/monitor.py
@@ -133,7 +133,11 @@ def _run_monitor_source(job: dict) -> tuple[bool, str]:
         from cron.scheduler import _run_job_script
 
         workdir = (job.get("workdir") or "").strip() or None
-        return _run_job_script(monitor_script, workdir=workdir)
+        return _run_job_script(
+            monitor_script,
+            workdir=workdir,
+            interpreter=job.get("interpreter"),
+        )
     monitor_url = (job.get("monitor_url") or "").strip()
     if monitor_url:
         return _fetch_monitor_url(monitor_url)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3496,29 +3496,39 @@ def _resolve_cron_interpreter(interpreter: Optional[str]) -> tuple[bool, str, st
         return True, sys.executable, ""
 
     raw = str(interpreter).strip()
-    resolved = Path(raw).expanduser()
+    # Expand ``~`` and validate the path. ``Path.expanduser()`` raises
+    # ``RuntimeError`` for an unknown user (``~nobody/...``) when it cannot
+    # determine that user's home directory, and the subsequent existence /
+    # permission checks can raise ``OSError`` on a broken symlink or a path
+    # inside an unreadable directory. Both must be converted into the
+    # resolver's ``(False, message)`` contract — the caller surfaces it as a
+    # clear scheduled-run failure, never an uncaught exception.
+    try:
+        resolved = Path(raw).expanduser()
+        is_absolute = resolved.is_absolute()
+        exists = resolved.exists()
+        is_file = resolved.is_file() if exists else False
+        mode = resolved.stat().st_mode if (exists and is_file) else 0
+    except (RuntimeError, OSError) as exc:
+        return False, "", f"Unable to resolve interpreter path {raw!r}: {exc}"
     # Bare names like ``python3`` are rejected: they are not stable across PATH
     # changes and would silently pick up a different interpreter after a
     # profile/env change. Require an absolute or ``~``-prefixed path.
-    if not resolved.is_absolute():
+    if not is_absolute:
         return (
             False,
             "",
             f"Interpreter must be an absolute or ~-prefixed path (got {raw!r}). "
             "Bare names like 'python3' are not stable across PATH changes.",
         )
-    if not resolved.exists():
+    if not exists:
         return False, "", f"Interpreter not found: {resolved}"
-    if not resolved.is_file():
+    if not is_file:
         return False, "", f"Interpreter path is not a file: {resolved}"
     # On POSIX the interpreter must be executable. Skipped on Windows, where
     # the executable bit is not meaningful and the launcher re-execs anyway.
-    if sys.platform != "win32":
-        try:
-            if not (resolved.stat().st_mode & 0o111):
-                return False, "", f"Interpreter is not executable: {resolved}"
-        except OSError as exc:
-            return False, "", f"Interpreter check failed for {resolved}: {exc}"
+    if sys.platform != "win32" and not (mode & 0o111):
+        return False, "", f"Interpreter is not executable: {resolved}"
 
     return True, str(resolved), ""
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3479,10 +3479,55 @@ def _windows_cron_bootstrap_argv(
     return [python_exe, "-c", bootstrap, script_path]
 
 
+def _resolve_cron_interpreter(interpreter: Optional[str]) -> tuple[bool, str, str]:
+    """Resolve and validate a cron job's configured Python interpreter.
+
+    Args:
+        interpreter: Raw ``interpreter`` field from the job record (may be a
+            ``~``-prefixed path). ``None``/empty means "use Hermes Python".
+
+    Returns:
+        ``(ok, python_exe, message)``. When ``ok`` is True, ``python_exe`` is
+        the absolute path to invoke and ``message`` is empty. When ``ok`` is
+        False, ``python_exe`` is empty and ``message`` explains the failure so
+        the caller can surface it as a script-run error.
+    """
+    if not interpreter or not str(interpreter).strip():
+        return True, sys.executable, ""
+
+    raw = str(interpreter).strip()
+    resolved = Path(raw).expanduser()
+    # Bare names like ``python3`` are rejected: they are not stable across PATH
+    # changes and would silently pick up a different interpreter after a
+    # profile/env change. Require an absolute or ``~``-prefixed path.
+    if not resolved.is_absolute():
+        return (
+            False,
+            "",
+            f"Interpreter must be an absolute or ~-prefixed path (got {raw!r}). "
+            "Bare names like 'python3' are not stable across PATH changes.",
+        )
+    if not resolved.exists():
+        return False, "", f"Interpreter not found: {resolved}"
+    if not resolved.is_file():
+        return False, "", f"Interpreter path is not a file: {resolved}"
+    # On POSIX the interpreter must be executable. Skipped on Windows, where
+    # the executable bit is not meaningful and the launcher re-execs anyway.
+    if sys.platform != "win32":
+        try:
+            if not (resolved.stat().st_mode & 0o111):
+                return False, "", f"Interpreter is not executable: {resolved}"
+        except OSError as exc:
+            return False, "", f"Interpreter check failed for {resolved}: {exc}"
+
+    return True, str(resolved), ""
+
+
 def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    interpreter: Optional[str] = None,
 ) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -3495,8 +3540,9 @@ def _run_job_script(
 
     * ``.sh`` / ``.bash`` — run with ``/bin/bash``
     * anything else — run with the current Python interpreter
-      (``sys.executable``), preserving the original behaviour for
-      Python-based pre-check and data-collection scripts.
+      (``sys.executable``), or — when ``interpreter`` is set — the
+      configured Python executable.  Preserving the original behaviour
+      for Python-based pre-check and data-collection scripts.
 
     Shell support lets ``no_agent=True`` jobs ship classic bash watchdogs
     (the `memory-watchdog.sh` pattern) without wrapping them in Python.
@@ -3515,6 +3561,10 @@ def _run_job_script(
             mutated, avoiding the global-side-effect bug where a cron
             job's ``os.chdir()`` leaks into concurrent gateway sessions
             (#69396).
+        interpreter: Optional Python interpreter for the Python script branch.
+            An absolute or ``~``-prefixed path to a user-managed venv's
+            ``python``. Ignored for ``.sh`` / ``.bash`` scripts. ``None``/empty
+            keeps the default (``sys.executable``). Validated at run time.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -3572,6 +3622,8 @@ def _run_job_script(
     # everything else.  We deliberately do NOT honour the file's own
     # shebang: the scripts dir is trusted, but keeping the interpreter
     # choice explicit here keeps the allowed surface small and auditable.
+    # A configured ``interpreter`` overrides the default Python only for the
+    # Python branch — bash always wins for shell scripts.
     suffix = path.suffix.lower()
     if suffix in {".sh", ".bash"}:
         # Resolve bash dynamically so Windows (Git Bash) and Linux/macOS
@@ -3591,7 +3643,17 @@ def _run_job_script(
         argv = [_bash, str(path)]
         env_overlay: dict[str, str] = {}
     else:
-        python_exe, env_overlay = _windows_cron_python_invocation(sys.executable)
+        # Resolve the configured interpreter (or fall back to Hermes' Python).
+        # Validated here, at run time, so a missing/moved venv produces a clear
+        # script failure that flows through normal cron delivery — rather than
+        # silently picking up a different interpreter from PATH.
+        ok, python_base, err = _resolve_cron_interpreter(interpreter)
+        if not ok:
+            return False, err
+        # Still pass the selected Python through the Windows invocation helper
+        # so output capture and no-window behaviour stay intact (uv launcher
+        # bypass, pythonw→python sibling, PYTHONPATH overlay).
+        python_exe, env_overlay = _windows_cron_python_invocation(python_base)
         if env_overlay:
             # Overlay mode (Windows uv venv): PYTHONPATH alone cannot make
             # editable installs importable — .pth processing needs
@@ -3688,7 +3750,11 @@ def _run_job_script_with_claim_heartbeat(
     The claim owner is captured from the dispatched job and never re-read from
     storage.  ``heartbeat_run_claim`` compares that stable owner before every
     refresh, so a stale runner cannot extend a replacement owner's claim.
+
+    The job's configured ``interpreter`` is forwarded to ``_run_job_script`` on
+    every internal call path so the override survives the heartbeat wrapper.
     """
+    interpreter = job.get("interpreter")
     schedule = job.get("schedule")
     claim = job.get("run_claim")
     owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
@@ -3697,7 +3763,12 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(
+            script_path,
+            workdir=workdir,
+            cancel_event=cancel_event,
+            interpreter=interpreter,
+        )
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -3728,10 +3799,20 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(
+            script_path,
+            workdir=workdir,
+            cancel_event=cancel_event,
+            interpreter=interpreter,
+        )
 
     try:
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(
+            script_path,
+            workdir=workdir,
+            cancel_event=cancel_event,
+            interpreter=interpreter,
+        )
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -3802,7 +3883,9 @@ def _build_job_prompt(
         if prerun_script is not None:
             success, script_output = prerun_script
         else:
-            success, script_output = _run_job_script(script_path)
+            success, script_output = _run_job_script(
+                script_path, interpreter=job.get("interpreter")
+            )
         if success:
             if script_output:
                 prompt = (

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2366,29 +2366,39 @@ def _resolve_cron_interpreter(interpreter: Optional[str]) -> tuple[bool, str, st
         return True, sys.executable, ""
 
     raw = str(interpreter).strip()
-    resolved = Path(raw).expanduser()
+    # Expand ``~`` and validate the path. ``Path.expanduser()`` raises
+    # ``RuntimeError`` for an unknown user (``~nobody/...``) when it cannot
+    # determine that user's home directory, and the subsequent existence /
+    # permission checks can raise ``OSError`` on a broken symlink or a path
+    # inside an unreadable directory. Both must be converted into the
+    # resolver's ``(False, message)`` contract — the caller surfaces it as a
+    # clear scheduled-run failure, never an uncaught exception.
+    try:
+        resolved = Path(raw).expanduser()
+        is_absolute = resolved.is_absolute()
+        exists = resolved.exists()
+        is_file = resolved.is_file() if exists else False
+        mode = resolved.stat().st_mode if (exists and is_file) else 0
+    except (RuntimeError, OSError) as exc:
+        return False, "", f"Unable to resolve interpreter path {raw!r}: {exc}"
     # Bare names like ``python3`` are rejected: they are not stable across PATH
     # changes and would silently pick up a different interpreter after a
     # profile/env change. Require an absolute or ``~``-prefixed path.
-    if not resolved.is_absolute():
+    if not is_absolute:
         return (
             False,
             "",
             f"Interpreter must be an absolute or ~-prefixed path (got {raw!r}). "
             "Bare names like 'python3' are not stable across PATH changes.",
         )
-    if not resolved.exists():
+    if not exists:
         return False, "", f"Interpreter not found: {resolved}"
-    if not resolved.is_file():
+    if not is_file:
         return False, "", f"Interpreter path is not a file: {resolved}"
     # On POSIX the interpreter must be executable. Skipped on Windows, where
     # the executable bit is not meaningful and the launcher re-execs anyway.
-    if sys.platform != "win32":
-        try:
-            if not (resolved.stat().st_mode & 0o111):
-                return False, "", f"Interpreter is not executable: {resolved}"
-        except OSError as exc:
-            return False, "", f"Interpreter check failed for {resolved}: {exc}"
+    if sys.platform != "win32" and not (mode & 0o111):
+        return False, "", f"Interpreter is not executable: {resolved}"
 
     return True, str(resolved), ""
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2349,9 +2349,54 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
     return str(interpreter), env_overlay
 
 
+def _resolve_cron_interpreter(interpreter: Optional[str]) -> tuple[bool, str, str]:
+    """Resolve and validate a cron job's configured Python interpreter.
+
+    Args:
+        interpreter: Raw ``interpreter`` field from the job record (may be a
+            ``~``-prefixed path). ``None``/empty means "use Hermes Python".
+
+    Returns:
+        ``(ok, python_exe, message)``. When ``ok`` is True, ``python_exe`` is
+        the absolute path to invoke and ``message`` is empty. When ``ok`` is
+        False, ``python_exe`` is empty and ``message`` explains the failure so
+        the caller can surface it as a script-run error.
+    """
+    if not interpreter or not str(interpreter).strip():
+        return True, sys.executable, ""
+
+    raw = str(interpreter).strip()
+    resolved = Path(raw).expanduser()
+    # Bare names like ``python3`` are rejected: they are not stable across PATH
+    # changes and would silently pick up a different interpreter after a
+    # profile/env change. Require an absolute or ``~``-prefixed path.
+    if not resolved.is_absolute():
+        return (
+            False,
+            "",
+            f"Interpreter must be an absolute or ~-prefixed path (got {raw!r}). "
+            "Bare names like 'python3' are not stable across PATH changes.",
+        )
+    if not resolved.exists():
+        return False, "", f"Interpreter not found: {resolved}"
+    if not resolved.is_file():
+        return False, "", f"Interpreter path is not a file: {resolved}"
+    # On POSIX the interpreter must be executable. Skipped on Windows, where
+    # the executable bit is not meaningful and the launcher re-execs anyway.
+    if sys.platform != "win32":
+        try:
+            if not (resolved.stat().st_mode & 0o111):
+                return False, "", f"Interpreter is not executable: {resolved}"
+        except OSError as exc:
+            return False, "", f"Interpreter check failed for {resolved}: {exc}"
+
+    return True, str(resolved), ""
+
+
 def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
+    interpreter: Optional[str] = None,
 ) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -2364,8 +2409,9 @@ def _run_job_script(
 
     * ``.sh`` / ``.bash`` — run with ``/bin/bash``
     * anything else — run with the current Python interpreter
-      (``sys.executable``), preserving the original behaviour for
-      Python-based pre-check and data-collection scripts.
+      (``sys.executable``), or — when ``interpreter`` is set — the
+      configured Python executable.  Preserving the original behaviour
+      for Python-based pre-check and data-collection scripts.
 
     Shell support lets ``no_agent=True`` jobs ship classic bash watchdogs
     (the `memory-watchdog.sh` pattern) without wrapping them in Python.
@@ -2384,6 +2430,10 @@ def _run_job_script(
             mutated, avoiding the global-side-effect bug where a cron
             job's ``os.chdir()`` leaks into concurrent gateway sessions
             (#69396).
+        interpreter: Optional Python interpreter for the Python script branch.
+            An absolute or ``~``-prefixed path to a user-managed venv's
+            ``python``. Ignored for ``.sh`` / ``.bash`` scripts. ``None``/empty
+            keeps the default (``sys.executable``). Validated at run time.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -2429,6 +2479,8 @@ def _run_job_script(
     # everything else.  We deliberately do NOT honour the file's own
     # shebang: the scripts dir is trusted, but keeping the interpreter
     # choice explicit here keeps the allowed surface small and auditable.
+    # A configured ``interpreter`` overrides the default Python only for the
+    # Python branch — bash always wins for shell scripts.
     suffix = path.suffix.lower()
     if suffix in {".sh", ".bash"}:
         # Resolve bash dynamically so Windows (Git Bash) and Linux/macOS
@@ -2448,7 +2500,17 @@ def _run_job_script(
         argv = [_bash, str(path)]
         env_overlay: dict[str, str] = {}
     else:
-        python_exe, env_overlay = _windows_cron_python_invocation(sys.executable)
+        # Resolve the configured interpreter (or fall back to Hermes' Python).
+        # Validated here, at run time, so a missing/moved venv produces a clear
+        # script failure that flows through normal cron delivery — rather than
+        # silently picking up a different interpreter from PATH.
+        ok, python_base, err = _resolve_cron_interpreter(interpreter)
+        if not ok:
+            return False, err
+        # Still pass the selected Python through the Windows invocation helper
+        # so output capture and no-window behaviour stay intact (uv launcher
+        # bypass, pythonw→python sibling, PYTHONPATH overlay).
+        python_exe, env_overlay = _windows_cron_python_invocation(python_base)
         argv = [python_exe, str(path)]
 
     try:
@@ -2520,7 +2582,11 @@ def _run_job_script_with_claim_heartbeat(
     The claim owner is captured from the dispatched job and never re-read from
     storage.  ``heartbeat_run_claim`` compares that stable owner before every
     refresh, so a stale runner cannot extend a replacement owner's claim.
+
+    The job's configured ``interpreter`` is forwarded to ``_run_job_script`` on
+    every internal call path so the override survives the heartbeat wrapper.
     """
+    interpreter = job.get("interpreter")
     schedule = job.get("schedule")
     claim = job.get("run_claim")
     owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
@@ -2529,7 +2595,9 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(
+            script_path, workdir=workdir, interpreter=interpreter
+        )
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -2560,10 +2628,14 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(
+            script_path, workdir=workdir, interpreter=interpreter
+        )
 
     try:
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(
+            script_path, workdir=workdir, interpreter=interpreter
+        )
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -2634,7 +2706,9 @@ def _build_job_prompt(
         if prerun_script is not None:
             success, script_output = prerun_script
         else:
-            success, script_output = _run_job_script(script_path)
+            success, script_output = _run_job_script(
+                script_path, interpreter=job.get("interpreter")
+            )
         if success:
             if script_output:
                 prompt = (

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -173,6 +173,9 @@ def cron_list(show_all: bool = False):
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
+        interpreter = job.get("interpreter")
+        if interpreter:
+            print(f"    Python:    {interpreter}")
 
         # Execution history
         last_status = job.get("last_status")
@@ -392,6 +395,7 @@ def cron_create(args):
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
+        interpreter=getattr(args, "interpreter", None),
         no_agent=getattr(args, "no_agent", False) or None,
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
@@ -418,6 +422,8 @@ def cron_create(args):
         print("  Continuity: on (each run sees the previous run's output)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
+    if job_data.get("interpreter"):
+        print(f"  Python: {job_data['interpreter']}")
     print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0
@@ -466,6 +472,7 @@ def cron_edit(args):
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
+        interpreter=getattr(args, "interpreter", None),
         no_agent=getattr(args, "no_agent", None),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
@@ -495,6 +502,8 @@ def cron_edit(args):
         print("  Continuity: on (each run sees the previous run's output)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    if updated.get("interpreter"):
+        print(f"  Python: {updated['interpreter']}")
     return 0
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -173,6 +173,9 @@ def cron_list(show_all: bool = False):
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
+        interpreter = job.get("interpreter")
+        if interpreter:
+            print(f"    Python:    {interpreter}")
 
         # Execution history
         last_status = job.get("last_status")
@@ -361,6 +364,7 @@ def cron_create(args):
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
+        interpreter=getattr(args, "interpreter", None),
         no_agent=getattr(args, "no_agent", False) or None,
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
@@ -384,6 +388,8 @@ def cron_create(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
+    if job_data.get("interpreter"):
+        print(f"  Python: {job_data['interpreter']}")
     print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0
@@ -432,6 +438,7 @@ def cron_edit(args):
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
+        interpreter=getattr(args, "interpreter", None),
         no_agent=getattr(args, "no_agent", None),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
@@ -458,6 +465,8 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    if updated.get("interpreter"):
+        print(f"  Python: {updated['interpreter']}")
     return 0
 
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -118,6 +118,16 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "monitors, incremental digests). First run is unchanged."
         ),
     )
+    cron_create.add_argument(
+        "--interpreter",
+        help=(
+            "Optional Python interpreter for --script or --monitor-script — an absolute or ~-prefixed "
+            "path to a Python executable in a user-managed venv (e.g. "
+            "~/venvs/reporting/bin/python3). Lets a Python script import packages "
+            "the Hermes runtime does not carry. Applies only to Python scripts; "
+            ".sh/.bash always run via bash. Omit to use Hermes' own Python."
+        ),
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -230,6 +240,14 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--provider",
         dest="model_provider",
         help="Inference provider paired with --model. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--interpreter",
+        help=(
+            "Optional Python interpreter for --script or --monitor-script — an absolute or ~-prefixed "
+            "path to a Python executable in a user-managed venv. Pass an empty string "
+            "to clear (revert to Hermes' own Python). Applies only to Python scripts."
+        ),
     )
 
     # lifecycle actions

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -105,6 +105,16 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="model_provider",
         help="Inference provider paired with --model (e.g. 'openrouter', 'nous').",
     )
+    cron_create.add_argument(
+        "--interpreter",
+        help=(
+            "Optional Python interpreter for --script or --monitor-script — an absolute or ~-prefixed "
+            "path to a Python executable in a user-managed venv (e.g. "
+            "~/venvs/reporting/bin/python3). Lets a Python script import packages "
+            "the Hermes runtime does not carry. Applies only to Python scripts; "
+            ".sh/.bash always run via bash. Omit to use Hermes' own Python."
+        ),
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -196,6 +206,14 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--provider",
         dest="model_provider",
         help="Inference provider paired with --model. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--interpreter",
+        help=(
+            "Optional Python interpreter for --script or --monitor-script — an absolute or ~-prefixed "
+            "path to a Python executable in a user-managed venv. Pass an empty string "
+            "to clear (revert to Hermes' own Python). Applies only to Python scripts."
+        ),
     )
 
     # lifecycle actions

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -367,3 +367,53 @@ def test_agent_job_provider_classification_unchanged(error, expected):
 
     job = {"name": "daily-digest", "no_agent": False}
     assert expected in _summarize_cron_failure_for_delivery(job, error)
+
+
+# ---------------------------------------------------------------------------
+# no_agent jobs honoring a configured Python interpreter
+# ---------------------------------------------------------------------------
+
+
+def test_run_job_no_agent_uses_configured_interpreter(hermes_env):
+    """A no-agent job's script must run through the configured interpreter.
+
+    Proves the override survives the no_agent branch of ``run_job`` →
+    ``_run_job_script_with_claim_heartbeat`` → ``_run_job_script``.
+    """
+    import os
+    import stat as _stat
+    import sys
+
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    # A wrapper that re-execs the real interpreter with an env marker.
+    wrapper = hermes_env / "scripts" / "python-wrapper"
+    wrapper.write_text(
+        f"#!{sys.executable}\n"
+        "import os, sys\n"
+        "env = os.environ.copy()\n"
+        'env["CRON_WRAPPER_USED"] = "1"\n'
+        "os.execve(sys.executable, [sys.executable, *sys.argv[1:]], env)\n"
+    )
+    wrapper.chmod(wrapper.stat().st_mode | _stat.S_IXUSR)
+
+    script_path = hermes_env / "scripts" / "marker.py"
+    script_path.write_text(
+        'import os\nprint(os.environ.get("CRON_WRAPPER_USED", "0"))\n'
+    )
+
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="marker.py",
+        no_agent=True,
+        deliver="local",
+        interpreter=str(wrapper),
+    )
+
+    success, doc, final_response, error = run_job(job)
+    assert success is True
+    assert error is None
+    assert final_response == "1"
+    assert "1" in doc

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -161,3 +161,51 @@ def test_run_job_script_nul_path_fails_cleanly(hermes_env):
     ok, output = _run_job_script("~user\x00bad.sh")
     assert ok is False
     assert "Blocked" in output
+# ---------------------------------------------------------------------------
+# no_agent jobs honoring a configured Python interpreter
+# ---------------------------------------------------------------------------
+
+
+def test_run_job_no_agent_uses_configured_interpreter(hermes_env):
+    """A no-agent job's script must run through the configured interpreter.
+
+    Proves the override survives the no_agent branch of ``run_job`` →
+    ``_run_job_script_with_claim_heartbeat`` → ``_run_job_script``.
+    """
+    import os
+    import stat as _stat
+    import sys
+
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    # A wrapper that re-execs the real interpreter with an env marker.
+    wrapper = hermes_env / "scripts" / "python-wrapper"
+    wrapper.write_text(
+        f"#!{sys.executable}\n"
+        "import os, sys\n"
+        "env = os.environ.copy()\n"
+        'env["CRON_WRAPPER_USED"] = "1"\n'
+        "os.execve(sys.executable, [sys.executable, *sys.argv[1:]], env)\n"
+    )
+    wrapper.chmod(wrapper.stat().st_mode | _stat.S_IXUSR)
+
+    script_path = hermes_env / "scripts" / "marker.py"
+    script_path.write_text(
+        'import os\nprint(os.environ.get("CRON_WRAPPER_USED", "0"))\n'
+    )
+
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="marker.py",
+        no_agent=True,
+        deliver="local",
+        interpreter=str(wrapper),
+    )
+
+    success, doc, final_response, error = run_job(job)
+    assert success is True
+    assert error is None
+    assert final_response == "1"
+    assert "1" in doc

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -10,11 +10,12 @@ Tests cover:
 import json
 import os
 import re
+import stat
 import sys
 import textwrap
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -67,6 +68,123 @@ class TestJobScriptField:
 
         updated = update_job(job["id"], {"script": "/new/script.py"})
         assert updated["script"] == "/new/script.py"
+
+    # --- interpreter field persistence ------------------------------------
+
+    def test_create_job_with_interpreter(self, cron_env):
+        from cron.jobs import create_job, get_job
+
+        job = create_job(
+            prompt="Analyze the data",
+            schedule="every 30m",
+            script="monitor.py",
+            interpreter="~/workspace/.venv/bin/python3",
+        )
+        assert job["interpreter"] == "~/workspace/.venv/bin/python3"
+
+        loaded = get_job(job["id"])
+        assert loaded["interpreter"] == "~/workspace/.venv/bin/python3"
+
+    def test_create_job_without_interpreter_has_no_field(self, cron_env):
+        from cron.jobs import create_job
+
+        job = create_job(prompt="Hello", schedule="every 1h", script="monitor.py")
+        # Absent (not a falsy sentinel) so existing records stay byte-identical.
+        assert "interpreter" not in job
+
+    def test_create_job_interpreter_whitespace_trimmed(self, cron_env):
+        from cron.jobs import create_job
+
+        job = create_job(
+            prompt="Hello",
+            schedule="every 1h",
+            script="monitor.py",
+            interpreter="  /opt/venv/bin/python  ",
+        )
+        assert job["interpreter"] == "/opt/venv/bin/python"
+
+    def test_create_job_empty_interpreter_normalized_to_absent(self, cron_env):
+        from cron.jobs import create_job
+
+        job = create_job(
+            prompt="Hello",
+            schedule="every 1h",
+            script="monitor.py",
+            interpreter="   ",
+        )
+        assert "interpreter" not in job
+
+    def test_update_job_set_interpreter(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        job = create_job(prompt="Hello", schedule="every 1h", script="monitor.py")
+        assert "interpreter" not in job
+
+        updated = update_job(job["id"], {"interpreter": "/opt/venv/bin/python"})
+        assert updated["interpreter"] == "/opt/venv/bin/python"
+
+    def test_update_job_clear_interpreter(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        job = create_job(
+            prompt="Hello",
+            schedule="every 1h",
+            script="monitor.py",
+            interpreter="/opt/venv/bin/python",
+        )
+        assert job["interpreter"] == "/opt/venv/bin/python"
+
+        updated = update_job(job["id"], {"interpreter": ""})
+        assert "interpreter" not in updated
+
+    def test_update_job_preserves_interpreter_when_absent(self, cron_env):
+        """A partial update that does not mention interpreter must keep it.
+
+        Desktop/web editors send only the fields they render; the field is
+        load-bearing for that preservation contract.
+        """
+        from cron.jobs import create_job, update_job
+
+        job = create_job(
+            prompt="Hello",
+            schedule="every 1h",
+            script="monitor.py",
+            interpreter="/opt/venv/bin/python",
+        )
+        updated = update_job(job["id"], {"prompt": "New prompt"})
+        assert updated["interpreter"] == "/opt/venv/bin/python"
+        assert updated["prompt"] == "New prompt"
+
+    def test_interpreter_coexists_with_inference_overrides(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        job = create_job(
+            prompt="Hello",
+            schedule="every 1h",
+            script="monitor.py",
+            model="model-a",
+            provider="provider-a",
+            base_url="https://example.invalid/v1",
+            interpreter="/opt/venv/bin/python",
+        )
+
+        assert job["model"] == "model-a"
+        assert job["provider"] == "provider-a"
+        assert job["base_url"] == "https://example.invalid/v1"
+        assert job["interpreter"] == "/opt/venv/bin/python"
+
+        updated = update_job(
+            job["id"],
+            {
+                "model": "model-b",
+                "interpreter": "/opt/venv/bin/python3",
+            },
+        )
+
+        assert updated["model"] == "model-b"
+        assert updated["provider"] == "provider-a"
+        assert updated["base_url"] == "https://example.invalid/v1"
+        assert updated["interpreter"] == "/opt/venv/bin/python3"
 
 
 def test_cronjob_tool_rejects_stale_past_one_shot(cron_env, monkeypatch):
@@ -399,6 +517,246 @@ class TestRunJobScript:
         assert isinstance(success, bool)
         assert isinstance(output, str)
         assert output  # a message is always produced, never a silent drop
+    # --- interpreter selection / validation --------------------------------
+
+    def test_default_python_uses_sys_executable(self, cron_env, monkeypatch):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        captured = {}
+
+        def capture_python(python_exe):
+            captured["python_exe"] = python_exe
+            return python_exe, {}
+
+        monkeypatch.setattr(sched_mod, "_windows_cron_python_invocation", capture_python)
+
+        success, output = _run_job_script("probe.py")
+        assert success is True
+        assert output == "ok"
+        assert captured["python_exe"] == sys.executable
+
+    def test_script_uses_configured_interpreter(self, cron_env):
+        """An external interpreter (absolute, executable) replaces sys.executable."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "uses_env.py"
+        script.write_text(textwrap.dedent("""\
+            import os
+            print(os.environ.get("CRON_WRAPPER_USED", "0"))
+        """))
+
+        # A wrapper that re-execs the real interpreter with an env marker so we
+        # can prove it was the one Hermes invoked.
+        wrapper = cron_env / "scripts" / "python-wrapper"
+        wrapper.write_text(textwrap.dedent(f"""\
+            #!{sys.executable}
+            import os
+            import sys
+
+            env = os.environ.copy()
+            env["CRON_WRAPPER_USED"] = "1"
+            os.execve(sys.executable, [sys.executable, *sys.argv[1:]], env)
+        """))
+        wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+
+        success, output = _run_job_script(str(script), interpreter=str(wrapper))
+        assert success is True
+        assert output == "1"
+
+    def test_script_uses_external_interpreter_importing_local_module(self, cron_env, tmp_path):
+        """A Python script can import a module only available to the external env.
+
+        Builds a throwaway stdlib venv (no network) and plants a tiny test-only
+        module into its site-packages, then asserts the cron script — run via
+        that interpreter — can import it.
+        """
+        import subprocess
+        import venv as _venv
+
+        from cron.scheduler import _run_job_script
+
+        ext_venv = tmp_path / "extvenv"
+        _venv.EnvBuilder(with_pip=False, symlinks=True, clear=True).create(str(ext_venv))
+        ext_python = ext_venv / ("Scripts" if os.name == "nt" else "bin") / (
+            "python.exe" if os.name == "nt" else "python"
+        )
+        assert ext_python.exists(), "external venv python was not created"
+
+        # Plant a test-only module into the venv's site-packages so only that
+        # interpreter can import it (Hermes' own interpreter cannot).
+        site_dir = subprocess.run(
+            [str(ext_python), "-c",
+             "import site,sys; print(next(p for p in site.getsitepackages() if 'packages' in p))"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        Path(site_dir, "cron_ext_marker.py").write_text(
+            "VALUE = 'from-external-venv'\n",
+            encoding="utf-8",
+        )
+
+        script = cron_env / "scripts" / "importer.py"
+        script.write_text(textwrap.dedent("""\
+            from cron_ext_marker import VALUE
+            print(VALUE)
+        """))
+
+        success, output = _run_job_script(str(script), interpreter=str(ext_python))
+        assert success is True
+        assert output == "from-external-venv"
+
+    def test_interpreter_tilde_expanded_at_run_time(self, cron_env, monkeypatch, tmp_path):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        # Put the interpreter under a temp HOME so "~" expands to tmp_path
+        # (expanduser reads the HOME env var, not Path.home()).
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        real_python = fake_home / "python-bin"
+        real_python.write_text("", encoding="utf-8")
+        real_python.chmod(real_python.stat().st_mode | stat.S_IXUSR)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        captured = {}
+
+        def capture_python(python_exe):
+            captured["python_exe"] = python_exe
+            return sys.executable, {}
+
+        monkeypatch.setattr(sched_mod, "_windows_cron_python_invocation", capture_python)
+
+        success, output = _run_job_script("probe.py", interpreter="~/python-bin")
+        assert success is True
+        assert output == "ok"
+        assert captured["python_exe"] == str(real_python)
+
+    def test_interpreter_relative_path_rejected(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        success, output = _run_job_script("probe.py", interpreter="python3")
+        assert success is False
+        assert "absolute" in output.lower()
+
+    def test_interpreter_missing_rejected(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        success, output = _run_job_script("probe.py", interpreter="/no/such/python")
+        assert success is False
+        assert "interpreter" in output.lower()
+
+    def test_interpreter_directory_rejected(self, cron_env, tmp_path):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        success, output = _run_job_script("probe.py", interpreter=str(tmp_path))
+        assert success is False
+        assert "not a file" in output.lower()
+
+    def test_interpreter_non_executable_rejected_on_posix(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        if sys.platform == "win32":
+            pytest.skip("executable bit is a POSIX-only check")
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        not_exec = cron_env / "scripts" / "python-noexec"
+        not_exec.write_text("", encoding="utf-8")
+        not_exec.chmod(0o644)  # explicitly NOT executable
+
+        success, output = _run_job_script("probe.py", interpreter=str(not_exec))
+        assert success is False
+        assert "execut" in output.lower()
+
+    def test_interpreter_ignored_for_shell_scripts(self, cron_env):
+        """``.sh``/``.bash`` always run under bash; the interpreter override
+        is a Python-script-only contract."""
+        from cron.scheduler import _run_job_script
+
+        # A shell script that prints which interpreter ran it would be ideal,
+        # but the simpler contract is: a present interpreter does not break the
+        # bash path, and bash still executes the script.
+        script = cron_env / "scripts" / "shelly.sh"
+        script.write_text("#!/bin/bash\necho 'shell ran'\n")
+
+        success, output = _run_job_script("shelly.sh", interpreter="/opt/venv/bin/python")
+        assert success is True
+        assert output == "shell ran"
+
+    def test_configured_interpreter_passes_through_windows_helper(self, cron_env, tmp_path, monkeypatch):
+        """The configured interpreter must still flow through the Windows
+        invocation helper (output capture / no-window behavior)."""
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        venv = tmp_path / "venv"
+        venv_scripts = venv / "Scripts"
+        site_packages = venv / "Lib" / "site-packages"
+        base = tmp_path / "base"
+        venv_scripts.mkdir(parents=True)
+        site_packages.mkdir(parents=True)
+        base.mkdir()
+        venv_python = venv_scripts / "python.exe"
+        base_python = base / "python.exe"
+        venv_python.write_text("", encoding="utf-8")
+        base_python.write_text("", encoding="utf-8")
+        (venv / "pyvenv.cfg").write_text(f"home = {base}\nuv = true\n", encoding="utf-8")
+
+        captured = {}
+
+        class FakeProc:
+            def __init__(self, argv, **kwargs):
+                captured["argv"] = argv
+                captured["kwargs"] = kwargs
+                self.returncode = 0
+
+            def poll(self):
+                return self.returncode
+
+            def communicate(self, timeout=None):
+                return ("ok\n", "")
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "win32")
+        monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", FakeProc)
+
+        success, output = _run_job_script("probe.py", interpreter=str(venv_python))
+
+        assert success is True
+        assert output == "ok"
+        # The helper bypassed the uv launcher and bootstrapped the venv's
+        # site-packages with the base Python executable.
+        assert captured["argv"][0] == str(base_python)
+        assert captured["argv"][1] == "-c"
+        assert "site.addsitedir" in captured["argv"][2]
+        assert captured["argv"][3] == str(script.resolve())
+        expected_flags = sched_mod.windows_hide_flags() | getattr(
+            sched_mod.subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        )
+        assert captured["kwargs"]["creationflags"] == expected_flags
+        assert captured["kwargs"]["env"]["VIRTUAL_ENV"] == str(venv)
 
 
 class TestBuildJobPromptWithScript:
@@ -439,6 +797,85 @@ class TestBuildJobPromptWithScript:
         assert "## Script Output" not in prompt
         assert "Simple job." in prompt
 
+    def test_build_job_prompt_passes_interpreter(self, cron_env):
+        """The inline prompt-build path must forward the interpreter to
+        ``_run_job_script`` (the path used when no precomputed result is
+        handed in)."""
+        from cron.scheduler import _build_job_prompt
+
+        script = cron_env / "scripts" / "collector.py"
+        script.write_text('print("ok")\n')
+
+        job = {
+            "prompt": "Report any notable changes.",
+            "script": str(script),
+            "interpreter": "~/workspace/.venv/bin/python3",
+        }
+
+        with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
+            prompt = _build_job_prompt(job)
+
+        mock_run.assert_called_once_with(
+            str(script), interpreter="~/workspace/.venv/bin/python3"
+        )
+        assert "## Script Output" in prompt
+
+
+class TestInterpreterPropagationThroughRunJob:
+    """The job-level interpreter must reach the script runner on every path."""
+
+    def test_run_job_wake_gate_passes_interpreter(self, cron_env):
+        from cron.scheduler import SILENT_MARKER, run_job
+
+        job = {
+            "id": "abc123def456",
+            "name": "wake-gated-job",
+            "prompt": "Report status.",
+            "schedule_display": "every 1h",
+            "script": "gate.py",
+            "interpreter": "~/workspace/.venv/bin/python3",
+        }
+
+        with patch(
+            "cron.scheduler._run_job_script_with_claim_heartbeat",
+            return_value=(True, '{"wakeAgent": false}'),
+        ) as mock_run:
+            success, output, final_response, error = run_job(job)
+
+        mock_run.assert_called_once()
+        # The wrapper receives the whole job; the interpreter is read from it.
+        _args, kwargs = mock_run.call_args
+        passed_job = kwargs.get("job") or (_args[0] if _args else None)
+        assert passed_job is not None
+        assert passed_job.get("interpreter") == "~/workspace/.venv/bin/python3"
+        assert success is True
+        assert "wakeAgent=false" in output
+        assert final_response == SILENT_MARKER
+        assert error is None
+
+    def test_claim_heartbeat_forwards_interpreter_to_runner(self, cron_env):
+        """The claim-heartbeat wrapper reads the interpreter off the job and
+        passes it down to ``_run_job_script`` on every internal call path."""
+        from cron.scheduler import _run_job_script_with_claim_heartbeat
+
+        # Recurring job → no durable one-shot claim → plain passthrough path.
+        job = {
+            "id": "rec123abc456",
+            "schedule": {"kind": "interval", "minutes": 5},
+            "script": "monitor.py",
+            "interpreter": "/opt/venv/bin/python",
+        }
+
+        with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
+            success, output = _run_job_script_with_claim_heartbeat(job, "monitor.py")
+
+        assert success is True
+        assert output == "ok"
+        mock_run.assert_called_once_with(
+            "monitor.py",
+            cancel_event=None,
+            interpreter="/opt/venv/bin/python",
+        )
 
 class TestCronjobToolScript:
     """Test the cronjob tool's script parameter."""
@@ -479,6 +916,79 @@ class TestCronjobToolScript:
         assert list_result["success"] is True
         assert len(list_result["jobs"]) == 1
         assert list_result["jobs"][0]["script"] == "data_collector.py"
+
+    def test_create_with_interpreter(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="monitor.py",
+            interpreter="~/venvs/reporting/bin/python3",
+        ))
+        assert result["success"] is True
+        assert result["job"]["script"] == "monitor.py"
+        assert result["job"]["interpreter"] == "~/venvs/reporting/bin/python3"
+
+    def test_update_interpreter(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="monitor.py",
+        ))
+        job_id = create_result["job_id"]
+        assert "interpreter" not in create_result["job"]
+
+        update_result = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            interpreter="~/venvs/reporting/bin/python3",
+        ))
+        assert update_result["success"] is True
+        assert update_result["job"]["interpreter"] == "~/venvs/reporting/bin/python3"
+
+    def test_clear_interpreter(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="monitor.py",
+            interpreter="~/venvs/reporting/bin/python3",
+        ))
+        job_id = create_result["job_id"]
+
+        update_result = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            interpreter="",
+        ))
+        assert update_result["success"] is True
+        assert "interpreter" not in update_result["job"]
+
+    def test_list_shows_interpreter(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="monitor.py",
+            interpreter="~/venvs/reporting/bin/python3",
+        )
+
+        list_result = json.loads(cronjob(action="list"))
+        assert list_result["success"] is True
+        assert list_result["jobs"][0]["interpreter"] == "~/venvs/reporting/bin/python3"
 
 
 class TestScriptPathContainment:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -911,13 +911,15 @@ class TestInterpreterPropagationThroughRunJob:
         }
 
         with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
-            success, output = _run_job_script_with_claim_heartbeat(job, "monitor.py")
+            success, output = _run_job_script_with_claim_heartbeat(
+                job, "monitor.py", workdir="/srv/reporting"
+            )
 
         assert success is True
         assert output == "ok"
         mock_run.assert_called_once_with(
             "monitor.py",
-            workdir=None,
+            workdir="/srv/reporting",
             cancel_event=None,
             interpreter="/opt/venv/bin/python",
         )
@@ -978,13 +980,15 @@ class TestInterpreterPropagationThroughRunJob:
         monkeypatch.setattr(sched_mod.threading, "Thread", _BrokenThread)
 
         with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
-            success, output = _run_job_script_with_claim_heartbeat(job, "oneshot.py")
+            success, output = _run_job_script_with_claim_heartbeat(
+                job, "oneshot.py", workdir="/srv/fallback"
+            )
 
         assert success is True
         assert output == "ok"
         mock_run.assert_called_once_with(
             "oneshot.py",
-            workdir=None,
+            workdir="/srv/fallback",
             cancel_event=None,
             interpreter="/opt/venv/bin/python",
         )

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -1045,6 +1045,35 @@ class TestCronjobToolScript:
         assert result["job"]["script"] == "monitor.py"
         assert result["job"]["interpreter"] == "~/venvs/reporting/bin/python3"
 
+    def test_cronjob_positional_task_id_not_shifted_by_interpreter(self, cron_env, monkeypatch):
+        """``interpreter`` must not break positional callers of ``cronjob()``.
+
+        Existing callers may pass the trailing monitor/task/session fields
+        positionally. ``interpreter`` is appended after ``session_id`` so none
+        of those established slots can be rebound to an interpreter path.
+        """
+        import inspect
+        from tools.cronjob_tools import cronjob
+
+        params = list(inspect.signature(cronjob).parameters)
+        assert params.index("interpreter") > params.index("task_id")
+        assert params.index("interpreter") > params.index("session_id")
+
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        # Simulate a positional call through task_id. ``interpreter`` stays at
+        # its default; a wrong signature order would persist the task id as a
+        # bogus interpreter path.
+        positional = [None] * (params.index("task_id") + 1)
+        positional[0] = "create"            # action
+        positional[2] = "Monitor things"    # prompt
+        positional[3] = "every 1h"          # schedule
+        positional[14] = "monitor.py"       # script
+        positional[params.index("task_id")] = "legacy-task-id"
+        result = json.loads(cronjob(*positional))
+        assert result["success"] is True
+        # No interpreter was supplied; the task id must not leak into the job.
+        assert "interpreter" not in result["job"]
+
     def test_update_interpreter(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -92,6 +92,29 @@ class TestJobScriptField:
         # Absent (not a falsy sentinel) so existing records stay byte-identical.
         assert "interpreter" not in job
 
+    def test_no_agent_positional_arg_not_shifted_by_interpreter(self, cron_env):
+        """The new ``interpreter`` param must not break positional callers.
+
+        ``interpreter`` is appended AFTER ``no_agent``/``attach_to_session`` so
+        an existing positional call like ``create_job(p, sched, script=..., True)``
+        keeps binding ``True`` to ``no_agent`` — not silently to ``interpreter``,
+        which would flip a no-agent watchdog into an LLM job.
+        """
+        import inspect
+        from cron.jobs import create_job
+
+        params = list(inspect.signature(create_job).parameters)
+        # interpreter must come after both no_agent and attach_to_session.
+        assert params.index("interpreter") > params.index("no_agent")
+        assert params.index("interpreter") > params.index("attach_to_session")
+        assert params.index("interpreter") > params.index("monitor_script")
+        assert params.index("interpreter") > params.index("monitor_url")
+
+        # And the real positional call must still set no_agent=True.
+        job = create_job(None, "every 5m", script="w.sh", no_agent=True)
+        assert job["no_agent"] is True
+        assert "interpreter" not in job
+
     def test_create_job_interpreter_whitespace_trimmed(self, cron_env):
         from cron.jobs import create_job
 
@@ -684,6 +707,27 @@ class TestRunJobScript:
         assert success is False
         assert "execut" in output.lower()
 
+    def test_interpreter_unknown_user_does_not_raise(self, cron_env):
+        """A ``~unknown-user/...`` interpreter must NOT escape as a RuntimeError.
+
+        ``Path.expanduser()`` raises ``RuntimeError: Could not determine home
+        directory`` for an unknown user. The resolver must convert that into its
+        ``(False, message)`` contract so the cron tick surfaces a clear
+        scheduled-run failure instead of crashing the scheduler.
+        """
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        # An extremely unlikely-to-exist user name so expanduser() fails to
+        # resolve a home directory regardless of the test host.
+        success, output = _run_job_script(
+            "probe.py", interpreter="~definitely-no-such-user-zzz/python"
+        )
+        assert success is False
+        assert "interpreter" in output.lower() or "resolve" in output.lower()
+
     def test_interpreter_ignored_for_shell_scripts(self, cron_env):
         """``.sh``/``.bash`` always run under bash; the interpreter override
         is a Python-script-only contract."""
@@ -873,9 +917,78 @@ class TestInterpreterPropagationThroughRunJob:
         assert output == "ok"
         mock_run.assert_called_once_with(
             "monitor.py",
+            workdir=None,
             cancel_event=None,
             interpreter="/opt/venv/bin/python",
         )
+
+    def test_one_shot_heartbeat_forwards_interpreter_to_runner(self, cron_env, monkeypatch):
+        """The one-shot claim-heartbeat path (the threaded branch) must also
+        forward the interpreter to ``_run_job_script``."""
+        from cron.scheduler import _run_job_script_with_claim_heartbeat
+
+        # A claimed one-shot job triggers the heartbeat-threaded branch.
+        job = {
+            "id": "once123abc456",
+            "schedule": {"kind": "once"},
+            "script": "oneshot.py",
+            "interpreter": "/opt/venv/bin/python",
+            "run_claim": {"by": "owner-xyz"},
+        }
+        # Keep the heartbeat snappy and no-op so the test doesn't hit storage.
+        monkeypatch.setattr("cron.scheduler._RUN_CLAIM_HEARTBEAT_SECONDS", 3600)
+        monkeypatch.setattr("cron.scheduler.heartbeat_run_claim", lambda *a, **k: None)
+
+        with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
+            success, output = _run_job_script_with_claim_heartbeat(job, "oneshot.py")
+
+        assert success is True
+        assert output == "ok"
+        mock_run.assert_called_once_with(
+            "oneshot.py",
+            workdir=None,
+            cancel_event=None,
+            interpreter="/opt/venv/bin/python",
+        )
+
+    def test_heartbeat_start_failure_falls_back_with_interpreter(self, cron_env, monkeypatch):
+        """When the heartbeat thread cannot start, the wrapper falls back to a
+        direct ``_run_job_script`` call — the interpreter must survive that
+        fallback path too."""
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script_with_claim_heartbeat
+
+        job = {
+            "id": "once456abc789",
+            "schedule": {"kind": "once"},
+            "script": "oneshot.py",
+            "interpreter": "/opt/venv/bin/python",
+            "run_claim": {"by": "owner-xyz"},
+        }
+        monkeypatch.setattr("cron.scheduler._RUN_CLAIM_HEARTBEAT_SECONDS", 3600)
+        monkeypatch.setattr("cron.scheduler.heartbeat_run_claim", lambda *a, **k: None)
+
+        # Force Thread.start() to raise so the wrapper takes the fallback branch.
+        real_thread = sched_mod.threading.Thread
+
+        class _BrokenThread(real_thread):
+            def start(self):
+                raise RuntimeError("cannot start thread")
+
+        monkeypatch.setattr(sched_mod.threading, "Thread", _BrokenThread)
+
+        with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
+            success, output = _run_job_script_with_claim_heartbeat(job, "oneshot.py")
+
+        assert success is True
+        assert output == "ok"
+        mock_run.assert_called_once_with(
+            "oneshot.py",
+            workdir=None,
+            cancel_event=None,
+            interpreter="/opt/venv/bin/python",
+        )
+
 
 class TestCronjobToolScript:
     """Test the cronjob tool's script parameter."""

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -740,12 +740,16 @@ class TestInterpreterPropagationThroughRunJob:
         }
 
         with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
-            success, output = _run_job_script_with_claim_heartbeat(job, "monitor.py")
+            success, output = _run_job_script_with_claim_heartbeat(
+                job, "monitor.py", workdir="/srv/reporting"
+            )
 
         assert success is True
         assert output == "ok"
         mock_run.assert_called_once_with(
-            "monitor.py", workdir=None, interpreter="/opt/venv/bin/python"
+            "monitor.py",
+            workdir="/srv/reporting",
+            interpreter="/opt/venv/bin/python",
         )
 
     def test_one_shot_heartbeat_forwards_interpreter_to_runner(self, cron_env, monkeypatch):
@@ -801,12 +805,16 @@ class TestInterpreterPropagationThroughRunJob:
         monkeypatch.setattr(sched_mod.threading, "Thread", _BrokenThread)
 
         with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
-            success, output = _run_job_script_with_claim_heartbeat(job, "oneshot.py")
+            success, output = _run_job_script_with_claim_heartbeat(
+                job, "oneshot.py", workdir="/srv/fallback"
+            )
 
         assert success is True
         assert output == "ok"
         mock_run.assert_called_once_with(
-            "oneshot.py", workdir=None, interpreter="/opt/venv/bin/python"
+            "oneshot.py",
+            workdir="/srv/fallback",
+            interpreter="/opt/venv/bin/python",
         )
 
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -92,6 +92,29 @@ class TestJobScriptField:
         # Absent (not a falsy sentinel) so existing records stay byte-identical.
         assert "interpreter" not in job
 
+    def test_no_agent_positional_arg_not_shifted_by_interpreter(self, cron_env):
+        """The new ``interpreter`` param must not break positional callers.
+
+        ``interpreter`` is appended AFTER ``no_agent``/``attach_to_session`` so
+        an existing positional call like ``create_job(p, sched, script=..., True)``
+        keeps binding ``True`` to ``no_agent`` — not silently to ``interpreter``,
+        which would flip a no-agent watchdog into an LLM job.
+        """
+        import inspect
+        from cron.jobs import create_job
+
+        params = list(inspect.signature(create_job).parameters)
+        # interpreter must come after both no_agent and attach_to_session.
+        assert params.index("interpreter") > params.index("no_agent")
+        assert params.index("interpreter") > params.index("attach_to_session")
+        assert params.index("interpreter") > params.index("monitor_script")
+        assert params.index("interpreter") > params.index("monitor_url")
+
+        # And the real positional call must still set no_agent=True.
+        job = create_job(None, "every 5m", script="w.sh", no_agent=True)
+        assert job["no_agent"] is True
+        assert "interpreter" not in job
+
     def test_create_job_interpreter_whitespace_trimmed(self, cron_env):
         from cron.jobs import create_job
 
@@ -530,6 +553,27 @@ class TestRunJobScript:
         assert success is False
         assert "execut" in output.lower()
 
+    def test_interpreter_unknown_user_does_not_raise(self, cron_env):
+        """A ``~unknown-user/...`` interpreter must NOT escape as a RuntimeError.
+
+        ``Path.expanduser()`` raises ``RuntimeError: Could not determine home
+        directory`` for an unknown user. The resolver must convert that into its
+        ``(False, message)`` contract so the cron tick surfaces a clear
+        scheduled-run failure instead of crashing the scheduler.
+        """
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        # An extremely unlikely-to-exist user name so expanduser() fails to
+        # resolve a home directory regardless of the test host.
+        success, output = _run_job_script(
+            "probe.py", interpreter="~definitely-no-such-user-zzz/python"
+        )
+        assert success is False
+        assert "interpreter" in output.lower() or "resolve" in output.lower()
+
     def test_interpreter_ignored_for_shell_scripts(self, cron_env):
         """``.sh``/``.bash`` always run under bash; the interpreter override
         is a Python-script-only contract."""
@@ -701,8 +745,70 @@ class TestInterpreterPropagationThroughRunJob:
         assert success is True
         assert output == "ok"
         mock_run.assert_called_once_with(
-            "monitor.py", interpreter="/opt/venv/bin/python"
+            "monitor.py", workdir=None, interpreter="/opt/venv/bin/python"
         )
+
+    def test_one_shot_heartbeat_forwards_interpreter_to_runner(self, cron_env, monkeypatch):
+        """The one-shot claim-heartbeat path (the threaded branch) must also
+        forward the interpreter to ``_run_job_script``."""
+        from cron.scheduler import _run_job_script_with_claim_heartbeat
+
+        # A claimed one-shot job triggers the heartbeat-threaded branch.
+        job = {
+            "id": "once123abc456",
+            "schedule": {"kind": "once"},
+            "script": "oneshot.py",
+            "interpreter": "/opt/venv/bin/python",
+            "run_claim": {"by": "owner-xyz"},
+        }
+        # Keep the heartbeat snappy and no-op so the test doesn't hit storage.
+        monkeypatch.setattr("cron.scheduler._RUN_CLAIM_HEARTBEAT_SECONDS", 3600)
+        monkeypatch.setattr("cron.scheduler.heartbeat_run_claim", lambda *a, **k: None)
+
+        with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
+            success, output = _run_job_script_with_claim_heartbeat(job, "oneshot.py")
+
+        assert success is True
+        assert output == "ok"
+        mock_run.assert_called_once_with(
+            "oneshot.py", workdir=None, interpreter="/opt/venv/bin/python"
+        )
+
+    def test_heartbeat_start_failure_falls_back_with_interpreter(self, cron_env, monkeypatch):
+        """When the heartbeat thread cannot start, the wrapper falls back to a
+        direct ``_run_job_script`` call — the interpreter must survive that
+        fallback path too."""
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script_with_claim_heartbeat
+
+        job = {
+            "id": "once456abc789",
+            "schedule": {"kind": "once"},
+            "script": "oneshot.py",
+            "interpreter": "/opt/venv/bin/python",
+            "run_claim": {"by": "owner-xyz"},
+        }
+        monkeypatch.setattr("cron.scheduler._RUN_CLAIM_HEARTBEAT_SECONDS", 3600)
+        monkeypatch.setattr("cron.scheduler.heartbeat_run_claim", lambda *a, **k: None)
+
+        # Force Thread.start() to raise so the wrapper takes the fallback branch.
+        real_thread = sched_mod.threading.Thread
+
+        class _BrokenThread(real_thread):
+            def start(self):
+                raise RuntimeError("cannot start thread")
+
+        monkeypatch.setattr(sched_mod.threading, "Thread", _BrokenThread)
+
+        with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
+            success, output = _run_job_script_with_claim_heartbeat(job, "oneshot.py")
+
+        assert success is True
+        assert output == "ok"
+        mock_run.assert_called_once_with(
+            "oneshot.py", workdir=None, interpreter="/opt/venv/bin/python"
+        )
+
 
 class TestCronjobToolScript:
     """Test the cronjob tool's script parameter."""

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -9,11 +9,13 @@ Tests cover:
 
 import json
 import os
+import stat
 import sys
 import textwrap
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -66,6 +68,123 @@ class TestJobScriptField:
 
         updated = update_job(job["id"], {"script": "/new/script.py"})
         assert updated["script"] == "/new/script.py"
+
+    # --- interpreter field persistence ------------------------------------
+
+    def test_create_job_with_interpreter(self, cron_env):
+        from cron.jobs import create_job, get_job
+
+        job = create_job(
+            prompt="Analyze the data",
+            schedule="every 30m",
+            script="monitor.py",
+            interpreter="~/workspace/.venv/bin/python3",
+        )
+        assert job["interpreter"] == "~/workspace/.venv/bin/python3"
+
+        loaded = get_job(job["id"])
+        assert loaded["interpreter"] == "~/workspace/.venv/bin/python3"
+
+    def test_create_job_without_interpreter_has_no_field(self, cron_env):
+        from cron.jobs import create_job
+
+        job = create_job(prompt="Hello", schedule="every 1h", script="monitor.py")
+        # Absent (not a falsy sentinel) so existing records stay byte-identical.
+        assert "interpreter" not in job
+
+    def test_create_job_interpreter_whitespace_trimmed(self, cron_env):
+        from cron.jobs import create_job
+
+        job = create_job(
+            prompt="Hello",
+            schedule="every 1h",
+            script="monitor.py",
+            interpreter="  /opt/venv/bin/python  ",
+        )
+        assert job["interpreter"] == "/opt/venv/bin/python"
+
+    def test_create_job_empty_interpreter_normalized_to_absent(self, cron_env):
+        from cron.jobs import create_job
+
+        job = create_job(
+            prompt="Hello",
+            schedule="every 1h",
+            script="monitor.py",
+            interpreter="   ",
+        )
+        assert "interpreter" not in job
+
+    def test_update_job_set_interpreter(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        job = create_job(prompt="Hello", schedule="every 1h", script="monitor.py")
+        assert "interpreter" not in job
+
+        updated = update_job(job["id"], {"interpreter": "/opt/venv/bin/python"})
+        assert updated["interpreter"] == "/opt/venv/bin/python"
+
+    def test_update_job_clear_interpreter(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        job = create_job(
+            prompt="Hello",
+            schedule="every 1h",
+            script="monitor.py",
+            interpreter="/opt/venv/bin/python",
+        )
+        assert job["interpreter"] == "/opt/venv/bin/python"
+
+        updated = update_job(job["id"], {"interpreter": ""})
+        assert "interpreter" not in updated
+
+    def test_update_job_preserves_interpreter_when_absent(self, cron_env):
+        """A partial update that does not mention interpreter must keep it.
+
+        Desktop/web editors send only the fields they render; the field is
+        load-bearing for that preservation contract.
+        """
+        from cron.jobs import create_job, update_job
+
+        job = create_job(
+            prompt="Hello",
+            schedule="every 1h",
+            script="monitor.py",
+            interpreter="/opt/venv/bin/python",
+        )
+        updated = update_job(job["id"], {"prompt": "New prompt"})
+        assert updated["interpreter"] == "/opt/venv/bin/python"
+        assert updated["prompt"] == "New prompt"
+
+    def test_interpreter_coexists_with_inference_overrides(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        job = create_job(
+            prompt="Hello",
+            schedule="every 1h",
+            script="monitor.py",
+            model="model-a",
+            provider="provider-a",
+            base_url="https://example.invalid/v1",
+            interpreter="/opt/venv/bin/python",
+        )
+
+        assert job["model"] == "model-a"
+        assert job["provider"] == "provider-a"
+        assert job["base_url"] == "https://example.invalid/v1"
+        assert job["interpreter"] == "/opt/venv/bin/python"
+
+        updated = update_job(
+            job["id"],
+            {
+                "model": "model-b",
+                "interpreter": "/opt/venv/bin/python3",
+            },
+        )
+
+        assert updated["model"] == "model-b"
+        assert updated["provider"] == "provider-a"
+        assert updated["base_url"] == "https://example.invalid/v1"
+        assert updated["interpreter"] == "/opt/venv/bin/python3"
 
 
 def test_cronjob_tool_rejects_stale_past_one_shot(cron_env, monkeypatch):
@@ -246,6 +365,227 @@ class TestRunJobScript:
         assert isinstance(success, bool)
         assert isinstance(output, str)
         assert output  # a message is always produced, never a silent drop
+    # --- interpreter selection / validation --------------------------------
+
+    def test_default_python_uses_sys_executable(self, cron_env, monkeypatch):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+
+        success, output = _run_job_script("probe.py")
+        assert success is True
+        assert captured["argv"][0] == sys.executable
+
+    def test_script_uses_configured_interpreter(self, cron_env):
+        """An external interpreter (absolute, executable) replaces sys.executable."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "uses_env.py"
+        script.write_text(textwrap.dedent("""\
+            import os
+            print(os.environ.get("CRON_WRAPPER_USED", "0"))
+        """))
+
+        # A wrapper that re-execs the real interpreter with an env marker so we
+        # can prove it was the one Hermes invoked.
+        wrapper = cron_env / "scripts" / "python-wrapper"
+        wrapper.write_text(textwrap.dedent(f"""\
+            #!{sys.executable}
+            import os
+            import sys
+
+            env = os.environ.copy()
+            env["CRON_WRAPPER_USED"] = "1"
+            os.execve(sys.executable, [sys.executable, *sys.argv[1:]], env)
+        """))
+        wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+
+        success, output = _run_job_script(str(script), interpreter=str(wrapper))
+        assert success is True
+        assert output == "1"
+
+    def test_script_uses_external_interpreter_importing_local_module(self, cron_env, tmp_path):
+        """A Python script can import a module only available to the external env.
+
+        Builds a throwaway stdlib venv (no network) and plants a tiny test-only
+        module into its site-packages, then asserts the cron script — run via
+        that interpreter — can import it.
+        """
+        import subprocess
+        import venv as _venv
+
+        from cron.scheduler import _run_job_script
+
+        ext_venv = tmp_path / "extvenv"
+        _venv.EnvBuilder(with_pip=False, symlinks=True, clear=True).create(str(ext_venv))
+        ext_python = ext_venv / ("Scripts" if os.name == "nt" else "bin") / (
+            "python.exe" if os.name == "nt" else "python"
+        )
+        assert ext_python.exists(), "external venv python was not created"
+
+        # Plant a test-only module into the venv's site-packages so only that
+        # interpreter can import it (Hermes' own interpreter cannot).
+        site_dir = subprocess.run(
+            [str(ext_python), "-c",
+             "import site,sys; print(next(p for p in site.getsitepackages() if 'packages' in p))"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        Path(site_dir, "cron_ext_marker.py").write_text(
+            "VALUE = 'from-external-venv'\n",
+            encoding="utf-8",
+        )
+
+        script = cron_env / "scripts" / "importer.py"
+        script.write_text(textwrap.dedent("""\
+            from cron_ext_marker import VALUE
+            print(VALUE)
+        """))
+
+        success, output = _run_job_script(str(script), interpreter=str(ext_python))
+        assert success is True
+        assert output == "from-external-venv"
+
+    def test_interpreter_tilde_expanded_at_run_time(self, cron_env, monkeypatch, tmp_path):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        # Put the interpreter under a temp HOME so "~" expands to tmp_path
+        # (expanduser reads the HOME env var, not Path.home()).
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        real_python = fake_home / "python-bin"
+        real_python.write_text("", encoding="utf-8")
+        real_python.chmod(real_python.stat().st_mode | stat.S_IXUSR)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+
+        success, output = _run_job_script("probe.py", interpreter="~/python-bin")
+        assert success is True
+        assert captured["argv"][0] == str(real_python)
+
+    def test_interpreter_relative_path_rejected(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        success, output = _run_job_script("probe.py", interpreter="python3")
+        assert success is False
+        assert "absolute" in output.lower()
+
+    def test_interpreter_missing_rejected(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        success, output = _run_job_script("probe.py", interpreter="/no/such/python")
+        assert success is False
+        assert "interpreter" in output.lower()
+
+    def test_interpreter_directory_rejected(self, cron_env, tmp_path):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        success, output = _run_job_script("probe.py", interpreter=str(tmp_path))
+        assert success is False
+        assert "not a file" in output.lower()
+
+    def test_interpreter_non_executable_rejected_on_posix(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        if sys.platform == "win32":
+            pytest.skip("executable bit is a POSIX-only check")
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        not_exec = cron_env / "scripts" / "python-noexec"
+        not_exec.write_text("", encoding="utf-8")
+        not_exec.chmod(0o644)  # explicitly NOT executable
+
+        success, output = _run_job_script("probe.py", interpreter=str(not_exec))
+        assert success is False
+        assert "execut" in output.lower()
+
+    def test_interpreter_ignored_for_shell_scripts(self, cron_env):
+        """``.sh``/``.bash`` always run under bash; the interpreter override
+        is a Python-script-only contract."""
+        from cron.scheduler import _run_job_script
+
+        # A shell script that prints which interpreter ran it would be ideal,
+        # but the simpler contract is: a present interpreter does not break the
+        # bash path, and bash still executes the script.
+        script = cron_env / "scripts" / "shelly.sh"
+        script.write_text("#!/bin/bash\necho 'shell ran'\n")
+
+        success, output = _run_job_script("shelly.sh", interpreter="/opt/venv/bin/python")
+        assert success is True
+        assert output == "shell ran"
+
+    def test_configured_interpreter_passes_through_windows_helper(self, cron_env, tmp_path, monkeypatch):
+        """The configured interpreter must still flow through the Windows
+        invocation helper (output capture / no-window behavior)."""
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        venv = tmp_path / "venv"
+        venv_scripts = venv / "Scripts"
+        site_packages = venv / "Lib" / "site-packages"
+        base = tmp_path / "base"
+        venv_scripts.mkdir(parents=True)
+        site_packages.mkdir(parents=True)
+        base.mkdir()
+        venv_python = venv_scripts / "python.exe"
+        base_python = base / "python.exe"
+        venv_python.write_text("", encoding="utf-8")
+        base_python.write_text("", encoding="utf-8")
+        (venv / "pyvenv.cfg").write_text(f"home = {base}\nuv = true\n", encoding="utf-8")
+
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "win32")
+        monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+
+        success, output = _run_job_script("probe.py", interpreter=str(venv_python))
+
+        assert success is True
+        assert output == "ok"
+        # The helper bypassed the uv launcher and ran the base python directly.
+        assert captured["argv"][0] == str(base_python)
+        assert captured["kwargs"]["creationflags"] == 0x08000000
+        assert captured["kwargs"]["env"]["VIRTUAL_ENV"] == str(venv)
 
 
 class TestBuildJobPromptWithScript:
@@ -286,6 +626,83 @@ class TestBuildJobPromptWithScript:
         assert "## Script Output" not in prompt
         assert "Simple job." in prompt
 
+    def test_build_job_prompt_passes_interpreter(self, cron_env):
+        """The inline prompt-build path must forward the interpreter to
+        ``_run_job_script`` (the path used when no precomputed result is
+        handed in)."""
+        from cron.scheduler import _build_job_prompt
+
+        script = cron_env / "scripts" / "collector.py"
+        script.write_text('print("ok")\n')
+
+        job = {
+            "prompt": "Report any notable changes.",
+            "script": str(script),
+            "interpreter": "~/workspace/.venv/bin/python3",
+        }
+
+        with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
+            prompt = _build_job_prompt(job)
+
+        mock_run.assert_called_once_with(
+            str(script), interpreter="~/workspace/.venv/bin/python3"
+        )
+        assert "## Script Output" in prompt
+
+
+class TestInterpreterPropagationThroughRunJob:
+    """The job-level interpreter must reach the script runner on every path."""
+
+    def test_run_job_wake_gate_passes_interpreter(self, cron_env):
+        from cron.scheduler import SILENT_MARKER, run_job
+
+        job = {
+            "id": "abc123def456",
+            "name": "wake-gated-job",
+            "prompt": "Report status.",
+            "schedule_display": "every 1h",
+            "script": "gate.py",
+            "interpreter": "~/workspace/.venv/bin/python3",
+        }
+
+        with patch(
+            "cron.scheduler._run_job_script_with_claim_heartbeat",
+            return_value=(True, '{"wakeAgent": false}'),
+        ) as mock_run:
+            success, output, final_response, error = run_job(job)
+
+        mock_run.assert_called_once()
+        # The wrapper receives the whole job; the interpreter is read from it.
+        _args, kwargs = mock_run.call_args
+        passed_job = kwargs.get("job") or (_args[0] if _args else None)
+        assert passed_job is not None
+        assert passed_job.get("interpreter") == "~/workspace/.venv/bin/python3"
+        assert success is True
+        assert "wakeAgent=false" in output
+        assert final_response == SILENT_MARKER
+        assert error is None
+
+    def test_claim_heartbeat_forwards_interpreter_to_runner(self, cron_env):
+        """The claim-heartbeat wrapper reads the interpreter off the job and
+        passes it down to ``_run_job_script`` on every internal call path."""
+        from cron.scheduler import _run_job_script_with_claim_heartbeat
+
+        # Recurring job → no durable one-shot claim → plain passthrough path.
+        job = {
+            "id": "rec123abc456",
+            "schedule": {"kind": "interval", "minutes": 5},
+            "script": "monitor.py",
+            "interpreter": "/opt/venv/bin/python",
+        }
+
+        with patch("cron.scheduler._run_job_script", return_value=(True, "ok")) as mock_run:
+            success, output = _run_job_script_with_claim_heartbeat(job, "monitor.py")
+
+        assert success is True
+        assert output == "ok"
+        mock_run.assert_called_once_with(
+            "monitor.py", interpreter="/opt/venv/bin/python"
+        )
 
 class TestCronjobToolScript:
     """Test the cronjob tool's script parameter."""
@@ -326,6 +743,79 @@ class TestCronjobToolScript:
         assert list_result["success"] is True
         assert len(list_result["jobs"]) == 1
         assert list_result["jobs"][0]["script"] == "data_collector.py"
+
+    def test_create_with_interpreter(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="monitor.py",
+            interpreter="~/venvs/reporting/bin/python3",
+        ))
+        assert result["success"] is True
+        assert result["job"]["script"] == "monitor.py"
+        assert result["job"]["interpreter"] == "~/venvs/reporting/bin/python3"
+
+    def test_update_interpreter(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="monitor.py",
+        ))
+        job_id = create_result["job_id"]
+        assert "interpreter" not in create_result["job"]
+
+        update_result = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            interpreter="~/venvs/reporting/bin/python3",
+        ))
+        assert update_result["success"] is True
+        assert update_result["job"]["interpreter"] == "~/venvs/reporting/bin/python3"
+
+    def test_clear_interpreter(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="monitor.py",
+            interpreter="~/venvs/reporting/bin/python3",
+        ))
+        job_id = create_result["job_id"]
+
+        update_result = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            interpreter="",
+        ))
+        assert update_result["success"] is True
+        assert "interpreter" not in update_result["job"]
+
+    def test_list_shows_interpreter(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="monitor.py",
+            interpreter="~/venvs/reporting/bin/python3",
+        )
+
+        list_result = json.loads(cronjob(action="list"))
+        assert list_result["success"] is True
+        assert list_result["jobs"][0]["interpreter"] == "~/venvs/reporting/bin/python3"
 
 
 class TestScriptPathContainment:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -865,6 +865,35 @@ class TestCronjobToolScript:
         assert result["job"]["script"] == "monitor.py"
         assert result["job"]["interpreter"] == "~/venvs/reporting/bin/python3"
 
+    def test_cronjob_positional_task_id_not_shifted_by_interpreter(self, cron_env, monkeypatch):
+        """``interpreter`` must not break positional callers of ``cronjob()``.
+
+        Existing callers may pass the trailing monitor/task/session fields
+        positionally. ``interpreter`` is appended after ``session_id`` so none
+        of those established slots can be rebound to an interpreter path.
+        """
+        import inspect
+        from tools.cronjob_tools import cronjob
+
+        params = list(inspect.signature(cronjob).parameters)
+        assert params.index("interpreter") > params.index("task_id")
+        assert params.index("interpreter") > params.index("session_id")
+
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        # Simulate a positional call through task_id. ``interpreter`` stays at
+        # its default; a wrong signature order would persist the task id as a
+        # bogus interpreter path.
+        positional = [None] * (params.index("task_id") + 1)
+        positional[0] = "create"            # action
+        positional[2] = "Monitor things"    # prompt
+        positional[3] = "every 1h"          # schedule
+        positional[14] = "monitor.py"       # script
+        positional[params.index("task_id")] = "legacy-task-id"
+        result = json.loads(cronjob(*positional))
+        assert result["success"] is True
+        # No interpreter was supplied; the task id must not leak into the job.
+        assert "interpreter" not in result["job"]
+
     def test_update_interpreter(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -292,6 +292,45 @@ def test_first_run_always_runs_agent(hermes_env, monkeypatch):
     assert "state A" in observed["prompts"][0]
 
 
+def test_monitor_script_uses_configured_interpreter(hermes_env, monkeypatch):
+    """A monitor script uses the same job-level interpreter as `script`."""
+    import stat
+
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    wrapper = hermes_env / "scripts" / "python-wrapper"
+    wrapper.write_text(
+        f"#!{sys.executable}\n"
+        "import os, sys\n"
+        "env = os.environ.copy()\n"
+        'env["CRON_MONITOR_WRAPPER_USED"] = "1"\n'
+        "os.execve(sys.executable, [sys.executable, *sys.argv[1:]], env)\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+    _write_script(
+        hermes_env,
+        "mon.py",
+        'import os\nprint(os.environ.get("CRON_MONITOR_WRAPPER_USED", "0"))\n',
+    )
+    job = create_job(
+        prompt="React to the change",
+        schedule="every 5m",
+        monitor_script="mon.py",
+        interpreter=str(wrapper),
+        deliver="local",
+    )
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    success, _, _, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert "1" in observed["prompts"][0]
+
+
 def test_unchanged_output_suppresses_agent_run(hermes_env, monkeypatch):
     from cron.jobs import get_job
     from cron.scheduler import SILENT_MARKER, run_job

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -383,3 +383,135 @@ class TestCronRunBackgroundDispatch:
         assert rc == 0
         assert "Running in background (delegation del-xyz)." in out
         assert "failed" not in out.lower()
+
+
+class TestCronInterpreterCli:
+    """``hermes cron create/edit`` plumb the ``--interpreter`` flag through."""
+
+    def test_create_passes_interpreter_to_api(self, monkeypatch):
+        captured = {}
+
+        def fake_api(**kwargs):
+            captured.update(kwargs)
+            return {
+                "success": True,
+                "job_id": "job-1",
+                "name": "Report",
+                "schedule": "0 8 * * *",
+                "skills": [],
+                "next_run_at": "2026-06-01T00:00:00Z",
+                "job": {"interpreter": "~/venvs/reporting/bin/python3"},
+            }
+
+        monkeypatch.setattr(cron_cli, "_cron_api", fake_api)
+        monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+        args = SimpleNamespace(
+            schedule="0 8 * * *",
+            prompt="Daily report",
+            name="Report",
+            deliver=None,
+            repeat=None,
+            skill=None,
+            skills=None,
+            script=None,
+            workdir=None,
+            interpreter="~/venvs/reporting/bin/python3",
+            no_agent=False,
+        )
+        rc = cron_cli.cron_create(args)
+        assert rc == 0
+        assert captured.get("interpreter") == "~/venvs/reporting/bin/python3"
+
+    def test_create_shows_interpreter_in_confirmation(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **kwargs: {
+                "success": True,
+                "job_id": "job-1",
+                "name": "Report",
+                "schedule": "0 8 * * *",
+                "skills": [],
+                "next_run_at": "2026-06-01T00:00:00Z",
+                "job": {"interpreter": "~/venvs/reporting/bin/python3"},
+            },
+        )
+        monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+        args = SimpleNamespace(
+            schedule="0 8 * * *",
+            prompt="Daily report",
+            name="Report",
+            deliver=None,
+            repeat=None,
+            skill=None,
+            skills=None,
+            script=None,
+            workdir=None,
+            interpreter="~/venvs/reporting/bin/python3",
+            no_agent=False,
+        )
+        cron_cli.cron_create(args)
+        out = capsys.readouterr().out
+        assert "Python: ~/venvs/reporting/bin/python3" in out
+
+    def test_edit_passes_interpreter_to_api(self, monkeypatch):
+        captured = {}
+
+        def fake_api(**kwargs):
+            captured.update(kwargs)
+            return {
+                "success": True,
+                "job": {
+                    "job_id": "job-1",
+                    "name": "Report",
+                    "schedule": "0 8 * * *",
+                    "skills": [],
+                    "interpreter": "~/venvs/reporting/bin/python3",
+                },
+            }
+
+        monkeypatch.setattr(cron_cli, "_cron_api", fake_api)
+
+        # resolve_job_ref is called at the top of cron_edit; point the job it
+        # returns at a real record so the skills-diff logic has something to
+        # read. The captured kwargs are what we assert on.
+        job = create_job(prompt="Report", schedule="0 8 * * *")
+        monkeypatch.setattr(
+            "cron.jobs.resolve_job_ref", lambda ref: get_job(job["id"])
+        )
+
+        args = SimpleNamespace(
+            job_id=job["id"],
+            schedule=None,
+            prompt=None,
+            name=None,
+            deliver=None,
+            repeat=None,
+            skill=None,
+            skills=None,
+            add_skills=None,
+            remove_skills=None,
+            clear_skills=False,
+            script=None,
+            workdir=None,
+            interpreter="~/venvs/reporting/bin/python3",
+            no_agent=None,
+        )
+        rc = cron_cli.cron_edit(args)
+        assert rc == 0
+        assert captured.get("interpreter") == "~/venvs/reporting/bin/python3"
+
+    def test_list_shows_interpreter_when_set(self, tmp_cron_dir, capsys, monkeypatch):
+        monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+        create_job(
+            prompt="Report",
+            schedule="0 8 * * *",
+            script="daily.py",
+            interpreter="~/venvs/reporting/bin/python3",
+        )
+        cron_command(Namespace(cron_command="list", all=True))
+        out = capsys.readouterr().out
+        assert "Python:" in out
+        assert "~/venvs/reporting/bin/python3" in out

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -234,3 +234,136 @@ def test_cron_create_failure_returns_nonzero(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert rc == 1
     assert "Failed to create job: boom" in out
+
+
+class TestCronInterpreterCli:
+    """``hermes cron create/edit`` plumb the ``--interpreter`` flag through."""
+
+    def test_create_passes_interpreter_to_api(self, monkeypatch):
+        captured = {}
+
+        def fake_api(**kwargs):
+            captured.update(kwargs)
+            return {
+                "success": True,
+                "job_id": "job-1",
+                "name": "Report",
+                "schedule": "0 8 * * *",
+                "skills": [],
+                "next_run_at": "2026-06-01T00:00:00Z",
+                "job": {"interpreter": "~/venvs/reporting/bin/python3"},
+            }
+
+        monkeypatch.setattr(cron_cli, "_cron_api", fake_api)
+        monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+        args = SimpleNamespace(
+            schedule="0 8 * * *",
+            prompt="Daily report",
+            name="Report",
+            deliver=None,
+            repeat=None,
+            skill=None,
+            skills=None,
+            script=None,
+            workdir=None,
+            interpreter="~/venvs/reporting/bin/python3",
+            no_agent=False,
+        )
+        rc = cron_cli.cron_create(args)
+        assert rc == 0
+        # The flag must be forwarded to the underlying tool/api.
+        assert captured.get("interpreter") == "~/venvs/reporting/bin/python3"
+
+    def test_create_shows_interpreter_in_confirmation(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **kwargs: {
+                "success": True,
+                "job_id": "job-1",
+                "name": "Report",
+                "schedule": "0 8 * * *",
+                "skills": [],
+                "next_run_at": "2026-06-01T00:00:00Z",
+                "job": {"interpreter": "~/venvs/reporting/bin/python3"},
+            },
+        )
+        monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+        args = SimpleNamespace(
+            schedule="0 8 * * *",
+            prompt="Daily report",
+            name="Report",
+            deliver=None,
+            repeat=None,
+            skill=None,
+            skills=None,
+            script=None,
+            workdir=None,
+            interpreter="~/venvs/reporting/bin/python3",
+            no_agent=False,
+        )
+        cron_cli.cron_create(args)
+        out = capsys.readouterr().out
+        assert "Python: ~/venvs/reporting/bin/python3" in out
+
+    def test_edit_passes_interpreter_to_api(self, monkeypatch):
+        captured = {}
+
+        def fake_api(**kwargs):
+            captured.update(kwargs)
+            return {
+                "success": True,
+                "job": {
+                    "job_id": "job-1",
+                    "name": "Report",
+                    "schedule": "0 8 * * *",
+                    "skills": [],
+                    "interpreter": "~/venvs/reporting/bin/python3",
+                },
+            }
+
+        monkeypatch.setattr(cron_cli, "_cron_api", fake_api)
+
+        # resolve_job_ref is called at the top of cron_edit; point the job it
+        # returns at a real record so the skills-diff logic has something to
+        # read. The captured kwargs are what we assert on.
+        job = create_job(prompt="Report", schedule="0 8 * * *")
+        monkeypatch.setattr(
+            "cron.jobs.resolve_job_ref", lambda ref: get_job(job["id"])
+        )
+
+        args = SimpleNamespace(
+            job_id=job["id"],
+            schedule=None,
+            prompt=None,
+            name=None,
+            deliver=None,
+            repeat=None,
+            skill=None,
+            skills=None,
+            add_skills=None,
+            remove_skills=None,
+            clear_skills=False,
+            script=None,
+            workdir=None,
+            interpreter="~/venvs/reporting/bin/python3",
+            no_agent=None,
+        )
+        rc = cron_cli.cron_edit(args)
+        assert rc == 0
+        assert captured.get("interpreter") == "~/venvs/reporting/bin/python3"
+
+    def test_list_shows_interpreter_when_set(self, tmp_cron_dir, capsys, monkeypatch):
+        monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+        create_job(
+            prompt="Report",
+            schedule="0 8 * * *",
+            script="daily.py",
+            interpreter="~/venvs/reporting/bin/python3",
+        )
+        cron_command(Namespace(cron_command="list", all=True))
+        out = capsys.readouterr().out
+        assert "Python:" in out
+        assert "~/venvs/reporting/bin/python3" in out

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -33,6 +33,41 @@ def test_cron_subactions_present():
         assert ns.cron_command == action
 
 
+def test_cron_create_interpreter_flag():
+    parser = _build()
+    ns = parser.parse_args(
+        [
+            "cron",
+            "create",
+            "30m",
+            "task",
+            "--interpreter",
+            "~/venvs/reporting/bin/python3",
+        ]
+    )
+    assert ns.interpreter == "~/venvs/reporting/bin/python3"
+
+
+def test_cron_create_interpreter_defaults_to_none():
+    parser = _build()
+    ns = parser.parse_args(["cron", "create", "30m", "task"])
+    assert ns.interpreter is None
+
+
+def test_cron_edit_interpreter_flag():
+    parser = _build()
+    ns = parser.parse_args([
+        "cron", "edit", "j", "--interpreter", "/opt/venv/bin/python",
+    ])
+    assert ns.interpreter == "/opt/venv/bin/python"
+    # Empty string clears the field.
+    ns_clear = parser.parse_args(["cron", "edit", "j", "--interpreter", ""])
+    assert ns_clear.interpreter == ""
+    # Absent by default.
+    ns_default = parser.parse_args(["cron", "edit", "j"])
+    assert ns_default.interpreter is None
+
+
 def test_cron_edit_no_agent_tristate():
     parser = _build()
     # --no-agent -> True, --agent -> False, neither -> None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -670,6 +670,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     ]
     if external_refs:
         result["context_from"] = external_refs
+    if job.get("interpreter"):
+        result["interpreter"] = job["interpreter"]
     return result
 
 
@@ -1197,6 +1199,7 @@ def cronjob(
     continuity: Optional[bool] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    interpreter: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
@@ -1297,6 +1300,7 @@ def cronjob(
                     context_from=context_from,
                     enabled_toolsets=enabled_toolsets or None,
                     workdir=_normalize_optional_job_value(workdir),
+                    interpreter=_normalize_optional_job_value(interpreter),
                     no_agent=_no_agent,
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
@@ -1571,6 +1575,11 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if interpreter is not None:
+                # Empty string clears the field (reverts to Hermes Python);
+                # otherwise pass raw — update_job() trims/normalizes. The path
+                # itself is validated at run time, not here.
+                updates["interpreter"] = _normalize_optional_job_value(interpreter)
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -1733,6 +1742,10 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "interpreter": {
+                "type": "string",
+                "description": "Optional Python interpreter for the job's script or monitor_script — an absolute or ~-prefixed path to a Python executable in a user-managed venv (e.g. '~/venvs/reporting/bin/python3'). Lets a Python script import packages the Hermes runtime does not carry (openpyxl, a database driver) without polluting the managed environment. Applies only to Python scripts; .sh/.bash always run via bash. Omit to use Hermes' own Python (sys.executable), which preserves the default behaviour. On update, pass an empty string to clear. The path is validated at run time."
+            },
             "attach_to_session": {
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
@@ -1794,6 +1807,7 @@ registry.register(
         continuity=args.get("continuity"),
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
+        interpreter=args.get("interpreter"),
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1199,13 +1199,13 @@ def cronjob(
     continuity: Optional[bool] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
-    interpreter: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
+    interpreter: Optional[str] = None,
 ) -> str:
     """Unified cron job management tool."""
     del task_id  # unused but kept for handler signature compatibility

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1050,13 +1050,13 @@ def cronjob(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
-    interpreter: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
+    interpreter: Optional[str] = None,
 ) -> str:
     """Unified cron job management tool."""
     del task_id  # unused but kept for handler signature compatibility

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -594,6 +594,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("interpreter"):
+        result["interpreter"] = job["interpreter"]
     return result
 
 
@@ -1048,6 +1050,7 @@ def cronjob(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    interpreter: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
@@ -1136,6 +1139,7 @@ def cronjob(
                     context_from=context_from,
                     enabled_toolsets=enabled_toolsets or None,
                     workdir=_normalize_optional_job_value(workdir),
+                    interpreter=_normalize_optional_job_value(interpreter),
                     no_agent=_no_agent,
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
@@ -1399,6 +1403,11 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if interpreter is not None:
+                # Empty string clears the field (reverts to Hermes Python);
+                # otherwise pass raw — update_job() trims/normalizes. The path
+                # itself is validated at run time, not here.
+                updates["interpreter"] = _normalize_optional_job_value(interpreter)
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -1548,6 +1557,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "interpreter": {
+                "type": "string",
+                "description": "Optional Python interpreter for the job's script or monitor_script — an absolute or ~-prefixed path to a Python executable in a user-managed venv (e.g. '~/venvs/reporting/bin/python3'). Lets a Python script import packages the Hermes runtime does not carry (openpyxl, a database driver) without polluting the managed environment. Applies only to Python scripts; .sh/.bash always run via bash. Omit to use Hermes' own Python (sys.executable), which preserves the default behaviour. On update, pass an empty string to clear. The path is validated at run time."
+            },
             "attach_to_session": {
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
@@ -1608,6 +1621,7 @@ registry.register(
         context_from=args.get("context_from"),
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
+        interpreter=args.get("interpreter"),
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),

--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -28,7 +28,7 @@ Hermes calls this **no-agent mode**. It's the cron system minus the LLM.
 
 - **No LLM call.** Zero tokens, zero agent loop, zero model spend.
 - **Script is the job.** The script decides whether to alert. Emit output → message gets sent. Emit nothing → silent tick.
-- **Bash or Python.** `.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash`; any other extension runs under the current Python interpreter. Paths must resolve inside `~/.hermes/scripts/` (relative, absolute, or `~` forms are OK if they stay in that directory). Cron scripts do **not** inherit provider credentials from the Hermes process environment.
+- **Bash or Python.** `.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash`; any other extension runs under the current Python interpreter. A Python script can also pin a **user-managed venv** via `--interpreter` (see [Using your own Python environment](#using-your-own-python-environment)). Paths must resolve inside `~/.hermes/scripts/` (relative, absolute, or `~` forms are OK if they stay in that directory). Cron scripts do **not** inherit provider credentials from the Hermes process environment.
 - **Same scheduler.** Lives in `cronjob` alongside LLM jobs — pausing, resuming, listing, logs, and delivery targeting all work the same way.
 
 ## When to Use It
@@ -151,16 +151,53 @@ The "silent when empty" behavior is the key to the classic watchdog pattern: the
 
 ## Script Rules
 
-Scripts must live in `~/.hermes/scripts/`. This is enforced at both job-creation time and run time — absolute paths, `~/` expansion, and path-traversal patterns (`../`) are rejected. The same directory is shared with the pre-check script gate used by LLM jobs.
+Scripts must resolve inside `~/.hermes/scripts/`. This is enforced at run time — relative names, absolute paths, and `~`-prefixed paths are accepted when the resolved target stays in that directory; path traversal and symlink escapes are rejected. The same directory is shared with the pre-check script gate used by LLM jobs.
 
 Interpreter choice is by file extension:
 
 | Extension | Interpreter |
 |-----------|-------------|
 | `.sh`, `.bash` | `bash` from `PATH` (fallback `/bin/bash`) |
-| anything else | `sys.executable` (current Python) |
+| anything else | `sys.executable` (current Python), or a [configured interpreter](#using-your-own-python-environment) |
 
 We intentionally do NOT honour `#!/...` shebangs — keeping the interpreter set explicit and small reduces the surface the scheduler trusts.
+
+### Using your own Python environment
+
+By default a Python cron script runs under Hermes' own Python (`sys.executable`), which lives in the Hermes-managed virtualenv. That environment only carries Hermes' own dependencies — so a script that imports `openpyxl`, a database driver, or any other package you installed would fail with `ModuleNotFoundError`.
+
+You can point the job at a **user-managed venv** instead with `--interpreter`:
+
+```bash
+# 1. Create a venv you own — it survives Hermes reinstalls/rebuilds.
+uv venv ~/venvs/hermes-reporting --python 3.11
+uv pip install --python ~/venvs/hermes-reporting/bin/python openpyxl
+
+# 2. Schedule the job with that interpreter.
+hermes cron create "0 8 * * *" \
+  --no-agent \
+  --script daily-report.py \
+  --interpreter ~/venvs/hermes-reporting/bin/python \
+  --deliver telegram
+```
+
+The same field is exposed to the agent through the `cronjob` tool:
+
+```python
+cronjob(action="create", schedule="0 8 * * *",
+        script="daily-report.py", no_agent=True,
+        interpreter="~/venvs/hermes-reporting/bin/python",
+        deliver="telegram")
+```
+
+Rules:
+
+- The venv is **user-managed**. Hermes does not create, freeze, restore, or install packages into it — it just invokes the path you give.
+- The path must be **absolute or `~`-prefixed** (e.g. `~/venvs/reporting/bin/python3`). Bare names like `python3` are rejected, because they are not stable across `PATH` changes.
+- Applies **only to Python scripts**. `.sh` / `.bash` always run under bash regardless.
+- The job-level setting applies to both `script` and `monitor_script` when they are Python files.
+- It is validated **at run time**, not at creation — a cron job is long-lived, and the venv may be rebuilt or moved between when you create the job and when it fires. A missing or non-executable interpreter produces a clear script failure that is delivered like any other error.
+- To clear it later: `hermes cron edit <job_id> --interpreter ""`.
 
 ## Schedule Syntax
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -573,7 +573,7 @@ Semantics:
 - `{"wakeAgent": false}` on the last line → silent tick (same gate LLM jobs use).
 - No tokens, no model, no provider fallback — the job never touches the inference layer.
 
-`.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash` (important on Windows Git Bash). Anything else runs under the current Python interpreter (`sys.executable`). Scripts must resolve inside `$HERMES_HOME/scripts/` — relative names, absolute paths, and `~`-prefixed paths are accepted when the resolved target stays in that directory; paths that escape it are rejected. Subprocess env is sanitized (`_sanitize_subprocess_env`): provider API credentials and other Hermes-managed secrets are **not** inherited by cron scripts.
+`.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash` (important on Windows Git Bash). Anything else runs under the current Python interpreter (`sys.executable`). Scripts must resolve inside `$HERMES_HOME/scripts/` — relative names, absolute paths, and `~`-prefixed paths are accepted when the resolved target stays in that directory; paths that escape it are rejected. A Python `script` or `monitor_script` can also pin a user-managed venv (for packages the Hermes runtime doesn't carry) by passing `--interpreter ~/venvs/.../bin/python` at create/edit time — see [Using your own Python environment](/guides/cron-script-only#using-your-own-python-environment). The Hermes-managed venv stays Hermes-owned; nothing is installed or restored automatically. The subprocess environment is sanitized, so provider API credentials and other Hermes-managed secrets are **not** inherited by cron scripts.
 
 ### The agent sets these up for you
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -507,7 +507,7 @@ Semantics:
 - `{"wakeAgent": false}` on the last line → silent tick (same gate LLM jobs use).
 - No tokens, no model, no provider fallback — the job never touches the inference layer.
 
-`.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash` (important on Windows Git Bash). Anything else runs under the current Python interpreter (`sys.executable`). Scripts must resolve inside `$HERMES_HOME/scripts/` — relative names, absolute paths, and `~`-prefixed paths are accepted when the resolved target stays in that directory; paths that escape it are rejected. Subprocess env is sanitized (`_sanitize_subprocess_env`): provider API credentials and other Hermes-managed secrets are **not** inherited by cron scripts.
+`.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash` (important on Windows Git Bash). Anything else runs under the current Python interpreter (`sys.executable`). Scripts must resolve inside `$HERMES_HOME/scripts/` — relative names, absolute paths, and `~`-prefixed paths are accepted when the resolved target stays in that directory; paths that escape it are rejected. A Python `script` or `monitor_script` can also pin a user-managed venv (for packages the Hermes runtime doesn't carry) by passing `--interpreter ~/venvs/.../bin/python` at create/edit time — see [Using your own Python environment](/guides/cron-script-only#using-your-own-python-environment). The Hermes-managed venv stays Hermes-owned; nothing is installed or restored automatically. The subprocess environment is sanitized, so provider API credentials and other Hermes-managed secrets are **not** inherited by cron scripts.
 
 ### The agent sets these up for you
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/cron-script-only.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/cron-script-only.md
@@ -28,7 +28,7 @@ Hermes 将此称为**无 agent 模式**。这是去掉 LLM 的 cron 系统。
 
 - **无 LLM 调用。** 零 token，零 agent 循环，零模型费用。
 - **脚本即任务。** 由脚本决定是否告警。有输出 → 发送消息；无输出 → 静默执行。
-- **Bash 或 Python。** `.sh` / `.bash` 文件在 `/bin/bash` 下运行；其他扩展名在当前 Python 解释器下运行。`~/.hermes/scripts/` 中的任何文件均可接受。
+- **Bash 或 Python。** `.sh` / `.bash` 文件优先使用 `PATH` 中的 `bash`，不可用时回退到 `/bin/bash`；其他扩展名默认使用当前 Python 解释器。Python 脚本也可以通过 `--interpreter` 指定一个**用户自管的 venv**（参见[使用你自己的 Python 环境](#使用你自己的-python-环境)）。脚本路径必须解析到 `~/.hermes/scripts/` 内部（只要不逃逸该目录，相对路径、绝对路径和 `~` 形式都可以）。cron 脚本不会继承 Hermes 进程中的 provider 凭据。
 - **同一调度器。** 与 LLM 任务共存于 `cronjob` 中——暂停、恢复、列出、日志和投递目标的操作方式完全相同。
 
 ## 适用场景
@@ -151,16 +151,53 @@ hermes cron run <job_id>    # 触发一次以测试
 
 ## 脚本规则
 
-脚本必须位于 `~/.hermes/scripts/`。这在任务创建时和运行时均会强制检查——绝对路径、`~/` 展开以及路径穿越模式（`../`）均会被拒绝。该目录与 LLM 任务使用的预检脚本门控共享。
+脚本路径必须解析到 `~/.hermes/scripts/` 内部。调度器会在运行时强制检查——只要解析后的目标仍位于该目录，相对路径、绝对路径和以 `~` 开头的路径都可以；路径穿越和符号链接逃逸会被拒绝。该目录与 LLM 任务使用的预检脚本门控共享。
 
 解释器由文件扩展名决定：
 
 | 扩展名 | 解释器 |
 |-----------|-------------|
-| `.sh`、`.bash` | `/bin/bash` |
-| 其他任意扩展名 | `sys.executable`（当前 Python） |
+| `.sh`、`.bash` | `PATH` 中的 `bash`（回退到 `/bin/bash`） |
+| 其他任意扩展名 | `sys.executable`（当前 Python），或一个[自定义解释器](#使用你自己的-python-环境) |
 
 我们有意**不**遵循 `#!/...` shebang——保持解释器集合明确且精简，可减少调度器信任的攻击面。
+
+### 使用你自己的 Python 环境
+
+默认情况下，Python cron 脚本运行在 Hermes 自身的 Python（`sys.executable`）下，它位于 Hermes 管理的虚拟环境中。该环境只包含 Hermes 自身的依赖——因此如果你的脚本 `import openpyxl`、数据库驱动或任何其他你安装的包，会因 `ModuleNotFoundError` 而失败。
+
+你可以通过 `--interpreter` 让任务指向一个**用户自管的 venv**：
+
+```bash
+# 1. 创建一个属于你自己的 venv——它在 Hermes 重装/重建后依然保留。
+uv venv ~/venvs/hermes-reporting --python 3.11
+uv pip install --python ~/venvs/hermes-reporting/bin/python openpyxl
+
+# 2. 用该解释器调度任务。
+hermes cron create "0 8 * * *" \
+  --no-agent \
+  --script daily-report.py \
+  --interpreter ~/venvs/hermes-reporting/bin/python \
+  --deliver telegram
+```
+
+该字段同样通过 `cronjob` 工具暴露给 agent：
+
+```python
+cronjob(action="create", schedule="0 8 * * *",
+        script="daily-report.py", no_agent=True,
+        interpreter="~/venvs/hermes-reporting/bin/python",
+        deliver="telegram")
+```
+
+规则：
+
+- 该 venv 是**用户自管**的。Hermes 不会创建、冻结、恢复或向其中安装包——它只是调用你指定的路径。
+- 路径必须是**绝对路径或以 `~` 开头**（例如 `~/venvs/reporting/bin/python3`）。像 `python3` 这样的裸名会被拒绝，因为它们在 `PATH` 变化时并不稳定。
+- 仅对 **Python 脚本**生效。`.sh` / `.bash` 始终用 bash 运行，不受影响。
+- 这是任务级设置；当 `script` 或 `monitor_script` 是 Python 文件时都会使用它。
+- 解释器在**运行时**校验，而非创建时——cron 任务是长期存在的，venv 可能在你创建任务和它真正触发之间被重建或移动。缺失或不可执行的解释器会产生一个清晰的脚本失败，像其他错误一样被投递。
+- 之后想清除它：`hermes cron edit <job_id> --interpreter ""`。
 
 ## 计划语法
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/cron.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/cron.md
@@ -442,7 +442,7 @@ hermes cron create "every 5m" \
 - 最后一行输出 `{"wakeAgent": false}` → 静默 tick（与 LLM 任务使用相同的门控）。
 - 无 token、无模型、无 provider 回退——任务永远不会触及推理层。
 
-`.sh`/`.bash` 文件在 `/bin/bash` 下运行；其他文件在当前 Python 解释器（`sys.executable`）下运行。脚本必须位于 `~/.hermes/scripts/`（与预运行脚本门控相同的沙箱规则）。
+`.sh`/`.bash` 文件优先使用 `PATH` 中的 `bash`，不可用时回退到 `/bin/bash`（这对 Windows Git Bash 尤其重要）；其他文件默认使用当前 Python 解释器（`sys.executable`）。脚本路径必须解析到 `$HERMES_HOME/scripts/` 内部——只要解析后的目标仍位于该目录，相对路径、绝对路径和以 `~` 开头的路径都可以；逃逸该目录的路径会被拒绝。Python `script` 或 `monitor_script` 也可以通过在创建/编辑时传入 `--interpreter ~/venvs/.../bin/python` 来指定一个用户自管的 venv（用于 Hermes 运行时不携带的包）——参见[使用你自己的 Python 环境](/guides/cron-script-only#使用你自己的-python-环境)。Hermes 管理的 venv 仍归 Hermes 所有；系统不会自动安装或恢复任何包。子进程环境会被净化，因此 cron 脚本**不会**继承 provider API 凭据和其他由 Hermes 管理的秘密。
 
 ### Agent 为你设置这些
 


### PR DESCRIPTION
## What does this PR do?

This fixes Python cron scripts that need packages outside Hermes' managed runtime by adding an optional per-job `interpreter` field. A job can point to a user-managed virtual environment such as `~/venvs/reporting/bin/python`; when the field is omitted, Python scripts continue to use `sys.executable`. The same setting also applies to Python `monitor_script` jobs.

The interpreter path is normalized in storage and validated when the job runs. It must resolve to an absolute file, and it must be executable on POSIX. Invalid paths fail through the existing cron script error path with a clear message.

Shell behavior is unchanged: `.sh` and `.bash` scripts continue to use bash from `PATH` with the existing `/bin/bash` fallback, and an interpreter override is ignored for shell scripts.

## Related issues and contributor credit

Fixes #8714

Addresses the cron-script portion of #69889

Supersedes #8741 with @MestreY0d4-Uninter credited through `Co-authored-by` trailers.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes made

- Persist and round-trip `interpreter` through create, update, clear, list, CLI, and the existing `cronjob` tool.
- Keep the field absent when unset; an empty update removes the key, while partial updates preserve it.
- Preserve existing positional-call semantics by appending `interpreter` after `monitor_url` in `create_job()` and after `session_id` in `cronjob()`.
- Route Python scripts through the runtime-validated interpreter while preserving the existing Windows launcher/bootstrap, workdir, cancellation, timeout, output capture, redaction, script containment, and sanitized subprocess environment.
- Propagate the override through Python `monitor_script`, no-agent, inline pre-run, wake-gate, recurring and one-shot claim-heartbeat, and heartbeat thread-start fallback paths.
- Keep `model`, `provider`, and `base_url` inference routing independent from `interpreter`; coexistence and partial-update behavior have regression coverage.
- Document user-managed Python environments in the English and Chinese cron guides.

## Non-goals

- This PR does not capture, freeze, restore, or install packages in Hermes' managed venv.
- This PR does not manage runtime dependencies for third-party plugins; that broader concern is independent of this cron fix.

## Diff shape

Rebased and fully reverified against `upstream/main` at `aebab05f9ec08c29672dd709db2e639d00a8544a`.

- Total: 15 files, `+1180/-20`.
- Production code: 6 files, `+182/-8` (about 15% of added lines).
- Tests: 5 files, `+913/-1`.
- English and Chinese docs: 4 files, `+85/-11`.

The larger line count is therefore primarily behavior coverage and bilingual documentation, not scheduler surface area.

## Verification

Focused interpreter and monitor paths:

```bash
scripts/run_tests.sh \
  tests/cron/test_cron_script.py \
  tests/cron/test_cron_no_agent.py \
  tests/cron/test_script_claim_heartbeat.py \
  tests/cron/test_monitor_kind.py \
  tests/hermes_cli/test_cron.py \
  tests/hermes_cli/test_cron_parser_builder.py \
  tests/tools/test_cronjob_tools.py
```

Result: **7 files, 201 passed, 0 failed, 1 Windows-only skipped**.

Broader cron regression:

```bash
scripts/run_tests.sh \
  tests/cron \
  tests/hermes_cli/test_cron.py \
  tests/hermes_cli/test_cron_parser_builder.py \
  tests/tools/test_cronjob_tools.py
```

Result: **68 files, 929 passed, 0 failed, 1 Windows-only skipped**.

Also passed:

- `ruff check` on all changed Python files
- `python -m py_compile` on all changed production Python files
- `python scripts/check-windows-footguns.py --all` (988 files scanned)
- conflict-marker scan, final `git range-diff`, and `git diff --check upstream/main...HEAD`
- lockfile-pinned website install with npm 11.17.0
- website diagram lint (409 files, 0 errors)
- Docusaurus production builds for `en` and `zh-Hans`

## Checklist

- [x] I've read the contributing guide.
- [x] Commit messages follow Conventional Commits.
- [x] The PR contains only changes related to this cron fix.
- [x] Tests cover persistence, compatibility, CLI/tool round-trips, a real temporary venv import, invalid paths, shell behavior, environment sanitization, Windows invocation, monitor mode, no-agent, wake-gate, heartbeat, cancellation, and workdir propagation.
- [x] Tested on Linux with Python 3.13.9.
- [x] Relevant English and Chinese documentation is updated.
- [x] No config key or managed-venv behavior is added.
