### PR TITLE
fix(sessions): build resumed agents on first demand

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -245,6 +245,88 @@ def test_sess_missing(server):
     assert err["error"]["code"] == 4001
 
 
+def test_session_create_defers_build_until_agent_is_demanded(
+    server, monkeypatch, tmp_path
+):
+    scheduled: list[str] = []
+    demanded: list[str] = []
+
+    monkeypatch.setattr(server, "_completion_cwd", lambda _params=None: str(tmp_path))
+    monkeypatch.setattr(
+        server, "_schedule_agent_build", lambda sid: scheduled.append(sid)
+    )
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+
+    response = server.handle_request(
+        {
+            "id": "create-1",
+            "method": "session.create",
+            "params": {"cols": 100, "source": "desktop"},
+        }
+    )
+
+    assert "error" not in response
+    sid = response["result"]["session_id"]
+    session = server._sessions[sid]
+    assert scheduled == []
+    assert session["agent"] is None
+    assert not session["agent_ready"].is_set()
+
+    def _start_on_demand(runtime_sid, runtime_session):
+        demanded.append(runtime_sid)
+        runtime_session["agent"] = MagicMock()
+        runtime_session["agent_ready"].set()
+
+    monkeypatch.setattr(server, "_start_agent_build", _start_on_demand)
+    created_session, error = server._sess({"session_id": sid}, "create-2")
+
+    assert error is None
+    assert created_session is session
+    assert demanded == [sid]
+
+
+def test_first_prompt_submit_builds_deferred_agent(server, monkeypatch, tmp_path):
+    delivered = threading.Event()
+    builds: list[str] = []
+
+    monkeypatch.setattr(server, "_completion_cwd", lambda _params=None: str(tmp_path))
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *_args: None)
+    monkeypatch.setattr(server, "_load_dashboard_process_isolation_config", lambda: {})
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda *_args: None)
+
+    created = server.handle_request(
+        {"id": "create-1", "method": "session.create", "params": {}}
+    )
+    sid = created["result"]["session_id"]
+
+    def _start_on_demand(runtime_sid, runtime_session):
+        builds.append(runtime_sid)
+        runtime_session["agent"] = MagicMock()
+        runtime_session["agent_ready"].set()
+
+    monkeypatch.setattr(server, "_start_agent_build", _start_on_demand)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *_args, **_kwargs: delivered.set(),
+    )
+
+    response = server.handle_request(
+        {
+            "id": "prompt-1",
+            "method": "prompt.submit",
+            "params": {"session_id": sid, "text": "hello"},
+        }
+    )
+
+    assert response["result"] == {"status": "streaming"}
+    assert builds == [sid]
+    assert delivered.wait(timeout=1)
+
+
 # ── session.resume payload ────────────────────────────────────────────
 
 
@@ -300,6 +382,113 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
         {"role": "assistant", "text": "yo", "reasoning": "thoughts"},
         {"role": "tool", "name": "tool", "context": ""},
     ]
+
+
+def test_session_resume_defers_build_until_agent_is_demanded(server, monkeypatch):
+    target = "20260409_010101_abc123"
+
+    class _DB:
+        def get_session(self, _sid):
+            return {
+                "id": target,
+                "model": "vendor/cool-model",
+                "model_config": {"provider": "vendor"},
+            }
+
+        def get_session_by_title(self, _title):
+            return None
+
+        def resolve_resume_session_id(self, sid):
+            return sid
+
+        def reopen_session(self, _sid):
+            return None
+
+        def get_resume_conversations(self, session_id):
+            return (
+                self.get_messages_as_conversation(
+                    session_id, repair_alternation=True
+                ),
+                self.get_messages_as_conversation(
+                    session_id, include_ancestors=True
+                ),
+            )
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
+        def get_messages_as_conversation(
+            self, _sid, include_ancestors=False, repair_alternation=False
+        ):
+            return [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "yo"},
+            ]
+
+    scheduled: list[str] = []
+    demanded: list[str] = []
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(
+        server,
+        "_make_agent",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("no eager build")
+        ),
+    )
+    monkeypatch.setattr(
+        server, "_schedule_agent_build", lambda sid: scheduled.append(sid)
+    )
+
+    def _start_on_demand(sid, session):
+        demanded.append(sid)
+        session["agent"] = MagicMock()
+        session["agent_ready"].set()
+
+    monkeypatch.setattr(server, "_start_agent_build", _start_on_demand)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+
+    resp = server.handle_request(
+        {
+            "id": "r1",
+            "method": "session.resume",
+            "params": {"session_id": target, "cols": 100},
+        }
+    )
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["resumed"] == target
+    assert result["session_key"] == target
+    assert result["message_count"] == 2
+    assert result["messages"] == [
+        {"role": "user", "text": "hello"},
+        {"role": "assistant", "text": "yo"},
+    ]
+    assert result["info"]["lazy"] is True
+    assert result["info"]["model"] == "vendor/cool-model"
+    assert result["info"]["provider"] == "vendor"
+    assert result["info"]["desktop_contract"] == server.DESKTOP_BACKEND_CONTRACT
+
+    sid = result["session_id"]
+    session = server._sessions[sid]
+    assert session["agent"] is None
+    assert session["resume_session_id"] == target
+    assert not session["agent_ready"].is_set()
+    assert not session.get("lazy")
+    assert (
+        session["resume_runtime_overrides"]["model_override"]["model"]
+        == "vendor/cool-model"
+    )
+    assert server._find_live_session_by_key(target) == (sid, session)
+    assert scheduled == []
+    assert demanded == []
+
+    resumed_session, error = server._sess({"session_id": sid}, "r2")
+
+    assert error is None
+    assert resumed_session is session
+    assert demanded == [sid]
 
 
 def test_enforce_session_cap_evicts_oldest_detached_only(server, monkeypatch):
@@ -614,5 +803,4 @@ def test_unregister_live_transport_stops_delivery(capture):
     assert a.frames == []
     # No live transports left → fell back to stdio.
     assert json.loads(buf.getvalue())["params"]["type"] == "skin.changed"
-
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -117,11 +117,10 @@ def _(rid, params: dict) -> dict:
     # lazily on the first prompt (see _ensure_session_db_row + prompt.submit),
     # and the AIAgent's own INSERT-OR-IGNORE persists it on the first turn too.
 
-    # Return the lightweight session immediately so Ink can paint the composer
-    # + skeleton panel, then build the real AIAgent just after this response is
-    # flushed.  This keeps startup responsive while still hydrating tools/skills
-    # without requiring the user to submit a first prompt.
-    _schedule_agent_build(sid)
+    # Keep the session lightweight until an RPC actually needs its agent.
+    # ``_sess()`` and ``prompt.submit`` both call ``_start_agent_build`` on
+    # demand.  Starting a timer here still competes with the client's immediate
+    # follow-up RPCs for the GIL while tools and skills are being discovered.
     _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
 
     return _ok(
@@ -473,9 +472,9 @@ def _(rid, params: dict) -> dict:
     # construction), and every resume caller (desktop + Ink TUI) awaits this RPC
     # before it paints — so building eagerly is the bulk of the multi-second
     # "switching sessions is frozen" latency. Return the full display transcript
-    # immediately and pre-warm the agent on a short timer (the same deferred-
-    # build contract session.create uses); _sess() also builds on demand if the
-    # first prompt beats the timer. A caller that needs the agent built
+    # immediately and leave the agent unbuilt until an agent-requiring RPC
+    # arrives. ``_sess()`` and ``prompt.submit`` both build on demand. A caller
+    # that needs the agent built
     # synchronously (e.g. tests of the build race) passes ``eager_build: true``
     # to fall through to the eager path below. Distinct from the lazy/watch
     # branch above: a normal resume restores the full ancestor history and the
@@ -526,7 +525,6 @@ def _(rid, params: dict) -> dict:
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
             return _ok(rid, _reuse_live_payload(*live))
 
-        _schedule_agent_build(sid)
         _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
         auto_continue = _maybe_schedule_auto_continue(sid, record, target)
 


### PR DESCRIPTION
## Problem

`session.resume` returned a lightweight hydrated session, then scheduled agent construction 50 ms later. On a constrained host that construction can hold the GIL before the response/history path paints, so a completed resume is observed as a client timeout. `session.create` had the same unsolicited pre-warm race.

## Fix

Leave cold-created and cold-resumed agents unbuilt until the first agent-requiring RPC reaches `_sess()` or `prompt.submit`. The existing on-demand build path remains the authority, while `eager_build: true` still preserves synchronous callers.

The change is ported to the current modular handler location, `tui_gateway/methods_session.py`.

## Verification

- `scripts/run_tests.sh tests/tui_gateway/test_protocol.py -q` — 40 passed
- Added behavioral coverage for create, resume, and first `prompt.submit` demand-build paths
- `scripts/run_tests.sh tests/tui_gateway -q` — 323 passed; one unrelated local failure in `test_slash_worker_mcp_discovery.py`, where the live-system guard blocks that test's own `proc.terminate()` cleanup (reproduces in isolation)