### PR TITLE
fix(desktop): pass OAuth provider for mixed gateways

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -123,6 +123,7 @@ import {
   type NativeTokenSet,
   parseTokenResponse,
   resolveLoginStrategy,
+  selectNativeLoginProvider,
   tokenNeedsRefresh
 } from './native-oauth'
 import { runNativeLogin } from './native-oauth-login'
@@ -8917,12 +8918,26 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
   const strategy = resolveLoginStrategy(statusBody)
 
   if (strategy === 'native') {
+    let provider: string | undefined
+
     try {
-      const tokens = await runNativeLogin(baseUrl, {
-        openExternal: url => shell.openExternal(url),
-        postJson: (url, body, opts) => postJsonNoAuth(url, body, opts),
-        rememberLog
-      })
+      const providerBody = await fetchPublicJson(`${baseUrl}/api/auth/providers`, { timeoutMs: 8_000 })
+      provider = selectNativeLoginProvider(providerBody)
+    } catch {
+      // Optional metadata. A single-provider gateway can still auto-select;
+      // an ambiguous gateway will fall back to the embedded chooser below.
+    }
+
+    try {
+      const tokens = await runNativeLogin(
+        baseUrl,
+        {
+          openExternal: url => shell.openExternal(url),
+          postJson: (url, body, opts) => postJsonNoAuth(url, body, opts),
+          rememberLog
+        },
+        { provider }
+      )
 
       _storeNativeTokens(baseUrl, tokens)
 

--- a/apps/desktop/electron/native-oauth.test.ts
+++ b/apps/desktop/electron/native-oauth.test.ts
@@ -22,6 +22,7 @@ import {
   parseLoopbackCallback,
   parseTokenResponse,
   resolveLoginStrategy,
+  selectNativeLoginProvider,
   statusSupportsNativeFlow,
   tokenNeedsRefresh
 } from './native-oauth'
@@ -82,6 +83,33 @@ test('resolveLoginStrategy picks native only when advertised and not forced', ()
   assert.equal(resolveLoginStrategy(legacy), 'embedded')
   // A user/env override can pin the legacy flow even on a capable gateway.
   assert.equal(resolveLoginStrategy(gated, { forceEmbedded: true }), 'embedded')
+})
+
+test('selectNativeLoginProvider picks the sole redirect provider from a mixed gateway', () => {
+  assert.equal(
+    selectNativeLoginProvider({
+      providers: [
+        { name: 'basic', supports_password: true },
+        { name: 'nous', supports_password: false }
+      ]
+    }),
+    'nous'
+  )
+})
+
+test('selectNativeLoginProvider leaves ambiguous or malformed provider lists to the login chooser', () => {
+  assert.equal(
+    selectNativeLoginProvider({
+      providers: [
+        { name: 'nous', supports_password: false },
+        { name: 'other-oauth', supports_password: false }
+      ]
+    }),
+    undefined
+  )
+  assert.equal(selectNativeLoginProvider({ providers: [{ name: 'basic', supports_password: true }] }), undefined)
+  assert.equal(selectNativeLoginProvider({ providers: [{ name: 'nous' }] }), undefined)
+  assert.equal(selectNativeLoginProvider(null), undefined)
 })
 
 // --- URL building ---

--- a/apps/desktop/electron/native-oauth.ts
+++ b/apps/desktop/electron/native-oauth.ts
@@ -95,6 +95,30 @@ export function resolveLoginStrategy(statusBody: any, opts: { forceEmbedded?: bo
 }
 
 /**
+ * Pick a native-PKCE provider only when the gateway advertises exactly one
+ * redirect-based provider. Mixed password + OAuth deployments need this
+ * explicit name because the server cannot auto-select from multiple session
+ * providers. Multiple redirect providers remain ambiguous and intentionally
+ * fall back to the embedded chooser.
+ */
+export function selectNativeLoginProvider(body: any): string | undefined {
+  const providers = Array.isArray(body?.providers) ? body.providers : []
+
+  const redirectProviders = providers
+    .filter(
+      (provider: any) =>
+        provider &&
+        typeof provider === 'object' &&
+        provider.supports_password === false &&
+        typeof provider.name === 'string' &&
+        provider.name.trim()
+    )
+    .map((provider: any) => provider.name.trim())
+
+  return redirectProviders.length === 1 ? redirectProviders[0] : undefined
+}
+
+/**
  * Build the gateway `/auth/native/authorize` URL the system browser opens.
  * `redirectUri` is the desktop's loopback callback (127.0.0.1:<port>/...).
  * `provider` is optional — omitted lets the gateway pick when it has exactly


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop remote sign-in when a gated gateway advertises both a password provider (for example `basic`) and one redirect/OAuth provider (for example `nous`).

The Desktop already fetched provider metadata for its sign-in UI, but the native PKCE IPC path called `runNativeLogin()` without a provider. The gateway only auto-selects an omitted provider when exactly one session provider is registered, so mixed deployments rejected the native authorize request with `Unknown provider: ''`.

The native login path now reads the gateway's public provider metadata, selects the sole explicitly non-password provider, and passes its name through the existing PKCE URL builder. Multiple redirect providers remain ambiguous and preserve the existing embedded login chooser fallback. Provider metadata failures also preserve the prior fallback behavior.

## Related Issue

Fixes #70572

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a pure selector for the unique redirect-based gateway provider in `apps/desktop/electron/native-oauth.ts`.
- Passed that selected provider through the existing native PKCE login path in `apps/desktop/electron/main.ts`.
- Added behavior-contract coverage for mixed password/OAuth gateways and ambiguous or malformed provider lists.

## How to Test

1. Configure a remote `hermes serve` gateway with `basic` and `nous` session providers and native PKCE advertised.
2. In Desktop Settings → Gateway, enter the remote URL and click Sign in.
3. Verify the native authorize URL carries `provider=nous`, sign-in completes, and generic multi-OAuth deployments still fall back to the embedded chooser.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: Desktop-only TypeScript change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (automated Desktop tests only)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral provider metadata only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Validation:

- Regression proof before the fix: 2 new contract tests failed while 16 existing tests passed.
- Targeted native OAuth tests: 23 passed.
- Full Electron project: 699 passed, 2 skipped.
- Full Desktop suite: 2,748 passed, 3 skipped.
- Full Desktop TypeScript typecheck: passed.
- Full Desktop ESLint: 0 errors, 17 pre-existing warnings outside the changed files.
- Prettier check and `git diff --check`: passed.

Draft limitation: the full remote `basic` + `nous` OAuth round trip was not manually smoke-tested against a live gateway; validation covers the provider-selection and PKCE URL contracts plus the complete Desktop automated suite.
