### PR TITLE
fix: move [SILENT] instruction after user prompt in cron preamble (#69495)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2493,18 +2493,25 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     # Always prepend cron execution guidance so the agent knows how
     # delivery works and can suppress delivery when appropriate.
+    # The DELIVERY hint goes before the user prompt (operational, not
+    # behavioral).  The SILENT hint is appended AFTER the user prompt
+    # so the LLM reads and executes the task before considering silence.
+    # See #69495 — prepending [SILENT] caused models to bail immediately.
     cron_hint = (
         "[IMPORTANT: You are running as a scheduled cron job. "
         "DELIVERY: Your final response will be automatically delivered "
         "to the user — do NOT use send_message or try to deliver "
         "the output yourself. Just produce your report/output as your "
-        "final response and the system handles the rest. "
-        "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
-        "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        "final response and the system handles the rest.]\n\n"
     )
-    prompt = cron_hint + prompt
+    cron_silent_suffix = (
+        "\n\n[REMINDER: After completing ALL steps above, if you have "
+        "genuinely found nothing new to report (no data, no changes, "
+        "no insights), respond with exactly \"[SILENT]\" (nothing else) "
+        "to suppress delivery. Otherwise, report your findings normally. "
+        "Never combine [SILENT] with content.]"
+    )
+    prompt = cron_hint + prompt + cron_silent_suffix
     if skills is None:
         legacy = job.get("skill")
         skills = [legacy] if legacy else []


### PR DESCRIPTION
## Summary
- Moves the `[SILENT]` suppression instruction from BEFORE the user prompt to AFTER it
- Rephrases the instruction to emphasize "After completing ALL steps above"
- Splits cron preamble into DELIVERY hint (before) and SILENT suffix (after)

## Root Cause
The cron runner prepended a `[SILENT]` instruction before the user's actual prompt. LLMs (Grok 4.3 and others) overweight early instructions and interpret "respond with exactly [SILENT]" as "just return [SILENT] without doing anything." The agent bails without executing any steps, output files are never created, and downstream jobs in chains go silent.

This is a prompt engineering anti-pattern: checking for `nothing_found` before doing the work.

## Fix
Split the cron preamble into two parts:
1. **DELIVERY hint** (before prompt): operational guidance about auto-delivery — non-behavioral, safe to prepend
2. **SILENT suffix** (after prompt): behavioral instruction about suppression — appended AFTER the task so the LLM reads and executes first

The suffix is rephrased: "After completing ALL steps above, if you have genuinely found nothing new to report..."

## Test Plan
- [ ] Existing cron scheduler tests still pass
- [ ] Manual test: create a cron job with a multi-step task, verify the agent executes all steps before considering [SILENT]

Closes #69495