### PR TITLE
fix(skills): accuracy + concision pass over the hermes-agent hub references

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hermes-agent
 description: "Use, configure, theme, extend, and orchestrate Hermes Agent."
-version: 3.0.0
+version: 3.1.0
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]

--- a/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
@@ -50,8 +50,9 @@ Background maintenance for agent-created skills. Tracks usage, marks
 idle skills stale, archives stale ones, keeps a pre-run tar.gz backup
 so nothing is lost.
 
-- **CLI:** `hermes curator <verb>` — `status`, `run`, `pause`, `resume`,
-  `pin`, `unpin`, `archive`, `restore`, `prune`, `backup`, `rollback`.
+- **CLI:** `hermes curator <verb>` — `status`, `usage`, `run`, `pause`,
+  `resume`, `pin`, `unpin`, `archive`, `restore`, `list-archived`, `prune`,
+  `backup`, `rollback`.
 - **Slash:** `/curator <subcommand>` mirrors the CLI.
 - **Scope:** only touches skills with `created_by: "agent"` provenance.
   Bundled + hub-installed skills are off-limits. **Never deletes** —

--- a/skills/autonomous-ai-agents/hermes-agent/references/cli-reference.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/cli-reference.md
@@ -1,213 +1,150 @@
 # Hermes CLI Reference
 
-Full command surface. `hermes --help` / `hermes <command> --help` and
-https://hermes-agent.nousresearch.com/docs/reference/cli-commands are the
-live sources if anything here looks stale.
+Live sources when anything looks stale: `hermes --help`, `hermes <command> --help`,
+https://hermes-agent.nousresearch.com/docs/reference/cli-commands
 
 ### Global Flags
 
 ```
-hermes [flags] [command]
+hermes [flags] [command]        (no subcommand = interactive chat)
 
   --version, -V             Show version
+  -z, --oneshot PROMPT      One-shot: print ONLY the final response (for scripts/pipes)
+  -m MODEL  --provider P    Model/provider override for this invocation
+  -t, --toolsets LIST       Comma-separated toolsets for this invocation
   --resume, -r SESSION      Resume session by ID or title
   --continue, -c [NAME]     Resume by name, or most recent session
   --worktree, -w            Isolated git worktree mode (parallel agents)
   --skills, -s SKILL        Preload skills (comma-separate or repeat)
   --profile, -p NAME        Use a named profile
   --yolo                    Skip dangerous command approval
+  --tui / --cli             Force the Ink TUI / classic REPL
+  --ignore-rules            Skip AGENTS.md/SOUL.md/memory/skill injection
+  --safe-mode               Disable ALL customizations (troubleshooting)
   --pass-session-id         Include session ID in system prompt
 ```
-
-No subcommand defaults to `chat`.
 
 ### Chat
 
 ```
 hermes chat [flags]
   -q, --query TEXT          Single query, non-interactive
-  -m, --model MODEL         Model (e.g. anthropic/claude-sonnet-4)
-  -t, --toolsets LIST       Comma-separated toolsets
-  --provider PROVIDER       Force provider (openrouter, anthropic, nous, etc.)
-  -v, --verbose             Verbose output
+  --image PATH              Attach a local image to a single query
   -Q, --quiet               Suppress banner, spinner, tool previews
   --checkpoints             Enable filesystem checkpoints (/rollback)
+  --max-turns N             Cap tool-calling iterations
   --source TAG              Session source tag (default: cli)
 ```
+(plus the global flags above)
 
 ### Configuration
 
 ```
-hermes setup [section]      Interactive wizard (model|terminal|gateway|tools|agent)
+hermes setup [section]      Wizard (model|tts|terminal|gateway|tools|agent)
 hermes model                Interactive model/provider picker
-hermes config               View current config
-hermes config edit          Open config.yaml in $EDITOR
-hermes config set KEY VAL   Set a config value
-hermes config path          Print config.yaml path
-hermes config env-path      Print .env path
-hermes config check         Check for missing/outdated config
-hermes config migrate       Update config with new options
+hermes fallback [add|remove|list]  Fallback provider chain
+hermes config [show|edit|get|set|unset|path|env-path|check|migrate]
+hermes login / logout       OAuth sign-in / clear stored auth
 hermes doctor [--fix]       Check dependencies and config
-hermes status [--all]       Show component status
+hermes status [--all]       Component status
 ```
-
-Credentials (OAuth + API keys, with pooling) are managed under `hermes auth` — see the Credentials & Pools section below.
 
 ### Tools & Skills
 
 ```
-hermes tools                Interactive tool enable/disable (curses UI)
-hermes tools list           Show all tools and status
-hermes tools enable NAME    Enable a toolset
-hermes tools disable NAME   Disable a toolset
+hermes tools [list|enable NAME|disable NAME]   Per-platform toolsets (curses UI with no args)
 
-hermes skills list          List installed skills
-hermes skills search QUERY  Search the skills hub
-hermes skills install ID    Install a skill (ID can be a hub identifier OR a direct https://…/SKILL.md URL; pass --name to override when frontmatter has no name)
-hermes skills inspect ID    Preview without installing
+hermes skills list|browse|search QUERY|inspect ID
+hermes skills install ID    Hub identifier OR a direct https://…/SKILL.md URL
 hermes skills config        Enable/disable skills per platform
-hermes skills check         Check for updates
-hermes skills update        Update outdated skills
-hermes skills uninstall N   Remove a hub skill
-hermes skills publish PATH  Publish to registry
-hermes skills browse        Browse all available skills
-hermes skills tap add REPO  Add a GitHub repo as skill source
+hermes skills check|update|uninstall|publish PATH
+hermes skills tap add REPO  Add a GitHub repo as a skill source
+hermes bundles              Skill bundles (one /<name> alias loads several skills)
 ```
 
 ### MCP Servers
 
 ```
-hermes mcp serve            Run Hermes as an MCP server
-hermes mcp add NAME         Add an MCP server (--url or --command)
-hermes mcp remove NAME      Remove an MCP server
-hermes mcp list             List configured servers
-hermes mcp test NAME        Test connection
-hermes mcp configure NAME   Toggle tool selection
+hermes mcp add NAME (--url or --command) | remove | list | test NAME
+hermes mcp catalog | install NAME     Curated catalog install
+hermes mcp configure NAME             Toggle tool selection
+hermes mcp serve                      Run Hermes as an MCP server
 ```
-
-How the built-in MCP client connects servers (stdio/HTTP), auto-discovers
-their tools, and exposes them as first-class tools, plus catalog install
-(`hermes mcp install <name>`): `skill_view(name="hermes-agent", file_path="references/native-mcp.md")`.
+Details (transport, tool discovery, catalog): `references/native-mcp.md`.
 
 ### Gateway (Messaging Platforms)
 
 ```
-hermes gateway run          Start gateway foreground
-hermes gateway install      Install as background service
-hermes gateway start/stop   Control the service
-hermes gateway restart      Restart the service
-hermes gateway status       Check status
-hermes gateway setup        Configure platforms
+hermes gateway run|install|start|stop|restart|status|setup
 ```
 
-Supported platforms (20+): Telegram, Discord, Slack, WhatsApp (Baileys bridge + official Business Cloud API), iMessage (Photon — `hermes photon setup`, the BlueBubbles successor with no Mac relay), Signal, Email, SMS, Matrix, Mattermost, Microsoft Teams, LINE, SimpleX, ntfy, Google Chat, Home Assistant, DingTalk, Feishu, WeCom, Weixin (WeChat), Raft (agent network), API Server, Webhooks. Open WebUI connects via the API Server adapter. Most adapters ship under `plugins/platforms/`, so new ones drop in without touching core.
-
-Platform docs: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/
+20+ platforms: Telegram, Discord, Slack, WhatsApp (Baileys + Business Cloud API), iMessage (Photon — `hermes photon setup`), Signal, Email, SMS, Matrix, Mattermost, Teams, LINE, SimpleX, ntfy, Google Chat, Home Assistant, DingTalk, Feishu, WeCom, Weixin, API Server, Webhooks. Open WebUI connects via the API Server adapter. Most adapters ship under `plugins/platforms/`.
+Docs: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/
 
 ### Sessions
 
 ```
-hermes sessions list        List recent sessions
-hermes sessions browse      Interactive picker
-hermes sessions export OUT  Export to JSONL
-hermes sessions rename ID T Rename a session
-hermes sessions delete ID   Delete a session
-hermes sessions prune       Clean up old sessions (--older-than N days)
-hermes sessions stats       Session store statistics
+hermes sessions list|browse|rename ID TITLE|delete ID|export OUT|prune|stats
 ```
 
-### Cron Jobs
+### Cron / Webhooks
 
 ```
-hermes cron list            List jobs (--all for disabled)
-hermes cron create SCHED    Create: '30m', 'every 2h', '0 9 * * *'
-hermes cron edit ID         Edit schedule, prompt, delivery
-hermes cron pause/resume ID Control job state
-hermes cron run ID          Trigger on next tick
-hermes cron remove ID       Delete a job
-hermes cron status          Scheduler status
+hermes cron list|create SCHED|edit ID|pause|resume|run ID|remove|status
+    Schedules: '30m', 'every 2h', '0 9 * * *', ISO timestamp
+hermes webhook subscribe NAME|list|remove NAME|test NAME
 ```
-
-### Webhooks
-
-```
-hermes webhook subscribe N  Create route at /webhooks/<name>
-hermes webhook list         List subscriptions
-hermes webhook remove NAME  Remove a subscription
-hermes webhook test NAME    Send a test POST
-```
-
-Full setup, route config, payload templating, and event-driven agent-run
-patterns: `skill_view(name="hermes-agent", file_path="references/webhooks.md")`.
+Webhook payloads/routes: `references/webhooks.md`.
 
 ### Profiles
 
 ```
-hermes profile list         List all profiles
-hermes profile create NAME  Create (--clone, --clone-all, --clone-from)
-hermes profile use NAME     Set sticky default
-hermes profile delete NAME  Delete a profile
-hermes profile show NAME    Show details
-hermes profile alias NAME   Manage wrapper scripts
-hermes profile rename A B   Rename a profile
-hermes profile export NAME  Export to tar.gz
-hermes profile import FILE  Import from archive
+hermes profile list|create NAME (--clone|--clone-all|--clone-from)|use|show|delete
+hermes profile rename A B | alias NAME | export NAME | import FILE
 ```
 
 ### Credentials & Pools
 
 ```
 hermes auth                 Interactive credential manager
-hermes auth add [PROVIDER]  Add OAuth or API-key credential
-                            (e.g. nous, openai-codex, qwen-oauth, anthropic)
-hermes auth list [PROVIDER] List pooled credentials
-hermes auth remove P INDEX  Remove by provider + index
-hermes auth reset PROVIDER  Clear exhaustion status
+hermes auth add [PROVIDER]  Add OAuth or API-key credential (nous, openai-codex, qwen-oauth, …)
+hermes auth list|remove P IDX|reset PROVIDER|status
 ```
-
 Multiple credentials per provider form a pool that rotates automatically and skips exhausted keys.
 
 ### Other
 
 ```
-hermes insights [--days N]  Usage analytics
-hermes update               Update to latest version
-hermes desktop / gui        Launch the native desktop app
-hermes dashboard            Web admin panel + embedded chat
+hermes desktop / gui        Native desktop app
+hermes dashboard            Web admin panel + embedded chat (--stop / --status)
 hermes proxy                OpenAI-compatible local proxy backed by an OAuth provider
 hermes portal               Quick setup / sign in via Nous Portal
-hermes kanban <verb>        Multi-agent work-queue board (init/create/list/show/assign/…)
-hermes pairing list/approve/revoke  DM authorization
-hermes plugins list/install/remove  Plugin management
-hermes secrets bitwarden …  External secret store (Bitwarden Secrets Manager)
-hermes memory setup/status/off  Memory provider config
-hermes send                 Send a one-off message through a gateway platform
-hermes completion bash|zsh  Shell completions
+hermes kanban <verb>        Multi-agent work-queue board
+hermes project              Named multi-folder workspaces
+hermes skin list|use|set    Switch/tweak skins (see references/themes.md)
+hermes pets <verb>          Pet mascots (see references/petdex.md)
+hermes memory setup|status|off|reset   Memory provider
+hermes secrets bitwarden|onepassword   External secret stores
+hermes moa                  Mixture-of-Agents slots
+hermes hooks / security / backup / import / checkpoints / console
+hermes logs [-f] [errors]   View agent/error logs
+hermes send                 One-off message through a gateway platform
+hermes pairing / plugins / insights / journey / computer-use
 hermes acp                  ACP server (IDE integration)
-hermes claw migrate         Migrate from OpenClaw
-hermes uninstall            Uninstall Hermes
+hermes completion bash|zsh|fish
+hermes update / uninstall / claw migrate
 ```
 
-For the full, authoritative command list run `hermes --help` (and `hermes <command> --help`). Plugin- and provider-supplied subcommands (e.g. `hermes photon setup` for iMessage) only appear once their plugin is installed/active.
+Plugin- and provider-supplied subcommands (e.g. `hermes photon setup`) only appear once their plugin is installed/active.
 
----
-
-## Where to Find Things
+### Where to Find Things
 
 | Looking for... | Location |
-|----------------|----------|
-| Config options | `hermes config edit` or [Configuration docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) |
-| Available tools | `hermes tools list` or [Tools reference](https://hermes-agent.nousresearch.com/docs/reference/tools-reference) |
-| Slash commands | `/help` in session or [Slash commands reference](https://hermes-agent.nousresearch.com/docs/reference/slash-commands) |
-| Skills catalog | `hermes skills browse` or [Skills catalog](https://hermes-agent.nousresearch.com/docs/reference/skills-catalog) |
-| Provider setup | `hermes model` or [Providers guide](https://hermes-agent.nousresearch.com/docs/integrations/providers) |
-| Platform setup | `hermes gateway setup` or [Messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/) |
-| MCP servers | `hermes mcp list` or [MCP guide](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) |
-| Profiles | `hermes profile list` or [Profiles docs](https://hermes-agent.nousresearch.com/docs/user-guide/profiles) |
-| Cron jobs | `hermes cron list` or [Cron docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/cron) |
-| Memory | `hermes memory status` or [Memory docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory) |
-| Env variables | `hermes config env-path` or [Env vars reference](https://hermes-agent.nousresearch.com/docs/reference/environment-variables) |
-| CLI commands | `hermes --help` or [CLI reference](https://hermes-agent.nousresearch.com/docs/reference/cli-commands) |
-| Gateway logs | `~/.hermes/logs/gateway.log` |
-| Session files | `hermes sessions browse` (reads state.db) |
-| Source code | `~/.hermes/hermes-agent/` |
+|---|---|
+| Config options | `hermes config edit` · [Configuration docs](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) |
+| Tools / toolsets | `hermes tools list` · [Tools reference](https://hermes-agent.nousresearch.com/docs/reference/tools-reference) |
+| Skills catalog | `hermes skills browse` · [Skills catalog](https://hermes-agent.nousresearch.com/docs/reference/skills-catalog) |
+| Provider setup | `hermes model` · [Providers guide](https://hermes-agent.nousresearch.com/docs/integrations/providers) |
+| Env variables | `hermes config env-path` · [Env vars reference](https://hermes-agent.nousresearch.com/docs/reference/environment-variables) |
+| Gateway logs | `~/.hermes/logs/gateway.log` (or `hermes logs`) |
+| Sessions | `hermes sessions browse` (reads state.db) |

--- a/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
@@ -1,112 +1,89 @@
 # Configuration, Toolsets & Voice
 
-```
-~/.hermes/config.yaml       Main configuration
-~/.hermes/.env              API keys and secrets (under $HERMES_HOME if set)
-$HERMES_HOME/skills/        Installed skills
-~/.hermes/sessions/         Gateway routing index, request dumps, *.jsonl transcripts (and optional per-session JSON snapshots when sessions.write_json_snapshots: true)
-~/.hermes/state.db          Canonical session store (SQLite + FTS5)
-~/.hermes/logs/             Gateway and error logs
-~/.hermes/auth.json         OAuth tokens and credential pools
-~/.hermes/hermes-agent/     Source code (if git-installed)
-```
-
-Profiles use `~/.hermes/profiles/<name>/` with the same layout.
-
-### Config Sections
-
 Edit with `hermes config edit` or `hermes config set section.key value`.
+Full reference: https://hermes-agent.nousresearch.com/docs/user-guide/configuration
+
+### Config Sections (most-used keys)
 
 | Section | Key options |
 |---------|-------------|
-| `model` | `default`, `provider`, `base_url`, `api_key`, `context_length` |
-| `agent` | `max_turns` (90), `tool_use_enforcement` |
-| `terminal` | `backend` (local/docker/ssh/modal), `cwd`, `timeout` (180) |
+| `model` | `default`, `provider`, `base_url`, `api_key`, `context_length`, `aliases` |
+| `agent` | `max_turns` (90), `tool_use_enforcement`, `service_tier`, `verify_on_stop` |
+| `terminal` | `backend` (local/docker/ssh/modal/daytona/singularity), `cwd`, `timeout` (180) |
 | `compression` | `enabled`, `threshold` (0.50), `target_ratio` (0.20) |
-| `display` | `skin`, `interface` (cli/tui), `tool_progress`, `show_reasoning`, `show_cost`, `language` |
-| `stt` | `enabled`, `provider` (local/groq/openai/mistral) |
-| `tts` | `provider` (edge/elevenlabs/openai/minimax/mistral/neutts) |
-| `memory` | `memory_enabled`, `user_profile_enabled`, `provider` |
-| `security` | `tirith_enabled`, `website_blocklist` |
-| `delegation` | `model`, `provider`, `base_url`, `api_key`, `max_iterations` (50), `reasoning_effort` |
+| `display` | `skin`, `interface` (cli/tui), `language`, `show_reasoning`, `show_cost`, `pet` |
+| `approvals` | `mode` (smart/manual/off), `timeout`, `cron_mode` |
+| `stt` | `enabled`, `provider` (local/groq/openai/mistral/elevenlabs/deepinfra) |
+| `tts` | `provider` (edge/elevenlabs/openai/minimax/mistral/neutts/gemini/piper/kittentts/deepinfra/xai) |
+| `memory` | `memory_enabled`, `user_profile_enabled`, `provider`, `write_approval` |
+| `security` | `redact_secrets`, `tirith_enabled`, `website_blocklist` |
+| `delegation` | `model`, `provider`, `max_concurrent_children`, `max_iterations` (50), `max_spawn_depth` |
 | `checkpoints` | `enabled`, `max_snapshots` (50) |
-| `curator` | `enabled`, `consolidate` (false — opt-in aux-model skill consolidation), `interval_hours`, `stale_after_days` |
+| `curator` | `enabled`, `consolidate` (false, opt-in aux-model consolidation), `interval_hours`, `stale_after_days` |
 
-Full config reference: https://hermes-agent.nousresearch.com/docs/user-guide/configuration
+`hermes config check` reports sections missing from an older config.
 
 ### Toolsets
 
 Enable/disable via `hermes tools` (interactive) or `hermes tools enable/disable NAME`.
+Full enumeration: `TOOLSETS` dict in `toolsets.py` (`_HERMES_CORE_TOOLS` is the default bundle most platforms inherit).
 
 | Toolset | What it provides |
 |---------|-----------------|
-| `web` | Web search and content extraction |
-| `search` | Web search only (subset of `web`) |
+| `web` / `search` | Web search + extraction / search-only subset |
 | `browser` | Browser automation (Browserbase, Camofox, or local Chromium) |
 | `terminal` | Shell commands and process management |
 | `file` | File read/write/search/patch |
 | `code_execution` | Sandboxed Python execution |
+| `coding` | Code-editing helpers (LSP-backed) |
+| `computer_use` | Desktop GUI control (cua-driver) |
 | `vision` | Image analysis |
-| `image_gen` | AI image generation and image-to-image editing |
-| `video` | Video analysis (`video_analyze`) and generation |
-| `x_search` | First-class X (Twitter) search (X OAuth or API key) |
+| `image_gen` | Image generation and image-to-image editing |
+| `video` / `video_gen` | Video analysis / video generation |
+| `x_search` | X (Twitter) search (X OAuth or API key) |
 | `tts` | Text-to-speech |
 | `skills` | Skill browsing and management |
 | `memory` | Persistent cross-session memory |
 | `session_search` | Search past conversations |
+| `context_engine` | Pluggable context-engine hooks |
+| `project` | Named multi-folder workspace tools |
 | `delegation` | Subagent task delegation |
 | `cronjob` | Scheduled task management |
 | `clarify` | Ask user clarifying questions |
-| `messaging` | Cross-platform message sending |
-| `todo` | In-session task planning and tracking |
+| `todo` | In-session task planning |
 | `kanban` | Multi-agent work-queue tools (gated to workers) |
-| `debugging` | Extra introspection/debug tools (off by default) |
-| `safe` | Minimal, low-risk toolset for locked-down sessions |
-| `spotify` | Spotify playback and playlist control |
-| `homeassistant` | Smart home control (off by default) |
-| `discord` | Discord integration tools |
-| `discord_admin` | Discord admin/moderation tools |
-| `feishu_doc` | Feishu (Lark) document tools |
-| `feishu_drive` | Feishu (Lark) drive tools |
-| `yuanbao` | Yuanbao integration tools |
-| `rl` | Reinforcement learning tools (off by default) |
+| `debugging` | Extra introspection tools (off by default) |
+| `safe` | Minimal low-risk toolset for locked-down sessions |
+| `spotify`, `homeassistant`, `discord`, `discord_admin`, `feishu_doc`, `feishu_drive`, `yuanbao` | Service integrations (gated on their credentials) |
 
-Full enumeration lives in `toolsets.py` as the `TOOLSETS` dict; `_HERMES_CORE_TOOLS` is the default bundle most platforms inherit from.
+Tool changes take effect on `/reset` (new session) — never mid-conversation, to preserve prompt caching.
 
-Tool changes take effect on `/reset` (new session). They do NOT apply mid-conversation to preserve prompt caching.
-
----
-
-## Voice & Transcription
+## Voice
 
 ### STT (Voice → Text)
 
 Voice messages from messaging platforms are auto-transcribed.
 
-Provider priority (auto-detected):
-1. **Local faster-whisper** — free, no API key: `pip install faster-whisper`
-2. **Groq Whisper** — free tier: set `GROQ_API_KEY`
-3. **OpenAI Whisper** — paid: set `VOICE_TOOLS_OPENAI_KEY`
-4. **Mistral Voxtral** — set `MISTRAL_API_KEY`
-
-Config:
 ```yaml
 stt:
   enabled: true
-  provider: local        # local, groq, openai, mistral
+  provider: local   # local (faster-whisper, free) | groq | openai | mistral | elevenlabs | deepinfra
   local:
-    model: base          # tiny, base, small, medium, large-v3
+    model: base     # tiny, base, small, medium, large-v3
 ```
+
+Auto-detect priority: local faster-whisper (`pip install faster-whisper`) → Groq (`GROQ_API_KEY`, free tier) → OpenAI (`VOICE_TOOLS_OPENAI_KEY`) → Mistral Voxtral (`MISTRAL_API_KEY`).
 
 ### TTS (Text → Voice)
 
 | Provider | Env var | Free? |
 |----------|---------|-------|
-| Edge TTS | None | Yes (default) |
+| Edge TTS (default) | None | Yes |
 | ElevenLabs | `ELEVENLABS_API_KEY` | Free tier |
 | OpenAI | `VOICE_TOOLS_OPENAI_KEY` | Paid |
 | MiniMax | `MINIMAX_API_KEY` | Paid |
-| Mistral (Voxtral) | `MISTRAL_API_KEY` | Paid |
-| NeuTTS (local) | None (`pip install neutts[all]` + `espeak-ng`) | Free |
+| Mistral | `MISTRAL_API_KEY` | Paid |
+| Gemini | `GOOGLE_API_KEY` | Free tier |
+| NeuTTS / Piper / KittenTTS (local) | None | Free |
 
 Voice commands: `/voice on` (voice-to-voice), `/voice tts` (always voice), `/voice off`.

--- a/skills/autonomous-ai-agents/hermes-agent/references/contributor-guide.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/contributor-guide.md
@@ -96,8 +96,8 @@ scripts/run_tests.sh -v --tb=long             # pass-through pytest flags
 
 - Tests auto-redirect `HERMES_HOME` to temp dirs — never touch real `~/.hermes/`.
 - The script probes `.venv`, then `venv`, then the shared worktree venv.
-- **Windows:** the wrapper is POSIX-only; see the **Windows-Specific Quirks**
-  section above for the direct-pytest workaround.
+- **Windows:** the wrapper is POSIX-only; see `references/windows-quirks.md`
+  for the direct-pytest workaround.
 
 **Cross-platform test guards:** tests using POSIX-only syscalls need a skip marker. Common ones already in the codebase:
 - Symlink creation → `@pytest.mark.skipif(sys.platform == "win32", reason="Symlinks require elevated privileges on Windows")` (see `tests/cron/test_cron_script.py`)

--- a/skills/autonomous-ai-agents/hermes-agent/references/providers-and-models.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/providers-and-models.md
@@ -1,29 +1,64 @@
-# Providers
+# Providers & Model Aliases
 
-20+ providers supported. Set via `hermes model` or `hermes setup`.
+Set via `hermes model` (picker) or `hermes setup`. 35+ provider profiles ship as
+plugins under `plugins/model-providers/`; user plugins of the same name override.
+Full docs: https://hermes-agent.nousresearch.com/docs/integrations/providers
 
-| Provider | Auth | Key env var |
-|----------|------|-------------|
-| OpenRouter | API key | `OPENROUTER_API_KEY` |
-| Anthropic | API key | `ANTHROPIC_API_KEY` |
-| Nous Portal | OAuth | `hermes auth` |
-| OpenAI Codex | OAuth | `hermes auth` |
-| GitHub Copilot | Token | `COPILOT_GITHUB_TOKEN` |
-| Google Gemini | API key | `GOOGLE_API_KEY` or `GEMINI_API_KEY` |
-| DeepSeek | API key | `DEEPSEEK_API_KEY` |
-| xAI / Grok | API key | `XAI_API_KEY` |
-| Hugging Face | Token | `HF_TOKEN` |
-| Z.AI / GLM | API key | `GLM_API_KEY` |
-| MiniMax | API key | `MINIMAX_API_KEY` |
-| MiniMax CN | API key | `MINIMAX_CN_API_KEY` |
-| Kimi / Moonshot | API key | `KIMI_API_KEY` |
-| Alibaba / DashScope | API key | `DASHSCOPE_API_KEY` |
-| Xiaomi MiMo | API key | `XIAOMI_API_KEY` |
-| Kilo Code | API key | `KILOCODE_API_KEY` |
-| OpenCode Zen | API key | `OPENCODE_ZEN_API_KEY` |
-| OpenCode Go | API key | `OPENCODE_GO_API_KEY` |
-| Qwen OAuth | OAuth | `hermes auth add qwen-oauth` |
-| Custom endpoint | Config | `model.base_url` + `model.api_key` in config.yaml |
-| GitHub Copilot ACP | External | `COPILOT_CLI_PATH` or Copilot CLI |
+### Providers
 
-Full provider docs: https://hermes-agent.nousresearch.com/docs/integrations/providers
+| Provider | Auth | Key env var(s) |
+|----------|------|----------------|
+| openrouter | API key | `OPENROUTER_API_KEY` |
+| anthropic | API key | `ANTHROPIC_API_KEY` (also `CLAUDE_CODE_OAUTH_TOKEN`) |
+| nous | OAuth device code | `hermes auth add nous` (or `NOUS_API_KEY`) |
+| openai-codex | OAuth | `hermes auth add openai-codex` |
+| qwen-oauth | OAuth | `hermes auth add qwen-oauth` |
+| minimax-oauth | OAuth | `hermes auth add minimax-oauth` |
+| copilot | Token | `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` (Copilot device flow — `gh auth login` tokens do NOT work) |
+| copilot-acp | External CLI | Copilot CLI on PATH or `COPILOT_CLI_PATH` |
+| gemini | API key | `GOOGLE_API_KEY` or `GEMINI_API_KEY` |
+| xai | API key | `XAI_API_KEY` (SuperGrok OAuth also supported) |
+| deepseek | API key | `DEEPSEEK_API_KEY` |
+| zai (GLM) | API key | `GLM_API_KEY` / `ZAI_API_KEY` |
+| minimax / minimax-cn | API key | `MINIMAX_API_KEY` / `MINIMAX_CN_API_KEY` |
+| kimi-coding / -cn | API key | `KIMI_API_KEY` / `KIMI_CN_API_KEY` |
+| alibaba (+coding-plan) | API key | `DASHSCOPE_API_KEY` / `ALIBABA_CODING_PLAN_API_KEY` |
+| xiaomi | API key | `XIAOMI_API_KEY` |
+| huggingface | Token | `HF_TOKEN` |
+| fireworks / novita / nvidia / deepinfra / gmi / arcee / stepfun / upstage / kilocode / opencode-zen / opencode-go / ollama-cloud | API key | `<NAME>_API_KEY` |
+| bedrock / vertex / azure-foundry | Cloud SDK / key | AWS SDK creds / Vertex ADC / `AZURE_FOUNDRY_API_KEY` |
+| custom | Config | `model.base_url` + `model.api_key` in config.yaml |
+
+Multiple credentials per provider pool and rotate automatically (`hermes auth`).
+Fallback chain when the primary fails: `hermes fallback add|remove|list`.
+
+### User-defined model aliases
+
+Work with `/model <name>` in CLI and every gateway platform. Resolved by
+`hermes_cli/model_switch.py::resolve_alias()`; user aliases are checked BEFORE
+the built-in table, so a user `sonnet`/`grok` shadows the built-in.
+
+```yaml
+# Full form
+model_aliases:
+  fav:
+    model: claude-sonnet-4.6
+    provider: anthropic
+  local-qwen:
+    model: qwen3.5:397b
+    provider: custom
+    base_url: "https://ollama.com/v1"
+
+# Short form ("provider/model"), also via CLI:
+#   hermes config set model.aliases.fav openrouter/anthropic/claude-sonnet-4.6
+model:
+  aliases:
+    fav: openrouter/anthropic/claude-sonnet-4.6
+```
+
+`/model fav` — session-scoped; add `--global` to persist as default.
+
+Built-in aliases (catalog-resolved against the active provider): `sonnet`,
+`opus`, `haiku`, `claude`, `gpt5`, `gpt`, `codex`, `o3`, `o4`, `gemini`,
+`deepseek`, `grok`, `llama`, `qwen`, `minimax`, `nemotron`, `kimi`, `glm`,
+`step`, `mimo`, `trinity`.

--- a/skills/autonomous-ai-agents/hermes-agent/references/security-privacy.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/security-privacy.md
@@ -45,11 +45,23 @@ Per-invocation bypass without changing config:
 
 Note: YOLO / `approvals.mode: off` does NOT turn off secret redaction. They are independent.
 
+### "Reset permissions" / "make Hermes ask again"
+
+The user usually means: wipe the accumulated "Always allow" state — NOT yolo
+mode, and NOT a per-edit diff prompt (which doesn't exist; file writes never
+go through the approval prompt, only shell commands do). Two stores hold it:
+
+1. Shell-command allowlist: `hermes config set command_allowlist '[]'`
+2. Shell-hook consent (only if present): `rm -f ~/.hermes/shell-hooks-allowlist.json`
+
+Then sanity-check `hermes config get approvals.mode` (should not be `off`)
+and confirm `--yolo` isn't baked into their launch alias or systemd unit.
+
 ### Shell hooks allowlist
 
 Some shell-hook integrations require explicit allowlisting before they fire. Managed via `~/.hermes/shell-hooks-allowlist.json` — prompted interactively the first time a hook wants to run.
 
 ### Disabling the web/browser/image-gen tools
 
-To keep the model away from network or media tools entirely, open `hermes tools` and toggle per-platform. Takes effect on next session (`/reset`). See the Tools & Skills section above.
+To keep the model away from network or media tools entirely, open `hermes tools` and toggle per-platform. Takes effect on next session (`/reset`). See `references/configuration.md` for the toolset list.
 

--- a/skills/autonomous-ai-agents/hermes-agent/references/slash-commands.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/slash-commands.md
@@ -1,101 +1,110 @@
 # Slash Commands (In-Session)
 
-Type these during an interactive chat session. New commands land fairly
-often; if something below looks stale, run `/help` in-session for the
-authoritative list or see the [live slash commands reference](https://hermes-agent.nousresearch.com/docs/reference/slash-commands).
-The registry of record is `hermes_cli/commands.py` — every consumer
-(autocomplete, Telegram menu, Slack mapping, `/help`) derives from it.
+Registry of record: `hermes_cli/commands.py` (`COMMAND_REGISTRY`) — every
+consumer (autocomplete, `/help`, Telegram menu, Slack mapping) derives from
+it. New commands land often; `/help` in-session is always authoritative.
+(CLI) = interactive CLI/TUI only. (GW) = gateway platforms only.
 
-### Session Control
+### Session
 ```
-/new (/reset)        Fresh session
-/clear               Clear screen + new session (CLI)
-/retry               Resend last message
-/undo                Remove last exchange
-/title [name]        Name the session
-/compress            Manually compress context
-/stop                Kill background processes
-/rollback [N]        Restore filesystem checkpoint
-/snapshot [sub]      Create or restore state snapshots of Hermes config/state (CLI)
-/background <prompt> Run prompt in background
-/queue <prompt>      Queue for next turn
-/steer <prompt>      Inject a message after the next tool call without interrupting
-/agents (/tasks)     Show active agents and running tasks
-/resume [name]       Resume a named session
-/goal [text|sub]     Set a standing goal Hermes works on across turns until achieved
-                     (subcommands: status, pause, resume, clear)
-/redraw              Force a full UI repaint (CLI)
+/new (/reset) [name]     Fresh session
+/clear                   Clear screen + new session (CLI)
+/retry                   Resend last message
+/undo [N]                Back up N user turns and re-prompt
+/title [name]            Name the session
+/prompt (/compose)       Compose next prompt in $EDITOR (CLI)
+/compress (/compact)     Compress context ('here [N]' keeps N turns; --preview)
+/stop                    Kill background processes
+/rollback [N]            List/restore filesystem checkpoints
+/snapshot [sub]          Create/restore Hermes config+state snapshots (CLI)
+/background (/bg) <p>    Run prompt in background
+/queue (/q) <prompt>     Queue prompt for next turn
+/steer <prompt>          Inject a message after the next tool call
+/agents (/tasks)         Show active agents and running tasks
+/goal [text|sub]         Standing goal across turns (status|pause|resume|clear)
+/subgoal [text]          Add/manage criteria on the active goal
+/branch (/fork) [name]   Branch the session
+/resume [name]           Resume a named session
+/sessions                Browse and resume previous sessions
+/handoff <platform>      Hand live session off to a messaging platform (CLI)
+/status                  Session, model, token, and context info
+/redraw                  Force full UI repaint (CLI)
 ```
 
 ### Configuration
 ```
-/config              Show config (CLI)
-/model [name]        Show or change model
-/personality [name]  Set personality
-/reasoning [level]   Set reasoning (none|minimal|low|medium|high|xhigh|max|ultra|show|hide)
-/verbose             Cycle: off → new → all → verbose
-/voice [on|off|tts]  Voice mode
-/yolo                Toggle approval bypass
-/busy [sub]          Control what Enter does while Hermes is working (CLI)
-                     (subcommands: queue, steer, interrupt, status)
-/indicator [style]   Pick the TUI busy-indicator style (CLI)
-                     (styles: kaomoji, emoji, unicode, ascii)
-/footer [on|off]     Toggle gateway runtime-metadata footer on final replies
-/skin [name]         Change theme (CLI)
-/statusbar           Toggle status bar (CLI)
+/config                  Show config (CLI)
+/model [name] [--global] Switch model (session-scoped by default)
+/personality [name]      Set a personality
+/reasoning [level|show|hide] Reasoning effort/display (none..xhigh|max|ultra)
+/fast [normal|fast]      Priority/fast processing tier
+/verbose                 Cycle tool progress: off → new → all → verbose → log (CLI)
+/voice [on|off|tts]      Voice mode
+/yolo                    Toggle approval bypass
+/busy [queue|steer|interrupt] What Enter does while working (CLI)
+/indicator [style]       TUI busy indicator: kaomoji|emoji|unicode|ascii (CLI)
+/footer [on|off]         Gateway runtime-metadata footer on replies
+/skin [name]             Change theme (CLI)
+/statusbar (/sb)         Toggle status bar (CLI)
+/battery [on|off]        Battery indicator in status bar (CLI)
+/timestamps (/ts) [on|off] Message timestamps (CLI)
+/codex-runtime [auto|codex_app_server] Codex runtime toggle
 ```
 
 ### Tools & Skills
 ```
-/tools               Manage tools (CLI)
-/toolsets            List toolsets (CLI)
-/skills              Search/install skills (CLI)
-/skill <name>        Load a skill into session
-/reload-skills       Re-scan ~/.hermes/skills/ for added/removed skills
-/reload              Reload .env variables into the running session (CLI)
-/reload-mcp          Reload MCP servers
-/cron                Manage cron jobs (CLI)
-/curator [sub]       Background skill maintenance (status, run, pin, archive, …)
-/kanban [sub]        Multi-profile collaboration board (tasks, links, comments)
-/plugins             List plugins (CLI)
+/tools [list|enable|disable] Manage tools (CLI)
+/toolsets                List toolsets (CLI)
+/skills                  Search/install/manage skills (CLI)
+/bundles                 List skill bundles (/<name> loads several skills)
+/learn <source>          Learn a reusable skill from dirs/URLs/this chat
+/memory [pending|approve|reject] Review pending memory writes / approval gate
+/pet [toggle|list|<slug>] Petdex mascot control (CLI)
+/hatch [description]     Generate a new pet from a description (CLI)
+/cron [sub]              Manage scheduled tasks (CLI)
+/suggestions (/suggest)  Review suggested automations
+/blueprint (/bp) [name]  Set up an automation from a blueprint
+/curator [sub]           Skill maintenance (status, run, pin, archive, …)
+/kanban [sub]            Multi-profile collaboration board
+/moa <prompt>            One prompt through the Mixture-of-Agents preset
+/reload                  Reload .env into the running session (CLI)
+/reload-mcp              Reload MCP servers
+/reload-skills           Re-scan skills directory
+/browser [connect|status] CDP connection to your live browser (CLI)
+/plugins                 List plugins (CLI)
 ```
 
 ### Gateway
 ```
-/approve             Approve a pending command (gateway)
-/deny                Deny a pending command (gateway)
-/restart             Restart gateway (gateway)
-/sethome             Set current chat as home channel (gateway)
-/update              Update Hermes to latest (gateway)
-/topic [sub]         Enable or inspect Telegram DM topic sessions (gateway)
-/platforms (/gateway) Show platform connection status (gateway)
-```
-
-### Utility
-```
-/branch (/fork)      Branch the current session
-/handoff <platform>  Hand the live session off to a messaging platform (CLI)
-/fast                Toggle priority/fast processing
-/browser             Open CDP browser connection
-/history             Show conversation history (CLI)
-/save                Save conversation to file (CLI)
-/copy [N]            Copy the last assistant response to clipboard (CLI)
-/paste               Attach clipboard image (CLI)
-/image               Attach local image file (CLI)
+/approve [session|always]  Approve a pending dangerous command (GW)
+/deny [all] [reason]       Deny a pending dangerous command (GW)
+/restart                   Restart gateway after draining active runs (GW)
+/sethome                   Set current chat as home channel (GW)
+/topic [off|help]          Telegram DM topic sessions (GW)
+/platform <pause|resume|list> Pause/resume a failing platform (GW)
+/commands [page]           Browse all commands, paginated (GW)
 ```
 
 ### Info
 ```
-/help                Show commands
-/commands [page]     Browse all commands (gateway)
-/usage               Token usage
-/insights [days]     Usage analytics
-/status              Session info (gateway)
-/profile             Active profile info
-/debug               Upload debug report (system info + logs) and get shareable links
+/help                    Show commands
+/usage [reset]           Token usage and rate limits
+/insights [days]         Usage analytics
+/whoami                  Slash-command access level (admin/user)
+/profile                 Active profile info
+/platforms (/gateway)    Platform connection status (CLI)
+/journey (/learning)     Learned skills + memories timeline (CLI)
+/subscription (/upgrade) Nous plan info (CLI)
+/topup                   Nous balance / billing
+/copy [N]                Copy last response to clipboard (CLI)
+/paste                   Attach clipboard image (CLI)
+/image <path>            Attach a local image file (CLI)
+/update                  Update Hermes to latest
+/version (/v)            Show version
+/debug [nous|local]      Upload debug report, get shareable links
 ```
 
 ### Exit
 ```
-/quit (/exit, /q)    Exit CLI
+/quit (/exit) [--delete] Exit CLI; --delete also removes session history
 ```

--- a/skills/autonomous-ai-agents/hermes-agent/references/troubleshooting.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/troubleshooting.md
@@ -24,7 +24,7 @@
 ### Skills not showing
 1. `hermes skills list` — verify installed
 2. `hermes skills config` — check platform enablement
-3. Load explicitly: `/skill name` or `hermes -s name`
+3. Load explicitly: `hermes -s name` (or the skill's own `/<name>` slash command)
 
 ### Gateway issues
 Check logs first:
@@ -40,7 +40,7 @@ Common gateway problems:
 ### Platform-specific issues
 - **Discord bot silent**: Must enable **Message Content Intent** in Bot → Privileged Gateway Intents.
 - **Slack bot only works in DMs**: Must subscribe to `message.channels` event. Without it, the bot ignores public channels.
-- **Windows-specific issues** (`Alt+Enter` newline, WinError 10106, UTF-8 BOM config, test suite, line endings): see the dedicated **Windows-Specific Quirks** section above.
+- **Windows-specific issues** (`Alt+Enter` newline, WinError 10106, UTF-8 BOM config, line endings): see `references/windows-quirks.md`.
 
 ### Auxiliary models not working
 If `auxiliary` tasks (vision, compression, session_search) fail silently, the `auto` provider can't find a backend. Either set `OPENROUTER_API_KEY` or `GOOGLE_API_KEY`, or explicitly configure each auxiliary task's provider:
@@ -48,4 +48,7 @@ If `auxiliary` tasks (vision, compression, session_search) fail silently, the `a
 hermes config set auxiliary.vision.provider <your_provider>
 hermes config set auxiliary.vision.model <model_name>
 ```
+
+### "Reset permissions" / auto-approving everything
+See `references/security-privacy.md` — wipe the "Always allow" stores, don't touch yolo mode.
 

--- a/skills/autonomous-ai-agents/hermes-agent/references/windows-quirks.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/windows-quirks.md
@@ -42,8 +42,8 @@ export PYTHONPATH="$(pwd)"
 "/c/Program Files/Python311/python" -m pytest tests/foo/test_bar.py -v --tb=short -n 0
 ```
 
-(POSIX-only tests need skip guards — see the cross-platform guard list in the
-Contributor section below.)
+(POSIX-only tests need skip guards — see the cross-platform guard list in
+`references/contributor-guide.md`.)
 
 ### Path / Filesystem
 

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -16,7 +16,7 @@ Use, configure, theme, extend, and orchestrate Hermes Agent.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/autonomous-ai-agents/hermes-agent` |
-| Version | `3.0.0` |
+| Version | `3.1.0` |
 | Author | Hermes Agent + Teknium |
 | License | MIT |
 | Platforms | linux, macos, windows |


### PR DESCRIPTION
## Summary

Every hermes-agent skill reference now matches ground truth — audited against `COMMAND_REGISTRY`, live `--help` output, the `TOOLSETS` dict, the 36 shipped provider profiles, and `DEFAULT_CONFIG` — and the sweep findings from #50608/#50613 are fixed with credit.

## Changes

- `references/slash-commands.md`: rebuilt from the live registry. Removes the phantom `/skill` command and the wrong `/q` alias on `/quit` (`/q` = `/queue`) — first reported by @liuhao1024 (#50608) and @gauravsaxena1997 (#50613). Adds ~25 real commands that were missing (`/learn`, `/memory`, `/pet`, `/hatch`, `/bundles`, `/moa`, `/suggestions`, `/blueprint`, `/whoami`, `/prompt`, `/subgoal`, …) with verified aliases and CLI/GW scoping.
- `references/cli-reference.md`: flags verified against `hermes --help` (`-z/--oneshot`, `--tui/--cli`, `--safe-mode`, `--ignore-rules`); subcommand sets for config/setup/sessions/skills/gateway/mcp/profile/auth/webhook/cron/skin/pets taken from argparse; added missing top-level commands (`fallback`, `project`, `moa`, `logs`, `console`, `hooks`, `security`, `backup`).
- `references/providers-and-models.md`: rebuilt from the 36 shipped provider profiles with their actual env vars (previous table had 21 rows, several stale).
- `references/configuration.md`: toolset table matches `TOOLSETS` (adds `coding`, `computer_use`, `video_gen`, `context_engine`, `project`; drops nonexistent `messaging`/`rl` rows); config-section keys match `DEFAULT_CONFIG`; STT/TTS provider lists match the shipped set.
- `references/background-systems.md`: curator verbs match argparse (`usage`, `list-archived` added).
- Fixed all dangling "see section above/below" references left over from the body split; reset-permissions playbook consolidated in `security-privacy.md` with a one-line pointer from troubleshooting.
- Skill version 3.1.0; docs page regenerated.

## Validation

| Check | Result |
|---|---|
| Slash table vs `COMMAND_REGISTRY` dump | 1:1 (names, aliases, CLI/GW gating) |
| CLI subcommands vs argparse `--help` | Verified per command |
| Providers vs `list_providers()` | 36/36, env vars from profile `env_vars` |
| Toolsets vs `TOOLSETS` dict | Matched (platform-internal keys excluded) |
| Routing-table targets + cross-links | All resolve, 0 dangling |
| Description | 60 chars |

Closes #50608. Closes #50613 (same fix; its source-reading test violates the no-source-in-tests rule and is not carried).

## Infographic

![hermes-agent-skill-accuracy-pass](https://v3b.fal.media/files/b/0aa37c27/ny0tnIsWoMxFnK1R7h5iE_SPQRpqWQ.png)
