### PR TITLE
feat(plugins): add WebSocket Server platform adapter (ws_server)

### DIFF
--- a/docs/install-ws-server.sh
+++ b/docs/install-ws-server.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# ───────────────────────────────────────────────────────────
+# Hermes Agent WebSocket Server Plugin - 一键安装脚本
+# ───────────────────────────────────────────────────────────
+# 用法：
+#   bash docs/install-ws-server.sh
+#
+# 从仓库根目录运行，将插件文件安装到默认路径。
+# ───────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+# ── 颜色 ──
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+log_info()  { echo -e "${CYAN}[INFO]${NC}  $1"; }
+log_ok()    { echo -e "${GREEN}[OK]${NC}    $1"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# ── 检测 hermes-agent 仓库根目录 ──
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ ! -f "$REPO_DIR/run_agent.py" ] && [ ! -f "$REPO_DIR/cli.py" ]; then
+    log_warn "当前目录不是 hermes-agent 仓库根目录（未找到 run_agent.py）"
+    log_info "尝试从脚本位置推导..."
+
+    # 尝试向上查找
+    CANDIDATE="$SCRIPT_DIR"
+    for _ in $(seq 1 5); do
+        if [ -f "$CANDIDATE/run_agent.py" ] || [ -f "$CANDIDATE/cli.py" ]; then
+            REPO_DIR="$CANDIDATE"
+            break
+        fi
+        CANDIDATE="$(cd "$CANDIDATE/.." && pwd)"
+    done
+
+    if [ ! -f "$REPO_DIR/run_agent.py" ]; then
+        log_error "无法定位 hermes-agent 仓库根目录"
+        log_error "请将此脚本放在仓库的 docs/ 目录下运行"
+        exit 1
+    fi
+fi
+
+log_info "Hermes Agent 仓库: $REPO_DIR"
+
+# ── 源文件 ──
+SRC_DIR="$REPO_DIR/plugins/platforms/ws_server"
+if [ ! -d "$SRC_DIR" ]; then
+    log_error "插件源目录不存在: $SRC_DIR"
+    log_error "请确保在 feature/ws-server 分支上运行此脚本"
+    exit 1
+fi
+
+# ── 目标路径 ──
+# 默认安装到 ~/.hermes/plugins/platforms/ws_server/
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+INSTALL_DIR="$HERMES_HOME/plugins/platforms/ws_server"
+
+log_info "安装目标: $INSTALL_DIR"
+
+# ── 创建目录 ──
+mkdir -p "$INSTALL_DIR"
+
+# ── 复制文件 ──
+cp "$SRC_DIR/__init__.py" "$INSTALL_DIR/__init__.py"
+cp "$SRC_DIR/adapter.py"  "$INSTALL_DIR/adapter.py"
+cp "$SRC_DIR/plugin.yaml" "$INSTALL_DIR/plugin.yaml"
+
+log_ok "文件已复制到 $INSTALL_DIR"
+log_info "  ├── __init__.py"
+log_info "  ├── adapter.py"
+log_info "  └── plugin.yaml"
+
+# ── 验证 ──
+if [ -f "$INSTALL_DIR/__init__.py" ] && [ -f "$INSTALL_DIR/adapter.py" ] && [ -f "$INSTALL_DIR/plugin.yaml" ]; then
+    log_ok "插件安装完成"
+else
+    log_error "插件安装不完整，请检查 $INSTALL_DIR"
+    exit 1
+fi
+
+echo ""
+echo -e "${CYAN}══════════════════════════════════════════════════════════${NC}"
+echo -e "  下一步"
+echo -e "${CYAN}══════════════════════════════════════════════════════════${NC}"
+echo ""
+echo "  1. 配置认证密钥："
+echo "     hermes config set gateway.platforms.ws_server.extra.api_key 'your-secret-key'"
+echo ""
+echo "  2. 重启网关："
+echo "     supervisorctl restart hermes"
+echo "     # 或: hermes gateway restart"
+echo ""
+echo "  3. 验证："
+echo "     curl http://127.0.0.1:8765/health"
+echo ""
+
+# ── 可选：自动配置 ──
+if command -v hermes &>/dev/null; then
+    echo -ne "${YELLOW}是否自动配置 ws_server 并重启网关？(y/N): ${NC}"
+    read -r answer
+    if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
+        log_info "正在配置..."
+
+        # 生成随机密钥
+        if command -v openssl &>/dev/null; then
+            KEY=$(openssl rand -hex 32)
+        else
+            KEY="ws-server-$(date +%s)-$$"
+        fi
+
+        # 通过 hermes config 命令配置
+        hermes config set gateway.platforms.ws_server.enabled true 2>/dev/null || true
+        hermes config set gateway.platforms.ws_server.extra.api_key "$KEY" 2>/dev/null || true
+        hermes config set gateway.platforms.ws_server.extra.host "0.0.0.0" 2>/dev/null || true
+        hermes config set gateway.platforms.ws_server.extra.port "8765" 2>/dev/null || true
+
+        log_ok "配置已完成 (api_key: $KEY)"
+
+        # 重启网关
+        log_info "正在重启网关..."
+        if command -v supervisorctl &>/dev/null && supervisorctl status hermes &>/dev/null 2>&1; then
+            supervisorctl restart hermes
+            log_ok "网关已重启 (supervisor)"
+        else
+            log_warn "未检测到 supervisor，请手动重启网关"
+        fi
+    fi
+fi
+
+echo -e "${GREEN}✅ 安装完成！${NC}"

--- a/docs/ws-server-plugin.md
+++ b/docs/ws-server-plugin.md
@@ -1,0 +1,237 @@
+# WebSocket Server 平台插件
+
+## 概述
+
+`plugins/platforms/ws_server/` 是一个 Hermes Agent 平台插件，为 Agent 添加 **WebSocket 服务端** 能力。外部前端（如 hermes-webui）通过 WebSocket 客户端连接后，可以使用完整的 `_HERMES_CORE_TOOLS` 工具集，包括 `terminal`、`execute_code`、`browser`、`file` 等所有核心工具。
+
+### 文件结构
+
+```
+plugins/platforms/ws_server/
+├── plugin.yaml      # 插件清单（kind: platform）
+├── __init__.py      # 导出 register()
+└── adapter.py       # WSServerAdapter 实现 (~550 行)
+```
+
+### 工作原理
+
+- 基于 aiohttp `WebSocketResponse` 实现
+- 继承 `BasePlatformAdapter`，复用 Hermes Gateway 完整的 agent 管线
+- 通过 `resolve_toolset("hermes-ws-server")` 自动继承 `_HERMES_CORE_TOOLS`
+- 支持 per-chat 串行锁、审批交互、后台任务推送
+
+---
+
+## 安装
+
+### 前提条件
+
+- Hermes Agent 已安装并可用
+- Python 3.10+
+- aiohttp（Hermes Agent 自带）
+
+### 手动安装
+
+```bash
+# 1. 进入 hermes-agent 仓库
+cd /path/to/hermes-agent
+
+# 2. 复制插件文件到 plugins 目录
+mkdir -p plugins/platforms/ws_server
+cp path/to/ws_server/*.py plugins/platforms/ws_server/
+cp path/to/ws_server/plugin.yaml plugins/platforms/ws_server/
+
+# 3. 重启 gateway
+supervisorctl restart hermes
+# 或
+hermes gateway restart
+```
+
+### 一键安装
+
+```bash
+# 从仓库根目录运行
+bash docs/install-ws-server.sh
+```
+
+---
+
+## 配置
+
+### 方式一：config.yaml（推荐）
+
+```bash
+hermes config set gateway.platforms.ws_server.enabled true
+hermes config set gateway.platforms.ws_server.extra.api_key "your-secret-key"
+hermes config set gateway.platforms.ws_server.extra.host "0.0.0.0"
+hermes config set gateway.platforms.ws_server.extra.port 8765
+```
+
+或直接编辑 `~/.hermes/config.yaml`：
+
+```yaml
+gateway:
+  platforms:
+    ws_server:
+      enabled: true
+      extra:
+        api_key: "your-strong-secret-key-here"
+        host: "0.0.0.0"
+        port: 8765
+```
+
+### 方式二：环境变量
+
+```bash
+WS_SERVER_API_KEY=your-key
+WS_SERVER_HOST=0.0.0.0
+WS_SERVER_PORT=8765
+```
+
+---
+
+## 使用
+
+### 启动
+
+```bash
+supervisorctl restart hermes
+```
+
+### 验证
+
+```bash
+# 检查端口
+ss -tlnp | grep 8765
+
+# 健康检查
+curl http://127.0.0.1:8765/health
+
+# 预期输出：
+# {"status":"ok","platform":"ws_server","connected_clients":0}
+
+# 查看日志
+tail -f ~/.hermes/logs/gateway.log | grep ws_server
+# 成功时显示：
+# [ws_server] Listening on ws://0.0.0.0:8765/_ws
+# ✓ ws_server connected
+```
+
+---
+
+## WebSocket 协议
+
+### 端点
+
+```
+ws://host:port/_ws
+```
+
+### 认证
+
+**客户端 → 服务端**（连接后第一条消息必须为认证消息）：
+
+```json
+{"type": "auth", "api_key": "your-key"}
+```
+
+**服务端 → 客户端**：
+
+```json
+{"type": "auth_ok", "chat_id": "ws_abc123def456"}
+```
+
+### 客户端 → 服务端消息
+
+| 类型 | 用途 | 必填字段 |
+|------|------|---------|
+| `msg` | 发送用户消息 | `chat_id`, `text` |
+| `approve` | 审批响应 | `approval_id`, `choice` |
+| `stop` | 停止运行 | `run_id` |
+| `ping` | 心跳 | 无 |
+
+### 服务端 → 客户端事件
+
+| 类型 | 用途 | 关键字段 |
+|------|------|---------|
+| `send` | 文本回复 | `chat_id`, `content` |
+| `edit` | 编辑消息 | `chat_id`, `message_id`, `content` |
+| `approval_card` | 审批请求 | `chat_id`, `approval_id`, `command`, `reason` |
+| `typing` | 打字指示 | `chat_id` |
+| `send_file` | 文件/图片 | `chat_id`, `file_path`, `caption` |
+| `system` | 系统消息 | `chat_id`, `message` |
+| `done` | 处理完成 | `chat_id` |
+| `ping` | 心跳 | 无 |
+| `pong` | 心跳回复 | 无 |
+
+---
+
+## 工具集
+
+该插件自动使用 `hermes-ws-server` 工具集，无需手动配置。通过 `toolsets.py` 的自动回退机制，`resolve_toolset("hermes-ws-server")` 会自动展开为 `_HERMES_CORE_TOOLS`：
+
+- `terminal`, `process` — 终端执行
+- `execute_code` — 代码执行
+- `read_file`, `write_file`, `patch`, `search_files` — 文件操作
+- `browser_*` — 浏览器自动化
+- `web_search`, `web_extract` — 网络搜索
+- `delegate_task` — 子代理委派
+- `todo`, `memory` — 任务和记忆
+- `cronjob` — 定时任务
+- 等全部核心工具
+
+可以通过 `hermes tools` 命令按平台启用/禁用具体工具集。
+
+---
+
+## 架构
+
+### 类层次
+
+```
+BasePlatformAdapter (gateway/platforms/base.py)
+  └─ WSServerAdapter (plugins/platforms/ws_server/adapter.py)
+       ├─ connect()      → 启动 aiohttp WS 服务端
+       ├─ disconnect()   → 停止服务端
+       ├─ send()         → 通过 WS 发送文本
+       ├─ edit_message() → 编辑消息
+       ├─ send_image()   → 发送文件/图片
+       ├─ send_typing()  → 打字指示
+       ├─ send_exec_approval() → 审批请求
+       ├─ on_processing_start() → 开始处理
+       └─ on_processing_complete() → 处理完成（发送 done）
+```
+
+### 连接生命周期
+
+```
+WS 客户端连接
+    ↓
+_auth_ok（认证 + chat_id 绑定）
+    ↓
+_dispatch_ws_message（消息分发）
+    ↓
+_handle_inbound → MessageEvent → handle_message()
+    ↓
+Agent 管线处理
+    ↓
+send() / edit_message() / send_exec_approval() → WS 推送
+    ↓
+on_processing_complete() → {"type": "done"}
+```
+
+---
+
+## 与 API Server 的对比
+
+| 特性 | API Server | WS Server |
+|------|-----------|-----------|
+| 协议 | HTTP/SSE | WebSocket |
+| 依赖 | aiohttp | aiohttp |
+| 工具集 | `hermes-api-server` | `hermes-ws-server`（同 `_HERMES_CORE_TOOLS`） |
+| 全双工 | ❌ | ✅ |
+| 后台通知 | ❌ | ✅ |
+| 连接持久性 | 无状态 | 有状态 |
+| 鉴权 | `API_SERVER_KEY` | `WS_SERVER_API_KEY` |
+| 实现方式 | 内置（`gateway/platforms/`） | 插件（`plugins/platforms/`） |
+| 核心代码修改 | 无 | 无 |

--- a/plugins/platforms/ws_server/__init__.py
+++ b/plugins/platforms/ws_server/__init__.py
@@ -1,0 +1,8 @@
+"""
+WebSocket Server platform adapter for Hermes Agent.
+Listens for incoming WebSocket connections from frontend clients.
+"""
+
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/ws_server/adapter.py
+++ b/plugins/platforms/ws_server/adapter.py
@@ -1,0 +1,560 @@
+"""
+WebSocket Server adapter — Hermes Agent 作为 WS 服务端，前端客户端主动连接。
+
+让 hermes-webui（或其他前端）通过 WebSocket 直连 Hermes Agent，获得完整的
+工具集访问（terminal, execute_code, browser, file ops 等）。
+
+架构：
+  前端 (Vue SPA) → HTTP/SSE → webui 后端 (FastAPI)
+                                      ↓ WS 客户端
+  Hermes Agent (WS Server Adapter) ←←←←←←←← 监听 :8765/_ws
+
+对比 api_server adapter：
+  - WS server 使用 aiohttp WebSocket，而非 HTTP SSE
+  - 持久的全双工连接（支持 async_delivery）
+  - 精简的消息协议（JSON over WS），无 OpenAI 兼容开销
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+import uuid
+from datetime import datetime
+from typing import Any, Callable, Optional
+
+import aiohttp
+from aiohttp import web
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+    SessionSource,
+)
+
+logger = logging.getLogger(__name__)
+
+AIOHTTP_AVAILABLE = True
+
+_HEARTBEAT_INTERVAL = 30  # seconds
+
+
+class WSServerAdapter(BasePlatformAdapter):
+    """
+    WebSocket 服务端适配器。
+
+    监听 TCP 端口，接受 WS 客户端连接。每条连接认证后绑定一个 chat_id，
+    所有消息/事件通过 WS 帧传输。
+    """
+
+    supports_code_blocks = True
+    splits_long_messages = True
+    supports_async_delivery = True
+    MAX_MESSAGE_LENGTH = 32000
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform("ws_server"))
+        extra = config.extra or {}
+
+        self._host: str = (
+            extra.get("host")
+            or os.environ.get("WS_SERVER_HOST", "127.0.0.1")
+        )
+        self._port: int = int(
+            extra.get("port")
+            or os.environ.get("WS_SERVER_PORT", "8765")
+        )
+        self._api_key: str = (
+            extra.get("api_key")
+            or os.environ.get("WS_SERVER_API_KEY", "")
+        )
+
+        # aiohttp 组件
+        self._app: Optional[web.Application] = None
+        self._runner: Optional[web.AppRunner] = None
+        self._site: Optional[web.TCPSite] = None
+
+        # chat_id → WebSocketResponse 映射
+        self._clients: dict[str, web.WebSocketResponse] = {}
+        self._ws_close_events: dict[str, asyncio.Event] = {}
+
+        # per-chat 串行锁
+        self._chat_locks: dict[str, asyncio.Lock] = {}
+        _CHAT_LOCKS_MAX = 1000
+
+        # 审批状态
+        self._pending_approvals: dict[str, dict] = {}
+        self._approval_counter = 0
+
+        # 后台任务跟踪
+        self._background_tasks: set[asyncio.Task] = set()
+        self._heartbeat_task: Optional[asyncio.Task] = None
+
+        # 是否正在运行
+        self._running = False
+
+    # ════════════════════════════════════════════════════════════════
+    # 平台生命周期
+    # ════════════════════════════════════════════════════════════════
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """启动 aiohttp WebSocket 服务端。"""
+        if not self._api_key:
+            logger.error(
+                "[ws_server] Refusing to start: WS_SERVER_API_KEY is required "
+                "(set in config.yaml platforms.ws_server.extra.api_key or "
+                "WS_SERVER_API_KEY env var). This endpoint dispatches "
+                "terminal-capable agent work — a guessable key is RCE."
+            )
+            return False
+
+        self._app = web.Application()
+
+        # 路由
+        self._app.router.add_get("/_ws", self._handle_websocket)
+        self._app.router.add_get("/health", self._handle_health)
+        self._app["ws_server_adapter"] = self
+
+        # 端口冲突检测
+        try:
+            with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _s:
+                _s.settimeout(1)
+                _s.connect(("127.0.0.1", self._port))
+            logger.error(
+                "[ws_server] Port %d already in use. Set a different port "
+                "via WS_SERVER_PORT or config.yaml",
+                self._port,
+            )
+            return False
+        except (ConnectionRefusedError, OSError):
+            pass  # port is free
+
+        self._runner = web.AppRunner(self._app)
+        await self._runner.setup()
+        self._site = web.TCPSite(self._runner, self._host, self._port)
+        await self._site.start()
+
+        # 后台心跳
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        self._background_tasks.add(self._heartbeat_task)
+
+        self._running = True
+        self._mark_connected()
+        logger.info(
+            "[ws_server] Listening on ws://%s:%d/_ws",
+            self._host, self._port,
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        """停止 WS 服务端，断开所有客户端连接。"""
+        self._running = False
+        self._mark_disconnected()
+
+        # 断开所有 WS 客户端
+        for chat_id, ws in list(self._clients.items()):
+            try:
+                await ws.close()
+            except Exception:
+                pass
+        self._clients.clear()
+
+        # 停止后台任务
+        for task in list(self._background_tasks):
+            task.cancel()
+        self._background_tasks.clear()
+
+        # 停止 aiohttp 服务
+        if self._site:
+            try:
+                await self._site.stop()
+            except Exception:
+                pass
+            self._site = None
+        if self._runner:
+            try:
+                await self._runner.cleanup()
+            except Exception:
+                pass
+            self._runner = None
+        self._app = None
+        logger.info("[ws_server] Server stopped")
+
+    # ════════════════════════════════════════════════════════════════
+    # HTTP / WS 端点
+    # ════════════════════════════════════════════════════════════════
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        """GET /health — 健康检查。"""
+        return web.json_response({
+            "status": "ok",
+            "platform": "ws_server",
+            "connected_clients": len(self._clients),
+        })
+
+    async def _handle_websocket(self, request: web.Request) -> web.WebSocketResponse:
+        """WebSocket 连接主处理。
+
+        认证流程：
+          1. 客户端连接后第一条消息必须是 {"type": "auth", "api_key": "..."}
+          2. 服务端验证 api_key，回复 {"type": "auth_ok", "chat_id": "..."}
+          3. 后续消息按 type 路由
+        """
+        ws = web.WebSocketResponse(
+            max_msg_size=1024 * 1024,  # 1MB
+            heartbeat=_HEARTBEAT_INTERVAL,
+        )
+        await ws.prepare(request)
+
+        # ── 等待认证 ──────────────────────────────────────────────
+        try:
+            auth_msg = await ws.receive_json()
+        except Exception:
+            await ws.close(code=4001, message=b"auth required")
+            return ws
+
+        if not isinstance(auth_msg, dict) or auth_msg.get("type") != "auth":
+            await ws.send_json({"type": "error", "message": "first message must be auth"})
+            await ws.close(code=4001, message=b"auth required")
+            return ws
+
+        if auth_msg.get("api_key") != self._api_key:
+            await ws.send_json({"type": "error", "message": "invalid api_key"})
+            await ws.close(code=4001, message=b"invalid api_key")
+            return ws
+
+        # 分配/使用客户端指定的 chat_id
+        chat_id = str(auth_msg.get("chat_id", "")) or f"ws_{uuid.uuid4().hex[:12]}"
+
+        # 如果已有相同 chat_id 的连接，关闭旧的
+        old_ws = self._clients.get(chat_id)
+        if old_ws and not old_ws.closed:
+            try:
+                await old_ws.close(code=4000, message=b"replaced by new connection")
+            except Exception:
+                pass
+
+        self._clients[chat_id] = ws
+        await ws.send_json({"type": "auth_ok", "chat_id": chat_id})
+        logger.info("[ws_server] Client '%s' authenticated (total: %d)",
+                     chat_id, len(self._clients))
+
+        # ── 消息接收循环 ──────────────────────────────────────────
+        try:
+            async for msg in ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    try:
+                        data = json.loads(msg.data)
+                    except json.JSONDecodeError:
+                        continue
+                    await self._dispatch_ws_message(data, chat_id)
+                elif msg.type == aiohttp.WSMsgType.ERROR:
+                    logger.warning("[ws_server] WS error for '%s': %s",
+                                   chat_id, ws.exception())
+                    break
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("[ws_server] WS receive error for '%s'", chat_id)
+        finally:
+            self._clients.pop(chat_id, None)
+            logger.info("[ws_server] Client '%s' disconnected (remaining: %d)",
+                         chat_id, len(self._clients))
+
+        return ws
+
+    async def _dispatch_ws_message(self, data: dict, chat_id: str) -> None:
+        """根据 type 分发 WS 消息。"""
+        t = data.get("type", "")
+
+        if t == "ping":
+            await self._ws_send(chat_id, {"type": "pong"})
+        elif t == "pong":
+            pass
+        elif t == "msg":
+            # 动态注册 chat_id → WS 连接映射。
+            # 客户端可能在 auth 后通过不同 chat_id 发消息，
+            # 如果不重新注册，adapter.send(chat_id) 会找不到连接。
+            msg_chat_id = data.get("chat_id", chat_id)
+            ws = self._clients.get(chat_id)
+            if ws and msg_chat_id != chat_id:
+                self._clients[msg_chat_id] = ws
+            await self._handle_inbound(data, msg_chat_id)
+        elif t == "approve":
+            await self._handle_approval(data)
+        elif t == "stop":
+            logger.info("[ws_server] Stop signal for '%s': %s",
+                        chat_id, data.get("run_id", ""))
+        else:
+            logger.debug("[ws_server] Unknown message type '%s' from '%s'", t, chat_id)
+
+    # ════════════════════════════════════════════════════════════════
+    # 入站消息处理
+    # ════════════════════════════════════════════════════════════════
+
+    async def _handle_inbound(self, msg: dict, chat_id: str) -> None:
+        """处理用户消息 → 构造 MessageEvent → agent pipeline。"""
+        text = msg.get("text", "")
+        if not text:
+            return
+
+        user_id = str(msg.get("user_id", chat_id))
+        username = str(msg.get("username", user_id))
+
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=username,
+            chat_type="dm",
+            user_id=user_id,
+            user_name=username,
+        )
+
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.COMMAND if text.startswith("/") else MessageType.TEXT,
+            source=source,
+            raw_message=msg,
+            message_id=str(uuid.uuid4()),
+            timestamp=datetime.now(),
+        )
+
+        await self._handle_message_with_guards(event, chat_id)
+
+    async def _handle_message_with_guards(self, event: MessageEvent, chat_id: str) -> None:
+        """per-chat 串行锁保证同一 chat 的消息串行处理。"""
+        lock = self._chat_locks.get(chat_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._chat_locks[chat_id] = lock
+
+        async with lock:
+            await self.handle_message(event)
+
+    # ════════════════════════════════════════════════════════════════
+    # 审批处理
+    # ════════════════════════════════════════════════════════════════
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[dict] = None,
+    ) -> SendResult:
+        """发送审批请求到前端。"""
+        self._approval_counter += 1
+        approval_id = str(self._approval_counter)
+
+        self._pending_approvals[approval_id] = {
+            "session_key": session_key,
+            "chat_id": chat_id,
+        }
+
+        ok = await self._ws_send(chat_id, {
+            "type": "approval_card",
+            "chat_id": chat_id,
+            "approval_id": approval_id,
+            "command": command,
+            "reason": description,
+        })
+
+        return SendResult(success=ok, message_id=approval_id)
+
+    async def _handle_approval(self, msg: dict) -> None:
+        """处理前端返回的审批结果。"""
+        approval_id = str(msg.get("approval_id", ""))
+        choice = msg.get("choice", "deny")
+
+        state = self._pending_approvals.pop(approval_id, None)
+        if not state:
+            logger.warning("[ws_server] Approval %s not found (expired?)", approval_id)
+            return
+
+        session_key = state["session_key"]
+
+        logger.info(
+            "[ws_server] Approval %s resolved: %s (session_key=%s)",
+            approval_id, choice, session_key,
+        )
+
+        try:
+            from tools.approval import resolve_gateway_approval
+            resolve_gateway_approval(session_key, choice)
+        except Exception as exc:
+            logger.error("[ws_server] Resolve approval failed: %s", exc)
+
+    # ════════════════════════════════════════════════════════════════
+    # 出站消息（BasePlatformAdapter 接口）
+    # ════════════════════════════════════════════════════════════════
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> SendResult:
+        ok = await self._ws_send(chat_id, {
+            "type": "send",
+            "chat_id": chat_id,
+            "content": content,
+        })
+        return SendResult(success=ok, message_id=str(uuid.uuid4()))
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+    ) -> SendResult:
+        ok = await self._ws_send(chat_id, {
+            "type": "edit",
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "content": content,
+        })
+        return SendResult(success=ok, message_id=message_id)
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> SendResult:
+        ok = await self._ws_send(chat_id, {
+            "type": "send_file",
+            "chat_id": chat_id,
+            "file_path": image_url,
+            "caption": caption or "",
+        })
+        return SendResult(success=ok, message_id=str(uuid.uuid4()))
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: str = "",
+        **kwargs,
+    ) -> SendResult:
+        return await self.send_image(chat_id, file_path, caption)
+
+    send_document = send_image_file
+    send_voice = send_image_file
+    send_video = send_image_file
+
+    async def send_typing(self, chat_id: str, metadata: Optional[dict] = None) -> None:
+        await self._ws_send(chat_id, {
+            "type": "typing",
+            "chat_id": chat_id,
+        })
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """处理开始 → 发送 typing 指示。"""
+        chat_id = (
+            getattr(event.source, "chat_id", "") or ""
+            if event.source else ""
+        )
+        await self.send_typing(chat_id)
+
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
+        """处理完成 → 发送 done 事件，失败时额外发送错误提示。"""
+        chat_id = (
+            getattr(event.source, "chat_id", "") or ""
+            if event.source else ""
+        )
+        if outcome is ProcessingOutcome.FAILURE:
+            await self._ws_send(chat_id, {
+                "type": "system",
+                "chat_id": chat_id,
+                "message": "❌ Processing failed, please retry",
+            })
+        await self._ws_send(chat_id, {
+            "type": "done",
+            "chat_id": chat_id,
+        })
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        return {"name": chat_id, "type": "dm"}
+
+    # ════════════════════════════════════════════════════════════════
+    # 心跳
+    # ════════════════════════════════════════════════════════════════
+
+    async def _heartbeat_loop(self) -> None:
+        """定期向所有客户端发送 ping。"""
+        while self._running:
+            await asyncio.sleep(_HEARTBEAT_INTERVAL)
+            for chat_id in list(self._clients.keys()):
+                await self._ws_send(chat_id, {"type": "ping"})
+
+    # ════════════════════════════════════════════════════════════════
+    # 辅助方法
+    # ════════════════════════════════════════════════════════════════
+
+    async def _ws_send(self, chat_id: str, data: dict) -> bool:
+        """向指定 chat 发送 JSON 消息。"""
+        ws = self._clients.get(chat_id)
+        if not ws or ws.closed:
+            return False
+        try:
+            await ws.send_json(data, dumps=lambda o: json.dumps(o, ensure_ascii=False))
+            return True
+        except Exception as exc:
+            logger.debug("[ws_server] Send to '%s' failed: %s", chat_id, exc)
+            return False
+
+    def _get_cron_sender(self) -> Optional[Callable]:
+        """返回 cron 投递函数。"""
+        return None  # WS server 暂不支持 cron 投递
+
+
+# ════════════════════════════════════════════════════════════════════
+# 模块级辅助
+# ════════════════════════════════════════════════════════════════════
+
+import socket as _socket
+
+
+def _check_requirements() -> bool:
+    """检查 aiohttp 是否可用。"""
+    try:
+        import aiohttp  # noqa: F401
+        return True
+    except ImportError:
+        logger.error("[ws_server] aiohttp not installed")
+        return False
+
+
+def _build_adapter(config: PlatformConfig) -> WSServerAdapter:
+    return WSServerAdapter(config)
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by Hermes plugin system."""
+    ctx.register_platform(
+        name="ws_server",
+        label="WebSocket Server",
+        adapter_factory=_build_adapter,
+        check_fn=_check_requirements,
+        is_connected=lambda: _check_requirements(),
+        validate_config=lambda _cfg: _check_requirements(),
+        required_env=["WS_SERVER_API_KEY"],
+        install_hint="aiohttp is bundled with Hermes Agent",
+        emoji="🔌",
+        max_message_length=32000,
+        allow_update_command=True,
+    )

--- a/plugins/platforms/ws_server/plugin.yaml
+++ b/plugins/platforms/ws_server/plugin.yaml
@@ -1,0 +1,24 @@
+name: ws-server-platform
+label: WebSocket Server
+kind: platform
+version: 1.0.0
+description: >
+  WebSocket server gateway adapter for Hermes Agent.
+  Listens for incoming WebSocket connections from local or intranet
+  frontend clients (e.g. hermes-webui), providing full agent
+  capabilities including terminal and code execution.
+author: XuanLingZi
+requires_env:
+  - name: WS_SERVER_API_KEY
+    description: "API key for WebSocket authentication"
+    prompt: "WS Server API Key"
+    password: true
+optional_env:
+  - name: WS_SERVER_HOST
+    description: "Bind address (default: 127.0.0.1)"
+    prompt: "WS Server bind address"
+    default: "127.0.0.1"
+  - name: WS_SERVER_PORT
+    description: "Listen port (default: 8765)"
+    prompt: "WS Server port"
+    default: "8765"


### PR DESCRIPTION
Add a new `ws_server` platform plugin that enables Hermes Agent to act as a WebSocket server, allowing frontend clients to connect directly via WebSocket and use the full core toolset (terminal, code execution, browser, file operations, etc.).

Key features:
- aiohttp-based WebSocket server with per-chat serial locks
- API key authentication with connection-level isolation
- Full approval workflow (send_exec_approval → approve/deny)
- Async delivery support with typing indicators
- Heartbeat/ping-pong for connection health
- Dynamic chat_id↔WS connection mapping
- Graceful cleanup on disconnect

Includes:
- plugins/platforms/ws_server/{__init__,adapter,plugin.yaml}
- docs/ws-server-plugin.md
- docs/install-ws-server.sh (one-click installer)

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

