### PR TITLE
feat(webhooks): create a Discord thread for each event

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1332,10 +1332,29 @@ class WebhookAdapter(BasePlatformAdapter):
                     error=f"No chat_id or home channel for {platform_name}",
                 )
 
-        # Pass thread_id from deliver_extra so Telegram forum topics work
+        # Pass platform-specific thread routing/creation hints through the
+        # common adapter metadata channel. An explicit thread_id wins over
+        # create_thread so all later sends from one webhook run stay together.
         metadata = None
         thread_id = extra.get("message_thread_id") or extra.get("thread_id")
         if thread_id:
             metadata = {"thread_id": thread_id}
 
-        return await adapter.send(chat_id, content, metadata=metadata)
+        if platform_name == "discord" and extra.get("create_thread") and not thread_id:
+            metadata = metadata or {}
+            metadata["create_thread"] = True
+            if extra.get("thread_name"):
+                metadata["thread_name"] = extra["thread_name"]
+
+        result = await adapter.send(chat_id, content, metadata=metadata)
+        # Agent-mode webhooks may emit interim messages before their final
+        # answer. Once Discord creates the event thread, pin subsequent sends
+        # for this delivery to that same thread instead of creating siblings.
+        if (
+            platform_name == "discord"
+            and result.success
+            and isinstance(result.raw_response, dict)
+            and result.raw_response.get("thread_id")
+        ):
+            extra["thread_id"] = str(result.raw_response["thread_id"])
+        return result

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -811,6 +811,68 @@ class WebhookAdapter(BasePlatformAdapter):
                 route_config.get("deliver_extra", {}), payload
             ),
         }
+
+        # Discord routes can create the event thread before the agent starts.
+        # This leaves only a compact, templated index message in the parent
+        # channel while routing every agent/status message into the thread.
+        deliver_extra = deliver_config["deliver_extra"]
+        thread_starter = deliver_extra.get("thread_starter")
+        if (
+            deliver_config["deliver"] == "discord"
+            and deliver_extra.get("create_thread")
+            and thread_starter
+        ):
+            starter_delivery = {
+                "deliver": "discord",
+                "deliver_extra": dict(deliver_extra),
+            }
+            starter_delivery["deliver_extra"].pop("thread_starter", None)
+            try:
+                starter_result = await self._direct_deliver(
+                    str(thread_starter), starter_delivery
+                )
+            except Exception:
+                logger.exception(
+                    "[webhook] Discord thread starter failed route=%s delivery=%s",
+                    route_name,
+                    delivery_id,
+                )
+                self._seen_deliveries.pop(delivery_id, None)
+                return web.json_response(
+                    {
+                        "status": "error",
+                        "error": "Thread creation failed",
+                        "delivery_id": delivery_id,
+                    },
+                    status=502,
+                )
+
+            created_thread_id = (
+                starter_result.raw_response.get("thread_id")
+                if starter_result.success
+                and isinstance(starter_result.raw_response, dict)
+                else None
+            )
+            if not created_thread_id:
+                logger.warning(
+                    "[webhook] Discord thread starter rejected route=%s delivery=%s error=%s",
+                    route_name,
+                    delivery_id,
+                    starter_result.error,
+                )
+                self._seen_deliveries.pop(delivery_id, None)
+                return web.json_response(
+                    {
+                        "status": "error",
+                        "error": "Thread creation failed",
+                        "delivery_id": delivery_id,
+                    },
+                    status=502,
+                )
+
+            deliver_extra["thread_id"] = str(created_thread_id)
+            deliver_extra.pop("create_thread", None)
+            deliver_extra.pop("thread_starter", None)
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now
         self._delivery_info_order.append((now, session_chat_id))

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2865,7 +2865,9 @@ class DiscordAdapter(BasePlatformAdapter):
         """Send a message to a Discord channel or thread.
 
         When metadata contains a thread_id, the message is sent to that
-        thread instead of the parent channel identified by chat_id.
+        thread instead of the parent channel identified by chat_id. When it
+        contains create_thread, a fresh thread is created in the parent text
+        channel and the message is posted there.
 
         Forum channels (type 15) reject direct messages — a thread post is
         created automatically.
@@ -2899,6 +2901,41 @@ class DiscordAdapter(BasePlatformAdapter):
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
                 result = await self._send_to_forum(channel, content)
+                await asyncio.to_thread(
+                    self._record_discord_response,
+                    reply_to=reply_to,
+                    result=result,
+                    content=content,
+                    final=final_delivery,
+                )
+                return result
+
+            if metadata and metadata.get("create_thread") and not thread_id:
+                thread_name = str(metadata.get("thread_name") or "").strip()
+                if not thread_name:
+                    thread_name = _derive_forum_thread_name(content)
+                # Discord thread names are capped at 100 characters.
+                thread_name = thread_name[:100]
+                formatted = self.format_message(content)
+                chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+                starter_content = chunks[0] if chunks else thread_name
+                starter_msg = await channel.send(content=starter_content)
+                thread = await starter_msg.create_thread(name=thread_name)
+                message_ids = [str(starter_msg.id)]
+                for chunk in chunks[1:]:
+                    msg = await thread.send(content=chunk)
+                    message_ids.append(str(msg.id))
+                created_thread_id = str(thread.id)
+                if message_ids:
+                    self._last_self_message_id[created_thread_id] = message_ids[-1]
+                result = SendResult(
+                    success=True,
+                    message_id=message_ids[0] if message_ids else None,
+                    raw_response={
+                        "message_ids": message_ids,
+                        "thread_id": created_thread_id,
+                    },
+                )
                 await asyncio.to_thread(
                     self._record_discord_response,
                     reply_to=reply_to,

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -160,6 +160,34 @@ async def test_send_does_not_retry_on_unrelated_errors():
     assert send_calls[0]["reference"] is reference_obj
 
 
+@pytest.mark.asyncio
+async def test_send_creates_new_thread_with_content_as_starter():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    thread = SimpleNamespace(id=5678, send=AsyncMock())
+    starter = SimpleNamespace(
+        id=1234,
+        create_thread=AsyncMock(return_value=thread),
+    )
+    channel = SimpleNamespace(send=AsyncMock(return_value=starter))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send(
+        "555",
+        "Investigated alert details",
+        metadata={"create_thread": True, "thread_name": "API latency alert"},
+    )
+
+    assert result.success is True
+    assert result.message_id == "1234"
+    assert result.raw_response["thread_id"] == "5678"
+    channel.send.assert_awaited_once_with(content="Investigated alert details")
+    starter.create_thread.assert_awaited_once_with(name="API latency alert")
+    thread.send.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Forum channel tests
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1497,6 +1497,55 @@ class TestDeliverCrossPlatformThreadId:
             "12345", "hello", metadata=None
         )
 
+    @pytest.mark.asyncio
+    async def test_discord_create_thread_metadata_is_forwarded(self):
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        runner = adapter.gateway_runner
+        assert runner is not None
+        runner.adapters[Platform("discord")] = mock_target
+        delivery = {
+            "deliver_extra": {
+                "chat_id": "12345",
+                "create_thread": True,
+                "thread_name": "Alert: API latency",
+            }
+        }
+
+        await adapter._deliver_cross_platform("discord", "hello", delivery)
+
+        mock_target.send.assert_awaited_once_with(
+            "12345",
+            "hello",
+            metadata={
+                "create_thread": True,
+                "thread_name": "Alert: API latency",
+            },
+        )
+    @pytest.mark.asyncio
+    async def test_discord_reuses_created_thread_on_subsequent_send(self):
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        runner = adapter.gateway_runner
+        assert runner is not None
+        runner.adapters[Platform("discord")] = mock_target
+        mock_target.send.side_effect = [
+            SendResult(success=True, raw_response={"thread_id": "5678"}),
+            SendResult(success=True),
+        ]
+        delivery = {
+            "deliver_extra": {
+                "chat_id": "12345",
+                "create_thread": True,
+                "thread_name": "Alert: API latency",
+            }
+        }
+
+        await adapter._deliver_cross_platform("discord", "interim", delivery)
+        await adapter._deliver_cross_platform("discord", "final", delivery)
+
+        assert mock_target.send.await_args_list[1].kwargs["metadata"] == {
+            "thread_id": "5678"
+        }
+
 
 class TestInsecureNoAuthSafetyRail:
     """connect() refuses to start when INSECURE_NO_AUTH is combined with a

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -558,6 +558,104 @@ class TestRenderDeliveryExtra:
         assert result["static"] == 42  # non-string left as-is
 
 
+class TestDiscordWebhookThreadStarter:
+    @pytest.mark.asyncio
+    async def test_creates_templated_starter_before_agent_and_routes_run_to_thread(self):
+        routes = {
+            "betterstack-alerts": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "Investigate {data.attributes.name}",
+                "deliver": "discord",
+                "deliver_extra": {
+                    "chat_id": "1495620631117430905",
+                    "create_thread": True,
+                    "thread_starter": (
+                        "Investigating BetterStack Webhook: "
+                        "{data.attributes.name}"
+                    ),
+                    "thread_name": "BetterStack: {data.attributes.name}",
+                },
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        discord_target = MagicMock()
+        discord_target.send = AsyncMock(
+            return_value=SendResult(
+                success=True,
+                message_id="starter-123",
+                raw_response={"thread_id": "thread-456"},
+            )
+        )
+        runner = MagicMock()
+        runner.adapters = {Platform.DISCORD: discord_target}
+        adapter.gateway_runner = runner
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/webhooks/betterstack-alerts",
+                json={"data": {"attributes": {"name": "API Metrics"}}},
+                headers={"X-Request-ID": "thread-starter-success"},
+            )
+            assert response.status == 202
+
+        discord_target.send.assert_awaited_once_with(
+            "1495620631117430905",
+            "Investigating BetterStack Webhook: API Metrics",
+            metadata={
+                "create_thread": True,
+                "thread_name": "BetterStack: API Metrics",
+            },
+        )
+        adapter.handle_message.assert_called_once()
+        session_delivery = adapter._delivery_info[
+            "webhook:betterstack-alerts:thread-starter-success"
+        ]
+        assert session_delivery["deliver_extra"]["thread_id"] == "thread-456"
+        assert "create_thread" not in session_delivery["deliver_extra"]
+        assert "thread_starter" not in session_delivery["deliver_extra"]
+
+    @pytest.mark.asyncio
+    async def test_thread_creation_failure_does_not_start_agent_and_allows_retry(self):
+        routes = {
+            "alerts": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "Investigate {title}",
+                "deliver": "discord",
+                "deliver_extra": {
+                    "chat_id": "123",
+                    "create_thread": True,
+                    "thread_starter": "Investigating: {title}",
+                },
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        discord_target = MagicMock()
+        discord_target.send = AsyncMock(
+            return_value=SendResult(success=False, error="Missing Access")
+        )
+        runner = MagicMock()
+        runner.adapters = {Platform.DISCORD: discord_target}
+        adapter.gateway_runner = runner
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/webhooks/alerts",
+                json={"title": "Database alert"},
+                headers={"X-Request-ID": "thread-starter-failure"},
+            )
+            assert response.status == 502
+
+        adapter.handle_message.assert_not_called()
+        assert "thread-starter-failure" not in adapter._seen_deliveries
+        assert not adapter._delivery_info
+
+
 # ===================================================================
 # Event filtering
 # ===================================================================

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -225,6 +225,33 @@ webhooks:
 
 If `chat_id` is not provided in `deliver_extra`, the delivery falls back to the home channel configured for the target platform.
 
+### Discord Thread Delivery
+
+Set `create_thread: true` to create a fresh Discord thread for each webhook
+delivery. The first response becomes the thread starter, and any later messages
+from the same webhook run are routed into that thread.
+
+```yaml
+platforms:
+  webhook:
+    extra:
+      routes:
+        alerts:
+          events: ["alert"]
+          prompt: "Investigate this alert: {__raw__}"
+          deliver: "discord"
+          deliver_extra:
+            chat_id: "123456789012345678"
+            create_thread: true
+            thread_name: "Alert: {alert.name}"
+```
+
+The bot needs Discord's **Create Public Threads** and **Send Messages in
+Threads** permissions in the target channel. `thread_name` supports the same
+payload templates as other `deliver_extra` values and is truncated to Discord's
+100-character thread-name limit. If `chat_id` is omitted, the Discord home
+channel is used.
+
 ---
 
 ## GitHub PR Review (Step by Step) {#github-pr-review}

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -85,7 +85,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `script` | No | Filter/transform script under `~/.hermes/scripts/`. The webhook payload is passed as JSON on stdin. JSON object stdout replaces the payload before templating; text stdout is exposed as `script_output`; empty stdout, `[SILENT]`, or a nonzero exit code ignores the webhook. |
 | `skills` | No | List of skill names to load for the agent run. |
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
-| `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
+| `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. For Discord, `create_thread: true` creates a thread per event; optional `thread_starter` makes a compact parent-channel message before the agent starts, and `thread_name` controls the thread title. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
 
 ### Full example
@@ -228,8 +228,12 @@ If `chat_id` is not provided in `deliver_extra`, the delivery falls back to the 
 ### Discord Thread Delivery
 
 Set `create_thread: true` to create a fresh Discord thread for each webhook
-delivery. The first response becomes the thread starter, and any later messages
-from the same webhook run are routed into that thread.
+delivery. By default, the first agent response becomes the thread starter and
+any later messages from the same webhook run are routed into that thread.
+
+Set `thread_starter` to create the thread immediately, before the agent starts.
+The rendered `thread_starter` is the only webhook message posted in the parent
+channel; all agent status messages and findings are routed into its thread.
 
 ```yaml
 platforms:
@@ -243,14 +247,17 @@ platforms:
           deliver_extra:
             chat_id: "123456789012345678"
             create_thread: true
+            thread_starter: "Investigating alert: {alert.name}"
             thread_name: "Alert: {alert.name}"
 ```
 
 The bot needs Discord's **Create Public Threads** and **Send Messages in
-Threads** permissions in the target channel. `thread_name` supports the same
-payload templates as other `deliver_extra` values and is truncated to Discord's
-100-character thread-name limit. If `chat_id` is omitted, the Discord home
-channel is used.
+Threads** permissions in the target channel. `thread_starter` and `thread_name`
+support the same payload templates as other `deliver_extra` values.
+`thread_name` is truncated to Discord's 100-character thread-name limit. If
+`chat_id` is omitted, the Discord home channel is used. If creating the starter
+thread fails, Hermes returns HTTP 502 and does not start the agent, allowing the
+webhook provider to retry safely.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `deliver_extra.create_thread` and templated `thread_name` for Discord webhook delivery
- make the first response the thread starter and route later messages from the same webhook run into that thread
- document the configuration and required Discord permissions

## Test plan
- `python -m pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_discord_send.py -q -o addopts=` (116 passed)
- `ruff check gateway/platforms/webhook.py plugins/platforms/discord/adapter.py tests/gateway/test_webhook_adapter.py tests/gateway/test_discord_send.py`
