### PR TITLE
fix(mcp): honor tool-level OAuth challenges from CallToolResult._meta

### DIFF
--- a/tests/tools/test_mcp_tool_challenge.py
+++ b/tests/tools/test_mcp_tool_challenge.py
@@ -1,0 +1,501 @@
+"""Tests for MCP tool-level OAuth challenge handling (#69811).
+
+Servers may accept anonymous ``initialize`` but protect individual tools,
+returning ``isError: true`` with ``CallToolResult._meta["mcp/www_authenticate"]``
+instead of a transport-level HTTP 401. The client must:
+
+  1. Preserve the structured challenge while mapping the result.
+  2. Route it through the existing PKCE OAuth manager (protected-resource
+     discovery seeded from the challenge's ``resource_metadata`` + ``scope``).
+  3. Reconnect with ``Authorization: Bearer`` transport auth.
+  4. Retry the original tool at most once — a second protected failure must
+     not trigger an unbounded retry loop.
+  5. Leave ordinary MCP tool errors (no challenge metadata) unchanged.
+"""
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+pytest.importorskip("mcp.client.auth.oauth2")
+
+
+# The reproduction challenge from GH#69811 (Resin8 staging).
+CHALLENGE = (
+    'Bearer error="unauthorized", scope="resin8.buyer.profile.read", '
+    'resource_metadata="https://api.stage.resin8.ai/.well-known/'
+    'oauth-protected-resource/mcp"'
+)
+
+
+def _tool_result(is_error: bool, meta=None, text: str = "denied"):
+    from mcp.types import CallToolResult
+
+    payload = {
+        "content": [{"type": "text", "text": text}],
+        "isError": is_error,
+    }
+    if meta is not None:
+        payload["_meta"] = meta
+    return CallToolResult.model_validate(payload)
+
+
+# ---------------------------------------------------------------------------
+# _extract_tool_auth_challenges
+# ---------------------------------------------------------------------------
+
+
+def test_extract_challenges_from_list_meta():
+    from tools.mcp_tool import _extract_tool_auth_challenges
+
+    result = _tool_result(True, meta={"mcp/www_authenticate": [CHALLENGE]})
+    assert _extract_tool_auth_challenges(result) == [CHALLENGE]
+
+
+def test_extract_challenges_from_string_meta():
+    from tools.mcp_tool import _extract_tool_auth_challenges
+
+    result = _tool_result(True, meta={"mcp/www_authenticate": CHALLENGE})
+    assert _extract_tool_auth_challenges(result) == [CHALLENGE]
+
+
+def test_extract_challenges_absent_meta():
+    from tools.mcp_tool import _extract_tool_auth_challenges
+
+    assert _extract_tool_auth_challenges(_tool_result(True)) == []
+    assert _extract_tool_auth_challenges(
+        _tool_result(True, meta={"other": "value"})
+    ) == []
+
+
+def test_extract_challenges_filters_non_strings_and_blanks():
+    from tools.mcp_tool import _extract_tool_auth_challenges
+
+    result = _tool_result(
+        True,
+        meta={"mcp/www_authenticate": [42, "", "  ", None, f"  {CHALLENGE}  ", {}]},
+    )
+    assert _extract_tool_auth_challenges(result) == [CHALLENGE]
+
+
+def test_extract_challenges_rejects_non_list_shapes_and_caps():
+    from tools.mcp_tool import _extract_tool_auth_challenges
+
+    assert _extract_tool_auth_challenges(
+        _tool_result(True, meta={"mcp/www_authenticate": {"nested": "dict"}})
+    ) == []
+    flooded = _tool_result(
+        True, meta={"mcp/www_authenticate": [f"Bearer n={i}" for i in range(50)]}
+    )
+    assert len(_extract_tool_auth_challenges(flooded)) == 8
+
+
+def test_synthetic_response_feeds_sdk_extractors():
+    """The joined challenge header must be parseable by the SDK's own
+    WWW-Authenticate field extractors — that is what seeds protected-resource
+    discovery (resource_metadata, path included) and scope selection."""
+    import httpx
+    from mcp.client.auth.utils import (
+        extract_resource_metadata_from_www_auth,
+        extract_scope_from_www_auth,
+    )
+
+    request = httpx.Request("POST", "https://api.stage.resin8.ai/mcp")
+    response = httpx.Response(
+        401, headers={"WWW-Authenticate": CHALLENGE}, request=request
+    )
+    assert extract_resource_metadata_from_www_auth(response) == (
+        "https://api.stage.resin8.ai/.well-known/oauth-protected-resource/mcp"
+    )
+    assert extract_scope_from_www_auth(response) == "resin8.buyer.profile.read"
+
+
+# ---------------------------------------------------------------------------
+# MCPOAuthManager.handle_tool_challenge — generator driver
+# ---------------------------------------------------------------------------
+
+
+class _FakeProvider:
+    """Scripted OAuthClientProvider standing in for the SDK.
+
+    Yields the anchor request; on a 401 with the challenge header it marks
+    tokens valid (as the real PKCE flow would) and yields the anchor once
+    more, expecting the driver to unwind with a synthetic 200.
+    """
+
+    def __init__(self, server_url: str, valid_upfront: bool = False):
+        self._valid = valid_upfront
+        self.flow_runs = 0
+        self.responses_seen = []
+        self.context = SimpleNamespace(
+            server_url=server_url,
+            is_token_valid=lambda: self._valid,
+        )
+
+    async def async_auth_flow(self, request):
+        self.flow_runs += 1
+        response = yield request
+        self.responses_seen.append(response)
+        if response.status_code == 401:
+            self._valid = True  # simulate completed authorization
+            response = yield request
+            self.responses_seen.append(response)
+
+
+def _manager_with_fake_provider(monkeypatch, provider):
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    manager = MCPOAuthManager()
+    monkeypatch.setattr(
+        manager, "get_or_build_provider", lambda *a, **kw: provider,
+    )
+    return manager
+
+
+def _seed_entry(manager, server_name, server_url, provider):
+    from tools.mcp_oauth_manager import _ProviderEntry
+
+    entry = _ProviderEntry(server_url=server_url, oauth_config=None)
+    entry.provider = provider
+    manager._entries[manager._key(server_name)] = entry
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_challenge_runs_flow_from_synthetic_401(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _FakeProvider("https://api.stage.resin8.ai/mcp")
+    manager = _manager_with_fake_provider(monkeypatch, provider)
+    _seed_entry(manager, "srv", "https://api.stage.resin8.ai/mcp", provider)
+
+    ok = await manager.handle_tool_challenge(
+        "srv", "https://api.stage.resin8.ai/mcp", None, [CHALLENGE],
+    )
+
+    assert ok is True
+    assert provider.flow_runs == 1
+    first, second = provider.responses_seen
+    assert first.status_code == 401
+    assert first.headers["WWW-Authenticate"] == CHALLENGE
+    assert second.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_challenge_joins_multiple_values(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _FakeProvider("https://api.example/mcp")
+    manager = _manager_with_fake_provider(monkeypatch, provider)
+    _seed_entry(manager, "srv", "https://api.example/mcp", provider)
+
+    ok = await manager.handle_tool_challenge(
+        "srv", "https://api.example/mcp", None,
+        ['Bearer error="unauthorized"', 'Basic realm="x"'],
+    )
+
+    assert ok is True
+    assert provider.responses_seen[0].headers["WWW-Authenticate"] == (
+        'Bearer error="unauthorized", Basic realm="x"'
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_challenge_skips_reauth_when_tokens_valid(
+    monkeypatch, tmp_path,
+):
+    """Cached tokens from a previous process: no browser flow, no 401 —
+    the driver unwinds immediately and the caller just reconnects."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _FakeProvider("https://api.example/mcp", valid_upfront=True)
+    manager = _manager_with_fake_provider(monkeypatch, provider)
+    _seed_entry(manager, "srv", "https://api.example/mcp", provider)
+
+    ok = await manager.handle_tool_challenge(
+        "srv", "https://api.example/mcp", None, [CHALLENGE],
+    )
+
+    assert ok is True
+    assert [r.status_code for r in provider.responses_seen] == [200]
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_challenge_flow_failure_returns_false(
+    monkeypatch, tmp_path, caplog,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    class _ExplodingProvider(_FakeProvider):
+        async def async_auth_flow(self, request):
+            self.flow_runs += 1
+            yield request
+            raise RuntimeError("callback timed out")
+
+    provider = _ExplodingProvider("https://api.example/mcp")
+    manager = _manager_with_fake_provider(monkeypatch, provider)
+    _seed_entry(manager, "srv", "https://api.example/mcp", provider)
+
+    ok = await manager.handle_tool_challenge(
+        "srv", "https://api.example/mcp", None, [CHALLENGE],
+    )
+
+    assert ok is False
+    # No auth-flow material in diagnostics: the challenge string (scope,
+    # resource_metadata URL) must not be logged.
+    assert CHALLENGE not in caplog.text
+    assert "resin8.buyer.profile.read" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_challenge_provider_setup_failure_returns_false(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    manager = MCPOAuthManager()
+
+    def _raise(*a, **kw):
+        raise RuntimeError("non-interactive environment")
+
+    monkeypatch.setattr(manager, "get_or_build_provider", _raise)
+    ok = await manager.handle_tool_challenge(
+        "srv", "https://api.example/mcp", None, [CHALLENGE],
+    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_challenge_single_flight(monkeypatch, tmp_path):
+    """Concurrent protected calls share one flow — no browser-window storm."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    class _SlowProvider(_FakeProvider):
+        async def async_auth_flow(self, request):
+            self.flow_runs += 1
+            response = yield request
+            self.responses_seen.append(response)
+            if response.status_code == 401:
+                await asyncio.sleep(0.05)
+                self._valid = True
+                response = yield request
+                self.responses_seen.append(response)
+
+    provider = _SlowProvider("https://api.example/mcp")
+    manager = _manager_with_fake_provider(monkeypatch, provider)
+    _seed_entry(manager, "srv", "https://api.example/mcp", provider)
+
+    results = await asyncio.gather(*[
+        manager.handle_tool_challenge(
+            "srv", "https://api.example/mcp", None, [CHALLENGE],
+        )
+        for _ in range(3)
+    ])
+
+    assert results == [True, True, True]
+    assert provider.flow_runs == 1
+
+
+# ---------------------------------------------------------------------------
+# Tool handler integration — challenge → OAuth → reconnect → one retry
+# ---------------------------------------------------------------------------
+
+
+def _stub_server(name: str, results):
+    """MagicMock MCPServerTask whose call_tool pops scripted results."""
+    server = MagicMock()
+    server.name = name
+    server._config = {"url": "https://api.example/mcp"}
+    server._is_http = lambda: True
+    server._ready = MagicMock()
+    server._ready.is_set.return_value = True
+    session = MagicMock()
+    calls = {"count": 0}
+
+    async def _call_tool(*a, **kw):
+        calls["count"] += 1
+        return results.pop(0)
+
+    session.call_tool = _call_tool
+    server.session = session
+    server._rpc_lock = asyncio.Lock()
+    return server, calls
+
+
+def _install_server(monkeypatch, server):
+    from tools import mcp_tool
+
+    mcp_tool._servers[server.name] = server
+    mcp_tool._server_error_counts.pop(server.name, None)
+    mcp_tool._ensure_mcp_loop()
+
+
+def _patch_manager_challenge(monkeypatch, outcome, record=None):
+    from tools.mcp_oauth_manager import get_manager, reset_manager_for_tests
+
+    reset_manager_for_tests()
+    manager = get_manager()
+
+    async def _handle(name, url, oauth_cfg, challenges):
+        if record is not None:
+            record.append((name, url, oauth_cfg, list(challenges)))
+        return outcome
+
+    monkeypatch.setattr(manager, "handle_tool_challenge", _handle)
+    return manager
+
+
+def test_challenge_triggers_oauth_reconnect_and_single_retry(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    challenge_result = _tool_result(
+        True, meta={"mcp/www_authenticate": [CHALLENGE]},
+    )
+    success_result = _tool_result(False, text="alice@example.com")
+    server, calls = _stub_server("srv-chal", [challenge_result, success_result])
+    _install_server(monkeypatch, server)
+
+    seen = []
+    _patch_manager_challenge(monkeypatch, True, record=seen)
+    reconnects = []
+    monkeypatch.setattr(
+        mcp_tool, "_signal_reconnect_and_wait",
+        lambda name, srv, **kw: reconnects.append(name) or True,
+    )
+
+    try:
+        handler = _make_tool_handler("srv-chal", "whoami", 10.0)
+        out = json.loads(handler({}))
+    finally:
+        mcp_tool._servers.pop("srv-chal", None)
+
+    assert out == {"result": "alice@example.com"}
+    assert calls["count"] == 2  # original + exactly one retry
+    assert seen == [(
+        "srv-chal", "https://api.example/mcp", None, [CHALLENGE],
+    )]
+    assert reconnects == ["srv-chal"]
+    # The rebuilt transport must carry OAuth auth (Authorization: Bearer).
+    assert server._config["auth"] == "oauth"
+    assert server._auth_type == "oauth"
+
+
+def test_challenge_unrecoverable_returns_needs_reauth_without_retry(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    challenge_result = _tool_result(
+        True, meta={"mcp/www_authenticate": [CHALLENGE]},
+    )
+    server, calls = _stub_server("srv-noauth", [challenge_result])
+    _install_server(monkeypatch, server)
+    _patch_manager_challenge(monkeypatch, False)
+
+    try:
+        handler = _make_tool_handler("srv-noauth", "whoami", 10.0)
+        out = json.loads(handler({}))
+    finally:
+        mcp_tool._servers.pop("srv-noauth", None)
+
+    assert out["needs_reauth"] is True
+    assert out["server"] == "srv-noauth"
+    assert calls["count"] == 1  # no retry without authorization
+    assert "auth" not in server._config  # unchanged on failure
+
+
+def test_second_challenge_does_not_loop(monkeypatch, tmp_path):
+    """A second protected failure after OAuth + reconnect is a hard stop."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    challenge_result = _tool_result(
+        True, meta={"mcp/www_authenticate": [CHALLENGE]},
+    )
+    challenge_again = _tool_result(
+        True, meta={"mcp/www_authenticate": [CHALLENGE]},
+    )
+    server, calls = _stub_server(
+        "srv-loop", [challenge_result, challenge_again],
+    )
+    _install_server(monkeypatch, server)
+    _patch_manager_challenge(monkeypatch, True)
+    monkeypatch.setattr(
+        mcp_tool, "_signal_reconnect_and_wait", lambda *a, **kw: True,
+    )
+
+    try:
+        handler = _make_tool_handler("srv-loop", "whoami", 10.0)
+        out = json.loads(handler({}))
+    finally:
+        mcp_tool._servers.pop("srv-loop", None)
+
+    assert out["needs_reauth"] is True
+    assert calls["count"] == 2  # original + exactly one retry, then stop
+
+
+def test_ordinary_tool_error_without_challenge_is_unchanged(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    plain_error = _tool_result(True, text="row not found")
+    server, calls = _stub_server("srv-plain", [plain_error])
+    _install_server(monkeypatch, server)
+
+    manager = _patch_manager_challenge(monkeypatch, True)
+
+    async def _must_not_run(*a, **kw):  # pragma: no cover — assertion guard
+        raise AssertionError("OAuth flow must not run for ordinary errors")
+
+    monkeypatch.setattr(manager, "handle_tool_challenge", _must_not_run)
+
+    try:
+        handler = _make_tool_handler("srv-plain", "lookup", 10.0)
+        out = json.loads(handler({}))
+    finally:
+        mcp_tool._servers.pop("srv-plain", None)
+
+    assert out == {"error": "row not found"}
+    assert calls["count"] == 1
+
+
+def test_challenge_on_stdio_server_stays_ordinary_error(
+    monkeypatch, tmp_path,
+):
+    """OAuth over stdio is not a thing — challenge metadata on a non-HTTP
+    server maps to the ordinary error path."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    challenge_result = _tool_result(
+        True, meta={"mcp/www_authenticate": [CHALLENGE]}, text="denied",
+    )
+    server, calls = _stub_server("srv-stdio", [challenge_result])
+    server._config = {"command": "some-binary"}
+    server._is_http = lambda: False
+    _install_server(monkeypatch, server)
+
+    try:
+        handler = _make_tool_handler("srv-stdio", "whoami", 10.0)
+        out = json.loads(handler({}))
+    finally:
+        mcp_tool._servers.pop("srv-stdio", None)
+
+    assert out == {"error": "denied"}
+    assert calls["count"] == 1

--- a/tests/tools/test_mcp_tool_challenge.py
+++ b/tests/tools/test_mcp_tool_challenge.py
@@ -415,6 +415,37 @@ def test_challenge_unrecoverable_returns_needs_reauth_without_retry(
     assert "auth" not in server._config  # unchanged on failure
 
 
+def test_challenge_reconnect_failure_does_not_retry_stale_session(
+    monkeypatch, tmp_path,
+):
+    """Successful OAuth is not enough to retry: the transport must be fresh."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    challenge_result = _tool_result(
+        True, meta={"mcp/www_authenticate": [CHALLENGE]},
+    )
+    server, calls = _stub_server("srv-reconnect", [challenge_result])
+    _install_server(monkeypatch, server)
+    _patch_manager_challenge(monkeypatch, True)
+    monkeypatch.setattr(
+        mcp_tool, "_signal_reconnect_and_wait", lambda *a, **kw: False,
+    )
+
+    try:
+        handler = _make_tool_handler("srv-reconnect", "whoami", 10.0)
+        out = json.loads(handler({}))
+    finally:
+        mcp_tool._servers.pop("srv-reconnect", None)
+
+    assert calls["count"] == 1
+    assert out["server"] == "srv-reconnect"
+    assert out["reconnect_failed"] is True
+    assert "reconnect" in out["error"].lower()
+    assert "needs_reauth" not in out
+
+
 def test_second_challenge_does_not_loop(monkeypatch, tmp_path):
     """A second protected failure after OAuth + reconnect is a hard stop."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -755,6 +755,169 @@ class MCPOAuthManager:
             return False
 
 
+    async def handle_tool_challenge(
+        self,
+        server_name: str,
+        server_url: str,
+        oauth_config: Optional[dict],
+        challenges: list[str],
+    ) -> bool:
+        """Run the OAuth flow from a tool-level structured challenge (#69811).
+
+        Servers may accept an anonymous ``initialize`` but protect individual
+        tools, delivering the WWW-Authenticate challenge in
+        ``CallToolResult._meta["mcp/www_authenticate"]`` instead of an HTTP
+        401 header. The SDK's httpx-layer auth flow never sees a 401 in that
+        case, so this method drives the provider's ``async_auth_flow``
+        generator directly, feeding it a synthetic 401 response that carries
+        the challenge. Everything downstream — protected-resource metadata
+        discovery (honoring the challenge's ``resource_metadata`` URL and
+        RFC 8707 resource, path included), scope selection from the
+        challenge's ``scope``, client registration, Authorization Code +
+        S256 PKCE, token exchange — is the SDK's own 401-branch code,
+        identical to a transport-level 401.
+
+        Single-flight per server: concurrent protected tool calls await the
+        same flow instead of racing N browser windows.
+
+        Returns:
+            True  if valid tokens are now available — caller should flip the
+                  server to OAuth transport auth, reconnect, and retry once.
+            False if no recovery is possible (SDK unavailable, non-interactive
+                  environment without cached tokens, user abandoned the flow).
+        """
+        try:
+            provider = self.get_or_build_provider(
+                server_name, server_url, oauth_config,
+            )
+        except Exception as exc:
+            # OAuthNonInteractiveError lands here: headless without cached
+            # tokens. Never log challenge contents or flow material.
+            logger.warning(
+                "MCP OAuth '%s': tool-challenge provider setup failed: %s",
+                server_name, exc,
+            )
+            return False
+        if provider is None:
+            return False
+
+        entry = self._entries.get(self._key(server_name))
+        if entry is None:  # pragma: no cover — get_or_build_provider creates it
+            return False
+
+        key = "tool-challenge"
+        loop = asyncio.get_running_loop()
+
+        async with entry.lock:
+            pending = entry.pending_401.get(key)
+            if pending is None:
+                pending = loop.create_future()
+                entry.pending_401[key] = pending
+                task = asyncio.create_task(
+                    self._run_tool_challenge_flow(
+                        server_name, provider, challenges, entry, key, pending,
+                    )
+                )
+                self._inflight_tasks.add(task)
+                task.add_done_callback(self._inflight_tasks.discard)
+
+        try:
+            return await pending
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning(
+                "MCP OAuth '%s': awaiting tool-challenge flow failed: %s",
+                server_name, exc,
+            )
+            return False
+
+    async def _run_tool_challenge_flow(
+        self,
+        server_name: str,
+        provider: Any,
+        challenges: list[str],
+        entry: _ProviderEntry,
+        key: str,
+        pending: "asyncio.Future[bool]",
+    ) -> None:
+        """Drive ``provider.async_auth_flow`` against a synthetic 401.
+
+        Generator protocol: the provider yields requests; we feed responses
+        back via ``asend``. When it yields the ORIGINAL (anchor) request we
+        answer from script — a synthetic 401 carrying the challenge the
+        first time tokens are invalid, a synthetic 200 once tokens are valid
+        so the generator unwinds cleanly. Every other yielded request
+        (metadata discovery, client registration, token refresh/exchange) is
+        a real OAuth endpoint call and is sent over the network.
+
+        Feeding the anchor request a synthetic 200 when tokens are already
+        valid also makes the no-op paths cheap and browser-free: cached
+        tokens from a previous process just reconnect, and expired-but-
+        refreshable tokens take only the SDK's refresh branch.
+        """
+        import httpx
+
+        ok = False
+        try:
+            anchor = httpx.Request("POST", provider.context.server_url)
+            # RFC 9110 permits joining multiple challenge values with ", ";
+            # the SDK's extractors regex-scan the combined header for
+            # resource_metadata= and scope=.
+            www_authenticate = ", ".join(
+                c.strip() for c in challenges if c and c.strip()
+            )
+            challenged = False
+
+            flow = provider.async_auth_flow(anchor)
+            try:
+                outgoing = await flow.__anext__()
+                async with httpx.AsyncClient(
+                    timeout=30.0, follow_redirects=True,
+                ) as client:
+                    while True:
+                        if outgoing is anchor:
+                            if provider.context.is_token_valid():
+                                # Fresh/refreshed/cached tokens — unwind.
+                                response = httpx.Response(200, request=anchor)
+                                ok = True
+                            elif not challenged and www_authenticate:
+                                challenged = True
+                                response = httpx.Response(
+                                    401,
+                                    headers={
+                                        "WWW-Authenticate": www_authenticate,
+                                    },
+                                    request=anchor,
+                                )
+                            else:
+                                # Second invalid-token anchor pass: the flow
+                                # already ran and produced nothing usable.
+                                # Unwind without re-challenging (bounded).
+                                response = httpx.Response(200, request=anchor)
+                        else:
+                            response = await client.send(outgoing)
+                        outgoing = await flow.asend(response)
+            except StopAsyncIteration:
+                pass
+            finally:
+                await flow.aclose()
+
+            if not ok:
+                ok = bool(provider.context.is_token_valid())
+        except Exception as exc:
+            # OAuthFlowError / OAuthTokenError / callback timeout / network.
+            # Log the failure shape only — never authorization URLs, codes,
+            # tokens, state, or PKCE material.
+            logger.warning(
+                "MCP OAuth '%s': tool-challenge flow failed: %s: %s",
+                server_name, type(exc).__name__, exc,
+            )
+            ok = False
+        finally:
+            if not pending.done():
+                pending.set_result(ok)
+            entry.pending_401.pop(key, None)
+
+
 # ---------------------------------------------------------------------------
 # Module-level singleton
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -969,6 +969,62 @@ class NonMcpEndpointError(ConnectionError):
     """
 
 
+# _meta key carrying structured WWW-Authenticate challenges on a tool result
+# (SEP-835 convention: servers that accept anonymous ``initialize`` but
+# protect individual tools deliver the challenge here instead of an HTTP 401).
+_WWW_AUTHENTICATE_META_KEY = "mcp/www_authenticate"
+
+
+class McpToolAuthChallengeError(RuntimeError):
+    """A tool result carried a structured OAuth challenge in ``_meta`` (#69811).
+
+    Raised from the tool-call mapping when ``CallToolResult.isError`` is set
+    and ``_meta["mcp/www_authenticate"]`` is present, so the handler layer can
+    route the challenge through the OAuth manager and retry once. The message
+    intentionally excludes the challenge contents — no auth-flow material in
+    diagnostics.
+    """
+
+    def __init__(
+        self,
+        server_name: str,
+        challenges: List[str],
+        error_text: str = "",
+    ):
+        super().__init__(
+            f"MCP server '{server_name}' returned an OAuth challenge "
+            f"in a tool result"
+        )
+        self.server_name = server_name
+        self.challenges = challenges
+        self.error_text = error_text
+
+
+def _extract_tool_auth_challenges(result: Any) -> List[str]:
+    """Return WWW-Authenticate challenge strings from a tool result's _meta.
+
+    The MCP python SDK exposes ``_meta`` as ``CallToolResult.meta``. The value
+    under ``mcp/www_authenticate`` may be a single string or a list of
+    strings; anything else is ignored. Returns [] when no structured
+    challenge is present — ordinary tool errors must stay untouched.
+    """
+    meta = getattr(result, "meta", None)
+    if not isinstance(meta, dict):
+        return []
+    raw = meta.get(_WWW_AUTHENTICATE_META_KEY)
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return []
+    challenges = [
+        item.strip() for item in raw
+        if isinstance(item, str) and item.strip()
+    ]
+    # Defensive cap: a hostile server can't stuff megabytes of "challenges"
+    # into a synthesized header.
+    return challenges[:8]
+
+
 def _unwrap_exception_group(exc: BaseException) -> BaseException:
     """Extract the root-cause exception from anyio TaskGroup wrappers.
 
@@ -3888,6 +3944,128 @@ def _handle_auth_error_and_retry(
     }, ensure_ascii=False)
 
 
+def _handle_tool_challenge_and_retry(
+    server_name: str,
+    exc: BaseException,
+    retry_call,
+    op_description: str,
+):
+    """Recover from a tool-level OAuth challenge and retry once (#69811).
+
+    Counterpart of :func:`_handle_auth_error_and_retry` for challenges that
+    arrive in ``CallToolResult._meta["mcp/www_authenticate"]`` rather than as
+    a transport-level 401 (servers that allow anonymous ``initialize`` but
+    protect individual tools). Workflow:
+
+      1. Route the structured challenge through
+         :meth:`MCPOAuthManager.handle_tool_challenge`, which drives the
+         SDK's own discovery + Authorization Code + S256 PKCE flow from the
+         challenge's ``resource_metadata`` and ``scope``.
+      2. On success, flip the live server to OAuth transport auth (so the
+         rebuilt session sends ``Authorization: Bearer``), signal a
+         reconnect, and wait for readiness.
+      3. Retry the original tool call at most ONCE. A second challenge (or
+         any other failure) surfaces a structured ``needs_reauth`` error —
+         never an unbounded retry loop.
+      4. Return None if ``exc`` is not a tool challenge, so the caller falls
+         through to the other recovery paths.
+    """
+    if not isinstance(exc, McpToolAuthChallengeError):
+        return None
+
+    with _lock:
+        srv = _servers.get(server_name)
+    config = getattr(srv, "_config", None) if srv is not None else None
+    url = (config or {}).get("url")
+
+    recovered = False
+    if srv is not None and url:
+        from tools.mcp_oauth_manager import get_manager
+        manager = get_manager()
+        oauth_cfg = config.get("oauth")
+        challenges = list(exc.challenges)
+
+        async def _recover():
+            return await manager.handle_tool_challenge(
+                server_name, url, oauth_cfg, challenges,
+            )
+
+        # The interactive browser flow legitimately takes minutes — size the
+        # loop timeout from the provider timeout (default 300s) rather than
+        # the 10s used by the non-interactive 401 recovery path.
+        flow_timeout = float((oauth_cfg or {}).get("timeout", 300)) + 30.0
+        try:
+            recovered = bool(_run_on_mcp_loop(_recover, timeout=flow_timeout))
+        except Exception as rec_exc:
+            logger.warning(
+                "MCP OAuth '%s': tool-challenge recovery failed: %s",
+                server_name, rec_exc,
+            )
+            recovered = False
+
+    if recovered:
+        # The server connected anonymously; make the rebuilt transport carry
+        # the OAuth provider. run() reuses this same config dict on every
+        # reconnect iteration, so the flip persists for the process lifetime.
+        if (config.get("auth") or "").lower().strip() != "oauth":
+            config["auth"] = "oauth"
+            srv._auth_type = "oauth"
+            logger.info(
+                "MCP server '%s': enabling OAuth transport auth after a tool "
+                "challenge. Add `auth: oauth` to this server's config to "
+                "skip the challenge round-trip in future sessions.",
+                server_name,
+            )
+
+        reconnected = _signal_reconnect_and_wait(
+            server_name,
+            srv,
+            op_description=f"{op_description} after tool OAuth challenge",
+            timeout=15,
+        )
+        if reconnected:
+            _reset_server_error(server_name)
+
+        try:
+            result = retry_call()
+            try:
+                parsed = json.loads(result)
+                if "error" in parsed:
+                    _bump_server_error(server_name)
+                else:
+                    _reset_server_error(server_name)
+            except (json.JSONDecodeError, TypeError):
+                _reset_server_error(server_name)
+            # Authorization worked — surface the retry outcome verbatim,
+            # success or the tool's ordinary (non-challenge) error.
+            return result
+        except McpToolAuthChallengeError:
+            # Still challenged after OAuth + reconnect: authorization did not
+            # satisfy the server. Hard stop — one retry only.
+            logger.warning(
+                "MCP %s/%s: tool still challenged after OAuth recovery; "
+                "not retrying again",
+                server_name, op_description,
+            )
+        except Exception as retry_exc:
+            logger.warning(
+                "MCP %s/%s retry after tool OAuth challenge failed: %s",
+                server_name, op_description, retry_exc,
+            )
+
+    _bump_server_error(server_name)
+    return json.dumps({
+        "error": (
+            f"MCP server '{server_name}' requires authorization for this "
+            f"tool and automatic OAuth did not complete. Run `hermes mcp "
+            f"login {server_name}` to authorize, then try again. Do NOT "
+            f"retry this tool immediately."
+        ),
+        "needs_reauth": True,
+        "server": server_name,
+    }, ensure_ascii=False)
+
+
 # Substrings (lower-cased match) that indicate the MCP server rejected
 # the request because its server-side transport session expired /
 # was garbage-collected.  The caller's OAuth token is still valid —
@@ -4637,6 +4815,16 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     res_text = getattr(getattr(block, "resource", None), "text", None)
                     if res_text:
                         error_text += str(res_text)
+                # Structured OAuth challenge in _meta (#69811): the server
+                # accepted anonymous initialize but protects this tool.
+                # Surface as a typed exception so the handler layer can run
+                # the OAuth flow, reconnect, and retry once. HTTP-only —
+                # OAuth over a stdio transport is not a thing.
+                challenges = _extract_tool_auth_challenges(result)
+                if challenges and server._is_http():
+                    raise McpToolAuthChallengeError(
+                        server_name, challenges, error_text,
+                    )
                 return json.dumps({
                     "error": _sanitize_error(
                         error_text or "MCP tool returned an error"
@@ -4724,6 +4912,16 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
+            # Tool-level OAuth challenge (#69811): the result carried a
+            # structured www-authenticate challenge in _meta. Run the OAuth
+            # flow, reconnect, retry once. Returns None for other exceptions.
+            recovered = _handle_tool_challenge_and_retry(
+                server_name, exc, _call_once,
+                f"tools/call {tool_name}",
+            )
+            if recovered is not None:
+                return recovered
+
             # Auth-specific recovery path: consult the manager, signal
             # reconnect if viable, retry once. Returns None to fall
             # through for non-auth exceptions.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4023,8 +4023,23 @@ def _handle_tool_challenge_and_retry(
             op_description=f"{op_description} after tool OAuth challenge",
             timeout=15,
         )
-        if reconnected:
-            _reset_server_error(server_name)
+        if not reconnected:
+            logger.warning(
+                "MCP server '%s': OAuth completed but the transport did not "
+                "reconnect; not retrying %s against the stale session",
+                server_name, op_description,
+            )
+            _bump_server_error(server_name)
+            return json.dumps({
+                "error": (
+                    f"MCP server '{server_name}' was authorized, but its "
+                    f"transport did not reconnect. Try this tool again shortly."
+                ),
+                "reconnect_failed": True,
+                "server": server_name,
+            }, ensure_ascii=False)
+
+        _reset_server_error(server_name)
 
         try:
             result = retry_call()


### PR DESCRIPTION
## Problem

Servers that accept anonymous `initialize` but protect individual tools (e.g. the Resin8 staging MCP endpoint in #69811) never produce a transport-level HTTP 401. Instead the tool call succeeds at the protocol layer and returns `isError: true` with the OAuth challenge tucked into `CallToolResult._meta["mcp/www_authenticate"]`:

```json
"_meta": {
  "mcp/www_authenticate": [
    "Bearer error=\"unauthorized\", scope=\"resin8.buyer.profile.read\", resource_metadata=\"https://api.stage.resin8.ai/.well-known/oauth-protected-resource/mcp\""
  ]
}
```

The SDK's `OAuthClientProvider.async_auth_flow` only reacts to real 401 responses, so it never fired; Hermes mapped the result to a plain `{"error": ...}` string and **dropped the `_meta`**, leaving sessions wedged on `Invalid access token` with no recovery path.

## Fix

**Preserve the challenge** — `_extract_tool_auth_challenges` reads `result.meta["mcp/www_authenticate"]` (string or list, filtered/trimmed/capped) while mapping tool results. On an HTTP server it raises a typed `McpToolAuthChallengeError`; stdio servers and challenge-less errors keep the exact ordinary-error behavior. The exception message intentionally excludes challenge contents.

**Replay it through the existing OAuth machinery** — `MCPOAuthManager.handle_tool_challenge` drives the SDK provider's own `async_auth_flow` generator manually: it anchors a synthetic `httpx` 401 at the exact configured server URL, sets `WWW-Authenticate` to the joined challenge values, and feeds it to the generator. From there the SDK does what it already knows how to do — protected-resource metadata discovery (seeded by `resource_metadata` from the challenge), scope selection (from `scope`), client registration, Authorization Code + S256 PKCE, token exchange. Non-anchor requests the generator yields (discovery/registration/token) are sent for real. Notable properties:

- **Cached valid tokens unwind immediately** (synthetic 200, no re-auth) — covers process restarts where tokens are on disk but the server entry hasn't flipped to oauth yet.
- **Single-flight**: concurrent protected tool calls share one flow — no browser-window storm.
- **RFC 8707 resource retention** (including path components like `/mcp`) and the `Authorization: Bearer` scheme come from the SDK flow itself.
- No challenge scope/URL material is logged on failure.

**Reconnect + retry once** — `_handle_tool_challenge_and_retry` mirrors the existing 401-recovery handler: on success it flips the server config to `auth: "oauth"` (with an INFO hint to make it permanent), signals reconnect so the rebuilt transport carries Bearer auth, and retries the original tool exactly once. A second protected failure is a hard stop returning the structured `needs_reauth` payload (`hermes mcp login` guidance) — no loops.

## Acceptance criteria mapping

| Criterion (#69811) | Where |
|---|---|
| Challenge metadata preserved, not dropped | `_extract_tool_auth_challenges` + typed error raised in the `isError` branch |
| Parse challenge + protected-resource metadata | SDK `extract_resource_metadata_from_www_auth` / `extract_scope_from_www_auth` against the synthetic 401 (test pins the issue's exact challenge string) |
| Invoke existing Auth Code + PKCE flow | generator replay reuses `OAuthClientProvider.async_auth_flow` wholesale |
| Reconnect and retry original tool ≤ once | `_handle_tool_challenge_and_retry`; tests pin call counts (2 on success, 2 then hard stop on repeat challenge) |
| Ordinary errors unchanged | challenge-less `isError` and stdio tests pin exact prior payloads |
| Exact resource retention incl. `/mcp` path | SDK `context.get_resource_url()` (PRM resource when valid parent) |
| `Authorization: Bearer` | SDK `_add_auth_header` on the reconnected transport |
| No auth material in logs | failure paths log exception type/message only; test asserts challenge/scope absent from caplog |

## Testing

- `tests/tools/test_mcp_tool_challenge.py` (17 new tests): extractor shapes/filtering/cap, SDK-extractor compatibility with the issue's challenge, generator-driver paths (full flow from synthetic 401, cached-valid unwind, provider/setup/flow failure, single-flight concurrency), and handler integration (success retry + config flip + reconnect, needs_reauth without retry, second-challenge hard stop, ordinary error untouched, stdio untouched).
- Full MCP scope green: `uv run --frozen --extra dev pytest tests/tools/test_mcp_*.py tests/tools/test_refresh_agent_mcp_tools.py` → **762 passed**.
- `ruff check` clean on all touched files.

Fixes #69811
