### PR TITLE
fix(anthropic): deduplicate replayed tool block IDs

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2256,6 +2256,48 @@ def _strip_orphaned_tool_blocks(result: List[Dict[str, Any]]) -> None:
             m["content"] = new_content if new_content else [{"type": "text", "text": "(tool result removed)"}]
 
 
+def _dedup_tool_blocks_within_turns(result: List[Dict[str, Any]]) -> None:
+    """Collapse duplicate tool_use / tool_result blocks *within* a single turn.
+
+    Reconstruction / context-compression paths can replay the same assistant
+    turn more than once; ``_merge_consecutive_roles`` then concatenates their
+    block lists (``prev_blocks + curr_blocks``), producing a single assistant
+    message that carries the SAME tool_use id multiple times (observed: 63
+    tool_use blocks, 18 unique). ``_strip_orphaned_tool_blocks`` cannot catch
+    this — it collects ids into a set, so a duplicated id still "has a result"
+    and survives. Anthropic then rejects the payload with HTTP 400
+    ``tool_use ids were found without tool_result blocks immediately after``.
+
+    Keep the FIRST occurrence of each id per turn; drop later duplicates.
+    Mutates ``result`` in place. Must run AFTER _merge_consecutive_roles.
+    """
+    for m in result:
+        content = m.get("content")
+        if not isinstance(content, list):
+            continue
+        role = m.get("role")
+        seen: set = set()
+        deduped: List[Any] = []
+        changed = False
+        for b in content:
+            if isinstance(b, dict):
+                if role == "assistant" and b.get("type") == "tool_use":
+                    bid = b.get("id")
+                    if bid in seen:
+                        changed = True
+                        continue
+                    seen.add(bid)
+                elif role == "user" and b.get("type") == "tool_result":
+                    bid = b.get("tool_use_id")
+                    if bid in seen:
+                        changed = True
+                        continue
+                    seen.add(bid)
+            deduped.append(b)
+        if changed:
+            m["content"] = deduped if deduped else [{"type": "text", "text": "(empty message)"}]
+
+
 def _merge_consecutive_roles(result: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Merge consecutive same-role messages to enforce Anthropic alternation.
 
@@ -2523,6 +2565,11 @@ def convert_messages_to_anthropic(
     _strip_orphaned_tool_blocks(result)
     result = _merge_consecutive_roles(result)
     _ensure_leading_user_turn(result)
+    # Merge may concatenate replayed turns, producing duplicate tool_use ids
+    # within one assistant message. Collapse them, then re-run the orphan strip
+    # so any pair broken by dedup is cleaned up before the payload ships.
+    _dedup_tool_blocks_within_turns(result)
+    _strip_orphaned_tool_blocks(result)
     _manage_thinking_signatures(result, base_url, model)
     _evict_old_screenshots(result)
 

--- a/tests/agent/test_anthropic_tool_block_dedup.py
+++ b/tests/agent/test_anthropic_tool_block_dedup.py
@@ -1,0 +1,40 @@
+"""Regression coverage for duplicate Anthropic tool blocks in replayed turns."""
+
+from agent.anthropic_adapter import convert_messages_to_anthropic
+
+
+def test_duplicate_tool_use_and_tool_result_ids_are_collapsed_per_turn():
+    """Replay/merge duplication must not produce an invalid Anthropic payload."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": "t1", "name": "lookup", "input": {}},
+                {"type": "tool_use", "id": "t1", "name": "lookup", "input": {}},
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "t1",
+            "content": "first",
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "t1",
+            "content": "duplicate",
+        },
+    ]
+
+    _, result = convert_messages_to_anthropic(messages)
+    assistant = next(message for message in result if message["role"] == "assistant")
+    user = next(
+        message
+        for message in result
+        if message["role"] == "user"
+        and any(block.get("type") == "tool_result" for block in message["content"])
+    )
+
+    assert [block["id"] for block in assistant["content"] if block["type"] == "tool_use"] == ["t1"]
+    assert [
+        block["tool_use_id"] for block in user["content"] if block["type"] == "tool_result"
+    ] == ["t1"]


### PR DESCRIPTION
## Symptom

Replay/merge paths can place repeated `tool_use` or `tool_result` blocks with the same ID in one converted Anthropic turn. Anthropic rejects that payload, making the session fall back unnecessarily.

## Fix

Deduplicate `tool_use` IDs per assistant turn and `tool_result` IDs per user turn, retaining the first block. Re-run orphan stripping after dedup so the remaining pair stays structurally valid.

## Validation

```
pytest -q tests/agent/test_anthropic_tool_block_dedup.py
# 1 passed
```

The regression fixture uses the actual `role=tool` conversion path and asserts exactly one tool use/result remains for a duplicate ID.