### PR TITLE
fix(agent): classify Cloudflare challenges as upstream

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4498,6 +4498,8 @@ def run_conversation(
                             agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
                         elif classified.reason == FailoverReason.ssl_cert_verification:
                             agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
+                        elif classified.reason == FailoverReason.upstream_html:
+                            agent._buffer_status("⚠️ Upstream CDN/gateway blocked this request — trying fallback...")
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
                     if agent._try_activate_fallback():
@@ -4529,6 +4531,11 @@ def run_conversation(
                     elif classified.reason == FailoverReason.ssl_cert_verification:
                         agent._emit_status(
                             f"❌ TLS certificate verification failed: "
+                            f"{_nonretryable_summary}"
+                        )
+                    elif classified.reason == FailoverReason.upstream_html:
+                        agent._emit_status(
+                            f"❌ Upstream CDN/gateway blocked this request: "
                             f"{_nonretryable_summary}"
                         )
                     else:
@@ -4580,6 +4587,15 @@ def run_conversation(
                             agent._vprint(f"{agent.log_prefix}      • Does your account have access to {_model}?", force=True)
                             if base_url_host_matches(str(_base), "openrouter.ai"):
                                 agent._vprint(f"{agent.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
+                    elif classified.reason == FailoverReason.upstream_html:
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 The provider endpoint returned a browser challenge.",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}      Try another network, endpoint, or fallback provider.",
+                            force=True,
+                        )
                     else:
                         agent._vprint(f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
                     # Content-policy blocks deserve their own actionable

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5487,6 +5487,8 @@ def run_conversation(
                             agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
                         elif classified.reason == FailoverReason.ssl_cert_verification:
                             agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
+                        elif classified.reason == FailoverReason.upstream_html:
+                            agent._buffer_status("⚠️ Upstream CDN/gateway blocked this request — trying fallback...")
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
                     if agent._try_activate_fallback():
@@ -5518,6 +5520,11 @@ def run_conversation(
                     elif classified.reason == FailoverReason.ssl_cert_verification:
                         agent._emit_status(
                             f"❌ TLS certificate verification failed: "
+                            f"{_nonretryable_summary}"
+                        )
+                    elif classified.reason == FailoverReason.upstream_html:
+                        agent._emit_status(
+                            f"❌ Upstream CDN/gateway blocked this request: "
                             f"{_nonretryable_summary}"
                         )
                     else:
@@ -5569,6 +5576,15 @@ def run_conversation(
                             agent._vprint(f"{agent.log_prefix}      • Does your account have access to {_model}?", force=True)
                             if base_url_host_matches(str(_base), "openrouter.ai"):
                                 agent._vprint(f"{agent.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
+                    elif classified.reason == FailoverReason.upstream_html:
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 The provider endpoint returned a browser challenge.",
+                            force=True,
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}      Try another network, endpoint, or fallback provider.",
+                            force=True,
+                        )
                     else:
                         agent._vprint(f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
                     # Content-policy blocks deserve their own actionable

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -38,6 +38,7 @@ class FailoverReason(enum.Enum):
     # Server-side
     overloaded = "overloaded"            # 503/529 — provider overloaded, backoff
     server_error = "server_error"        # 500/502 — internal server error, retry
+    upstream_html = "upstream_html"      # CDN/gateway challenge page — fallback, don't re-auth
 
     # Transport
     timeout = "timeout"                  # Connection/read timeout — rebuild client + retry
@@ -122,6 +123,14 @@ _BILLING_PATTERNS = [
     "model_not_supported_on_free_tier",
     "not available on the free tier",
 ]
+
+_CLOUDFLARE_CHALLENGE_PATTERNS = (
+    "enable javascript and cookies to continue",
+    "cf-browser-verification",
+    "__cf_challenge",
+    "cdn-cgi/challenge-platform",
+    "challenge-error-text",
+)
 
 # xAI's explicit Grok credit-exhaustion code. Keep the HTTP 403 special case
 # provider-scoped: other providers' generic billing codes historically remain
@@ -951,6 +960,16 @@ def _classify_by_status(
         )
 
     if status_code == 403:
+        # Cloudflare browser challenges block the request before it reaches the
+        # provider. Treating these pages as auth failures produces misleading
+        # API-key guidance and may rotate otherwise healthy credentials.
+        if any(p in error_msg for p in _CLOUDFLARE_CHALLENGE_PATTERNS):
+            return result_fn(
+                FailoverReason.upstream_html,
+                retryable=False,
+                should_fallback=True,
+            )
+
         # OpenRouter 403 "key limit exceeded" is actually billing. Other
         # providers also use 403 for account-plan or credit exhaustion.
         if (

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -38,6 +38,7 @@ class FailoverReason(enum.Enum):
     # Server-side
     overloaded = "overloaded"            # 503/529 — provider overloaded, backoff
     server_error = "server_error"        # 500/502 — internal server error, retry
+    upstream_html = "upstream_html"      # CDN/gateway challenge page — fallback, don't re-auth
 
     # Transport
     timeout = "timeout"                  # Connection/read timeout — rebuild client + retry
@@ -122,6 +123,14 @@ _BILLING_PATTERNS = [
     "model_not_supported_on_free_tier",
     "not available on the free tier",
 ]
+
+_CLOUDFLARE_CHALLENGE_PATTERNS = (
+    "enable javascript and cookies to continue",
+    "cf-browser-verification",
+    "__cf_challenge",
+    "cdn-cgi/challenge-platform",
+    "challenge-error-text",
+)
 
 # xAI's explicit Grok credit-exhaustion code. Keep the HTTP 403 special case
 # provider-scoped: other providers' generic billing codes historically remain
@@ -1033,6 +1042,16 @@ def _classify_by_status(
         )
 
     if status_code == 403:
+        # Cloudflare browser challenges block the request before it reaches the
+        # provider. Treating these pages as auth failures produces misleading
+        # API-key guidance and may rotate otherwise healthy credentials.
+        if any(p in error_msg for p in _CLOUDFLARE_CHALLENGE_PATTERNS):
+            return result_fn(
+                FailoverReason.upstream_html,
+                retryable=False,
+                should_fallback=True,
+            )
+
         # OpenRouter 403 "key limit exceeded" is actually billing. Other
         # providers also use 403 for account-plan or credit exhaustion.
         if (

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -54,7 +54,7 @@ class TestFailoverReason:
         expected = {
             "auth", "auth_permanent", "billing", "rate_limit",
             "upstream_rate_limit",
-            "overloaded", "server_error", "timeout",
+            "overloaded", "server_error", "upstream_html", "timeout",
             "ssl_cert_verification",
             "context_overflow", "payload_too_large", "image_too_large",
             "model_not_found", "format_error",
@@ -245,6 +245,51 @@ class TestClassifyApiError:
     def test_403_classified_as_auth(self):
         e = MockAPIError("Forbidden", status_code=403)
         result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.auth
+        assert result.should_fallback is True
+
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            "Enable JavaScript and cookies to continue",
+            "cf-browser-verification",
+            "__cf_challenge",
+            "cdn-cgi/challenge-platform",
+            "challenge-error-text",
+        ],
+    )
+    def test_403_cloudflare_challenge_classified_as_upstream_html(self, marker):
+        e = MockAPIError(
+            f"<!doctype html><html><body>{marker}</body></html>",
+            status_code=403,
+        )
+
+        result = classify_api_error(e, provider="openai-codex")
+
+        assert result.reason == FailoverReason.upstream_html
+        assert result.retryable is False
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+
+    def test_401_cloudflare_marker_remains_auth(self):
+        e = MockAPIError(
+            "<html>Enable JavaScript and cookies to continue</html>",
+            status_code=401,
+        )
+
+        result = classify_api_error(e, provider="openai-codex")
+
+        assert result.reason == FailoverReason.auth
+        assert result.should_rotate_credential is True
+
+    def test_generic_403_html_remains_auth(self):
+        e = MockAPIError(
+            "<html><title>Forbidden</title><body>Access denied</body></html>",
+            status_code=403,
+        )
+
+        result = classify_api_error(e, provider="openai-codex")
+
         assert result.reason == FailoverReason.auth
         assert result.should_fallback is True
 
@@ -2169,4 +2214,3 @@ class Test408RequestTimeout:
         assert result.retryable is False
         assert result.should_fallback is True
         assert result.should_compress is False
-

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -54,7 +54,7 @@ class TestFailoverReason:
         expected = {
             "auth", "auth_permanent", "billing", "rate_limit",
             "upstream_rate_limit",
-            "overloaded", "server_error", "timeout",
+            "overloaded", "server_error", "upstream_html", "timeout",
             "ssl_cert_verification",
             "context_overflow", "payload_too_large", "image_too_large",
             "model_not_found", "format_error",
@@ -199,6 +199,58 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.auth
         assert result.should_fallback is True
 
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            "Enable JavaScript and cookies to continue",
+            "cf-browser-verification",
+            "__cf_challenge",
+            "cdn-cgi/challenge-platform",
+            "challenge-error-text",
+        ],
+    )
+    def test_403_cloudflare_challenge_classified_as_upstream_html(self, marker):
+        e = MockAPIError(
+            f"<!doctype html><html><body>{marker}</body></html>",
+            status_code=403,
+        )
+
+        result = classify_api_error(e, provider="openai-codex")
+
+        assert result.reason == FailoverReason.upstream_html
+        assert result.retryable is False
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+
+    def test_401_cloudflare_marker_remains_auth(self):
+        e = MockAPIError(
+            "<html>Enable JavaScript and cookies to continue</html>",
+            status_code=401,
+        )
+
+        result = classify_api_error(e, provider="openai-codex")
+
+        assert result.reason == FailoverReason.auth
+        assert result.should_rotate_credential is True
+
+    def test_generic_403_html_remains_auth(self):
+        e = MockAPIError(
+            "<html><title>Forbidden</title><body>Access denied</body></html>",
+            status_code=403,
+        )
+
+        result = classify_api_error(e, provider="openai-codex")
+
+        assert result.reason == FailoverReason.auth
+        assert result.should_fallback is True
+
+    def test_403_key_limit_classified_as_billing(self):
+        """OpenRouter 403 'key limit exceeded' is billing, not auth."""
+        e = MockAPIError("Key limit exceeded for this key", status_code=403)
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.billing
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
 
 
 

--- a/tests/run_agent/test_nonretryable_error_html_summary.py
+++ b/tests/run_agent/test_nonretryable_error_html_summary.py
@@ -127,3 +127,23 @@ def test_non_retryable_failure_error_is_summarized_not_raw_html():
     # The original page was tens of kilobytes; a summary is short.
     assert len(error) < 500
     assert len(error) < len(_CLOUDFLARE_CHALLENGE_HTML)
+
+
+def test_cloudflare_challenge_skips_credential_pool_and_uses_fallback():
+    from tests.run_agent.test_run_agent import _mock_response
+
+    agent = _make_agent()
+    agent._credential_pool = pool = MagicMock(provider="openai")
+    agent._fallback_chain = [{"provider": "openrouter", "model": "openai/gpt-4o"}]
+    agent.client.chat.completions.create.side_effect = _make_403_html_error()
+    fallback = MagicMock(api_key="fallback-key", base_url="https://openrouter.ai/api/v1")
+    fallback.chat.completions.create.return_value = _mock_response(content="Recovered on fallback.", finish_reason="stop")
+
+    with patch("agent.auxiliary_client.resolve_provider_client", return_value=(fallback, None)), \
+         patch("agent.credential_pool.load_pool", return_value=None), \
+         patch.object(agent, "_persist_session"), patch.object(agent, "_save_trajectory"), \
+         patch.object(agent, "_cleanup_task_resources"):
+        result = agent.run_conversation("daily briefing please")
+
+    assert not pool.try_refresh_matching.called and not pool.mark_exhausted_and_rotate.called
+    assert (agent.provider, result["final_response"]) == ("openrouter", "Recovered on fallback.")


### PR DESCRIPTION
﻿## Summary

- classify HTTP 403 Cloudflare browser-challenge pages as an upstream CDN/gateway failure instead of an authentication failure
- keep generic 403 and all 401 behavior unchanged
- avoid credential rotation and same-request retries for the blocked endpoint while retaining configured provider fallback
- surface CDN/gateway-specific status and remediation instead of API-key guidance

Fixes #70566.

## Why

Cloudflare challenge responses such as `Enable JavaScript and cookies to continue`, `challenge-error-text`, and `/cdn-cgi/challenge-platform/` are generated before a request reaches the model provider. Treating them as `auth` sends operators toward healthy credentials and hides the network-layer cause.

The detector is intentionally gated to HTTP 403 and five established challenge markers. A normal 403 HTML response still follows the existing auth path, and a 401 containing the same text remains auth.

## Validation

```text
python -m pytest tests/agent/test_error_classifier.py tests/run_agent/test_nonretryable_error_html_summary.py -q -p no:cacheprovider
208 passed in 10.09s

python -m ruff check agent/error_classifier.py agent/conversation_loop.py tests/agent/test_error_classifier.py
All checks passed!

git diff --check
(clean)
```

Regression coverage verifies:

- all five recognized Cloudflare challenge markers on 403 become `upstream_html`;
- the result is non-retryable, does not rotate credentials, and permits fallback;
- a Cloudflare marker on 401 remains auth;
- generic 403 HTML remains auth;
- existing raw-HTML summarization behavior remains intact.

## Review

Codex Auto Review completed against the uncommitted patch:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.93)
```
