### PR TITLE
fix: propagate clarify callback through plugin tool dispatch bridge

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2695,6 +2695,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
+                clarify_callback=getattr(agent, "clarify_callback", None),
             )
             if skip_tool_execution_middleware:
                 dispatch_kwargs["skip_tool_execution_middleware"] = True

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1691,6 +1691,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         tool_request_middleware_trace=list(middleware_trace),
                         enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                         disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                        clarify_callback=getattr(agent, "clarify_callback", None),
                     )
 
                 (
@@ -1761,6 +1762,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         tool_request_middleware_trace=list(middleware_trace),
                         enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                         disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                        clarify_callback=getattr(agent, "clarify_callback", None),
                     )
 
                 (

--- a/model_tools.py
+++ b/model_tools.py
@@ -27,7 +27,7 @@ import asyncio
 import logging
 import threading
 import time
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, Callable, List, Optional, Tuple
 
 from tools.registry import discover_builtin_tools, registry
 from toolsets import resolve_toolset, validate_toolset
@@ -1097,6 +1097,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    clarify_callback: Optional[Callable] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1106,6 +1107,16 @@ def handle_function_call(
         function_args: Arguments for the function.
         task_id: Unique identifier for terminal/browser session isolation.
         user_task: The user's original task (for browser_snapshot context).
+        clarify_callback: The platform's clarify UI callback
+                       (``callback(question, choices) -> str``), threaded down
+                       from the agent as *framework execution context* — a
+                       dedicated parameter, never sourced from ``function_args``,
+                       so the model cannot spoof it. It is forwarded verbatim
+                       into every registry dispatch (and across the ``tool_call``
+                       bridge) so registry-dispatched tools — notably plugin
+                       handlers — can nested-dispatch ``clarify`` and reach the
+                       real user. ``None`` (the default) keeps clarify failing
+                       closed, exactly as when no platform callback is wired.
         enabled_tools: Tool names enabled for this session.  When provided,
                        execute_code uses this list to determine which sandbox
                        tools to generate.  Falls back to the process-global
@@ -1208,6 +1219,7 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                clarify_callback=clarify_callback,
             )
 
     _tool_original_args = dict(function_args)
@@ -1342,6 +1354,7 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         user_task=user_task,
+                        clarify_callback=clarify_callback,
                     )
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3152,8 +3152,23 @@ class TestConcurrentToolExecution:
                 enabled_toolsets=agent.enabled_toolsets,
                 disabled_toolsets=agent.disabled_toolsets,
                 tool_request_middleware_trace=[],
+                clarify_callback=agent.clarify_callback,
             )
             assert result == "result"
+
+    @pytest.mark.parametrize("quiet_mode", [False, True])
+    def test_sequential_forwards_clarify_callback(self, agent, quiet_mode):
+        def sentinel(*a, **k):
+            return None
+
+        agent.quiet_mode = quiet_mode
+        agent.clarify_callback = sentinel
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        with patch("run_agent.handle_function_call", return_value="search result") as mock_hfc:
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+        assert mock_hfc.call_args.kwargs["clarify_callback"] is sentinel
 
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2851,6 +2851,27 @@ class TestConcurrentToolExecution:
         assert "beta" in messages[1]["content"]
         assert "gamma" in messages[2]["content"]
 
+    def test_concurrent_forwards_clarify_callback_to_registry_dispatch(self, agent):
+        """Concurrent registry dispatch must preserve the platform callback."""
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"alpha"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"beta"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        captured = {}
+
+        def platform_callback(question, choices):
+            return "USER_RESPONSE"
+
+        def fake_handle(name, args, task_id, **kwargs):
+            captured[kwargs["tool_call_id"]] = kwargs.get("clarify_callback")
+            return "ok"
+
+        agent.clarify_callback = platform_callback
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert captured == {"c1": platform_callback, "c2": platform_callback}
+
     def test_concurrent_none_args_rejected_without_crash(self, agent):
         """Concurrent executor must not crash on arguments=None. Current
         contract (_parse_tool_arguments): non-object args are rejected with

--- a/tests/test_nested_plugin_clarify_callback.py
+++ b/tests/test_nested_plugin_clarify_callback.py
@@ -1,0 +1,119 @@
+"""Regression tests: the platform clarify callback threads through the generic
+``handle_function_call`` -> ``registry.dispatch`` -> plugin handler ->
+``ctx.dispatch_tool("clarify")`` chain, and can never be sourced from model args.
+"""
+
+import json
+
+import pytest
+
+import tools.clarify_tool  # noqa: F401 -- import registers the "clarify" tool
+from tools.registry import registry
+
+_CLARIFY_Q = "Proceed with the plugin action?"
+_SPOOF = {"clarify_callback": "EVIL", "callback": "EVIL"}
+
+
+@pytest.fixture
+def register_probe():
+    """Register a clarify-nesting probe tool; deregister it on teardown.
+
+    The handler runs in a real gateway-mode ``PluginContext`` (``_cli_ref=None``
+    injects no ``parent_agent``, so the framework ``clarify_callback`` is the
+    only way clarify can reach the user). It records the framework kwargs it
+    receives, copies the model's tool args into the nested clarify call (a naive
+    plugin that would leak a spoofed callback key), and forwards ``**kwargs``.
+    """
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    registered = []
+
+    def _register(name, *, toolset="clarifyprobe"):
+        mgr = PluginManager()
+        mgr._cli_ref = None
+        ctx = PluginContext(PluginManifest(name="clarify-probe-plugin", source="user"), mgr)
+        captured = {}
+
+        def handler(args, **kwargs):
+            captured["kwargs"] = dict(kwargs)
+            return ctx.dispatch_tool("clarify", {"question": _CLARIFY_Q, **args}, **kwargs)
+
+        registry.register(
+            name=name,
+            toolset=toolset,
+            schema={"name": name, "description": name,
+                    "parameters": {"type": "object", "properties": {}}},
+            handler=handler,
+        )
+        registered.append(name)
+        return name, captured
+
+    yield _register
+
+    for name in registered:
+        registry.deregister(name)
+
+
+def test_real_callback_wins_over_spoofed_args(register_probe):
+    import model_tools
+
+    name, captured = register_probe("clarify_probe_ok")
+    calls = []
+
+    def real_cb(question, choices):
+        calls.append(question)
+        return "REAL_USER"
+
+    raw = model_tools.handle_function_call(
+        name,
+        dict(_SPOOF),
+        task_id="t1",
+        clarify_callback=real_cb,
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+    )
+
+    assert captured["kwargs"]["clarify_callback"] is real_cb
+    result = json.loads(raw)
+    assert result["user_response"] == "REAL_USER"
+    assert result["question"] == _CLARIFY_Q
+    assert calls == [_CLARIFY_Q]
+
+
+def test_no_framework_callback_fails_closed_despite_spoofed_args(register_probe):
+    import model_tools
+
+    name, captured = register_probe("clarify_probe_absent")
+
+    raw = model_tools.handle_function_call(
+        name,
+        dict(_SPOOF),
+        task_id="t1",
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+    )
+
+    assert captured["kwargs"].get("clarify_callback") is None
+    result = json.loads(raw)
+    assert "not available in this execution context" in result["error"].lower()
+
+
+def test_tool_call_bridge_recursion_preserves_callback(register_probe):
+    import model_tools
+
+    name, captured = register_probe("clarify_probe_bridge", toolset="clarifyprobebridge")
+
+    def platform_cb(question, choices):
+        return "BRIDGE_USER"
+
+    raw = model_tools.handle_function_call(
+        function_name="tool_call",
+        function_args={"name": name, "arguments": {}},
+        enabled_toolsets=["clarifyprobebridge"],
+        clarify_callback=platform_cb,
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+    )
+
+    assert captured["kwargs"].get("clarify_callback") is platform_cb
+    assert json.loads(raw)["user_response"] == "BRIDGE_USER"

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -262,11 +262,18 @@ registry.register(
     name="clarify",
     toolset="clarify",
     schema=CLARIFY_SCHEMA,
+    # The callback comes only from framework kwargs, never from model ``args``.
+    # Prefer the threaded ``clarify_callback``; fall back to the legacy
+    # ``callback`` kwarg for direct registry callers. Absent both, fail closed.
     handler=lambda args, **kw: clarify_tool(
         question=args.get("question", ""),
         choices=args.get("choices"),
         multi_select=args.get("multi_select", False),
-        callback=kw.get("callback")),
+        callback=(
+            kw["clarify_callback"]
+            if kw.get("clarify_callback") is not None
+            else kw.get("callback")
+        )),
     check_fn=check_clarify_requirements,
     emoji="❓",
 )


### PR DESCRIPTION
## Summary

- propagate the platform `clarify_callback` through concurrent and sequential tool execution
- preserve it across nested `tool_call` recursion and plugin registry dispatch
- prevent model-supplied arguments from overriding the framework callback
- retain the legacy direct-registry callback fallback and fail closed when no callback exists
- add regression tests for nested plugin clarification

## Problem

When a plugin-dispatched tool invokes `clarify` through the `tool_call` bridge, the platform callback is dropped. The nested call reaches the clarify handler without the callback and fails even though a valid callback exists on the originating agent.

Reproduction path:

1. Register a plugin tool that dispatches `clarify` through `tool_call`.
2. Attach a working `clarify_callback` to the agent.
3. Invoke the plugin tool.
4. The nested clarification fails because the callback was not forwarded.

## Root cause

`handle_function_call` and the executor/helper chain did not accept or propagate the agent's callback. Nested dispatch constructs a fresh context, so the callback was lost before the clarify registry handler ran.

## Solution

- `agent_runtime_helpers.py` forwards the callback for concurrent tool invocation.
- `tool_executor.py` forwards it from sequential quiet and non-quiet dispatch.
- `model_tools.py` preserves it across `tool_call` recursion and into registry dispatch.
- `clarify_tool.py` consumes the explicit callback with legacy fallback.

The new parameter is optional, preserving existing callers.

## Security properties

- The callback is sourced from framework state, not model-controlled function arguments.
- Model arguments cannot inject or replace the framework callback.
- Missing framework and legacy callbacks still fail closed.
- The callback remains call-local; no process-global or shared mutable context is introduced.
- No new IPC, serialization, or network surface is added.

## Tests

Current candidate rebased onto upstream `cb47f59ffa`:

- `tests/test_nested_plugin_clarify_callback.py` — **3 passed**
- `tests/run_agent/test_run_agent.py -k "clarify"` — **4 passed**
- implementation-phase coherent executor/timeout suite — **260 passed** on the immediately preceding reviewed base; the final four-commit upstream refresh replayed both PR commits byte-identically
- upstream-delta send-target parsing — **11 passed** on the private mirror candidate
- `git diff --check`, changed-module compilation, and candidate-local import-origin probes — passed
- independent exact-candidate release gate — **PASS**

The regression tests cover:

- a real framework callback winning over model-spoofed callback arguments
- failure when no framework callback exists despite spoofed arguments
- recursive dispatch through the `tool_call` bridge preserving the callback
- both sequential quiet-mode branches
- concurrent registry dispatch preserving the exact platform callback

The original July 24 candidate also completed the canonical full runner with **46,600 passed** and zero candidate-only final failures; its 23 final failures reproduced exactly on pristine upstream. This historical broad-suite result predates the current upstream rebase and is included for provenance, not presented as a current-base run.

## Related work

- #12576 addresses gateway-created agent wiring and is non-equivalent.
- #12814 adds an `on_clarify` notification hook once a callback is available; this PR fixes callback preservation before that point. Both touch `clarify_tool.py`, so normal conflict resolution may be needed if #12814 lands first.
- #14602 adds CLI/plugin response hooks and is non-equivalent.
- #29526 proposed a CLI-only `PluginContext.ask_user` overlay and is closed.
