### PR TITLE
fix(telegram): restore 2x2 exec-approval button layout

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5073,7 +5073,10 @@ class TelegramAdapter(BasePlatformAdapter):
                         InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}")
                     )
             buttons.append(InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"))
-            keyboard = InlineKeyboardMarkup([buttons])
+            # Pair into rows (2x2 for the full set) so labels stay readable on
+            # mobile — a single 4-button row truncates to "Allo… / Ses… / …".
+            rows = [buttons[i:i + 2] for i in range(0, len(buttons), 2)]
+            keyboard = InlineKeyboardMarkup(rows)
 
             kwargs: Dict[str, Any] = {
                 "chat_id": normalize_telegram_chat_id(chat_id),

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -149,6 +149,54 @@ class TestTelegramExecApproval:
         assert buttons == ["✅ Allow Once", "✅ Session", "❌ Deny"]
 
     @pytest.mark.asyncio
+    async def test_full_approval_keyboard_is_two_by_two(self, monkeypatch):
+        """Regression: d48bf743f flattened all buttons into one row (4x1)."""
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+        captured_rows = []
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: text,
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup",
+            lambda rows: captured_rows.extend(rows) or rows,
+        )
+
+        await adapter.send_exec_approval(
+            chat_id="12345", command="curl example.test", session_key="s",
+        )
+
+        assert captured_rows == [
+            ["✅ Allow Once", "✅ Session"],
+            ["✅ Always", "❌ Deny"],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_three_button_keyboard_pairs_then_singleton(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+        captured_rows = []
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: text,
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup",
+            lambda rows: captured_rows.extend(rows) or rows,
+        )
+
+        await adapter.send_exec_approval(
+            chat_id="12345", command="curl example.test", session_key="s",
+            allow_permanent=False,
+        )
+
+        assert captured_rows == [
+            ["✅ Allow Once", "✅ Session"],
+            ["❌ Deny"],
+        ]
+
+    @pytest.mark.asyncio
     async def test_stores_approval_state(self):
         adapter = _make_adapter()
         mock_msg = MagicMock()


### PR DESCRIPTION
## Summary
- Exec-approval buttons on Telegram were flattened into a single 4-button row after the smart-deny conditional keyboard change, so labels truncated on mobile (`Allo…` / `Ses…` / `Alw…`).
- Pair the built button list into rows of two so the full set is again a readable 2×2 grid (`Allow Once` | `Session` / `Always` | `Deny`), including the 3- and 2-button variants.
- Add regression coverage for the full 2×2 layout and the three-button case.

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_telegram_approval_buttons.py -q`
- [ ] Trigger a dangerous command approval in Telegram and confirm buttons render as two rows of two with full labels
- [ ] With smart deny / `allow_permanent=false`, confirm the reduced button sets still render without a single cramped row