### PR TITLE
fix(telegram): surface message.quote (selected fragment) in agent context

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8184,6 +8184,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        # Hermes Stevenson: подтягиваем ВЫДЕЛЕННЫЙ/ПРОЦИТИРОВАННЫЙ фрагмент
+        # (message.quote) прямо в текст, чтобы агент видел, на что отвечает.
+        _q = getattr(msg, "quote", None)
+        _qtext = getattr(_q, "text", None) if _q is not None else None
+        if _qtext:
+            event.text = (
+                "%s\n[ПОЛЬЗОВАТЕЛЬ ПРОЦИТИРОВАЛ ФРАГМЕНТ:\n«%s»\n"
+                "— отвечай ПО СУТИ этого фрагмента.]\n" % (event.text, _qtext)
+            )
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)


### PR DESCRIPTION
## What
Telegram delivers a native partial quote in `message.quote` when a user replies to a *selected substring* of a prior message. Hermes previously only surfaced this in reply metadata (`reply_to_text`), so the agent could not see which fragment the user was responding to — it only saw the whole replied-to message or nothing.

This injects the quoted fragment into `event.text` (with a clear marker) so the agent answers on the substance of the quoted text.

## Where
`plugins/platforms/telegram/adapter.py` → `_handle_text_message`, right after `event.text = self._clean_bot_trigger_text(event.text)`.

## Why minimal
- Scoped to text messages only (no change to command/reply paths beyond visibility).
- Does not mutate prompt caching or role alternation — it only enriches the inbound user text, which is already rebuilt per message.
- Preserves existing `reply_to_text` extraction (used elsewhere for attribution); this is additive.

## Behavior
When a user quotes a fragment and asks a question, the agent now receives:
```
<user text>
[ПОЛЬЗОВАТЕЛЬ ПРОЦИТИРОВАЛ ФРАГМЕНТ:
«<quoted text>»
— отвечай ПО СУТИ этого фрагмента.]
```
(The marker is operator-localized; happy to make it configurable / English if preferred.)

## Test
- Reply to a selected substring of a prior message in Telegram → agent sees the quoted fragment and answers on it.
- Plain reply without a quote → unchanged.
- Command message → unchanged.

Fixes a reported operator bug: agent was blind to quoted/selected text in Telegram.