### PR TITLE
fix(desktop): persist selected profile across reconnect

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8114,6 +8114,7 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
 })
 
 ipcMain.handle('hermes:profile:get', async () => ({ profile: readActiveDesktopProfile() }))
+ipcMain.handle('hermes:profile:remember', async (_event, name) => ({ profile: writeActiveDesktopProfile(name) }))
 ipcMain.handle('hermes:profile:set', async (_event, name) => {
   const next = writeActiveDesktopProfile(name)
 
@@ -8303,6 +8304,10 @@ async function remoteSessionList(profile, searchParams) {
 
   for (const s of rowsOf(data)) {
     s.profile = profile
+    // Older remote dashboards may omit profile_name because they serve only
+    // one state.db and do not know the Desktop-side route label. Keep both
+    // public identity fields explicit after remote aggregation.
+    s.profile_name = profile
     s.is_default_profile = false
   }
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -54,7 +54,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   },
   profile: {
     get: () => ipcRenderer.invoke('hermes:profile:get'),
-    set: name => ipcRenderer.invoke('hermes:profile:set', name)
+    set: name => ipcRenderer.invoke('hermes:profile:set', name),
+    remember: name => ipcRenderer.invoke('hermes:profile:remember', name)
   },
   api: request => ipcRenderer.invoke('hermes:api', request),
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -30,7 +30,13 @@ import { latestSessionTodos } from '@/lib/todos'
 import { setCronFocusJobId } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { $filePreviewTarget, $previewTarget } from '@/store/preview'
-import { $activeGatewayProfile, $freshSessionRequest, $profileScope, refreshActiveProfile } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $freshSessionRequest,
+  $profileScope,
+  freshSessionDraftOptions,
+  refreshActiveProfile
+} from '@/store/profile'
 import { $startWorkSessionRequest, followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
 import {
   $activeSessionId,
@@ -410,15 +416,15 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // A profile switch/create drops to a fresh new-session draft so the
   // previously open session doesn't bleed across contexts. Skip initial value.
   const freshSessionRequest = useStore($freshSessionRequest)
-  const lastFreshRef = useRef(freshSessionRequest)
+  const lastFreshRef = useRef(freshSessionRequest.generation)
 
   useEffect(() => {
-    if (freshSessionRequest === lastFreshRef.current) {
+    if (freshSessionRequest.generation === lastFreshRef.current) {
       return
     }
 
-    lastFreshRef.current = freshSessionRequest
-    startFreshSessionDraft()
+    lastFreshRef.current = freshSessionRequest.generation
+    startFreshSessionDraft(freshSessionDraftOptions(freshSessionRequest))
   }, [freshSessionRequest, startFreshSessionDraft])
 
   // Swapping the live gateway to another profile must re-pull that profile's

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -66,6 +66,9 @@ declare global {
       }
       profile: {
         get: () => Promise<DesktopActiveProfile>
+        // Persists the profile used by live multi-profile routing without
+        // tearing down the current backend or reloading the window.
+        remember: (name: string | null) => Promise<DesktopActiveProfile>
         // Persists the desktop's profile choice and relaunches the local
         // backend under the new HERMES_HOME (reloads the window). Pass null to
         // clear the preference.

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -19,8 +19,16 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, $profiles, ensureGatewayProfile, prewarmProfileBackend, refreshProfiles, selectProfile } =
-  await import('./profile')
+const {
+  $activeGatewayProfile,
+  $freshSessionRequest,
+  $profiles,
+  ensureGatewayProfile,
+  freshSessionDraftOptions,
+  prewarmProfileBackend,
+  refreshProfiles,
+  selectProfile
+} = await import('./profile')
 
 const { $connection } = await import('./session')
 const { invalidateProfileScopedQueries } = await import('@/lib/query-client')
@@ -114,6 +122,25 @@ describe('ensureGatewayProfile → $connection sync (#46651)', () => {
 })
 
 describe('selected profile persistence', () => {
+  it('maps a profile switch request to an explicitly detached fresh draft', () => {
+    expect(freshSessionDraftOptions({ generation: 1, workspaceTarget: null })).toEqual({ workspaceTarget: null })
+  })
+
+  it('leaves ordinary fresh-session requests project-aware', () => {
+    expect(freshSessionDraftOptions({ generation: 1 })).toBeUndefined()
+  })
+
+  it('starts the target profile on a detached workspace instead of inheriting the prior profile cwd', () => {
+    const previousGeneration = $freshSessionRequest.get().generation
+
+    selectProfile('secretary')
+
+    expect($freshSessionRequest.get()).toEqual({
+      generation: previousGeneration + 1,
+      workspaceTarget: null
+    })
+  })
+
   it('remembers a named profile only after its gateway becomes active', async () => {
     getConnection.mockResolvedValue(remoteConn({ profile: 'secretary' }))
 

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, $profiles, ensureGatewayProfile, prewarmProfileBackend, refreshProfiles } =
+const { $activeGatewayProfile, $profiles, ensureGatewayProfile, prewarmProfileBackend, refreshProfiles, selectProfile } =
   await import('./profile')
 
 const { $connection } = await import('./session')
@@ -43,16 +43,19 @@ const localConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
   ({ baseUrl: '', mode: 'local', profile: 'default', ...over }) as HermesConnection
 
 const getConnection = vi.fn<(profile?: string | null) => Promise<HermesConnection>>()
+const rememberProfile = vi.fn<(profile?: string | null) => Promise<{ profile: string | null }>>()
 
 beforeEach(() => {
   getConnection.mockReset()
+  rememberProfile.mockReset()
+  rememberProfile.mockResolvedValue({ profile: null })
   ensureGatewayForProfile.mockClear()
   openGatewayForProfile.mockClear()
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
   $profiles.set([])
-  vi.stubGlobal('window', { hermesDesktop: { getConnection } })
+  vi.stubGlobal('window', { hermesDesktop: { getConnection, profile: { remember: rememberProfile } } })
   vi.mocked(invalidateProfileScopedQueries).mockClear()
   resetStarmapGraph.mockClear()
 })
@@ -107,6 +110,26 @@ describe('ensureGatewayProfile → $connection sync (#46651)', () => {
     expect(getConnection).not.toHaveBeenCalled()
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
     expect($connection.get()?.mode).toBe('remote')
+  })
+})
+
+describe('selected profile persistence', () => {
+  it('remembers a named profile only after its gateway becomes active', async () => {
+    getConnection.mockResolvedValue(remoteConn({ profile: 'secretary' }))
+
+    selectProfile('secretary')
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('secretary'))
+
+    expect($activeGatewayProfile.get()).toBe('secretary')
+  })
+
+  it('does not remember a profile when its gateway activation fails', async () => {
+    ensureGatewayForProfile.mockRejectedValueOnce(new Error('backend unavailable'))
+
+    selectProfile('secretary')
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('secretary'))
+
+    expect(rememberProfile).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -225,6 +225,7 @@ export function prewarmProfileBackend(name: string): void {
 }
 
 let gatewaySwitch: Promise<void> | null = null
+let profileSelectionGeneration = 0
 
 // Keep the renderer's $connection (mode / baseUrl / profile) in lockstep with
 // the profile the live gateway is now on. $connection seeds from the PRIMARY
@@ -335,6 +336,7 @@ export const $profileScope = computed([$showAllProfiles, $activeGatewayProfile],
 // $activeGatewayProfile → name, so $profileScope follows).
 export function selectProfile(name: string): void {
   const target = normalizeProfileKey(name)
+  const selectionGeneration = ++profileSelectionGeneration
   // Switching profiles (or coming back from the all-profiles browse view) starts
   // fresh; re-tapping the profile you're already in leaves your session be.
   const switching = $showAllProfiles.get() || target !== normalizeProfileKey($activeGatewayProfile.get())
@@ -345,7 +347,17 @@ export function selectProfile(name: string): void {
     requestFreshSession()
   }
 
-  void ensureGatewayProfile(target)
+  void ensureGatewayProfile(target).then(async () => {
+    // Persist only the latest completed explicit selection. Rapid A → B clicks
+    // can finish their backend opens out of order; an older completion must not
+    // overwrite newer intent. A failed activation is never persisted.
+    if (
+      selectionGeneration === profileSelectionGeneration &&
+      normalizeProfileKey($activeGatewayProfile.get()) === target
+    ) {
+      await window.hermesDesktop.profile.remember(target)
+    }
+  }).catch(() => undefined)
 }
 
 // Start a fresh session in `name` WITHOUT collapsing the "All profiles" browse

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -156,12 +156,26 @@ export const $newChatProfile = atom<string | null>(null)
 
 // Bumped whenever the open session should be dropped for a fresh new-session
 // draft: a profile switch/create (below), or deleting the project that owns the
-// currently-open session (store/projects). The chat controller subscribes and
-// resets to the intro draft, so we never strand the user in an orphaned view.
-export const $freshSessionRequest = atom(0)
+// currently-open session (store/projects). A profile switch also carries an
+// explicit detached workspace target: the request fires before the async gateway
+// swap completes, so resolving a default at that instant would read the previous
+// profile's remembered cwd and leak its project context into the target profile.
+export interface FreshSessionRequest {
+  generation: number
+  workspaceTarget?: null
+}
 
-export function requestFreshSession(): void {
-  $freshSessionRequest.set($freshSessionRequest.get() + 1)
+export const $freshSessionRequest = atom<FreshSessionRequest>({ generation: 0 })
+
+export function freshSessionDraftOptions(request: FreshSessionRequest): { workspaceTarget: null } | undefined {
+  return request.workspaceTarget === null ? { workspaceTarget: null } : undefined
+}
+
+export function requestFreshSession(options: { workspaceTarget?: null } = {}): void {
+  $freshSessionRequest.set({
+    generation: $freshSessionRequest.get().generation + 1,
+    ...options
+  })
 }
 
 // Route profile-scoped REST settings (config/env/skills/tools/model/…) to the
@@ -344,7 +358,7 @@ export function selectProfile(name: string): void {
   $newChatProfile.set(target)
 
   if (switching) {
-    requestFreshSession()
+    requestFreshSession({ workspaceTarget: null })
   }
 
   void ensureGatewayProfile(target).then(async () => {
@@ -369,7 +383,7 @@ export function selectProfile(name: string): void {
 export function newSessionInProfile(name: string): void {
   const target = normalizeProfileKey(name)
   $newChatProfile.set(target)
-  requestFreshSession()
+  requestFreshSession({ workspaceTarget: null })
   void ensureGatewayProfile(target)
 }
 


### PR DESCRIPTION
## Summary
- persist an explicitly selected Desktop profile without reloading the window
- record the choice only after the named gateway activates successfully
- guard rapid profile switches so stale completions cannot overwrite newer intent
- expose `profile_name` when aggregating sessions from older remote dashboards

## Problem
A Desktop connected to a remote multi-profile Dashboard could select a named profile in memory, then silently return to `default` after a hard reconnect or native reopen. This made the active agent identity ambiguous and could leave remote session metadata without an explicit `profile_name`.

## Verification
- `npm exec vitest run -- --project ui src/store/profile.test.ts` — 13 passed
- `npm test -- --project ui` — 1,699 passed, 1 skipped
- `npm test -- --project electron` — 472 passed, 1 skipped
- `npm run typecheck` — passed
- `npm run build` — passed
- ESLint — zero errors

## Safety / rollback
The change only writes the existing Desktop `active-profile.json` preference after a successful explicit selection. It does not alter profile contents, sessions, credentials, or remote connection settings. Revert commit `950aad8` to roll back.