### PR TITLE
docs(skills): bring 69 skill descriptions under the 60-char routing budget

### DIFF
--- a/optional-skills/autonomous-ai-agents/blackbox/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/blackbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blackbox
-description: Delegate coding tasks to Blackbox AI CLI agent. Multi-model agent with built-in judge that runs tasks through multiple LLMs and picks the best result. Requires the blackbox CLI and a Blackbox AI API key.
+description: Delegate coding tasks to the Blackbox AI multi-model CLI.
 version: 1.0.0
 author: Hermes Agent (Nous Research)
 license: MIT

--- a/optional-skills/autonomous-ai-agents/honcho/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/honcho/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: honcho
-description: Configure and use Honcho memory with Hermes -- cross-session user modeling, multi-profile peer isolation, observation config, dialectic reasoning, session summaries, and context budget enforcement. Use when setting up Honcho, troubleshooting memory, managing profiles with Honcho peers, or tuning observation, recall, and dialectic settings.
+description: Configure and troubleshoot Honcho memory for Hermes.
 version: 2.0.0
 author: Hermes Agent
 license: MIT

--- a/optional-skills/blockchain/solana/SKILL.md
+++ b/optional-skills/blockchain/solana/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: solana
-description: Query Solana blockchain data with USD pricing — wallet balances, token portfolios with values, transaction details, NFTs, whale detection, and live network stats. Uses Solana RPC + CoinGecko. No API key required.
+description: Query Solana wallets, tokens, txs, and NFTs in USD.
 version: 0.2.0
 author: Deniz Alagoz (gizdusum), enhanced by Hermes Agent
 license: MIT

--- a/optional-skills/creative/concept-diagrams/SKILL.md
+++ b/optional-skills/creative/concept-diagrams/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: concept-diagrams
-description: Generate flat, minimal light/dark-aware SVG diagrams as standalone HTML files, using a unified educational visual language with 9 semantic color ramps, sentence-case typography, and automatic dark mode. Best suited for educational and non-software visuals — physics setups, chemistry mechanisms, math curves, physical objects (aircraft, turbines, smartphones, mechanical watches), anatomy, floor plans, cross-sections, narrative journeys (lifecycle of X, process of Y), hub-spoke system integrations (smart city, IoT), and exploded layer views. If a more specialized skill exists for the subject (dedicated software/cloud architecture, hand-drawn sketches, animated explainers, etc.), prefer that — otherwise this skill can also serve as a general-purpose SVG diagram fallback with a clean educational look. Ships with 15 example diagrams.
+description: Generate flat, minimal educational SVG visuals as HTML.
 version: 0.1.0
 author: v1k22 (original PR), ported into hermes-agent
 license: MIT

--- a/optional-skills/creative/hyperframes/SKILL.md
+++ b/optional-skills/creative/hyperframes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hyperframes
-description: Create HTML-based video compositions, animated title cards, social overlays, captioned talking-head videos, audio-reactive visuals, and shader transitions using HyperFrames. HTML is the source of truth for video. Use when the user wants a rendered MP4/WebM from an HTML composition, wants to animate text/logos/charts over media, needs captions synced to audio, wants TTS narration, or wants to convert a website into a video.
+description: Render MP4/WebM videos from HTML compositions.
 version: 1.0.0
 author: heygen-com
 license: Apache-2.0

--- a/optional-skills/creative/kanban-video-orchestrator/SKILL.md
+++ b/optional-skills/creative/kanban-video-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kanban-video-orchestrator
-description: Plan, set up, and monitor a multi-agent video production pipeline backed by Hermes Kanban. Use when the user wants to make ANY video — narrative film, product/marketing, music video, explainer, ASCII/terminal art, abstract/generative loop, comic, 3D, real-time/installation — and the work warrants decomposition into specialized profiles (writer, designer, animator, renderer, voice, editor, etc.) coordinated through a kanban board. Performs adaptive discovery to scope the brief, designs an appropriate team for the requested style, generates the setup script that creates Hermes profiles + initial kanban task, then helps monitor execution and intervene when tasks stall or fail. Routes scenes to whichever Hermes rendering / audio / design skill fits each beat (`ascii-video`, `manim-video`, `p5js`, `comfyui`, `touchdesigner-mcp`, `blender-mcp`, `pixel-art`, `baoyu-comic`, `claude-design`, `excalidraw`, `songsee`, `heartmula`, …) plus external APIs for TTS, image-gen, and image-to-video as needed.
+description: Plan and run multi-agent video production pipelines.
 version: 1.0.0
 author: [SHL0MS, alt-glitch]
 license: MIT

--- a/optional-skills/creative/meme-generation/SKILL.md
+++ b/optional-skills/creative/meme-generation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meme-generation
-description: Generate real meme images by picking a template and overlaying text with Pillow. Produces actual .png meme files.
+description: Create meme PNGs from templates with Pillow text overlay.
 version: 2.0.0
 author: adanaleycio
 license: MIT

--- a/optional-skills/creative/unreal-mcp/SKILL.md
+++ b/optional-skills/creative/unreal-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unreal-mcp
-description: "Use when the user wants to do anything in Unreal Engine through Epic's official editor-embedded MCP server (catalog entry: unreal-engine) — build/light/populate scenes, place and transform actors, author Blueprints, animate with Sequencer, create material instances, frame cameras, take screenshots, render, import assets, run PIE test sessions and automation tests, or automate the editor end-to-end from plain-English prompts with no Unreal knowledge required. Covers the tool-search discovery walk (list_toolsets/describe_toolset/call_tool), serial game-thread call discipline, ProgrammaticToolset batching, the Blueprint graph DSL loop, scene-craft numbers (physical light units, exposure, scale conventions), complete build recipes, save/undo hygiene, and extending the tool surface with custom Python toolsets."
+description: Automate Unreal Engine editor scenes, actors, and renders.
 version: 1.0.0
 requires: Unreal Editor 5.8+ with the Unreal MCP plugin enabled and its server running
 author: Hermes Agent

--- a/optional-skills/devops/cli/SKILL.md
+++ b/optional-skills/devops/cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inference-sh-cli
-description: "Run 150+ AI apps via inference.sh CLI (infsh) — image generation, video creation, LLMs, search, 3D, social automation. Uses the terminal tool. Triggers: inference.sh, infsh, ai apps, flux, veo, image generation, video generation, seedream, seedance, tavily"
+description: Run 150+ AI apps (image, video, LLM) via inference.sh CLI.
 version: 1.0.0
 author: okaris
 license: MIT

--- a/optional-skills/devops/docker-management/SKILL.md
+++ b/optional-skills/devops/docker-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docker-management
-description: Manage Docker containers, images, volumes, networks, and Compose stacks — lifecycle ops, debugging, cleanup, and Dockerfile optimization.
+description: Manage Docker containers, images, volumes, and Compose.
 version: 1.0.0
 author: sprmn24
 license: MIT

--- a/optional-skills/devops/hermes-s6-container-supervision/SKILL.md
+++ b/optional-skills/devops/hermes-s6-container-supervision/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hermes-s6-container-supervision
-description: Modify, debug, or extend the s6-overlay supervision tree inside the Hermes Agent Docker image — adding new services, debugging profile gateways, understanding the Architecture B main-program pattern.
+description: Modify or debug s6 services in the Hermes Docker image.
 version: 1.0.0
 author: Hermes Agent
 license: MIT

--- a/optional-skills/dogfood/adversarial-ux-test/SKILL.md
+++ b/optional-skills/dogfood/adversarial-ux-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adversarial-ux-test
-description: Roleplay the most difficult, tech-resistant user for your product. Browse the app as that persona, find every UX pain point, then filter complaints through a pragmatism layer to separate real problems from noise. Creates actionable tickets from genuine issues only.
+description: Roleplay a hostile user to find and triage UX pain points.
 version: 1.0.0
 author: Omni @ Comelse
 license: MIT

--- a/optional-skills/email/agentmail/SKILL.md
+++ b/optional-skills/email/agentmail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentmail
-description: Give the agent its own dedicated email inbox via AgentMail. Send, receive, and manage email autonomously using agent-owned email addresses (e.g. hermes-agent@agentmail.to).
+description: "Give the agent its own inbox: send and receive email."
 version: 1.0.0
 platforms: [linux, macos, windows]
 metadata:

--- a/optional-skills/finance/3-statement-model/SKILL.md
+++ b/optional-skills/finance/3-statement-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 3-statement-model
-description: Build fully-integrated 3-statement models (IS, BS, CF) in Excel with working capital schedules, D&A roll-forwards, debt schedule, and the plugs that make cash and retained earnings tie. Pairs with excel-author.
+description: Build integrated IS/BS/CF financial workbooks in Excel.
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0

--- a/optional-skills/finance/comps-analysis/SKILL.md
+++ b/optional-skills/finance/comps-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: comps-analysis
-description: Build comparable company analysis in Excel — operating metrics, valuation multiples, statistical benchmarking vs peer sets. Pairs with excel-author. Use for public-company valuation, IPO pricing, sector benchmarking, or outlier detection.
+description: Build comparable-company valuation workbooks in Excel.
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0

--- a/optional-skills/finance/dcf-model/SKILL.md
+++ b/optional-skills/finance/dcf-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dcf-model
-description: Build institutional-quality DCF valuation models in Excel — revenue projections, FCF build, WACC, terminal value, Bear/Base/Bull scenarios, 5x5 sensitivity tables. Pairs with excel-author. Use for intrinsic-value equity analysis.
+description: Build discounted cash flow valuation workbooks in Excel.
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0

--- a/optional-skills/finance/excel-author/SKILL.md
+++ b/optional-skills/finance/excel-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: excel-author
-description: Build auditable Excel workbooks headless with openpyxl — blue/black/green cell conventions, formulas over hardcodes, named ranges, balance checks, sensitivity tables. Use for financial models, audit outputs, reconciliations.
+description: Build auditable financial workbooks headless via openpyxl.
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0

--- a/optional-skills/finance/lbo-model/SKILL.md
+++ b/optional-skills/finance/lbo-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lbo-model
-description: Build leveraged buyout models in Excel — sources & uses, debt schedule, cash sweep, exit multiple, IRR/MOIC sensitivity. Pairs with excel-author. Use for PE screening, sponsor-case valuation, or illustrative LBO in a pitch.
+description: Build leveraged buyout workbooks with IRR/MOIC in Excel.
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0

--- a/optional-skills/finance/merger-model/SKILL.md
+++ b/optional-skills/finance/merger-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: merger-model
-description: Build accretion/dilution (merger) models in Excel — pro-forma P&L, synergies, financing mix, EPS impact. Pairs with excel-author. Use for M&A pitches, board materials, or deal evaluation.
+description: Build M&A accretion/dilution workbooks in Excel.
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0

--- a/optional-skills/finance/pptx-author/SKILL.md
+++ b/optional-skills/finance/pptx-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pptx-author
-description: Build PowerPoint decks headless with python-pptx. Pairs with excel-author for model-backed decks where every number traces to a workbook cell. Use for pitch decks, IC memos, earnings notes.
+description: Build PowerPoint decks headless with python-pptx.
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0

--- a/optional-skills/mcp/fastmcp/SKILL.md
+++ b/optional-skills/mcp/fastmcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fastmcp
-description: Build, test, inspect, install, and deploy MCP servers with FastMCP in Python. Use when creating a new MCP server, wrapping an API or database as MCP tools, exposing resources or prompts, or preparing a FastMCP server for Claude Code, Cursor, or HTTP deployment.
+description: Build, test, and deploy Python MCP servers.
 version: 1.0.0
 author: Hermes Agent
 license: MIT

--- a/optional-skills/mcp/mcporter/SKILL.md
+++ b/optional-skills/mcp/mcporter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcporter
-description: Use the mcporter CLI to list, configure, auth, and call MCP servers/tools directly (HTTP or stdio), including ad-hoc servers, config edits, and CLI/type generation.
+description: List, auth, and call MCP servers/tools from the terminal.
 version: 1.0.0
 author: community
 license: MIT

--- a/optional-skills/migration/openclaw-migration/SKILL.md
+++ b/optional-skills/migration/openclaw-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openclaw-migration
-description: Migrate a user's OpenClaw customization footprint into Hermes Agent. Imports Hermes-compatible memories, SOUL.md, command allowlists, user skills, and selected workspace assets from ~/.openclaw, then reports exactly what could not be migrated and why.
+description: Import an OpenClaw setup (memories, skills) into Hermes.
 version: 1.0.0
 author: Hermes Agent (Nous Research)
 license: MIT

--- a/optional-skills/mlops/accelerate/SKILL.md
+++ b/optional-skills/mlops/accelerate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huggingface-accelerate
-description: Simplest distributed training API. 4 lines to add distributed support to any PyTorch script. Unified API for DeepSpeed/FSDP/Megatron/DDP. Automatic device placement, mixed precision (FP16/BF16/FP8). Interactive config, single launch command. HuggingFace ecosystem standard.
+description: Run PyTorch training across GPUs with minimal changes.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/chroma/SKILL.md
+++ b/optional-skills/mlops/chroma/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chroma
-description: Open-source embedding database for AI applications. Store embeddings and metadata, perform vector and full-text search, filter by metadata. Simple 4-function API. Scales from notebooks to production clusters. Use for semantic search, RAG applications, or document retrieval. Best for local development and open-source projects.
+description: Embedding database for RAG and semantic search.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/clip/SKILL.md
+++ b/optional-skills/mlops/clip/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clip
-description: OpenAI's model connecting vision and language. Enables zero-shot image classification, image-text matching, and cross-modal retrieval. Trained on 400M image-text pairs. Use for image search, content moderation, or vision-language tasks without fine-tuning. Best for general-purpose image understanding.
+description: Zero-shot image classification and image-text search.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/faiss/SKILL.md
+++ b/optional-skills/mlops/faiss/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: faiss
-description: Facebook's library for efficient similarity search and clustering of dense vectors. Supports billions of vectors, GPU acceleration, and various index types (Flat, IVF, HNSW). Use for fast k-NN search, large-scale vector retrieval, or when you need pure similarity search without metadata. Best for high-performance applications.
+description: Fast vector similarity search at billion scale.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/flash-attention/SKILL.md
+++ b/optional-skills/mlops/flash-attention/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimizing-attention-flash
-description: Optimizes transformer attention with Flash Attention for 2-4x speedup and 10-20x memory reduction. Use when training/running transformers with long sequences (>512 tokens), encountering GPU memory issues with attention, or need faster inference. Supports PyTorch native SDPA, flash-attn library, H100 FP8, and sliding window attention.
+description: Speed up long-sequence transformer training and inference.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/guidance/SKILL.md
+++ b/optional-skills/mlops/guidance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: guidance
-description: Control LLM output with regex and grammars, guarantee valid JSON/XML/code generation, enforce structured formats, and build multi-step workflows with Guidance - Microsoft Research's constrained generation framework
+description: Constrain LLM output with grammars; guarantee valid JSON.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/huggingface-tokenizers/SKILL.md
+++ b/optional-skills/mlops/huggingface-tokenizers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huggingface-tokenizers
-description: Fast tokenizers optimized for research and production. Rust-based implementation tokenizes 1GB in <20 seconds. Supports BPE, WordPiece, and Unigram algorithms. Train custom vocabularies, track alignments, handle padding/truncation. Integrates seamlessly with transformers. Use when you need high-performance tokenization or custom tokenizer training.
+description: Fast BPE/WordPiece tokenization and custom vocab training.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/instructor/SKILL.md
+++ b/optional-skills/mlops/instructor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: instructor
-description: Extract structured data from LLM responses with Pydantic validation, retry failed extractions automatically, parse complex JSON with type safety, and stream partial results with Instructor - battle-tested structured output library
+description: Structured LLM outputs validated with Pydantic.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/lambda-labs/SKILL.md
+++ b/optional-skills/mlops/lambda-labs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lambda-labs-gpu-cloud
-description: Reserved and on-demand GPU cloud instances for ML training and inference. Use when you need dedicated GPU instances with simple SSH access, persistent filesystems, or high-performance multi-node clusters for large-scale training.
+description: On-demand GPU cloud instances for ML training.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/llava/SKILL.md
+++ b/optional-skills/mlops/llava/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llava
-description: Large Language and Vision Assistant. Enables visual instruction tuning and image-based conversations. Combines CLIP vision encoder with Vicuna/LLaMA language models. Supports multi-turn image chat, visual question answering, and instruction following. Use for vision-language chatbots or image understanding tasks. Best for conversational image analysis.
+description: "Vision-language chat: VQA, captioning, image dialogue."
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/modal/SKILL.md
+++ b/optional-skills/mlops/modal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: modal-serverless-gpu
-description: Serverless GPU cloud platform for running ML workloads. Use when you need on-demand GPU access without infrastructure management, deploying ML models as APIs, or running batch jobs with automatic scaling.
+description: Serverless GPU cloud for ML jobs and model APIs.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/nemo-curator/SKILL.md
+++ b/optional-skills/mlops/nemo-curator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nemo-curator
-description: GPU-accelerated data curation for LLM training. Supports text/image/video/audio. Features fuzzy deduplication (16× faster), quality filtering (30+ heuristics), semantic deduplication, PII redaction, NSFW detection. Scales across GPUs with RAPIDS. Use for preparing high-quality training datasets, cleaning web data, or deduplicating large corpora.
+description: "Curate LLM training data: dedupe, filter, PII redaction."
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/peft/SKILL.md
+++ b/optional-skills/mlops/peft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: peft-fine-tuning
-description: Parameter-efficient fine-tuning for LLMs using LoRA, QLoRA, and 25+ methods. Use when fine-tuning large models (7B-70B) with limited GPU memory, when you need to train <1% of parameters with minimal accuracy loss, or for multi-adapter serving. HuggingFace's official library integrated with transformers ecosystem.
+description: Fine-tune large LLMs with LoRA on limited GPU memory.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/pytorch-fsdp/SKILL.md
+++ b/optional-skills/mlops/pytorch-fsdp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pytorch-fsdp
-description: Expert guidance for Fully Sharded Data Parallel training with PyTorch FSDP - parameter sharding, mixed precision, CPU offloading, FSDP2
+description: Fully sharded data-parallel training for large models.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/pytorch-lightning/SKILL.md
+++ b/optional-skills/mlops/pytorch-lightning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pytorch-lightning
-description: High-level PyTorch framework with Trainer class, automatic distributed training (DDP/FSDP/DeepSpeed), callbacks system, and minimal boilerplate. Scales from laptop to supercomputer with same code. Use when you want clean training loops with built-in best practices.
+description: Clean training loops with built-in distributed support.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/qdrant/SKILL.md
+++ b/optional-skills/mlops/qdrant/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qdrant-vector-search
-description: High-performance vector similarity search engine for RAG and semantic search. Use when building production RAG systems requiring fast nearest neighbor search, hybrid search with filtering, or scalable vector storage with Rust-powered performance.
+description: Vector search engine for production RAG systems.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/saelens/SKILL.md
+++ b/optional-skills/mlops/saelens/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sparse-autoencoder-training
-description: Provides guidance for training and analyzing Sparse Autoencoders (SAEs) using SAELens to decompose neural network activations into interpretable features. Use when discovering interpretable features, analyzing superposition, or studying monosemantic representations in language models.
+description: Train sparse autoencoders to interpret model features.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/simpo/SKILL.md
+++ b/optional-skills/mlops/simpo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simpo-training
-description: Simple Preference Optimization for LLM alignment. Reference-free alternative to DPO with better performance (+6.4 points on AlpacaEval 2.0). No reference model needed, more efficient than DPO. Use for preference alignment when want simpler, faster training than DPO/PPO.
+description: Reference-free preference alignment, simpler than DPO.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/slime/SKILL.md
+++ b/optional-skills/mlops/slime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slime-rl-training
-description: Provides guidance for LLM post-training with RL using slime, a Megatron+SGLang framework. Use when training GLM models, implementing custom data generation workflows, or needing tight Megatron-LM integration for RL scaling.
+description: RL post-training for LLMs with Megatron and SGLang.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/stable-diffusion/SKILL.md
+++ b/optional-skills/mlops/stable-diffusion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stable-diffusion-image-generation
-description: State-of-the-art text-to-image generation with Stable Diffusion models via HuggingFace Diffusers. Use when generating images from text prompts, performing image-to-image translation, inpainting, or building custom diffusion pipelines.
+description: Text-to-image generation, inpainting, and img2img.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/tensorrt-llm/SKILL.md
+++ b/optional-skills/mlops/tensorrt-llm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tensorrt-llm
-description: Optimizes LLM inference with NVIDIA TensorRT for maximum throughput and lowest latency. Use for production deployment on NVIDIA GPUs (A100/H100), when you need 10-100x faster inference than PyTorch, or for serving models with quantization (FP8/INT4), in-flight batching, and multi-GPU scaling.
+description: High-throughput LLM inference on NVIDIA GPUs.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/torchtitan/SKILL.md
+++ b/optional-skills/mlops/torchtitan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: distributed-llm-pretraining-torchtitan
-description: Provides PyTorch-native distributed LLM pretraining using torchtitan with 4D parallelism (FSDP2, TP, PP, CP). Use when pretraining Llama 3.1, DeepSeek V3, or custom models at scale from 8 to 512+ GPUs with Float8, torch.compile, and distributed checkpointing.
+description: Pretrain LLMs at scale with PyTorch 4D parallelism.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/whisper/SKILL.md
+++ b/optional-skills/mlops/whisper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: whisper
-description: OpenAI's general-purpose speech recognition model. Supports 99 languages, transcription, translation to English, and language identification. Six model sizes from tiny (39M params) to large (1550M params). Use for speech-to-text, podcast transcription, or multilingual audio processing. Best for robust, multilingual ASR.
+description: Transcribe and translate speech in 99 languages.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/productivity/canvas/SKILL.md
+++ b/optional-skills/productivity/canvas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canvas
-description: Canvas LMS integration — fetch enrolled courses and assignments using API token authentication.
+description: Fetch Canvas LMS courses and assignments via API token.
 version: 1.0.0
 author: community
 license: MIT

--- a/optional-skills/productivity/here-now/SKILL.md
+++ b/optional-skills/productivity/here-now/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: here.now
-description: Publish static sites to {slug}.here.now and store private files in cloud Drives for agent-to-agent handoff.
+description: Publish sites to {slug}.here.now and store files in Drives.
 version: 1.15.3
 author: here.now
 license: MIT

--- a/optional-skills/productivity/shopify/SKILL.md
+++ b/optional-skills/productivity/shopify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shopify
-description: Shopify Admin & Storefront GraphQL APIs via curl. Products, orders, customers, inventory, metafields.
+description: Query Shopify Admin/Storefront GraphQL APIs via curl.
 version: 1.0.0
 author: community
 license: MIT

--- a/optional-skills/productivity/siyuan/SKILL.md
+++ b/optional-skills/productivity/siyuan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: siyuan
-description: SiYuan Note API for searching, reading, creating, and managing blocks and documents in a self-hosted knowledge base via curl.
+description: Query and edit a SiYuan knowledge base via its API.
 version: 1.0.0
 author: FEUAZUR
 license: MIT

--- a/optional-skills/productivity/telephony/SKILL.md
+++ b/optional-skills/productivity/telephony/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telephony
-description: Give Hermes phone capabilities without core tool changes. Provision and persist a Twilio number, send and receive SMS/MMS, make direct calls, and place AI-driven outbound calls through Bland.ai or Vapi.
+description: Provision Twilio numbers, SMS/MMS, and AI outbound calls.
 version: 1.0.0
 author: Nous Research
 license: MIT

--- a/optional-skills/research/bioinformatics/SKILL.md
+++ b/optional-skills/research/bioinformatics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bioinformatics
-description: Gateway to 400+ bioinformatics skills from bioSkills and ClawBio. Covers genomics, transcriptomics, single-cell, variant calling, pharmacogenomics, metagenomics, structural biology, and more. Fetches domain-specific reference material on demand.
+description: Gateway to 400+ genomics and computational biology skills.
 version: 1.0.0
 platforms: [linux, macos]
 metadata:

--- a/optional-skills/research/domain-intel/SKILL.md
+++ b/optional-skills/research/domain-intel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domain-intel
-description: Passive domain reconnaissance using Python stdlib. Subdomain discovery, SSL certificate inspection, WHOIS lookups, DNS records, domain availability checks, and bulk multi-domain analysis. No API keys required.
+description: Passive recon of subdomains, SSL certs, WHOIS, and DNS.
 platforms: [linux, macos, windows]
 ---
 

--- a/optional-skills/research/duckduckgo-search/SKILL.md
+++ b/optional-skills/research/duckduckgo-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duckduckgo-search
-description: Free web search via DuckDuckGo — text, news, images, videos. No API key needed. Prefer the `ddgs` CLI when installed; use the Python DDGS library only after verifying that `ddgs` is available in the current runtime.
+description: Free keyless web, news, and image search via ddgs.
 version: 1.3.0
 author: gamedevCloudy
 license: MIT

--- a/optional-skills/research/gitnexus-explorer/SKILL.md
+++ b/optional-skills/research/gitnexus-explorer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitnexus-explorer
-description: Index a codebase with GitNexus and serve an interactive knowledge graph via web UI + Cloudflare tunnel.
+description: Serve an interactive codebase knowledge graph web UI.
 version: 1.0.0
 author: Hermes Agent + Teknium
 license: MIT

--- a/optional-skills/research/osint-investigation/SKILL.md
+++ b/optional-skills/research/osint-investigation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: osint-investigation
-description: Public-records OSINT investigation framework — SEC EDGAR filings, USAspending contracts, Senate lobbying, OFAC sanctions, ICIJ offshore leaks, NYC property records (ACRIS), OpenCorporates registries, CourtListener court records, Wayback Machine archives, Wikipedia + Wikidata, GDELT news monitoring. Entity resolution across sources, cross-link analysis, timing correlation, evidence chains. Python stdlib only.
+description: Follow the money via public records and sanctions data.
 version: 0.1.0
 platforms: [linux, macos, windows]
 author: Hermes Agent (adapted from ShinMegamiBoson/OpenPlanter, MIT)

--- a/optional-skills/research/parallel-cli/SKILL.md
+++ b/optional-skills/research/parallel-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel-cli
-description: Optional vendor skill for Parallel CLI — agent-native web search, extraction, deep research, enrichment, FindAll, and monitoring. Prefer JSON output and non-interactive flows.
+description: Agent-native web search, deep research, and enrichment.
 version: 1.1.0
 author: Hermes Agent
 license: MIT

--- a/optional-skills/research/qmd/SKILL.md
+++ b/optional-skills/research/qmd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qmd
-description: Search personal knowledge bases, notes, docs, and meeting transcripts locally using qmd — a hybrid retrieval engine with BM25, vector search, and LLM reranking. Supports CLI and MCP integration.
+description: Hybrid local search over notes, docs, and transcripts.
 version: 1.0.0
 author: Hermes Agent + Teknium
 license: MIT

--- a/optional-skills/research/scrapling/SKILL.md
+++ b/optional-skills/research/scrapling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scrapling
-description: Web scraping with Scrapling - HTTP fetching, stealth browser automation, Cloudflare bypass, and spider crawling via CLI and Python.
+description: Scrape sites with stealth browsing and Cloudflare bypass.
 version: 1.0.0
 author: FEUAZUR
 license: MIT

--- a/optional-skills/research/searxng-search/SKILL.md
+++ b/optional-skills/research/searxng-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: searxng-search
-description: Free meta-search via SearXNG — aggregates results from 70+ search engines. Self-hosted or use a public instance. No API key needed. Falls back automatically when the web search toolset is unavailable.
+description: Free keyless meta-search aggregating 70+ engines.
 version: 1.0.0
 author: hermes-agent
 license: MIT

--- a/optional-skills/security/1password/SKILL.md
+++ b/optional-skills/security/1password/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 1password
-description: Set up and use 1Password CLI (op). Use when installing the CLI, enabling desktop app integration, signing in, and reading/injecting secrets for commands.
+description: Set up op CLI, sign in, and read or inject secrets.
 version: 1.0.0
 author: arceus77-7, enhanced by Hermes Agent
 license: MIT

--- a/optional-skills/security/sherlock/SKILL.md
+++ b/optional-skills/security/sherlock/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sherlock
-description: OSINT username search across 400+ social networks. Hunt down social media accounts by username.
+description: Find accounts for a username across 400+ platforms.
 version: 1.0.0
 author: unmodeled-tyler
 license: MIT

--- a/optional-skills/web-development/page-agent/SKILL.md
+++ b/optional-skills/web-development/page-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: page-agent
-description: Embed alibaba/page-agent into your own web application — a pure-JavaScript in-page GUI agent that ships as a single <script> tag or npm package and lets end-users of your site drive the UI with natural language ("click login, fill username as John"). No Python, no headless browser, no extension required. Use this skill when the user is a web developer who wants to add an AI copilot to their SaaS / admin panel / B2B tool, make a legacy web app accessible via natural language, or evaluate page-agent against a local (Ollama) or cloud (Qwen / OpenAI / OpenRouter) LLM. NOT for server-side browser automation — point those users to Hermes' built-in browser tool instead.
+description: Embed an in-page natural-language GUI copilot in web apps.
 version: 1.0.0
 author: Hermes Agent
 license: MIT

--- a/skills/creative/comfyui/SKILL.md
+++ b/skills/creative/comfyui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: comfyui
-description: "Generate images, video, and audio with ComfyUI — install, launch, manage nodes/models, run workflows with parameter injection. Uses the official comfy-cli for lifecycle and direct REST/WebSocket API for execution."
+description: Generate images, video, and audio via diffusion workflows.
 version: 5.1.0
 author: [kshitijk4poor, alt-glitch, purzbeats]
 license: MIT

--- a/skills/creative/pretext/SKILL.md
+++ b/skills/creative/pretext/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pretext
-description: "Use when building creative browser demos with @chenglou/pretext — DOM-free text layout for ASCII art, typographic flow around obstacles, text-as-geometry games, kinetic typography, and text-powered generative art. Produces single-file HTML demos by default."
+description: Build creative browser demos with DOM-free text layout.
 version: 1.0.0
 author: Hermes Agent
 license: MIT

--- a/skills/creative/touchdesigner-mcp/SKILL.md
+++ b/skills/creative/touchdesigner-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: touchdesigner-mcp
-description: "Control a running TouchDesigner instance via twozero MCP — create operators, set parameters, wire connections, execute Python, build real-time visuals. 36 native tools."
+description: Control TouchDesigner via twozero MCP.
 version: 1.1.0
 author: kshitijk4poor
 license: MIT

--- a/skills/productivity/teams-meeting-pipeline/SKILL.md
+++ b/skills/productivity/teams-meeting-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: teams-meeting-pipeline
-description: "Operate the Teams meeting summary pipeline via Hermes CLI — summarize meetings, inspect pipeline status, replay jobs, manage Microsoft Graph subscriptions."
+description: Teams meeting summaries, job replay, Graph subscriptions.
 version: 1.1.0
 author: Hermes Agent + Teknium
 license: MIT

--- a/skills/software-development/hermes-agent-skill-authoring/SKILL.md
+++ b/skills/software-development/hermes-agent-skill-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hermes-agent-skill-authoring
-description: "Author in-repo SKILL.md: frontmatter, validator, structure, and writing-quality principles."
+description: "Author in-repo SKILL.md files: frontmatter and structure."
 version: 1.1.0
 author: Hermes Agent
 license: MIT

--- a/skills/software-development/plan/SKILL.md
+++ b/skills/software-development/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: "Plan mode: write an actionable markdown plan to .hermes/plans/, no execution. Bite-sized tasks, exact paths, complete code."
+description: Write a markdown plan to .hermes/plans/; no execution.
 version: 2.0.0
 author: Hermes Agent (writing-craft adapted from obra/superpowers)
 license: MIT

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -32,9 +32,9 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**antigravity-cli**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli) | Operate the Antigravity CLI (agy): plugins, auth, sandbox. |
-| [**blackbox**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox) | Delegate coding tasks to Blackbox AI CLI agent. Multi-model agent with built-in judge that runs tasks through multiple LLMs and picks the best result. Requires the blackbox CLI and a Blackbox AI API key. |
+| [**blackbox**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox) | Delegate coding tasks to the Blackbox AI multi-model CLI. |
 | [**grok**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok) | Delegate coding to xAI Grok Build CLI (features, PRs). |
-| [**honcho**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho) | Configure and use Honcho memory with Hermes -- cross-session user modeling, multi-profile peer isolation, observation config, dialectic reasoning, session summaries, and context budget enforcement. Use when setting up Honcho, troubleshoo... |
+| [**honcho**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho) | Configure and troubleshoot Honcho memory for Hermes. |
 | [**openhands**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands) | Delegate coding to OpenHands CLI (model-agnostic, LiteLLM). |
 
 ## blockchain
@@ -43,7 +43,7 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**evm**](/docs/user-guide/skills/optional/blockchain/blockchain-evm) | Read-only EVM client: wallets, tokens, gas across 8 chains. |
 | [**hyperliquid**](/docs/user-guide/skills/optional/blockchain/blockchain-hyperliquid) | Hyperliquid market data, account history, trade review. |
-| [**solana**](/docs/user-guide/skills/optional/blockchain/blockchain-solana) | Query Solana blockchain data with USD pricing — wallet balances, token portfolios with values, transaction details, NFTs, whale detection, and live network stats. Uses Solana RPC + CoinGecko. No API key required. |
+| [**solana**](/docs/user-guide/skills/optional/blockchain/blockchain-solana) | Query Solana wallets, tokens, txs, and NFTs in USD. |
 
 ## communication
 
@@ -59,14 +59,15 @@ hermes skills uninstall <skill-name>
 | [**baoyu-article-illustrator**](/docs/user-guide/skills/optional/creative/creative-baoyu-article-illustrator) | Article illustrations: type × style × palette consistency. |
 | [**baoyu-comic**](/docs/user-guide/skills/optional/creative/creative-baoyu-comic) | Knowledge comics (知识漫画): educational, biography, tutorial. |
 | [**blender-mcp**](/docs/user-guide/skills/optional/creative/creative-blender-mcp) | Drive Blender via the catalog blender MCP, with bpy recipes. |
-| [**concept-diagrams**](/docs/user-guide/skills/optional/creative/creative-concept-diagrams) | Generate flat, minimal light/dark-aware SVG diagrams as standalone HTML files, using a unified educational visual language with 9 semantic color ramps, sentence-case typography, and automatic dark mode. Best suited for educational and no... |
+| [**concept-diagrams**](/docs/user-guide/skills/optional/creative/creative-concept-diagrams) | Generate flat, minimal educational SVG visuals as HTML. |
 | [**creative-ideation**](/docs/user-guide/skills/optional/creative/creative-creative-ideation) | Generate ideas via named methods from creative practice. |
 | [**heartmula**](/docs/user-guide/skills/optional/creative/creative-heartmula) | HeartMuLa: Suno-like song generation from lyrics + tags. |
-| [**hyperframes**](/docs/user-guide/skills/optional/creative/creative-hyperframes) | Create HTML-based video compositions, animated title cards, social overlays, captioned talking-head videos, audio-reactive visuals, and shader transitions using HyperFrames. HTML is the source of truth for video. Use when the user wants... |
-| [**kanban-video-orchestrator**](/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator) | Plan, set up, and monitor a multi-agent video production pipeline backed by Hermes Kanban. Use when the user wants to make ANY video — narrative film, product/marketing, music video, explainer, ASCII/terminal art, abstract/generative loo... |
-| [**meme-generation**](/docs/user-guide/skills/optional/creative/creative-meme-generation) | Generate real meme images by picking a template and overlaying text with Pillow. Produces actual .png meme files. |
+| [**hyperframes**](/docs/user-guide/skills/optional/creative/creative-hyperframes) | Render MP4/WebM videos from HTML compositions. |
+| [**kanban-video-orchestrator**](/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator) | Plan and run multi-agent video production pipelines. |
+| [**meme-generation**](/docs/user-guide/skills/optional/creative/creative-meme-generation) | Create meme PNGs from templates with Pillow text overlay. |
 | [**pixel-art**](/docs/user-guide/skills/optional/creative/creative-pixel-art) | Pixel art w/ era palettes (NES, Game Boy, PICO-8). |
-| [**unreal-mcp**](/docs/user-guide/skills/optional/creative/creative-unreal-mcp) | Use when the user wants to do anything in Unreal Engine through Epic's official editor-embedded MCP server (catalog entry: unreal-engine) — build/light/populate scenes, place and transform actors, author Blueprints, animate with Sequence... |
+| [**tldraw-offline**](/docs/user-guide/skills/optional/creative/creative-tldraw-offline) | Drive and script tldraw offline canvases with an agent. |
+| [**unreal-mcp**](/docs/user-guide/skills/optional/creative/creative-unreal-mcp) | Automate Unreal Engine editor scenes, actors, and renders. |
 
 ## data-science
 
@@ -78,9 +79,9 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
-| [**inference-sh-cli**](/docs/user-guide/skills/optional/devops/devops-cli) | Run 150+ AI apps via inference.sh CLI (infsh) — image generation, video creation, LLMs, search, 3D, social automation. Uses the terminal tool. Triggers: inference.sh, infsh, ai apps, flux, veo, image generation, video generation, seedrea... |
-| [**docker-management**](/docs/user-guide/skills/optional/devops/devops-docker-management) | Manage Docker containers, images, volumes, networks, and Compose stacks — lifecycle ops, debugging, cleanup, and Dockerfile optimization. |
-| [**hermes-s6-container-supervision**](/docs/user-guide/skills/optional/devops/devops-hermes-s6-container-supervision) | Modify, debug, or extend the s6-overlay supervision tree inside the Hermes Agent Docker image — adding new services, debugging profile gateways, understanding the Architecture B main-program pattern. |
+| [**inference-sh-cli**](/docs/user-guide/skills/optional/devops/devops-cli) | Run 150+ AI apps (image, video, LLM) via inference.sh CLI. |
+| [**docker-management**](/docs/user-guide/skills/optional/devops/devops-docker-management) | Manage Docker containers, images, volumes, and Compose. |
+| [**hermes-s6-container-supervision**](/docs/user-guide/skills/optional/devops/devops-hermes-s6-container-supervision) | Modify or debug s6 services in the Hermes Docker image. |
 | [**pinggy-tunnel**](/docs/user-guide/skills/optional/devops/devops-pinggy-tunnel) | Zero-install localhost tunnels over SSH via Pinggy. |
 | [**watchers**](/docs/user-guide/skills/optional/devops/devops-watchers) | Poll RSS, JSON APIs, and GitHub with watermark dedup. |
 
@@ -88,25 +89,25 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
-| [**adversarial-ux-test**](/docs/user-guide/skills/optional/dogfood/dogfood-adversarial-ux-test) | Roleplay the most difficult, tech-resistant user for your product. Browse the app as that persona, find every UX pain point, then filter complaints through a pragmatism layer to separate real problems from noise. Creates actionable ticke... |
+| [**adversarial-ux-test**](/docs/user-guide/skills/optional/dogfood/dogfood-adversarial-ux-test) | Roleplay a hostile user to find and triage UX pain points. |
 
 ## email
 
 | Skill | Description |
 |-------|-------------|
-| [**agentmail**](/docs/user-guide/skills/optional/email/email-agentmail) | Give the agent its own dedicated email inbox via AgentMail. Send, receive, and manage email autonomously using agent-owned email addresses (e.g. hermes-agent@agentmail.to). |
+| [**agentmail**](/docs/user-guide/skills/optional/email/email-agentmail) | Give the agent its own inbox: send and receive email. |
 
 ## finance
 
 | Skill | Description |
 |-------|-------------|
-| [**3-statement-model**](/docs/user-guide/skills/optional/finance/finance-3-statement-model) | Build fully-integrated 3-statement models (IS, BS, CF) in Excel with working capital schedules, D&A roll-forwards, debt schedule, and the plugs that make cash and retained earnings tie. Pairs with excel-author. |
-| [**comps-analysis**](/docs/user-guide/skills/optional/finance/finance-comps-analysis) | Build comparable company analysis in Excel — operating metrics, valuation multiples, statistical benchmarking vs peer sets. Pairs with excel-author. Use for public-company valuation, IPO pricing, sector benchmarking, or outlier detection. |
-| [**dcf-model**](/docs/user-guide/skills/optional/finance/finance-dcf-model) | Build institutional-quality DCF valuation models in Excel — revenue projections, FCF build, WACC, terminal value, Bear/Base/Bull scenarios, 5x5 sensitivity tables. Pairs with excel-author. Use for intrinsic-value equity analysis. |
-| [**excel-author**](/docs/user-guide/skills/optional/finance/finance-excel-author) | Build auditable Excel workbooks headless with openpyxl — blue/black/green cell conventions, formulas over hardcodes, named ranges, balance checks, sensitivity tables. Use for financial models, audit outputs, reconciliations. |
-| [**lbo-model**](/docs/user-guide/skills/optional/finance/finance-lbo-model) | Build leveraged buyout models in Excel — sources & uses, debt schedule, cash sweep, exit multiple, IRR/MOIC sensitivity. Pairs with excel-author. Use for PE screening, sponsor-case valuation, or illustrative LBO in a pitch. |
-| [**merger-model**](/docs/user-guide/skills/optional/finance/finance-merger-model) | Build accretion/dilution (merger) models in Excel — pro-forma P&L, synergies, financing mix, EPS impact. Pairs with excel-author. Use for M&A pitches, board materials, or deal evaluation. |
-| [**pptx-author**](/docs/user-guide/skills/optional/finance/finance-pptx-author) | Build PowerPoint decks headless with python-pptx. Pairs with excel-author for model-backed decks where every number traces to a workbook cell. Use for pitch decks, IC memos, earnings notes. |
+| [**3-statement-model**](/docs/user-guide/skills/optional/finance/finance-3-statement-model) | Build integrated IS/BS/CF financial workbooks in Excel. |
+| [**comps-analysis**](/docs/user-guide/skills/optional/finance/finance-comps-analysis) | Build comparable-company valuation workbooks in Excel. |
+| [**dcf-model**](/docs/user-guide/skills/optional/finance/finance-dcf-model) | Build discounted cash flow valuation workbooks in Excel. |
+| [**excel-author**](/docs/user-guide/skills/optional/finance/finance-excel-author) | Build auditable financial workbooks headless via openpyxl. |
+| [**lbo-model**](/docs/user-guide/skills/optional/finance/finance-lbo-model) | Build leveraged buyout workbooks with IRR/MOIC in Excel. |
+| [**merger-model**](/docs/user-guide/skills/optional/finance/finance-merger-model) | Build M&A accretion/dilution workbooks in Excel. |
+| [**pptx-author**](/docs/user-guide/skills/optional/finance/finance-pptx-author) | Build PowerPoint decks headless with python-pptx. |
 | [**stocks**](/docs/user-guide/skills/optional/finance/finance-stocks) | Stock quotes, history, search, compare, crypto via Yahoo. |
 
 ## gaming
@@ -127,51 +128,51 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
-| [**fastmcp**](/docs/user-guide/skills/optional/mcp/mcp-fastmcp) | Build, test, inspect, install, and deploy MCP servers with FastMCP in Python. Use when creating a new MCP server, wrapping an API or database as MCP tools, exposing resources or prompts, or preparing a FastMCP server for Claude Code, Cur... |
+| [**fastmcp**](/docs/user-guide/skills/optional/mcp/mcp-fastmcp) | Build, test, and deploy Python MCP servers. |
 | [**mcp-oauth-remote-gateway**](/docs/user-guide/skills/optional/mcp/mcp-mcp-oauth-remote-gateway) | Manual OAuth for remote MCP servers on headless gateways. |
-| [**mcporter**](/docs/user-guide/skills/optional/mcp/mcp-mcporter) | Use the mcporter CLI to list, configure, auth, and call MCP servers/tools directly (HTTP or stdio), including ad-hoc servers, config edits, and CLI/type generation. |
+| [**mcporter**](/docs/user-guide/skills/optional/mcp/mcp-mcporter) | List, auth, and call MCP servers/tools from the terminal. |
 
 ## migration
 
 | Skill | Description |
 |-------|-------------|
-| [**openclaw-migration**](/docs/user-guide/skills/optional/migration/migration-openclaw-migration) | Migrate a user's OpenClaw customization footprint into Hermes Agent. Imports Hermes-compatible memories, SOUL.md, command allowlists, user skills, and selected workspace assets from ~/.openclaw, then reports exactly what could not be mig... |
+| [**openclaw-migration**](/docs/user-guide/skills/optional/migration/migration-openclaw-migration) | Import an OpenClaw setup (memories, skills) into Hermes. |
 
 ## mlops
 
 | Skill | Description |
 |-------|-------------|
-| [**huggingface-accelerate**](/docs/user-guide/skills/optional/mlops/mlops-accelerate) | Simplest distributed training API. 4 lines to add distributed support to any PyTorch script. Unified API for DeepSpeed/FSDP/Megatron/DDP. Automatic device placement, mixed precision (FP16/BF16/FP8). Interactive config, single launch comm... |
+| [**huggingface-accelerate**](/docs/user-guide/skills/optional/mlops/mlops-accelerate) | Run PyTorch training across GPUs with minimal changes. |
 | [**axolotl**](/docs/user-guide/skills/optional/mlops/mlops-training-axolotl) | Axolotl: YAML LLM fine-tuning (LoRA, DPO, GRPO). |
-| [**chroma**](/docs/user-guide/skills/optional/mlops/mlops-chroma) | Open-source embedding database for AI applications. Store embeddings and metadata, perform vector and full-text search, filter by metadata. Simple 4-function API. Scales from notebooks to production clusters. Use for semantic search, RAG... |
-| [**clip**](/docs/user-guide/skills/optional/mlops/mlops-clip) | OpenAI's model connecting vision and language. Enables zero-shot image classification, image-text matching, and cross-modal retrieval. Trained on 400M image-text pairs. Use for image search, content moderation, or vision-language tasks w... |
+| [**chroma**](/docs/user-guide/skills/optional/mlops/mlops-chroma) | Embedding database for RAG and semantic search. |
+| [**clip**](/docs/user-guide/skills/optional/mlops/mlops-clip) | Zero-shot image classification and image-text search. |
 | [**dspy**](/docs/user-guide/skills/optional/mlops/mlops-research-dspy) | DSPy: declarative LM programs, auto-optimize prompts, RAG. |
-| [**faiss**](/docs/user-guide/skills/optional/mlops/mlops-faiss) | Facebook's library for efficient similarity search and clustering of dense vectors. Supports billions of vectors, GPU acceleration, and various index types (Flat, IVF, HNSW). Use for fast k-NN search, large-scale vector retrieval, or whe... |
-| [**optimizing-attention-flash**](/docs/user-guide/skills/optional/mlops/mlops-flash-attention) | Optimizes transformer attention with Flash Attention for 2-4x speedup and 10-20x memory reduction. Use when training/running transformers with long sequences (>512 tokens), encountering GPU memory issues with attention, or need faster in... |
-| [**guidance**](/docs/user-guide/skills/optional/mlops/mlops-guidance) | Control LLM output with regex and grammars, guarantee valid JSON/XML/code generation, enforce structured formats, and build multi-step workflows with Guidance - Microsoft Research's constrained generation framework |
-| [**huggingface-tokenizers**](/docs/user-guide/skills/optional/mlops/mlops-huggingface-tokenizers) | Fast tokenizers optimized for research and production. Rust-based implementation tokenizes 1GB in &lt;20 seconds. Supports BPE, WordPiece, and Unigram algorithms. Train custom vocabularies, track alignments, handle padding/truncation. Integ... |
-| [**instructor**](/docs/user-guide/skills/optional/mlops/mlops-instructor) | Extract structured data from LLM responses with Pydantic validation, retry failed extractions automatically, parse complex JSON with type safety, and stream partial results with Instructor - battle-tested structured output library |
-| [**lambda-labs-gpu-cloud**](/docs/user-guide/skills/optional/mlops/mlops-lambda-labs) | Reserved and on-demand GPU cloud instances for ML training and inference. Use when you need dedicated GPU instances with simple SSH access, persistent filesystems, or high-performance multi-node clusters for large-scale training. |
-| [**llava**](/docs/user-guide/skills/optional/mlops/mlops-llava) | Large Language and Vision Assistant. Enables visual instruction tuning and image-based conversations. Combines CLIP vision encoder with Vicuna/LLaMA language models. Supports multi-turn image chat, visual question answering, and instruct... |
-| [**modal-serverless-gpu**](/docs/user-guide/skills/optional/mlops/mlops-modal) | Serverless GPU cloud platform for running ML workloads. Use when you need on-demand GPU access without infrastructure management, deploying ML models as APIs, or running batch jobs with automatic scaling. |
-| [**nemo-curator**](/docs/user-guide/skills/optional/mlops/mlops-nemo-curator) | GPU-accelerated data curation for LLM training. Supports text/image/video/audio. Features fuzzy deduplication (16× faster), quality filtering (30+ heuristics), semantic deduplication, PII redaction, NSFW detection. Scales across GPUs wit... |
+| [**faiss**](/docs/user-guide/skills/optional/mlops/mlops-faiss) | Fast vector similarity search at billion scale. |
+| [**optimizing-attention-flash**](/docs/user-guide/skills/optional/mlops/mlops-flash-attention) | Speed up long-sequence transformer training and inference. |
+| [**guidance**](/docs/user-guide/skills/optional/mlops/mlops-guidance) | Constrain LLM output with grammars; guarantee valid JSON. |
+| [**huggingface-tokenizers**](/docs/user-guide/skills/optional/mlops/mlops-huggingface-tokenizers) | Fast BPE/WordPiece tokenization and custom vocab training. |
+| [**instructor**](/docs/user-guide/skills/optional/mlops/mlops-instructor) | Structured LLM outputs validated with Pydantic. |
+| [**lambda-labs-gpu-cloud**](/docs/user-guide/skills/optional/mlops/mlops-lambda-labs) | On-demand GPU cloud instances for ML training. |
+| [**llava**](/docs/user-guide/skills/optional/mlops/mlops-llava) | Vision-language chat: VQA, captioning, image dialogue. |
+| [**modal-serverless-gpu**](/docs/user-guide/skills/optional/mlops/mlops-modal) | Serverless GPU cloud for ML jobs and model APIs. |
+| [**nemo-curator**](/docs/user-guide/skills/optional/mlops/mlops-nemo-curator) | Curate LLM training data: dedupe, filter, PII redaction. |
 | [**obliteratus**](/docs/user-guide/skills/optional/mlops/mlops-obliteratus) | OBLITERATUS: abliterate LLM refusals (diff-in-means). |
 | [**outlines**](/docs/user-guide/skills/optional/mlops/mlops-inference-outlines) | Outlines: structured JSON/regex/Pydantic LLM generation. |
-| [**peft-fine-tuning**](/docs/user-guide/skills/optional/mlops/mlops-peft) | Parameter-efficient fine-tuning for LLMs using LoRA, QLoRA, and 25+ methods. Use when fine-tuning large models (7B-70B) with limited GPU memory, when you need to train &lt;1% of parameters with minimal accuracy loss, or for multi-adapter se... |
+| [**peft-fine-tuning**](/docs/user-guide/skills/optional/mlops/mlops-peft) | Fine-tune large LLMs with LoRA on limited GPU memory. |
 | [**pinecone**](/docs/user-guide/skills/optional/mlops/mlops-pinecone) | Managed vector database for production AI applications. Fully managed, auto-scaling, with hybrid search (dense + sparse), metadata filtering, and namespaces. Low latency (&lt;100ms p95). Use for production RAG, recommendation systems, or se... |
-| [**pytorch-fsdp**](/docs/user-guide/skills/optional/mlops/mlops-pytorch-fsdp) | Expert guidance for Fully Sharded Data Parallel training with PyTorch FSDP - parameter sharding, mixed precision, CPU offloading, FSDP2 |
-| [**pytorch-lightning**](/docs/user-guide/skills/optional/mlops/mlops-pytorch-lightning) | High-level PyTorch framework with Trainer class, automatic distributed training (DDP/FSDP/DeepSpeed), callbacks system, and minimal boilerplate. Scales from laptop to supercomputer with same code. Use when you want clean training loops w... |
-| [**qdrant-vector-search**](/docs/user-guide/skills/optional/mlops/mlops-qdrant) | High-performance vector similarity search engine for RAG and semantic search. Use when building production RAG systems requiring fast nearest neighbor search, hybrid search with filtering, or scalable vector storage with Rust-powered per... |
-| [**sparse-autoencoder-training**](/docs/user-guide/skills/optional/mlops/mlops-saelens) | Provides guidance for training and analyzing Sparse Autoencoders (SAEs) using SAELens to decompose neural network activations into interpretable features. Use when discovering interpretable features, analyzing superposition, or studying... |
+| [**pytorch-fsdp**](/docs/user-guide/skills/optional/mlops/mlops-pytorch-fsdp) | Fully sharded data-parallel training for large models. |
+| [**pytorch-lightning**](/docs/user-guide/skills/optional/mlops/mlops-pytorch-lightning) | Clean training loops with built-in distributed support. |
+| [**qdrant-vector-search**](/docs/user-guide/skills/optional/mlops/mlops-qdrant) | Vector search engine for production RAG systems. |
+| [**sparse-autoencoder-training**](/docs/user-guide/skills/optional/mlops/mlops-saelens) | Train sparse autoencoders to interpret model features. |
 | [**segment-anything-model**](/docs/user-guide/skills/optional/mlops/mlops-models-segment-anything) | SAM: zero-shot image segmentation via points, boxes, masks. |
-| [**simpo-training**](/docs/user-guide/skills/optional/mlops/mlops-simpo) | Simple Preference Optimization for LLM alignment. Reference-free alternative to DPO with better performance (+6.4 points on AlpacaEval 2.0). No reference model needed, more efficient than DPO. Use for preference alignment when want simpl... |
-| [**slime-rl-training**](/docs/user-guide/skills/optional/mlops/mlops-slime) | Provides guidance for LLM post-training with RL using slime, a Megatron+SGLang framework. Use when training GLM models, implementing custom data generation workflows, or needing tight Megatron-LM integration for RL scaling. |
-| [**stable-diffusion-image-generation**](/docs/user-guide/skills/optional/mlops/mlops-stable-diffusion) | State-of-the-art text-to-image generation with Stable Diffusion models via HuggingFace Diffusers. Use when generating images from text prompts, performing image-to-image translation, inpainting, or building custom diffusion pipelines. |
-| [**tensorrt-llm**](/docs/user-guide/skills/optional/mlops/mlops-tensorrt-llm) | Optimizes LLM inference with NVIDIA TensorRT for maximum throughput and lowest latency. Use for production deployment on NVIDIA GPUs (A100/H100), when you need 10-100x faster inference than PyTorch, or for serving models with quantizatio... |
-| [**distributed-llm-pretraining-torchtitan**](/docs/user-guide/skills/optional/mlops/mlops-torchtitan) | Provides PyTorch-native distributed LLM pretraining using torchtitan with 4D parallelism (FSDP2, TP, PP, CP). Use when pretraining Llama 3.1, DeepSeek V3, or custom models at scale from 8 to 512+ GPUs with Float8, torch.compile, and dist... |
+| [**simpo-training**](/docs/user-guide/skills/optional/mlops/mlops-simpo) | Reference-free preference alignment, simpler than DPO. |
+| [**slime-rl-training**](/docs/user-guide/skills/optional/mlops/mlops-slime) | RL post-training for LLMs with Megatron and SGLang. |
+| [**stable-diffusion-image-generation**](/docs/user-guide/skills/optional/mlops/mlops-stable-diffusion) | Text-to-image generation, inpainting, and img2img. |
+| [**tensorrt-llm**](/docs/user-guide/skills/optional/mlops/mlops-tensorrt-llm) | High-throughput LLM inference on NVIDIA GPUs. |
+| [**distributed-llm-pretraining-torchtitan**](/docs/user-guide/skills/optional/mlops/mlops-torchtitan) | Pretrain LLMs at scale with PyTorch 4D parallelism. |
 | [**fine-tuning-with-trl**](/docs/user-guide/skills/optional/mlops/mlops-training-trl-fine-tuning) | TRL: SFT, DPO, PPO, GRPO, reward modeling for LLM RLHF. |
 | [**unsloth**](/docs/user-guide/skills/optional/mlops/mlops-training-unsloth) | Unsloth: 2-5x faster LoRA/QLoRA fine-tuning, less VRAM. |
-| [**whisper**](/docs/user-guide/skills/optional/mlops/mlops-whisper) | OpenAI's general-purpose speech recognition model. Supports 99 languages, transcription, translation to English, and language identification. Six model sizes from tiny (39M params) to large (1550M params). Use for speech-to-text, podcast... |
+| [**whisper**](/docs/user-guide/skills/optional/mlops/mlops-whisper) | Transcribe and translate speech in 99 languages. |
 
 ## payments
 
@@ -185,38 +186,38 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
-| [**canvas**](/docs/user-guide/skills/optional/productivity/productivity-canvas) | Canvas LMS integration — fetch enrolled courses and assignments using API token authentication. |
-| [**here.now**](/docs/user-guide/skills/optional/productivity/productivity-here-now) | Publish static sites to &#123;slug&#125;.here.now and store private files in cloud Drives for agent-to-agent handoff. |
+| [**canvas**](/docs/user-guide/skills/optional/productivity/productivity-canvas) | Fetch Canvas LMS courses and assignments via API token. |
+| [**here.now**](/docs/user-guide/skills/optional/productivity/productivity-here-now) | Publish sites to &#123;slug&#125;.here.now and store files in Drives. |
 | [**memento-flashcards**](/docs/user-guide/skills/optional/productivity/productivity-memento-flashcards) | Spaced-repetition flashcard system. Create cards from facts or text, chat with flashcards using free-text answers graded by the agent, generate quizzes from YouTube transcripts, review due cards with adaptive scheduling, and export/impor... |
 | [**shop**](/docs/user-guide/skills/optional/productivity/productivity-shop) | Shop catalog search, checkout, order tracking, returns. |
-| [**shopify**](/docs/user-guide/skills/optional/productivity/productivity-shopify) | Shopify Admin & Storefront GraphQL APIs via curl. Products, orders, customers, inventory, metafields. |
-| [**siyuan**](/docs/user-guide/skills/optional/productivity/productivity-siyuan) | SiYuan Note API for searching, reading, creating, and managing blocks and documents in a self-hosted knowledge base via curl. |
-| [**telephony**](/docs/user-guide/skills/optional/productivity/productivity-telephony) | Give Hermes phone capabilities without core tool changes. Provision and persist a Twilio number, send and receive SMS/MMS, make direct calls, and place AI-driven outbound calls through Bland.ai or Vapi. |
+| [**shopify**](/docs/user-guide/skills/optional/productivity/productivity-shopify) | Query Shopify Admin/Storefront GraphQL APIs via curl. |
+| [**siyuan**](/docs/user-guide/skills/optional/productivity/productivity-siyuan) | Query and edit a SiYuan knowledge base via its API. |
+| [**telephony**](/docs/user-guide/skills/optional/productivity/productivity-telephony) | Provision Twilio numbers, SMS/MMS, and AI outbound calls. |
 
 ## research
 
 | Skill | Description |
 |-------|-------------|
-| [**bioinformatics**](/docs/user-guide/skills/optional/research/research-bioinformatics) | Gateway to 400+ bioinformatics skills from bioSkills and ClawBio. Covers genomics, transcriptomics, single-cell, variant calling, pharmacogenomics, metagenomics, structural biology, and more. Fetches domain-specific reference material on... |
+| [**bioinformatics**](/docs/user-guide/skills/optional/research/research-bioinformatics) | Gateway to 400+ genomics and computational biology skills. |
 | [**darwinian-evolver**](/docs/user-guide/skills/optional/research/research-darwinian-evolver) | Evolve prompts/regex/SQL/code with Imbue's evolution loop. |
-| [**domain-intel**](/docs/user-guide/skills/optional/research/research-domain-intel) | Passive domain reconnaissance using Python stdlib. Subdomain discovery, SSL certificate inspection, WHOIS lookups, DNS records, domain availability checks, and bulk multi-domain analysis. No API keys required. |
+| [**domain-intel**](/docs/user-guide/skills/optional/research/research-domain-intel) | Passive recon of subdomains, SSL certs, WHOIS, and DNS. |
 | [**drug-discovery**](/docs/user-guide/skills/optional/research/research-drug-discovery) | Pharmaceutical research assistant for drug discovery workflows. Search bioactive compounds on ChEMBL, calculate drug-likeness (Lipinski Ro5, QED, TPSA, synthetic accessibility), look up drug-drug interactions via OpenFDA, interpret ADMET... |
-| [**duckduckgo-search**](/docs/user-guide/skills/optional/research/research-duckduckgo-search) | Free web search via DuckDuckGo — text, news, images, videos. No API key needed. Prefer the `ddgs` CLI when installed; use the Python DDGS library only after verifying that `ddgs` is available in the current runtime. |
-| [**gitnexus-explorer**](/docs/user-guide/skills/optional/research/research-gitnexus-explorer) | Index a codebase with GitNexus and serve an interactive knowledge graph via web UI + Cloudflare tunnel. |
-| [**osint-investigation**](/docs/user-guide/skills/optional/research/research-osint-investigation) | Public-records OSINT investigation framework — SEC EDGAR filings, USAspending contracts, Senate lobbying, OFAC sanctions, ICIJ offshore leaks, NYC property records (ACRIS), OpenCorporates registries, CourtListener court records, Wayback... |
-| [**parallel-cli**](/docs/user-guide/skills/optional/research/research-parallel-cli) | Optional vendor skill for Parallel CLI — agent-native web search, extraction, deep research, enrichment, FindAll, and monitoring. Prefer JSON output and non-interactive flows. |
-| [**qmd**](/docs/user-guide/skills/optional/research/research-qmd) | Search personal knowledge bases, notes, docs, and meeting transcripts locally using qmd — a hybrid retrieval engine with BM25, vector search, and LLM reranking. Supports CLI and MCP integration. |
-| [**scrapling**](/docs/user-guide/skills/optional/research/research-scrapling) | Web scraping with Scrapling - HTTP fetching, stealth browser automation, Cloudflare bypass, and spider crawling via CLI and Python. |
-| [**searxng-search**](/docs/user-guide/skills/optional/research/research-searxng-search) | Free meta-search via SearXNG — aggregates results from 70+ search engines. Self-hosted or use a public instance. No API key needed. Falls back automatically when the web search toolset is unavailable. |
+| [**duckduckgo-search**](/docs/user-guide/skills/optional/research/research-duckduckgo-search) | Free keyless web, news, and image search via ddgs. |
+| [**gitnexus-explorer**](/docs/user-guide/skills/optional/research/research-gitnexus-explorer) | Serve an interactive codebase knowledge graph web UI. |
+| [**osint-investigation**](/docs/user-guide/skills/optional/research/research-osint-investigation) | Follow the money via public records and sanctions data. |
+| [**parallel-cli**](/docs/user-guide/skills/optional/research/research-parallel-cli) | Agent-native web search, deep research, and enrichment. |
+| [**qmd**](/docs/user-guide/skills/optional/research/research-qmd) | Hybrid local search over notes, docs, and transcripts. |
+| [**scrapling**](/docs/user-guide/skills/optional/research/research-scrapling) | Scrape sites with stealth browsing and Cloudflare bypass. |
+| [**searxng-search**](/docs/user-guide/skills/optional/research/research-searxng-search) | Free keyless meta-search aggregating 70+ engines. |
 
 ## security
 
 | Skill | Description |
 |-------|-------------|
-| [**1password**](/docs/user-guide/skills/optional/security/security-1password) | Set up and use 1Password CLI (op). Use when installing the CLI, enabling desktop app integration, signing in, and reading/injecting secrets for commands. |
+| [**1password**](/docs/user-guide/skills/optional/security/security-1password) | Set up op CLI, sign in, and read or inject secrets. |
 | [**godmode**](/docs/user-guide/skills/optional/security/security-godmode) | Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN. |
 | [**oss-forensics**](/docs/user-guide/skills/optional/security/security-oss-forensics) | Supply chain investigation, evidence recovery, and forensic analysis for GitHub repositories. Covers deleted commit recovery, force-push detection, IOC extraction, multi-source evidence collection, hypothesis formation/validation, and st... |
-| [**sherlock**](/docs/user-guide/skills/optional/security/security-sherlock) | OSINT username search across 400+ social networks. Hunt down social media accounts by username. |
+| [**sherlock**](/docs/user-guide/skills/optional/security/security-sherlock) | Find accounts for a username across 400+ platforms. |
 | [**unbroker**](/docs/user-guide/skills/optional/security/security-unbroker) | Autonomously remove your info from data-broker sites. |
 | [**web-pentest**](/docs/user-guide/skills/optional/security/security-web-pentest) | Authorized web application penetration testing — reconnaissance, vulnerability analysis, proof-based exploitation, and professional reporting. Adapts Shannon's "No Exploit, No Report" methodology with hard guardrails for scope, authoriza... |
 
@@ -233,7 +234,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**cloudflare-temporary-deploy**](/docs/user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy) | Deploy a Worker live, no account, via wrangler --temporary. |
-| [**page-agent**](/docs/user-guide/skills/optional/web-development/web-development-page-agent) | Embed alibaba/page-agent into your own web application — a pure-JavaScript in-page GUI agent that ships as a single &lt;script> tag or npm package and lets end-users of your site drive the UI with natural language ("click login, fill userna... |
+| [**page-agent**](/docs/user-guide/skills/optional/web-development/web-development-page-agent) | Embed an in-page natural-language GUI copilot in web apps. |
 
 ## yuanbao
 

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -45,17 +45,17 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`ascii-video`](/docs/user-guide/skills/bundled/creative/creative-ascii-video) | ASCII video: convert video/audio to colored ASCII MP4/GIF. | `creative/ascii-video` |
 | [`baoyu-infographic`](/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic) | Infographics: 21 layouts x 21 styles (信息图, 可视化). | `creative/baoyu-infographic` |
 | [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design) | Design one-off HTML artifacts (landing, deck, prototype). | `creative/claude-design` |
-| [`comfyui`](/docs/user-guide/skills/bundled/creative/creative-comfyui) | Generate images, video, and audio with ComfyUI — install, launch, manage nodes/models, run workflows with parameter injection. Uses the official comfy-cli for lifecycle and direct REST/WebSocket API for execution. | `creative/comfyui` |
+| [`comfyui`](/docs/user-guide/skills/bundled/creative/creative-comfyui) | Generate images, video, and audio via diffusion workflows. | `creative/comfyui` |
 | [`design-md`](/docs/user-guide/skills/bundled/creative/creative-design-md) | Author/validate/export Google's DESIGN.md token spec files. | `creative/design-md` |
 | [`excalidraw`](/docs/user-guide/skills/bundled/creative/creative-excalidraw) | Hand-drawn Excalidraw JSON diagrams (arch, flow, seq). | `creative/excalidraw` |
 | [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer) | Humanize text: strip AI-isms and add real voice. | `creative/humanizer` |
 | [`manim-video`](/docs/user-guide/skills/bundled/creative/creative-manim-video) | Manim CE animations: 3Blue1Brown math/algo videos. | `creative/manim-video` |
 | [`p5js`](/docs/user-guide/skills/bundled/creative/creative-p5js) | p5.js sketches: gen art, shaders, interactive, 3D. | `creative/p5js` |
 | [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs) | 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS. | `creative/popular-web-designs` |
-| [`pretext`](/docs/user-guide/skills/bundled/creative/creative-pretext) | Use when building creative browser demos with @chenglou/pretext — DOM-free text layout for ASCII art, typographic flow around obstacles, text-as-geometry games, kinetic typography, and text-powered generative art. Produces single-file HT... | `creative/pretext` |
+| [`pretext`](/docs/user-guide/skills/bundled/creative/creative-pretext) | Build creative browser demos with DOM-free text layout. | `creative/pretext` |
 | [`sketch`](/docs/user-guide/skills/bundled/creative/creative-sketch) | Throwaway HTML mockups: 2-3 design variants to compare. | `creative/sketch` |
 | [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music) | Songwriting craft and Suno AI music prompts. | `creative/songwriting-and-ai-music` |
-| [`touchdesigner-mcp`](/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp) | Control a running TouchDesigner instance via twozero MCP — create operators, set parameters, wire connections, execute Python, build real-time visuals. 36 native tools. | `creative/touchdesigner-mcp` |
+| [`touchdesigner-mcp`](/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp) | Control TouchDesigner via twozero MCP. | `creative/touchdesigner-mcp` |
 
 ## email
 
@@ -111,7 +111,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`ocr-and-documents`](/docs/user-guide/skills/bundled/productivity/productivity-ocr-and-documents) | Extract text from PDFs/scans (pymupdf, marker-pdf). | `productivity/ocr-and-documents` |
 | [`pdf`](/docs/user-guide/skills/bundled/productivity/productivity-pdf) | Create, merge, split, fill, and secure PDF files. | `productivity/pdf` |
 | [`powerpoint`](/docs/user-guide/skills/bundled/productivity/productivity-powerpoint) | Create, read, edit .pptx decks, slides, notes, templates. | `productivity/powerpoint` |
-| [`teams-meeting-pipeline`](/docs/user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline) | Operate the Teams meeting summary pipeline via Hermes CLI — summarize meetings, inspect pipeline status, replay jobs, manage Microsoft Graph subscriptions. | `productivity/teams-meeting-pipeline` |
+| [`teams-meeting-pipeline`](/docs/user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline) | Teams meeting summaries, job replay, Graph subscriptions. | `productivity/teams-meeting-pipeline` |
 | [`xlsx`](/docs/user-guide/skills/bundled/productivity/productivity-xlsx) | Create, read, edit Excel .xlsx spreadsheets and CSVs. | `productivity/xlsx` |
 
 ## research
@@ -134,16 +134,16 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
-| [`xurl`](/docs/user-guide/skills/bundled/social-media/social-media-xurl) | X/Twitter via xurl CLI: post, search, DM, media, v2 API. | `social-media/xurl` |
+| [`xurl`](/docs/user-guide/skills/bundled/social-media/social-media-xurl) | X/Twitter via xurl CLI: raw post search, posting, DM, media. | `social-media/xurl` |
 
 ## software-development
 
 | Skill | Description | Path |
 |-------|-------------|------|
 | [`dogfood`](/docs/user-guide/skills/bundled/software-development/software-development-dogfood) | Exploratory QA of web apps: find bugs, evidence, reports. | `software-development/dogfood` |
-| [`hermes-agent-skill-authoring`](/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring) | Author in-repo SKILL.md: frontmatter, validator, structure, and writing-quality principles. | `software-development/hermes-agent-skill-authoring` |
+| [`hermes-agent-skill-authoring`](/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring) | Author in-repo SKILL.md files: frontmatter and structure. | `software-development/hermes-agent-skill-authoring` |
 | [`node-inspect-debugger`](/docs/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger) | Debug Node.js via --inspect + Chrome DevTools Protocol CLI. | `software-development/node-inspect-debugger` |
-| [`plan`](/docs/user-guide/skills/bundled/software-development/software-development-plan) | Plan mode: write an actionable markdown plan to .hermes/plans/, no execution. Bite-sized tasks, exact paths, complete code. | `software-development/plan` |
+| [`plan`](/docs/user-guide/skills/bundled/software-development/software-development-plan) | Write a markdown plan to .hermes/plans/; no execution. | `software-development/plan` |
 | [`python-debugpy`](/docs/user-guide/skills/bundled/software-development/software-development-python-debugpy) | Debug Python: pdb REPL + debugpy remote (DAP). | `software-development/python-debugpy` |
 | [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review) | Pre-commit review: security scan, quality gates, auto-fix. | `software-development/requesting-code-review` |
 | [`simplify-code`](/docs/user-guide/skills/bundled/software-development/software-development-simplify-code) | Parallel 4-agent cleanup of recent code changes. | `software-development/simplify-code` |

--- a/website/docs/user-guide/skills/bundled/creative/creative-comfyui.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-comfyui.md
@@ -1,14 +1,14 @@
 ---
-title: "Comfyui"
+title: "Comfyui — Generate images, video, and audio via diffusion workflows"
 sidebar_label: "Comfyui"
-description: "Generate images, video, and audio with ComfyUI — install, launch, manage nodes/models, run workflows with parameter injection"
+description: "Generate images, video, and audio via diffusion workflows"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Comfyui
 
-Generate images, video, and audio with ComfyUI — install, launch, manage nodes/models, run workflows with parameter injection. Uses the official comfy-cli for lifecycle and direct REST/WebSocket API for execution.
+Generate images, video, and audio via diffusion workflows.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/creative/creative-pretext.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-pretext.md
@@ -1,14 +1,14 @@
 ---
-title: "Pretext"
+title: "Pretext — Build creative browser demos with DOM-free text layout"
 sidebar_label: "Pretext"
-description: "Use when building creative browser demos with @chenglou/pretext — DOM-free text layout for ASCII art, typographic flow around obstacles, text-as-geometry gam..."
+description: "Build creative browser demos with DOM-free text layout"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Pretext
 
-Use when building creative browser demos with @chenglou/pretext — DOM-free text layout for ASCII art, typographic flow around obstacles, text-as-geometry games, kinetic typography, and text-powered generative art. Produces single-file HTML demos by default.
+Build creative browser demos with DOM-free text layout.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp.md
@@ -1,14 +1,14 @@
 ---
-title: "Touchdesigner Mcp"
+title: "Touchdesigner Mcp — Control TouchDesigner via twozero MCP"
 sidebar_label: "Touchdesigner Mcp"
-description: "Control a running TouchDesigner instance via twozero MCP — create operators, set parameters, wire connections, execute Python, build real-time visuals"
+description: "Control TouchDesigner via twozero MCP"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Touchdesigner Mcp
 
-Control a running TouchDesigner instance via twozero MCP — create operators, set parameters, wire connections, execute Python, build real-time visuals. 36 native tools.
+Control TouchDesigner via twozero MCP.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline.md
@@ -1,14 +1,14 @@
 ---
-title: "Teams Meeting Pipeline"
+title: "Teams Meeting Pipeline — Teams meeting summaries, job replay, Graph subscriptions"
 sidebar_label: "Teams Meeting Pipeline"
-description: "Operate the Teams meeting summary pipeline via Hermes CLI — summarize meetings, inspect pipeline status, replay jobs, manage Microsoft Graph subscriptions"
+description: "Teams meeting summaries, job replay, Graph subscriptions"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Teams Meeting Pipeline
 
-Operate the Teams meeting summary pipeline via Hermes CLI — summarize meetings, inspect pipeline status, replay jobs, manage Microsoft Graph subscriptions.
+Teams meeting summaries, job replay, Graph subscriptions.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
@@ -8,7 +8,7 @@ description: "Author in-repo SKILL"
 
 # Hermes Agent Skill Authoring
 
-Author in-repo SKILL.md: frontmatter, validator, structure.
+Author in-repo SKILL.md files: frontmatter and structure.
 
 ## Skill metadata
 
@@ -16,7 +16,7 @@ Author in-repo SKILL.md: frontmatter, validator, structure.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/software-development/hermes-agent-skill-authoring` |
-| Version | `1.0.0` |
+| Version | `1.1.0` |
 | Author | Hermes Agent |
 | License | MIT |
 | Platforms | linux, macos, windows |
@@ -61,7 +61,7 @@ Peer-matched shape used by every skill under `skills/software-development/`:
 ---
 name: my-skill-name               # lowercase, hyphens, ≤64 chars (MAX_NAME_LENGTH)
 description: Use when <trigger>. <one-line behavior>.
-version: 1.0.0
+version: 1.1.0
 author: Hermes Agent
 license: MIT
 metadata:
@@ -78,6 +78,29 @@ metadata:
 - Description: ≤ 1024 chars (enforced).
 - Full SKILL.md: ≤ 100,000 chars (enforced as `MAX_SKILL_CONTENT_CHARS`, ~36k tokens).
 - Peer skills in `software-development/` sit at **8-14k chars**. Aim for that range. If you're pushing past 20k, split into `references/*.md` and reference them from SKILL.md.
+
+## Writing Quality Principles
+
+A skill exists to make the agent's process more predictable. Predictability does **not** mean identical output every run; it means the agent reliably follows the same useful discipline.
+
+Use these quality checks when writing or editing any skill:
+
+1. **Optimize for process predictability.** Ask: what behavior should change when this skill loads? If a line does not change behavior, cut it.
+2. **Choose the right context load.** A model-invoked Hermes skill pays for its description every turn. Keep descriptions focused on trigger classes and the skill's distinctive behavior. Put details in the body or linked references.
+3. **Use an information hierarchy.** Put always-needed steps in `SKILL.md`; put branch-specific or bulky reference material in `references/`, `templates/`, or `scripts/` and point to it only when needed.
+4. **End steps with completion criteria.** Each ordered step should say how the agent knows it is done. Good criteria are checkable and, when it matters, exhaustive: "every modified file accounted for" beats "summarize changes."
+5. **Co-locate rules with the concept they govern.** Avoid scattering one idea across the file. Keep definition, caveats, examples, and verification near each other.
+6. **Use strong leading words.** Prefer compact concepts the model already knows — e.g. "tight loop," "tracer bullet," "root cause," "regression test" — over long repeated explanations. A good leading word saves tokens and anchors behavior.
+7. **Prune duplication and no-ops.** Keep each meaning in one source of truth. Sentence by sentence, ask whether the sentence changes agent behavior versus the default. If not, delete it rather than polishing it.
+8. **Watch for premature completion.** If agents tend to rush a step, first sharpen that step's completion criterion. Split the sequence only when later steps distract from doing the current step well.
+
+Common quality failures:
+
+- **Premature completion** — the skill lets the agent move on before the work is genuinely done.
+- **Duplication** — the same rule appears in multiple places and drifts.
+- **Sediment** — stale lines remain because adding felt safer than deleting.
+- **Sprawl** — too much always-visible material; push branch-specific reference behind pointers.
+- **No-op prose** — generic advice the agent would already follow without the skill.
 
 ## Peer-Matched Structure
 
@@ -168,7 +191,11 @@ Pick the closest existing category. Don't invent new top-level categories casual
 
 6. **Expecting the current session to see the new skill.** It won't. The skill loader is initialized at session start. Verify in a fresh session or via `skill_view` using the exact path.
 
-7. **Linking to skills that don't exist in-repo.** `related_skills: [some-user-local-skill]` works for you but breaks for other clones. Prefer only in-repo links.
+7. **Letting skills accumulate sediment.** A skill should get shorter or sharper over time. When adding a rule, remove the old wording it replaces; don't layer advice forever.
+
+8. **Writing no-op prose.** "Be careful," "be thorough," and "use best practices" rarely change model behavior. Replace with a checkable completion criterion or a stronger leading word.
+
+9. **Linking to skills that don't exist in-repo.** `related_skills: [some-user-local-skill]` works for you but breaks for other clones. Prefer only in-repo links.
 
 ## Verification Checklist
 
@@ -179,5 +206,9 @@ Pick the closest existing category. Don't invent new top-level categories casual
 - [ ] Description ≤ 1024 chars and starts with "Use when ..."
 - [ ] Total file ≤ 100,000 chars (aim for 8-15k)
 - [ ] Structure: `# Title` → `## Overview` → `## When to Use` → body → `## Common Pitfalls` → `## Verification Checklist`
+- [ ] Each ordered step has a checkable completion criterion
+- [ ] Description is trigger-focused and avoids duplicated body content
+- [ ] Bulky or branch-specific reference is progressively disclosed in linked files
+- [ ] No-op prose and duplicated rules removed
 - [ ] `related_skills` references resolve in-repo (or are explicitly OK to be user-local)
 - [ ] `git add skills/<category>/<name>/ && git commit` completed on the intended branch

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-plan.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-plan.md
@@ -1,14 +1,14 @@
 ---
-title: "Plan — Plan mode: write an actionable markdown plan to"
+title: "Plan — Write a markdown plan to"
 sidebar_label: "Plan"
-description: "Plan mode: write an actionable markdown plan to"
+description: "Write a markdown plan to"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Plan
 
-Plan mode: write an actionable markdown plan to .hermes/plans/, no execution. Bite-sized tasks, exact paths, complete code.
+Write a markdown plan to .hermes/plans/; no execution.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox.md
@@ -1,14 +1,14 @@
 ---
-title: "Blackbox — Delegate coding tasks to Blackbox AI CLI agent"
+title: "Blackbox — Delegate coding tasks to the Blackbox AI multi-model CLI"
 sidebar_label: "Blackbox"
-description: "Delegate coding tasks to Blackbox AI CLI agent"
+description: "Delegate coding tasks to the Blackbox AI multi-model CLI"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Blackbox
 
-Delegate coding tasks to Blackbox AI CLI agent. Multi-model agent with built-in judge that runs tasks through multiple LLMs and picks the best result. Requires the blackbox CLI and a Blackbox AI API key.
+Delegate coding tasks to the Blackbox AI multi-model CLI.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
@@ -1,14 +1,14 @@
 ---
-title: "Honcho"
+title: "Honcho — Configure and troubleshoot Honcho memory for Hermes"
 sidebar_label: "Honcho"
-description: "Configure and use Honcho memory with Hermes -- cross-session user modeling, multi-profile peer isolation, observation config, dialectic reasoning, session su..."
+description: "Configure and troubleshoot Honcho memory for Hermes"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Honcho
 
-Configure and use Honcho memory with Hermes -- cross-session user modeling, multi-profile peer isolation, observation config, dialectic reasoning, session summaries, and context budget enforcement. Use when setting up Honcho, troubleshooting memory, managing profiles with Honcho peers, or tuning observation, recall, and dialectic settings.
+Configure and troubleshoot Honcho memory for Hermes.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/blockchain/blockchain-solana.md
+++ b/website/docs/user-guide/skills/optional/blockchain/blockchain-solana.md
@@ -1,14 +1,14 @@
 ---
-title: "Solana"
+title: "Solana — Query Solana wallets, tokens, txs, and NFTs in USD"
 sidebar_label: "Solana"
-description: "Query Solana blockchain data with USD pricing — wallet balances, token portfolios with values, transaction details, NFTs, whale detection, and live network s..."
+description: "Query Solana wallets, tokens, txs, and NFTs in USD"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Solana
 
-Query Solana blockchain data with USD pricing — wallet balances, token portfolios with values, transaction details, NFTs, whale detection, and live network stats. Uses Solana RPC + CoinGecko. No API key required.
+Query Solana wallets, tokens, txs, and NFTs in USD.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/creative/creative-concept-diagrams.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-concept-diagrams.md
@@ -1,14 +1,14 @@
 ---
-title: "Concept Diagrams"
+title: "Concept Diagrams — Generate flat, minimal educational SVG visuals as HTML"
 sidebar_label: "Concept Diagrams"
-description: "Generate flat, minimal light/dark-aware SVG diagrams as standalone HTML files, using a unified educational visual language with 9 semantic color ramps, sente..."
+description: "Generate flat, minimal educational SVG visuals as HTML"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Concept Diagrams
 
-Generate flat, minimal light/dark-aware SVG diagrams as standalone HTML files, using a unified educational visual language with 9 semantic color ramps, sentence-case typography, and automatic dark mode. Best suited for educational and non-software visuals — physics setups, chemistry mechanisms, math curves, physical objects (aircraft, turbines, smartphones, mechanical watches), anatomy, floor plans, cross-sections, narrative journeys (lifecycle of X, process of Y), hub-spoke system integrations (smart city, IoT), and exploded layer views. If a more specialized skill exists for the subject (dedicated software/cloud architecture, hand-drawn sketches, animated explainers, etc.), prefer that — otherwise this skill can also serve as a general-purpose SVG diagram fallback with a clean educational look. Ships with 15 example diagrams.
+Generate flat, minimal educational SVG visuals as HTML.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/creative/creative-hyperframes.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-hyperframes.md
@@ -1,14 +1,14 @@
 ---
-title: "Hyperframes"
+title: "Hyperframes — Render MP4/WebM videos from HTML compositions"
 sidebar_label: "Hyperframes"
-description: "Create HTML-based video compositions, animated title cards, social overlays, captioned talking-head videos, audio-reactive visuals, and shader transitions us..."
+description: "Render MP4/WebM videos from HTML compositions"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Hyperframes
 
-Create HTML-based video compositions, animated title cards, social overlays, captioned talking-head videos, audio-reactive visuals, and shader transitions using HyperFrames. HTML is the source of truth for video. Use when the user wants a rendered MP4/WebM from an HTML composition, wants to animate text/logos/charts over media, needs captions synced to audio, wants TTS narration, or wants to convert a website into a video.
+Render MP4/WebM videos from HTML compositions.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator.md
@@ -1,14 +1,14 @@
 ---
-title: "Kanban Video Orchestrator — Plan, set up, and monitor a multi-agent video production pipeline backed by Hermes Kanban"
+title: "Kanban Video Orchestrator — Plan and run multi-agent video production pipelines"
 sidebar_label: "Kanban Video Orchestrator"
-description: "Plan, set up, and monitor a multi-agent video production pipeline backed by Hermes Kanban"
+description: "Plan and run multi-agent video production pipelines"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Kanban Video Orchestrator
 
-Plan, set up, and monitor a multi-agent video production pipeline backed by Hermes Kanban. Use when the user wants to make ANY video — narrative film, product/marketing, music video, explainer, ASCII/terminal art, abstract/generative loop, comic, 3D, real-time/installation — and the work warrants decomposition into specialized profiles (writer, designer, animator, renderer, voice, editor, etc.) coordinated through a kanban board. Performs adaptive discovery to scope the brief, designs an appropriate team for the requested style, generates the setup script that creates Hermes profiles + initial kanban task, then helps monitor execution and intervene when tasks stall or fail. Routes scenes to whichever Hermes rendering / audio / design skill fits each beat (`ascii-video`, `manim-video`, `p5js`, `comfyui`, `touchdesigner-mcp`, `blender-mcp`, `pixel-art`, `baoyu-comic`, `claude-design`, `excalidraw`, `songsee`, `heartmula`, …) plus external APIs for TTS, image-gen, and image-to-video as needed.
+Plan and run multi-agent video production pipelines.
 
 ## Skill metadata
 
@@ -21,7 +21,7 @@ Plan, set up, and monitor a multi-agent video production pipeline backed by Herm
 | License | MIT |
 | Platforms | linux, macos, windows |
 | Tags | `video`, `kanban`, `multi-agent`, `orchestration`, `production-pipeline` |
-| Related skills | [`ascii-video`](/docs/user-guide/skills/bundled/creative/creative-ascii-video), [`manim-video`](/docs/user-guide/skills/bundled/creative/creative-manim-video), [`p5js`](/docs/user-guide/skills/bundled/creative/creative-p5js), [`comfyui`](/docs/user-guide/skills/bundled/creative/creative-comfyui), [`touchdesigner-mcp`](/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp), [`blender-mcp`](/docs/user-guide/skills/optional/creative/creative-blender-mcp), [`pixel-art`](/docs/user-guide/skills/optional/creative/creative-pixel-art), [`ascii-art`](/docs/user-guide/skills/bundled/creative/creative-ascii-art), [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music), [`heartmula`](/docs/user-guide/skills/bundled/media/media-heartmula), [`songsee`](/docs/user-guide/skills/bundled/media/media-songsee), `spotify`, [`youtube-content`](/docs/user-guide/skills/bundled/media/media-youtube-content), [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design), [`excalidraw`](/docs/user-guide/skills/bundled/creative/creative-excalidraw), [`architecture-diagram`](/docs/user-guide/skills/bundled/creative/creative-architecture-diagram), [`concept-diagrams`](/docs/user-guide/skills/optional/creative/creative-concept-diagrams), [`baoyu-comic`](/docs/user-guide/skills/optional/creative/creative-baoyu-comic), [`baoyu-infographic`](/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic), [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer), [`gif-search`](/docs/user-guide/skills/bundled/media/media-gif-search), [`meme-generation`](/docs/user-guide/skills/optional/creative/creative-meme-generation) |
+| Related skills | [`ascii-video`](/docs/user-guide/skills/bundled/creative/creative-ascii-video), [`manim-video`](/docs/user-guide/skills/bundled/creative/creative-manim-video), [`p5js`](/docs/user-guide/skills/bundled/creative/creative-p5js), [`comfyui`](/docs/user-guide/skills/bundled/creative/creative-comfyui), [`touchdesigner-mcp`](/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp), [`blender-mcp`](/docs/user-guide/skills/optional/creative/creative-blender-mcp), [`pixel-art`](/docs/user-guide/skills/optional/creative/creative-pixel-art), [`ascii-art`](/docs/user-guide/skills/bundled/creative/creative-ascii-art), [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music), [`heartmula`](/docs/user-guide/skills/optional/creative/creative-heartmula), [`songsee`](/docs/user-guide/skills/bundled/media/media-songsee), `spotify`, [`youtube-content`](/docs/user-guide/skills/bundled/media/media-youtube-content), [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design), [`excalidraw`](/docs/user-guide/skills/bundled/creative/creative-excalidraw), [`architecture-diagram`](/docs/user-guide/skills/bundled/creative/creative-architecture-diagram), [`concept-diagrams`](/docs/user-guide/skills/optional/creative/creative-concept-diagrams), [`baoyu-comic`](/docs/user-guide/skills/optional/creative/creative-baoyu-comic), [`baoyu-infographic`](/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic), [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer), [`gif-search`](/docs/user-guide/skills/bundled/media/media-gif-search), [`meme-generation`](/docs/user-guide/skills/optional/creative/creative-meme-generation) |
 
 ## Reference: full SKILL.md
 
@@ -186,8 +186,9 @@ task graphs. See **[references/examples.md](https://github.com/NousResearch/herm
 6. **The director never executes.** Even with the full `kanban + terminal +
    file` toolset, the director's `SOUL.md` rules forbid it from executing
    work itself. It decomposes and routes only — every concrete task becomes
-   a `hermes kanban create` call to a specialist profile. The
-   auto-injected kanban orchestration guidance spells this out further.
+   a `hermes kanban create` call to a specialist profile. The kanban
+   orchestration guidance auto-injected into every kanban worker's system
+   prompt spells this out further.
 
 7. **Don't over-decompose.** A 30-second product video does NOT need 20 tasks.
    Aim for the smallest task graph that still parallelizes well and exposes the

--- a/website/docs/user-guide/skills/optional/creative/creative-meme-generation.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-meme-generation.md
@@ -1,14 +1,14 @@
 ---
-title: "Meme Generation — Generate real meme images by picking a template and overlaying text with Pillow"
+title: "Meme Generation — Create meme PNGs from templates with Pillow text overlay"
 sidebar_label: "Meme Generation"
-description: "Generate real meme images by picking a template and overlaying text with Pillow"
+description: "Create meme PNGs from templates with Pillow text overlay"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Meme Generation
 
-Generate real meme images by picking a template and overlaying text with Pillow. Produces actual .png meme files.
+Create meme PNGs from templates with Pillow text overlay.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/creative/creative-unreal-mcp.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-unreal-mcp.md
@@ -1,14 +1,14 @@
 ---
-title: "Unreal Mcp"
+title: "Unreal Mcp — Automate Unreal Engine editor scenes, actors, and renders"
 sidebar_label: "Unreal Mcp"
-description: "Use when the user wants to do anything in Unreal Engine through Epic's official editor-embedded MCP server (catalog entry: unreal-engine) — build/light/popul..."
+description: "Automate Unreal Engine editor scenes, actors, and renders"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Unreal Mcp
 
-Use when the user wants to do anything in Unreal Engine through Epic's official editor-embedded MCP server (catalog entry: unreal-engine) — build/light/populate scenes, place and transform actors, author Blueprints, animate with Sequencer, create material instances, frame cameras, take screenshots, render, import assets, run PIE test sessions and automation tests, or automate the editor end-to-end from plain-English prompts with no Unreal knowledge required. Covers the tool-search discovery walk (list_toolsets/describe_toolset/call_tool), serial game-thread call discipline, ProgrammaticToolset batching, the Blueprint graph DSL loop, scene-craft numbers (physical light units, exposure, scale conventions), complete build recipes, save/undo hygiene, and extending the tool surface with custom Python toolsets.
+Automate Unreal Engine editor scenes, actors, and renders.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/devops/devops-cli.md
+++ b/website/docs/user-guide/skills/optional/devops/devops-cli.md
@@ -1,14 +1,14 @@
 ---
-title: "Inference Sh Cli — Run 150+ AI apps via inference"
+title: "Inference Sh Cli — Run 150+ AI apps (image, video, LLM) via inference"
 sidebar_label: "Inference Sh Cli"
-description: "Run 150+ AI apps via inference"
+description: "Run 150+ AI apps (image, video, LLM) via inference"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Inference Sh Cli
 
-Run 150+ AI apps via inference.sh CLI (infsh) — image generation, video creation, LLMs, search, 3D, social automation. Uses the terminal tool. Triggers: inference.sh, infsh, ai apps, flux, veo, image generation, video generation, seedream, seedance, tavily
+Run 150+ AI apps (image, video, LLM) via inference.sh CLI.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/devops/devops-docker-management.md
+++ b/website/docs/user-guide/skills/optional/devops/devops-docker-management.md
@@ -1,14 +1,14 @@
 ---
-title: "Docker Management"
+title: "Docker Management — Manage Docker containers, images, volumes, and Compose"
 sidebar_label: "Docker Management"
-description: "Manage Docker containers, images, volumes, networks, and Compose stacks — lifecycle ops, debugging, cleanup, and Dockerfile optimization"
+description: "Manage Docker containers, images, volumes, and Compose"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Docker Management
 
-Manage Docker containers, images, volumes, networks, and Compose stacks — lifecycle ops, debugging, cleanup, and Dockerfile optimization.
+Manage Docker containers, images, volumes, and Compose.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/devops/devops-hermes-s6-container-supervision.md
+++ b/website/docs/user-guide/skills/optional/devops/devops-hermes-s6-container-supervision.md
@@ -1,14 +1,14 @@
 ---
-title: "Hermes S6 Container Supervision"
+title: "Hermes S6 Container Supervision — Modify or debug s6 services in the Hermes Docker image"
 sidebar_label: "Hermes S6 Container Supervision"
-description: "Modify, debug, or extend the s6-overlay supervision tree inside the Hermes Agent Docker image — adding new services, debugging profile gateways, understandin..."
+description: "Modify or debug s6 services in the Hermes Docker image"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Hermes S6 Container Supervision
 
-Modify, debug, or extend the s6-overlay supervision tree inside the Hermes Agent Docker image — adding new services, debugging profile gateways, understanding the Architecture B main-program pattern.
+Modify or debug s6 services in the Hermes Docker image.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/dogfood/dogfood-adversarial-ux-test.md
+++ b/website/docs/user-guide/skills/optional/dogfood/dogfood-adversarial-ux-test.md
@@ -1,14 +1,14 @@
 ---
-title: "Adversarial Ux Test — Roleplay the most difficult, tech-resistant user for your product"
+title: "Adversarial Ux Test — Roleplay a hostile user to find and triage UX pain points"
 sidebar_label: "Adversarial Ux Test"
-description: "Roleplay the most difficult, tech-resistant user for your product"
+description: "Roleplay a hostile user to find and triage UX pain points"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Adversarial Ux Test
 
-Roleplay the most difficult, tech-resistant user for your product. Browse the app as that persona, find every UX pain point, then filter complaints through a pragmatism layer to separate real problems from noise. Creates actionable tickets from genuine issues only.
+Roleplay a hostile user to find and triage UX pain points.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/email/email-agentmail.md
+++ b/website/docs/user-guide/skills/optional/email/email-agentmail.md
@@ -1,14 +1,14 @@
 ---
-title: "Agentmail — Give the agent its own dedicated email inbox via AgentMail"
+title: "Agentmail — Give the agent its own inbox: send and receive email"
 sidebar_label: "Agentmail"
-description: "Give the agent its own dedicated email inbox via AgentMail"
+description: "Give the agent its own inbox: send and receive email"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Agentmail
 
-Give the agent its own dedicated email inbox via AgentMail. Send, receive, and manage email autonomously using agent-owned email addresses (e.g. hermes-agent@agentmail.to).
+Give the agent its own inbox: send and receive email.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/finance/finance-3-statement-model.md
+++ b/website/docs/user-guide/skills/optional/finance/finance-3-statement-model.md
@@ -1,14 +1,14 @@
 ---
-title: "3 Statement Model"
+title: "3 Statement Model — Build integrated IS/BS/CF financial workbooks in Excel"
 sidebar_label: "3 Statement Model"
-description: "Build fully-integrated 3-statement models (IS, BS, CF) in Excel with working capital schedules, D&A roll-forwards, debt schedule, and the plugs that make cas..."
+description: "Build integrated IS/BS/CF financial workbooks in Excel"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # 3 Statement Model
 
-Build fully-integrated 3-statement models (IS, BS, CF) in Excel with working capital schedules, D&A roll-forwards, debt schedule, and the plugs that make cash and retained earnings tie. Pairs with excel-author.
+Build integrated IS/BS/CF financial workbooks in Excel.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/finance/finance-comps-analysis.md
+++ b/website/docs/user-guide/skills/optional/finance/finance-comps-analysis.md
@@ -1,14 +1,14 @@
 ---
-title: "Comps Analysis"
+title: "Comps Analysis — Build comparable-company valuation workbooks in Excel"
 sidebar_label: "Comps Analysis"
-description: "Build comparable company analysis in Excel — operating metrics, valuation multiples, statistical benchmarking vs peer sets"
+description: "Build comparable-company valuation workbooks in Excel"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Comps Analysis
 
-Build comparable company analysis in Excel — operating metrics, valuation multiples, statistical benchmarking vs peer sets. Pairs with excel-author. Use for public-company valuation, IPO pricing, sector benchmarking, or outlier detection.
+Build comparable-company valuation workbooks in Excel.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/finance/finance-dcf-model.md
+++ b/website/docs/user-guide/skills/optional/finance/finance-dcf-model.md
@@ -1,14 +1,14 @@
 ---
-title: "Dcf Model"
+title: "Dcf Model — Build discounted cash flow valuation workbooks in Excel"
 sidebar_label: "Dcf Model"
-description: "Build institutional-quality DCF valuation models in Excel — revenue projections, FCF build, WACC, terminal value, Bear/Base/Bull scenarios, 5x5 sensitivity t..."
+description: "Build discounted cash flow valuation workbooks in Excel"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Dcf Model
 
-Build institutional-quality DCF valuation models in Excel — revenue projections, FCF build, WACC, terminal value, Bear/Base/Bull scenarios, 5x5 sensitivity tables. Pairs with excel-author. Use for intrinsic-value equity analysis.
+Build discounted cash flow valuation workbooks in Excel.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/finance/finance-excel-author.md
+++ b/website/docs/user-guide/skills/optional/finance/finance-excel-author.md
@@ -1,14 +1,14 @@
 ---
-title: "Excel Author"
+title: "Excel Author — Build auditable financial workbooks headless via openpyxl"
 sidebar_label: "Excel Author"
-description: "Build auditable Excel workbooks headless with openpyxl — blue/black/green cell conventions, formulas over hardcodes, named ranges, balance checks, sensitivit..."
+description: "Build auditable financial workbooks headless via openpyxl"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Excel Author
 
-Build auditable Excel workbooks headless with openpyxl — blue/black/green cell conventions, formulas over hardcodes, named ranges, balance checks, sensitivity tables. Use for financial models, audit outputs, reconciliations.
+Build auditable financial workbooks headless via openpyxl.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/finance/finance-lbo-model.md
+++ b/website/docs/user-guide/skills/optional/finance/finance-lbo-model.md
@@ -1,14 +1,14 @@
 ---
-title: "Lbo Model"
+title: "Lbo Model — Build leveraged buyout workbooks with IRR/MOIC in Excel"
 sidebar_label: "Lbo Model"
-description: "Build leveraged buyout models in Excel — sources & uses, debt schedule, cash sweep, exit multiple, IRR/MOIC sensitivity"
+description: "Build leveraged buyout workbooks with IRR/MOIC in Excel"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Lbo Model
 
-Build leveraged buyout models in Excel — sources & uses, debt schedule, cash sweep, exit multiple, IRR/MOIC sensitivity. Pairs with excel-author. Use for PE screening, sponsor-case valuation, or illustrative LBO in a pitch.
+Build leveraged buyout workbooks with IRR/MOIC in Excel.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/finance/finance-merger-model.md
+++ b/website/docs/user-guide/skills/optional/finance/finance-merger-model.md
@@ -1,14 +1,14 @@
 ---
-title: "Merger Model — Build accretion/dilution (merger) models in Excel — pro-forma P&L, synergies, financing mix, EPS impact"
+title: "Merger Model — Build M&A accretion/dilution workbooks in Excel"
 sidebar_label: "Merger Model"
-description: "Build accretion/dilution (merger) models in Excel — pro-forma P&L, synergies, financing mix, EPS impact"
+description: "Build M&A accretion/dilution workbooks in Excel"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Merger Model
 
-Build accretion/dilution (merger) models in Excel — pro-forma P&L, synergies, financing mix, EPS impact. Pairs with excel-author. Use for M&A pitches, board materials, or deal evaluation.
+Build M&A accretion/dilution workbooks in Excel.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/finance/finance-pptx-author.md
+++ b/website/docs/user-guide/skills/optional/finance/finance-pptx-author.md
@@ -8,7 +8,7 @@ description: "Build PowerPoint decks headless with python-pptx"
 
 # Pptx Author
 
-Build PowerPoint decks headless with python-pptx. Pairs with excel-author for model-backed decks where every number traces to a workbook cell. Use for pitch decks, IC memos, earnings notes.
+Build PowerPoint decks headless with python-pptx.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mcp/mcp-fastmcp.md
+++ b/website/docs/user-guide/skills/optional/mcp/mcp-fastmcp.md
@@ -1,14 +1,14 @@
 ---
-title: "Fastmcp — Build, test, inspect, install, and deploy MCP servers with FastMCP in Python"
+title: "Fastmcp — Build, test, and deploy Python MCP servers"
 sidebar_label: "Fastmcp"
-description: "Build, test, inspect, install, and deploy MCP servers with FastMCP in Python"
+description: "Build, test, and deploy Python MCP servers"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Fastmcp
 
-Build, test, inspect, install, and deploy MCP servers with FastMCP in Python. Use when creating a new MCP server, wrapping an API or database as MCP tools, exposing resources or prompts, or preparing a FastMCP server for Claude Code, Cursor, or HTTP deployment.
+Build, test, and deploy Python MCP servers.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mcp/mcp-mcporter.md
+++ b/website/docs/user-guide/skills/optional/mcp/mcp-mcporter.md
@@ -1,14 +1,14 @@
 ---
-title: "Mcporter"
+title: "Mcporter — List, auth, and call MCP servers/tools from the terminal"
 sidebar_label: "Mcporter"
-description: "Use the mcporter CLI to list, configure, auth, and call MCP servers/tools directly (HTTP or stdio), including ad-hoc servers, config edits, and CLI/type gene..."
+description: "List, auth, and call MCP servers/tools from the terminal"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Mcporter
 
-Use the mcporter CLI to list, configure, auth, and call MCP servers/tools directly (HTTP or stdio), including ad-hoc servers, config edits, and CLI/type generation.
+List, auth, and call MCP servers/tools from the terminal.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/migration/migration-openclaw-migration.md
+++ b/website/docs/user-guide/skills/optional/migration/migration-openclaw-migration.md
@@ -1,14 +1,14 @@
 ---
-title: "Openclaw Migration — Migrate a user's OpenClaw customization footprint into Hermes Agent"
+title: "Openclaw Migration — Import an OpenClaw setup (memories, skills) into Hermes"
 sidebar_label: "Openclaw Migration"
-description: "Migrate a user's OpenClaw customization footprint into Hermes Agent"
+description: "Import an OpenClaw setup (memories, skills) into Hermes"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Openclaw Migration
 
-Migrate a user's OpenClaw customization footprint into Hermes Agent. Imports Hermes-compatible memories, SOUL.md, command allowlists, user skills, and selected workspace assets from ~/.openclaw, then reports exactly what could not be migrated and why.
+Import an OpenClaw setup (memories, skills) into Hermes.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-accelerate.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-accelerate.md
@@ -1,14 +1,14 @@
 ---
-title: "Huggingface Accelerate — Simplest distributed training API"
+title: "Huggingface Accelerate — Run PyTorch training across GPUs with minimal changes"
 sidebar_label: "Huggingface Accelerate"
-description: "Simplest distributed training API"
+description: "Run PyTorch training across GPUs with minimal changes"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Huggingface Accelerate
 
-Simplest distributed training API. 4 lines to add distributed support to any PyTorch script. Unified API for DeepSpeed/FSDP/Megatron/DDP. Automatic device placement, mixed precision (FP16/BF16/FP8). Interactive config, single launch command. HuggingFace ecosystem standard.
+Run PyTorch training across GPUs with minimal changes.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-chroma.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-chroma.md
@@ -1,14 +1,14 @@
 ---
-title: "Chroma — Open-source embedding database for AI applications"
+title: "Chroma — Embedding database for RAG and semantic search"
 sidebar_label: "Chroma"
-description: "Open-source embedding database for AI applications"
+description: "Embedding database for RAG and semantic search"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Chroma
 
-Open-source embedding database for AI applications. Store embeddings and metadata, perform vector and full-text search, filter by metadata. Simple 4-function API. Scales from notebooks to production clusters. Use for semantic search, RAG applications, or document retrieval. Best for local development and open-source projects.
+Embedding database for RAG and semantic search.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-clip.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-clip.md
@@ -1,14 +1,14 @@
 ---
-title: "Clip — OpenAI's model connecting vision and language"
+title: "Clip — Zero-shot image classification and image-text search"
 sidebar_label: "Clip"
-description: "OpenAI's model connecting vision and language"
+description: "Zero-shot image classification and image-text search"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Clip
 
-OpenAI's model connecting vision and language. Enables zero-shot image classification, image-text matching, and cross-modal retrieval. Trained on 400M image-text pairs. Use for image search, content moderation, or vision-language tasks without fine-tuning. Best for general-purpose image understanding.
+Zero-shot image classification and image-text search.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-faiss.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-faiss.md
@@ -1,14 +1,14 @@
 ---
-title: "Faiss — Facebook's library for efficient similarity search and clustering of dense vectors"
+title: "Faiss — Fast vector similarity search at billion scale"
 sidebar_label: "Faiss"
-description: "Facebook's library for efficient similarity search and clustering of dense vectors"
+description: "Fast vector similarity search at billion scale"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Faiss
 
-Facebook's library for efficient similarity search and clustering of dense vectors. Supports billions of vectors, GPU acceleration, and various index types (Flat, IVF, HNSW). Use for fast k-NN search, large-scale vector retrieval, or when you need pure similarity search without metadata. Best for high-performance applications.
+Fast vector similarity search at billion scale.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-flash-attention.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-flash-attention.md
@@ -1,14 +1,14 @@
 ---
-title: "Optimizing Attention Flash"
+title: "Optimizing Attention Flash — Speed up long-sequence transformer training and inference"
 sidebar_label: "Optimizing Attention Flash"
-description: "Optimizes transformer attention with Flash Attention for 2-4x speedup and 10-20x memory reduction"
+description: "Speed up long-sequence transformer training and inference"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Optimizing Attention Flash
 
-Optimizes transformer attention with Flash Attention for 2-4x speedup and 10-20x memory reduction. Use when training/running transformers with long sequences (>512 tokens), encountering GPU memory issues with attention, or need faster inference. Supports PyTorch native SDPA, flash-attn library, H100 FP8, and sliding window attention.
+Speed up long-sequence transformer training and inference.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-guidance.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-guidance.md
@@ -1,14 +1,14 @@
 ---
-title: "Guidance"
+title: "Guidance — Constrain LLM output with grammars; guarantee valid JSON"
 sidebar_label: "Guidance"
-description: "Control LLM output with regex and grammars, guarantee valid JSON/XML/code generation, enforce structured formats, and build multi-step workflows with Guidanc..."
+description: "Constrain LLM output with grammars; guarantee valid JSON"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Guidance
 
-Control LLM output with regex and grammars, guarantee valid JSON/XML/code generation, enforce structured formats, and build multi-step workflows with Guidance - Microsoft Research's constrained generation framework
+Constrain LLM output with grammars; guarantee valid JSON.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-huggingface-tokenizers.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-huggingface-tokenizers.md
@@ -1,14 +1,14 @@
 ---
-title: "Huggingface Tokenizers — Fast tokenizers optimized for research and production"
+title: "Huggingface Tokenizers — Fast BPE/WordPiece tokenization and custom vocab training"
 sidebar_label: "Huggingface Tokenizers"
-description: "Fast tokenizers optimized for research and production"
+description: "Fast BPE/WordPiece tokenization and custom vocab training"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Huggingface Tokenizers
 
-Fast tokenizers optimized for research and production. Rust-based implementation tokenizes 1GB in &lt;20 seconds. Supports BPE, WordPiece, and Unigram algorithms. Train custom vocabularies, track alignments, handle padding/truncation. Integrates seamlessly with transformers. Use when you need high-performance tokenization or custom tokenizer training.
+Fast BPE/WordPiece tokenization and custom vocab training.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-instructor.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-instructor.md
@@ -1,14 +1,14 @@
 ---
-title: "Instructor"
+title: "Instructor — Structured LLM outputs validated with Pydantic"
 sidebar_label: "Instructor"
-description: "Extract structured data from LLM responses with Pydantic validation, retry failed extractions automatically, parse complex JSON with type safety, and stream ..."
+description: "Structured LLM outputs validated with Pydantic"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Instructor
 
-Extract structured data from LLM responses with Pydantic validation, retry failed extractions automatically, parse complex JSON with type safety, and stream partial results with Instructor - battle-tested structured output library
+Structured LLM outputs validated with Pydantic.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-lambda-labs.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-lambda-labs.md
@@ -1,14 +1,14 @@
 ---
-title: "Lambda Labs Gpu Cloud — Reserved and on-demand GPU cloud instances for ML training and inference"
+title: "Lambda Labs Gpu Cloud — On-demand GPU cloud instances for ML training"
 sidebar_label: "Lambda Labs Gpu Cloud"
-description: "Reserved and on-demand GPU cloud instances for ML training and inference"
+description: "On-demand GPU cloud instances for ML training"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Lambda Labs Gpu Cloud
 
-Reserved and on-demand GPU cloud instances for ML training and inference. Use when you need dedicated GPU instances with simple SSH access, persistent filesystems, or high-performance multi-node clusters for large-scale training.
+On-demand GPU cloud instances for ML training.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-llava.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-llava.md
@@ -1,14 +1,14 @@
 ---
-title: "Llava — Large Language and Vision Assistant"
+title: "Llava — Vision-language chat: VQA, captioning, image dialogue"
 sidebar_label: "Llava"
-description: "Large Language and Vision Assistant"
+description: "Vision-language chat: VQA, captioning, image dialogue"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Llava
 
-Large Language and Vision Assistant. Enables visual instruction tuning and image-based conversations. Combines CLIP vision encoder with Vicuna/LLaMA language models. Supports multi-turn image chat, visual question answering, and instruction following. Use for vision-language chatbots or image understanding tasks. Best for conversational image analysis.
+Vision-language chat: VQA, captioning, image dialogue.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-modal.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-modal.md
@@ -1,14 +1,14 @@
 ---
-title: "Modal Serverless Gpu — Serverless GPU cloud platform for running ML workloads"
+title: "Modal Serverless Gpu — Serverless GPU cloud for ML jobs and model APIs"
 sidebar_label: "Modal Serverless Gpu"
-description: "Serverless GPU cloud platform for running ML workloads"
+description: "Serverless GPU cloud for ML jobs and model APIs"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Modal Serverless Gpu
 
-Serverless GPU cloud platform for running ML workloads. Use when you need on-demand GPU access without infrastructure management, deploying ML models as APIs, or running batch jobs with automatic scaling.
+Serverless GPU cloud for ML jobs and model APIs.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-nemo-curator.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-nemo-curator.md
@@ -1,14 +1,14 @@
 ---
-title: "Nemo Curator — GPU-accelerated data curation for LLM training"
+title: "Nemo Curator — Curate LLM training data: dedupe, filter, PII redaction"
 sidebar_label: "Nemo Curator"
-description: "GPU-accelerated data curation for LLM training"
+description: "Curate LLM training data: dedupe, filter, PII redaction"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Nemo Curator
 
-GPU-accelerated data curation for LLM training. Supports text/image/video/audio. Features fuzzy deduplication (16× faster), quality filtering (30+ heuristics), semantic deduplication, PII redaction, NSFW detection. Scales across GPUs with RAPIDS. Use for preparing high-quality training datasets, cleaning web data, or deduplicating large corpora.
+Curate LLM training data: dedupe, filter, PII redaction.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-peft.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-peft.md
@@ -1,14 +1,14 @@
 ---
-title: "Peft Fine Tuning — Parameter-efficient fine-tuning for LLMs using LoRA, QLoRA, and 25+ methods"
+title: "Peft Fine Tuning — Fine-tune large LLMs with LoRA on limited GPU memory"
 sidebar_label: "Peft Fine Tuning"
-description: "Parameter-efficient fine-tuning for LLMs using LoRA, QLoRA, and 25+ methods"
+description: "Fine-tune large LLMs with LoRA on limited GPU memory"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Peft Fine Tuning
 
-Parameter-efficient fine-tuning for LLMs using LoRA, QLoRA, and 25+ methods. Use when fine-tuning large models (7B-70B) with limited GPU memory, when you need to train &lt;1% of parameters with minimal accuracy loss, or for multi-adapter serving. HuggingFace's official library integrated with transformers ecosystem.
+Fine-tune large LLMs with LoRA on limited GPU memory.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-pytorch-fsdp.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-pytorch-fsdp.md
@@ -1,14 +1,14 @@
 ---
-title: "Pytorch Fsdp"
+title: "Pytorch Fsdp — Fully sharded data-parallel training for large models"
 sidebar_label: "Pytorch Fsdp"
-description: "Expert guidance for Fully Sharded Data Parallel training with PyTorch FSDP - parameter sharding, mixed precision, CPU offloading, FSDP2"
+description: "Fully sharded data-parallel training for large models"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Pytorch Fsdp
 
-Expert guidance for Fully Sharded Data Parallel training with PyTorch FSDP - parameter sharding, mixed precision, CPU offloading, FSDP2
+Fully sharded data-parallel training for large models.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-pytorch-lightning.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-pytorch-lightning.md
@@ -1,14 +1,14 @@
 ---
-title: "Pytorch Lightning"
+title: "Pytorch Lightning — Clean training loops with built-in distributed support"
 sidebar_label: "Pytorch Lightning"
-description: "High-level PyTorch framework with Trainer class, automatic distributed training (DDP/FSDP/DeepSpeed), callbacks system, and minimal boilerplate"
+description: "Clean training loops with built-in distributed support"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Pytorch Lightning
 
-High-level PyTorch framework with Trainer class, automatic distributed training (DDP/FSDP/DeepSpeed), callbacks system, and minimal boilerplate. Scales from laptop to supercomputer with same code. Use when you want clean training loops with built-in best practices.
+Clean training loops with built-in distributed support.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-qdrant.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-qdrant.md
@@ -1,14 +1,14 @@
 ---
-title: "Qdrant Vector Search — High-performance vector similarity search engine for RAG and semantic search"
+title: "Qdrant Vector Search — Vector search engine for production RAG systems"
 sidebar_label: "Qdrant Vector Search"
-description: "High-performance vector similarity search engine for RAG and semantic search"
+description: "Vector search engine for production RAG systems"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Qdrant Vector Search
 
-High-performance vector similarity search engine for RAG and semantic search. Use when building production RAG systems requiring fast nearest neighbor search, hybrid search with filtering, or scalable vector storage with Rust-powered performance.
+Vector search engine for production RAG systems.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-saelens.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-saelens.md
@@ -1,14 +1,14 @@
 ---
-title: "Sparse Autoencoder Training"
+title: "Sparse Autoencoder Training — Train sparse autoencoders to interpret model features"
 sidebar_label: "Sparse Autoencoder Training"
-description: "Provides guidance for training and analyzing Sparse Autoencoders (SAEs) using SAELens to decompose neural network activations into interpretable features"
+description: "Train sparse autoencoders to interpret model features"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Sparse Autoencoder Training
 
-Provides guidance for training and analyzing Sparse Autoencoders (SAEs) using SAELens to decompose neural network activations into interpretable features. Use when discovering interpretable features, analyzing superposition, or studying monosemantic representations in language models.
+Train sparse autoencoders to interpret model features.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-simpo.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-simpo.md
@@ -1,14 +1,14 @@
 ---
-title: "Simpo Training — Simple Preference Optimization for LLM alignment"
+title: "Simpo Training — Reference-free preference alignment, simpler than DPO"
 sidebar_label: "Simpo Training"
-description: "Simple Preference Optimization for LLM alignment"
+description: "Reference-free preference alignment, simpler than DPO"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Simpo Training
 
-Simple Preference Optimization for LLM alignment. Reference-free alternative to DPO with better performance (+6.4 points on AlpacaEval 2.0). No reference model needed, more efficient than DPO. Use for preference alignment when want simpler, faster training than DPO/PPO.
+Reference-free preference alignment, simpler than DPO.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-slime.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-slime.md
@@ -1,14 +1,14 @@
 ---
-title: "Slime Rl Training — Provides guidance for LLM post-training with RL using slime, a Megatron+SGLang framework"
+title: "Slime Rl Training — RL post-training for LLMs with Megatron and SGLang"
 sidebar_label: "Slime Rl Training"
-description: "Provides guidance for LLM post-training with RL using slime, a Megatron+SGLang framework"
+description: "RL post-training for LLMs with Megatron and SGLang"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Slime Rl Training
 
-Provides guidance for LLM post-training with RL using slime, a Megatron+SGLang framework. Use when training GLM models, implementing custom data generation workflows, or needing tight Megatron-LM integration for RL scaling.
+RL post-training for LLMs with Megatron and SGLang.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-stable-diffusion.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-stable-diffusion.md
@@ -1,14 +1,14 @@
 ---
-title: "Stable Diffusion Image Generation"
+title: "Stable Diffusion Image Generation — Text-to-image generation, inpainting, and img2img"
 sidebar_label: "Stable Diffusion Image Generation"
-description: "State-of-the-art text-to-image generation with Stable Diffusion models via HuggingFace Diffusers"
+description: "Text-to-image generation, inpainting, and img2img"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Stable Diffusion Image Generation
 
-State-of-the-art text-to-image generation with Stable Diffusion models via HuggingFace Diffusers. Use when generating images from text prompts, performing image-to-image translation, inpainting, or building custom diffusion pipelines.
+Text-to-image generation, inpainting, and img2img.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-tensorrt-llm.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-tensorrt-llm.md
@@ -1,14 +1,14 @@
 ---
-title: "Tensorrt Llm — Optimizes LLM inference with NVIDIA TensorRT for maximum throughput and lowest latency"
+title: "Tensorrt Llm — High-throughput LLM inference on NVIDIA GPUs"
 sidebar_label: "Tensorrt Llm"
-description: "Optimizes LLM inference with NVIDIA TensorRT for maximum throughput and lowest latency"
+description: "High-throughput LLM inference on NVIDIA GPUs"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Tensorrt Llm
 
-Optimizes LLM inference with NVIDIA TensorRT for maximum throughput and lowest latency. Use for production deployment on NVIDIA GPUs (A100/H100), when you need 10-100x faster inference than PyTorch, or for serving models with quantization (FP8/INT4), in-flight batching, and multi-GPU scaling.
+High-throughput LLM inference on NVIDIA GPUs.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-torchtitan.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-torchtitan.md
@@ -1,14 +1,14 @@
 ---
-title: "Distributed Llm Pretraining Torchtitan"
+title: "Distributed Llm Pretraining Torchtitan — Pretrain LLMs at scale with PyTorch 4D parallelism"
 sidebar_label: "Distributed Llm Pretraining Torchtitan"
-description: "Provides PyTorch-native distributed LLM pretraining using torchtitan with 4D parallelism (FSDP2, TP, PP, CP)"
+description: "Pretrain LLMs at scale with PyTorch 4D parallelism"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Distributed Llm Pretraining Torchtitan
 
-Provides PyTorch-native distributed LLM pretraining using torchtitan with 4D parallelism (FSDP2, TP, PP, CP). Use when pretraining Llama 3.1, DeepSeek V3, or custom models at scale from 8 to 512+ GPUs with Float8, torch.compile, and distributed checkpointing.
+Pretrain LLMs at scale with PyTorch 4D parallelism.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-whisper.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-whisper.md
@@ -1,14 +1,14 @@
 ---
-title: "Whisper — OpenAI's general-purpose speech recognition model"
+title: "Whisper — Transcribe and translate speech in 99 languages"
 sidebar_label: "Whisper"
-description: "OpenAI's general-purpose speech recognition model"
+description: "Transcribe and translate speech in 99 languages"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Whisper
 
-OpenAI's general-purpose speech recognition model. Supports 99 languages, transcription, translation to English, and language identification. Six model sizes from tiny (39M params) to large (1550M params). Use for speech-to-text, podcast transcription, or multilingual audio processing. Best for robust, multilingual ASR.
+Transcribe and translate speech in 99 languages.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/productivity/productivity-canvas.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-canvas.md
@@ -1,14 +1,14 @@
 ---
-title: "Canvas — Canvas LMS integration — fetch enrolled courses and assignments using API token authentication"
+title: "Canvas — Fetch Canvas LMS courses and assignments via API token"
 sidebar_label: "Canvas"
-description: "Canvas LMS integration — fetch enrolled courses and assignments using API token authentication"
+description: "Fetch Canvas LMS courses and assignments via API token"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Canvas
 
-Canvas LMS integration — fetch enrolled courses and assignments using API token authentication.
+Fetch Canvas LMS courses and assignments via API token.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/productivity/productivity-here-now.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-here-now.md
@@ -1,14 +1,14 @@
 ---
-title: "Here.Now — Publish static sites to {slug}"
+title: "Here.Now — Publish sites to {slug}"
 sidebar_label: "Here.Now"
-description: "Publish static sites to {slug}"
+description: "Publish sites to {slug}"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Here.Now
 
-Publish static sites to &#123;slug&#125;.here.now and store private files in cloud Drives for agent-to-agent handoff.
+Publish sites to &#123;slug&#125;.here.now and store files in Drives.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/productivity/productivity-shopify.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-shopify.md
@@ -1,14 +1,14 @@
 ---
-title: "Shopify — Shopify Admin & Storefront GraphQL APIs via curl"
+title: "Shopify — Query Shopify Admin/Storefront GraphQL APIs via curl"
 sidebar_label: "Shopify"
-description: "Shopify Admin & Storefront GraphQL APIs via curl"
+description: "Query Shopify Admin/Storefront GraphQL APIs via curl"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Shopify
 
-Shopify Admin & Storefront GraphQL APIs via curl. Products, orders, customers, inventory, metafields.
+Query Shopify Admin/Storefront GraphQL APIs via curl.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/productivity/productivity-siyuan.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-siyuan.md
@@ -1,14 +1,14 @@
 ---
-title: "Siyuan"
+title: "Siyuan — Query and edit a SiYuan knowledge base via its API"
 sidebar_label: "Siyuan"
-description: "SiYuan Note API for searching, reading, creating, and managing blocks and documents in a self-hosted knowledge base via curl"
+description: "Query and edit a SiYuan knowledge base via its API"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Siyuan
 
-SiYuan Note API for searching, reading, creating, and managing blocks and documents in a self-hosted knowledge base via curl.
+Query and edit a SiYuan knowledge base via its API.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/productivity/productivity-telephony.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-telephony.md
@@ -1,14 +1,14 @@
 ---
-title: "Telephony — Give Hermes phone capabilities without core tool changes"
+title: "Telephony — Provision Twilio numbers, SMS/MMS, and AI outbound calls"
 sidebar_label: "Telephony"
-description: "Give Hermes phone capabilities without core tool changes"
+description: "Provision Twilio numbers, SMS/MMS, and AI outbound calls"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Telephony
 
-Give Hermes phone capabilities without core tool changes. Provision and persist a Twilio number, send and receive SMS/MMS, make direct calls, and place AI-driven outbound calls through Bland.ai or Vapi.
+Provision Twilio numbers, SMS/MMS, and AI outbound calls.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/research/research-bioinformatics.md
+++ b/website/docs/user-guide/skills/optional/research/research-bioinformatics.md
@@ -1,14 +1,14 @@
 ---
-title: "Bioinformatics — Gateway to 400+ bioinformatics skills from bioSkills and ClawBio"
+title: "Bioinformatics — Gateway to 400+ genomics and computational biology skills"
 sidebar_label: "Bioinformatics"
-description: "Gateway to 400+ bioinformatics skills from bioSkills and ClawBio"
+description: "Gateway to 400+ genomics and computational biology skills"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Bioinformatics
 
-Gateway to 400+ bioinformatics skills from bioSkills and ClawBio. Covers genomics, transcriptomics, single-cell, variant calling, pharmacogenomics, metagenomics, structural biology, and more. Fetches domain-specific reference material on demand.
+Gateway to 400+ genomics and computational biology skills.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/research/research-domain-intel.md
+++ b/website/docs/user-guide/skills/optional/research/research-domain-intel.md
@@ -1,14 +1,14 @@
 ---
-title: "Domain Intel — Passive domain reconnaissance using Python stdlib"
+title: "Domain Intel — Passive recon of subdomains, SSL certs, WHOIS, and DNS"
 sidebar_label: "Domain Intel"
-description: "Passive domain reconnaissance using Python stdlib"
+description: "Passive recon of subdomains, SSL certs, WHOIS, and DNS"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Domain Intel
 
-Passive domain reconnaissance using Python stdlib. Subdomain discovery, SSL certificate inspection, WHOIS lookups, DNS records, domain availability checks, and bulk multi-domain analysis. No API keys required.
+Passive recon of subdomains, SSL certs, WHOIS, and DNS.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/research/research-duckduckgo-search.md
+++ b/website/docs/user-guide/skills/optional/research/research-duckduckgo-search.md
@@ -1,14 +1,14 @@
 ---
-title: "Duckduckgo Search — Free web search via DuckDuckGo — text, news, images, videos"
+title: "Duckduckgo Search — Free keyless web, news, and image search via ddgs"
 sidebar_label: "Duckduckgo Search"
-description: "Free web search via DuckDuckGo — text, news, images, videos"
+description: "Free keyless web, news, and image search via ddgs"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Duckduckgo Search
 
-Free web search via DuckDuckGo — text, news, images, videos. No API key needed. Prefer the `ddgs` CLI when installed; use the Python DDGS library only after verifying that `ddgs` is available in the current runtime.
+Free keyless web, news, and image search via ddgs.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/research/research-gitnexus-explorer.md
+++ b/website/docs/user-guide/skills/optional/research/research-gitnexus-explorer.md
@@ -1,14 +1,14 @@
 ---
-title: "Gitnexus Explorer"
+title: "Gitnexus Explorer — Serve an interactive codebase knowledge graph web UI"
 sidebar_label: "Gitnexus Explorer"
-description: "Index a codebase with GitNexus and serve an interactive knowledge graph via web UI + Cloudflare tunnel"
+description: "Serve an interactive codebase knowledge graph web UI"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Gitnexus Explorer
 
-Index a codebase with GitNexus and serve an interactive knowledge graph via web UI + Cloudflare tunnel.
+Serve an interactive codebase knowledge graph web UI.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/research/research-osint-investigation.md
+++ b/website/docs/user-guide/skills/optional/research/research-osint-investigation.md
@@ -1,14 +1,14 @@
 ---
-title: "Osint Investigation"
+title: "Osint Investigation — Follow the money via public records and sanctions data"
 sidebar_label: "Osint Investigation"
-description: "Public-records OSINT investigation framework — SEC EDGAR filings, USAspending contracts, Senate lobbying, OFAC sanctions, ICIJ offshore leaks, NYC property r..."
+description: "Follow the money via public records and sanctions data"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Osint Investigation
 
-Public-records OSINT investigation framework — SEC EDGAR filings, USAspending contracts, Senate lobbying, OFAC sanctions, ICIJ offshore leaks, NYC property records (ACRIS), OpenCorporates registries, CourtListener court records, Wayback Machine archives, Wikipedia + Wikidata, GDELT news monitoring. Entity resolution across sources, cross-link analysis, timing correlation, evidence chains. Python stdlib only.
+Follow the money via public records and sanctions data.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/research/research-parallel-cli.md
+++ b/website/docs/user-guide/skills/optional/research/research-parallel-cli.md
@@ -1,14 +1,14 @@
 ---
-title: "Parallel Cli"
+title: "Parallel Cli — Agent-native web search, deep research, and enrichment"
 sidebar_label: "Parallel Cli"
-description: "Optional vendor skill for Parallel CLI — agent-native web search, extraction, deep research, enrichment, FindAll, and monitoring"
+description: "Agent-native web search, deep research, and enrichment"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Parallel Cli
 
-Optional vendor skill for Parallel CLI — agent-native web search, extraction, deep research, enrichment, FindAll, and monitoring. Prefer JSON output and non-interactive flows.
+Agent-native web search, deep research, and enrichment.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/research/research-qmd.md
+++ b/website/docs/user-guide/skills/optional/research/research-qmd.md
@@ -1,14 +1,14 @@
 ---
-title: "Qmd"
+title: "Qmd — Hybrid local search over notes, docs, and transcripts"
 sidebar_label: "Qmd"
-description: "Search personal knowledge bases, notes, docs, and meeting transcripts locally using qmd — a hybrid retrieval engine with BM25, vector search, and LLM reranking"
+description: "Hybrid local search over notes, docs, and transcripts"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Qmd
 
-Search personal knowledge bases, notes, docs, and meeting transcripts locally using qmd — a hybrid retrieval engine with BM25, vector search, and LLM reranking. Supports CLI and MCP integration.
+Hybrid local search over notes, docs, and transcripts.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/research/research-scrapling.md
+++ b/website/docs/user-guide/skills/optional/research/research-scrapling.md
@@ -1,14 +1,14 @@
 ---
-title: "Scrapling"
+title: "Scrapling — Scrape sites with stealth browsing and Cloudflare bypass"
 sidebar_label: "Scrapling"
-description: "Web scraping with Scrapling - HTTP fetching, stealth browser automation, Cloudflare bypass, and spider crawling via CLI and Python"
+description: "Scrape sites with stealth browsing and Cloudflare bypass"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Scrapling
 
-Web scraping with Scrapling - HTTP fetching, stealth browser automation, Cloudflare bypass, and spider crawling via CLI and Python.
+Scrape sites with stealth browsing and Cloudflare bypass.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/research/research-searxng-search.md
+++ b/website/docs/user-guide/skills/optional/research/research-searxng-search.md
@@ -1,14 +1,14 @@
 ---
-title: "Searxng Search — Free meta-search via SearXNG — aggregates results from 70+ search engines"
+title: "Searxng Search — Free keyless meta-search aggregating 70+ engines"
 sidebar_label: "Searxng Search"
-description: "Free meta-search via SearXNG — aggregates results from 70+ search engines"
+description: "Free keyless meta-search aggregating 70+ engines"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Searxng Search
 
-Free meta-search via SearXNG — aggregates results from 70+ search engines. Self-hosted or use a public instance. No API key needed. Falls back automatically when the web search toolset is unavailable.
+Free keyless meta-search aggregating 70+ engines.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/security/security-1password.md
+++ b/website/docs/user-guide/skills/optional/security/security-1password.md
@@ -1,14 +1,14 @@
 ---
-title: "1Password — Set up and use 1Password CLI (op)"
+title: "1Password — Set up op CLI, sign in, and read or inject secrets"
 sidebar_label: "1Password"
-description: "Set up and use 1Password CLI (op)"
+description: "Set up op CLI, sign in, and read or inject secrets"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # 1Password
 
-Set up and use 1Password CLI (op). Use when installing the CLI, enabling desktop app integration, signing in, and reading/injecting secrets for commands.
+Set up op CLI, sign in, and read or inject secrets.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/security/security-sherlock.md
+++ b/website/docs/user-guide/skills/optional/security/security-sherlock.md
@@ -1,14 +1,14 @@
 ---
-title: "Sherlock — OSINT username search across 400+ social networks"
+title: "Sherlock — Find accounts for a username across 400+ platforms"
 sidebar_label: "Sherlock"
-description: "OSINT username search across 400+ social networks"
+description: "Find accounts for a username across 400+ platforms"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Sherlock
 
-OSINT username search across 400+ social networks. Hunt down social media accounts by username.
+Find accounts for a username across 400+ platforms.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/web-development/web-development-page-agent.md
+++ b/website/docs/user-guide/skills/optional/web-development/web-development-page-agent.md
@@ -1,14 +1,14 @@
 ---
-title: "Page Agent"
+title: "Page Agent — Embed an in-page natural-language GUI copilot in web apps"
 sidebar_label: "Page Agent"
-description: "Embed alibaba/page-agent into your own web application — a pure-JavaScript in-page GUI agent that ships as a single <script> tag or npm package and lets end-..."
+description: "Embed an in-page natural-language GUI copilot in web apps"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Page Agent
 
-Embed alibaba/page-agent into your own web application — a pure-JavaScript in-page GUI agent that ships as a single &lt;script> tag or npm package and lets end-users of your site drive the UI with natural language ("click login, fill username as John"). No Python, no headless browser, no extension required. Use this skill when the user is a web developer who wants to add an AI copilot to their SaaS / admin panel / B2B tool, make a legacy web app accessible via natural language, or evaluate page-agent against a local (Ollama) or cloud (Qwen / OpenAI / OpenRouter) LLM. NOT for server-side browser automation — point those users to Hermes' built-in browser tool instead.
+Embed an in-page natural-language GUI copilot in web apps.
 
 ## Skill metadata
 


### PR DESCRIPTION
## Summary
All 179 bundled + optional skill descriptions now fit the 60-char system-prompt budget — previously 69 of them were silently truncated to 57 chars + `...` in the skill index, destroying their routing signal (worst offender: 1,005 chars).

The system prompt shows only the first 57 chars of each description (`extract_skill_description`, `agent/skill_utils.py`), so anything past that was invisible to the router. Rewrites front-load the trigger, follow the authoring standard (≤60 chars, one sentence, ends with period, no marketing words, no name repetition), and rely on each skill's body for the detail that was dropped.

## Changes
- 69 `SKILL.md` frontmatter descriptions rewritten (23 mlops, 18 finance/research/security, 22 creative/devops/misc optional skills; 6 bundled)
- `website/`: both catalogs + 69 per-skill docs pages regenerated via `generate-skill-docs.py`
- Only `description:` lines touched in skill files; excluded `optional-skills/mlops/pinecone` (handled in #70512)

## Credit
- `touchdesigner-mcp` uses @JeliTron's exact trim from PR #32361 (co-author on the commit)
- Aligns with the router-precision direction of PR #48780 by @John-Lussier

## Validation
| | Result |
|---|---|
| Over-limit descriptions | 69 → 0 (pinecone lands via #70512) |
| YAML validity | all 69 parse via `yaml.safe_load` |
| `scripts/run_tests.sh tests/skills/` | 341/341 passed |

## Infographic

![description-cleanup](https://v3b.fal.media/files/b/0aa37ce7/jgHh3lKW6KdNZ-Xwmqh0k_KOXtwEBo.png)
