### PR TITLE
test(desktop): give the auto-compaction E2E real headroom over threshold_tokens

### DIFF
--- a/apps/desktop/e2e/session-compression-and-queue-stop.spec.ts
+++ b/apps/desktop/e2e/session-compression-and-queue-stop.spec.ts
@@ -122,11 +122,16 @@ auxiliary:
     // A normal message crosses the tiny configured context budget. The mock
     // blocks only the resulting summary request, so these assertions run
     // during automatic compaction rather than a slash-command path.
+    // The payload must cross threshold_tokens (22k) on its OWN weight
+    // (~12k tokens) on top of the system prompt. Do not shrink it: at
+    // repeat(500) the trigger only worked because the ambient system prompt
+    // (skills index + tool schemas) happened to carry it over the line, and
+    // a 160-token skills-index cleanup on main broke the test for a day.
     await pasteAndSend(page, 'E2E_COMPACTION_HISTORY_ONE '.repeat(5))
     await waitForTranscript(page, MOCK_REPLY)
     await pasteAndSend(page, 'E2E_COMPACTION_HISTORY_TWO '.repeat(5))
     await waitForTranscript(page, MOCK_REPLY)
-    await pasteAndSend(page, 'E2E_TRIGGER_AUTOMATIC_COMPACTION '.repeat(500))
+    await pasteAndSend(page, 'E2E_TRIGGER_AUTOMATIC_COMPACTION '.repeat(1500))
     await fixture.mock.waitForHeldCompletion()
     await expect(page.getByRole('status', { name: 'Summarizing thread' }).last()).toBeVisible()
 


### PR DESCRIPTION
## Summary

The Desktop E2E test "queues an Enter-submitted draft while compaction is active" now crosses the compaction threshold on its own payload weight, un-breaking the check that has been red on main and every PR branch since `9a4d1a0130` (~02:47Z today).

Root cause: at `repeat(500)` the trigger message is only ~4k tokens; the other ~18k needed to cross the fixture's `threshold_tokens: 22000` came from the ambient system prompt (tool schemas + bundled skills index + memory). The hermes-agent skill hub restructure (`e3d524b482`) legitimately shrank the bundled skills index by ~160 tokens, dropping the total just under threshold — compaction never started, `waitForHeldCompletion()` hung, and the test timed out at 90s on both attempts of every run.

## Changes

- `apps/desktop/e2e/session-compression-and-queue-stop.spec.ts`: trigger payload `repeat(500)` → `repeat(1500)` (~12.4k tokens, total ~30k vs the 22k threshold — ~8k margin), plus a comment documenting the invariant so future prompt-weight changes can't resurrect this.

## Validation

| | Before | After |
|---|---|---|
| Payload weight | ~4k tokens (trigger depended on ambient prompt) | ~12.4k tokens (self-sufficient) |
| Margin over 22k threshold | ~0 (one 160-token prompt change flipped it) | ~8k |
| Desktop E2E on main | red since 9a4d1a0130, 2/2 attempts, timeout 90s | green expected — CI on this PR is the proof |

Evidence: main runs 30062551968 / 30063335713 / 30064675595 all fail on exactly this one test; last green main run (4025329ac4) predates the skills-index shrink. Same single-test failure on 8 unrelated PR branches including markdown-only diffs.

## Infographic

![desktop-e2e-compaction-margin](https://v3b.fal.media/files/b/0aa37d1b/YsUv77pWAss_C6oGrbKy6_HzgDzJLt.png)
