### PR TITLE
fix(doctor): warn on volatile Hermes state storage

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -5,10 +5,13 @@ Diagnoses issues with Hermes Agent setup.
 """
 
 import os
+import re
 import sys
 import subprocess
 import shutil
-from pathlib import Path
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -78,6 +81,130 @@ def _safe_which(cmd: str) -> str | None:
         return shutil.which(cmd)
     except Exception:
         return None
+
+
+_VOLATILE_LINUX_FS_TYPES = frozenset({"tmpfs", "ramfs"})
+
+
+@dataclass(frozen=True)
+class _LinuxMountInfoEntry:
+    mount_id: int
+    parent_id: int
+    mount_point: PurePosixPath
+    fs_type: str
+
+
+def _decode_mountinfo_path(value: str) -> str:
+    """Decode octal escapes used by /proc/self/mountinfo."""
+    return re.sub(
+        r"\\([0-7]{3})",
+        lambda match: chr(int(match.group(1), 8)),
+        value,
+    )
+
+
+def _detect_linux_volatile_state_dir(
+    state_dir: Path,
+    *,
+    platform: str | None = None,
+    mount_info: str | None = None,
+    resolve_state_dir: Callable[[Path], str] | None = None,
+) -> tuple[str, str] | None:
+    """Return the matching volatile mount and filesystem type, if any."""
+    if (platform or sys.platform) != "linux":
+        return None
+
+    try:
+        resolved_state_dir = PurePosixPath(
+            resolve_state_dir(state_dir)
+            if resolve_state_dir is not None
+            else str(state_dir.resolve(strict=False))
+        )
+    except (OSError, RuntimeError):
+        resolved_state_dir = PurePosixPath(str(state_dir.absolute()))
+
+    if mount_info is None:
+        try:
+            mount_info = Path("/proc/self/mountinfo").read_text(
+                encoding="utf-8",
+                errors="replace",
+            )
+        except OSError:
+            return None
+
+    entries: list[_LinuxMountInfoEntry] = []
+    for line in mount_info.splitlines():
+        before_separator, separator, after_separator = line.partition(" - ")
+        if not separator:
+            continue
+        mount_fields = before_separator.split()
+        fs_fields = after_separator.split()
+        if len(mount_fields) < 5 or not fs_fields:
+            continue
+
+        try:
+            mount_id = int(mount_fields[0])
+            parent_id = int(mount_fields[1])
+        except ValueError:
+            continue
+        entries.append(
+            _LinuxMountInfoEntry(
+                mount_id=mount_id,
+                parent_id=parent_id,
+                mount_point=PurePosixPath(
+                    _decode_mountinfo_path(mount_fields[4])
+                ),
+                fs_type=fs_fields[0],
+            )
+        )
+
+    entries_by_id = {entry.mount_id: entry for entry in entries}
+    hidden_mount_ids = {
+        parent.mount_id
+        for entry in entries
+        if entry.mount_id != entry.parent_id
+        and (parent := entries_by_id.get(entry.parent_id)) is not None
+        and parent.mount_point == entry.mount_point
+    }
+
+    def is_visible(entry: _LinuxMountInfoEntry) -> bool:
+        seen: set[int] = set()
+        child: _LinuxMountInfoEntry | None = None
+        current: _LinuxMountInfoEntry | None = entry
+        while current is not None and current.mount_id not in seen:
+            if current.mount_id in hidden_mount_ids:
+                child_is_its_overmount = (
+                    child is not None
+                    and child.parent_id == current.mount_id
+                    and child.mount_point == current.mount_point
+                )
+                if not child_is_its_overmount:
+                    return False
+            seen.add(current.mount_id)
+            if current.parent_id == current.mount_id:
+                break
+            child = current
+            current = entries_by_id.get(current.parent_id)
+        return True
+
+    best_match: _LinuxMountInfoEntry | None = None
+    for entry in entries:
+        if not is_visible(entry):
+            continue
+        try:
+            resolved_state_dir.relative_to(entry.mount_point)
+        except ValueError:
+            continue
+
+        if (
+            best_match is None
+            or len(entry.mount_point.parts) >= len(best_match.mount_point.parts)
+        ):
+            best_match = entry
+
+    if best_match and best_match.fs_type in _VOLATILE_LINUX_FS_TYPES:
+        return str(best_match.mount_point), best_match.fs_type
+    return None
 
 
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
@@ -1388,6 +1515,18 @@ def run_doctor(args):
     
     # Check SQLite session store
     state_db_path = hermes_home / "state.db"
+    volatile_state_mount = _detect_linux_volatile_state_dir(hermes_home)
+    if volatile_state_mount is not None:
+        mount_point, fs_type = volatile_state_mount
+        check_warn(
+            f"{_DHH} is on volatile {fs_type} storage",
+            f"(mount: {mount_point})",
+        )
+        manual_issues.append(
+            f"Move HERMES_HOME off {fs_type} ({mount_point}); state.db, "
+            "configuration, credentials, memories, and sessions will be lost on reboot"
+        )
+
     if state_db_path.exists():
         try:
             import sqlite3

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -5,11 +5,14 @@ Diagnoses issues with Hermes Agent setup.
 """
 
 import os
+import re
 import sys
 import subprocess
 import shutil
 import importlib.util
-from pathlib import Path
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 
 from hermes_cli.config import (
     detect_install_method,
@@ -204,6 +207,130 @@ def _safe_which(cmd: str) -> str | None:
         return shutil.which(cmd)
     except Exception:
         return None
+
+
+_VOLATILE_LINUX_FS_TYPES = frozenset({"tmpfs", "ramfs"})
+
+
+@dataclass(frozen=True)
+class _LinuxMountInfoEntry:
+    mount_id: int
+    parent_id: int
+    mount_point: PurePosixPath
+    fs_type: str
+
+
+def _decode_mountinfo_path(value: str) -> str:
+    """Decode octal escapes used by /proc/self/mountinfo."""
+    return re.sub(
+        r"\\([0-7]{3})",
+        lambda match: chr(int(match.group(1), 8)),
+        value,
+    )
+
+
+def _detect_linux_volatile_state_dir(
+    state_dir: Path,
+    *,
+    platform: str | None = None,
+    mount_info: str | None = None,
+    resolve_state_dir: Callable[[Path], str] | None = None,
+) -> tuple[str, str] | None:
+    """Return the matching volatile mount and filesystem type, if any."""
+    if (platform or sys.platform) != "linux":
+        return None
+
+    try:
+        resolved_state_dir = PurePosixPath(
+            resolve_state_dir(state_dir)
+            if resolve_state_dir is not None
+            else str(state_dir.resolve(strict=False))
+        )
+    except (OSError, RuntimeError):
+        resolved_state_dir = PurePosixPath(str(state_dir.absolute()))
+
+    if mount_info is None:
+        try:
+            mount_info = Path("/proc/self/mountinfo").read_text(
+                encoding="utf-8",
+                errors="replace",
+            )
+        except OSError:
+            return None
+
+    entries: list[_LinuxMountInfoEntry] = []
+    for line in mount_info.splitlines():
+        before_separator, separator, after_separator = line.partition(" - ")
+        if not separator:
+            continue
+        mount_fields = before_separator.split()
+        fs_fields = after_separator.split()
+        if len(mount_fields) < 5 or not fs_fields:
+            continue
+
+        try:
+            mount_id = int(mount_fields[0])
+            parent_id = int(mount_fields[1])
+        except ValueError:
+            continue
+        entries.append(
+            _LinuxMountInfoEntry(
+                mount_id=mount_id,
+                parent_id=parent_id,
+                mount_point=PurePosixPath(
+                    _decode_mountinfo_path(mount_fields[4])
+                ),
+                fs_type=fs_fields[0],
+            )
+        )
+
+    entries_by_id = {entry.mount_id: entry for entry in entries}
+    hidden_mount_ids = {
+        parent.mount_id
+        for entry in entries
+        if entry.mount_id != entry.parent_id
+        and (parent := entries_by_id.get(entry.parent_id)) is not None
+        and parent.mount_point == entry.mount_point
+    }
+
+    def is_visible(entry: _LinuxMountInfoEntry) -> bool:
+        seen: set[int] = set()
+        child: _LinuxMountInfoEntry | None = None
+        current: _LinuxMountInfoEntry | None = entry
+        while current is not None and current.mount_id not in seen:
+            if current.mount_id in hidden_mount_ids:
+                child_is_its_overmount = (
+                    child is not None
+                    and child.parent_id == current.mount_id
+                    and child.mount_point == current.mount_point
+                )
+                if not child_is_its_overmount:
+                    return False
+            seen.add(current.mount_id)
+            if current.parent_id == current.mount_id:
+                break
+            child = current
+            current = entries_by_id.get(current.parent_id)
+        return True
+
+    best_match: _LinuxMountInfoEntry | None = None
+    for entry in entries:
+        if not is_visible(entry):
+            continue
+        try:
+            resolved_state_dir.relative_to(entry.mount_point)
+        except ValueError:
+            continue
+
+        if (
+            best_match is None
+            or len(entry.mount_point.parts) >= len(best_match.mount_point.parts)
+        ):
+            best_match = entry
+
+    if best_match and best_match.fs_type in _VOLATILE_LINUX_FS_TYPES:
+        return str(best_match.mount_point), best_match.fs_type
+    return None
 
 
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
@@ -1688,6 +1815,18 @@ def run_doctor(args):
     
     # Check SQLite session store
     state_db_path = hermes_home / "state.db"
+    volatile_state_mount = _detect_linux_volatile_state_dir(hermes_home)
+    if volatile_state_mount is not None:
+        mount_point, fs_type = volatile_state_mount
+        check_warn(
+            f"{_DHH} is on volatile {fs_type} storage",
+            f"(mount: {mount_point})",
+        )
+        manual_issues.append(
+            f"Move HERMES_HOME off {fs_type} ({mount_point}); state.db, "
+            "configuration, credentials, memories, and sessions will be lost on reboot"
+        )
+
     if state_db_path.exists():
         try:
             import sqlite3

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -6,6 +6,7 @@ import types
 import io
 import contextlib
 from argparse import Namespace
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -14,6 +15,157 @@ import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
+
+
+class TestDoctorVolatileStateDirectory:
+    PERSISTENT_AND_VOLATILE_MOUNTS = "\n".join(
+        [
+            "22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw",
+            "30 22 0:30 / /home rw,relatime - ext4 /dev/sda2 rw",
+            "35 30 0:35 / /home/user/.hermes rw - tmpfs tmpfs rw,size=1048576k",
+        ]
+    )
+
+    @pytest.mark.parametrize("fs_type", ["tmpfs", "ramfs"])
+    def test_detects_volatile_linux_state_mount(self, fs_type):
+        mount_info = "\n".join(
+            [
+                "22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw",
+                f"35 22 0:35 / /home/user/.hermes rw - {fs_type} {fs_type} rw",
+            ]
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/home/user/.hermes"),
+            platform="linux",
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) == ("/home/user/.hermes", fs_type)
+
+    def test_uses_most_specific_matching_mount(self):
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/home/user/.hermes/profiles/coder"),
+            platform="linux",
+            mount_info=self.PERSISTENT_AND_VOLATILE_MOUNTS,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) == ("/home/user/.hermes", "tmpfs")
+
+    def test_uses_topmost_mount_at_same_path(self):
+        mount_info = "\n".join(
+            [
+                "22 22 0:21 / / rw - ext4 /dev/sda1 rw",
+                "30 22 0:30 / /data rw - ext4 /dev/sda2 rw",
+                "35 30 0:35 / /data rw - tmpfs tmpfs rw",
+            ]
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/data/hermes"),
+            platform="linux",
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) == ("/data", "tmpfs")
+
+    def test_ignores_tmpfs_hidden_by_persistent_overmount(self):
+        mount_info = "\n".join(
+            [
+                "22 22 0:21 / / rw - ext4 /dev/sda1 rw",
+                "30 22 0:30 / /data rw - tmpfs tmpfs rw",
+                "35 30 0:35 / /data rw - ext4 /dev/sda2 rw",
+            ]
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/data/hermes"),
+            platform="linux",
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) is None
+
+    def test_ignores_nested_mount_beneath_hidden_parent(self):
+        mount_info = "\n".join(
+            [
+                "22 22 0:21 / / rw - ext4 /dev/sda1 rw",
+                "30 22 0:30 / /data rw - ext4 /dev/sda2 rw",
+                "31 30 0:31 / /data/cache rw - tmpfs tmpfs rw",
+                "35 30 0:35 / /data rw - ext4 /dev/sda3 rw",
+            ]
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/data/cache/hermes"),
+            platform="linux",
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) is None
+
+    def test_resolves_missing_child_through_existing_symlink(self, tmp_path):
+        if sys.platform == "win32":
+            pytest.skip("creating directory symlinks requires elevated privileges on Windows")
+
+        volatile_target = tmp_path / "volatile"
+        volatile_target.mkdir()
+        state_link = tmp_path / "state"
+        state_link.symlink_to(volatile_target, target_is_directory=True)
+        resolved_target = volatile_target.resolve()
+        missing_state_dir = state_link / "profiles" / "coder"
+        mount_info = "\n".join(
+            [
+                "22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw",
+                f"35 22 0:35 / {resolved_target} rw - tmpfs tmpfs rw",
+            ]
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            missing_state_dir,
+            platform="linux",
+            mount_info=mount_info,
+        ) == (resolved_target.as_posix(), "tmpfs")
+
+    @pytest.mark.parametrize(
+        "platform,mount_info",
+        [
+            ("win32", PERSISTENT_AND_VOLATILE_MOUNTS),
+            ("darwin", PERSISTENT_AND_VOLATILE_MOUNTS),
+            ("linux", "22 1 0:21 / / rw - ext4 /dev/sda1 rw"),
+            ("linux", "22 1 0:21 / / rw - overlay overlay rw"),
+            ("linux", "malformed mountinfo"),
+        ],
+    )
+    def test_does_not_flag_nonvolatile_or_unsupported_mounts(
+        self,
+        platform,
+        mount_info,
+    ):
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/home/user/.hermes"),
+            platform=platform,
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) is None
+
+    def test_decodes_mountinfo_escaped_spaces(self):
+        mount_info = (
+            "35 22 0:35 / /run/hermes\\040state rw - tmpfs tmpfs rw"
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/run/hermes state/profile"),
+            platform="linux",
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) == ("/run/hermes state", "tmpfs")
+
+    def test_symlink_loop_resolution_failure_does_not_abort_doctor(self):
+        def raise_symlink_loop(_path):
+            raise RuntimeError("Symlink loop from '/state' path")
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/state"),
+            platform="linux",
+            mount_info="malformed mountinfo",
+            resolve_state_dir=raise_symlink_loop,
+        ) is None
 
 
 class TestDoctorPlatformHints:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -6,6 +6,7 @@ import types
 import io
 import contextlib
 from argparse import Namespace
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -14,6 +15,206 @@ import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
+
+
+@pytest.mark.parametrize("fix", [False, True])
+def test_run_doctor_reports_volatile_state_as_manual_without_moving(
+    monkeypatch, tmp_path, fix
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    sentinel = home / "state-sentinel"
+    sentinel.write_text("keep", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir()
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        doctor_mod,
+        "_detect_linux_volatile_state_dir",
+        lambda _path: ("/run/hermes-state", "tmpfs"),
+    )
+    moves = []
+    monkeypatch.setattr(
+        doctor_mod.shutil,
+        "move",
+        lambda source, destination, *args, **kwargs: moves.append(
+            (source, destination)
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "model_tools",
+        types.SimpleNamespace(
+            check_tool_availability=lambda *args, **kwargs: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        ),
+    )
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        doctor_mod.run_doctor(Namespace(fix=fix))
+
+    text = output.getvalue()
+    assert f"{home} is on volatile tmpfs storage" in text
+    assert "Move HERMES_HOME off tmpfs (/run/hermes-state)" in text
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+    assert moves == []
+
+
+class TestDoctorVolatileStateDirectory:
+    PERSISTENT_AND_VOLATILE_MOUNTS = "\n".join(
+        [
+            "22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw",
+            "30 22 0:30 / /home rw,relatime - ext4 /dev/sda2 rw",
+            "35 30 0:35 / /home/user/.hermes rw - tmpfs tmpfs rw,size=1048576k",
+        ]
+    )
+
+    @pytest.mark.parametrize("fs_type", ["tmpfs", "ramfs"])
+    def test_detects_volatile_linux_state_mount(self, fs_type):
+        mount_info = "\n".join(
+            [
+                "22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw",
+                f"35 22 0:35 / /home/user/.hermes rw - {fs_type} {fs_type} rw",
+            ]
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/home/user/.hermes"),
+            platform="linux",
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) == ("/home/user/.hermes", fs_type)
+
+    def test_uses_most_specific_matching_mount(self):
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/home/user/.hermes/profiles/coder"),
+            platform="linux",
+            mount_info=self.PERSISTENT_AND_VOLATILE_MOUNTS,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) == ("/home/user/.hermes", "tmpfs")
+
+    def test_uses_topmost_mount_at_same_path(self):
+        mount_info = "\n".join(
+            [
+                "22 22 0:21 / / rw - ext4 /dev/sda1 rw",
+                "30 22 0:30 / /data rw - ext4 /dev/sda2 rw",
+                "35 30 0:35 / /data rw - tmpfs tmpfs rw",
+            ]
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/data/hermes"),
+            platform="linux",
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) == ("/data", "tmpfs")
+
+    def test_ignores_tmpfs_hidden_by_persistent_overmount(self):
+        mount_info = "\n".join(
+            [
+                "22 22 0:21 / / rw - ext4 /dev/sda1 rw",
+                "30 22 0:30 / /data rw - tmpfs tmpfs rw",
+                "35 30 0:35 / /data rw - ext4 /dev/sda2 rw",
+            ]
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/data/hermes"),
+            platform="linux",
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) is None
+
+    def test_ignores_nested_mount_beneath_hidden_parent(self):
+        mount_info = "\n".join(
+            [
+                "22 22 0:21 / / rw - ext4 /dev/sda1 rw",
+                "30 22 0:30 / /data rw - ext4 /dev/sda2 rw",
+                "31 30 0:31 / /data/cache rw - tmpfs tmpfs rw",
+                "35 30 0:35 / /data rw - ext4 /dev/sda3 rw",
+            ]
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/data/cache/hermes"),
+            platform="linux",
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) is None
+
+    def test_resolves_missing_child_through_existing_symlink(self, tmp_path):
+        if sys.platform == "win32":
+            pytest.skip("creating directory symlinks requires elevated privileges on Windows")
+
+        volatile_target = tmp_path / "volatile"
+        volatile_target.mkdir()
+        state_link = tmp_path / "state"
+        state_link.symlink_to(volatile_target, target_is_directory=True)
+        resolved_target = volatile_target.resolve()
+        missing_state_dir = state_link / "profiles" / "coder"
+        mount_info = "\n".join(
+            [
+                "22 1 0:21 / / rw,relatime - ext4 /dev/sda1 rw",
+                f"35 22 0:35 / {resolved_target} rw - tmpfs tmpfs rw",
+            ]
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            missing_state_dir,
+            platform="linux",
+            mount_info=mount_info,
+        ) == (resolved_target.as_posix(), "tmpfs")
+
+    @pytest.mark.parametrize(
+        "platform,mount_info",
+        [
+            ("win32", PERSISTENT_AND_VOLATILE_MOUNTS),
+            ("darwin", PERSISTENT_AND_VOLATILE_MOUNTS),
+            ("linux", "22 1 0:21 / / rw - ext4 /dev/sda1 rw"),
+            ("linux", "22 1 0:21 / / rw - overlay overlay rw"),
+            ("linux", "malformed mountinfo"),
+        ],
+    )
+    def test_does_not_flag_nonvolatile_or_unsupported_mounts(
+        self,
+        platform,
+        mount_info,
+    ):
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/home/user/.hermes"),
+            platform=platform,
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) is None
+
+    def test_decodes_mountinfo_escaped_spaces(self):
+        mount_info = (
+            "35 22 0:35 / /run/hermes\\040state rw - tmpfs tmpfs rw"
+        )
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/run/hermes state/profile"),
+            platform="linux",
+            mount_info=mount_info,
+            resolve_state_dir=lambda path: path.as_posix(),
+        ) == ("/run/hermes state", "tmpfs")
+
+    def test_symlink_loop_resolution_failure_does_not_abort_doctor(self):
+        def raise_symlink_loop(_path):
+            raise RuntimeError("Symlink loop from '/state' path")
+
+        assert doctor._detect_linux_volatile_state_dir(
+            Path("/state"),
+            platform="linux",
+            mount_info="malformed mountinfo",
+            resolve_state_dir=raise_symlink_loop,
+        ) is None
 
 
 class TestDoctorPlatformHints:


### PR DESCRIPTION
## What does this PR do?

Warns when the active Linux `HERMES_HOME` resolves to `tmpfs` or `ramfs`.

Hermes keeps `state.db`, SQLite sidecars, configuration, credentials, memories, and sessions under this directory. A volatile mount can therefore look healthy in `hermes doctor` while all durable state is scheduled to disappear on reboot.

The check is diagnostic only. It does not move or delete state, including under `--fix`.

## Related Issue

Fixes #70542

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Parse `/proc/self/mountinfo`, including octal-escaped mount paths.
- Resolve missing state-directory descendants through existing symlink ancestors.
- Select the most specific visible mount, including stacked/hidden mount handling via mount IDs.
- Warn only for `tmpfs` and `ramfs`; persistent and overlay filesystems remain unchanged.
- Fail open when mount metadata or path resolution is unavailable.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_doctor.py -q -p no:cacheprovider`.
2. Run `python -m ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`.
3. On Linux, set `HERMES_HOME` beneath a `tmpfs` mount such as `/dev/shm` and run `hermes doctor`; it should report the volatile state location.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the affected behavior on Windows with simulated Linux mount metadata; the symlink test runs on Linux CI

### Documentation & Housekeeping

- [x] Documentation update: N/A; the doctor warning is self-contained
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered; non-Linux platforms return without reading mount metadata
- [x] Tool descriptions/schemas: N/A

## Proof

```text
python -m pytest tests/hermes_cli/test_doctor.py -q -p no:cacheprovider
88 passed, 1 skipped, 1 warning

python -m ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py
All checks passed!

autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.94)
```
