### PR TITLE
chore(gitignore): close infograficos/ loophole in the PR-infographic no-commit rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,5 +173,11 @@ apps/desktop/demo/
 # image-provider (fal.media) URL — they are NEVER committed to the repo. The
 # PR body is the archive. See the hermes-agent-dev skill's
 # pr-infographic-workflow reference (storage rule + lapse #8 / #COMMIT-1).
+# infograficos/ (pt-BR spelling) is the same rule — it was previously
+# unignored by accident and accumulating PNGs directly in the repo; a given
+# PR may still `git add -f` a one-off image into its own branch/commit when
+# it needs a real git-hosted URL, but that stays scoped to that PR, not a
+# tracked default.
 infographic/
+infograficos/
 native/fts5_cjk/*.so


### PR DESCRIPTION
## Summary

`infographic/` (English) was already ignored with an explicit policy: PR infographics are never committed, they're hosted via the image-provider and the PR body is the archive. `infograficos/` (pt-BR spelling) wasn't covered by that pattern — it had already accumulated a tracked PNG (`infograficos/bedrock_converse_cache_demoniaco_flow.png`) plus more staged for upcoming PRs, the exact accumulation problem the original rule exists to prevent, just under the other spelling.

## Change

Adds `infograficos/` next to the existing `infographic/` entry, same rule, same rationale.

Already-tracked files are untouched — `.gitignore` only affects new/untracked paths, so `infograficos/bedrock_converse_cache_demoniaco_flow.png` stays exactly as it is.

## Escape hatch (unchanged)

A PR can still `git add -f` a one-off image into its own branch/commit when it needs a real git-hosted URL (`raw.githubusercontent.com`) instead of the image-provider — that stays scoped to that PR's own commits, not a tracked repo default.

## Test plan
- [x] `git check-ignore -v infograficos/anything.png` now reports the new rule
- [x] `git ls-files infograficos/` confirms the pre-existing tracked file is unaffected