### PR TITLE
fix(lazy_deps): don't mark a feature active from a shared package

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -326,6 +326,37 @@ class TestActiveFeatures:
         )
         assert "platform.slack" in ld.active_features()
 
+    def test_shared_package_does_not_make_sibling_feature_active(self, monkeypatch):
+        # Regression: several messaging adapters (discord/slack/teams/matrix)
+        # each pin `aiohttp` to a common security floor. A user who enabled
+        # Discord has aiohttp installed, but NONE of matrix's distinctive
+        # packages (mautrix, aiosqlite, asyncpg, aiohttp-socks). aiohttp alone
+        # must NOT make platform.matrix look active — otherwise `hermes update`
+        # tries to refresh Matrix and triggers a doomed mautrix[encryption]
+        # (libolm) build on a machine that never enabled Matrix.
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) in {"discord.py", "brotlicffi", "aiohttp"},
+        )
+        active = ld.active_features()
+        assert "platform.discord" in active
+        assert "platform.matrix" not in active
+        assert "platform.slack" not in active
+        assert "platform.teams" not in active
+
+    def test_feature_without_distinctive_package_falls_back_to_any_present(self, monkeypatch):
+        # tts.mistral and stt.mistral both declare ONLY `mistralai`, which is
+        # shared between them — neither has a distinctive package. With no
+        # distinctive signal the check must fall back to presence-of-any so
+        # these features still register as active when mistralai is installed.
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "mistralai",
+        )
+        active = ld.active_features()
+        assert "tts.mistral" in active
+        assert "stt.mistral" in active
+
 
 class TestRefreshActiveFeatures:
     def test_no_active_features_returns_empty(self, monkeypatch):

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -864,16 +864,45 @@ def feature_install_command(feature: str) -> Optional[str]:
 def active_features() -> list[str]:
     """Return the list of features the user has ever lazy-installed.
 
-    A feature counts as "active" if at least one of its declared packages
-    is currently installed in the venv (presence check, ignoring version).
-    Features the user has never enabled stay quiet.
+    A feature counts as "active" when a package *distinctive* to it is
+    installed — "distinctive" meaning the package name appears in this
+    feature's spec list and in no *other* feature's list, so its presence
+    is real evidence the user activated this backend.
+
+    Packages shared across features are deliberately ignored for this
+    decision. Several messaging adapters (``platform.discord``,
+    ``platform.slack``, ``platform.teams``, ``platform.matrix``) each pin
+    ``aiohttp`` to a common security floor, so ``aiohttp`` being installed
+    for Discord must NOT make Matrix look active — otherwise ``hermes
+    update`` tries to refresh Matrix and triggers a doomed
+    ``mautrix[encryption]`` build (compiling the native ``libolm`` C lib)
+    on machines that never enabled Matrix.
+
+    Features whose *every* package is shared (e.g. ``tts.mistral`` and
+    ``stt.mistral`` both declare only ``mistralai``) have no distinctive
+    signal, so they fall back to the presence-of-any check — the best
+    available evidence without a false-positive vector.
 
     Used by ``hermes update`` to figure out which lazy backends need a
     refresh pass when pins move in :data:`LAZY_DEPS`.
     """
+    # How many distinct features declare each package name? A package
+    # claimed by exactly one feature is "distinctive" to it.
+    pkg_feature_count: dict[str, int] = {}
+    for specs in LAZY_DEPS.values():
+        for name in {_pkg_name_from_spec(s) for s in specs}:
+            pkg_feature_count[name] = pkg_feature_count.get(name, 0) + 1
+
     active = []
     for feature, specs in LAZY_DEPS.items():
-        if any(_is_present(s) for s in specs):
+        distinctive = [
+            s for s in specs
+            if pkg_feature_count.get(_pkg_name_from_spec(s), 0) == 1
+        ]
+        # Prefer distinctive-package evidence; fall back to any-present
+        # only when the feature has no package unique to it.
+        candidates = distinctive or list(specs)
+        if any(_is_present(s) for s in candidates):
             active.append(feature)
     return active
 


### PR DESCRIPTION
## Summary

`active_features()` (in `tools/lazy_deps.py`) counts a feature as active if **any** of its declared packages is present. Several messaging adapters — `platform.discord`, `platform.slack`, `platform.teams`, `platform.matrix` — each pin `aiohttp` to a common security floor (`aiohttp==3.14.1`). So a user who enabled Discord/Slack has `aiohttp` installed, which makes `platform.matrix` report itself **active** even though every package distinctive to Matrix (`mautrix[encryption]`, `aiosqlite`, `asyncpg`, `aiohttp-socks`) is absent.

`hermes update` then calls `refresh_active_features()`, sees Matrix as active-but-stale, and tries to install `mautrix[encryption]` — which compiles the native `libolm` C library via `make static`. That build fails on machines that never enabled Matrix, surfacing a noisy error on every update.

## Reproduction (current `main`)

On a machine with Discord + Slack enabled but no Matrix:

```python
from tools import lazy_deps as L
L.active_features()          # -> includes 'platform.matrix'
L.feature_missing('platform.matrix')
# -> ('mautrix[encryption]==0.21.0', 'aiosqlite==0.22.1',
#     'asyncpg==0.31.0', 'aiohttp-socks==0.11.0')   # all 4 distinctive pkgs absent
```

`aiohttp` alone (shared with Discord) is what flips Matrix to "active".

## Fix

A feature counts as active only when a package **distinctive** to it — one that appears in this feature's spec list and in *no other* feature's list — is installed. Shared packages (`aiohttp`, etc.) no longer provide activation evidence.

Features whose *every* package is shared (`tts.mistral` and `stt.mistral` both declare only `mistralai`) have no distinctive signal, so they **fall back** to the prior presence-of-any check. There's no false-positive vector there, and it preserves their existing behavior.

This fixes the whole bug class, not just Matrix — any future sibling adapters sharing a security-pinned transitive won't cross-activate each other.

## Tests

`tests/tools/test_lazy_deps.py`:

- `test_shared_package_does_not_make_sibling_feature_active` — with only `discord.py`/`brotlicffi`/`aiohttp` present, `platform.discord` is active while `platform.matrix`/`slack`/`teams` are not.
- `test_feature_without_distinctive_package_falls_back_to_any_present` — `mistralai` presence still activates both `tts.mistral` and `stt.mistral`.

Existing `TestActiveFeatures` cases (honcho, slack via distinctive `slack-bolt`) unchanged.

```
66 passed in 1.35s
```

## Risk

Low. Behavior only changes for features that had *no* distinctive package present but a shared one — previously false-active, now correctly quiet. The distinctive-package computation is derived from `LAZY_DEPS` itself, so it stays correct as the map evolves.
