### PR TITLE
feat(desktop): keyboard-accessible "Insert into Chat" in the Files panel

### DIFF
--- a/apps/desktop/src/app/right-sidebar/file-actions.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/file-actions.test.tsx
@@ -1,0 +1,189 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  onComposerFocusRequest,
+  onComposerInsertRequest
+} from '@/app/chat/composer/focus'
+import { $currentCwd } from '@/store/session'
+
+import {
+  FileEntryContextMenu,
+  insertFileTargetIntoChat,
+  isInsertIntoChatShortcut,
+  isRenameShortcut
+} from './file-actions'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  translateNow: (key: string) => key,
+  useI18n: () => ({
+    t: {
+      fileMenu: {
+        insertIntoChat: 'Insert into Chat',
+        revealFinder: 'Reveal in Finder',
+        revealExplorer: 'Reveal in File Explorer',
+        revealFileManager: 'Open Containing Folder',
+        copyPath: 'Copy Path',
+        copyRelativePath: 'Copy Relative Path',
+        rename: 'Rename…',
+        delete: 'Delete',
+        deleteTitle: (name: string) => `Delete ${name}?`,
+        deleteBody: 'It will be moved to the Trash.'
+      }
+    }
+  })
+}))
+
+vi.mock('@/lib/desktop-fs', () => ({
+  copyTextToClipboard: vi.fn(),
+  isDesktopFsRemoteMode: () => false,
+  readDesktopFileDataUrl: vi.fn(),
+  renameDesktopPath: vi.fn(),
+  revealDesktopPath: vi.fn(),
+  trashDesktopPath: vi.fn()
+}))
+
+// Radix menus measure themselves; jsdom has no ResizeObserver.
+beforeAll(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+})
+
+/** The insert/focus bus defers dispatch by a macrotask — flush it. */
+const flushBus = () => new Promise(resolve => setTimeout(resolve, 1))
+
+interface CapturedInsert {
+  mode: string
+  target: string
+  text: string
+}
+
+function captureBus() {
+  const inserts: CapturedInsert[] = []
+  const focuses: string[] = []
+  const offInsert = onComposerInsertRequest(detail => inserts.push(detail))
+  const offFocus = onComposerFocusRequest(detail => focuses.push(detail.target))
+
+  return { focuses, inserts, stop: () => (offInsert(), offFocus()) }
+}
+
+beforeEach(() => {
+  $currentCwd.set('/repo')
+})
+
+describe('insertFileTargetIntoChat', () => {
+  it('inserts a workspace-relative @file: chip inline', async () => {
+    const bus = captureBus()
+
+    expect(insertFileTargetIntoChat({ isDirectory: false, path: '/repo/src/main.ts' })).toBe(true)
+    await flushBus()
+    bus.stop()
+
+    expect(bus.inserts).toEqual([{ mode: 'inline', target: 'main', text: '@file:src/main.ts' }])
+    expect(bus.focuses).toEqual([])
+  })
+
+  it('inserts folders as @folder: chips', async () => {
+    const bus = captureBus()
+
+    expect(insertFileTargetIntoChat({ isDirectory: true, path: '/repo/src' })).toBe(true)
+    await flushBus()
+    bus.stop()
+
+    expect(bus.inserts).toEqual([{ mode: 'inline', target: 'main', text: '@folder:src' }])
+  })
+
+  it('keeps paths outside the workspace absolute', async () => {
+    const bus = captureBus()
+
+    insertFileTargetIntoChat({ isDirectory: false, path: '/elsewhere/notes.md' })
+    await flushBus()
+    bus.stop()
+
+    expect(bus.inserts.map(entry => entry.text)).toEqual(['@file:/elsewhere/notes.md'])
+  })
+
+  it('focuses the composer only when asked (context-menu flow)', async () => {
+    const bus = captureBus()
+
+    insertFileTargetIntoChat({ isDirectory: false, path: '/repo/a.ts' }, { focusComposer: true })
+    await flushBus()
+    bus.stop()
+
+    expect(bus.focuses).toEqual(['main'])
+  })
+
+  it('is a no-op for empty paths', async () => {
+    const bus = captureBus()
+
+    expect(insertFileTargetIntoChat({ isDirectory: false, path: '' })).toBe(false)
+    await flushBus()
+    bus.stop()
+
+    expect(bus.inserts).toEqual([])
+  })
+})
+
+describe('row shortcuts', () => {
+  it('Enter (unmodified) is the insert-into-chat shortcut', () => {
+    expect(isInsertIntoChatShortcut(new KeyboardEvent('keydown', { key: 'Enter' }))).toBe(true)
+
+    for (const modifier of ['altKey', 'ctrlKey', 'metaKey', 'shiftKey'] as const) {
+      const event = new KeyboardEvent('keydown', { key: 'Enter', [modifier]: true })
+
+      expect(isInsertIntoChatShortcut(event)).toBe(false)
+    }
+  })
+
+  it('rename is F2-only — Enter no longer renames', () => {
+    expect(isRenameShortcut(new KeyboardEvent('keydown', { key: 'F2' }))).toBe(true)
+    expect(isRenameShortcut(new KeyboardEvent('keydown', { key: 'Enter' }))).toBe(false)
+  })
+})
+
+describe('FileEntryContextMenu', () => {
+  it('offers "Insert into Chat" and routes it through the composer bus', async () => {
+    const bus = captureBus()
+
+    render(
+      <FileEntryContextMenu isDirectory={false} name="main.ts" path="/repo/src/main.ts" relativeTo="/repo">
+        <div data-testid="row">main.ts</div>
+      </FileEntryContextMenu>
+    )
+
+    fireEvent.contextMenu(screen.getByTestId('row'))
+    const item = await screen.findByText('Insert into Chat')
+    fireEvent.click(item)
+    await flushBus()
+    bus.stop()
+
+    expect(bus.inserts).toEqual([{ mode: 'inline', target: 'main', text: '@file:src/main.ts' }])
+    // Mouse flow: hand focus to the composer so the user can type the prompt.
+    expect(bus.focuses).toEqual(['main'])
+  })
+
+  it('inserts folder entries as @folder: chips', async () => {
+    const bus = captureBus()
+
+    render(
+      <FileEntryContextMenu isDirectory name="src" path="/repo/src" relativeTo="/repo">
+        <div data-testid="row">src</div>
+      </FileEntryContextMenu>
+    )
+
+    fireEvent.contextMenu(screen.getByTestId('row'))
+    fireEvent.click(await screen.findByText('Insert into Chat'))
+    await flushBus()
+    bus.stop()
+
+    expect(bus.inserts.map(entry => entry.text)).toEqual(['@folder:src'])
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/file-actions.tsx
+++ b/apps/desktop/src/app/right-sidebar/file-actions.tsx
@@ -1,6 +1,8 @@
 import { useStore } from '@nanostores/react'
 import { type KeyboardEvent as ReactKeyboardEvent, type ReactNode, useRef, useState } from 'react'
 
+import { requestComposerFocus, requestComposerInsert } from '@/app/chat/composer/focus'
+import { droppedFileInlineRef } from '@/app/chat/composer/inline-refs'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import {
   ContextMenu,
@@ -27,12 +29,50 @@ import {
   toRelativePath
 } from '@/store/file-actions'
 import { notifyError } from '@/store/notifications'
+import { $currentCwd } from '@/store/session'
 
 const IS_WIN = typeof navigator !== 'undefined' && /win/i.test(navigator.platform || navigator.userAgent || '')
 
-// F2 starts a rename anywhere; Enter starts one when a row is focused (VS Code).
+// F2 starts a rename (Explorer/VS Code-Windows style). Enter is reserved for
+// "Insert into chat" — the panel's primary action (see isInsertIntoChatShortcut).
 export function isRenameShortcut(event: KeyboardEvent | ReactKeyboardEvent): boolean {
-  return event.key === 'F2' || event.key === 'Enter'
+  return event.key === 'F2'
+}
+
+// Bare Enter on a focused row inserts it into the chat input — the keyboard
+// twin of the context menu's "Insert into Chat" (drag-free attach, #69741).
+// Modified Enter is left alone so future combos don't silently collide.
+export function isInsertIntoChatShortcut(event: KeyboardEvent | ReactKeyboardEvent): boolean {
+  return event.key === 'Enter' && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey
+}
+
+/**
+ * Insert a file/folder into the chat composer as an inline `@file:`/`@folder:`
+ * chip — the same workspace-relative ref an in-app drag onto the chat produces,
+ * minus the drag. Routed to the composer that last held focus (`'active'`).
+ *
+ * `focusComposer` moves focus to the composer after inserting: wanted from the
+ * context menu (mouse flow — type the prompt next), skipped for the Enter
+ * shortcut so keyboard users keep their place in the tree and can attach
+ * several files in a row.
+ */
+export function insertFileTargetIntoChat(
+  target: Pick<FileActionTarget, 'isDirectory' | 'path'>,
+  { focusComposer = false }: { focusComposer?: boolean } = {}
+): boolean {
+  const ref = droppedFileInlineRef({ isDirectory: target.isDirectory, path: target.path }, $currentCwd.get())
+
+  if (!ref) {
+    return false
+  }
+
+  requestComposerInsert(ref, { mode: 'inline' })
+
+  if (focusComposer) {
+    requestComposerFocus()
+  }
+
+  return true
 }
 
 /** The platform-appropriate "reveal in file manager" label (Finder / Explorer
@@ -68,6 +108,10 @@ export function FileEntryContextMenu({ children, isDirectory, name, path, relati
       {/* Don't restore focus to the row on close: "Rename" mounts an autofocused
           inline input, and the default focus-return would blur it immediately. */}
       <ContextMenuContent onCloseAutoFocus={event => event.preventDefault()}>
+        <ContextMenuItem onSelect={() => insertFileTargetIntoChat(target, { focusComposer: true })}>
+          {m.insertIntoChat}
+        </ContextMenuItem>
+        <ContextMenuSeparator />
         {localFs && (
           <>
             <ContextMenuItem onSelect={() => void revealFile(path)}>{revealLabel}</ContextMenuItem>

--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -10,7 +10,7 @@ import { $repoChangeByPath, type RepoChangeKind } from '@/store/coding-status'
 import { $renamingPath, beginInlineRename } from '@/store/file-actions'
 import { $revealInTreeRequest } from '@/store/layout'
 
-import { FileEntryContextMenu, InlineRenameInput, isRenameShortcut } from '../file-actions'
+import { FileEntryContextMenu, InlineRenameInput, insertFileTargetIntoChat, isInsertIntoChatShortcut, isRenameShortcut } from '../file-actions'
 
 import { getFileTreeDndManager } from './dnd-manager'
 import type { TreeNode } from './use-project-tree'
@@ -155,11 +155,21 @@ export function ProjectTree({
     [onPreviewFile]
   )
 
-  // F2 / Enter on the selected row begins an inline rename. Capture-phase so it
-  // beats arborist's own Enter-to-activate; skipped while an edit is in progress
-  // (the editor input owns Enter/Esc then) and for placeholder rows.
-  const handleRenameShortcut = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (!isRenameShortcut(event) || $renamingPath.get()) {
+  // Row keyboard actions, capture-phase so they beat arborist's own Enter-to-
+  // activate: Enter inserts the selected file/folder into the chat composer
+  // (the keyboard twin of the context menu's "Insert into Chat" — no drag
+  // needed, #69741); F2 begins an inline rename. Both are skipped while an
+  // edit is in progress (the editor input owns Enter/Esc then) and for
+  // placeholder rows.
+  const handleRowShortcuts = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if ($renamingPath.get()) {
+      return
+    }
+
+    const rename = isRenameShortcut(event)
+    const insert = !rename && isInsertIntoChatShortcut(event)
+
+    if (!rename && !insert) {
       return
     }
 
@@ -171,11 +181,18 @@ export function ProjectTree({
 
     event.preventDefault()
     event.stopPropagation()
-    beginInlineRename(node.data.id)
+
+    if (rename) {
+      beginInlineRename(node.data.id)
+    } else {
+      // Focus stays in the tree so arrow keys + Enter can attach several
+      // files in a row.
+      insertFileTargetIntoChat({ isDirectory: node.data.isDirectory, path: node.data.id })
+    }
   }, [])
 
   return (
-    <div className="min-h-0 flex-1 overflow-hidden" onKeyDownCapture={handleRenameShortcut} ref={containerRef}>
+    <div className="min-h-0 flex-1 overflow-hidden" onKeyDownCapture={handleRowShortcuts} ref={containerRef}>
       {size.height > 0 && size.width > 0 ? (
         <Tree<TreeNode>
           childrenAccessor={node => (node?.isDirectory ? (node.children ?? []) : null)}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -46,6 +46,7 @@ export const en: Translations = {
   },
 
   fileMenu: {
+    insertIntoChat: 'Insert into Chat',
     revealFinder: 'Reveal in Finder',
     revealExplorer: 'Reveal in File Explorer',
     revealFileManager: 'Open Containing Folder',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -46,6 +46,7 @@ export const ja = defineLocale({
   },
 
   fileMenu: {
+    insertIntoChat: 'チャットに挿入',
     revealFinder: 'Finder で表示',
     revealExplorer: 'エクスプローラーで表示',
     revealFileManager: '格納フォルダーを開く',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -91,6 +91,7 @@ export interface Translations {
   }
 
   fileMenu: {
+    insertIntoChat: string
     revealFinder: string
     revealExplorer: string
     revealFileManager: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -46,6 +46,7 @@ export const zhHant = defineLocale({
   },
 
   fileMenu: {
+    insertIntoChat: '插入至聊天',
     revealFinder: '在 Finder 中顯示',
     revealExplorer: '在檔案總管中顯示',
     revealFileManager: '開啟所在資料夾',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -46,6 +46,7 @@ export const zh: Translations = {
   },
 
   fileMenu: {
+    insertIntoChat: '插入到聊天',
     revealFinder: '在访达中显示',
     revealExplorer: '在文件资源管理器中显示',
     revealFileManager: '打开所在文件夹',


### PR DESCRIPTION
## Problem

The Files panel is drag-only: the sole way to get a file into the chat input is dragging the row across the window onto the composer. That's error-prone with a small drop target and completely blocks keyboard-only workflows (#69741).

## Fix (MVP shape B from the issue, plus the Enter shortcut from shape A)

**Context menu — "Insert into Chat"** as the first entry, for files and folders alike. It rides the exact insertion path an in-app drag onto the chat already uses — a workspace-relative `@file:`/`@folder:` chip through the composer insert bus (`droppedFileInlineRef` → `requestComposerInsert`, mode `inline`, target `'active'`) — then hands focus to the composer so the prompt can be typed immediately. Because the refs are workspace-relative and gateway-resolvable, the item is available in remote-fs mode too (unlike reveal/rename/delete, which stay local-only).

**Enter on a focused row** is the keyboard twin: same chip, same bus, but focus deliberately stays in the tree so arrow keys + Enter can attach several files in a row. Modified Enter (Shift/Ctrl/Cmd/Alt) is ignored.

**Rename moves to F2-only** (Explorer style; the context-menu Rename… stays). Enter previously began an inline rename — the issue explicitly asks for Enter to insert, and F2 + menu keep rename fully reachable.

No behavior change for drag-and-drop, double-click preview, shift-click, or the review/git tree.

## Acceptance mapping

| Issue ask | Where |
|---|---|
| Right-click → `Insert into chat` | `FileEntryContextMenu` first item, files + folders |
| Keyboard: Enter inserts selected entry | capture-phase handler in `ProjectTree` (beats arborist's Enter-to-activate) |
| Same render path as existing insertion | reuses the in-app drag ref path (`@file:`/`@folder:` chips, workspace-relative) |
| `Copy absolute path` for keyboard workflow | already present (`Copy Path`), unchanged |
| No silent no-op | insert returns false only for empty paths; menu/Enter always dispatch through the bus, pinned by tests |

## Testing

- `apps/desktop/src/app/right-sidebar/file-actions.test.tsx` (9 new tests): ref shape for files/folders, workspace-relativization + absolute fallback, focus-only-when-asked, empty-path no-op, Enter/F2 shortcut predicates (modifiers excluded), and Radix context-menu integration (menu item dispatches insert + focus through the bus).
- Full desktop suite: **304 files / 2755 tests green**; `npm run typecheck` (3 tsc projects) clean; eslint clean on touched files.
- Localized for en / ja / zh / zh-hant.

Fixes #69741
