### PR TITLE
fix(desktop): wrap markdown content in chat

### DIFF
--- a/apps/desktop/e2e/markdown-overflow.spec.ts
+++ b/apps/desktop/e2e/markdown-overflow.spec.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { type NoProviderFixture, setupNoProvider } from './fixtures'
+import { expect, test } from './test'
+
+const LONG_TOKEN = 'x'.repeat(500)
+
+function rendererCss(): string {
+  const assetsDir = path.resolve(import.meta.dirname, '..', 'dist', 'assets')
+  const stylesheet = fs.readdirSync(assetsDir).find(file => /^index-.*\.css$/.test(file))
+
+  if (!stylesheet) {
+    throw new Error(`Desktop renderer stylesheet not found in ${assetsDir}`)
+  }
+
+  return fs.readFileSync(path.join(assetsDir, stylesheet), 'utf8')
+}
+
+let fixture: NoProviderFixture | null = null
+
+test.beforeAll(async () => {
+  fixture = await setupNoProvider()
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('constrains prose and tables while code keeps its overlay scroller', async () => {
+  const page = fixture!.page
+
+  await page.setContent(`
+    <style>${rendererCss()}</style>
+    <main
+      class="aui-md prose w-full min-w-0 max-w-none overflow-hidden"
+      data-testid="markdown"
+      style="width: 320px"
+    >
+      <p class="wrap-anywhere">${LONG_TOKEN}</p>
+      <div class="aui-md-table my-2 max-w-full overflow-hidden">
+        <table class="m-0 w-full table-fixed border-collapse">
+          <thead>
+            <tr><th class="wrap-anywhere">Header with a long value</th><th>Other</th></tr>
+          </thead>
+          <tbody>
+            <tr><td class="wrap-anywhere">${LONG_TOKEN}</td><td>value</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div data-slot="code-card">
+        <div class="[&_pre]:overflow-x-auto [&_pre]:scrollbar-overlay" data-slot="code-card-body">
+          <div class="scrollbar-overlay overflow-y-auto overflow-x-auto">
+            <pre class="m-0 overflow-hidden" data-testid="code-scroller">
+              <code class="block whitespace-pre">${LONG_TOKEN}</code>
+            </pre>
+          </div>
+        </div>
+      </div>
+    </main>
+  `)
+
+  const metrics = await page.getByTestId('markdown').evaluate(async element => {
+    const root = element as HTMLElement
+
+    await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+
+    const prose = root.querySelector('p') as HTMLElement
+    const tableWrapper = root.querySelector('.aui-md-table') as HTMLElement
+    const codeScroller = root.querySelector('[data-testid="code-scroller"]') as HTMLElement
+
+    return {
+      codeClientWidth: codeScroller.clientWidth,
+      codeOverflowX: getComputedStyle(codeScroller).overflowX,
+      codeScrollWidth: codeScroller.scrollWidth,
+      proseClientWidth: prose.clientWidth,
+      proseScrollWidth: prose.scrollWidth,
+      rootClientWidth: root.clientWidth,
+      rootScrollWidth: root.scrollWidth,
+      tableClientWidth: tableWrapper.clientWidth,
+      tableOverflowX: getComputedStyle(tableWrapper).overflowX,
+      tableScrollWidth: tableWrapper.scrollWidth
+    }
+  })
+
+  expect(metrics.rootClientWidth).toBe(320)
+  expect(metrics.rootScrollWidth).toBe(metrics.rootClientWidth)
+  expect(metrics.proseScrollWidth).toBe(metrics.proseClientWidth)
+  expect(metrics.tableOverflowX).toBe('hidden')
+  expect(metrics.tableScrollWidth).toBe(metrics.tableClientWidth)
+  expect(metrics.codeOverflowX).toBe('auto')
+  expect(metrics.codeScrollWidth).toBeGreaterThan(metrics.codeClientWidth)
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.overflow.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.overflow.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { MarkdownTextContent } from './markdown-text'
@@ -76,5 +76,43 @@ describe('markdown surface survives stack-overflow content', () => {
     // the whole message to plain text.
     expect(await screen.findByRole('heading', { name: 'Disk report' })).toBeTruthy()
     expect(screen.getByText('full')).toBeTruthy()
+  })
+})
+
+describe('MarkdownTextContent overflow containment', () => {
+  it('wraps prose and tables while preserving fenced-code scrolling', async () => {
+    const longToken = 'x'.repeat(500)
+
+    const text = [
+      longToken,
+      '',
+      '```text',
+      longToken,
+      '```',
+      '',
+      '| Header with a long value | Other |',
+      '| --- | --- |',
+      `| ${longToken} | value |`
+    ].join('\n')
+
+    const { container } = render(<MarkdownTextContent isRunning={false} text={text} />)
+
+    await waitFor(() => expect(container.querySelector('[data-slot="code-card"]')).toBeTruthy())
+
+    const markdown = container.querySelector('.aui-md')!
+    const codePre = container.querySelector('[data-slot="code-card"] pre')!
+    const codeScroller = container.querySelector('[data-slot="code-card"] .scrollbar-overlay')!
+    const tableWrapper = container.querySelector('.aui-md-table')!
+    const table = tableWrapper.querySelector('table')!
+    const header = table.querySelector('th')!
+    const cell = table.querySelector('td')!
+
+    expect(markdown.className).toContain('min-w-0')
+    expect(codePre.querySelector('code')?.className).toContain('whitespace-pre')
+    expect(codeScroller.className).toContain('overflow-x-auto')
+    expect(tableWrapper.className).toContain('overflow-hidden')
+    expect(table.className).toContain('table-fixed')
+    expect(header.className).toContain('wrap-anywhere')
+    expect(cell.className).toContain('wrap-anywhere')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/markdown-text.overflow.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.overflow.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { MarkdownTextContent } from './markdown-text'
+
+afterEach(cleanup)
+
+describe('MarkdownTextContent overflow containment', () => {
+  it('wraps prose and tables while preserving fenced-code scrolling', async () => {
+    const longToken = 'x'.repeat(500)
+
+    const text = [
+      longToken,
+      '',
+      '```text',
+      longToken,
+      '```',
+      '',
+      '| Header with a long value | Other |',
+      '| --- | --- |',
+      `| ${longToken} | value |`
+    ].join('\n')
+
+    const { container } = render(<MarkdownTextContent isRunning={false} text={text} />)
+
+    await waitFor(() => expect(container.querySelector('[data-slot="code-card"]')).toBeTruthy())
+
+    const markdown = container.querySelector('.aui-md')!
+    const codePre = container.querySelector('[data-slot="code-card"] pre')!
+    const codeScroller = container.querySelector('[data-slot="code-card"] .scrollbar-overlay')!
+    const tableWrapper = container.querySelector('.aui-md-table')!
+    const table = tableWrapper.querySelector('table')!
+    const header = table.querySelector('th')!
+    const cell = table.querySelector('td')!
+
+    expect(markdown.className).toContain('min-w-0')
+    expect(codePre.querySelector('code')?.className).toContain('whitespace-pre')
+    expect(codeScroller.className).toContain('overflow-x-auto')
+    expect(tableWrapper.className).toContain('overflow-hidden')
+    expect(table.className).toContain('table-fixed')
+    expect(header.className).toContain('wrap-anywhere')
+    expect(cell.className).toContain('wrap-anywhere')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -420,7 +420,7 @@ const HEADING_SIZES: Record<'h1' | 'h2' | 'h3' | 'h4', string> = {
 }
 
 const MARKDOWN_CONTAINER_CLASS_NAME = cn(
-  'aui-md prose w-full max-w-none overflow-hidden text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground',
+  'aui-md prose w-full min-w-0 max-w-none overflow-hidden text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground',
   'prose-p:leading-(--dt-line-height) prose-li:leading-(--dt-line-height)',
   'prose-headings:text-foreground prose-strong:text-foreground',
   // Typography styles `pre` as a dark slab: light text (`--tw-prose-pre-code`,
@@ -548,10 +548,10 @@ function MarkdownTextSurface({
           <li className={cn('leading-(--dt-line-height)', className)} {...props} />
         ),
         table: ({ className, ...props }: ComponentProps<'table'>) => (
-          <div className="aui-md-table my-2 max-w-full overflow-x-auto rounded-[0.375rem] border border-(--ui-stroke-tertiary)">
+          <div className="aui-md-table my-2 max-w-full overflow-hidden rounded-[0.375rem] border border-(--ui-stroke-tertiary)">
             <table
               className={cn(
-                'm-0 w-full min-w-[18rem] border-collapse text-[0.8125rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
+                'm-0 w-full table-fixed border-collapse text-[0.8125rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
                 className
               )}
               {...props}
@@ -564,14 +564,17 @@ function MarkdownTextSurface({
         th: ({ className, ...props }: ComponentProps<'th'>) => (
           <th
             className={cn(
-              'whitespace-nowrap px-2.5 py-1.5 text-left align-middle text-[0.75rem] font-medium text-muted-foreground',
+              'px-2.5 py-1.5 text-left align-middle text-[0.75rem] font-medium text-muted-foreground wrap-anywhere',
               className
             )}
             {...props}
           />
         ),
         td: ({ className, ...props }: ComponentProps<'td'>) => (
-          <td className={cn('px-2.5 py-1.5 align-top text-[0.8125rem] leading-snug', className)} {...props} />
+          <td
+            className={cn('px-2.5 py-1.5 align-top text-[0.8125rem] leading-snug wrap-anywhere', className)}
+            {...props}
+          />
         ),
         img: MarkdownImage,
         // ```mermaid / ```svg fences route to their lazy renderers; substantial

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -419,7 +419,7 @@ const HEADING_SIZES: Record<'h1' | 'h2' | 'h3' | 'h4', string> = {
 }
 
 const MARKDOWN_CONTAINER_CLASS_NAME = cn(
-  'aui-md prose w-full max-w-none overflow-hidden text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground',
+  'aui-md prose w-full min-w-0 max-w-none overflow-hidden text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground',
   'prose-p:leading-(--dt-line-height) prose-li:leading-(--dt-line-height)',
   'prose-headings:text-foreground prose-strong:text-foreground',
   'prose-a:break-words prose-p:[overflow-wrap:anywhere]',
@@ -541,10 +541,10 @@ function MarkdownTextSurface({
           <li className={cn('leading-(--dt-line-height)', className)} {...props} />
         ),
         table: ({ className, ...props }: ComponentProps<'table'>) => (
-          <div className="aui-md-table my-2 max-w-full overflow-x-auto rounded-[0.375rem] border border-(--ui-stroke-tertiary)">
+          <div className="aui-md-table my-2 max-w-full overflow-hidden rounded-[0.375rem] border border-(--ui-stroke-tertiary)">
             <table
               className={cn(
-                'm-0 w-full min-w-[18rem] border-collapse text-[0.8125rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
+                'm-0 w-full table-fixed border-collapse text-[0.8125rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
                 className
               )}
               {...props}
@@ -557,14 +557,17 @@ function MarkdownTextSurface({
         th: ({ className, ...props }: ComponentProps<'th'>) => (
           <th
             className={cn(
-              'whitespace-nowrap px-2.5 py-1.5 text-left align-middle text-[0.75rem] font-medium text-muted-foreground',
+              'px-2.5 py-1.5 text-left align-middle text-[0.75rem] font-medium text-muted-foreground wrap-anywhere',
               className
             )}
             {...props}
           />
         ),
         td: ({ className, ...props }: ComponentProps<'td'>) => (
-          <td className={cn('px-2.5 py-1.5 align-top text-[0.8125rem] leading-snug', className)} {...props} />
+          <td
+            className={cn('px-2.5 py-1.5 align-top text-[0.8125rem] leading-snug wrap-anywhere', className)}
+            {...props}
+          />
         ),
         img: MarkdownImage,
         // ```mermaid / ```svg fences route to their lazy renderers; substantial


### PR DESCRIPTION
## What does this PR do?

Keeps normal Markdown prose and tables inside the Desktop chat reading column on narrow layouts. Fenced code intentionally retains the overlay horizontal scrollbar from the current `main` implementation.

The fix is scoped to Markdown containment and table wrapping. The shared code-card, `ExpandableBlock`, and Shiki rendering behavior remain unchanged.

## Related Issue

Fixes #70451

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Add `min-w-0` containment to the Markdown reading root.
- Keep tables inside the reading column with a fixed layout.
- Allow long table headers and cells to wrap.
- Preserve the existing horizontal-scroll behavior for fenced code.
- Add both a component contract test and an Electron browser-layout regression test.

## How to Test

1. Open a Desktop chat containing a long unbroken prose token, a wide Markdown table, and a fenced code block with a long line.
2. Resize the conversation column to about 320px.
3. Confirm prose and the table remain bounded by the reading column.
4. Confirm the fenced-code overlay can still scroll horizontally.

Validation on Windows 11:

- Focused Markdown UI tests — 3 passed.
- Desktop typecheck — passed.
- ESLint on the touched TypeScript files — passed.
- Desktop production build — passed.
- Electron layout E2E at a 320px reading column — 1 passed; prose and table stay bounded while the code scroller has `scrollWidth > clientWidth` with `overflow-x: auto`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs.
- [x] This PR contains only changes related to this fix.
- [ ] `pytest tests/ -q` — N/A; this is a Desktop TypeScript change.
- [x] I've added regression tests.
- [x] I've tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation update is N/A; no public API or workflow changed.
- [x] `cli-config.yaml.example` update is N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A.
- [x] Cross-platform impact considered; the behavior is exercised in Electron/Chromium.
- [x] Tool descriptions/schemas update is N/A.
