### PR TITLE
fix(api): classify failed tool stream events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2645,7 +2645,11 @@ class APIServerAdapter(BasePlatformAdapter):
             if event_type == "reasoning.available":
                 _enqueue("tool.progress", {"message_id": message_id, "tool_name": tool_name or "_thinking", "delta": preview or ""})
             elif event_type in {"tool.started", "tool.completed", "tool.failed"}:
-                event_name = event_type.replace("tool.", "tool.")
+                event_name = (
+                    "tool.failed"
+                    if event_type == "tool.completed" and kwargs.get("is_error")
+                    else event_type
+                )
                 _enqueue(event_name, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
 
         async def _run_and_signal() -> None:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3877,7 +3877,11 @@ class APIServerAdapter(BasePlatformAdapter):
             if event_type == "reasoning.available":
                 _enqueue("tool.progress", {"message_id": message_id, "tool_name": tool_name or "_thinking", "delta": preview or ""})
             elif event_type in {"tool.started", "tool.completed", "tool.failed"}:
-                event_name = event_type.replace("tool.", "tool.")
+                event_name = (
+                    "tool.failed"
+                    if event_type == "tool.completed" and kwargs.get("is_error")
+                    else event_type
+                )
                 _enqueue(event_name, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
 
         async def _run_and_signal() -> None:

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -341,6 +341,34 @@ async def test_session_chat_stream_emits_lifecycle_events_and_keepalive_safe_sha
 
 
 @pytest.mark.asyncio
+async def test_session_chat_stream_classifies_failed_tool_completions(adapter, session_db):
+    session_id = session_db.create_session("tool-status-stream", "api_server")
+
+    async def fake_run(**kwargs):
+        progress = kwargs["tool_progress_callback"]
+        progress("tool.completed", tool_name="read_file", is_error=False)
+        progress("tool.completed", tool_name="terminal", is_error=True)
+        progress("tool.failed", tool_name="web_search")
+        return {"final_response": "done", "session_id": session_id}, {"total_tokens": 1}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "run tools"},
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    assert body.count("event: tool.completed") == 1
+    assert body.count("event: tool.failed") == 2
+    assert '"tool_name": "read_file"' in body
+    assert '"tool_name": "terminal"' in body
+    assert '"tool_name": "web_search"' in body
+
+
+@pytest.mark.asyncio
 async def test_session_chat_stream_run_completed_carries_turn_transcript(adapter, session_db):
     """run.completed must include the full interleaved turn transcript so a
     client that lost intermediate (pre-tool-call) assistant text from the live

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -161,6 +161,38 @@ async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_session_chat_stream_classifies_failed_tool_completions(adapter, session_db):
+    session_id = session_db.create_session("tool-status-stream", "api_server")
+
+    async def fake_run(**kwargs):
+        progress = kwargs["tool_progress_callback"]
+        progress("tool.completed", tool_name="read_file", is_error=False)
+        progress("tool.completed", tool_name="terminal", is_error=True)
+        progress("tool.failed", tool_name="web_search")
+        return {"final_response": "done", "session_id": session_id}, {"total_tokens": 1}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "run tools"},
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    blocks = body.split("\n\n")
+    assert any("event: tool.completed" in b and '"tool_name": "read_file"' in b for b in blocks)
+    assert any("event: tool.failed" in b and '"tool_name": "terminal"' in b for b in blocks)
+    assert any("event: tool.failed" in b and '"tool_name": "web_search"' in b for b in blocks)
+    assert body.count("event: tool.completed") == 1
+    assert body.count("event: tool.failed") == 2
+    assert '"tool_name": "read_file"' in body
+    assert '"tool_name": "terminal"' in body
+    assert '"tool_name": "web_search"' in body
+
+
+@pytest.mark.asyncio
 async def test_session_chat_stream_run_completed_carries_turn_transcript(adapter, session_db):
     """run.completed must include the full interleaved turn transcript so a
     client that lost intermediate (pre-tool-call) assistant text from the live

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -455,7 +455,7 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `GET` | `/api/sessions/{id}/messages` | Message history for a session |
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
 | `POST` | `/api/sessions/{id}/chat` | Run one synchronous agent turn |
-| `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
+| `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `tool.failed`, `run.completed` events |
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
 


### PR DESCRIPTION
## What does this PR do?

The session chat SSE endpoint currently forwards failed tool completions as `tool.completed` because the executor reports completion plus `is_error=true`, while the API adapter drops that error flag. This makes streaming clients render failed tools as successful completions.

This change maps error-marked completion callbacks to `tool.failed` at the API boundary. Successful completions and callers that already emit `tool.failed` remain unchanged.

## Related Issue

Fixes #70503

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Preserve the executor's failure classification in `gateway/platforms/api_server.py`.
- Add regression coverage for successful, error-marked, and explicit failed tool events in `tests/gateway/test_session_api.py`.

## How to Test

1. Run `uv run --extra dev --extra messaging python -m pytest tests/gateway/test_session_api.py -q`.
2. Confirm all 13 tests pass.
3. Run `uv run --extra dev ruff check gateway/platforms/api_server.py tests/gateway/test_session_api.py` and confirm it reports no errors.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

```text
13 passed in 3.35s
All checks passed!
```