### PR TITLE
fix(voice): serialize batch TTS playback to prevent audio overlap

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4333,6 +4333,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_continuous = False
         self._voice_tts_done = threading.Event()
         self._voice_tts_done.set()
+        self._voice_tts_queue: queue.Queue[str] = queue.Queue()
+        self._voice_tts_worker_lock = threading.Lock()
+        self._voice_tts_worker = None
+        self._voice_tts_generation = 0
         self._voice_tts_stop = None  # active streaming pipeline's stop event
         self._voice_barge_capture = threading.Event()  # barge monitor is capturing the interruption
 
@@ -11408,21 +11412,79 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self._voice_restart_recording_async()
 
     def _voice_speak_response_async(self, text: str) -> None:
-        """Schedule TTS and mark it pending before continuous recording can restart."""
+        """Queue TTS so rapid responses play sequentially without overlap."""
         if not self._voice_tts or not text:
             return
-        self._voice_tts_done.clear()
-        threading.Thread(
-            target=self._voice_speak_response,
-            args=(text,),
-            daemon=True,
-        ).start()
+        with self._voice_tts_worker_lock:
+            self._voice_tts_done.clear()
+            self._voice_tts_queue.put(text)
+            if self._voice_tts_worker is None:
+                my_generation = self._voice_tts_generation
+                self._voice_tts_worker = threading.Thread(
+                    target=self._voice_tts_worker_loop,
+                    args=(my_generation,),
+                    daemon=True,
+                )
+                try:
+                    self._voice_tts_worker.start()
+                except RuntimeError:
+                    self._voice_tts_worker = None
+                    self._drain_voice_tts_queue()
+                    self._voice_tts_done.set()
+                    raise
 
-    def _voice_speak_response(self, text: str):
+    def _cancel_voice_tts_queue(self) -> None:
+        """Bump generation and drain the queue so stale items never play."""
+        with self._voice_tts_worker_lock:
+            self._voice_tts_generation += 1
+            self._drain_voice_tts_queue()
+            self._voice_tts_done.set()
+
+    def _drain_voice_tts_queue(self) -> None:
+        """Discard all pending items without playing them."""
+        while not self._voice_tts_queue.empty():
+            try:
+                self._voice_tts_queue.get_nowait()
+                self._voice_tts_queue.task_done()
+            except queue.Empty:
+                break
+
+    def _voice_tts_worker_loop(self, generation: int) -> None:
+        """Drain queued responses in order on a single playback worker."""
+        while True:
+            try:
+                text = self._voice_tts_queue.get_nowait()
+            except queue.Empty:
+                with self._voice_tts_worker_lock:
+                    if self._voice_tts_queue.empty():
+                        self._voice_tts_worker = None
+                        self._voice_tts_done.set()
+                        return
+                continue
+
+            with self._voice_tts_worker_lock:
+                if self._voice_tts_generation != generation or not self._voice_tts:
+                    self._voice_tts_queue.task_done()
+                    continue
+
+            try:
+                self._voice_speak_response(text, update_done_event=False)
+            except Exception:
+                logger.exception("Queued voice TTS playback failed")
+            finally:
+                self._voice_tts_queue.task_done()
+
+    def _voice_speak_response(
+        self,
+        text: str,
+        *,
+        update_done_event: bool = True,
+    ) -> None:
         """Speak the agent's response aloud using TTS (runs in background thread)."""
         if not self._voice_tts:
             return
-        self._voice_tts_done.clear()
+        if update_done_event:
+            self._voice_tts_done.clear()
         try:
             from tools.tts_tool import text_to_speech_tool
             from tools.voice_mode import play_audio_file
@@ -11453,8 +11515,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             text_to_speech_tool(text=tts_text, output_path=mp3_path)
 
-            # Play the MP3 directly (the TTS tool returns OGG path but MP3 still exists)
-            if os.path.isfile(mp3_path) and os.path.getsize(mp3_path) > 0:
+            # Re-check after synthesis — disable/toggle may have fired while
+            # we were waiting on the network, so skip playback entirely.
+            if (
+                os.path.isfile(mp3_path)
+                and os.path.getsize(mp3_path) > 0
+                and self._voice_tts
+            ):
                 play_audio_file(mp3_path)
                 # Clean up
                 try:
@@ -11468,7 +11535,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             logger.warning("Voice TTS playback failed: %s", e)
             _cprint(f"{_DIM}TTS playback failed: {e}{_RST}")
         finally:
-            self._voice_tts_done.set()
+            if update_done_event:
+                self._voice_tts_done.set()
 
 
     def _voice_barge_in_monitor(self, stop_event: threading.Event) -> None:
@@ -11629,6 +11697,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._voice_recorder = None
 
         # Stop any active TTS playback (file player + streaming pipeline)
+        self._cancel_voice_tts_queue()
         try:
             if self._voice_tts_stop is not None:
                 self._voice_tts_stop.set()
@@ -11650,7 +11719,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._voice_tts = not self._voice_tts
         status = "enabled" if self._voice_tts else "disabled"
 
-        if self._voice_tts:
+        if not self._voice_tts:
+            self._cancel_voice_tts_queue()
+            try:
+                if self._voice_tts_stop is not None:
+                    self._voice_tts_stop.set()
+                from tools.voice_mode import stop_playback
+                stop_playback()
+            except Exception:
+                pass
+        elif self._voice_tts:
             from tools.tts_tool import check_tts_requirements
             if not check_tts_requirements():
                 _cprint(f"{_DIM}Warning: No TTS provider available. Install edge-tts or set API keys.{_RST}")
@@ -13630,6 +13708,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_continuous = False  # Whether to auto-restart after agent responds
         self._voice_tts_done = threading.Event()  # Signals TTS playback finished
         self._voice_tts_done.set()  # Initially "done" (no TTS pending)
+        self._voice_tts_queue: queue.Queue[str] = queue.Queue()
+        self._voice_tts_worker_lock = threading.Lock()
+        self._voice_tts_worker = None
+        self._voice_tts_generation = 0
         self._voice_tts_stop = None  # active streaming pipeline's stop event
         self._voice_barge_capture = threading.Event()  # barge monitor is capturing the interruption
 
@@ -14426,6 +14508,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     try:
                         from tools.tts_streaming import mark_speech_interrupted
                         mark_speech_interrupted()
+                        cli_ref._cancel_voice_tts_queue()
                         if cli_ref._voice_tts_stop is not None:
                             cli_ref._voice_tts_stop.set()
                         from tools.voice_mode import stop_playback

--- a/cli.py
+++ b/cli.py
@@ -4333,7 +4333,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_continuous = False
         self._voice_tts_done = threading.Event()
         self._voice_tts_done.set()
-        self._voice_tts_queue: queue.Queue[str] = queue.Queue()
+        self._voice_tts_queue: "queue.Queue[str]" = queue.Queue()
         self._voice_tts_worker_lock = threading.Lock()
         self._voice_tts_worker = None
         self._voice_tts_generation = 0
@@ -11442,12 +11442,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     def _drain_voice_tts_queue(self) -> None:
         """Discard all pending items without playing them."""
-        while not self._voice_tts_queue.empty():
+        while True:
             try:
                 self._voice_tts_queue.get_nowait()
-                self._voice_tts_queue.task_done()
             except queue.Empty:
                 break
+            self._voice_tts_queue.task_done()
 
     def _voice_tts_worker_loop(self, generation: int) -> None:
         """Drain queued responses in order on a single playback worker."""
@@ -13708,7 +13708,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_continuous = False  # Whether to auto-restart after agent responds
         self._voice_tts_done = threading.Event()  # Signals TTS playback finished
         self._voice_tts_done.set()  # Initially "done" (no TTS pending)
-        self._voice_tts_queue: queue.Queue[str] = queue.Queue()
+        self._voice_tts_queue: "queue.Queue[str]" = queue.Queue()
         self._voice_tts_worker_lock = threading.Lock()
         self._voice_tts_worker = None
         self._voice_tts_generation = 0

--- a/cli.py
+++ b/cli.py
@@ -4333,7 +4333,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_continuous = False
         self._voice_tts_done = threading.Event()
         self._voice_tts_done.set()
-        self._voice_tts_queue: "queue.Queue[str]" = queue.Queue()
+        self._voice_tts_queue: "queue.Queue[tuple[str, int]]" = queue.Queue()
         self._voice_tts_worker_lock = threading.Lock()
         self._voice_tts_worker = None
         self._voice_tts_generation = 0
@@ -11417,12 +11417,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return
         with self._voice_tts_worker_lock:
             self._voice_tts_done.clear()
-            self._voice_tts_queue.put(text)
+            item_generation = self._voice_tts_generation
+            self._voice_tts_queue.put((text, item_generation))
             if self._voice_tts_worker is None:
-                my_generation = self._voice_tts_generation
                 self._voice_tts_worker = threading.Thread(
                     target=self._voice_tts_worker_loop,
-                    args=(my_generation,),
                     daemon=True,
                 )
                 try:
@@ -11449,11 +11448,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 break
             self._voice_tts_queue.task_done()
 
-    def _voice_tts_worker_loop(self, generation: int) -> None:
+    def _voice_tts_worker_loop(self) -> None:
         """Drain queued responses in order on a single playback worker."""
         while True:
             try:
-                text = self._voice_tts_queue.get_nowait()
+                text, item_generation = self._voice_tts_queue.get_nowait()
             except queue.Empty:
                 with self._voice_tts_worker_lock:
                     if self._voice_tts_queue.empty():
@@ -11462,13 +11461,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         return
                 continue
 
-            with self._voice_tts_worker_lock:
-                if self._voice_tts_generation != generation or not self._voice_tts:
-                    self._voice_tts_queue.task_done()
-                    continue
-
             try:
-                self._voice_speak_response(text, update_done_event=False)
+                self._voice_speak_response(
+                    text,
+                    update_done_event=False,
+                    item_generation=item_generation,
+                )
             except Exception:
                 logger.exception("Queued voice TTS playback failed")
             finally:
@@ -11479,6 +11477,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         text: str,
         *,
         update_done_event: bool = True,
+        item_generation: Optional[int] = None,
     ) -> None:
         """Speak the agent's response aloud using TTS (runs in background thread)."""
         if not self._voice_tts:
@@ -11517,10 +11516,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             # Re-check after synthesis — disable/toggle may have fired while
             # we were waiting on the network, so skip playback entirely.
+            # Validate item_generation so a cancelled item doesn't play even
+            # if TTS was re-enabled before synthesis returned.
+            if item_generation is not None:
+                with self._voice_tts_worker_lock:
+                    generation_stale = self._voice_tts_generation != item_generation
+            else:
+                generation_stale = False
+
             if (
                 os.path.isfile(mp3_path)
                 and os.path.getsize(mp3_path) > 0
                 and self._voice_tts
+                and not generation_stale
             ):
                 play_audio_file(mp3_path)
                 # Clean up
@@ -13708,7 +13716,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_continuous = False  # Whether to auto-restart after agent responds
         self._voice_tts_done = threading.Event()  # Signals TTS playback finished
         self._voice_tts_done.set()  # Initially "done" (no TTS pending)
-        self._voice_tts_queue: "queue.Queue[str]" = queue.Queue()
+        self._voice_tts_queue: "queue.Queue[tuple[str, int]]" = queue.Queue()
         self._voice_tts_worker_lock = threading.Lock()
         self._voice_tts_worker = None
         self._voice_tts_generation = 0

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -29,6 +29,10 @@ def _make_voice_cli(**overrides):
     cli._voice_continuous = False
     cli._voice_tts_done = threading.Event()
     cli._voice_tts_done.set()
+    cli._voice_tts_queue = queue.Queue()
+    cli._voice_tts_worker_lock = threading.Lock()
+    cli._voice_tts_worker = None
+    cli._voice_tts_generation = 0
     cli._voice_tts_stop = None
     cli._voice_barge_capture = threading.Event()
     cli._pending_input = queue.Queue()
@@ -988,6 +992,141 @@ class TestVoiceSpeakResponseReal:
 
         assert starts == [False]
         assert not cli._voice_tts_done.is_set()
+
+    def test_async_responses_are_spoken_sequentially(self):
+        cli = _make_voice_cli(_voice_tts=True)
+        first_started = threading.Event()
+        second_started = threading.Event()
+        release_first = threading.Event()
+        spoken = []
+        active_calls = 0
+        maximum_active_calls = 0
+        state_lock = threading.Lock()
+
+        def speak(text, *args, **kwargs):
+            nonlocal active_calls, maximum_active_calls
+            with state_lock:
+                active_calls += 1
+                maximum_active_calls = max(maximum_active_calls, active_calls)
+            spoken.append(text)
+            if text == "first":
+                first_started.set()
+                assert release_first.wait(timeout=2)
+            else:
+                second_started.set()
+            with state_lock:
+                active_calls -= 1
+
+        cli._voice_speak_response = speak
+        cli._voice_speak_response_async("first")
+        assert first_started.wait(timeout=2)
+        cli._voice_speak_response_async("second")
+        assert not second_started.wait(timeout=0.1)
+        worker = cli._voice_tts_worker
+        assert worker is not None
+        release_first.set()
+        assert second_started.wait(timeout=2)
+        worker.join(timeout=2)
+
+        assert spoken == ["first", "second"]
+        assert maximum_active_calls == 1
+        assert cli._voice_tts_done.is_set()
+
+    @patch("cli._cprint")
+    def test_disable_during_synthesis_prevents_playback(self, _cp):
+        cli = _make_voice_cli(_voice_mode=True, _voice_tts=True)
+        synthesis_started = threading.Event()
+        release_synthesis = threading.Event()
+
+        def synthesize(**kwargs):
+            synthesis_started.set()
+            assert release_synthesis.wait(timeout=2)
+            return '{"success": true}'
+
+        with (
+            patch("tools.tts_tool.text_to_speech_tool", side_effect=synthesize),
+            patch("tools.voice_mode.play_audio_file") as play_audio,
+            patch("tools.voice_mode.stop_playback"),
+            patch("cli.os.makedirs"),
+            patch("cli.os.path.isfile", return_value=True),
+            patch("cli.os.path.getsize", return_value=1000),
+            patch("cli.os.unlink"),
+        ):
+            cli._voice_speak_response_async("first")
+            assert synthesis_started.wait(timeout=2)
+            worker = cli._voice_tts_worker
+            assert worker is not None
+            cli._disable_voice_mode()
+            release_synthesis.set()
+            worker.join(timeout=2)
+
+        play_audio.assert_not_called()
+        assert cli._voice_tts_done.is_set()
+
+    @patch("cli._cprint")
+    @patch("tools.voice_mode.stop_playback")
+    def test_disable_discards_responses_queued_before_reenable(self, _stop, _cp):
+        cli = _make_voice_cli(_voice_mode=True, _voice_tts=True)
+        first_started = threading.Event()
+        release_first = threading.Event()
+        spoken = []
+
+        def speak(text, *args, **kwargs):
+            spoken.append(text)
+            if text == "first":
+                first_started.set()
+                assert release_first.wait(timeout=2)
+
+        cli._voice_speak_response = speak
+        cli._voice_speak_response_async("first")
+        assert first_started.wait(timeout=2)
+        cli._voice_speak_response_async("stale second")
+        worker = cli._voice_tts_worker
+        assert worker is not None
+
+        cli._disable_voice_mode()
+        cli._voice_mode = True
+        cli._voice_tts = True
+        release_first.set()
+        worker.join(timeout=2)
+
+        assert spoken == ["first"]
+        assert cli._voice_tts_done.is_set()
+
+    @patch("cli._cprint")
+    @patch("tools.voice_mode.stop_playback")
+    def test_toggle_off_cancels_active_playback(self, stop_playback, _cp):
+        cli = _make_voice_cli(_voice_mode=True, _voice_tts=True)
+        cli._voice_tts_done.clear()
+
+        with patch("cli.threading.Thread"):
+            cli._voice_speak_response_async("queued item")
+
+        cli._toggle_voice_tts()
+
+        assert cli._voice_tts is False
+        assert cli._voice_tts_done.is_set()
+        stop_playback.assert_called_once_with()
+        assert cli._voice_tts_queue.empty()
+
+    def test_worker_start_failure_does_not_strand_queue(self):
+        cli = _make_voice_cli(_voice_tts=True)
+
+        class FailingThread:
+            def __init__(self, target=None, args=(), daemon=None):
+                self.target = target
+                self.daemon = daemon
+
+            def start(self):
+                raise RuntimeError("thread start failed")
+
+        with patch("cli.threading.Thread", FailingThread):
+            with pytest.raises(RuntimeError, match="thread start failed"):
+                cli._voice_speak_response_async("Hello")
+
+        assert cli._voice_tts_worker is None
+        assert cli._voice_tts_queue.empty()
+        assert cli._voice_tts_done.is_set()
 
     @patch("cli._cprint")
     def test_early_return_when_tts_off(self, _cp):

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -1095,6 +1095,57 @@ class TestVoiceSpeakResponseReal:
 
     @patch("cli._cprint")
     @patch("tools.voice_mode.stop_playback")
+    def test_cancel_reenable_race_old_item_skipped_fresh_item_plays(self, _stop, _cp):
+        """Cancel during synthesis, re-enable, enqueue fresh: old never plays, fresh plays once."""
+        cli = _make_voice_cli(_voice_mode=True, _voice_tts=True)
+        old_synthesis_started = threading.Event()
+        release_old_synthesis = threading.Event()
+        fresh_started = threading.Event()
+        release_fresh = threading.Event()
+        played = []
+
+        def synthesize(**kwargs):
+            text = kwargs.get("text", "")
+            if text == "old":
+                old_synthesis_started.set()
+                assert release_old_synthesis.wait(timeout=2)
+            elif text == "fresh":
+                fresh_started.set()
+                assert release_fresh.wait(timeout=2)
+            return '{"success": true}'
+
+        def play(path):
+            played.append(path)
+
+        with (
+            patch("tools.tts_tool.text_to_speech_tool", side_effect=synthesize),
+            patch("tools.voice_mode.play_audio_file", side_effect=play),
+            patch("tools.voice_mode.stop_playback"),
+            patch("cli.os.makedirs"),
+            patch("cli.os.path.isfile", return_value=True),
+            patch("cli.os.path.getsize", return_value=1000),
+            patch("cli.os.unlink"),
+        ):
+            cli._voice_speak_response_async("old")
+            assert old_synthesis_started.wait(timeout=2)
+            worker = cli._voice_tts_worker
+            assert worker is not None
+
+            cli._disable_voice_mode()
+            cli._voice_mode = True
+            cli._voice_tts = True
+
+            cli._voice_speak_response_async("fresh")
+            release_old_synthesis.set()
+            assert fresh_started.wait(timeout=2)
+            release_fresh.set()
+            worker.join(timeout=2)
+
+        assert len(played) == 1
+        assert cli._voice_tts_done.is_set()
+
+    @patch("cli._cprint")
+    @patch("tools.voice_mode.stop_playback")
     def test_toggle_off_cancels_active_playback(self, stop_playback, _cp):
         cli = _make_voice_cli(_voice_mode=True, _voice_tts=True)
         cli._voice_tts_done.clear()


### PR DESCRIPTION
## Summary

Rapid assistant responses each spawned an independent batch TTS thread, causing spoken audio to overlap. This PR replaces the per-response thread with a single serialised queue worker so responses play back-to-back without overlap.

- Single worker thread drains the TTS queue in order (FIFO)
- `_voice_tts_done` stays clear across the entire queue, set only when the queue drains
- Generation counter cancels stale queued items on disable, toggle-off, or record-key interruption
- Post-synthesis `_voice_tts` re-check skips playback when disable/toggle fires during synthesis
- Thread start failure cleans up queue and done event instead of wedging

## Test plan

- `scripts/run_tests.sh tests/tools/test_voice_cli_integration.py` (90 passed)
- `.venv/bin/ruff check cli.py tests/tools/test_voice_cli_integration.py`
- `.venv/bin/python -m py_compile cli.py tests/tools/test_voice_cli_integration.py`
- `git diff --check`
- Regression tests: sequential ordering, disable-during-synthesis, disable-discards-stale-queue, toggle-off-cancels, worker-start-failure