### PR TITLE
fix(truncate): preserve table boundaries and ordered list continuity in chunk splitting

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5885,12 +5885,12 @@ class BasePlatformAdapter(ABC):
         len_fn: Optional["Callable[[str], int]"] = None,
     ) -> List[str]:
         """
-        Split a long message into chunks, preserving code block boundaries.
+        Split a long message into chunks, preserving Markdown structure.
 
-        When a split falls inside a triple-backtick code block, the fence is
-        closed at the end of the current chunk and reopened (with the original
-        language tag) at the start of the next chunk.  Multi-chunk responses
-        receive indicators like ``(1/3)``.
+        Preserves code block fences, inline code spans, math block fences
+        (``$$...$$``), table boundaries, and ordered list continuity across
+        chunk splits.  Multi-chunk responses receive indicators like
+        ``(1/3)``.
 
         Args:
             content: The full message content
@@ -5909,17 +5909,35 @@ class BasePlatformAdapter(ABC):
 
         INDICATOR_RESERVE = 10   # room for " (XX/XX)"
         FENCE_CLOSE = "\n```"
+        MATH_FENCE_CLOSE = "\n$$"
 
         chunks: List[str] = []
         remaining = content
         # When the previous chunk ended mid-code-block, this holds the
         # language tag (possibly "") so we can reopen the fence.
         carry_lang: Optional[str] = None
+        # When the previous chunk ended mid-math-block ($$...$$), this
+        # is True so we reopen the math fence.
+        carry_math: bool = False
+        # When the previous chunk ended mid-table, this holds the
+        # header row + separator so the next chunk starts as a
+        # valid table.
+        carry_table_header: Optional[str] = None
 
         while remaining:
             # If we're continuing a code block from the previous chunk,
             # prepend a new opening fence with the same language tag.
-            prefix = f"```{carry_lang}\n" if carry_lang is not None else ""
+            # Math blocks take precedence (can't nest code inside math).
+            if carry_math:
+                prefix = "$$\n"
+            elif carry_lang is not None:
+                prefix = f"```{carry_lang}\n"
+            else:
+                prefix = ""
+            # If we're continuing a table, prepend the header + separator
+            # so the continuation chunk is a valid table.
+            if carry_table_header is not None:
+                prefix = carry_table_header + "\n" + prefix
 
             # How much body text we can fit after accounting for the prefix,
             # a potential closing fence, and the chunk indicator.
@@ -5951,6 +5969,15 @@ class BasePlatformAdapter(ABC):
                                 _final_lang = _tag.split()[0] if _tag else ""
                     if _final_in_code:
                         final_chunk += FENCE_CLOSE
+                # Same check for math blocks ($$...$$).  Code and math
+                # are mutually exclusive, so an else-if is sufficient.
+                elif carry_math:
+                    _final_in_math = True  # prefix already opened `$$\n`
+                    for _line in remaining.split("\n"):
+                        if _line.strip() == "$$":
+                            _final_in_math = not _final_in_math
+                    if _final_in_math:
+                        final_chunk += MATH_FENCE_CLOSE
                 chunks.append(final_chunk)
                 break
 
@@ -6011,18 +6038,43 @@ class BasePlatformAdapter(ABC):
                     if safe_split > _cp_limit // 4:
                         split_at = safe_split
 
+            # Prefer splitting before a Markdown table rather than inside one.
+            # Table rows start with `|`. If the next line after split_at starts
+            # with `|`, walk back to the blank line before the table.
+            _rest_stripped = remaining[split_at:].lstrip()
+            if _rest_stripped.startswith("|") and "|" in _rest_stripped[1:30]:
+                _before = remaining[:split_at]
+                _tbl_boundary = _before.rfind("\n\n")
+                if _tbl_boundary > max(10, _cp_limit // 3):
+                    split_at = _tbl_boundary + 1
+
+            # Prefer splitting before an ordered list so numbering is intact.
+            _rest_ls = remaining[split_at:].lstrip()
+            if _rest_ls[:1].isdigit() and (". " in _rest_ls[:5] or ") " in _rest_ls[:5]):
+                _before = remaining[:split_at]
+                _prev_nl = _before.rfind("\n")
+                if _prev_nl > 0:
+                    _prev_line = _before[_prev_nl + 1:].strip()
+                    if _prev_line[:1].isdigit() and (". " in _prev_line[:5] or ") " in _prev_line[:5]):
+                        _list_boundary = _before.rfind("\n\n")
+                        if _list_boundary > max(10, _cp_limit // 3):
+                            split_at = _list_boundary + 1
+
             chunk_body = remaining[:split_at]
             remaining = remaining[split_at:].lstrip()
 
             full_chunk = prefix + chunk_body
 
             # Walk only the chunk_body (not the prefix we prepended) to
-            # determine whether we end inside an open code block.
+            # determine whether we end inside an open code block or math block.
             in_code = carry_lang is not None
             lang = carry_lang or ""
+            in_math = carry_math
             for line in chunk_body.split("\n"):
                 stripped = line.strip()
-                if stripped.startswith("```"):
+                if stripped == "$$" and not in_code:
+                    in_math = not in_math
+                elif stripped.startswith("```") and not in_math:
                     if in_code:
                         in_code = False
                         lang = ""
@@ -6031,12 +6083,40 @@ class BasePlatformAdapter(ABC):
                         tag = stripped[3:].strip()
                         lang = tag.split()[0] if tag else ""
 
-            if in_code:
-                # Close the orphaned fence so the chunk is valid on its own
+            if in_math:
+                # Close the orphaned math fence so the chunk is valid
+                full_chunk += MATH_FENCE_CLOSE
+                carry_math = True
+                carry_lang = None
+            elif in_code:
+                # Close the orphaned code fence so the chunk is valid
                 full_chunk += FENCE_CLOSE
                 carry_lang = lang
+                carry_math = False
             else:
                 carry_lang = None
+                carry_math = False
+
+            # Detect if the chunk ends inside a table and extract the
+            # header row + separator for the next chunk to reconstruct.
+            if remaining and not (carry_math or carry_lang is not None):
+                _next_stripped = remaining.lstrip()
+                if _next_stripped.startswith("|") and "|" in _next_stripped[1:30]:
+                    if carry_table_header is None:
+                        # Find the last separator line in chunk_body
+                        _chunk_lines = chunk_body.split("\n")
+                        _last_sep = -1
+                        for _li, _line in enumerate(_chunk_lines):
+                            _s = _line.strip()
+                            if _s.startswith("|---") and _s.endswith("|") and "|" in _s[4:]:
+                                _last_sep = _li
+                        if _last_sep > 0:
+                            _hdr = _chunk_lines[_last_sep - 1].strip()
+                            _sep = _chunk_lines[_last_sep].strip()
+                            if _hdr.startswith("|") and _sep.startswith("|"):
+                                carry_table_header = _hdr + "\n" + _sep
+                else:
+                    carry_table_header = None
 
             chunks.append(full_chunk)
 

--- a/tests/gateway/test_truncate_message.py
+++ b/tests/gateway/test_truncate_message.py
@@ -1,0 +1,169 @@
+"""Tests for truncate_message Markdown structure preservation.
+
+Covers: code blocks, inline code, math blocks ($$), tables, ordered lists,
+and combinations.
+"""
+
+from gateway.platforms.base import BasePlatformAdapter
+
+truncate = BasePlatformAdapter.truncate_message
+
+
+def _assert_chunks(content, max_len, expected_count=None):
+    """Split and return chunks.  Optionally verify count."""
+    chunks = truncate(content, max_len)
+    if expected_count is not None:
+        assert len(chunks) == expected_count, \
+            f"Expected {expected_count} chunks, got {len(chunks)}"
+    return chunks
+
+
+# ---- Code blocks ----
+
+def test_code_block_preserved():
+    chunks = _assert_chunks(
+        "A\n\n```py\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n```\n\nB", 30, 3)
+    for c in chunks:
+        assert c.count("```") % 2 == 0, f"Unbalanced backticks in {c[:40]!r}"
+    # Each chunk except maybe the last should carry the lang tag
+    assert "```py" in chunks[1], f"Missing lang reopen in {chunks[1][:40]!r}"
+
+
+def test_code_block_no_tag():
+    chunks = _assert_chunks(
+        "```\na\nb\nc\nd\ne\nf\ng\nh\n```", 20)
+    for c in chunks:
+        assert c.count("```") % 2 == 0
+
+
+def test_short_message_unchanged():
+    chunks = truncate("Hello", 100)
+    assert chunks == ["Hello"]
+
+
+# ---- Inline code ----
+
+def test_inline_code_not_split():
+    # A long line with backtick span inside
+    text = "Use `some_function(x, y)` which " + "does stuff " * 15 + "here"
+    chunks = _assert_chunks(text, 80)
+    for c in chunks:
+        bt = c.count("`")
+        assert bt % 2 == 0, f"Unbalanced backticks in {c[:40]!r}"
+
+
+# ---- Math blocks ($$) ----
+
+def test_math_block_reopened():
+    """$$...$$ spanning chunks gets closed and reopened."""
+    content = "Before\n\n$$\nE = mc^2\n\\int_0^\\infty f(x) dx\n\\sum_{i=1}^n i\n$$\n\nAfter"
+    chunks = _assert_chunks(content, 30)
+    for c in chunks:
+        assert c.count("$$") % 2 == 0, f"Unbalanced $$ in {c[:40]!r}"
+    # The continuation chunk should start with $$
+    assert any(c.startswith("$$") for c in chunks[1:]), \
+        "No chunk reopens math fence"
+
+
+def test_math_and_code_independent():
+    """$$ and ``` tracking shouldn't interfere."""
+    content = (
+        "A\n\n```\ncode line 1\ncode line 2\ncode line 3\n"
+        "code line 4\ncode line 5\ncode line 6\n```\n\n"
+        "$$\nmath line 1\nmath line 2\nmath line 3\n"
+        "math line 4\n$$\n\nB"
+    )
+    chunks = _assert_chunks(content, 30)
+    for c in chunks:
+        assert c.count("```") % 2 == 0
+        assert c.count("$$") % 2 == 0
+
+
+def test_math_in_code_is_literal():
+    """$$ inside a code block must NOT toggle math mode."""
+    content = "```\n$$\nE = mc^2\n$$\n```\n"
+    # Short enough to fit in one chunk
+    chunks = truncate(content, 200)
+    assert len(chunks) == 1
+    assert chunks[0].count("$$") == 2  # literal, not toggling
+    assert chunks[0].count("```") == 2
+
+
+# ---- Tables ----
+
+def test_table_stays_whole_when_possible():
+    """If there's room, the whole table fits in one chunk."""
+    table = "Intro\n\n| H1 | H2 |\n|---|---|\n| A | B |\n| C | D |\n\nOutro"
+    chunks = truncate(table, 200)
+    assert len(chunks) == 1
+
+
+def test_table_boundary_preferred():
+    """When the table is too large, split before the table."""
+    table = ("Some text.\n\n| Col A | Col B |\n|---|---|\n"
+             + "| a | b |\n" * 20 + "\n\nMore text.")
+    chunks = _assert_chunks(table, 80)
+    for c in chunks:
+        pipes = [l for l in c.split("\n") if l.startswith("|")]
+        if pipes:
+            # Every chunk with pipe lines must have a separator
+            assert any("---" in l for l in pipes), f"No separator in {c[:50]!r}"
+
+
+def test_table_header_reconstructed():
+    """When a table spans chunks, each gets a header."""
+    text = ("| A | B |\n|---|---|\n"
+            + "| 1 | 2 |\n| 3 | 4 |\n| 5 | 6 |\n"
+            + "| 7 | 8 |\n| 9 | 10 |\n| 11 | 12 |\n"
+            + "| 13 | 14 |\n| 15 | 16 |\n\nOutro")
+    chunks = _assert_chunks(text, 60)
+    for i, c in enumerate(chunks):
+        pipes = [l for l in c.split("\n") if l.startswith("|")]
+        if pipes:
+            # First pipe must be a header, not a separator
+            first = pipes[0]
+            assert "---" not in first, f"Chunk {i} starts with separator: {first}"
+            # Must have a separator too
+            assert any("---" in l for l in pipes), f"Chunk {i} missing separator"
+            assert first == "| A | B |", \
+                f"Chunk {i} has wrong header: {first!r}"
+
+
+# ---- Ordered lists ----
+
+def test_ordered_list_boundary():
+    """Split before an ordered list when mid-list."""
+    text = "A paragraph with enough text to push the list boundary far enough.\n\n1. first\n2. second\n3. third\n4. fourth\n5. fifth\n\nOutro"
+    chunks = _assert_chunks(text, 55)
+    for c in chunks:
+        items = [l.strip() for l in c.split("\n") if l.strip()[:2].isdigit() and ". " in l.strip()[:5]]
+        if items:
+            assert items[0].startswith("1."), f"List doesn't start at 1: {items[0]!r}"
+
+
+# ---- Everything fits ----
+
+def test_short_fits():
+    chunks = truncate("Short", 50)
+    assert chunks == ["Short"]
+
+
+def test_exact_fit():
+    chunks = truncate("x" * 50, 55)
+    assert len(chunks) == 1
+
+
+# ---- Edge: mixed constructions ----
+
+def test_code_then_table_then_math():
+    """All three fence types in sequence, each requiring a split."""
+    content = (
+        "```\ncode\n```\n\n"
+        "| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |\n| 5 | 6 |\n"
+        "| 7 | 8 |\n| 9 | 10 |\n\n"
+        "$$\nmath\n$$\n\nEnd"
+    )
+    chunks = _assert_chunks(content, 40)
+    fences_ok = all(c.count("```") % 2 == 0 and c.count("$$") % 2 == 0
+                    for c in chunks)
+    assert fences_ok, "Unbalanced fences in mixed content"


### PR DESCRIPTION
## Summary

`truncate_message()` splits long messages into chunks respecting `max_length`.  Previously only triple-backtick code blocks and inline code spans were preserved across splits.  This PR adds protection for math blocks (`24622`), tables, and ordered lists.

## Changes

- **Math blocks (`24622...24622`)** — when a split falls inside a math fence, the fence is closed at the end of the current chunk and reopened (with `24622`) at the start of the next chunk, matching the code-block pattern.
- **Tables** — when a split would fall inside a table, the boundary is moved to the blank line before the table.  If the table is too large to fit in one chunk, the header row + separator is carried into the next chunk so every chunk is a valid renderable table.
- **Ordered lists** — when splitting mid-list (next line starts with a digit + `.` or `)` and the preceding line was also a list item), the split is moved to the blank line before the list, preserving continuous numbering.

## Tests

Adds `tests/gateway/test_truncate_message.py` with 14 tests covering:
- Code blocks (preserved, lang tags carried)
- Inline code (not split mid-span)
- Math blocks (fence reopened, no interference with code blocks, `24622` inside code is literal)
- Tables (whole fit, boundary preference, header reconstruction across chunks)
- Ordered lists (boundary preference)
- Mixed content (code → table → math in sequence)
- Edge cases (short messages, exact fits)

## Status

Replaces the previous version of this PR which was based on a stale local file.  This version is based on current upstream main (`3910ab2`).