### PR TITLE
fix(openai): recover invalid reasoning signatures

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -663,6 +663,19 @@ def classify_api_error(
             should_fallback=True,
         )
 
+    # OpenAI Responses may reject stale encrypted reasoning with this newer
+    # code. Match it before the generic "thinking" + "signature" heuristic
+    # below, which belongs to Anthropic-style signed thinking blocks.
+    if (
+        (error_code or "").lower() == "thinking_signature_invalid"
+        or "thinking_signature_invalid" in error_msg
+    ):
+        return _result(
+            FailoverReason.invalid_encrypted_content,
+            retryable=True,
+            should_fallback=False,
+        )
+
     # Anthropic thinking block recovery (400).  Two distinct failure modes,
     # same recovery (strip all reasoning_details and retry without thinking
     # blocks — see the thinking_signature handler in conversation_loop.py):

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -747,6 +747,22 @@ def classify_api_error(
             should_fallback=True,
         )
 
+    # OpenAI Responses may reject stale encrypted reasoning with this newer
+    # code. Match it before the generic "thinking" + "signature" heuristic
+    # below, which belongs to Anthropic-style signed thinking blocks.
+    if (
+        status_code == 400
+        and (
+            (error_code or "").lower() == "thinking_signature_invalid"
+            or "thinking_signature_invalid" in error_msg
+        )
+    ):
+        return _result(
+            FailoverReason.invalid_encrypted_content,
+            retryable=True,
+            should_fallback=False,
+        )
+
     # Anthropic thinking block recovery (400).  Two distinct failure modes,
     # same recovery (strip all reasoning_details and retry without thinking
     # blocks — see the thinking_signature handler in conversation_loop.py):

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -875,6 +875,26 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_fallback is False
 
+    def test_thinking_signature_invalid_uses_encrypted_replay_recovery(self):
+        e = MockAPIError(
+            "Error code: 400 - "
+            "{'error': {'code': 'thinking_signature_invalid', "
+            "'message': 'The reasoning signature is no longer valid.'}}",
+            status_code=400,
+            body={
+                "error": {
+                    "code": "thinking_signature_invalid",
+                    "message": "The reasoning signature is no longer valid.",
+                },
+            },
+        )
+
+        result = classify_api_error(e, provider="openai", model="gpt-5.5")
+
+        assert result.reason == FailoverReason.invalid_encrypted_content
+        assert result.retryable is True
+        assert result.should_fallback is False
+
     def test_xai_invalid_encrypted_content_wording_uses_replay_recovery(self):
         e = MockAPIError(
             "Error code: 400 - Could not decrypt the provided encrypted_content. "
@@ -2169,4 +2189,3 @@ class Test408RequestTimeout:
         assert result.retryable is False
         assert result.should_fallback is True
         assert result.should_compress is False
-

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -467,6 +467,25 @@ class TestClassifyApiError:
 
 
 
+    def test_thinking_signature_invalid_uses_encrypted_replay_recovery(self):
+        e = MockAPIError(
+            "Error code: 400 - "
+            "{'error': {'code': 'thinking_signature_invalid', "
+            "'message': 'The reasoning signature is no longer valid.'}}",
+            status_code=400,
+            body={
+                "error": {
+                    "code": "thinking_signature_invalid",
+                    "message": "The reasoning signature is no longer valid.",
+                },
+            },
+        )
+
+        result = classify_api_error(e, provider="openai", model="gpt-5.5")
+
+        assert result.reason == FailoverReason.invalid_encrypted_content
+        assert result.retryable is True
+        assert result.should_fallback is False
 
 
     @pytest.mark.parametrize("error_code", ["Invalid_Encrypted_Content", "INVALID_ENCRYPTED_CONTENT"])


### PR DESCRIPTION
## Summary

- recognize OpenAI Responses `thinking_signature_invalid` before the generic signed-thinking heuristic
- route the exact code into Hermes' existing one-shot encrypted reasoning replay recovery
- cover the SDK-shaped exception string that previously selected the wrong recovery branch

Fixes #70595.

## Root cause

The OpenAI error code contains both `thinking` and `signature`, so the earlier generic heuristic classified it as an Anthropic-style thinking signature failure. Hermes then stripped `reasoning_details` instead of disabling Codex reasoning replay, leaving the rejected `codex_reasoning_items` in the retry.

## Verification

- `python -m pytest tests/agent/test_error_classifier.py -q` — 200 passed
- `python -m pytest tests/agent/test_error_classifier.py tests/run_agent/test_run_agent_codex_responses.py -k 'invalid_encrypted_content or thinking_signature_invalid' -q` — 8 passed
- `python -m ruff check agent/error_classifier.py tests/agent/test_error_classifier.py` — passed
- `git diff --check` — passed
- local autoreview — clean, no accepted/actionable findings

## Scope

Two files. The existing encrypted replay recovery and retry bound are unchanged; this patch only corrects classifier priority for the newer provider code.