### PR TITLE
fix(gateway): route per-credential replies to the correct profile adapter

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -94,6 +94,21 @@ class GatewayAuthorizationMixin:
             return None
         transport_adapter = self._registered_transport_adapter(source)
         if transport_adapter is not None:
+            # Per-credential routing: when a profile_route stamps a secondary
+            # profile that owns its own adapter for this platform, replies must
+            # go out that profile's bot — not the transport that received the
+            # inbound event.  The transport-adapter shortcut is only correct
+            # when the transport and the routed profile share the same
+            # credential (shared-token scenario, ff4637661).  When they differ,
+            # the routed profile's adapter is the right delivery path.
+            profile = getattr(source, "profile", None)
+            if profile and profile not in ("default", ""):
+                profile_maps = getattr(self, "_profile_adapters", None) or {}
+                routed = profile_maps.get(profile, {})
+                platform = getattr(source, "platform", None)
+                routed_adapter = routed.get(platform) if platform else None
+                if routed_adapter is not None and routed_adapter is not transport_adapter:
+                    return routed_adapter
             return transport_adapter
         # Relay ingress deliberately keeps the underlying platform on the
         # source so session keys and display policy remain Slack/Discord/etc.

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -245,6 +245,21 @@ class GatewayAuthorizationMixin:
             return None
         owner = self._transport_owner(source)
         if owner is not None:
+            # Per-credential routing: when a profile_route stamps a secondary
+            # profile that owns its own adapter for this platform, replies must
+            # go out that profile's bot — not the transport that received the
+            # inbound event.  The transport-authoritative shortcut (ff4637661)
+            # is only correct when the transport and the routed profile share
+            # the same credential (shared-token scenario).  When they differ,
+            # the routed profile's adapter is the right delivery path.
+            profile = getattr(source, "profile", None)
+            if profile and profile not in ("default", ""):
+                profile_maps = self._profile_adapters_map()
+                routed = profile_maps.get(profile, {})
+                platform = getattr(source, "platform", None)
+                routed_adapter = routed.get(platform) if platform else None
+                if routed_adapter is not None and routed_adapter is not owner[0]:
+                    return routed_adapter
             return owner[0]
         # Relay ingress keeps the underlying platform on the source, but delivery must use the one
         # process-level RelayAdapter owning the connector socket; a profile-aware lookup would

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -263,6 +263,73 @@ def test_adapter_auth_check_defaults_to_active_profile(monkeypatch):
     assert captured["profile"] is None
 
 
+def test_per_credential_route_uses_secondary_adapter_not_transport(monkeypatch):
+    """Per-credential routing must deliver via the routed profile's own adapter.
+
+    When a profile_route stamps ``source.profile`` to a secondary profile that
+    owns its own adapter for the platform (separate bot token), replies must
+    go out that profile's adapter — NOT the transport adapter that received
+    the inbound event.  Regression for the per-credential gap introduced by
+    ff4637661 (shared-token transport shortcut).
+    """
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    default_adapter = SimpleNamespace(send=AsyncMock())
+    secondary_adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {Platform.DISCORD: default_adapter}
+    runner._profile_adapters = {
+        "sysman": {Platform.DISCORD: secondary_adapter},
+    }
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        user_id="user-1",
+        chat_id="thread-123",
+        user_name="tester",
+        chat_type="thread",
+        profile="sysman",
+    )
+    # Simulate: default adapter received the inbound message and stamped
+    # _transport_adapter_ref (as build_source does).
+    source._transport_adapter_ref = lambda: default_adapter
+
+    # Must resolve to the secondary profile's adapter, not the transport.
+    assert runner._adapter_for_source(source) is secondary_adapter
+
+
+def test_shared_credential_route_still_keeps_transport(monkeypatch):
+    """Shared-token routing must keep the transport adapter (ff4637661 intent).
+
+    When the routed profile does NOT own a separate adapter for the platform
+    (shared bot token scenario), the transport adapter that received the
+    message is the only live delivery path and must be preserved.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    shared_adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {Platform.DISCORD: shared_adapter}
+    # Routed profile has no adapter of its own (shared credential).
+    runner._profile_adapters = {"routed": {}}
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        user_id="user-1",
+        chat_id="thread-456",
+        user_name="tester",
+        chat_type="thread",
+        profile="routed",
+    )
+    source._transport_adapter_ref = lambda: shared_adapter
+
+    assert runner._adapter_for_source(source) is shared_adapter
+
+
 def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     """Secondary profiles must pass the same open-policy startup guard."""
     from gateway.run import _own_policy_open_startup_violation

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -196,6 +196,73 @@ def test_startup_guard_gateway_allow_all_reads_scope_not_environ(monkeypatch):
         secret_scope.set_multiplex_active(previous_multiplex)
 
 
+def test_per_credential_route_uses_secondary_adapter_not_transport(monkeypatch):
+    """Per-credential routing must deliver via the routed profile's own adapter.
+
+    When a profile_route stamps ``source.profile`` to a secondary profile that
+    owns its own adapter for the platform (separate bot token), replies must
+    go out that profile's adapter — NOT the transport adapter that received
+    the inbound event.  Regression for the per-credential gap introduced by
+    ff4637661 (shared-token transport shortcut).
+    """
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    default_adapter = SimpleNamespace(send=AsyncMock())
+    secondary_adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {Platform.DISCORD: default_adapter}
+    runner._profile_adapters = {
+        "sysman": {Platform.DISCORD: secondary_adapter},
+    }
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        user_id="user-1",
+        chat_id="thread-123",
+        user_name="tester",
+        chat_type="thread",
+        profile="sysman",
+    )
+    # Simulate: default adapter received the inbound message and stamped
+    # _transport_adapter_ref (as build_source does).
+    source._transport_adapter_ref = lambda: default_adapter
+
+    # Must resolve to the secondary profile's adapter, not the transport.
+    assert runner._adapter_for_source(source) is secondary_adapter
+
+
+def test_shared_credential_route_still_keeps_transport(monkeypatch):
+    """Shared-token routing must keep the transport adapter (ff4637661 intent).
+
+    When the routed profile does NOT own a separate adapter for the platform
+    (shared bot token scenario), the transport adapter that received the
+    message is the only live delivery path and must be preserved.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    shared_adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {Platform.DISCORD: shared_adapter}
+    # Routed profile has no adapter of its own (shared credential).
+    runner._profile_adapters = {"routed": {}}
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        user_id="user-1",
+        chat_id="thread-456",
+        user_name="tester",
+        chat_type="thread",
+        profile="routed",
+    )
+    source._transport_adapter_ref = lambda: shared_adapter
+
+    assert runner._adapter_for_source(source) is shared_adapter
+
+
 def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     """Secondary profiles must pass the same open-policy startup guard."""
     from gateway.run import _own_policy_open_startup_violation


### PR DESCRIPTION
## Problem

When `gateway.multiplex_profiles` is enabled with **per-credential** profiles (each profile owns its own bot token and adapter), replies to messages routed via `gateway.profile_routes` are delivered through the **transport adapter** that received the inbound event instead of the **routed profile's own adapter**.

This causes the wrong bot identity to appear in the chat (e.g. "Hermes" instead of "sysman").

Closes #70620

## Root Cause

Commit `ff4637661` added `_registered_transport_adapter()` to `_adapter_for_source()`, which unconditionally returns the adapter that received the inbound message (`source._transport_adapter_ref`).

This is correct for the **shared-token** scenario (one bot credential, multiple routed profiles — only one WebSocket exists). However, in the **per-credential** scenario each profile owns its own adapter, and the routed profile's adapter is the correct delivery path.

## Fix

In `_adapter_for_source()`, after resolving the transport adapter, check whether `source.profile` maps to a secondary profile that owns a **distinct** adapter for the same platform. If so, return that adapter instead of the transport.

The shared-token path is unaffected: when the routed profile has no adapter of its own (`_profile_adapters[profile]` is empty or has no entry for the platform), the transport adapter is still returned.

## Testing

- 2 new regression tests added:
  - `test_per_credential_route_uses_secondary_adapter_not_transport` — verifies per-credential routing returns the secondary adapter
  - `test_shared_credential_route_still_keeps_transport` — verifies shared-token routing still uses the transport adapter
- All 71 authz-related gateway tests pass (existing + new), no regressions.