### PR TITLE
fix(desktop): authenticate primary-profile session slices in OAuth mode

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9211,6 +9211,23 @@ async function remoteSessionList(profile, searchParams) {
   return { ...(data as any), sessions: rowsOf(data) }
 }
 
+// Primary-connection GET that stays authenticated for OAuth primaries, whose
+// token is null by design. Prefer the native RFC 8252 bearer when held, else
+// ride the cookie-bound session partition — plain fetchJson(url, primary.token)
+// 401s and callers' .catch silently blanks the primary profile's session rows
+// (mirrors the requestJsonForProfile pattern).
+async function fetchPrimaryGetJson(primary, url) {
+  const opts = { method: 'GET', timeoutMs: DEFAULT_FETCH_TIMEOUT_MS }
+  if (primary.authMode === 'oauth') {
+    const nativeAt = await ensureNativeAccessToken(primary.baseUrl).catch(() => null)
+    if (nativeAt) {
+      return fetchJson(url, null, { ...opts, bearer: nativeAt })
+    }
+    return fetchJsonViaOauthSession(url, opts)
+  }
+  return fetchJson(url, primary.token, opts)
+}
+
 // Resolve one /api/profiles/sessions slice with remote profiles spliced in —
 // the same branch logic as the GET /api/profiles/sessions intercept, but always
 // returns data (never `undefined`) so a batched caller can compose slices. A
@@ -9226,10 +9243,9 @@ async function fetchProfilesSessionSlice(searchParams, remoteProfiles) {
 
     const primary = await ensureBackend(null)
 
-    return fetchJson(`${primary.baseUrl}/api/profiles/sessions?${searchParams}`, primary.token, {
-      method: 'GET',
-      timeoutMs: DEFAULT_FETCH_TIMEOUT_MS
-    }).catch(() => ({ sessions: [], total: 0, profile_totals: {} }))
+    // OAuth-aware: token is null for OAuth primaries — see fetchPrimaryGetJson.
+    return fetchPrimaryGetJson(primary, `${primary.baseUrl}/api/profiles/sessions?${searchParams}`)
+      .catch(() => ({ sessions: [], total: 0, profile_totals: {} }))
   }
 
   return mergeRemoteProfileSessions(searchParams, remoteProfiles)
@@ -9246,10 +9262,11 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
 
   const primary = await ensureBackend(null)
 
-  const base = (await fetchJson(`${primary.baseUrl}/api/profiles/sessions?${searchParams}`, primary.token, {
-    method: 'GET',
-    timeoutMs: DEFAULT_FETCH_TIMEOUT_MS
-  }).catch(() => ({ sessions: [], total: 0, profile_totals: {} }))) as any
+  // Same OAuth caveat as fetchProfilesSessionSlice: token is null for OAuth
+  // primaries, so without the auth-aware fetch the base aggregate 401s and
+  // silently contributes zero rows.
+  const base = (await fetchPrimaryGetJson(primary, `${primary.baseUrl}/api/profiles/sessions?${searchParams}`)
+    .catch(() => ({ sessions: [], total: 0, profile_totals: {} }))) as any
 
   // Over-fetch each remote from offset 0 (limit+offset rows) so the merged window
   // is correct for this page — mirrors the primary's per-profile over-fetch.


### PR DESCRIPTION
## Bug Description

In remote OAuth mode, the desktop sidebar's **default/primary profile session list renders empty** while per-profile-override tabs populate correctly. Chat in the default tab still works (WS uses a minted ticket) — only the list is blank.

Supersedes #68169 (same fix, stale after the RFC 8252 native-login refactor; its branch was deleted).

## Root Cause

OAuth-mode primary connections carry `token: null` by design — REST is authenticated either by a native RFC 8252 bearer token or through the cookie-bound Electron session partition (`fetchJsonViaOauthSession`). The two remote-splice helpers that fetch the primary profile's session-list slices — `fetchProfilesSessionSlice`'s local-primary branch and `mergeRemoteProfileSessions`' base aggregate — called plain `fetchJson(url, primary.token)`, so every sidebar refresh for the primary profile got a `401 no_cookie` that the `.catch(() => ({ sessions: [] }))` then swallowed silently. Override profiles work because they route through the auth-aware `requestJsonForProfile`.

## Fix

- Add `fetchPrimaryGetJson(primary, url)`, mirroring `requestJsonForProfile`: for OAuth primaries, prefer the native access token (`bearer`) when held, else fall back to `fetchJsonViaOauthSession`; non-OAuth primaries keep plain `fetchJson(url, token)`.
- Route both helpers through it.

## How to Verify

1. Build the desktop app, then confirm the helper is wired into the packaged bundle: `grep -c fetchPrimaryGetJson apps/desktop/release/mac-arm64/Hermes.app/Contents/Resources/app.asar.unpacked/dist/electron-main.mjs` → 3 (definition + 2 call sites)
2. Connect a desktop client in remote OAuth mode with per-profile overrides → the default profile's session list populates alongside the override tabs
3. `npm run typecheck` (all three tsconfigs) and `npx vitest run --project electron`

## Test Plan

- [ ] Added regression test for this bug (the electron suite has no coverage of these helpers today)
- [x] Existing tests still pass — 697 electron vitest tests green
- [x] Manual verification of the fix — pre-refactor version of this change verified live on a remote OAuth setup (basic_auth dashboards, 800+ primary-profile sessions populating, 2026-07-21); this port verified via typecheck + full electron suite + packaged-bundle inspection (2026-07-23)

## Risk Assessment

Low — two call sites changed; non-OAuth behavior is byte-identical to before, and the OAuth path mirrors the existing `requestJsonForProfile` pattern already used everywhere else in `main.ts`.
