### PR TITLE
fix(profiles): keep branch/compression sessions on the parent profile

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1908,6 +1908,26 @@ def compress_context(
                     except Exception:
                         pass
                     agent._session_db_created = False
+                    # Compression children must keep the parent's profile stamp.
+                    # SessionDB backfills cwd/git from the parent, but profile_name
+                    # is not inferred from which state.db we write to — omitting it
+                    # leaves NULL and the unified desktop list tags the tip as
+                    # "default" even when the lineage started on a named profile.
+                    _parent_profile = None
+                    try:
+                        _prow = agent._session_db.get_session(old_session_id)
+                        if _prow:
+                            _parent_profile = _prow.get("profile_name")
+                    except Exception:
+                        _parent_profile = None
+                    if not _parent_profile:
+                        try:
+                            from hermes_cli.profiles import get_active_profile_name
+
+                            _pn = get_active_profile_name()
+                            _parent_profile = None if _pn in (None, "default") else _pn
+                        except Exception:
+                            _parent_profile = None
                     try:
                         agent._session_db.create_session(
                             session_id=agent.session_id,
@@ -1915,6 +1935,7 @@ def compress_context(
                             model=agent.model,
                             model_config=agent._session_init_model_config,
                             parent_session_id=old_session_id,
+                            profile_name=_parent_profile,
                         )
                     except Exception as _cs_err:
                         # The child row could not be created (e.g. FK constraint,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1090,6 +1090,41 @@ describe('branchStoredSession desktop source tagging', () => {
     })
   })
 
+  it('carries the parent profile on session.create so the branch stays off default', async () => {
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    setSessions([storedSession({ id: 'stored-parent', message_count: 1, profile: 'ai-engineer' })])
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let branchStoredSession: ((storedSessionId: string, sessionProfile?: string | null) => Promise<boolean>) | null =
+      null
+
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
+
+    expect(ensureGatewayProfile).toHaveBeenCalledWith('ai-engineer')
+    expect(createParams).toMatchObject({
+      parent_session_id: 'stored-parent',
+      profile: 'ai-engineer',
+      source: 'desktop'
+    })
+  })
+
   // #67603: right-clicking a session outside the paginated sidebar window is a
   // cache miss. Resolve its owning profile (cache → active → cross-profile) and
   // swap to it before reading the transcript / creating the branch, so the fork

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1056,15 +1056,31 @@ export function useSessionActions({
   // `parentStoredId` so it nests under its parent, then open it as its own tab
   // and switch to it — the parent chat stays put (mirrors openNewSessionTile).
   const forkBranch = useCallback(
-    async (branchMessages: BranchMessage[], parentStoredId: null | string, cwd?: string): Promise<boolean> => {
+    async (
+      branchMessages: BranchMessage[],
+      parentStoredId: null | string,
+      cwd?: string,
+      profile?: string | null
+    ): Promise<boolean> => {
       creatingSessionRef.current = true
 
       try {
+        // Branch must land in the SOURCE session's profile — not the new-chat
+        // picker / launch profile. In app-global remote mode one backend serves
+        // every profile, so omitting `profile` on session.create silently binds
+        // the branch to the launch HERMES_HOME/state.db ("rubberbands to default").
+        const sourceProfile = profile?.trim() || undefined
+
+        if (sourceProfile) {
+          await ensureGatewayProfile(sourceProfile)
+        }
+
         // No title: the backend auto-names the branch from its parent's lineage.
         const branched = await requestGateway<SessionCreateResponse>('session.create', {
           cols: 96,
           source: 'desktop',
           ...(cwd && { cwd }),
+          ...(sourceProfile ? { profile: sourceProfile } : {}),
           messages: branchMessages.map(({ content, role }) => ({ content, role })),
           ...(parentStoredId && { parent_session_id: parentStoredId })
         })
@@ -1165,7 +1181,17 @@ export function useSessionActions({
 
       clearNotifications()
 
-      return forkBranch(branchMessages, selectedStoredSessionIdRef.current, $currentCwd.get().trim())
+      const parentStoredId = selectedStoredSessionIdRef.current
+      const parentStored = parentStoredId
+        ? $sessions.get().find(session => sessionMatchesStoredId(session, parentStoredId))
+        : null
+
+      return forkBranch(
+        branchMessages,
+        parentStoredId,
+        $currentCwd.get().trim(),
+        parentStored?.profile
+      )
     },
     [activeSessionIdRef, busyRef, copy, forkBranch, selectedStoredSessionIdRef]
   )
@@ -1197,7 +1223,12 @@ export function useSessionActions({
           return false
         }
 
-        return await forkBranch(branchMessages, stored?.id ?? storedSessionId, stored?.cwd?.trim())
+        return await forkBranch(
+          branchMessages,
+          stored?.id ?? storedSessionId,
+          stored?.cwd?.trim(),
+          profile
+        )
       } catch (err) {
         notifyError(err, copy.branchFailed)
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3387,18 +3387,20 @@ class SessionDB:
 
         When ``parent_session_id`` is set (compression fork, delegate/subagent
         spawn, branch continuation) and this row's own ``cwd``/``git_repo_root``/
-        ``git_branch`` are still NULL after the insert, they are backfilled from
-        the parent row. Callers of ``create_session`` for a child session
-        historically didn't propagate these fields themselves (e.g. the
+        ``git_branch``/``profile_name`` are still NULL after the insert, they are
+        backfilled from the parent row. Callers of ``create_session`` for a child
+        session historically didn't propagate these fields themselves (e.g. the
         compression-fork path), so a lineage could silently lose its working
         directory and drop out of the project sidebar every time it forked
-        (#64709). This only fills NULLs — an explicit ``cwd``/``git_repo_root``
-        on the child is never overwritten. For compression forks specifically
-        (parent ended with ``end_reason='compression'``), the gateway origin
-        columns (``user_id``/``session_key``/``chat_id``/``chat_type``/
-        ``thread_id``/``display_name``/``origin_json``) are inherited too, so a
-        crash before the gateway re-records the peer can't strand the child
-        without a recoverable routing mapping (#59527).
+        (#64709), or lose its profile stamp and appear under "default" in the
+        unified desktop list. This only fills NULLs — an explicit
+        ``cwd``/``git_repo_root``/``profile_name`` on the child is never
+        overwritten. For compression forks specifically (parent ended with
+        ``end_reason='compression'``), the gateway origin columns
+        (``user_id``/``session_key``/``chat_id``/``chat_type``/``thread_id``/
+        ``display_name``/``origin_json``) are inherited too, so a crash before
+        the gateway re-records the peer can't strand the child without a
+        recoverable routing mapping (#59527).
         """
         def _do(conn):
             conn.execute(
@@ -3449,7 +3451,10 @@ class SessionDB:
                                              WHERE p.id = sessions.parent_session_id)),
                            git_branch = COALESCE(sessions.git_branch,
                                         (SELECT p.git_branch FROM sessions p
-                                          WHERE p.id = sessions.parent_session_id))
+                                          WHERE p.id = sessions.parent_session_id)),
+                           profile_name = COALESCE(sessions.profile_name,
+                                          (SELECT p.profile_name FROM sessions p
+                                            WHERE p.id = sessions.parent_session_id))
                      WHERE id = ? AND parent_session_id IS NOT NULL""",
                     (session_id,),
                 )

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -182,6 +182,27 @@ class TestWorkspaceMetadataFollowsRotation:
         assert row["chat_type"] == "private"
         assert row["user_id"] == "u1"
 
+    def test_child_row_inherits_profile_name_on_rotation(self, tmp_path: Path):
+        """Compression rotation must stamp the parent's profile_name on the
+        child so desktop aggregation doesn't retag the tip as default."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_PROFILE_ROT"
+        db.create_session(
+            parent,
+            source="desktop",
+            profile_name="ai-engineer",
+        )
+        agent = _build_agent_with_db(db, parent, platform="desktop")
+
+        agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+        child = agent.session_id
+        assert child != parent
+
+        row = db.get_session(child)
+        assert row is not None
+        assert row["parent_session_id"] == parent
+        assert row["profile_name"] == "ai-engineer"
+
 
 class TestPlatformForwardedAtBoundary:
     def test_on_session_start_receives_platform(self, tmp_path: Path):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -152,6 +152,31 @@ class TestSessionLifecycle:
         assert child["cwd"] == "/work/repo"
         assert child["git_repo_root"] == "/work/repo"
 
+    def test_child_session_inherits_profile_name_from_parent(self, db):
+        """Compression/branch children born without profile_name must inherit
+        the parent's stamp so the unified desktop list doesn't retag the tip
+        as 'default' after rotate/branch."""
+        db.create_session(
+            session_id="parent", source="desktop", profile_name="ai-engineer"
+        )
+        db.create_session(session_id="child", source="desktop", parent_session_id="parent")
+
+        child = db.get_session("child")
+        assert child["profile_name"] == "ai-engineer"
+
+    def test_child_session_explicit_profile_name_is_not_overwritten(self, db):
+        db.create_session(
+            session_id="parent", source="desktop", profile_name="ai-engineer"
+        )
+        db.create_session(
+            session_id="child",
+            source="desktop",
+            parent_session_id="parent",
+            profile_name="other",
+        )
+
+        assert db.get_session("child")["profile_name"] == "other"
+
     def test_child_session_explicit_cwd_is_not_overwritten_by_parent(self, db):
         """A child that explicitly sets its own cwd/git_repo_root keeps it —
         parent inheritance only fills in NULLs, never clobbers."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3893,7 +3893,7 @@ def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None):
+        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, **_kwargs):
             created.append(
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
@@ -3914,7 +3914,7 @@ def test_ensure_session_db_row_persists_session_source(monkeypatch):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None):
+        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, **_kwargs):
             created.append(
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
@@ -3935,7 +3935,7 @@ def test_ensure_session_db_row_defaults_to_no_workspace(monkeypatch, tmp_path):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None):
+        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, **_kwargs):
             created.append(
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
@@ -3964,7 +3964,7 @@ def test_ensure_session_db_row_persists_session_model_override(monkeypatch):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None):
+        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, **_kwargs):
             created.append(
                 {"key": key, "model": model, "model_config": model_config, "cwd": cwd}
             )
@@ -3996,7 +3996,7 @@ def test_ensure_session_db_row_no_override_uses_global(monkeypatch):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None):
+        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, **_kwargs):
             created.append({"model": model, "model_config": model_config})
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -6,6 +6,7 @@ import sys
 import threading
 import time
 import types
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1287,6 +1288,93 @@ def test_session_branch_persists_branched_from_marker(server, monkeypatch):
     assert kwargs["parent_session_id"] == parent_key
     # The marker — without it the branch is invisible in /resume and /sessions.
     assert kwargs["model_config"] == {"_branched_from": parent_key}
+
+
+def test_session_branch_uses_parent_profile_db(server, monkeypatch, tmp_path):
+    """/branch on a named-profile session must write the child into that
+    profile's state.db (with profile_name) and copy profile_home onto the
+    live branch — not the launch/default db."""
+    profile_home = tmp_path / "profiles" / "ai-engineer"
+    profile_home.mkdir(parents=True)
+    create_calls = []
+    opened_paths = []
+    init_kwargs = {}
+
+    class _DB:
+        def __init__(self, db_path=None):
+            if db_path is not None:
+                opened_paths.append(Path(db_path))
+
+        def get_session(self, _key):
+            return {"profile_name": "ai-engineer"}
+
+        def get_session_title(self, _key):
+            return "parent-title"
+
+        def get_next_title_in_lineage(self, base):
+            return f"{base} 2"
+
+        def create_session(self, new_key, **kwargs):
+            create_calls.append((new_key, kwargs))
+            return new_key
+
+        def append_message(self, **_kwargs):
+            return None
+
+        def set_session_title(self, _key, _title):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr("hermes_state.SessionDB", _DB)
+    # Launch db must not be used when the parent has a profile_home.
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: (_ for _ in ()).throw(AssertionError("launch db must not be used")),
+    )
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_new_session_key", lambda: "20260101_000001_child0")
+    monkeypatch.setattr(
+        server,
+        "_make_agent",
+        lambda _sid, key, session_id=None, session_db=None, **_kwargs: types.SimpleNamespace(
+            model="test/model", session_id=session_id or key
+        ),
+    )
+
+    def _capture_init(*_a, **kwargs):
+        init_kwargs.update(kwargs)
+
+    monkeypatch.setattr(server, "_init_session", _capture_init)
+    monkeypatch.setattr(server, "_set_session_context", lambda *_a, **_k: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda _s: "/tmp/branch-cwd")
+    monkeypatch.setattr(server, "set_hermes_home_override", lambda *_a, **_k: "token")
+    monkeypatch.setattr(server, "reset_hermes_home_override", lambda *_a, **_k: None)
+
+    parent_sid = "parent-prof"
+    parent_key = "20260101_000000_parent"
+    server._sessions[parent_sid] = {
+        "session_key": parent_key,
+        "history": [{"role": "user", "content": "hello"}],
+        "history_lock": threading.Lock(),
+        "cols": 80,
+        "profile_home": str(profile_home),
+    }
+
+    resp = server.handle_request(
+        {"id": "bp", "method": "session.branch", "params": {"session_id": parent_sid}}
+    )
+
+    assert "error" not in resp, resp
+    assert create_calls, "create_session was not called"
+    _new_key, kwargs = create_calls[0]
+    assert kwargs["profile_name"] == "ai-engineer"
+    assert kwargs["parent_session_id"] == parent_key
+    assert any(p == profile_home / "state.db" for p in opened_paths)
+    assert init_kwargs.get("profile_home") == str(profile_home)
 
 
 def test_session_branch_forwards_original_timestamps(server, monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1092,6 +1092,23 @@ def _profile_home(profile: str | None) -> Path | None:
     return home if (home / "state.db").exists() or home.exists() else None
 
 
+def _profile_name_for_home_path(home: str | Path | None) -> str | None:
+    """Return the named-profile id for a HERMES_HOME path, or None for default/root."""
+    if not home:
+        return None
+    path = Path(home)
+    if path.parent.name == "profiles":
+        return path.name
+    return None
+
+
+def _profile_name_for_session(session: dict | None) -> str | None:
+    """Best-effort profile stamp for a live session (profile_home → name)."""
+    if not session:
+        return None
+    return _profile_name_for_home_path(session.get("profile_home"))
+
+
 def _profile_scoped(handler):
     """Bind ``params['profile']``'s HERMES_HOME around a pet RPC handler.
 
@@ -2085,6 +2102,7 @@ def _ensure_session_db_row(session: dict) -> None:
             model_config=model_config or None,
             parent_session_id=parent_session_id,
             cwd=_session_cwd(session) if session.get("explicit_cwd") else None,
+            profile_name=_profile_name_for_session(session),
         )
     except Exception:
         logger.debug("failed to persist desktop session row", exc_info=True)
@@ -4108,7 +4126,9 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "update_behind": None,
         "update_command": "",
         "usage": _session_usage_snapshot(session),
-        "profile_name": _current_profile_name(),
+        # Prefer the session's own profile_home over the process launch profile
+        # so app-global remote mode doesn't report every chat as "default".
+        "profile_name": _profile_name_for_session(session) or _current_profile_name(),
     }
     try:
         from hermes_cli import __version__, __release_date__
@@ -5473,6 +5493,7 @@ def _init_session(
     cwd: str | None = None,
     session_db=None,
     source: str | None = None,
+    profile_home: str | None = None,
 ):
     now = time.time()
     with _sessions_lock:
@@ -5500,6 +5521,9 @@ def _init_session(
             # Honored on rebuild (/new, resume) so a switch in THIS session
             # never leaks into siblings via process-global env vars.
             "model_override": None,
+            # Named-profile home for app-global remote mode — branch/compress
+            # children must keep the parent's binding or they land in launch db.
+            "profile_home": str(profile_home) if profile_home else None,
             # Pin async event emissions to whichever transport created the
             # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
             "transport": current_transport() or _stdio_transport,
@@ -6301,7 +6325,9 @@ def _(rid, params: dict) -> dict:
                 "project": _project_info_for_cwd(_sessions[sid]["cwd"]),
                 "lazy": True,
                 "desktop_contract": DESKTOP_BACKEND_CONTRACT,
-                "profile_name": _current_profile_name(),
+                # Echo the requested profile (not just the launch profile) so the
+                # desktop optimistic row + aggregator stay on the right home.
+                "profile_name": profile or _current_profile_name(),
             },
         },
     )
@@ -6439,7 +6465,13 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"verification": {"status": "unknown", "evidence": None}})
 
 
-def _lazy_resume_info(cwd: str, *, model: str = "", provider: str = "") -> dict:
+def _lazy_resume_info(
+    cwd: str,
+    *,
+    model: str = "",
+    provider: str = "",
+    profile_name: str | None = None,
+) -> dict:
     """session.info for a not-yet-built session (the shape session.create
     returns). tools/skills land later when the deferred build emits session.info."""
     info = {
@@ -6451,7 +6483,7 @@ def _lazy_resume_info(cwd: str, *, model: str = "", provider: str = "") -> dict:
         "skills": {},
         "lazy": True,
         "desktop_contract": DESKTOP_BACKEND_CONTRACT,
-        "profile_name": _current_profile_name(),
+        "profile_name": profile_name or _current_profile_name(),
     }
     if provider:
         info["provider"] = provider
@@ -6703,7 +6735,10 @@ def _(rid, params: dict) -> dict:
                 "resumed": target,
                 "message_count": len(messages),
                 "messages": messages,
-                "info": _lazy_resume_info(cwd),
+                "info": _lazy_resume_info(
+                    cwd,
+                    profile_name=profile or _profile_name_for_home_path(profile_home),
+                ),
                 "inflight": None,
                 "running": child_running,
                 "session_key": target,
@@ -6790,6 +6825,7 @@ def _(rid, params: dict) -> dict:
                     cwd,
                     model=model_override.get("model") or "",
                     provider=overrides.get("provider_override") or "",
+                    profile_name=profile or _profile_name_for_home_path(profile_home),
                 ),
                 "inflight": None,
                 "running": False,
@@ -9531,13 +9567,31 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
-    db = _get_db()
+    # Branch into the PARENT's profile db/home — not the launch state.db.
+    # Without this, /branch on a non-default profile session drops the tip onto
+    # default (and later compression children follow it).
+    profile_home_str = session.get("profile_home") or None
+    profile_home = Path(profile_home_str) if profile_home_str else None
+    close_db = False
+    if profile_home is not None:
+        from hermes_state import SessionDB
+
+        try:
+            db = SessionDB(db_path=profile_home / "state.db")
+            close_db = True
+        except Exception as e:
+            return _err(rid, 5008, f"branch failed: {e}")
+    else:
+        db = _get_db()
     if db is None:
         return _db_unavailable_error(rid, code=5008)
     old_key = session["session_key"]
     with session["history_lock"]:
         history = [dict(msg) for msg in session.get("history", [])]
     if not history:
+        if close_db:
+            with contextlib.suppress(Exception):
+                db.close()
         return _err(rid, 4008, "nothing to branch — send a message first")
     new_key = _new_session_key()
     new_sid = uuid.uuid4().hex[:8]
@@ -9546,8 +9600,18 @@ def _(rid, params: dict) -> dict:
         new_key, live_session_id=new_sid, surface=source
     )
     if limit_message is not None:
+        if close_db:
+            with contextlib.suppress(Exception):
+                db.close()
         return _err(rid, 4090, limit_message)
     branch_name = params.get("name", "")
+    profile_name = _profile_name_for_session(session)
+    if not profile_name:
+        try:
+            parent_row = db.get_session(old_key) or {}
+            profile_name = parent_row.get("profile_name")
+        except Exception:
+            profile_name = None
     try:
         if branch_name:
             title = branch_name
@@ -9570,6 +9634,7 @@ def _(rid, params: dict) -> dict:
             model_config={"_branched_from": old_key},
             parent_session_id=old_key,
             cwd=_session_cwd(session),
+            profile_name=profile_name,
         )
         for msg in history:
             db.append_message(
@@ -9583,16 +9648,30 @@ def _(rid, params: dict) -> dict:
         if lease is not None:
             lease.release()
         return _err(rid, 5008, f"branch failed: {e}")
+    finally:
+        if close_db:
+            with contextlib.suppress(Exception):
+                db.close()
     try:
         tokens = _set_session_context(new_key)
+        home_token = None
+        branch_db = None
         try:
+            if profile_home is not None:
+                from hermes_state import SessionDB
+
+                home_token = set_hermes_home_override(str(profile_home))
+                branch_db = SessionDB(db_path=profile_home / "state.db")
             agent = _make_agent(
                 new_sid,
                 new_key,
                 session_id=new_key,
                 platform_override=source,
+                session_db=branch_db,
             )
         finally:
+            if home_token is not None:
+                reset_hermes_home_override(home_token)
             _clear_session_context(tokens)
         _init_session(
             new_sid,
@@ -9600,7 +9679,10 @@ def _(rid, params: dict) -> dict:
             agent,
             list(history),
             cols=session.get("cols", 80),
+            cwd=_session_cwd(session),
             source=source,
+            session_db=branch_db,
+            profile_home=profile_home_str,
         )
         if new_sid in _sessions:
             _sessions[new_sid]["active_session_lease"] = lease


### PR DESCRIPTION
## Summary
- Desktop `/branch` and TUI `session.branch` now keep the child session on the parent profile's `HERMES_HOME` / `state.db` instead of silently falling back to the launch (default) profile.
- Compression rotation stamps `profile_name` on the child row, and `SessionDB` backfills it from the parent when omitted, so lineage tips stay correctly tagged in the unified session list.

## Test plan
- [x] `scripts/run_tests.sh tests/test_hermes_state.py tests/agent/test_compression_rotation_state.py tests/tui_gateway/test_protocol.py -q -k "profile_name or parent_profile_db or branched_from_marker"`
- [x] `cd apps/desktop && npx vitest run src/app/session/hooks/use-session-actions.test.tsx -t "carries the parent profile"`
- [ ] Manual: open a chat on a non-default profile → `/branch` → confirm the tip stays on that profile (not default)
- [ ] Manual: compress a long non-default-profile session → confirm the continuation child stays on that profile
