### PR TITLE
feat(skills): make plugin-registered skills discoverable in the flat index

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1688,6 +1688,27 @@ def build_skills_system_prompt(
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
 
+    # ── Plugin-registered skills ───────────────────────────────────────
+    # Fold in skills registered by plugins (ctx.register_skill →
+    # 'plugin:skill'). Grouped under the plugin name as their category; the
+    # qualified name is shown so skill_view(name) resolves directly. Gated by
+    # tools.skills_tool.INDEX_PLUGIN_SKILLS (one-line kill switch).
+    try:
+        from tools.skills_tool import _plugin_skill_entries
+
+        for entry in _plugin_skill_entries():
+            pname = entry["name"]
+            if pname in seen_skill_names:
+                continue
+            if pname in disabled:
+                continue
+            seen_skill_names.add(pname)
+            skills_by_category.setdefault(entry["category"], []).append(
+                (pname, entry["description"])
+            )
+    except Exception as e:
+        logger.debug("Could not fold plugin skills into index: %s", e)
+
     # Posture-driven category demotion (e.g. non-coding skills while pairing
     # on code). Demoted categories stay in the index as a single names-only
     # line — descriptions are dropped to cut noise, but every skill name

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -97,8 +97,13 @@ def get_available_skills() -> Dict[str, List[str]]:
     user's ``skills.disabled`` config list.
     """
     try:
-        from tools.skills_tool import _find_all_skills
+        from tools.skills_tool import _find_all_skills, _plugin_skill_entries
         all_skills = _find_all_skills()  # already filtered
+        existing = {s["name"] for s in all_skills}
+        for entry in _plugin_skill_entries():
+            if entry["name"] not in existing:
+                all_skills.append(entry)
+                existing.add(entry["name"])
     except Exception:
         return {}
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -777,6 +777,68 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     return [dict(s) for s in skills]
 
 
+# When True, plugin-registered skills (ctx.register_skill → 'plugin:skill')
+# are folded into the flat skill index: the skills_list tool, the banner, and
+# the always-on system-prompt <available_skills> block. Set to False to hide
+# them from the system-prompt index again (they always stay loadable via
+# skill_view("plugin:skill") regardless). One-line kill switch by design.
+INDEX_PLUGIN_SKILLS = True
+
+
+def _plugin_skill_entries() -> List[Dict[str, Any]]:
+    """Return plugin-registered skills as flat index entries.
+
+    Each entry uses the qualified ``plugin:skill`` name (so ``skill_view(name)``
+    resolves it directly) and the plugin name as its category. Skills belonging
+    to disabled plugins are skipped. Descriptions come from the register_skill
+    call, falling back to the skill's own frontmatter. Returns ``[]`` when
+    ``INDEX_PLUGIN_SKILLS`` is False or the plugin manager is unavailable.
+    """
+    if not INDEX_PLUGIN_SKILLS:
+        return []
+    try:
+        from hermes_cli.plugins import _get_disabled_plugins, get_plugin_manager
+
+        pm = get_plugin_manager()
+        disabled_plugins = _get_disabled_plugins()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("Plugin skill enumeration unavailable: %s", e)
+        return []
+
+    entries: List[Dict[str, Any]] = []
+    for qualified, meta in getattr(pm, "_plugin_skills", {}).items():
+        try:
+            plugin = meta.get("plugin", "")
+            if plugin and plugin in disabled_plugins:
+                continue
+            description = meta.get("description", "") or ""
+            if not description:
+                # Fall back to the skill's frontmatter description.
+                try:
+                    content = Path(meta["path"]).read_text(encoding="utf-8")[:4000]
+                    frontmatter, body = _parse_frontmatter(content)
+                    description = frontmatter.get("description", "")
+                    if not description:
+                        for line in body.strip().split("\n"):
+                            line = line.strip()
+                            if line and not line.startswith("#"):
+                                description = line
+                                break
+                except Exception:
+                    description = ""
+            if len(description) > MAX_DESCRIPTION_LENGTH:
+                description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
+            entries.append({
+                "name": qualified,
+                "description": description,
+                "category": plugin or "plugins",
+            })
+        except Exception as e:  # pragma: no cover - defensive per-entry guard
+            logger.debug("Skipping plugin skill %s: %s", qualified, e)
+            continue
+    return entries
+
+
 def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Keep every skill listing path ordered the same way."""
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
@@ -812,6 +874,13 @@ def skills_list(category: str = None, task_id: str = None) -> str:
 
         # Find all skills
         all_skills = _find_all_skills()
+
+        # Fold in plugin-registered skills (namespaced 'plugin:skill').
+        existing = {s["name"] for s in all_skills}
+        for entry in _plugin_skill_entries():
+            if entry["name"] not in existing:
+                all_skills.append(entry)
+                existing.add(entry["name"])
 
         if not all_skills:
             return json.dumps(


### PR DESCRIPTION
## Problem

Plugin skills registered via `ctx.register_skill()` are namespaced as `plugin:skill` (e.g. `toolkit:humanize`) and load fine with `skill_view("plugin:skill")` — but they're invisible in every surface where skills are *discovered*:

- the `skills_list` tool
- the startup banner skill count
- the always-on system-prompt `<available_skills>` index

The agent overwhelmingly reaches for skills it can see in that index. Because bundled plugin skills never appear there, they go unused unless the user already knows the exact qualified name. `register_skill`'s docstring even calls this out ("not listed in the system prompt's `<available_skills>` index — plugin skills are opt-in explicit loads only"). This PR makes that opt-in *configurable* rather than hard-coded off.

## Why not `skills.external_dirs`?

Pointing `external_dirs` at plugin skill folders would list them, but by **bare name** — reintroducing exactly the collision that namespacing prevents (a plugin's `humanize` would collide with and shadow the built-in `humanize`). Preserving the `plugin:` namespace while listing them can only be done where the index is built, i.e. core.

## Change

Fold plugin skills into all three surfaces while keeping the qualified name:

- **`tools/skills_tool.py`** — new `INDEX_PLUGIN_SKILLS` flag (one-line kill switch) and `_plugin_skill_entries()` helper. Entries use the qualified `plugin:skill` as `name` (so `skill_view(name)` resolves directly), the plugin as `category`, skip disabled plugins, and take the description from the `register_skill` call with a frontmatter fallback. `skills_list()` folds them in, deduped by name.
- **`agent/prompt_builder.py`** — `build_skills_system_prompt()` folds the same entries into `skills_by_category`, respecting `seen_skill_names`/`disabled`.
- **`hermes_cli/banner.py`** — `get_available_skills()` includes them so the startup count and TUI match.

Defaults **on**. Set `INDEX_PLUGIN_SKILLS = False` to restore prior behavior; skills remain loadable via `skill_view` regardless. Happy to flip the default to `False` (pure opt-in) if maintainers prefer — easy one-liner.

## Testing

- `tests/test_plugin_skills.py` + `tests/hermes_cli/test_banner_skills.py`: **33 passed**
- Broader skill suites (`tests/{agent,tools,hermes_cli}/test_*skill*.py`): **977 passed**, 1 skipped. The 2 failures seen only in the full batch (`test_session_platform_env_var`, `test_real_temp_repo_and_home_install_e2e`) pass individually both with and without this patch — pre-existing cross-test temp-home isolation, unrelated to this change.
- Runtime smoke test against a real profile: 18 plugin skills registered → 18 entries when on, 0 when the flag is flipped off. All three plugin categories render in the `<available_skills>` block with qualified names + descriptions.

## Open question

Default `INDEX_PLUGIN_SKILLS` to `True` (discoverable out of the box, ~1 prompt line per plugin skill) or `False` (preserve current opt-in behavior)? Set to `True` here; trivial to change.
