### PR TITLE
fix(skills): sync coding-agent CLI skills to current flags/packages

### DIFF
--- a/optional-skills/autonomous-ai-agents/blackbox/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/blackbox/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: blackbox
 description: Delegate coding tasks to the Blackbox AI multi-model CLI.
-version: 1.0.0
+version: 1.0.1
 author: Hermes Agent (Nous Research)
 license: MIT
 platforms: [linux, macos, windows]
@@ -15,17 +15,12 @@ metadata:
 
 Delegate coding tasks to [Blackbox AI](https://www.blackbox.ai/) via the Hermes terminal. Blackbox is a multi-model coding agent CLI that dispatches tasks to multiple LLMs (Claude, Codex, Gemini, Blackbox Pro) and uses a judge to select the best implementation.
 
-The CLI is [open-source](https://github.com/blackboxaicode/cli) (GPL-3.0, TypeScript, forked from Gemini CLI) and supports interactive sessions, non-interactive one-shots, checkpointing, MCP, and vision model switching.
+The CLI (npm `@blackbox_ai/blackbox-cli`, binary `blackbox`) is a TypeScript coding agent (forked from Gemini CLI) and supports interactive sessions, non-interactive one-shots, checkpointing, MCP, and vision model switching.
 
 ## Prerequisites
 
 - Node.js 20+ installed
-- Blackbox CLI installed: `npm install -g @blackboxai/cli`
-- Or install from source:
-  ```
-  git clone https://github.com/blackboxaicode/cli.git
-  cd cli && npm install && npm install -g .
-  ```
+- Blackbox CLI installed: `npm install -g @blackbox_ai/blackbox-cli` (binary: `blackbox`)
 - API key from [app.blackbox.ai/dashboard](https://app.blackbox.ai/dashboard)
 - Configured: run `blackbox configure` and enter your API key
 - Use `pty=true` in terminal calls — Blackbox CLI is an interactive terminal app
@@ -110,12 +105,16 @@ Blackbox's unique feature is running the same task through multiple models and j
 
 | Flag | Effect |
 |------|--------|
-| `--prompt "task"` | Non-interactive one-shot execution |
+| `--prompt "task"` (`-p`) | Non-interactive one-shot execution |
 | `--resume-checkpoint "tag"` | Resume from a saved checkpoint |
-| `--yolo` | Auto-approve all actions and model switches |
-| `blackbox session` | Start interactive chat session |
+| `--yolo` (`-y`) | Auto-approve all actions and model switches |
+| `--vlm-switch-mode <mode>` | Image-handling: `once`, `session`, or `persist` |
+| `-c, --checkpointing` | Enable checkpointing of file edits |
 | `blackbox configure` | Change settings, providers, models |
-| `blackbox info` | Display system information |
+| `blackbox update` | Update the CLI to the latest version |
+| `blackbox mcp` | Manage MCP servers |
+| `blackbox extensions` | Manage CLI extensions |
+| `blackbox voice <action>` / `blackbox shortcut` | Configure voice input / the `b` shortcut |
 
 ## Vision Support
 

--- a/optional-skills/autonomous-ai-agents/grok/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/grok/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: grok
 description: "Delegate coding to xAI Grok Build CLI (features, PRs)."
-version: 0.1.0
+version: 0.1.1
 author: Matt Maximo (MattMaximo), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -108,14 +108,16 @@ For pure automation, headless `-p` is still cleaner than the TUI.
 |------|--------|
 | `-p, --single <PROMPT>` | Send one prompt, run headless, exit |
 | `-m, --model <MODEL>` | Choose a model |
-| `-s, --session-id <ID>` | Create or resume a named headless session |
-| `-r, --resume <ID>` | Resume an existing session |
+| `-s, --session-id <UUID>` | Assign a **NEW** valid UUID to a fresh conversation (must not already exist). Does **not** resume — use `--resume`/`--continue` for that. Only valid with `--resume`/`--continue` when paired with `--fork-session` |
+| `-r, --resume [<UUID>]` | Resume an existing session by its UUID (or the most recent if omitted) |
 | `-c, --continue` | Continue the most recent session in the current directory |
+| `--fork-session` | When resuming, create a new session ID instead of reusing the original |
+| `--max-turns <N>` | Cap the maximum number of agent turns |
 | `--cwd <PATH>` | Set the working directory |
 | `--output-format <FMT>` | `plain` (default), `json`, or `streaming-json` |
 | `--always-approve` | Auto-approve all tool executions (the `--full-auto` / `--yolo` equivalent) |
 | `--no-alt-screen` | Run inline, no fullscreen TUI takeover |
-| `--no-auto-update` | Skip background update checks (use in all automation) |
+| `--no-auto-update` | Skip background update checks (use in all automation; hidden from `--help` but still works) |
 
 ### Output Formats
 
@@ -151,14 +153,19 @@ with `tmux capture-pane`, exactly like the `claude-code` / `codex` skills.
 
 ### Session Continuation
 
+Sessions are keyed by **UUID**, not by name. `--session-id` assigns a *new* UUID
+to a fresh run (it does **not** resume); `--resume` takes an existing session's
+UUID (or omit the value to resume the most recent).
+
 ```
-# Start a named session
-terminal(command="grok --no-auto-update -s refactor-db -p 'Start refactoring the database layer' --always-approve", workdir="/project", timeout=240)
+# Start a session with a self-assigned UUID (must be a valid, unused UUID)
+SID=$(uuidgen)
+terminal(command="grok --no-auto-update -s $SID -p 'Start refactoring the database layer' --always-approve", workdir="/project", timeout=240)
 
-# Resume it later
-terminal(command="grok --no-auto-update -r refactor-db -p 'Now add connection pooling' --always-approve", workdir="/project", timeout=180)
+# Resume that exact session later by its UUID
+terminal(command="grok --no-auto-update -r $SID -p 'Now add connection pooling' --always-approve", workdir="/project", timeout=180)
 
-# Or continue the most recent session in this directory
+# Or just continue the most recent session in this directory (no UUID needed)
 terminal(command="grok --no-auto-update -c -p 'What did you change last time?'", workdir="/project", timeout=60)
 ```
 

--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: claude-code
 description: "Delegate coding to Claude Code CLI (features, PRs)."
-version: 2.2.0
+version: 2.2.1
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]
@@ -265,7 +265,7 @@ Automatically falls back to the specified model when the default is overloaded (
 | Flag | Effect |
 |------|--------|
 | `--model <alias>` | Model selection: `sonnet`, `opus`, `haiku`, or full name like `claude-sonnet-4-6` |
-| `--effort <level>` | Reasoning depth: `low`, `medium`, `high`, `max`, `auto` | Both |
+| `--effort <level>` | Reasoning depth: `low`, `medium`, `high`, `xhigh`, `max` |
 | `--max-turns <n>` | Limit agentic loops (print mode only; prevents runaway) |
 | `--max-budget-usd <n>` | Cap API spend in dollars (print mode only) |
 | `--fallback-model <model>` | Auto-fallback when default model is overloaded (print mode only) |
@@ -389,7 +389,7 @@ Use the `#` prefix in interactive mode to quickly add to memory: `# Always use 2
 | Command | Purpose |
 |---------|---------|
 | `/model [model]` | Switch models mid-session (use arrow keys to adjust effort) |
-| `/effort [level]` | Set reasoning effort: `low`, `medium`, `high`, `max`, or `auto` |
+| `/effort [level]` | Set reasoning effort: `low`, `medium`, `high`, `xhigh`, or `max` |
 | `/init` | Create a CLAUDE.md file for project memory |
 | `/memory` | Open CLAUDE.md for editing |
 | `/config` | Open interactive settings configuration |

--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: codex
 description: "Delegate coding to OpenAI Codex CLI (features, PRs)."
-version: 1.0.0
+version: 1.0.1
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -53,7 +53,7 @@ terminal(command="cd $(mktemp -d) && git init && codex exec 'Build a snake game 
 
 ```
 # Start in background with PTY
-terminal(command="codex exec --full-auto 'Refactor the auth module'", workdir="~/project", background=true, pty=true)
+terminal(command="codex exec --sandbox workspace-write 'Refactor the auth module'", workdir="~/project", background=true, pty=true)
 # Returns session_id
 
 # Monitor progress
@@ -72,9 +72,11 @@ process(action="kill", session_id="<id>")
 | Flag | Effect |
 |------|--------|
 | `exec "prompt"` | One-shot execution, exits when done |
-| `--full-auto` | Sandboxed but auto-approves file changes in workspace |
-| `--yolo` | No sandbox, no approvals (fastest, most dangerous) |
+| `--sandbox workspace-write` (`-s`) | Sandboxed but auto-approves file changes in the workspace (the recommended auto-build mode) |
+| `--dangerously-bypass-approvals-and-sandbox` | No sandbox, no approvals (fastest, most dangerous; `--yolo` still works as a hidden alias) |
 | `--sandbox danger-full-access` | No Codex sandbox; useful when the host service context breaks bubblewrap |
+
+> **Deprecated:** `--full-auto` still works but the live CLI warns to use `--sandbox workspace-write` instead.
 
 ## Hermes Gateway Caveat
 
@@ -110,8 +112,8 @@ terminal(command="git worktree add -b fix/issue-78 /tmp/issue-78 main", workdir=
 terminal(command="git worktree add -b fix/issue-99 /tmp/issue-99 main", workdir="~/project")
 
 # Launch Codex in each
-terminal(command="codex --yolo exec 'Fix issue #78: <description>. Commit when done.'", workdir="/tmp/issue-78", background=true, pty=true)
-terminal(command="codex --yolo exec 'Fix issue #99: <description>. Commit when done.'", workdir="/tmp/issue-99", background=true, pty=true)
+terminal(command="codex --sandbox workspace-write exec 'Fix issue #78: <description>. Commit when done.'", workdir="/tmp/issue-78", background=true, pty=true)
+terminal(command="codex --sandbox workspace-write exec 'Fix issue #99: <description>. Commit when done.'", workdir="/tmp/issue-99", background=true, pty=true)
 
 # Monitor
 process(action="list")
@@ -143,7 +145,7 @@ terminal(command="gh pr comment 86 --body '<review>'", workdir="~/project")
 1. **Always use `pty=true`** — Codex is an interactive terminal app and hangs without a PTY
 2. **Git repo required** — Codex won't run outside a git directory. Use `mktemp -d && git init` for scratch
 3. **Use `exec` for one-shots** — `codex exec "prompt"` runs and exits cleanly
-4. **`--full-auto` for building** — auto-approves changes within the sandbox
+4. **`--sandbox workspace-write` for building** — auto-approves changes within the sandbox (`--full-auto` is deprecated for this)
 5. **Background for long tasks** — use `background=true` and monitor with `process` tool
 6. **Don't interfere** — monitor with `poll`/`log`, be patient with long-running tasks
 7. **Parallel is fine** — run multiple Codex processes at once for batch work


### PR DESCRIPTION
## Summary
Four coding-agent CLI skills drifted from their live CLIs. Each fix was re-verified against the live `--help` output / npm before editing.

## Changes
- `skills/autonomous-ai-agents/codex`: `--full-auto` deprecated → `--sandbox workspace-write`; `--yolo` → `--dangerously-bypass-approvals-and-sandbox` (kept `--yolo` noted as a still-working hidden alias).
- `skills/autonomous-ai-agents/claude-code`: `--effort` levels now `low/medium/high/xhigh/max` (dropped removed `auto`, added `xhigh`) in both the flag row and `/effort` slash-command row; fixed a stray table cell.
- `optional-skills/autonomous-ai-agents/grok`: `--session-id` is now UUID-only for NEW sessions (cannot resume by name); rewrote the Session Continuation example; noted `--max-turns` now exists.
- `optional-skills/autonomous-ai-agents/blackbox`: wrong npm package (`@blackboxai/cli` is an unrelated MCP tool) → `@blackbox_ai/blackbox-cli`; removed a dead source-repo link and the phantom `session`/`info` subcommands.

## Validation
| skill | stale | corrected (live-verified) |
|---|---|---|
| codex | `--full-auto` / `--yolo` | `--sandbox workspace-write` / canonical flag |
| claude-code | `--effort ... auto` | `... xhigh, max` |
| grok | named-session resume | UUID-only session-id |
| blackbox | `@blackboxai/cli` | `@blackbox_ai/blackbox-cli` |

Each `version:` bumped (codex/blackbox 1.0.0→1.0.1, claude-code 2.2.0→2.2.1, grok 0.1.0→0.1.1). Website docs untouched.

## Infographic

![agent-cli-sync](https://v3b.fal.media/files/b/0aa37dcc/2NDlfD9lTnM_I7DlVxRFq_FwFyfzCh.png)
