### PR TITLE
fix(desktop-e2e): decouple compaction-queue test trigger from system-prompt size

### DIFF
--- a/apps/desktop/e2e/session-compression-and-queue-stop.spec.ts
+++ b/apps/desktop/e2e/session-compression-and-queue-stop.spec.ts
@@ -96,8 +96,15 @@ test.describe('session compression in progress', () => {
   test.beforeAll(async () => {
     fixture = await setupMockBackend({
       modelContextLength: 64_000,
+      // The trigger margin must not depend on system-prompt size: the prompt
+      // includes the bundled-skills listing, which grows/shrinks as skills are
+      // added or moved to optional-skills. A 22000 threshold with a ~4k-token
+      // trigger message left ~200 tokens of margin and broke when a skills
+      // restructure shrank the prompt (total 21.8k < 22k → compaction never
+      // fired, waitForHeldCompletion timed out). The ~16k-token trigger below
+      // plus this threshold keeps >8k tokens of margin on both sides.
       extraConfig: `compression:
-  threshold_tokens: 22000
+  threshold_tokens: 26000
   protect_first_n: 0
   protect_last_n: 1
 auxiliary:
@@ -126,7 +133,9 @@ auxiliary:
     await waitForTranscript(page, MOCK_REPLY)
     await pasteAndSend(page, 'E2E_COMPACTION_HISTORY_TWO '.repeat(5))
     await waitForTranscript(page, MOCK_REPLY)
-    await pasteAndSend(page, 'E2E_TRIGGER_AUTOMATIC_COMPACTION '.repeat(500))
+    // 2000 repeats ≈ 16k tokens — large enough to cross the 26000 threshold
+    // on its own margin, independent of how big the system prompt happens to be.
+    await pasteAndSend(page, 'E2E_TRIGGER_AUTOMATIC_COMPACTION '.repeat(2000))
     await fixture.mock.waitForHeldCompletion()
     await expect(page.getByRole('status', { name: 'Summarizing thread' }).last()).toBeVisible()
 


### PR DESCRIPTION
## Summary

Unbreaks the Desktop E2E `queues an Enter-submitted draft instead of steering while compaction is active` test, which fails deterministically on every open PR since the July 23 skills restructure.

Root cause: the test's compaction trigger silently depended on system-prompt size. With `threshold_tokens: 22000`, the ~4k-token trigger message only crossed the threshold because the system prompt (which embeds the bundled-skills listing) supplied the other ~18k. The skills restructure (e3d524b482 + optional-skills moves) shrank the prompt, leaving the conversation at 21.8k — 200 tokens short — so automatic compaction never fired, `waitForHeldCompletion()` waited forever, and the test timed out at 90s on both attempts.

## Changes

- `apps/desktop/e2e/session-compression-and-queue-stop.spec.ts`: raise threshold to 26000 and grow the trigger message to ~16k tokens, so the test crosses the threshold on its own margin (>8k tokens both sides) regardless of prompt size. Comment documents the invariant.

## Validation

| | Before | After |
|---|---|---|
| Test premise | trigger margin ≈ 200 tokens, owned by prompt size | trigger margin > 8k tokens, owned by the test |
| CI (all open PRs) | Playwright E2E fail ×2 retries | expected green (validates on this PR's own run) |

`tsc --noEmit` clean. Sole other `threshold_tokens` user (`hidden-history-messages.spec.ts`, threshold 1) is unaffected.

## Infographic

![Desktop E2E compaction fix](https://v3b.fal.media/files/b/0aa37da6/EBHPjySFuQBlYH-PZtp9I_VbCC55QV.png)
