### PR TITLE
fix(desktop): parse string display_metadata for delegation timeline

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -990,3 +990,58 @@ describe('collectUnspokenTurnSpeech', () => {
     expect(collectUnspokenTurnSpeech([user('u1', 'hello'), assistant('a1', '')], null)).toBeNull()
   })
 })
+
+
+describe('async_delegation_complete display', () => {
+  it('renders task_count from object display_metadata', () => {
+    const messages = toChatMessages([
+      {
+        role: 'system',
+        content: '',
+        timestamp: 1,
+        display_kind: 'async_delegation_complete',
+        display_metadata: {
+          delegation_id: 'deleg_test',
+          task_count: 3
+        }
+      }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(chatMessageText(messages[0])).toBe('3 background agents finished')
+  })
+
+  it('renders task_count when display_metadata is still a JSON string', () => {
+    const messages = toChatMessages([
+      {
+        role: 'system',
+        content: '',
+        timestamp: 1,
+        display_kind: 'async_delegation_complete',
+        // Some restore paths deliver the SQLite TEXT column unparsed (#70611).
+        display_metadata: JSON.stringify({
+          delegation_id: 'deleg_b6a3b009',
+          task_count: 2
+        }) as unknown as { delegation_id: string; task_count: number }
+      }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(chatMessageText(messages[0])).toBe('2 background agents finished')
+  })
+
+  it('falls back when display_metadata string is invalid', () => {
+    const messages = toChatMessages([
+      {
+        role: 'system',
+        content: '',
+        timestamp: 1,
+        display_kind: 'async_delegation_complete',
+        display_metadata: 'not-json{' as unknown as { delegation_id: string; task_count: number }
+      }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(chatMessageText(messages[0])).toBe('background agent work finished')
+  })
+})

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -5,7 +5,7 @@ import { dedupeGeneratedImageEchoesInParts } from '@/lib/generated-images'
 import { mediaDisplayLabel, mediaMarkdownHref } from '@/lib/media'
 import { normalize } from '@/lib/text'
 import { parseTodos } from '@/lib/todos'
-import type { SessionMessage, UsageStats } from '@/types/hermes'
+import type { SessionMessage, TimelineDisplayMetadata, UsageStats } from '@/types/hermes'
 
 export type ChatMessagePart = Exclude<ThreadMessageLike['content'], string>[number]
 
@@ -311,16 +311,42 @@ function transcriptContent(displayKind: SessionMessage['display_kind'], content:
   return displayKind === 'hidden' ? null : content
 }
 
+function normalizeDisplayMetadata(
+  metadata: SessionMessage['display_metadata']
+): TimelineDisplayMetadata | undefined {
+  if (metadata == null) {
+    return undefined
+  }
+
+  if (typeof metadata === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(metadata)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as TimelineDisplayMetadata
+      }
+    } catch {
+      return undefined
+    }
+
+    return undefined
+  }
+
+  if (typeof metadata === 'object') {
+    return metadata
+  }
+
+  return undefined
+}
+
 function timelineDisplayContent(message: SessionMessage, content: string): string {
   if (message.display_kind === 'model_switch') {
     return 'model changed'
   }
 
   if (message.display_kind === 'async_delegation_complete') {
+    const meta = normalizeDisplayMetadata(message.display_metadata)
     const count =
-      message.display_metadata && 'task_count' in message.display_metadata
-        ? message.display_metadata.task_count
-        : undefined
+      meta && typeof meta === 'object' && 'task_count' in meta ? meta.task_count : undefined
 
     return count === undefined
       ? 'background agent work finished'

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -442,7 +442,8 @@ export interface SessionMessage {
   reasoning_content?: null | string
   reasoning_details?: unknown
   display_kind?: 'async_delegation_complete' | 'hidden' | 'model_switch' | string
-  display_metadata?: TimelineDisplayMetadata
+  /** Prefer object; some restore paths still deliver the SQLite TEXT JSON string. */
+  display_metadata?: string | TimelineDisplayMetadata
   role: 'assistant' | 'system' | 'tool' | 'user'
   text?: unknown
   timestamp?: number


### PR DESCRIPTION
## Summary

Defensively parse `display_metadata` when it arrives as a JSON **string** so sessions with `async_delegation_complete` rows stop crashing the desktop timeline.

Closes #70611

## Motivation

`timelineDisplayContent` used the `in` operator on `display_metadata`. When a restore/IPC path delivered the SQLite TEXT value unparsed, JavaScript throws:

`TypeError: Cannot use 'in' operator to search for 'task_count' in "{\"delegation_id\":...}"`

That makes the whole session unloadable even though `state.db` is intact.

## Fix

- Normalize `display_metadata` from string | object before reading `task_count`
- Widen the TS type to allow string payloads from imperfect restore paths
- Vitest: object metadata, JSON-string metadata, invalid string fallback

## Verification

```bash
cd apps/desktop && npx vitest run src/lib/chat-messages.test.ts
# 44 passed
```

## Scope

Desktop chat mapping only — does not change DB write paths.