### PR TITLE
fix: overlay session ContextVars on execute_code child env (#69820)

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1361,6 +1361,14 @@ def execute_code(
         # passed through — without those, the child can't create a socket
         # or spawn a subprocess.  See ``_scrub_child_env`` for the rules.
         child_env = _scrub_child_env(os.environ)
+        # Overlay the current request's session ContextVars so the child
+        # inherits the *correct* HERMES_SESSION_ID — not whichever value
+        # last wrote to the process-global os.environ mirror.  See #69820.
+        try:
+            from tools.environments.local import _inject_session_context_env
+            _inject_session_context_env(child_env)
+        except Exception:
+            pass
         child_env["HERMES_RPC_SOCKET"] = rpc_endpoint
         child_env["HERMES_RPC_TOKEN"] = rpc_token
         child_env["PYTHONDONTWRITEBYTECODE"] = "1"


### PR DESCRIPTION
## Summary
- Fixes cross-request session ID leakage in `execute_code` child environment
- When `HERMES_SESSION_ID` is explicitly allowed via `env_passthrough`, the child process could receive another concurrent request's session ID because `os.environ` is last-writer-wins
- Calls `_inject_session_context_env()` on the scrubbed child env to overlay the current request's ContextVar value

## Root Cause
`_scrub_child_env(os.environ)` reads from the process-global `os.environ` mirror. Under concurrent requests, `set_current_session_id()` writes each request's session ID to `os.environ`, so the last writer wins. The ContextVar (which IS request-isolated) was not consulted.

## Fix
After `_scrub_child_env()`, call `_inject_session_context_env(child_env)` which reads the current request's ContextVar and overlays it onto the child env. This is the same pattern already used by `_sanitize_subprocess_env()` in `tools/environments/local.py`.

## Test Plan
- [ ] The existing `test_local_env_session_leak.py` tests cover the `_sanitize_subprocess_env` path
- [ ] Manual test: configure `HERMES_SESSION_ID` in `env_passthrough`, run concurrent `execute_code` calls, verify each child gets its own session ID

Closes #69820