### PR TITLE
fix(desktop): keep local update actions on client

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -59,7 +59,7 @@ export function useDesktopIntegrations({
   // process's "open updates" menu request.
   useEffect(() => {
     startUpdatePoller()
-    const unsubscribe = window.hermesDesktop?.onOpenUpdatesRequested?.(() => openUpdatesWindow())
+    const unsubscribe = window.hermesDesktop?.onOpenUpdatesRequested?.(() => openUpdatesWindow('client'))
 
     return () => {
       unsubscribe?.()

--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -144,10 +144,10 @@ export function AboutSettings() {
 
             {behind > 0 && supported && !applying && (
               <>
-                <Button onClick={() => startActiveUpdate()} size="sm">
+                <Button onClick={() => startActiveUpdate('client')} size="sm">
                   {a.updateNow}
                 </Button>
-                <Button onClick={() => openUpdatesWindow()} size="sm" variant="textStrong">
+                <Button onClick={() => openUpdatesWindow('client')} size="sm" variant="textStrong">
                   {a.seeWhatsNew}
                 </Button>
               </>

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -52,8 +52,10 @@ const {
   $updateApply,
   $updateOverlayOpen,
   $updateOverlayTarget,
+  openUpdatesWindow,
   requestActiveUpdate,
   resetUpdateApplyState,
+  startActiveUpdate,
   startUpdatePoller,
   stopUpdatePoller,
   $updateStatus
@@ -69,19 +71,23 @@ const status = (over: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus =>
   ...over
 })
 
-const lastToast = () => notifySpy.mock.calls.at(-1)?.[0] as { onDismiss: () => void }
-
-const setRemote = (on: boolean) =>
+const setConnectionMode = (mode: 'local' | 'remote') =>
   setConnection({
     baseUrl: 'http://box:9119',
     isFullscreen: false,
-    mode: on ? 'remote' : 'local',
+    mode,
     nativeOverlayWidth: 0,
     token: 't',
     wsUrl: 'ws://box:9119',
     logs: [],
     windowButtonPosition: null
   })
+
+const lastToast = () =>
+  notifySpy.mock.calls.at(-1)?.[0] as {
+    action: { onClick: () => void }
+    onDismiss: () => void
+  }
 
 describe('maybeNotifyUpdateAvailable', () => {
   beforeEach(() => {
@@ -122,6 +128,72 @@ describe('maybeNotifyUpdateAvailable', () => {
   it('does nothing when already up to date', () => {
     maybeNotifyUpdateAvailable(status({ behind: 0 }))
     expect(notifySpy).not.toHaveBeenCalled()
+  })
+
+  it('opens the explicitly requested backend target from a backend update toast', async () => {
+    setConnectionMode('remote')
+    $updateOverlayTarget.set('client')
+    checkHermesUpdateSpy.mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.16.0',
+      behind: 2,
+      update_available: true,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+
+    maybeNotifyUpdateAvailable(status(), 'backend')
+    lastToast().action.onClick()
+
+    expect($updateOverlayTarget.get()).toBe('backend')
+    await vi.waitFor(() => expect(checkHermesUpdateSpy).toHaveBeenCalledTimes(1))
+  })
+})
+
+describe('Desktop update entry points', () => {
+  const applyMock = vi.fn()
+  const checkMock = vi.fn()
+
+  beforeEach(() => {
+    storage.clear()
+    notifySpy.mockClear()
+    dismissSpy.mockClear()
+    checkHermesUpdateSpy.mockReset()
+    updateHermesSpy.mockReset()
+    applyMock.mockReset()
+    checkMock.mockReset()
+    applyMock.mockResolvedValue({ ok: false, error: 'test-stop' })
+    checkMock.mockResolvedValue(status({ behind: 0, targetSha: undefined }))
+    resetUpdateApplyState()
+    $updateOverlayOpen.set(false)
+    $updateOverlayTarget.set('backend')
+    setConnectionMode('remote')
+    ;(globalThis as unknown as { window: unknown }).window = {
+      hermesDesktop: { updates: { apply: applyMock, check: checkMock } }
+    }
+  })
+
+  afterEach(() => {
+    delete (globalThis as unknown as { window?: unknown }).window
+    setConnectionMode('local')
+  })
+
+  it('opens the Desktop client updater while connected to a remote backend', async () => {
+    openUpdatesWindow('client')
+
+    await vi.waitFor(() => expect(checkMock).toHaveBeenCalledTimes(1))
+    expect($updateOverlayTarget.get()).toBe('client')
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
+  })
+
+  it('applies the Desktop client update while connected to a remote backend', async () => {
+    startActiveUpdate('client')
+
+    expect($updateOverlayTarget.get()).toBe('client')
+    expect(applyMock).toHaveBeenCalledTimes(1)
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect($updateApply.get().applying).toBe(false))
   })
 })
 
@@ -190,7 +262,7 @@ describe('checkBackendUpdates', () => {
   })
 
   it('maps the backend /update/check onto the backend status, including commits', async () => {
-    setRemote(true)
+    setConnectionMode('remote')
     checkHermesUpdateSpy.mockResolvedValue({
       install_method: 'git',
       current_version: '0.16.0',
@@ -213,7 +285,7 @@ describe('checkBackendUpdates', () => {
   })
 
   it('preserves backend update_available when the backend cannot count commits', async () => {
-    setRemote(true)
+    setConnectionMode('remote')
     checkHermesUpdateSpy.mockResolvedValue({
       install_method: 'nixos',
       current_version: '0.16.0',
@@ -232,7 +304,7 @@ describe('checkBackendUpdates', () => {
   })
 
   it('honours can_apply=false (docker/nix): not supported, carries message', async () => {
-    setRemote(true)
+    setConnectionMode('remote')
     checkHermesUpdateSpy.mockResolvedValue({
       install_method: 'docker',
       current_version: '0.16.0',
@@ -250,7 +322,7 @@ describe('checkBackendUpdates', () => {
   })
 
   it('is a no-op in local mode (backend check only runs when remote)', async () => {
-    setRemote(false)
+    setConnectionMode('local')
     await checkBackendUpdates()
     expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
   })
@@ -295,12 +367,12 @@ describe('requestActiveUpdate', () => {
     // memoizes the in-flight run, so a dangling promise here would be handed
     // to the next suite's tests instead of a fresh run.
     await vi.waitFor(() => expect($backendUpdateApply.get().applying).toBe(false), { timeout: 5000 })
-    setRemote(false)
+    setConnectionMode('local')
     delete (globalThis as unknown as { window?: unknown }).window
   })
 
   it('applies the CLIENT update in local mode, never the backend', async () => {
-    setRemote(false)
+    setConnectionMode('local')
     $updateStatus.set(status({ behind: 3 }))
 
     requestActiveUpdate()
@@ -311,7 +383,7 @@ describe('requestActiveUpdate', () => {
   })
 
   it('applies the BACKEND update in remote mode', async () => {
-    setRemote(true)
+    setConnectionMode('remote')
     $backendUpdateStatus.set(status({ behind: 3 }))
 
     requestActiveUpdate()
@@ -322,7 +394,7 @@ describe('requestActiveUpdate', () => {
   })
 
   it('always opens the overlay, so selecting the row is never a silent no-op', () => {
-    setRemote(false)
+    setConnectionMode('local')
     $updateStatus.set(status({ behind: 3 }))
 
     requestActiveUpdate()
@@ -331,7 +403,7 @@ describe('requestActiveUpdate', () => {
   })
 
   it('opens the overlay to re-check instead of applying when already current', () => {
-    setRemote(false)
+    setConnectionMode('local')
     $updateStatus.set(status({ behind: 0, updateAvailable: false }))
 
     requestActiveUpdate()
@@ -342,7 +414,7 @@ describe('requestActiveUpdate', () => {
   })
 
   it('applies on a backend that reports an update it cannot count commits for', async () => {
-    setRemote(true)
+    setConnectionMode('remote')
     $backendUpdateStatus.set(status({ behind: 0, updateAvailable: true }))
 
     requestActiveUpdate()

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -199,7 +199,7 @@ export function reportInstallMethodWarning(message: string | undefined): void {
  * (re)starts the cooldown, so a busy upstream branch doesn't re-spam the user
  * on every new commit. The snooze is persisted, so it survives relaunches too.
  */
-export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
+export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null, target: UpdateTarget = 'client') {
   if (!status || status.supported === false || status.error || !status.targetSha) {
     return
   }
@@ -223,7 +223,7 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
       label: translateNow('notifications.seeWhatsNew'),
       onClick: () => {
         snoozeUpdateToast()
-        openUpdatesWindow()
+        openUpdateOverlayFor(target)
       }
     },
     durationMs: 0,
@@ -236,19 +236,21 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
   })
 }
 
-export function openUpdatesWindow(): void {
-  openUpdateOverlayFor(isRemoteMode() ? 'backend' : 'client')
+function activeUpdateTarget(): UpdateTarget {
+  return isRemoteMode() ? 'backend' : 'client'
+}
+
+export function openUpdatesWindow(target: UpdateTarget = activeUpdateTarget()): void {
+  openUpdateOverlayFor(target)
 }
 
 /**
- * Start applying the available update for the active target right away. Opens
- * the updates overlay first so the user sees apply progress (the overlay
- * renders ApplyingView once `applying` flips true), then kicks off the install.
- * Used by the "Update now" affordance on the About panel, which would otherwise
- * only be able to open the changelog overlay.
+ * Start applying an update right away. Callers tied to a specific status
+ * surface pass its target explicitly; generic commands default to the active
+ * local/remote connection. Opens the matching overlay first so apply progress
+ * remains visible.
  */
-export function startActiveUpdate(): void {
-  const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
+export function startActiveUpdate(target: UpdateTarget = activeUpdateTarget()): void {
   $updateOverlayTarget.set(target)
   $updateOverlayOpen.set(true)
   void (target === 'backend' ? applyBackendUpdate() : applyUpdates())
@@ -265,7 +267,7 @@ export function requestActiveUpdate(): void {
   const status = target === 'backend' ? $backendUpdateStatus.get() : $updateStatus.get()
 
   if ((status?.behind ?? 0) > 0 || status?.updateAvailable) {
-    startActiveUpdate()
+    startActiveUpdate(target)
 
     return
   }
@@ -330,7 +332,7 @@ export async function checkBackendUpdates(): Promise<DesktopUpdateStatus | null>
   try {
     const status = mapBackendCheck(await checkHermesUpdate(true))
     $backendUpdateStatus.set(status)
-    maybeNotifyUpdateAvailable(status)
+    maybeNotifyUpdateAvailable(status, 'backend')
 
     return status
   } catch (error) {
@@ -361,7 +363,7 @@ export async function checkUpdates(): Promise<DesktopUpdateStatus | null> {
   try {
     const status = await bridge.check()
     $updateStatus.set(status)
-    maybeNotifyUpdateAvailable(status)
+    maybeNotifyUpdateAvailable(status, 'client')
     void refreshDesktopVersion()
 
     return status


### PR DESCRIPTION
## Summary

- let update entry points explicitly select the Desktop client or remote backend
- keep About and the native Check for Updates menu scoped to the local client
- preserve the remote command palette's backend target and make update notifications target-aware

## Root cause

The shared update helpers inferred their target only from connection mode. That conflicts with UI surfaces such as About and the native menu, which display Desktop-client state even while the app is connected to a remote backend. The first version fixed those surfaces by hard-coding `client`, but that discarded the backend target selected by `requestActiveUpdate()`.

The helpers now accept an explicit `UpdateTarget` while retaining a connection-aware default. About and the native menu pass `client`; the command palette passes through its selected target; backend and client notifications open the updater that produced them.

## Validation

- `npm run test:ui --workspace apps/desktop -- src/store/updates.test.ts src/app/contrib/hooks/use-desktop-integrations.test.tsx` — 65 passed
- Desktop typecheck, targeted ESLint, and Prettier — passed
- Desktop production build and `git diff --check` — passed
- GitHub required CI on `ac38f14e69` — passed; merge state `CLEAN`

Tested on Windows with Node 22.23.1.

Fixes #70266
