### PR TITLE
fix(tts): batch synchronous provider playback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12391,9 +12391,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._reasoning_shown_this_turn = False
 
             # --- Streaming TTS setup ---
-            # Any working TTS provider streams sentence-by-sentence as the agent
-            # generates tokens: PCM-streaming providers (ElevenLabs, OpenAI) play
-            # chunks as they arrive, everything else synthesizes per sentence.
+            # Providers with chunked PCM APIs stream sentence-by-sentence as the
+            # agent generates tokens. Synchronous providers use batch TTS after
+            # the response completes to avoid pauses between synthesis requests.
             use_streaming_tts = False
             _streaming_box_opened = False
             text_queue = None
@@ -12405,11 +12405,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 try:
                     from tools.tts_tool import (
                         _import_sounddevice,
-                        check_tts_requirements,
+                        supports_realtime_streaming_tts,
                         stream_tts_to_speaker,
                     )
                     _import_sounddevice()
-                    use_streaming_tts = check_tts_requirements()
+                    use_streaming_tts = supports_realtime_streaming_tts()
                 except Exception:
                     pass
 

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -8,7 +8,7 @@ the chunked-streamer playback path, and the universal per-sentence sync fallback
 
 import queue
 import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -123,16 +123,138 @@ def test_never_swaps_provider_for_streaming(monkeypatch):
 # ── Built-in provider availability ───────────────────────────────────────
 
 
-def test_elevenlabs_available_reflects_key(monkeypatch):
+def test_elevenlabs_available_requires_key_and_sdk(monkeypatch):
+    from tools import tts_tool
+
     monkeypatch.setattr(ts, "get_env_value", lambda k, *a: "key" if k == "ELEVENLABS_API_KEY" else None)
+    monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: MagicMock())
     assert ts.ElevenLabsStreamer.available() is True
     monkeypatch.setattr(ts, "get_env_value", lambda k, *a: None)
     assert ts.ElevenLabsStreamer.available() is False
 
 
-def test_openai_available_reflects_key(monkeypatch):
-    monkeypatch.setattr(ts, "get_env_value", lambda k, *a: "key" if k == "OPENAI_API_KEY" else None)
+def test_elevenlabs_unavailable_when_sdk_import_fails(monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setattr(ts, "get_env_value", lambda k, *a: "key" if k == "ELEVENLABS_API_KEY" else None)
+    monkeypatch.setattr(
+        tts_tool,
+        "_import_elevenlabs",
+        MagicMock(side_effect=ImportError("missing elevenlabs")),
+    )
+
+    assert ts.ElevenLabsStreamer.available() is False
+
+
+def test_openai_available_requires_resolved_audio_credentials_and_sdk(monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: MagicMock())
+    monkeypatch.setattr(
+        tts_tool,
+        "_resolve_openai_audio_client_config",
+        lambda: ("voice-key", "https://api.openai.com/v1", False),
+    )
     assert ts.OpenAIStreamer.available() is True
+
+
+def test_openai_unavailable_when_sdk_import_fails(monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setattr(
+        tts_tool,
+        "_resolve_openai_audio_client_config",
+        lambda: ("voice-key", "https://api.openai.com/v1", False),
+    )
+    monkeypatch.setattr(
+        tts_tool,
+        "_import_openai_client",
+        MagicMock(side_effect=ImportError("missing openai")),
+    )
+
+    assert ts.OpenAIStreamer.available() is False
+
+
+def test_openai_unavailable_when_audio_credentials_cannot_resolve(monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: MagicMock())
+    monkeypatch.setattr(
+        tts_tool,
+        "_resolve_openai_audio_client_config",
+        MagicMock(side_effect=ValueError("missing credentials")),
+    )
+
+    assert ts.OpenAIStreamer.available() is False
+
+
+def test_openai_stream_uses_resolved_audio_credentials_and_config_base_url(monkeypatch):
+    from tools import tts_tool
+
+    client_class = MagicMock()
+    client = client_class.return_value
+    response = client.audio.speech.with_streaming_response.create.return_value
+    response.__enter__.return_value.iter_bytes.return_value = iter([b"pcm"])
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: client_class)
+    monkeypatch.setattr(
+        tts_tool,
+        "_resolve_openai_audio_client_config",
+        lambda: ("voice-key", "https://resolved.example/v1", False),
+    )
+    streamer = ts.OpenAIStreamer(
+        {},
+        {
+            "base_url": "https://configured.example/v1",
+            "model": "custom-tts",
+            "voice": "nova",
+        },
+    )
+
+    assert list(streamer.stream("hello")) == [b"pcm"]
+    client_class.assert_called_once_with(
+        api_key="voice-key",
+        base_url="https://configured.example/v1",
+    )
+    client.audio.speech.with_streaming_response.create.assert_called_once_with(
+        model="custom-tts",
+        voice="nova",
+        input="hello",
+        response_format="pcm",
+        extra_headers={"x-idempotency-key": ANY},
+    )
+    client.close.assert_called_once_with()
+
+
+def test_openai_stream_keeps_managed_token_on_managed_gateway(monkeypatch):
+    from tools import tts_tool
+
+    client_class = MagicMock()
+    client = client_class.return_value
+    response = client.audio.speech.with_streaming_response.create.return_value
+    response.__enter__.return_value.iter_bytes.return_value = iter([b"pcm"])
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: client_class)
+    monkeypatch.setattr(
+        tts_tool,
+        "_resolve_openai_audio_client_config",
+        lambda: ("managed-token", "https://managed.example/v1", True),
+    )
+    streamer = ts.OpenAIStreamer(
+        {},
+        {
+            "base_url": "https://untrusted.example/v1",
+            "model": "unsupported-model",
+        },
+    )
+
+    assert list(streamer.stream("hello")) == [b"pcm"]
+    client_class.assert_called_once_with(
+        api_key="managed-token",
+        base_url="https://managed.example/v1",
+    )
+    request = client.audio.speech.with_streaming_response.create
+    assert request.call_args.kwargs["model"] == tts_tool.DEFAULT_OPENAI_MODEL
+    assert request.call_args.kwargs["extra_headers"]["x-idempotency-key"]
+    client.close.assert_called_once_with()
 
 
 # ── Dispatch: chunked streamer path ──────────────────────────────────────

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -178,39 +178,39 @@ class TestVoiceStateLock:
 # ============================================================================
 
 class TestStreamingTTSActivation:
-    """The CLI streaming gate: sounddevice + a working provider, ANY provider.
+    """The CLI streaming gate requires sounddevice and a chunked provider.
 
-    Mirrors cli.py's gate exactly — streaming engages whenever audio output
-    exists and check_tts_requirements() passes, regardless of which provider
-    is configured (non-streamers get the per-sentence sync path downstream).
+    Synchronous providers use the existing batch TTS path so playback remains
+    continuous instead of pausing between sentence-level synthesis requests.
     """
 
     @staticmethod
     def _gate() -> bool:
         """The cli.py streaming-TTS gate, verbatim."""
         try:
-            from tools.tts_tool import _import_sounddevice, check_tts_requirements
+            from tools.tts_tool import (
+                _import_sounddevice,
+                supports_realtime_streaming_tts,
+            )
             _import_sounddevice()
-            return check_tts_requirements()
+            return supports_realtime_streaming_tts()
         except Exception:
             return False
 
-    def test_activates_for_any_working_provider(self):
-        """Any provider that passes check_tts_requirements engages streaming."""
+    def test_activates_for_chunked_provider(self):
         with patch("tools.tts_tool._import_sounddevice", return_value=MagicMock()), \
-             patch("tools.tts_tool.check_tts_requirements", return_value=True):
+             patch("tools.tts_tool.supports_realtime_streaming_tts", return_value=True):
             assert self._gate() is True
 
-    def test_does_not_activate_when_provider_unavailable(self):
-        """No working TTS provider → no streaming pipeline."""
+    def test_does_not_activate_for_synchronous_provider(self):
         with patch("tools.tts_tool._import_sounddevice", return_value=MagicMock()), \
-             patch("tools.tts_tool.check_tts_requirements", return_value=False):
+             patch("tools.tts_tool.supports_realtime_streaming_tts", return_value=False):
             assert self._gate() is False
 
     def test_does_not_activate_when_sounddevice_missing(self):
         """No audio output device → no streaming pipeline, even with a provider."""
         with patch("tools.tts_tool._import_sounddevice", side_effect=OSError("no PortAudio")), \
-             patch("tools.tts_tool.check_tts_requirements", return_value=True):
+             patch("tools.tts_tool.supports_realtime_streaming_tts", return_value=True):
             assert self._gate() is False
 
     def test_stale_boolean_imports_no_longer_exist(self):
@@ -220,6 +220,21 @@ class TestStreamingTTSActivation:
             "_HAS_ELEVENLABS should not exist -- lazy imports replaced it"
         assert not hasattr(tts_mod, "_HAS_AUDIO"), \
             "_HAS_AUDIO should not exist -- lazy imports replaced it"
+
+    def test_requires_a_registered_chunked_provider(self):
+        from tools.tts_tool import supports_realtime_streaming_tts
+
+        with patch("tools.tts_streaming.resolve_streaming_provider", return_value=None):
+            assert supports_realtime_streaming_tts() is False
+
+    def test_accepts_an_available_chunked_provider(self):
+        from tools.tts_tool import supports_realtime_streaming_tts
+
+        with patch(
+            "tools.tts_streaming.resolve_streaming_provider",
+            return_value=MagicMock(),
+        ):
+            assert supports_realtime_streaming_tts() is True
 
 
 # ============================================================================

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -250,4 +250,6 @@ class OpenAIStreamer(StreamingTTSProvider):
             ) as response:
                 yield from response.iter_bytes()
         finally:
-            client.close()
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -11,9 +11,9 @@ Two provider shapes, one contract (int16 mono PCM at ``sample_rate``):
 * **True streamers** (`StreamingTTSProvider.stream`) — chunked APIs
   (ElevenLabs pcm_24000, OpenAI pcm, …) that yield audio as it synthesizes.
   Lowest time-to-first-audio.
-* **Everyone else** — providers with no chunked API still get per-*sentence*
-  playback via the proven sync `text_to_speech_tool` path (handled by the
-  dispatcher, not here), so edge (the default) is conversational too.
+* **Everyone else** — direct dispatcher callers retain per-*sentence* sync
+  playback. The CLI instead routes these providers through whole-response batch
+  TTS so separate synthesis requests cannot introduce inter-sentence pauses.
 
 Adding a streamer is `@register("name")` on a `StreamingTTSProvider` subclass;
 the dispatcher, config gate (`tts.<name>.streaming`), and resolver come free.
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+import uuid
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, Iterator, List, Optional
 
@@ -144,9 +145,9 @@ def resolve_streaming_provider(
 ) -> Optional[StreamingTTSProvider]:
     """Return a ready streamer for the *configured* provider, else ``None``.
 
-    ``None`` means "no chunked API for this provider" — the dispatcher then
-    speaks per-sentence via the sync path, preserving the user's chosen voice.
-    We never silently swap to a different provider just to get streaming.
+    ``None`` means "no chunked API for this provider". Direct dispatcher callers
+    retain the sync path, while the CLI uses whole-response batch TTS. We never
+    silently swap to a different provider just to get streaming.
     """
     name = (preferred or _get_provider(tts_config)).lower().strip()
     cls = _REGISTRY.get(name)
@@ -171,7 +172,15 @@ class ElevenLabsStreamer(StreamingTTSProvider):
 
     @staticmethod
     def available() -> bool:
-        return bool(get_env_value("ELEVENLABS_API_KEY"))
+        if not get_env_value("ELEVENLABS_API_KEY"):
+            return False
+        try:
+            from tools.tts_tool import _import_elevenlabs
+
+            _import_elevenlabs()
+            return True
+        except ImportError:
+            return False
 
     def stream(self, text: str) -> Iterator[bytes]:
         from tools.tts_tool import (
@@ -202,21 +211,43 @@ class OpenAIStreamer(StreamingTTSProvider):
 
     @staticmethod
     def available() -> bool:
-        return bool(get_env_value("OPENAI_API_KEY"))
+        try:
+            from tools.tts_tool import (
+                _import_openai_client,
+                _resolve_openai_audio_client_config,
+            )
+
+            _import_openai_client()
+            _resolve_openai_audio_client_config()
+            return True
+        except (ImportError, ValueError):
+            return False
 
     def stream(self, text: str) -> Iterator[bytes]:
-        from openai import OpenAI
-
-        client = OpenAI(
-            api_key=get_env_value("OPENAI_API_KEY"),
-            base_url=get_env_value("OPENAI_BASE_URL") or None,
+        from tools.tts_tool import (
+            DEFAULT_OPENAI_MODEL,
+            DEFAULT_OPENAI_VOICE,
+            MANAGED_OPENAI_TTS_MODELS,
+            _import_openai_client,
+            _resolve_openai_audio_client_config,
         )
-        model = self.section.get("model", "gpt-4o-mini-tts")
-        voice = self.section.get("voice", "alloy")
-        with client.audio.speech.with_streaming_response.create(
-            model=model,
-            voice=voice,
-            input=text,
-            response_format="pcm",
-        ) as response:
-            yield from response.iter_bytes()
+
+        api_key, resolved_base_url, is_managed = _resolve_openai_audio_client_config()
+        configured_base_url = self.section.get("base_url")
+        base_url = resolved_base_url if is_managed else configured_base_url or resolved_base_url
+        model = self.section.get("model", DEFAULT_OPENAI_MODEL)
+        if is_managed and model not in MANAGED_OPENAI_TTS_MODELS:
+            model = DEFAULT_OPENAI_MODEL
+        voice = self.section.get("voice", DEFAULT_OPENAI_VOICE)
+        client = _import_openai_client()(api_key=api_key, base_url=base_url)
+        try:
+            with client.audio.speech.with_streaming_response.create(
+                model=model,
+                voice=voice,
+                input=text,
+                response_format="pcm",
+                extra_headers={"x-idempotency-key": str(uuid.uuid4())},
+            ) as response:
+                yield from response.iter_bytes()
+        finally:
+            client.close()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2721,6 +2721,26 @@ def _has_openai_audio_backend() -> bool:
 # ===========================================================================
 # Streaming TTS: sentence-by-sentence pipeline
 # ===========================================================================
+
+def supports_realtime_streaming_tts(provider: Optional[str] = None) -> bool:
+    """Return whether the configured provider can stream PCM audio chunks.
+
+    Sentence-at-a-time synthesis through a synchronous provider introduces a
+    full network round trip between sentences. Callers should use batch TTS
+    instead so the provider generates one continuous clip with natural pacing.
+
+    Args:
+        provider: Optional provider override. The configured provider is used
+            when omitted.
+
+    Returns:
+        True when a registered, available streaming provider resolves.
+    """
+    from tools.tts_streaming import resolve_streaming_provider
+
+    tts_config = _load_tts_config()
+    return resolve_streaming_provider(tts_config, preferred=provider) is not None
+
 # Markdown stripping patterns (same as cli.py _voice_speak_response)
 _MD_CODE_BLOCK = re.compile(r'```[\s\S]*?```')
 _MD_LINK = re.compile(r'\[([^\]]+)\]\([^)]+\)')
@@ -2784,8 +2804,9 @@ def stream_tts_to_speaker(
         output_stream = None
         tts_config = _load_tts_config()
 
-        # Prefer a chunked streamer for low time-to-first-audio; fall back to
-        # per-sentence sync synthesis (universal — edge + every non-streamer).
+        # Prefer a chunked streamer for low time-to-first-audio. This function
+        # retains its sync fallback for direct callers; the CLI only enters this
+        # pipeline when a chunked provider is available.
         from tools.tts_streaming import SentenceChunker, resolve_streaming_provider
         streamer = resolve_streaming_provider(tts_config, preferred=provider)
 


### PR DESCRIPTION
## Summary

- use realtime sentence playback only for providers with an available chunked PCM implementation
- route synchronous providers through the existing whole-response batch path to avoid pauses between synthesis requests
- preserve OpenAI audio credential, endpoint, managed-gateway, and model-selection behavior in realtime mode
- prevent managed credentials from being sent to custom origins and close per-request clients
- add provider capability and credential-routing regression coverage

## Test plan

- `scripts/run_tests.sh tests/tools/test_voice_cli_integration.py tests/tools/test_tts_streaming.py` (111 passed)
- `.venv/bin/ruff check cli.py tools/tts_tool.py tools/tts_streaming.py tests/tools/test_voice_cli_integration.py tests/tools/test_tts_streaming.py`
- `.venv/bin/python -m py_compile cli.py tools/tts_tool.py tools/tts_streaming.py tests/tools/test_voice_cli_integration.py tests/tools/test_tts_streaming.py`
- `git diff --check`