### PR TITLE
fix(skills): sync bundled + misc CLI skills to current upstream

### DIFF
--- a/optional-skills/research/searxng-search/SKILL.md
+++ b/optional-skills/research/searxng-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: searxng-search
 description: Free keyless meta-search aggregating 70+ engines.
-version: 1.0.0
+version: 1.0.1
 author: hermes-agent
 license: MIT
 platforms: [linux, macos]
@@ -123,23 +123,6 @@ for r in data.get("results", []):
     print(r.get("content", "")[:200])
     print()
 ```
-
-## Method 3: searxng-data Python Package
-
-For more structured access, install the `searxng-data` package:
-
-```bash
-pip install searxng-data
-```
-
-```python
-from searxng_data import engines
-
-# List available engines
-print(engines.list_engines())
-```
-
-Note: This package only provides engine metadata, not the search API itself.
 
 ## Self-Hosting SearXNG
 

--- a/skills/apple/apple-notes/SKILL.md
+++ b/skills/apple/apple-notes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: apple-notes
 description: "Manage Apple Notes via memo CLI: create, search, edit."
-version: 1.0.0
+version: 1.0.1
 author: Hermes Agent
 license: MIT
 platforms: [macos]
@@ -49,9 +49,13 @@ memo notes -s "query"             # Search notes (fuzzy)
 ### Create Notes
 
 ```bash
-memo notes -a                     # Interactive editor
-memo notes -a "Note Title"        # Quick add with title
+memo notes -a                     # Add a note (opens your $EDITOR)
+memo notes -a -f "Folder Name"    # Add a note into a specific folder
 ```
+
+`-a`/`--add` is a bare flag — it opens your `$EDITOR` to compose the note; it does
+not take a title argument. Use `-f/--folder` to target a folder. Set `$EDITOR`
+first (e.g. `export EDITOR=vim`).
 
 ### Edit Notes
 

--- a/skills/creative/excalidraw/SKILL.md
+++ b/skills/creative/excalidraw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: excalidraw
 description: "Hand-drawn Excalidraw JSON diagrams (arch, flow, seq)."
-version: 1.0.0
+version: 1.0.1
 author: Hermes Agent
 license: MIT
 dependencies: []
@@ -51,7 +51,7 @@ Save to any path, e.g. `~/diagrams/my_diagram.excalidraw`.
 Run the upload script (located in this skill's `scripts/` directory) via terminal:
 
 ```bash
-python skills/diagramming/excalidraw/scripts/upload.py ~/diagrams/my_diagram.excalidraw
+python skills/creative/excalidraw/scripts/upload.py ~/diagrams/my_diagram.excalidraw
 ```
 
 This uploads to excalidraw.com (no account needed) and prints a shareable URL. Requires the `cryptography` pip package (`pip install cryptography`).

--- a/skills/creative/sketch/SKILL.md
+++ b/skills/creative/sketch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sketch
 description: "Throwaway HTML mockups: 2-3 design variants to compare."
-version: 1.0.0
+version: 1.0.1
 author: Hermes Agent (adapted from gsd-build/get-shit-done)
 license: MIT
 platforms: [linux, macos, windows]
@@ -26,7 +26,9 @@ Load this when the user says things like "sketch this screen", "show me what X c
 
 ## If the user has the full GSD system installed
 
-If `gsd-sketch` shows up as a sibling skill (installed via `npx get-shit-done-cc --hermes`), prefer **`gsd-sketch`** for the full workflow: persistent `.planning/sketches/` with MANIFEST, frontier mode analysis, consistency audits across past sketches, and integration with the rest of GSD. This skill is the lightweight standalone version — one-off sketching without the state machinery.
+If `gsd-sketch` shows up as a sibling skill (installed via `npx get-shit-done-cc --hermes`), you can use **`gsd-sketch`** for the fuller workflow: persistent `.planning/sketches/` with MANIFEST, frontier mode analysis, consistency audits across past sketches, and integration with the rest of GSD. This skill is the lightweight standalone version — one-off sketching without the state machinery.
+
+> **Note:** The upstream GSD project ([gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done)) is **archived / no longer maintained** on GitHub. The npm package (`get-shit-done-cc`) still installs, but treat it as an archived community project — this standalone `sketch` skill is the maintained path and needs nothing extra.
 
 ## Core method
 
@@ -215,4 +217,4 @@ Repeat for each variant, then present the comparison table.
 
 ## Attribution
 
-Adapted from the GSD (Get Shit Done) project's `/gsd-sketch` workflow — MIT © 2025 Lex Christopherson ([gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done)). The full GSD system ships persistent sketch state, theme/variant pattern references, and consistency-audit workflows; install with `npx get-shit-done-cc --hermes --global`.
+Adapted from the GSD (Get Shit Done) project's `/gsd-sketch` workflow — MIT © 2025 Lex Christopherson ([gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done)). The upstream GSD repo is now **archived/unmaintained** on GitHub; the `get-shit-done-cc` npm package still installs (`npx get-shit-done-cc --hermes --global`) and ships persistent sketch state, theme/variant pattern references, and consistency-audit workflows, but treat it as an archived community project.

--- a/skills/mlops/evaluation/evaluating-llms-harness/SKILL.md
+++ b/skills/mlops/evaluation/evaluating-llms-harness/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: evaluating-llms-harness
 description: "lm-eval-harness: benchmark LLMs (MMLU, GSM8K, etc.)."
-version: 1.0.0
+version: 1.0.1
 author: Orchestra Research
 license: MIT
 dependencies: [lm-eval, transformers, vllm]
@@ -38,7 +38,7 @@ lm_eval --model hf \
 
 **View available tasks**:
 ```bash
-lm_eval --tasks list
+lm-eval ls tasks
 ```
 
 ## Common workflows
@@ -451,18 +451,18 @@ Verify model and tokenizer match:
 
 **Issue: HumanEval not executing code**
 
-Install execution dependencies:
-```bash
-pip install human-eval
-```
+Code-executing tasks (HumanEval, MBPP, etc.) are gated behind an explicit
+confirmation flag — you must pass `--confirm_run_unsafe_code` to run them:
 
-Enable code execution:
 ```bash
 lm_eval --model hf \
   --model_args pretrained=model-name \
   --tasks humaneval \
-  --allow_code_execution  # Required for HumanEval
+  --confirm_run_unsafe_code  # Required to run tasks that execute generated code
 ```
+
+Without this flag lm-eval refuses to run the task rather than silently skipping
+code execution.
 
 ## Advanced topics
 

--- a/skills/mlops/evaluation/weights-and-biases/SKILL.md
+++ b/skills/mlops/evaluation/weights-and-biases/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: weights-and-biases
 description: "W&B: log ML experiments, sweeps, model registry, dashboards."
-version: 1.0.0
+version: 1.0.1
 author: Orchestra Research
 license: MIT
 dependencies: [wandb]
@@ -238,7 +238,7 @@ sweep_config = {
     },
     'parameters': {
         'learning_rate': {
-            'distribution': 'log_uniform',
+            'distribution': 'log_uniform_values',
             'min': 1e-5,
             'max': 1e-1
         },
@@ -317,7 +317,7 @@ sweep_config = {
     'method': 'bayes',
     'metric': {'name': 'val/loss', 'goal': 'minimize'},
     'parameters': {
-        'lr': {'distribution': 'log_uniform', 'min': 1e-5, 'max': 1e-1}
+        'lr': {'distribution': 'log_uniform_values', 'min': 1e-5, 'max': 1e-1}
     }
 }
 ```
@@ -433,17 +433,21 @@ trainer.fit(model, datamodule=dm)
 
 ```python
 import wandb
-from wandb.keras import WandbCallback
+from wandb.integration.keras import WandbMetricsLogger, WandbModelCheckpoint
 
 # Initialize
 wandb.init(project="keras-demo")
 
-# Add callback
+# Add callbacks (the monolithic WandbCallback was removed;
+# use the dedicated callbacks from wandb.integration.keras instead)
 model.fit(
     x_train, y_train,
     validation_data=(x_val, y_val),
     epochs=10,
-    callbacks=[WandbCallback()]  # Auto-logs metrics
+    callbacks=[
+        WandbMetricsLogger(),                        # Auto-logs metrics
+        WandbModelCheckpoint("models/model-{epoch}")  # Saves checkpoints
+    ]
 )
 ```
 

--- a/skills/mlops/huggingface-hub/SKILL.md
+++ b/skills/mlops/huggingface-hub/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: huggingface-hub
 description: "HuggingFace hf CLI: search/download/upload models, datasets."
-version: 1.0.0
+version: 1.0.1
 author: Hugging Face
 license: MIT
 tags: [huggingface, hf, models, datasets, hub, mlops]
@@ -25,8 +25,8 @@ The `hf` command is the modern command-line interface for interacting with the H
 
 ### General Operations
 *   `hf download REPO_ID`: Download files from the Hub.
-*   `hf upload REPO_ID`: Upload files/folders (recommended for single-commit).
-*   `hf upload-large-folder REPO_ID LOCAL_PATH`: Recommended for resumable uploads of large directories.
+*   `hf upload REPO_ID`: Upload files/folders (recommended for single-commit; also handles resumable uploads of large directories).
+*   `hf upload-large-folder REPO_ID LOCAL_PATH`: **[Deprecated]** — use `hf upload` instead.
 *   `hf sync`: Sync files between a local directory and a bucket.
 *   `hf env` / `hf version`: View environment and version details.
 
@@ -50,7 +50,7 @@ The `hf` command is the modern command-line interface for interacting with the H
 *   **Datasets:** `hf datasets list`, `info`, and `parquet` (list parquet URLs).
 *   **SQL Queries:** `hf datasets sql SQL` — Execute raw SQL via DuckDB against dataset parquet URLs.
 *   **Models:** `hf models list` and `info`.
-*   **Papers:** `hf papers list` — View daily papers.
+*   **Papers:** `hf papers ls` — View daily papers.
 
 ### Discussions & Pull Requests (`hf discussions`)
 *   Manage the lifecycle of Hub contributions: `list`, `create`, `info`, `comment`, `close`, `reopen`, and `rename`.

--- a/skills/mlops/inference/serving-llms-vllm/SKILL.md
+++ b/skills/mlops/inference/serving-llms-vllm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: serving-llms-vllm
 description: "vLLM: high-throughput LLM serving, OpenAI API, quantization."
-version: 1.0.0
+version: 1.0.1
 author: Orchestra Research
 license: MIT
 dependencies: [vllm, torch, transformers]
@@ -31,7 +31,7 @@ pip install vllm
 ```python
 from vllm import LLM, SamplingParams
 
-llm = LLM(model="meta-llama/Llama-3-8B-Instruct")
+llm = LLM(model="meta-llama/Meta-Llama-3-8B-Instruct")
 sampling = SamplingParams(temperature=0.7, max_tokens=256)
 
 outputs = llm.generate(["Explain quantum computing"], sampling)
@@ -40,14 +40,14 @@ print(outputs[0].outputs[0].text)
 
 **OpenAI-compatible server**:
 ```bash
-vllm serve meta-llama/Llama-3-8B-Instruct
+vllm serve meta-llama/Meta-Llama-3-8B-Instruct
 
 # Query with OpenAI SDK
 python -c "
 from openai import OpenAI
 client = OpenAI(base_url='http://localhost:8000/v1', api_key='EMPTY')
 print(client.chat.completions.create(
-    model='meta-llama/Llama-3-8B-Instruct',
+    model='meta-llama/Meta-Llama-3-8B-Instruct',
     messages=[{'role': 'user', 'content': 'Hello!'}]
 ).choices[0].message.content)
 "
@@ -74,24 +74,23 @@ Choose configuration based on your model size:
 
 ```bash
 # For 7B-13B models on single GPU
-vllm serve meta-llama/Llama-3-8B-Instruct \
+vllm serve meta-llama/Meta-Llama-3-8B-Instruct \
   --gpu-memory-utilization 0.9 \
   --max-model-len 8192 \
   --port 8000
 
 # For 30B-70B models with tensor parallelism
-vllm serve meta-llama/Llama-2-70b-hf \
+vllm serve meta-llama/Meta-Llama-3-70B-Instruct \
   --tensor-parallel-size 4 \
   --gpu-memory-utilization 0.9 \
   --quantization awq \
   --port 8000
 
-# For production with caching and metrics
-vllm serve meta-llama/Llama-3-8B-Instruct \
+# For production with caching (Prometheus metrics are exposed
+# automatically at /metrics on the API port)
+vllm serve meta-llama/Meta-Llama-3-8B-Instruct \
   --gpu-memory-utilization 0.9 \
   --enable-prefix-caching \
-  --enable-metrics \
-  --metrics-port 9090 \
   --port 8000 \
   --host 0.0.0.0
 ```
@@ -112,10 +111,10 @@ Verify TTFT (time to first token) < 500ms and throughput > 100 req/sec.
 
 **Step 3: Enable monitoring**
 
-vLLM exposes Prometheus metrics on port 9090:
+vLLM exposes Prometheus metrics at `/metrics` on the API port (default 8000):
 
 ```bash
-curl http://localhost:9090/metrics | grep vllm
+curl http://localhost:8000/metrics | grep vllm
 ```
 
 Key metrics to monitor:
@@ -131,7 +130,7 @@ Use Docker for consistent deployment:
 # Run vLLM in Docker
 docker run --gpus all -p 8000:8000 \
   vllm/vllm-openai:latest \
-  --model meta-llama/Llama-3-8B-Instruct \
+  --model meta-llama/Meta-Llama-3-8B-Instruct \
   --gpu-memory-utilization 0.9 \
   --enable-prefix-caching
 ```
@@ -175,7 +174,7 @@ print(f"Loaded {len(prompts)} prompts")
 from vllm import LLM, SamplingParams
 
 llm = LLM(
-    model="meta-llama/Llama-3-8B-Instruct",
+    model="meta-llama/Meta-Llama-3-8B-Instruct",
     tensor_parallel_size=2,  # Use 2 GPUs
     gpu_memory_utilization=0.9,
     max_model_len=4096
@@ -338,9 +337,11 @@ Verify tensor parallelism uses power of 2 GPUs:
 vllm serve MODEL --tensor-parallel-size 4  # Not 3
 ```
 
-Enable speculative decoding for faster generation:
+Enable speculative decoding for faster generation (pass config as JSON;
+`--speculative-model` was removed in favor of `--speculative-config`):
 ```bash
-vllm serve MODEL --speculative-model DRAFT_MODEL
+vllm serve MODEL \
+  --speculative-config '{"model": "DRAFT_MODEL", "num_speculative_tokens": 5, "method": "draft_model"}'
 ```
 
 ## Advanced topics

--- a/skills/smart-home/openhue/SKILL.md
+++ b/skills/smart-home/openhue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: openhue
 description: "Control Philips Hue lights, scenes, rooms via OpenHue CLI."
-version: 1.0.0
+version: 1.0.1
 author: community
 license: MIT
 platforms: [linux, macos, windows]
@@ -20,8 +20,11 @@ Control Philips Hue lights and scenes via a Hue Bridge from the terminal.
 ## Prerequisites
 
 ```bash
-# Linux (pre-built binary)
-curl -sL https://github.com/openhue/openhue-cli/releases/latest/download/openhue-linux-amd64 -o ~/.local/bin/openhue && chmod +x ~/.local/bin/openhue
+# Linux (pre-built binary — releases ship tarballs, not bare binaries)
+curl -sL "https://github.com/openhue/openhue-cli/releases/latest/download/openhue_Linux_x86_64.tar.gz" \
+  | tar -xz -C /tmp openhue \
+  && install -m 0755 /tmp/openhue ~/.local/bin/openhue
+# (use openhue_Linux_arm64.tar.gz on ARM64)
 
 # macOS
 brew install openhue/cli/openhue-cli


### PR DESCRIPTION
## Summary
Nine bundled and optional skills had stale flags, install URLs, package names, and file paths. Each fix was re-verified against upstream (PyPI JSON, GitHub raw source, `gh release view`, `gh repo view`, READMEs) before editing.

## Changes
- `skills/mlops/inference/vllm`: removed bogus `--enable-metrics`/`--metrics-port` (metrics are at `/metrics` on the API port, default 8000); `--speculative-model` → `--speculative-config` JSON; canonical HF model IDs.
- `skills/mlops/evaluation/lm-evaluation-harness`: `lm_eval --tasks list` → `lm-eval ls tasks`; `--allow_code_execution` → `--confirm_run_unsafe_code`.
- `skills/mlops/evaluation/weights-and-biases`: removed `wandb.keras` import (gone) → `wandb.integration.keras` (`WandbMetricsLogger`); `log_uniform` → `log_uniform_values` for raw min/max.
- `skills/mlops/huggingface-hub`: `upload-large-folder` now `[Deprecated]`; `hf papers list` → `ls`.
- `skills/smart-home/openhue`: Linux install 404 → `openhue_Linux_x86_64.tar.gz` tarball (release repo `openhue/openhue-cli`, v0.24 — verified live).
- `skills/apple/apple-notes`: `memo notes -a` is a bare flag, no positional title.
- `skills/creative/excalidraw`: `upload.py` path `skills/diagramming/...` → `skills/creative/...` (verified the scripts dir exists).
- `optional-skills/research/searxng-search`: removed "Method 3" (`searxng-data` pip package is a PyPI 404).
- `optional-skills/creative/sketch`: noted the `get-shit-done` upstream is archived/unmaintained (`isArchived: true`).

## Validation
| skill | stale | corrected |
|---|---|---|
| vllm | `--metrics-port 9090` | `/metrics` on :8000 |
| lm-eval | `--tasks list` | `lm-eval ls tasks` |
| wandb | `wandb.keras` | `wandb.integration.keras` |
| hf | `papers list` | `papers ls` |
| openhue | 404 binary URL | `openhue_Linux_x86_64.tar.gz` |
| apple-notes | `-a "Title"` | bare `-a` |
| excalidraw | `skills/diagramming/...` | `skills/creative/...` |
| searxng | `searxng-data` (404) | removed |
| sketch | GSD as live | noted archived |

Each `version:` bumped `1.0.0 → 1.0.1`. Website docs untouched.

## Infographic

![bundled-cli-sync](https://v3b.fal.media/files/b/0aa37dd2/rUHEmUlFmGouYb2ooawYg_g1EHAgjE.png)
