### PR TITLE
fix(secret_scope): profile scope inherits global default home credentials

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -6,7 +6,14 @@ has its own ``.env`` with its own provider keys and platform tokens, so we
 profile A's keys to profile B's turns, and to every subprocess spawned with
 ``env=dict(os.environ)``).
 
-This module provides a fail-closed, context-local secret scope:
+Instead each profile turn gets a fail-closed, context-local secret scope
+(``build_profile_secret_scope``). A profile's scope is **layered**: it starts
+from the global/default home's ``.env`` (a shared credential baseline so a
+deployment-common key like ``OPENROUTER_API_KEY`` doesn't have to be copied
+into every profile), then overlays the profile's own ``.env``. Only this
+context-local dict is affected — nothing is written to ``os.environ`` — so
+sibling profiles stay isolated from each other (each sees the global baseline
+plus its own secrets, never another profile's):
 
 - ``set_secret_scope(mapping)`` installs the active profile's secrets for the
   current task (a contextvar, so it propagates into the agent's worker thread
@@ -211,25 +218,66 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
     return secrets
 
 
-def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
-    """Build a profile's secret mapping from its ``<home>/.env``.
+def _resolve_global_home(profile_home: Path) -> Optional[Path]:
+    """Return the global/default HERMES_HOME a profile inherits from, or None.
 
-    Returns a fresh dict (safe to install via ``set_secret_scope``). Genuinely
-    global vars are intentionally NOT copied in — ``get_secret`` reads those
-    from ``os.environ`` directly, so the scope holds only profile secrets.
+    Profiles live at ``<hermes_home>/profiles/<name>``; their shared baseline is
+    ``<hermes_home>`` (the ``default`` profile's home). This is resolved by path
+    shape (``parent.name == "profiles"``) rather than via ``get_hermes_home()``,
+    because inside a multiplex turn ``HERMES_HOME`` is overridden to the active
+    profile's home — a lookup there would return the profile, not the global
+    root. Returns ``None`` for the ``default`` profile itself (it IS the global
+    home) and for any non-standard layout, preserving legacy behavior.
+    """
+    home = Path(profile_home).resolve()
+    if home.parent.name == "profiles":
+        return home.parent.parent
+    return None
+
+
+def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
+    """Build a profile's secret mapping, inheriting the global default home.
+
+    The scope is layered (each later layer overrides the previous):
+
+    1. The global/default home's ``.env`` and external-secret snapshot — a
+       shared credential baseline so profiles don't each have to duplicate
+       deployment-common keys (e.g. a shared ``OPENROUTER_API_KEY``).
+    2. The profile's own ``.env`` and external-secret snapshot — profile-specific
+       values override the global baseline.
+
+    Genuinely global vars (``_is_global_env``) are skipped from the external
+    snapshots; ``get_secret`` reads those from ``os.environ`` directly. The
+    result is a fresh dict, safe for ``set_secret_scope``. Only this
+    context-local scope dict is affected — nothing is written to ``os.environ``,
+    and sibling profiles stay isolated (each sees only the global baseline plus
+    its own secrets, never another profile's).
     """
     home = Path(hermes_home)
-    secrets = load_env_file(home / ".env")
+    secrets: Dict[str, str] = {}
 
     try:
         from hermes_cli.env_loader import get_secret_source_values
-        external_secrets = get_secret_source_values(home)
     except Exception:
-        external_secrets = {}
+        get_secret_source_values = None  # type: ignore[assignment]
 
-    for key, value in external_secrets.items():
-        if _is_global_env(key):
-            continue
-        secrets[key] = value
+    def _merge_external(scope_home: Path) -> None:
+        if get_secret_source_values is None:
+            return
+        try:
+            for key, value in get_secret_source_values(scope_home).items():
+                if _is_global_env(key):
+                    continue
+                secrets[key] = value
+        except Exception:
+            pass
+
+    global_home = _resolve_global_home(home)
+    if global_home is not None:
+        secrets.update(load_env_file(global_home / ".env"))
+        _merge_external(global_home)
+
+    secrets.update(load_env_file(home / ".env"))
+    _merge_external(home)
 
     return secrets

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -209,3 +209,63 @@ class TestEnvFileParsing:
         )
 
         assert ss.build_profile_secret_scope(profile) == {}
+
+
+class TestProfileSecretScopeInheritsGlobal:
+    """A profile's scope layers the global/default home's secrets as a baseline.
+
+    Profiles live at ``<root>/profiles/<name>``; the ``<root>`` (default) home
+    supplies a shared credential baseline that each profile overlays. Sibling
+    profiles never see each other's secrets — only the shared baseline.
+    """
+
+    def test_inherits_global_default_env(self, tmp_path):
+        profile = tmp_path / "profiles" / "product-manager"
+        profile.mkdir(parents=True)
+        (tmp_path / ".env").write_text("OPENROUTER_API_KEY=sk-global\n")
+        (profile / ".env").write_text("DEEPSEEK_API_KEY=sk-profile\n")
+
+        assert ss.build_profile_secret_scope(profile) == {
+            "OPENROUTER_API_KEY": "sk-global",
+            "DEEPSEEK_API_KEY": "sk-profile",
+        }
+
+    def test_profile_overrides_global(self, tmp_path):
+        profile = tmp_path / "profiles" / "pm"
+        profile.mkdir(parents=True)
+        (tmp_path / ".env").write_text("OPENROUTER_API_KEY=sk-global\n")
+        (profile / ".env").write_text("OPENROUTER_API_KEY=sk-profile\n")
+
+        assert ss.build_profile_secret_scope(profile) == {
+            "OPENROUTER_API_KEY": "sk-profile"
+        }
+
+    def test_sibling_profiles_are_isolated(self, tmp_path):
+        profile_a = tmp_path / "profiles" / "a"
+        profile_b = tmp_path / "profiles" / "b"
+        profile_a.mkdir(parents=True)
+        profile_b.mkdir()
+        (tmp_path / ".env").write_text("SHARED_KEY=sk-shared\n")
+        (profile_a / ".env").write_text("ONLY_A=sk-a\n")
+        (profile_b / ".env").write_text("ONLY_B=sk-b\n")
+
+        scope_a = ss.build_profile_secret_scope(profile_a)
+        scope_b = ss.build_profile_secret_scope(profile_b)
+
+        assert scope_a == {"SHARED_KEY": "sk-shared", "ONLY_A": "sk-a"}
+        assert scope_b == {"SHARED_KEY": "sk-shared", "ONLY_B": "sk-b"}
+
+    def test_inherits_global_external_secrets(self, tmp_path, monkeypatch):
+        from hermes_cli import env_loader
+
+        profile = tmp_path / "profiles" / "pm"
+        profile.mkdir(parents=True)
+        monkeypatch.setitem(
+            env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+            str(tmp_path.resolve()),
+            {"XIAOMI_API_KEY": "sk-global-bitwarden"},
+        )
+
+        assert ss.build_profile_secret_scope(profile) == {
+            "XIAOMI_API_KEY": "sk-global-bitwarden"
+        }


### PR DESCRIPTION
## Problem

In the multiplex gateway each profile is an independent HERMES_HOME. `build_profile_secret_scope` built a profile's secret scope from **only** that profile's `<home>/.env` + its own external-secret snapshot. Credentials that live solely in the global `~/.hermes/.env` (e.g. a shared `OPENROUTER_API_KEY`) were unreachable.

When a profile's declared provider needed such a key, agent init hit `RuntimeError: No LLM provider configured` (`agent/agent_init.py:1241`). Outwardly this surfaced as "some messages get no reply": messages routed to the affected profile failed (only a short error line was returned).

Root cause is two-layer:
- `load_hermes_dotenv` loads only the single home passed to it — no cascade to the global/default home.
- Under multiplexing, per-turn credentials resolve through the profile `_SECRET_SCOPE` via `build_profile_secret_scope`; `get_secret` does **not** fall back to `os.environ` on a scope miss, and keys like `OPENROUTER_API_KEY` are not on the global allowlist.

## Fix

`build_profile_secret_scope` now **layers** the scope:
1. global/default home `.env` + external-secret snapshot — a shared baseline so deployment-common keys don't need copying into every profile;
2. the profile's own `.env` + external-secret snapshot — profile values override the global baseline.

Only the context-local scope dict is affected. `os.environ` is never written, and **sibling profiles stay isolated** (each sees the global baseline plus its own secrets, never another profile's). The global home is resolved by path shape (`profiles/<name>` → `<root>`) rather than `get_hermes_home()`, to avoid the per-turn `HERMES_HOME` override trap.

## Files
- `agent/secret_scope.py`: add `_resolve_global_home`; rewrite `build_profile_secret_scope` with layered merge; update docstrings.
- `tests/agent/test_secret_scope.py`: add `TestProfileSecretScopeInheritsGlobal` (inherit global, profile overrides global, sibling isolation, inherit global external secrets).

## Verification
- `pytest tests/agent/test_secret_scope.py tests/gateway/test_multiplex_credential_isolation.py tests/test_env_loader_secret_sources.py tests/gateway/test_64674_multiplex_primary_token_scope.py -q` → **56 passed**; existing isolation tests stay green.
- Existing tests use `tmp_path` directly as home (non-`profiles/<name>` layout), so the path-shape guard returns `None` and they are unaffected.

## Notes
This makes the global/default home a shared credential baseline for all multiplex profiles. A profile that needs a key fully private must override (or blank) it in its own `.env`. Applies wherever `build_profile_secret_scope` is called: multiplex turns (`gateway/run.py`), cron jobs (`cron/scheduler.py`), and webui flows (`hermes_cli/web_server.py`).
