### PR TITLE
fix(desktop-e2e): overshoot compaction threshold decisively in queue-during-compaction test

### DIFF
--- a/apps/desktop/e2e/session-compression-and-queue-stop.spec.ts
+++ b/apps/desktop/e2e/session-compression-and-queue-stop.spec.ts
@@ -122,11 +122,21 @@ auxiliary:
     // A normal message crosses the tiny configured context budget. The mock
     // blocks only the resulting summary request, so these assertions run
     // during automatic compaction rather than a slash-command path.
+    //
+    // The repeat count must overshoot the 22k threshold decisively: the
+    // request estimate includes the system prompt, whose bundled-skills
+    // listing shrinks/grows as skills are added, moved to optional-skills/,
+    // or absorbed. At 500 repeats the margin over threshold was <250 tokens
+    // and a skills-tree cleanup (July 2026) pushed the request under the
+    // threshold, so compaction never fired and this test timed out. 1500
+    // repeats (~12k tokens) gives an ~8k-token cushion while staying well
+    // under the 64k mock context and leaving the two small history turns
+    // below threshold.
     await pasteAndSend(page, 'E2E_COMPACTION_HISTORY_ONE '.repeat(5))
     await waitForTranscript(page, MOCK_REPLY)
     await pasteAndSend(page, 'E2E_COMPACTION_HISTORY_TWO '.repeat(5))
     await waitForTranscript(page, MOCK_REPLY)
-    await pasteAndSend(page, 'E2E_TRIGGER_AUTOMATIC_COMPACTION '.repeat(500))
+    await pasteAndSend(page, 'E2E_TRIGGER_AUTOMATIC_COMPACTION '.repeat(1500))
     await fixture.mock.waitForHeldCompletion()
     await expect(page.getByRole('status', { name: 'Summarizing thread' }).last()).toBeVisible()
 


### PR DESCRIPTION
## Summary
Un-reds main: the Desktop E2E "queues an Enter-submitted draft instead of steering while compaction is active" test now overshoots the compaction threshold decisively instead of sitting ~250 tokens over it, so it no longer breaks whenever the system prompt's bundled-skills listing shrinks.

Root cause: the test triggers automatic compaction with a 500-repeat message against a 22k `threshold_tokens` budget. The request estimate includes the system prompt, and the July 2026 skills-tree cleanup (hermes-agent hub absorption `e3d524b482` + moves to optional-skills/) shrank the skills listing enough to drop the request under the threshold. Compaction never fired, `waitForHeldCompletion()` never resolved, and the test hit its 90s timeout — red on main since `9a4d1a0130` (3 consecutive main runs) and on every PR since, including #70513 and #70517.

## Changes
- `apps/desktop/e2e/session-compression-and-queue-stop.spec.ts`: trigger message 500 → 1500 repeats (~12.4k tokens), with a comment explaining the margin so the next skills cleanup doesn't re-break it

## Validation
| Check | Result |
|---|---|
| Numeric reconstruction: messages (~4.3k) + tool schemas (~13.4k) matches the failing run's 17.7k/64k context meter | ✔ |
| At 1500 repeats: request ~26k > 22k threshold, < 64k mock context; history-only base ~13.6k stays under threshold | ✔ |
| Skills-listing delta green→red measured at -251 tokens — exactly the vanished margin | ✔ |
| Sibling compaction E2E (`hidden-history-messages.spec.ts`) pins `threshold_tokens: 1` — immune, untouched | ✔ |
| `tsc --noEmit` on apps/desktop | clean |

Local Electron E2E execution isn't possible on this headless box (no xvfb, root-owned X socket) — CI's Desktop E2E job is the authoritative verification for this PR, and it runs the exact test being fixed.

## Infographic

![desktop-e2e-threshold-margin](https://v3b.fal.media/files/b/0aa37df6/hqZsp4NunFaG-cfF1iqkO_s3Z00HQT.png)
