### PR TITLE
fix(desktop): deserialize timeline metadata on resume

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -179,6 +179,7 @@ describe('toChatMessages', () => {
         role: 'user',
         content: 'opaque delegation context payload',
         display_kind: 'async_delegation_complete',
+        display_metadata: { delegation_id: 'del-1', task_count: 2 },
         timestamp: 5
       }
     ])
@@ -188,8 +189,29 @@ describe('toChatMessages', () => {
       'real user turn',
       'real assistant reply',
       'model changed',
-      'background agent work finished'
+      '2 background agents finished'
     ])
+  })
+
+  it.each([
+    ['string metadata', '{"task_count":1}'],
+    ['array metadata', []],
+    ['null metadata', null],
+    ['NaN task count', { task_count: Number.NaN }],
+    ['positive infinite task count', { task_count: Number.POSITIVE_INFINITY }],
+    ['negative infinite task count', { task_count: Number.NEGATIVE_INFINITY }]
+  ])('falls back safely for %s', (_case, displayMetadata) => {
+    const [message] = toChatMessages([
+      {
+        role: 'user',
+        content: 'opaque delegation context payload',
+        display_kind: 'async_delegation_complete',
+        display_metadata: displayMetadata as never,
+        timestamp: 1
+      }
+    ])
+
+    expect(chatMessageText(message)).toBe('background agent work finished')
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -317,9 +317,15 @@ function timelineDisplayContent(message: SessionMessage, content: string): strin
   }
 
   if (message.display_kind === 'async_delegation_complete') {
+    const metadata = message.display_metadata
+
     const count =
-      message.display_metadata && 'task_count' in message.display_metadata
-        ? message.display_metadata.task_count
+      metadata !== null &&
+      typeof metadata === 'object' &&
+      'task_count' in metadata &&
+      typeof metadata.task_count === 'number' &&
+      Number.isFinite(metadata.task_count)
+        ? metadata.task_count
         : undefined
 
     return count === undefined

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5709,6 +5709,42 @@ class SessionDB:
                 return content
         return content
 
+    @staticmethod
+    def _encode_display_metadata(
+        display_metadata: Optional[Dict[str, Any]], *, context: str,
+    ) -> Optional[str]:
+        """Serialize presentation metadata without emitting non-standard JSON."""
+        if display_metadata is None:
+            return None
+        if not isinstance(display_metadata, dict):
+            logger.warning("Ignoring non-object display metadata in %s", context)
+            return None
+        if not display_metadata:
+            return None
+        try:
+            return json.dumps(display_metadata, allow_nan=False)
+        except (RecursionError, TypeError, ValueError):
+            logger.warning("Ignoring invalid display metadata in %s", context)
+            return None
+
+    @staticmethod
+    def _decode_display_metadata(value: Any, *, context: str) -> Optional[Dict[str, Any]]:
+        """Decode object-shaped metadata that a strict JSON response can serialize."""
+        if value is None:
+            return None
+        try:
+            decoded = json.loads(value)
+            if not isinstance(decoded, dict):
+                raise TypeError("display metadata must decode to an object")
+            # Python accepts NaN/Infinity (and overflows like 1e400) while the
+            # REST serializer rejects them. Re-encode strictly to validate all
+            # nested values before returning the object to an API caller.
+            json.dumps(decoded, allow_nan=False)
+            return decoded
+        except (json.JSONDecodeError, RecursionError, TypeError, ValueError):
+            logger.warning("Ignoring invalid display metadata in %s", context)
+            return None
+
     def append_message(
         self,
         session_id: str,
@@ -5754,7 +5790,9 @@ class SessionDB:
         """
         # Display metadata is presentation-only and never changes the model
         # context role/content replayed to providers.
-        display_metadata_json = json.dumps(display_metadata) if display_metadata else None
+        display_metadata_json = self._encode_display_metadata(
+            display_metadata, context="append_message",
+        )
         # Serialize structured fields to JSON before entering the write txn
         reasoning_details_json = (
             json.dumps(reasoning_details)
@@ -5867,11 +5905,14 @@ class SessionDB:
             ).fetchone()
             if row is None:
                 return False
+            display_metadata_json = self._encode_display_metadata(
+                display_metadata, context="set_latest_matching_message_display_kind",
+            )
             conn.execute(
                 "UPDATE messages SET display_kind = ?, display_metadata = ? WHERE id = ?",
                 (
                     _scrub_surrogates(display_kind),
-                    json.dumps(display_metadata) if display_metadata else None,
+                    display_metadata_json,
                     row[0],
                 ),
             )
@@ -5937,6 +5978,9 @@ class SessionDB:
             )
 
             api_content = msg.get("api_content")
+            display_metadata_json = self._encode_display_metadata(
+                msg.get("display_metadata"), context="_insert_message_rows",
+            )
 
             conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
@@ -5965,7 +6009,7 @@ class SessionDB:
                     1,
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
                     _scrub_surrogates(msg.get("display_kind")) if isinstance(msg.get("display_kind"), str) else None,
-                    json.dumps(msg["display_metadata"]) if msg.get("display_metadata") else None,
+                    display_metadata_json,
                 ),
             )
             inserted += 1
@@ -6169,6 +6213,10 @@ class SessionDB:
                 except (json.JSONDecodeError, TypeError):
                     logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
                     msg["tool_calls"] = []
+            if msg.get("display_metadata") is not None:
+                msg["display_metadata"] = self._decode_display_metadata(
+                    msg["display_metadata"], context="get_messages",
+                )
             result.append(msg)
         return result
 
@@ -6238,6 +6286,10 @@ class SessionDB:
                         "Failed to deserialize tool_calls in get_messages_around, falling back to []"
                     )
                     msg["tool_calls"] = []
+            if msg.get("display_metadata") is not None:
+                msg["display_metadata"] = self._decode_display_metadata(
+                    msg["display_metadata"], context="get_messages_around",
+                )
             result.append(msg)
 
         # before_rows includes the anchor itself; subtract 1 for the count of
@@ -6360,6 +6412,10 @@ class SessionDB:
                         "Failed to deserialize tool_calls in get_anchored_view, falling back to []"
                     )
                     msg["tool_calls"] = []
+            if msg.get("display_metadata") is not None:
+                msg["display_metadata"] = self._decode_display_metadata(
+                    msg["display_metadata"], context="get_anchored_view",
+                )
             return msg
 
         return {
@@ -6557,11 +6613,12 @@ class SessionDB:
                 msg["api_content"] = row["api_content"]
             if row["display_kind"]:
                 msg["display_kind"] = row["display_kind"]
-            if row["display_metadata"]:
-                try:
-                    msg["display_metadata"] = json.loads(row["display_metadata"])
-                except (TypeError, json.JSONDecodeError):
-                    logger.warning("Ignoring invalid display metadata on message row")
+            if row["display_metadata"] is not None:
+                display_metadata = self._decode_display_metadata(
+                    row["display_metadata"], context="conversation replay",
+                )
+                if display_metadata is not None:
+                    msg["display_metadata"] = display_metadata
             if row["timestamp"]:
                 msg["timestamp"] = row["timestamp"]
             if row["tool_call_id"]:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,6 +1,7 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
 import sqlite3
+import sys
 import time
 import json
 from unittest import mock
@@ -7202,6 +7203,187 @@ class TestDisplayMetadataPersistence:
         conv = db.get_messages_as_conversation("s1")
         assert conv[0]["display_kind"] == "async_delegation_complete"
         assert conv[0]["display_metadata"] == meta
+
+    def test_get_messages_decodes_display_metadata(self, db):
+        db.create_session("s1", source="desktop")
+        meta = {"task_count": 1, "delegation_id": "del-rest"}
+        db.append_message(
+            "s1", "user", "event text",
+            display_kind="async_delegation_complete",
+            display_metadata=meta,
+        )
+
+        messages = db.get_messages("s1")
+
+        assert messages[0]["display_metadata"] == meta
+
+    def test_get_messages_around_decodes_display_metadata(self, db):
+        db.create_session("s1", source="desktop")
+        meta = {"task_count": 2, "delegation_id": "del-window"}
+        message_id = db.append_message(
+            "s1", "user", "event text",
+            display_kind="async_delegation_complete",
+            display_metadata=meta,
+        )
+
+        result = db.get_messages_around("s1", message_id, window=0)
+
+        assert result["window"][0]["display_metadata"] == meta
+
+    def test_get_anchored_view_decodes_display_metadata_in_bookends(self, db):
+        db.create_session("s1", source="desktop")
+        meta = {"task_count": 2, "delegation_id": "del-bookend"}
+        db.append_message(
+            "s1", "user", "bookend event",
+            display_kind="async_delegation_complete",
+            display_metadata=meta,
+        )
+        anchor_id = db.append_message("s1", "assistant", "anchor")
+
+        result = db.get_anchored_view("s1", anchor_id, window=0, bookend=1)
+
+        assert result["bookend_start"][0]["display_metadata"] == meta
+
+    @pytest.mark.parametrize(
+        "reader",
+        ["get_messages", "get_messages_around", "conversation", "anchored_bookend"],
+    )
+    @pytest.mark.parametrize(
+        "raw_metadata",
+        [
+            "",
+            "{not-json",
+            "[]",
+            '"string"',
+            "0",
+            '{"duration_seconds": NaN}',
+            '{"duration_seconds": 1e400}',
+        ],
+    )
+    def test_message_readers_drop_non_json_compliant_display_metadata(
+        self, db, reader, raw_metadata,
+    ):
+        db.create_session("s1", source="desktop")
+        message_id = db.append_message(
+            "s1", "user", "event text",
+            display_kind="async_delegation_complete",
+            display_metadata={"task_count": 1},
+        )
+
+        def _replace_metadata(conn):
+            conn.execute(
+                "UPDATE messages SET display_metadata = ? WHERE id = ?",
+                (raw_metadata, message_id),
+            )
+
+        db._execute_write(_replace_metadata)
+
+        if reader == "get_messages":
+            message = db.get_messages("s1")[0]
+        elif reader == "get_messages_around":
+            message = db.get_messages_around("s1", message_id, window=0)["window"][0]
+        elif reader == "anchored_bookend":
+            anchor_id = db.append_message("s1", "assistant", "anchor")
+            message = db.get_anchored_view(
+                "s1", anchor_id, window=0, bookend=1,
+            )["bookend_start"][0]
+        else:
+            message = db.get_messages_as_conversation("s1")[0]
+
+        assert message.get("display_metadata") is None
+
+    @pytest.mark.parametrize(
+        "reader",
+        ["get_messages", "get_messages_around", "conversation", "anchored_bookend"],
+    )
+    def test_message_readers_drop_recursively_nested_display_metadata(self, db, reader):
+        db.create_session("s1", source="desktop")
+        message_id = db.append_message("s1", "user", "event text")
+        depth = sys.getrecursionlimit() * 5
+        raw_metadata = '{"nested":' * depth + "null" + "}" * depth
+
+        def _replace_metadata(conn):
+            conn.execute(
+                "UPDATE messages SET display_metadata = ? WHERE id = ?",
+                (raw_metadata, message_id),
+            )
+
+        db._execute_write(_replace_metadata)
+
+        if reader == "get_messages":
+            message = db.get_messages("s1")[0]
+        elif reader == "get_messages_around":
+            message = db.get_messages_around("s1", message_id, window=0)["window"][0]
+        elif reader == "anchored_bookend":
+            anchor_id = db.append_message("s1", "assistant", "anchor")
+            message = db.get_anchored_view(
+                "s1", anchor_id, window=0, bookend=1,
+            )["bookend_start"][0]
+        else:
+            message = db.get_messages_as_conversation("s1")[0]
+
+        assert message.get("display_metadata") is None
+
+    @pytest.mark.parametrize("non_finite", [float("nan"), float("inf"), float("-inf")])
+    def test_append_message_drops_non_finite_display_metadata(self, db, non_finite):
+        db.create_session("s1", source="desktop")
+
+        message_id = db.append_message(
+            "s1", "user", "event text",
+            display_kind="async_delegation_complete",
+            display_metadata={"duration_seconds": non_finite},
+        )
+
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT content, display_metadata FROM messages WHERE id = ?",
+                (message_id,),
+            ).fetchone()
+
+        assert row["content"] == "event text"
+        assert row["display_metadata"] is None
+
+    @pytest.mark.parametrize("metadata", [["unexpected"], "unexpected", 1])
+    def test_append_message_drops_non_object_display_metadata(self, db, metadata):
+        db.create_session("s1", source="desktop")
+
+        message_id = db.append_message(
+            "s1", "user", "event text",
+            display_kind="async_delegation_complete",
+            display_metadata=metadata,
+        )
+
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT content, display_metadata FROM messages WHERE id = ?",
+                (message_id,),
+            ).fetchone()
+
+        assert row["content"] == "event text"
+        assert row["display_metadata"] is None
+
+    def test_append_message_drops_recursively_nested_display_metadata(self, db):
+        db.create_session("s1", source="desktop")
+        metadata = {}
+        cursor = metadata
+        for _ in range(sys.getrecursionlimit() * 5):
+            cursor["nested"] = {}
+            cursor = cursor["nested"]
+
+        message_id = db.append_message(
+            "s1", "user", "event text",
+            display_kind="async_delegation_complete",
+            display_metadata=metadata,
+        )
+
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT content, display_metadata FROM messages WHERE id = ?",
+                (message_id,),
+            ).fetchone()
+
+        assert row["content"] == "event text"
+        assert row["display_metadata"] is None
 
     def test_replace_messages_preserves_display_metadata(self, db):
         db.create_session("s1", source="cli")


### PR DESCRIPTION
## Bug Description

Desktop session resume could fail after a completed asynchronous delegation timeline event. The session remained healthy, but transcript reconstruction threw before it could open.

## Root Cause

SQLite persists `display_metadata` as JSON text. Several message-reading paths returned that text unchanged, while Desktop timeline reconstruction assumed object-shaped metadata and used the JavaScript `in` operator.

Persisted malformed, non-object, non-finite, or excessively nested metadata could also escape the read boundary or raise during serialization and make presentation metadata block the underlying message/session.

## Fix

- Add a shared strict codec for object-shaped `display_metadata`.
- Decode metadata consistently in `get_messages()`, `get_messages_around()`, conversation replay, and anchored-view bookends.
- Reject malformed/non-object data, `NaN`/infinities, overflow-to-infinity, and excessive nesting; degrade invalid presentation metadata to `None` without dropping the message.
- Prevent invalid metadata from being persisted through the covered write paths.
- Guard Desktop timeline reconstruction by checking object shape and `Number.isFinite(task_count)` before using delegation counts.
- Add synthetic backend and Desktop regression coverage for valid and invalid metadata.

## How to Verify

1. Persist an `async_delegation_complete` message with object-shaped display metadata.
2. Load it through the full-message, around-message, conversation replay, and anchored-bookend paths; metadata should be an object.
3. Repeat with malformed, non-object, non-finite, or deeply nested metadata; the message should remain available and metadata should safely fall back.
4. Reconstruct Desktop chat messages from object and malformed metadata; transcript conversion should not throw.

## Test Plan

- [x] `tests/test_hermes_state.py`: 455 passed
- [x] Desktop UI suite: 2,055 passed, 1 skipped
- [x] Desktop TypeScript typecheck passed
- [x] ESLint completed with 0 errors (existing unrelated warnings only)
- [x] Ruff, Python compilation, and diff checks passed
- [x] Independent pre-commit review completed with no blocking or important findings

## Risk Assessment

Low. The change is limited to presentation metadata boundaries and Desktop timeline labeling. Valid metadata retains its existing object shape; invalid metadata is discarded while message content and session history remain intact.
