### PR TITLE
fix: validate Chronos fire token against job's profile, not default (#69715)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12334,16 +12334,9 @@ async def cron_fire_webhook(request: Request):
     auth = request.headers.get("Authorization", "")
     token = auth[7:].strip() if auth.startswith("Bearer ") else ""
 
-    cfg = load_config()
-    claims = get_fire_verifier()(
-        token=token,
-        expected_audience=cfg_get(cfg, "cron", "chronos", "expected_audience", default=""),
-        jwks_or_key=cfg_get(cfg, "cron", "chronos", "nas_jwks_url", default="") or None,
-        issuer=cfg_get(cfg, "cron", "chronos", "portal_url", default="") or None,
-    )
-    if claims is None:
-        return JSONResponse({"error": "invalid fire token"}, status_code=401)
-
+    # Parse job_id first so we can resolve the owning profile before
+    # validating the fire token.  See #69715 — the token must be verified
+    # against the *job's* profile, not the process-wide default.
     try:
         body = await request.json()
     except Exception:
@@ -12360,6 +12353,25 @@ async def cron_fire_webhook(request: Request):
         # Job is gone (cancelled / completed) — nothing to fire. 200 so NAS
         # does not retry a fire that is intentionally absent.
         return JSONResponse({"status": "gone", "job_id": job_id}, status_code=200)
+
+    # Load the *job's* profile config so the fire token is validated against
+    # the correct Chronos audience / JWKS / issuer — not the default profile.
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    _, profile_home = _cron_profile_home(profile)
+    override_token = set_hermes_home_override(str(profile_home))
+    try:
+        cfg = load_config()
+    finally:
+        reset_hermes_home_override(override_token)
+
+    claims = get_fire_verifier()(
+        token=token,
+        expected_audience=cfg_get(cfg, "cron", "chronos", "expected_audience", default=""),
+        jwks_or_key=cfg_get(cfg, "cron", "chronos", "nas_jwks_url", default="") or None,
+        issuer=cfg_get(cfg, "cron", "chronos", "portal_url", default="") or None,
+    )
+    if claims is None:
+        return JSONResponse({"error": "invalid fire token"}, status_code=401)
 
     # Run in the background; the store CAS claim inside fire_due de-dupes a
     # NAS/scheduler retry that arrives while this is in flight.


### PR DESCRIPTION
## Summary
- Fixes Chronos fire webhook validating tokens against the default profile instead of the job's actual profile
- Reorders the webhook handler to parse `job_id` and resolve the owning profile BEFORE token validation
- Loads the job's profile config via `set_hermes_home_override` so Chronos audience/JWKS/issuer come from the correct profile

## Root Cause
`cron_fire_webhook()` called `load_config()` (which loads the default profile's config) and validated the bearer token against those Chronos settings. Only after token validation did it parse `job_id` and resolve the profile. This meant valid fire tokens for non-default profiles were always rejected with 401 because the audience/JWKS/issuer didn't match.

## Fix
1. Parse `job_id` from the request body first
2. Resolve the owning profile via `_find_cron_job_profile(job_id)`
3. Use `set_hermes_home_override(str(profile_home))` to load that profile's config
4. Validate the fire token against the job's profile's Chronos settings
5. Reset the home override in a `finally` block

## Test Plan
- [ ] Existing `test_cron_fire_dashboard.py` tests still pass
- [ ] Manual test: create two profiles with different `expected_audience`, fire a job in the non-default profile, verify 202 instead of 401

Closes #69715