### PR TITLE
fix: handle RetryAfter in Telegram overflow split continuation loop (#70504)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4727,7 +4727,45 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                     break
                 except Exception as send_err:
-                    if "reply message not found" in str(send_err).lower():
+                    err_str = str(send_err).lower()
+                    # Flood control / RetryAfter — mirror edit_message's
+                    # handling: short waits retry inline, long waits return
+                    # a clean failure so the caller can fall back instead of
+                    # cascading retries that produce duplicate messages.
+                    retry_after = getattr(send_err, "retry_after", None)
+                    if retry_after is not None or "retry after" in err_str:
+                        wait = retry_after if retry_after else 1.0
+                        logger.warning(
+                            "[%s] Overflow continuation flood control, waiting %.1fs",
+                            self.name, wait,
+                        )
+                        if wait > 5.0:
+                            logger.warning(
+                                "[%s] Overflow split: flood control wait too long (%.0fs), stopping",
+                                self.name, wait,
+                            )
+                            sent_msg = None
+                            break
+                        await asyncio.sleep(wait)
+                        try:
+                            text = _strip_mdv2(chunk) if finalize else chunk
+                            sent_msg = await self._bot.send_message(
+                                chat_id=normalize_telegram_chat_id(chat_id),
+                                text=text,
+                                reply_to_message_id=reply_to_id,
+                                **thread_kwargs,
+                                **self._link_preview_kwargs(),
+                                **self._notification_kwargs(metadata),
+                            )
+                            break
+                        except Exception as retry_err:
+                            logger.warning(
+                                "[%s] Overflow continuation retry after flood wait failed: %s",
+                                self.name, _redact_telegram_error_text(retry_err),
+                            )
+                            sent_msg = None
+                            break
+                    if "reply message not found" in err_str:
                         # Drop the reply anchor and try again.  Private DM
                         # topic fallback needs the anchor and topic id together;
                         # forum topics can still safely keep message_thread_id.


### PR DESCRIPTION
## Summary

When a long message triggers `_edit_overflow_split()`, the continuation send loop fires chunks at network speed with no flood-control awareness. When Telegram responds with `RetryAfter`, the chunk is silently dropped, the split returns partial failure, and the streaming engine retries the edit from scratch — producing **duplicate message storms** (up to 32 copies observed).

## Root Cause

`edit_message()` (line 4527) handles `RetryAfter` properly: sleeps inline for short waits, returns clean failure for long waits. The overflow split continuation loop has none of this.

## Fix

Add `RetryAfter` handling to the continuation send loop, mirroring `edit_message()`:
- **Short waits (<=5s)**: `await asyncio.sleep(wait)`, retry once with plain text
- **Long waits (>5s)**: return clean failure so the caller falls back to `send_message` instead of cascading retries

Fixes #70504
