### PR TITLE
fix(acp): honor configured max turns

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -619,6 +619,12 @@ class SessionManager:
             for name, cfg in (config.get("mcp_servers") or {}).items()
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
+        agent_config = config.get("agent")
+        max_turns = (
+            agent_config.get("max_turns")
+            if isinstance(agent_config, dict)
+            else None
+        )
 
         kwargs = {
             "platform": "acp",
@@ -631,6 +637,12 @@ class SessionManager:
             "session_db": self._get_db(),
             "model": model or default_model,
         }
+        if (
+            isinstance(max_turns, int)
+            and not isinstance(max_turns, bool)
+            and max_turns > 0
+        ):
+            kwargs["max_iterations"] = max_turns
 
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -439,6 +439,58 @@ class TestPersistence:
             manager.create_session(cwd="/work")
 
         assert captured["enabled_toolsets"] == ["hermes-acp", "mcp-olympus", "mcp-exa"]
+        assert "max_iterations" not in captured
+
+    @pytest.mark.parametrize(
+        ("agent_config", "expected"),
+        [
+            ({"max_turns": 8}, 8),
+            ({"max_turns": True}, None),
+            ({"max_turns": 0}, None),
+            ({"max_turns": -1}, None),
+            ({"max_turns": "8"}, None),
+            ("invalid", None),
+        ],
+    )
+    def test_create_session_validates_agent_max_turns(
+        self, tmp_path, monkeypatch, agent_config, expected
+    ):
+        captured = {}
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            return {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(model=kwargs.get("model"))
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"provider": "openrouter", "default": "test-model"},
+                "agent": agent_config,
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+            manager.create_session(cwd="/work")
+
+        if expected is None:
+            assert "max_iterations" not in captured
+        else:
+            assert captured["max_iterations"] == expected
 
     def test_create_session_writes_to_db(self, manager):
         state = manager.create_session(cwd="/project")


### PR DESCRIPTION
## What does this PR do?

ACP sessions now honor the existing `agent.max_turns` setting when constructing
`AIAgent`. Previously, `SessionManager._make_agent()` omitted `max_iterations`,
so ACP always used the agent constructor default even when a profile configured
a smaller turn limit.

The setting is forwarded only when it is a positive integer. Missing or invalid
values remain omitted, preserving the existing `AIAgent` default and avoiding a
second copy of that default in the ACP adapter.

This is intentionally separate from #64045 and the other open ACP toolset PRs;
it does not change ACP tool selection.

#67696 proposes a shared resolver with additional unlimited/string spellings but
does not currently update ACP. This patch targets `main`'s positive-integer
contract; if #67696 lands first, the ACP read can switch to that resolver during
rebase instead of keeping the local validation.

## Related Issue

No linked issue. Related but non-overlapping: #64045 configures the ACP tool
surface, and #67696 proposes broader turn-limit parsing. This PR only propagates
the existing turn limit into ACP agent construction.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Read `agent.max_turns` in `acp_adapter/session.py`.
- Pass valid positive integers to `AIAgent` as `max_iterations`.
- Preserve the existing constructor default for missing, boolean, string, zero,
  negative, or otherwise invalid values.
- Add regression coverage for the configured and fallback paths.

## How to Test

1. Run `TMPDIR=<non-sensitive-path> uv run --isolated --frozen --extra acp --extra dev pytest tests/acp tests/acp_adapter -q`.
2. Confirm all 338 tests pass.
3. Run `uv run --isolated --frozen --extra acp --extra dev ruff check acp_adapter/session.py tests/acp/test_session.py`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs and kept this change separate from the open ACP toolset work.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` across the entire repository.
- [x] I've added tests for my changes.
- [x] I've tested on macOS 26.5.1.

### Documentation & Housekeeping

- [x] Documentation update: N/A; this uses the existing `agent.max_turns` setting.
- [x] `cli-config.yaml.example`: N/A; no config key was added or changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered: the change is platform-neutral config propagation.
- [x] Tool descriptions/schemas: N/A; no tool behavior changed.

## Screenshots / Logs

Not applicable. The regression is covered by constructor-argument assertions and
the complete ACP/ACP-adapter test suites.
