### PR TITLE
fix(kanban): resolve linked worktree anchors by branch

### DIFF
--- a/contributors/emails/royce.personalassistant@gmail.com
+++ b/contributors/emails/royce.personalassistant@gmail.com
@@ -1,0 +1,1 @@
+roycepersonalassistant

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6251,12 +6251,18 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
 
 
 def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
-    """Materialize ``target`` as a linked git worktree under ``repo_root``."""
+    """Materialize or validate ``target`` as a linked worktree on ``branch_name``."""
     target = target.expanduser()
     repo_common = _git_common_dir(repo_root)
     if target.exists() and repo_common is not None:
         target_common = _git_common_dir(target)
         if target_common == repo_common:
+            actual_branch = _git_current_branch(target)
+            if actual_branch != branch_name:
+                raise ValueError(
+                    f"linked worktree target {str(target)!r} has branch mismatch: "
+                    f"expected {branch_name!r}, found {actual_branch!r}"
+                )
             return
     target.parent.mkdir(parents=True, exist_ok=True)
     if _git_branch_exists(repo_root, branch_name):
@@ -6334,24 +6340,34 @@ def _resolve_worktree_workspace(
     if requested.exists() and _is_linked_worktree_checkout(requested):
         actual_branch = _git_current_branch(requested)
         if actual_branch == branch_name:
-            return requested_resolved, actual_branch
+            return requested_resolved, branch_name
         # The requested path is an existing checkout of a DIFFERENT
         # task's branch. Decompose children inherit the root's
         # workspace_path verbatim, so siblings all point here; reusing
         # the checkout as-is would run this task on the other task's
         # branch — silent cross-task provenance corruption, and unsafe
-        # when siblings run concurrently. Fall back to a fresh worktree
-        # of our own under the same repo.
+        # when siblings run concurrently. If the checkout belongs to the
+        # surrounding repo, fall back to a fresh canonical task worktree.
         fallback_root = _repo_root_for_worktree_target(requested.parent)
-        if fallback_root is not None:
+        requested_common = _git_common_dir(requested)
+        if (
+            fallback_root is not None
+            and _git_common_dir(fallback_root) == requested_common
+        ):
             fallback = fallback_root / ".worktrees" / task.id
             if fallback.resolve(strict=False) != requested_resolved:
                 _ensure_git_worktree(fallback_root, fallback, branch_name)
                 return fallback.resolve(strict=False), branch_name
-        # No repo to anchor a fallback on (or the occupied path IS this
-        # task's own canonical worktree): keep the legacy reuse rather
-        # than failing dispatch.
-        return requested_resolved, actual_branch or branch_name
+            raise ValueError(
+                f"task {task.id} linked worktree target {str(requested)!r} has branch "
+                f"mismatch: expected {branch_name!r}, found {actual_branch!r}"
+            )
+        # The linked checkout is not owned by a surrounding checkout, so it is
+        # itself the requested repo-root anchor. Materialize the task worktree
+        # below that exact linked root instead of silently reusing its branch.
+        target = requested_resolved / ".worktrees" / task.id
+        _ensure_git_worktree(requested_resolved, target, branch_name)
+        return target, branch_name
 
     repo_root = _git_toplevel(requested)
     if repo_root is not None and requested_resolved == repo_root:
@@ -6384,13 +6400,16 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
       compute the absolute path themselves.
     - ``worktree``: a real linked git worktree. If ``workspace_path`` names
       a repo root, Hermes treats it as an anchor and materializes a linked
-      worktree at ``<repo>/.worktrees/<task-id>``. If ``workspace_path`` names
-      a concrete target path, Hermes creates/reuses that linked worktree. With
-      no ``workspace_path``, Hermes anchors on the board's ``default_workdir``
-      and materializes ``<repo>/.worktrees/<task-id>`` per task; if no
-      ``default_workdir`` is configured it raises rather than guessing from the
-      dispatcher's CWD. When ``branch_name`` is empty, Hermes uses
-      ``wt/<task-id>``.
+      worktree at ``<repo>/.worktrees/<task-id>``. An existing linked checkout
+      on the requested branch is safely reused. A checkout on another branch
+      falls back to the surrounding repo's canonical task worktree when it
+      belongs to that repo; otherwise the linked checkout itself is the anchor
+      and gets ``<linked-root>/.worktrees/<task-id>``. Branch mismatch at an
+      already-canonical target raises explicitly. With no ``workspace_path``,
+      Hermes anchors on the board's ``default_workdir`` and materializes
+      ``<repo>/.worktrees/<task-id>`` per task; if no ``default_workdir`` is
+      configured it raises rather than guessing from the dispatcher's CWD.
+      When ``branch_name`` is empty, Hermes uses ``wt/<task-id>``.
 
     Persist the resolved path back to the task row via ``set_workspace_path``
     so subsequent runs reuse the same directory.

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -66,6 +66,58 @@ def _add_worktree(repo: Path, target: Path, branch: str) -> Path:
     return target
 
 
+def test_resolve_linked_repo_root_anchor_materializes_task_worktree(
+    kanban_home, tmp_path
+):
+    repo = _make_repo(tmp_path)
+    linked_root = _add_worktree(repo, tmp_path / "linked-root", "anchor/main")
+    branch = "wt/linked-anchor-task"
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="linked anchor",
+            workspace_kind="worktree",
+            workspace_path=str(linked_root),
+            branch_name=branch,
+        )
+        task = kb.get_task(conn, tid)
+
+    assert task is not None
+    workspace, resolved_branch = kb._resolve_worktree_workspace(task)
+    expected = linked_root / ".worktrees" / tid
+    assert workspace == expected
+    assert resolved_branch == branch
+    head = subprocess.run(
+        ["git", "-C", str(workspace), "branch", "--show-current"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert head == branch
+
+
+def test_resolve_linked_anchor_rejects_existing_target_branch_mismatch(
+    kanban_home, tmp_path
+):
+    repo = _make_repo(tmp_path)
+    linked_root = _add_worktree(repo, tmp_path / "linked-root", "anchor/main")
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="linked anchor",
+            workspace_kind="worktree",
+            workspace_path=str(linked_root),
+            branch_name="wt/intended-task",
+        )
+        target = linked_root / ".worktrees" / tid
+        _add_worktree(linked_root, target, "wt/wrong-task")
+        task = kb.get_task(conn, tid)
+
+    assert task is not None
+    with pytest.raises(ValueError, match="branch mismatch"):
+        kb._resolve_worktree_workspace(task)
+
+
 def test_decompose_worktree_children_get_own_workspace(kanban_home):
     with kb.connect() as conn:
         root = kb.create_task(conn, title="build the feature", triage=True)
@@ -172,7 +224,7 @@ def test_resolve_worktree_same_branch_still_reuses(kanban_home, tmp_path):
     assert branch == f"wt/{tid}"
 
 
-def test_resolve_worktree_own_path_on_foreign_branch_keeps_legacy_reuse(
+def test_resolve_worktree_own_path_on_foreign_branch_rejects_mismatch(
     kanban_home, tmp_path
 ):
     repo = _make_repo(tmp_path)
@@ -191,8 +243,9 @@ def test_resolve_worktree_own_path_on_foreign_branch_keeps_legacy_reuse(
         conn.commit()
         task = kb.get_task(conn, tid)
 
-    # The fallback target would be the occupied path itself, so the
-    # legacy reuse applies rather than failing dispatch.
-    workspace, branch = kb._resolve_worktree_workspace(task)
-    assert workspace == own.resolve()
-    assert branch == "wt/foreign"
+    # The fallback target is the occupied path itself, so no safe alternate
+    # checkout exists. Fail explicitly rather than silently running the task
+    # on the wrong branch.
+    assert task is not None
+    with pytest.raises(ValueError, match="branch mismatch"):
+        kb._resolve_worktree_workspace(task)


### PR DESCRIPTION
## What does this PR do?

Fixes Kanban worktree resolution when an explicit repo-root anchor is itself a linked checkout. A linked root on a different branch now materializes `<linked-root>/.worktrees/<task-id>` on the requested task branch instead of silently reusing the anchor checkout.

The resolver preserves current sibling-isolation behavior by comparing Git common-directory identity: a foreign checkout owned by the surrounding repo still falls back to that repo’s canonical per-task worktree, while a standalone linked checkout is treated as the exact requested anchor. Existing targets are also validated against the requested branch before reuse.

## Related Issue

N/A — regression found in a local Kanban worktree workflow.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Update `hermes_cli/kanban_db.py` to distinguish standalone linked-root anchors from linked targets owned by a surrounding checkout.
- Reject an already-canonical or pre-existing materialized target whose checked-out branch differs from the requested task branch.
- Extend `tests/hermes_cli/test_kanban_worktree_isolation.py` with linked-root anchor, stale-target mismatch, same-branch reuse, sibling fallback, and canonical mismatch coverage.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_kanban_worktree_isolation.py -q` — 7 passed.
2. `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/tools/test_kanban_tools.py -q -k "not dashboard_direct_status_change and not connect_falls_back_to_delete_on_locking_protocol and not wal_checkpoint_truncates_wal_file"` — 881 passed.
3. `.venv/bin/ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_worktree_isolation.py` and `git diff --check` — clean.

Broader-suite exclusions are environment/baseline-only: two dashboard tests require FastAPI unavailable in this dev venv; the WAL checkpoint test cannot create a WAL because bundled SQLite 3.50.4 is intentionally forced to DELETE journal mode; the clean-main logging-order test fails in the full file on current `origin/main` but passes in isolation. None touches worktree resolution.

## Compatibility / Risk

- Same-branch linked worktree reuse is unchanged.
- Foreign sibling checkout fallback to `<repo>/.worktrees/<task-id>` is preserved.
- Intentional safety change: an already-canonical target on the wrong branch now raises instead of silently running on that branch.
- No schema, config, dependency, auth, runtime installation, or deployment changes.
- Rollback: revert commit `5006e4545`.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this is not a duplicate.
- [x] My PR contains only changes related to this bug fix.
- [x] I added regression tests for the changed behavior.
- [x] I tested on macOS.

### Documentation & Housekeeping

- [x] Relevant resolver docstrings are updated.
- [x] Config examples are N/A.
- [x] Architecture/workflow docs are N/A.
- [x] Cross-platform impact considered: logic uses existing Git subprocess/path helpers.
- [x] Tool descriptions/schemas are N/A.

Merge/install intentionally not performed.