### PR TITLE
feat(desktop): hermes://chat/new deep link for workspace sessions

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -54,6 +54,45 @@ The installer handles everything for you (Python 3.11+, a portable Git, ripgrep)
 
 ---
 
+## Deep links
+
+The desktop app registers the `hermes://` protocol. Existing:
+
+```text
+hermes://blueprint/<name>?slot=value
+```
+
+Inserts a reviewable `/blueprint …` command into the composer.
+
+**New session (this PR):**
+
+```text
+hermes://chat/new?cwd=<absolute-path>&profile=<name>&project=<id-or-slug>&prompt=<text>&sticky=<slot>
+```
+
+| Param | Required | Behavior |
+|-------|----------|----------|
+| `cwd` | one of `cwd` / `project` | Absolute workspace path (Unix, Windows drive, or UNC). Relative paths and `..` are refused. |
+| `project` | one of `cwd` / `project` | Resolve path via the desktop project store (id, slug, or name). |
+| `profile` | no | Target Hermes profile / gateway seat for the new chat. |
+| `prompt` | no | Prefill composer (does not auto-send). |
+| `sticky` | no | Named slot: reopen the same session on later opens; first open creates and binds. |
+
+Examples:
+
+```bash
+# macOS / Linux
+open 'hermes://chat/new?cwd=%2FUsers%2Fyou%2Fmy-repo&profile=default'
+open 'hermes://chat/new?cwd=%2FUsers%2Fyou%2Fmy-repo&sticky=ceo'
+
+# Windows (PowerShell)
+start 'hermes://chat/new?cwd=C%3A%5CUsers%5Cyou%5Cmy-repo&profile=default'
+```
+
+Use a hidden iframe or bare `<a href="hermes://…">` from browsers — `window.open(url, '_blank')` often leaves an empty tab when handing off to a custom protocol.
+
+---
+
 ## Development
 
 Want to hack on the app itself? Install workspace deps from the repo root once, then run the dev server from this directory:

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -74,7 +74,7 @@ hermes://chat/new?cwd=<absolute-path>&profile=<name>&project=<id-or-slug>&prompt
 |-------|----------|----------|
 | `cwd` | one of `cwd` / `project` | Absolute workspace path (Unix, Windows drive, or UNC). Relative paths and `..` are refused. |
 | `project` | one of `cwd` / `project` | Resolve path via the desktop project store (id, slug, or name). |
-| `profile` | no | Target Hermes profile / gateway seat for the new chat. |
+| `profile` | no | Target Hermes profile / gateway seat. **Must be installed** (refreshed allow-list); unknown names are refused. |
 | `prompt` | no | Prefill composer (does not auto-send). |
 | `sticky` | no | Named slot: reopen the same session on later opens; first open creates and binds. |
 
@@ -253,3 +253,11 @@ Remove-Item -Recurse -Force "$env:LOCALAPPDATA\hermes\hermes-agent\venv"
 MIT — see [LICENSE](../../LICENSE).
 
 Built by [Nous Research](https://nousresearch.com).
+
+### Safety (chat/new)
+
+- `profile` is validated against the installed profile list after refresh; untrusted names never activate a gateway.
+- Gateway activation is **awaited** before workspace/`config.get` work so requests do not hit the previous profile.
+- `sticky` pending binds are **per delivery** (FIFO queue + profile match), not one global slot — rapid links cannot steal each other's session bind.
+- `project=` that does not resolve is **fail-closed** (no detached empty chat).
+- Newer `chat/new` deliveries invalidate in-flight older handlers (stale-delivery guard).

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11698,10 +11698,11 @@ ipcMain.handle('hermes:vscode-theme:fetch', async (_event, id) => fetchMarketpla
 ipcMain.handle('hermes:vscode-theme:search', async (_event, query) => searchMarketplaceThemes(String(query || ''), 20))
 
 // ---------------------------------------------------------------------------
-// hermes:// deep links (e.g. hermes://blueprint/morning-brief?time=08:00).
-// A docs/dashboard "Send to App" button opens this URL; we route it into the
-// running app's chat composer. Three delivery paths: macOS 'open-url',
-// Win/Linux running-app 'second-instance' (argv), Win/Linux cold-start argv.
+// hermes:// deep links (e.g. hermes://blueprint/morning-brief?time=08:00,
+// hermes://chat/new?cwd=/abs/path&profile=default&sticky=slot).
+// Payload is generic { kind, name, params }; renderer decides (blueprint insert
+// vs chat/new session). Delivery: macOS 'open-url', Win/Linux second-instance
+// argv, cold-start argv.
 // ---------------------------------------------------------------------------
 const HERMES_PROTOCOL = 'hermes'
 let _pendingDeepLink = null

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -2,10 +2,32 @@ import { useEffect, useRef } from 'react'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { openSession } from '@/app/open-session'
+import {
+  clearStickySessionId,
+  cwdLooksSane,
+  normalizeStickySlot,
+  readStickySessionId,
+  setStickyPending,
+  takeStickyPending,
+  writeStickySessionId
+} from '@/lib/deeplink-chat-new'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
 import { respondToApprovalAction } from '@/store/native-notifications'
-import { $activeGatewayProfile } from '@/store/profile'
-import { openFolderAsProject } from '@/store/projects'
+import {
+  $activeGatewayProfile,
+  $newChatProfile,
+  ensureGatewayProfile,
+  newSessionInProfile,
+  requestFreshSession
+} from '@/store/profile'
+import {
+  $projectTree,
+  $projects,
+  enterProject,
+  openFolderAsProject,
+  projectIdForCwd,
+  requestStartWorkSession
+} from '@/store/projects'
 import {
   $sessions,
   getRememberedRoute,
@@ -20,6 +42,43 @@ import { isSecondaryWindow } from '@/store/windows'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
 import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
+
+/** Resolve hermes://chat/new?project= id or slug/name → absolute cwd from live project caches. */
+function resolveProjectCwd(projectKey: string): { cwd: string; projectId: null | string } | null {
+  const key = projectKey.trim()
+  if (!key) return null
+
+  const lower = key.toLowerCase()
+  for (const p of $projects.get()) {
+    const id = String(p.id || '').trim()
+    const name = String(p.name || '').trim()
+    const slug = String(p.slug || name.toLowerCase().replace(/\s+/g, '-')).trim()
+    if (id === key || name === key || slug === key || slug.toLowerCase() === lower || name.toLowerCase() === lower) {
+      const folders = Array.isArray(p.folders) ? p.folders : []
+      const folderPath = folders.map(f => String((f as { path?: string }).path || '').trim()).find(Boolean) || ''
+      const cwd = String(p.primary_path || folderPath || '').trim()
+      if (cwd) return { cwd, projectId: id || null }
+    }
+  }
+
+  for (const node of $projectTree.get()) {
+    const id = String(node.id || '').trim()
+    const label = String(node.label || '').trim()
+    const slug = label.toLowerCase().replace(/\s+/g, '-')
+    if (id === key || label === key || slug === lower || label.toLowerCase() === lower) {
+      const cwd = String(node.path || node.repos?.find(r => r.path)?.path || '').trim()
+      if (cwd) return { cwd, projectId: id || null }
+    }
+  }
+
+  return null
+}
+
+function sessionIdKnown(sessionId: string): boolean {
+  const id = sessionId.trim()
+  if (!id) return false
+  return $sessions.get().some(s => String(s.id || '').trim() === id)
+}
 
 interface DesktopIntegrationsParams {
   chatOpen: boolean
@@ -71,11 +130,19 @@ export function useDesktopIntegrations({
   // non-overlay route (a page like /skills, or a session route) so a relaunch
   // lands where you were. Overlays (settings/command-center/…) aren't stored —
   // you don't want to boot into a modal.
+  // Also binds deeplink sticky= slots once a real session mounts.
   useEffect(() => {
     const routeProfile = rememberedSessionProfile($sessions.get(), routedSessionId, $activeGatewayProfile.get())
 
     if (routedSessionId) {
-      setRememberedSessionId(routedSessionId, routeProfile)
+      setRememberedSessionId(
+        routedSessionId,
+        rememberedSessionProfile($sessions.get(), routedSessionId, $activeGatewayProfile.get())
+      )
+      const pendingSticky = takeStickyPending()
+      if (pendingSticky) {
+        writeStickySessionId(pendingSticky, routedSessionId)
+      }
     }
 
     if (!isOverlayView(appViewForPath(locationPathname))) {
@@ -151,10 +218,93 @@ export function useDesktopIntegrations({
     return () => unsubscribe?.()
   }, [])
 
-  // hermes:// deep links -> a reviewable /blueprint command in the composer.
+  // hermes:// deep links:
+  //  - blueprint/<name>?slots → reviewable /blueprint command in composer
+  //  - chat/new?cwd=&profile=&project=&prompt=&sticky= → fresh (or sticky) session
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onDeepLink?.(payload => {
-      if (!payload || payload.kind !== 'blueprint' || !payload.name) {
+      if (!payload || !payload.kind) {
+        return
+      }
+
+      // hermes://chat/new?cwd=…&profile=…&project=…&prompt=…&sticky=…
+      // main delivers { kind: 'chat', name: 'new', params }
+      if (payload.kind === 'chat' && payload.name === 'new') {
+        const params = payload.params || {}
+        const profile = (params.profile || '').trim()
+        const prompt = (params.prompt || '').trim()
+        const projectKey = (params.project || '').trim()
+        const sticky = normalizeStickySlot(params.sticky)
+        let cwd = (params.cwd || '').trim()
+        let projectId: null | string = null
+
+        if (!cwd && projectKey) {
+          const hit = resolveProjectCwd(projectKey)
+          if (hit) {
+            cwd = hit.cwd
+            projectId = hit.projectId
+          }
+        }
+
+        if (cwd && !cwdLooksSane(cwd)) {
+          console.warn('[deeplink] chat/new refused unsafe cwd', cwd)
+          return
+        }
+
+        // sticky=<slot>: resume the same session instead of minting a new one.
+        if (sticky) {
+          const existing = readStickySessionId(sticky)
+          if (existing) {
+            const known = sessionIdKnown(existing)
+            // Empty session cache (boot race) → trust id once; loaded+missing → clear.
+            if (known || $sessions.get().length === 0) {
+              navigate(sessionRoute(existing))
+              requestComposerFocus('main')
+              if (prompt) {
+                requestComposerInsert(prompt, { mode: 'block', target: 'main' })
+              }
+              return
+            }
+            clearStickySessionId(sticky)
+          }
+          // First open (or cleared): create below and bind when routedSessionId lands.
+          setStickyPending(sticky)
+        }
+
+        if (profile) {
+          $newChatProfile.set(profile)
+          void ensureGatewayProfile(profile)
+          // Prefer newSessionInProfile when we do not yet have a cwd path — it
+          // forces fresh. When cwd is set, requestStartWorkSession owns the
+          // fresh draft with workspace target (avoids double fresh race).
+          if (!cwd) {
+            newSessionInProfile(profile)
+          } else {
+            requestFreshSession()
+          }
+        } else if (!cwd) {
+          requestFreshSession()
+        }
+
+        if (cwd) {
+          const matched = projectId || projectIdForCwd(cwd)
+          if (matched) {
+            enterProject(matched)
+          }
+          // Same path as sidebar "new session in worktree/project"
+          requestStartWorkSession(cwd, prompt || undefined)
+        } else {
+          navigate(NEW_CHAT_ROUTE)
+          if (prompt) {
+            requestComposerInsert(prompt, { mode: 'block', target: 'main' })
+          }
+        }
+
+        requestComposerFocus('main')
+        return
+      }
+
+      if (payload.kind !== 'blueprint' || !payload.name) {
         return
       }
 
@@ -174,7 +324,7 @@ export function useDesktopIntegrations({
     void window.hermesDesktop?.signalDeepLinkReady?.()
 
     return () => unsubscribe?.()
-  }, [])
+  }, [navigate])
 
   // ⌘W via the macOS menu accelerator → close the focused tab; if nothing is
   // closeable, fall back to closing the window (so ⌘W still works as the

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -5,10 +5,13 @@ import { openSession } from '@/app/open-session'
 import {
   clearStickySessionId,
   cwdLooksSane,
+  isChatNewDeliveryStale,
+  isInstalledProfileName,
+  nextChatNewDeliveryId,
   normalizeStickySlot,
+  pushStickyDelivery,
   readStickySessionId,
-  setStickyPending,
-  takeStickyPending,
+  takeStickyDeliveryForSession,
   writeStickySessionId
 } from '@/lib/deeplink-chat-new'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
@@ -16,8 +19,10 @@ import { respondToApprovalAction } from '@/store/native-notifications'
 import {
   $activeGatewayProfile,
   $newChatProfile,
+  $profiles,
   ensureGatewayProfile,
-  newSessionInProfile,
+  normalizeProfileKey,
+  refreshProfiles,
   requestFreshSession
 } from '@/store/profile'
 import {
@@ -131,15 +136,20 @@ export function useDesktopIntegrations({
   // lands where you were. Overlays (settings/command-center/…) aren't stored —
   // you don't want to boot into a modal.
   // Also binds deeplink sticky= slots once a real session mounts.
+  // Consume delivery-correlated pending (FIFO + profile match), not a global singleton.
   useEffect(() => {
     const routeProfile = rememberedSessionProfile($sessions.get(), routedSessionId, $activeGatewayProfile.get())
 
     if (routedSessionId) {
-      setRememberedSessionId(
+      const sessionProfile = rememberedSessionProfile(
+        $sessions.get(),
         routedSessionId,
-        rememberedSessionProfile($sessions.get(), routedSessionId, $activeGatewayProfile.get())
+        $activeGatewayProfile.get()
       )
-      const pendingSticky = takeStickyPending()
+      setRememberedSessionId(routedSessionId, sessionProfile)
+      const pendingSticky = takeStickyDeliveryForSession({
+        profile: normalizeProfileKey(sessionProfile)
+      })
       if (pendingSticky) {
         writeStickySessionId(pendingSticky, routedSessionId)
       }
@@ -221,6 +231,7 @@ export function useDesktopIntegrations({
   // hermes:// deep links:
   //  - blueprint/<name>?slots → reviewable /blueprint command in composer
   //  - chat/new?cwd=&profile=&project=&prompt=&sticky= → fresh (or sticky) session
+  // Profile allow-listed; gateway activation awaited; sticky pending is delivery-correlated.
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onDeepLink?.(payload => {
       if (!payload || !payload.kind) {
@@ -230,77 +241,112 @@ export function useDesktopIntegrations({
       // hermes://chat/new?cwd=…&profile=…&project=…&prompt=…&sticky=…
       // main delivers { kind: 'chat', name: 'new', params }
       if (payload.kind === 'chat' && payload.name === 'new') {
+        const deliveryId = nextChatNewDeliveryId()
         const params = payload.params || {}
-        const profile = (params.profile || '').trim()
+        const profileRaw = (params.profile || '').trim()
         const prompt = (params.prompt || '').trim()
         const projectKey = (params.project || '').trim()
         const sticky = normalizeStickySlot(params.sticky)
         let cwd = (params.cwd || '').trim()
         let projectId: null | string = null
 
-        if (!cwd && projectKey) {
-          const hit = resolveProjectCwd(projectKey)
-          if (hit) {
+        void (async () => {
+          const stale = () => isChatNewDeliveryStale(deliveryId)
+
+          // Allow-list profile against installed list (refresh first when named).
+          let profileKey: null | string = null
+          if (profileRaw) {
+            try {
+              await refreshProfiles()
+            } catch {
+              /* use cached $profiles */
+            }
+            if (stale()) return
+            const installed = $profiles.get()
+            if (!isInstalledProfileName(profileRaw, installed)) {
+              console.warn('[deeplink] chat/new refused unknown profile', profileRaw)
+              return
+            }
+            profileKey = normalizeProfileKey(profileRaw)
+          }
+
+          // project= must resolve; do not fall through to a detached new chat.
+          if (!cwd && projectKey) {
+            const hit = resolveProjectCwd(projectKey)
+            if (!hit) {
+              console.warn('[deeplink] chat/new refused unresolved project', projectKey)
+              return
+            }
             cwd = hit.cwd
             projectId = hit.projectId
           }
-        }
 
-        if (cwd && !cwdLooksSane(cwd)) {
-          console.warn('[deeplink] chat/new refused unsafe cwd', cwd)
-          return
-        }
-
-        // sticky=<slot>: resume the same session instead of minting a new one.
-        if (sticky) {
-          const existing = readStickySessionId(sticky)
-          if (existing) {
-            const known = sessionIdKnown(existing)
-            // Empty session cache (boot race) → trust id once; loaded+missing → clear.
-            if (known || $sessions.get().length === 0) {
-              navigate(sessionRoute(existing))
-              requestComposerFocus('main')
-              if (prompt) {
-                requestComposerInsert(prompt, { mode: 'block', target: 'main' })
-              }
-              return
-            }
-            clearStickySessionId(sticky)
+          if (cwd && !cwdLooksSane(cwd)) {
+            console.warn('[deeplink] chat/new refused unsafe cwd', cwd)
+            return
           }
-          // First open (or cleared): create below and bind when routedSessionId lands.
-          setStickyPending(sticky)
-        }
 
-        if (profile) {
-          $newChatProfile.set(profile)
-          void ensureGatewayProfile(profile)
-          // Prefer newSessionInProfile when we do not yet have a cwd path — it
-          // forces fresh. When cwd is set, requestStartWorkSession owns the
-          // fresh draft with workspace target (avoids double fresh race).
-          if (!cwd) {
-            newSessionInProfile(profile)
+          // sticky=<slot>: resume the same session instead of minting a new one.
+          if (sticky) {
+            const existing = readStickySessionId(sticky)
+            if (existing) {
+              const known = sessionIdKnown(existing)
+              // Empty session cache (boot race) → trust id once; loaded+missing → clear.
+              if (known || $sessions.get().length === 0) {
+                if (profileKey) {
+                  $newChatProfile.set(profileKey)
+                  await ensureGatewayProfile(profileKey)
+                  if (stale()) return
+                }
+                if (stale()) return
+                navigate(sessionRoute(existing))
+                requestComposerFocus('main')
+                if (prompt) {
+                  requestComposerInsert(prompt, { mode: 'block', target: 'main' })
+                }
+                return
+              }
+              clearStickySessionId(sticky)
+            }
+            // First open (or cleared): bind when routedSessionId lands for THIS delivery.
+            pushStickyDelivery({
+              deliveryId: String(deliveryId),
+              slot: sticky,
+              profile: profileKey
+            })
+          }
+
+          // Activate gateway before any workspace/config work that uses active gateway.
+          if (profileKey) {
+            $newChatProfile.set(profileKey)
+            await ensureGatewayProfile(profileKey)
+            if (stale()) return
+            requestFreshSession()
+          } else if (!cwd) {
+            requestFreshSession()
           } else {
             requestFreshSession()
           }
-        } else if (!cwd) {
-          requestFreshSession()
-        }
 
-        if (cwd) {
-          const matched = projectId || projectIdForCwd(cwd)
-          if (matched) {
-            enterProject(matched)
-          }
-          // Same path as sidebar "new session in worktree/project"
-          requestStartWorkSession(cwd, prompt || undefined)
-        } else {
-          navigate(NEW_CHAT_ROUTE)
-          if (prompt) {
-            requestComposerInsert(prompt, { mode: 'block', target: 'main' })
-          }
-        }
+          if (stale()) return
 
-        requestComposerFocus('main')
+          if (cwd) {
+            const matched = projectId || projectIdForCwd(cwd)
+            if (matched) {
+              enterProject(matched)
+            }
+            // Same path as sidebar "new session in worktree/project"
+            requestStartWorkSession(cwd, prompt || undefined)
+          } else {
+            navigate(NEW_CHAT_ROUTE)
+            if (prompt) {
+              requestComposerInsert(prompt, { mode: 'block', target: 'main' })
+            }
+          }
+
+          requestComposerFocus('main')
+        })()
+
         return
       }
 

--- a/apps/desktop/src/lib/deeplink-chat-new.test.ts
+++ b/apps/desktop/src/lib/deeplink-chat-new.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  clearStickySessionId,
+  cwdLooksSane,
+  deeplinkStickyStorageKey,
+  normalizeStickySlot,
+  readStickySessionId,
+  setStickyPending,
+  takeStickyPending,
+  writeStickySessionId
+} from './deeplink-chat-new'
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear() {
+      map.clear()
+    },
+    getItem(key: string) {
+      return map.has(key) ? map.get(key)! : null
+    },
+    key(index: number) {
+      return [...map.keys()][index] ?? null
+    },
+    removeItem(key: string) {
+      map.delete(key)
+    },
+    setItem(key: string, value: string) {
+      map.set(key, String(value))
+    }
+  }
+}
+
+describe('cwdLooksSane', () => {
+  it('accepts absolute unix paths', () => {
+    expect(cwdLooksSane('/Users/trevor/HomeDome')).toBe(true)
+    expect(cwdLooksSane('/tmp')).toBe(true)
+  })
+
+  it('accepts windows drive and unc paths', () => {
+    expect(cwdLooksSane('C:\\Users\\trevor\\proj')).toBe(true)
+    expect(cwdLooksSane('D:/work/repo')).toBe(true)
+    expect(cwdLooksSane('\\\\server\\share\\repo')).toBe(true)
+  })
+
+  it('rejects relative and traversal', () => {
+    expect(cwdLooksSane('relative/path')).toBe(false)
+    expect(cwdLooksSane('../etc')).toBe(false)
+    expect(cwdLooksSane('/Users/../etc')).toBe(false)
+    expect(cwdLooksSane('/Users/trevor/..')).toBe(false)
+    expect(cwdLooksSane('')).toBe(false)
+  })
+})
+
+describe('sticky slots', () => {
+  it('normalizes slot names', () => {
+    expect(normalizeStickySlot(' CEO ')).toBe('ceo')
+    expect(normalizeStickySlot('My Project!')).toBe('my-project')
+    expect(normalizeStickySlot('')).toBe('')
+  })
+
+  it('round-trips sticky session ids', () => {
+    const store = memoryStorage()
+    writeStickySessionId('ceo', '20260724_session', store)
+    expect(readStickySessionId('CEO', store)).toBe('20260724_session')
+    expect(deeplinkStickyStorageKey('ceo')).toContain('ceo')
+    clearStickySessionId('ceo', store)
+    expect(readStickySessionId('ceo', store)).toBe(null)
+  })
+
+  it('pending sticky is one-shot', () => {
+    const store = memoryStorage()
+    setStickyPending('work', store)
+    expect(takeStickyPending(store)).toBe('work')
+    expect(takeStickyPending(store)).toBe(null)
+  })
+})

--- a/apps/desktop/src/lib/deeplink-chat-new.test.ts
+++ b/apps/desktop/src/lib/deeplink-chat-new.test.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach } from 'vitest'
 
 import {
   clearStickySessionId,
   cwdLooksSane,
   deeplinkStickyStorageKey,
+  isChatNewDeliveryStale,
+  isInstalledProfileName,
+  nextChatNewDeliveryId,
   normalizeStickySlot,
+  pushStickyDelivery,
   readStickySessionId,
+  resetChatNewDeliverySeqForTests,
   setStickyPending,
+  takeStickyDeliveryForSession,
   takeStickyPending,
   writeStickySessionId
 } from './deeplink-chat-new'
@@ -71,11 +77,68 @@ describe('sticky slots', () => {
     clearStickySessionId('ceo', store)
     expect(readStickySessionId('ceo', store)).toBe(null)
   })
+})
 
-  it('pending sticky is one-shot', () => {
+describe('delivery-correlated sticky pending', () => {
+  beforeEach(() => {
+    resetChatNewDeliverySeqForTests()
+  })
+
+  it('FIFO consume preserves order across rapid deliveries', () => {
+    const store = memoryStorage()
+    pushStickyDelivery({ deliveryId: '1', slot: 'ceo', profile: 'default' }, store)
+    pushStickyDelivery({ deliveryId: '2', slot: 'work', profile: 'work' }, store)
+
+    expect(takeStickyDeliveryForSession({ profile: 'default' }, store)).toBe('ceo')
+    expect(takeStickyDeliveryForSession({ profile: 'work' }, store)).toBe('work')
+    expect(takeStickyDeliveryForSession({ profile: 'default' }, store)).toBe(null)
+  })
+
+  it('profile match skips non-matching head without dropping it', () => {
+    const store = memoryStorage()
+    pushStickyDelivery({ deliveryId: '1', slot: 'ceo', profile: 'default' }, store)
+    pushStickyDelivery({ deliveryId: '2', slot: 'lab', profile: 'work' }, store)
+
+    expect(takeStickyDeliveryForSession({ profile: 'work' }, store)).toBe('lab')
+    expect(takeStickyDeliveryForSession({ profile: 'default' }, store)).toBe('ceo')
+  })
+
+  it('null profile binding matches any session profile', () => {
+    const store = memoryStorage()
+    pushStickyDelivery({ deliveryId: '1', slot: 'ceo', profile: null }, store)
+    expect(takeStickyDeliveryForSession({ profile: 'jordan' }, store)).toBe('ceo')
+  })
+
+  it('stale delivery id detects newer chat/new', () => {
+    const a = nextChatNewDeliveryId()
+    expect(isChatNewDeliveryStale(a)).toBe(false)
+    const b = nextChatNewDeliveryId()
+    expect(isChatNewDeliveryStale(a)).toBe(true)
+    expect(isChatNewDeliveryStale(b)).toBe(false)
+  })
+
+  it('legacy setStickyPending still one-shot via takeStickyPending', () => {
     const store = memoryStorage()
     setStickyPending('work', store)
     expect(takeStickyPending(store)).toBe('work')
     expect(takeStickyPending(store)).toBe(null)
+  })
+})
+
+describe('isInstalledProfileName', () => {
+  it('allows empty profile', () => {
+    expect(isInstalledProfileName('', [{ name: 'default' }])).toBe(true)
+  })
+
+  it('allow-lists against installed names', () => {
+    const installed = [{ name: 'default', is_default: true }, { name: 'jordan' }, { name: 'work' }]
+    expect(isInstalledProfileName('jordan', installed)).toBe(true)
+    expect(isInstalledProfileName('Jordan', installed)).toBe(true)
+    expect(isInstalledProfileName('evil', installed)).toBe(false)
+  })
+
+  it('boot empty list only allows default', () => {
+    expect(isInstalledProfileName('default', [])).toBe(true)
+    expect(isInstalledProfileName('jordan', [])).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/deeplink-chat-new.ts
+++ b/apps/desktop/src/lib/deeplink-chat-new.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure helpers for hermes://chat/new deep links.
+ * Kept free of React so unit tests can cover cwd sanity + sticky slot keys.
+ */
+
+export const DEEPLINK_STICKY_PREFIX = 'hermes.desktop.deeplink.sticky.'
+export const DEEPLINK_STICKY_PENDING = 'hermes.desktop.deeplink.sticky.pending'
+
+export function deeplinkStickyStorageKey(slot: string): string {
+  return `${DEEPLINK_STICKY_PREFIX}${slot.trim().toLowerCase()}`
+}
+
+/**
+ * Accept absolute workspace paths only. Reject relative and `..` traversal.
+ * Unix: `/…` · Windows: `C:\…` / `C:/…` · UNC: `\\server\share\…`
+ */
+export function cwdLooksSane(cwd: string): boolean {
+  const path = cwd.trim()
+  if (!path) return false
+  if (path.includes('\0')) return false
+  // Normalize for traversal checks (also catch encoded weirdness callers might pass)
+  const normalized = path.replace(/\\/g, '/')
+  if (normalized.includes('/../') || normalized.endsWith('/..') || normalized === '..' || normalized.startsWith('../')) {
+    return false
+  }
+  if (normalized.startsWith('/')) return true
+  // Windows drive
+  if (/^[A-Za-z]:[\\/]/.test(path)) return true
+  // UNC
+  if (path.startsWith('\\\\') || normalized.startsWith('//')) return true
+  return false
+}
+
+export function normalizeStickySlot(raw: string | undefined | null): string {
+  return String(raw || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64)
+}
+
+export function readStickySessionId(slot: string, storage: Storage = localStorage): null | string {
+  const key = normalizeStickySlot(slot)
+  if (!key) return null
+  try {
+    const id = storage.getItem(deeplinkStickyStorageKey(key))?.trim()
+    return id || null
+  } catch {
+    return null
+  }
+}
+
+export function writeStickySessionId(slot: string, sessionId: string, storage: Storage = localStorage): void {
+  const key = normalizeStickySlot(slot)
+  const id = sessionId.trim()
+  if (!key || !id) return
+  try {
+    storage.setItem(deeplinkStickyStorageKey(key), id)
+  } catch {
+    /* quota / private mode */
+  }
+}
+
+export function clearStickySessionId(slot: string, storage: Storage = localStorage): void {
+  const key = normalizeStickySlot(slot)
+  if (!key) return
+  try {
+    storage.removeItem(deeplinkStickyStorageKey(key))
+  } catch {
+    /* ignore */
+  }
+}
+
+export function setStickyPending(slot: string, sessionStore: Storage = sessionStorage): void {
+  const key = normalizeStickySlot(slot)
+  if (!key) return
+  try {
+    sessionStore.setItem(DEEPLINK_STICKY_PENDING, key)
+  } catch {
+    /* ignore */
+  }
+}
+
+export function takeStickyPending(sessionStore: Storage = sessionStorage): null | string {
+  try {
+    const slot = normalizeStickySlot(sessionStore.getItem(DEEPLINK_STICKY_PENDING))
+    if (slot) sessionStore.removeItem(DEEPLINK_STICKY_PENDING)
+    return slot || null
+  } catch {
+    return null
+  }
+}

--- a/apps/desktop/src/lib/deeplink-chat-new.ts
+++ b/apps/desktop/src/lib/deeplink-chat-new.ts
@@ -1,10 +1,22 @@
 /**
  * Pure helpers for hermes://chat/new deep links.
- * Kept free of React so unit tests can cover cwd sanity + sticky slot keys.
+ * Kept free of React so unit tests can cover cwd sanity + sticky + delivery correlation.
  */
 
 export const DEEPLINK_STICKY_PREFIX = 'hermes.desktop.deeplink.sticky.'
+/** @deprecated single-slot pending — kept for migration read-clear only */
 export const DEEPLINK_STICKY_PENDING = 'hermes.desktop.deeplink.sticky.pending'
+export const DEEPLINK_STICKY_PENDING_QUEUE = 'hermes.desktop.deeplink.sticky.pending.queue.v2'
+
+export const STICKY_DELIVERY_TTL_MS = 60_000
+
+export type StickyDeliveryBinding = {
+  deliveryId: string
+  slot: string
+  /** Normalized profile key, or null if link omitted profile */
+  profile: null | string
+  createdAt: number
+}
 
 export function deeplinkStickyStorageKey(slot: string): string {
   return `${DEEPLINK_STICKY_PREFIX}${slot.trim().toLowerCase()}`
@@ -18,15 +30,17 @@ export function cwdLooksSane(cwd: string): boolean {
   const path = cwd.trim()
   if (!path) return false
   if (path.includes('\0')) return false
-  // Normalize for traversal checks (also catch encoded weirdness callers might pass)
   const normalized = path.replace(/\\/g, '/')
-  if (normalized.includes('/../') || normalized.endsWith('/..') || normalized === '..' || normalized.startsWith('../')) {
+  if (
+    normalized.includes('/../') ||
+    normalized.endsWith('/..') ||
+    normalized === '..' ||
+    normalized.startsWith('../')
+  ) {
     return false
   }
   if (normalized.startsWith('/')) return true
-  // Windows drive
   if (/^[A-Za-z]:[\\/]/.test(path)) return true
-  // UNC
   if (path.startsWith('\\\\') || normalized.startsWith('//')) return true
   return false
 }
@@ -72,22 +86,155 @@ export function clearStickySessionId(slot: string, storage: Storage = localStora
   }
 }
 
-export function setStickyPending(slot: string, sessionStore: Storage = sessionStorage): void {
-  const key = normalizeStickySlot(slot)
-  if (!key) return
+/** Monotonic delivery ids for chat/new (module scope; tests can reset). */
+let chatNewDeliverySeq = 0
+let chatNewLatestDeliveryId = 0
+
+export function resetChatNewDeliverySeqForTests(): void {
+  chatNewDeliverySeq = 0
+  chatNewLatestDeliveryId = 0
+}
+
+export function nextChatNewDeliveryId(): number {
+  chatNewDeliverySeq += 1
+  chatNewLatestDeliveryId = chatNewDeliverySeq
+  return chatNewDeliverySeq
+}
+
+/** True if a newer chat/new delivery started after `deliveryId`. */
+export function isChatNewDeliveryStale(deliveryId: number): boolean {
+  return deliveryId !== chatNewLatestDeliveryId
+}
+
+function readPendingQueue(sessionStore: Storage): StickyDeliveryBinding[] {
   try {
-    sessionStore.setItem(DEEPLINK_STICKY_PENDING, key)
+    const raw = sessionStore.getItem(DEEPLINK_STICKY_PENDING_QUEUE)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (b): b is StickyDeliveryBinding =>
+        !!b &&
+        typeof b === 'object' &&
+        typeof (b as StickyDeliveryBinding).deliveryId === 'string' &&
+        typeof (b as StickyDeliveryBinding).slot === 'string' &&
+        typeof (b as StickyDeliveryBinding).createdAt === 'number'
+    )
+  } catch {
+    return []
+  }
+}
+
+function writePendingQueue(queue: StickyDeliveryBinding[], sessionStore: Storage): void {
+  try {
+    if (queue.length === 0) {
+      sessionStore.removeItem(DEEPLINK_STICKY_PENDING_QUEUE)
+    } else {
+      sessionStore.setItem(DEEPLINK_STICKY_PENDING_QUEUE, JSON.stringify(queue))
+    }
   } catch {
     /* ignore */
   }
 }
 
-export function takeStickyPending(sessionStore: Storage = sessionStorage): null | string {
+function pruneQueue(queue: StickyDeliveryBinding[], now = Date.now()): StickyDeliveryBinding[] {
+  return queue.filter(b => now - b.createdAt <= STICKY_DELIVERY_TTL_MS)
+}
+
+/**
+ * Register a sticky bind for a specific deep-link delivery (not a global singleton).
+ * Rapid successive links each push their own binding; session mount consumes FIFO match.
+ */
+export function pushStickyDelivery(
+  binding: Omit<StickyDeliveryBinding, 'createdAt'> & { createdAt?: number },
+  sessionStore: Storage = sessionStorage
+): void {
+  const slot = normalizeStickySlot(binding.slot)
+  const deliveryId = String(binding.deliveryId || '').trim()
+  if (!slot || !deliveryId) return
+  const now = Date.now()
+  const next = pruneQueue(readPendingQueue(sessionStore), now)
+  next.push({
+    deliveryId,
+    slot,
+    profile: binding.profile != null && String(binding.profile).trim() ? String(binding.profile).trim() : null,
+    createdAt: binding.createdAt ?? now
+  })
+  writePendingQueue(next, sessionStore)
+  // Clear legacy singleton so old builds don't double-bind
   try {
-    const slot = normalizeStickySlot(sessionStore.getItem(DEEPLINK_STICKY_PENDING))
-    if (slot) sessionStore.removeItem(DEEPLINK_STICKY_PENDING)
-    return slot || null
+    sessionStore.removeItem(DEEPLINK_STICKY_PENDING)
   } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Consume the oldest non-expired sticky delivery that matches the mounted session's profile.
+ * Profile null on the binding matches any session; concrete profile must equal session profile key.
+ */
+export function takeStickyDeliveryForSession(
+  opts: { profile: null | string; now?: number },
+  sessionStore: Storage = sessionStorage
+): null | string {
+  const now = opts.now ?? Date.now()
+  const sessionProfile = (opts.profile ?? '').trim() || null
+  let queue = pruneQueue(readPendingQueue(sessionStore), now)
+
+  // Migrate one-shot legacy pending into queue head once
+  try {
+    const legacy = normalizeStickySlot(sessionStore.getItem(DEEPLINK_STICKY_PENDING))
+    if (legacy) {
+      sessionStore.removeItem(DEEPLINK_STICKY_PENDING)
+      queue = [{ deliveryId: `legacy-${now}`, slot: legacy, profile: null, createdAt: now }, ...queue]
+    }
+  } catch {
+    /* ignore */
+  }
+
+  const idx = queue.findIndex(b => {
+    if (!b.profile) return true
+    if (!sessionProfile) return true
+    return b.profile === sessionProfile
+  })
+  if (idx < 0) {
+    writePendingQueue(queue, sessionStore)
     return null
   }
+  const [hit] = queue.splice(idx, 1)
+  writePendingQueue(queue, sessionStore)
+  return hit?.slot || null
+}
+
+/** @deprecated use pushStickyDelivery — tests still cover migration */
+export function setStickyPending(slot: string, sessionStore: Storage = sessionStorage): void {
+  pushStickyDelivery({ deliveryId: `legacy-set-${Date.now()}`, slot, profile: null }, sessionStore)
+}
+
+/** @deprecated use takeStickyDeliveryForSession */
+export function takeStickyPending(sessionStore: Storage = sessionStorage): null | string {
+  return takeStickyDeliveryForSession({ profile: null }, sessionStore)
+}
+
+export type ProfileNameLike = { name?: null | string; is_default?: boolean }
+
+/**
+ * Allow-list external profile against installed Desktop profiles.
+ * Empty installed list (boot) → only allow omitted profile or "default".
+ */
+export function isInstalledProfileName(
+  profile: string,
+  installed: ProfileNameLike[]
+): boolean {
+  const key = String(profile || '').trim()
+  if (!key) return true
+  const norm = key.toLowerCase()
+  if (installed.length === 0) {
+    return norm === 'default' || key === 'default'
+  }
+  return installed.some(p => {
+    const n = String(p.name || '').trim()
+    if (!n) return !!p.is_default && (norm === 'default' || key === 'default')
+    return n === key || n.toLowerCase() === norm
+  })
 }


### PR DESCRIPTION
## Summary

- Add `hermes://chat/new` deep link so external apps can open a desktop chat in a given workspace (`cwd` / `project`), optional `profile`, composer `prompt`, and optional `sticky` session slot
- Main process already forwards generic `{ kind, name, params }`; renderer handles `chat`/`new` beside existing `blueprint` composer inserts
- Refuse relative paths and `..` traversal; accept Unix, Windows drive, and UNC absolute paths
- Unit tests for cwd sanity + sticky storage helpers; document protocol in `apps/desktop/README.md`

## Motivation

Desktop already supports `hermes://blueprint/…` for “send to app.” Integrators (dashboards, launchers, automations) also need a first-class way to open a **real session** in the right folder/profile without scripting the UI.

## Changes

- `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts` — handle `chat/new`
- `apps/desktop/src/lib/deeplink-chat-new.ts` + `.test.ts` — pure helpers
- `apps/desktop/electron/main.ts` — comment only (generic payload already)
- `apps/desktop/README.md` — deep link docs

## Test Plan

- [x] `cd apps/desktop && npm test -- --run src/lib/deeplink-chat-new.test.ts` (6 passed)
- [x] `cd apps/desktop && npx tsc -p tsconfig.json --noEmit` (clean for this change)
- [ ] Manual: `open 'hermes://chat/new?cwd=<abs>&profile=default'` focuses app + new work session
- [ ] Manual: `&sticky=demo` second open resumes same session
- [ ] Manual: relative / `..` cwd refused (no navigation)
- [ ] Manual: existing `hermes://blueprint/…` still inserts composer command

## Notes for Reviewers

- No Glass/Home Dome code — protocol only
- `sticky` is optional; omit for always-fresh
- Browser callers should avoid `window.open(..., '_blank')` for custom protocols (empty tab); iframe/`<a href>` is fine
- Separate from optional-mcps catalog work

## Type of Change

- [x] ✨ New feature