### PR TITLE
fix(kanban): fail closed on unresolved explicit --project (#70386)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1495,32 +1495,36 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
-    with kb.connect_closing() as conn:
-        task_id = kb.create_task(
-            conn,
-            title=args.title,
-            body=args.body,
-            assignee=args.assignee,
-            created_by=args.created_by or _profile_author(),
-            workspace_kind=ws_kind,
-            workspace_path=ws_path,
-            branch_name=branch_name,
-            project_id=getattr(args, "project", None),
-            tenant=args.tenant,
-            priority=args.priority,
-            parents=tuple(args.parent or ()),
-            triage=bool(getattr(args, "triage", False)),
-            idempotency_key=getattr(args, "idempotency_key", None),
-            max_runtime_seconds=max_runtime,
-            skills=getattr(args, "skills", None) or None,
-            max_retries=max_retries,
-            model_override=getattr(args, "model_override", None),
-            provider_override=getattr(args, "provider_override", None),
-            goal_mode=bool(getattr(args, "goal_mode", False)),
-            goal_max_turns=getattr(args, "goal_max_turns", None),
-            initial_status=getattr(args, "initial_status", "running"),
-        )
-        task = kb.get_task(conn, task_id)
+    try:
+        with kb.connect_closing() as conn:
+            task_id = kb.create_task(
+                conn,
+                title=args.title,
+                body=args.body,
+                assignee=args.assignee,
+                created_by=args.created_by or _profile_author(),
+                workspace_kind=ws_kind,
+                workspace_path=ws_path,
+                branch_name=branch_name,
+                project_id=getattr(args, "project", None),
+                tenant=args.tenant,
+                priority=args.priority,
+                parents=tuple(args.parent or ()),
+                triage=bool(getattr(args, "triage", False)),
+                idempotency_key=getattr(args, "idempotency_key", None),
+                max_runtime_seconds=max_runtime,
+                skills=getattr(args, "skills", None) or None,
+                max_retries=max_retries,
+                model_override=getattr(args, "model_override", None),
+                provider_override=getattr(args, "provider_override", None),
+                goal_mode=bool(getattr(args, "goal_mode", False)),
+                goal_max_turns=getattr(args, "goal_max_turns", None),
+                initial_status=getattr(args, "initial_status", "running"),
+            )
+            task = kb.get_task(conn, task_id)
+    except ValueError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2970,10 +2970,22 @@ def create_task(
                             workspace_kind = "worktree"
 
         if project_obj is None:
-            # A project id/slug that doesn't resolve must not crash task
-            # creation or persist a dangling reference — drop the link and
-            # create the task as an ordinary (scratch) task.
-            project_id = None
+            # An explicit project id/slug that doesn't resolve must fail
+            # closed. Silently creating a scratch task here hid typos and
+            # per-profile registry mismatches behind exit 0 (#70386). The
+            # project_source_task_id fallback above still covers legitimate
+            # cross-profile worker children before we reach this branch.
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+
+                profile_name = get_active_profile_name()
+            except Exception:
+                profile_name = "default"
+            raise ValueError(
+                f"project {project_id!r} not found in profile {profile_name!r}. "
+                "Register it with `hermes project create` or check "
+                "`hermes project list` (projects are per-profile)."
+            )
         else:
             # Canonicalise (a slug may have been passed) and anchor the
             # worktree under the project's primary repo.

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -24,6 +24,24 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+def test_cmd_create_rejects_unknown_explicit_project(kanban_home, capsys):
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(
+        ["kanban", "create", "orphaned task", "--project", "does-not-exist"]
+    )
+
+    rc = kc._cmd_create(args)
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "project 'does-not-exist' not found" in captured.err
+    assert "hermes project list" in captured.err
+    with kb.connect_closing() as conn:
+        assert kb.list_tasks(conn, limit=100) == []
+
+
 # ---------------------------------------------------------------------------
 # Workspace flag parsing
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_project_link.py
+++ b/tests/hermes_cli/test_kanban_project_link.py
@@ -64,3 +64,16 @@ def test_unlinked_task_unchanged(kanban_conn):
     assert task.branch_name is None
 
 
+def test_unknown_project_id_fails_closed(kanban_conn):
+    # An explicit project id/slug that doesn't resolve must fail closed so a
+    # typo or per-profile registry mismatch cannot silently become a scratch
+    # task (#70386). Omitting project_id keeps ordinary scratch behaviour.
+    with pytest.raises(ValueError, match=r"project 'does-not-exist' not found"):
+        kb.create_task(kanban_conn, title="x", project_id="does-not-exist")
+
+
+def test_blank_project_id_treated_as_omitted(kanban_conn):
+    tid = kb.create_task(kanban_conn, title="x", project_id="  ")
+    task = kb.get_task(kanban_conn, tid)
+    assert task.project_id is None
+    assert task.workspace_kind == "scratch"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,31 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_rejects_unknown_explicit_project(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    with kb.connect_closing() as conn:
+        task_ids_before = {task.id for task in kb.list_tasks(conn, limit=100)}
+
+    result = json.loads(
+        kt._handle_create(
+            {
+                "title": "orphaned child",
+                "assignee": "peer",
+                "project": "does-not-exist",
+            }
+        )
+    )
+
+    assert result.get("error"), result
+    assert "project 'does-not-exist' not found" in result["error"]
+    assert "hermes project list" in result["error"]
+    with kb.connect_closing() as conn:
+        task_ids_after = {task.id for task in kb.list_tasks(conn, limit=100)}
+    assert task_ids_after == task_ids_before
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()


### PR DESCRIPTION
## Summary

Fixes #70386

`hermes kanban create --project <slug>` (and the equivalent tool argument) used to succeed even when the slug was missing from the active profile's project registry. `create_task()` dropped the unresolved id and created a scratch task instead, so the first signal of the mismatch was JSON with `project_id: null`.

An explicit project request should fail closed. Omitting `--project` keeps today's generic/scratch behaviour.

## Root cause

In `hermes_cli/kanban_db.py::create_task`, after `projects_db.get_project()` missed (and after the existing `project_source_task_id` cross-profile recovery path), the code did:

```python
project_id = None  # continue as scratch
```

That soft-drop made sense as a dangling-reference guard, but it hid typos and multi-profile registry mismatches behind exit 0.

## Fix

1. **`create_task()`** — raise `ValueError` naming the requested project + active profile, pointing at `hermes project create` / `hermes project list`.
2. **CLI `_cmd_create`** — catch `ValueError` and exit 2 with `kanban: …` on stderr (tool path already maps `ValueError` via `tool_error`).
3. **Tests** — flip `test_unknown_project_id_falls_back_gracefully` to the fail-closed contract; add blank-`project_id` treated-as-omitted coverage.

## Deliberately not changed

- **`project_source_task_id` cross-profile worker fallback** stays. Legitimate worker children that inherit a canonical project-linked source task still resolve without the creator profile's `projects.db`.
- **Omitting `project_id`** still creates an ordinary scratch/generic task.
- **Blank/whitespace `project_id`** still normalises to omitted (not an error).

## Sibling call paths

| Path | Behaviour after this PR |
|---|---|
| `hermes_cli/kanban_db.py::create_task` | raises on unresolved explicit project |
| `hermes_cli/kanban.py::_cmd_create` | surfaces as exit 2 |
| `tools/kanban_tools.py` create | already `except ValueError → tool_error` |
| omit / blank project | unchanged scratch path |
| `project_source_task_id` recovery | still tried before the raise |

## Test plan

- [x] RED on unpatched main: `test_unknown_project_id_fails_closed` DID NOT RAISE
- [x] GREEN with fix: `tests/hermes_cli/test_kanban_project_link.py` — 5 passed
- [x] Nearby CLI create tests still green (`test_kanban_cli.py -k create`)

```bash
source ~/.hermes/hermes-agent/venv/bin/activate
pytest tests/hermes_cli/test_kanban_project_link.py -v
```

---

NL (voor Michael): simpele fail-closed fix. Onbekend `--project` → harde fout i.p.v. stille scratch-card. Cross-profile worker-fallback blijft intact.
