### PR TITLE
fix(slack): record canonical sent thread

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2525,6 +2525,7 @@ class SlackAdapter(BasePlatformAdapter):
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            delivered_thread_ts = None
             last_result = None
 
             # reply_broadcast: also post thread replies to the main channel.
@@ -2569,6 +2570,11 @@ class SlackAdapter(BasePlatformAdapter):
                         ).chat_postMessage(**retry_kwargs)
                     else:
                         raise
+                response_message = last_result.get("message") if last_result else None
+                if delivered_thread_ts is None and hasattr(response_message, "get"):
+                    response_thread_ts = response_message.get("thread_ts")
+                    if response_thread_ts:
+                        delivered_thread_ts = str(response_thread_ts)
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -2582,9 +2588,10 @@ class SlackAdapter(BasePlatformAdapter):
                     self._workspace_message_marker(team_id, sent_ts)
                 )
                 # Also register the thread root so replies-to-my-replies work
-                if thread_ts:
+                participation_thread_ts = delivered_thread_ts or thread_ts
+                if participation_thread_ts:
                     self._bot_message_ts.add(
-                        self._workspace_message_marker(team_id, thread_ts)
+                        self._workspace_message_marker(team_id, participation_thread_ts)
                     )
                 self._trim_bot_message_timestamps()
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2536,6 +2536,7 @@ class SlackAdapter(BasePlatformAdapter):
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            delivered_thread_ts = None
             last_result = None
 
             # reply_broadcast: also post thread replies to the main channel.
@@ -2580,6 +2581,11 @@ class SlackAdapter(BasePlatformAdapter):
                         ).chat_postMessage(**retry_kwargs)
                     else:
                         raise
+                response_message = last_result.get("message") if last_result else None
+                if delivered_thread_ts is None and hasattr(response_message, "get"):
+                    response_thread_ts = response_message.get("thread_ts")
+                    if response_thread_ts:
+                        delivered_thread_ts = str(response_thread_ts)
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -2593,9 +2599,10 @@ class SlackAdapter(BasePlatformAdapter):
                     self._workspace_message_marker(team_id, sent_ts)
                 )
                 # Also register the thread root so replies-to-my-replies work
-                if thread_ts:
+                participation_thread_ts = delivered_thread_ts or thread_ts
+                if participation_thread_ts:
                     self._bot_message_ts.add(
-                        self._workspace_message_marker(team_id, thread_ts)
+                        self._workspace_message_marker(team_id, participation_thread_ts)
                     )
                 self._trim_bot_message_timestamps()
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -6187,6 +6187,45 @@ class TestReplyBroadcast:
         assert kwargs.get("reply_broadcast") is True
 
 
+class TestCanonicalSentThread:
+    """Track the thread Slack actually used, not only the requested reply."""
+
+    @pytest.mark.asyncio
+    async def test_send_records_canonical_thread_from_response(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={
+                "ok": True,
+                "ts": "300.000",
+                "message": {"thread_ts": "100.000"},
+            }
+        )
+
+        await adapter.send(
+            "C123",
+            "hello",
+            metadata={"thread_id": "200.000"},
+        )
+
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["thread_ts"] == "200.000"
+        assert adapter._workspace_message_marker("", "100.000") in adapter._bot_message_ts
+        assert adapter._workspace_message_marker("", "200.000") not in adapter._bot_message_ts
+
+    @pytest.mark.asyncio
+    async def test_send_falls_back_to_requested_thread(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "300.000"}
+        )
+
+        await adapter.send(
+            "C123",
+            "hello",
+            metadata={"thread_id": "200.000"},
+        )
+
+        assert adapter._workspace_message_marker("", "200.000") in adapter._bot_message_ts
+
+
 # ---------------------------------------------------------------------------
 # TestFallbackPreservesThreadContext
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3215,6 +3215,45 @@ class TestReplyBroadcast:
         assert kwargs.get("reply_broadcast") is True
 
 
+class TestCanonicalSentThread:
+    """Track the thread Slack actually used, not only the requested reply."""
+
+    @pytest.mark.asyncio
+    async def test_send_records_canonical_thread_from_response(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={
+                "ok": True,
+                "ts": "300.000",
+                "message": {"thread_ts": "100.000"},
+            }
+        )
+
+        await adapter.send(
+            "C123",
+            "hello",
+            metadata={"thread_id": "200.000"},
+        )
+
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["thread_ts"] == "200.000"
+        assert adapter._workspace_message_marker("", "100.000") in adapter._bot_message_ts
+        assert adapter._workspace_message_marker("", "200.000") not in adapter._bot_message_ts
+
+    @pytest.mark.asyncio
+    async def test_send_falls_back_to_requested_thread(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "300.000"}
+        )
+
+        await adapter.send(
+            "C123",
+            "hello",
+            metadata={"thread_id": "200.000"},
+        )
+
+        assert adapter._workspace_message_marker("", "200.000") in adapter._bot_message_ts
+
+
 # ---------------------------------------------------------------------------
 # TestFallbackPreservesThreadContext
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Uses Slack's canonical delivered thread timestamp for generic-send participation tracking. Slack may accept a child reply timestamp but return the root thread in `message.thread_ts`; recording only the requested child timestamp can make later unmentioned root-thread replies fail Hermes' participation check.

The outbound `thread_ts` remains unchanged. Hermes prefers the first canonical thread returned by Slack and falls back to the requested timestamp when the response omits it.

## Related Issue

Fixes #70518

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updated `plugins/platforms/slack/adapter.py` to retain the first canonical `message.thread_ts` returned by `chat.postMessage`.
- Kept the requested thread timestamp as the outbound API target.
- Recorded bot participation against the canonical delivered thread, with the existing requested-thread fallback.
- Added regression coverage for canonicalization and fallback behavior in `tests/gateway/test_slack.py`.

## How to Test

1. Run `uv run --extra dev --extra messaging python -m pytest tests/gateway/test_slack.py -q -k canonical`.
2. Run `uv run --extra dev --extra messaging python -m pytest tests/gateway/test_slack.py -q`.
3. Run `uv run --extra dev ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py` and `git diff --check`.

Observed results:

- Focused regression: `2 passed, 427 deselected`.
- Full Slack adapter file: `429 passed`.
- Ruff: clean.
- Diff check: clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: mapping-only logic is platform independent
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

No live Slack credential is required for this state transition. The regression fixture uses Slack's successful response shape and asserts both sides of the contract: the request still targets the child timestamp while participation is stored under the canonical root.