### PR TITLE
fix(desktop): rebuild the correct SSH tunnel after disconnect

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -39,6 +39,7 @@ import {
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
+  sshReconnectScope,
   tokenPreview
 } from './connection-config'
 
@@ -49,6 +50,17 @@ test('connectionScopeKey trims to a name or null for the global scope', () => {
   assert.equal(connectionScopeKey(''), null)
   assert.equal(connectionScopeKey(null), null)
   assert.equal(connectionScopeKey(undefined), null)
+})
+
+test('sshReconnectScope preserves the exact global or per-profile SSH owner scope', () => {
+  assert.equal(sshReconnectScope({ remoteKind: 'ssh', sshScope: '' }), '')
+  assert.equal(sshReconnectScope({ remoteKind: 'ssh', sshScope: 'goliath-main' }), 'goliath-main')
+})
+
+test('sshReconnectScope rejects non-SSH and malformed connection descriptors', () => {
+  assert.equal(sshReconnectScope({ remoteKind: 'url', sshScope: 'goliath-main' }), null)
+  assert.equal(sshReconnectScope({ remoteKind: 'ssh' }), null)
+  assert.equal(sshReconnectScope(null), null)
 })
 
 test('normAuthMode coerces to token unless explicitly oauth', () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -187,6 +187,22 @@ function connectionScopeKey(profile) {
   return String(profile ?? '').trim() || null
 }
 
+/**
+ * Recover the exact SSH owner scope embedded by bootstrapSshConnection.
+ *
+ * The empty string is a real, load-bearing value: it owns the app-global SSH
+ * tunnel. Treating it like a missing profile and substituting the active
+ * profile leaves that global tunnel alive after a failed liveness probe, so
+ * every reconnect reuses the same wedged SSH master.
+ */
+function sshReconnectScope(connection) {
+  if (connection?.remoteKind !== 'ssh' || typeof connection.sshScope !== 'string') {
+    return null
+  }
+
+  return connection.sshScope
+}
+
 // Coerce a remote auth mode to one of the two supported values ('token' default).
 function normAuthMode(mode) {
   return mode === 'oauth' ? 'oauth' : 'token'
@@ -509,5 +525,6 @@ export {
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
+  sshReconnectScope,
   tokenPreview
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -63,6 +63,7 @@ import {
   resolveAuthMode,
   resolveTestWsUrl,
   savedProfileSsh,
+  sshReconnectScope,
   tokenPreview
 } from './connection-config'
 import { adoptServedDashboardToken } from './dashboard-token'
@@ -6728,8 +6729,7 @@ async function sshProbeReuseProof(baseUrl, token, spawnNonce) {
   }
 }
 
-async function teardownSshConnection(profile) {
-  const scope = sshScopeKey(profile)
+async function teardownSshConnectionScope(scope) {
   const state = sshConnections.get(scope)
 
   if (!state) {
@@ -6757,6 +6757,10 @@ async function teardownSshConnection(profile) {
   } catch {
     // best effort
   }
+}
+
+async function teardownSshConnection(profile) {
+  return teardownSshConnectionScope(sshScopeKey(profile))
 }
 
 // CRITICAL: this must mirror resolveRemoteBackend's precedence, not just return
@@ -6943,7 +6947,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     result.ownershipId
   )
 
-  return { ...connection, remoteHermesVersion: result.hermesVersion || '' }
+  return { ...connection, remoteHermesVersion: result.hermesVersion || '', sshScope: scope }
 }
 
 function persistSshConnectionToken(profile, source, token) {
@@ -7793,6 +7797,7 @@ async function startHermes() {
         remoteHost: remote.remoteHost,
         remoteKind: remote.remoteKind,
         remoteHermesVersion: remote.remoteHermesVersion,
+        sshScope: remote.sshScope,
         token: remote.token,
         wsUrl: remote.wsUrl,
         logs: hermesLog.slice(-80),
@@ -8609,11 +8614,10 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
     // fresh bootstrap can't reattach to a dying transport.
     if (result.rebuilt) {
       const conn = await connectionPromise.catch(() => null)
+      const scope = sshReconnectScope(conn)
 
-      if (conn?.remoteKind === 'ssh') {
-        const profile = primaryProfileKey()
-        await sshBootstrapCoordinator.cancelAndWait(sshScopeKey(profile))
-        await teardownSshConnection(profile)
+      if (scope !== null) {
+        await sshBootstrapCoordinator.cancelAndWait(scope, () => teardownSshConnectionScope(scope))
       }
     }
 

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
@@ -190,3 +190,39 @@ test('a generation started during cancelAndWait cannot run before the drain comp
   assert.equal(await next, 'new')
   assert.deepEqual(events, ['old-start', 'new-start'])
 })
+
+test('cancelAndWait keeps new bootstraps blocked through caller cleanup', async () => {
+  const coordinator = createBootstrapCoordinator()
+  const oldGate = deferred()
+  const cleanupGate = deferred()
+  const events: string[] = []
+
+  const old = coordinator.start('scope', 'old', async lease => {
+    events.push('old-start')
+    await oldGate.promise
+    lease.assertCurrent()
+  })
+
+  await Promise.resolve()
+
+  const drain = coordinator.cancelAndWait('scope', async () => {
+    events.push('cleanup-start')
+    await cleanupGate.promise
+    events.push('cleanup-end')
+  })
+
+  const next = coordinator.start('scope', 'new', async () => {
+    events.push('new-start')
+
+    return 'new'
+  })
+
+  oldGate.resolve()
+  await assert.rejects(old, (error: any) => error.kind === 'superseded')
+  await Promise.resolve()
+  assert.deepEqual(events, ['old-start', 'cleanup-start'])
+  cleanupGate.resolve()
+  await drain
+  assert.equal(await next, 'new')
+  assert.deepEqual(events, ['old-start', 'cleanup-start', 'cleanup-end', 'new-start'])
+})

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.ts
@@ -84,7 +84,7 @@ function createBootstrapCoordinator() {
     pending.get(scope)?.controller.abort()
   }
 
-  async function cancelAndWait(scope) {
+  async function cancelAndWait(scope, whileDrained?) {
     let release
 
     const barrier = new Promise<void>(resolve => {
@@ -100,6 +100,7 @@ function createBootstrapCoordinator() {
 
     try {
       await Promise.allSettled(entries.map(entry => entry.promise))
+      await whileDrained?.()
     } finally {
       if (drains.get(scope) === barrier) {
         drains.delete(scope)


### PR DESCRIPTION
## Summary

- preserve the exact SSH ownership scope (`''` for app-global SSH, profile name for profile-scoped SSH) on the resolved connection descriptor
- tear down and restart the tunnel that actually owns a failed connection instead of deriving a different scope from the currently active profile
- make bootstrap cancellation wait for a newly started generation as well as the generation that was active when cancellation began

## Problem

A global Desktop SSH connection is stored under the intentionally empty scope `''`. During remote revalidation, the reconnect path instead derived the teardown scope from the active profile. With an active named profile, it therefore cancelled and tore down a different/nonexistent scoped connection while leaving the failed global tunnel alive. The next bootstrap could reuse that stale transport, and the renderer could lose the visible stream while the backend turn kept running.

There was a second race in `cancelAndWait`: a generation starting after cancellation began was not included in the wait set. Reconnect could therefore proceed before the newly started bootstrap had settled.

## Validation

Exact candidate: `acd1d4b6c2423ff4a34927ca24133a5feffc0c66`

- focused Electron regressions: 74 passed
- full Electron suite: 700 passed, 2 skipped
- full UI suite: 2038 passed, 1 skipped
- `npm run typecheck`: passed
- `npm run build`: passed
- `git diff --check origin/main...HEAD`: passed
- independent review of the complete five-file diff: PASS, no security or logic findings

## Relationship to current reconnect work

This is complementary to #69970 and #69059. Those changes improve profile pinning, visible-state retention, first-failure rebuilding, and bounded readiness retries. This PR fixes the ownership scope used when an SSH rebuild actually tears down the existing transport, plus the bootstrap-generation race at that seam.
