### PR TITLE
fix: use profile-scoped get_secret for MATRIX_RECOVERY_KEY (#69090)

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -121,6 +121,7 @@ except ImportError:
     TrustState = _TrustStateStub  # type: ignore[misc,assignment]
 
 from gateway.config import Platform, PlatformConfig
+from agent.secret_scope import get_secret
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -1439,7 +1440,7 @@ class MatrixAdapter(BasePlatformAdapter):
                             return False
                         logger.warning("Matrix: share_keys() warning during startup: %s", exc)
 
-                    recovery_key = os.getenv("MATRIX_RECOVERY_KEY", "").strip()
+                    recovery_key = (get_secret("MATRIX_RECOVERY_KEY", "") or "").strip()
                     if recovery_key:
                         try:
                             await olm.verify_with_recovery_key(recovery_key)
@@ -1737,7 +1738,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 "enabled": bool(self._encryption),
                 "deps_available": _check_e2ee_deps(),
                 "crypto_store_path": str(_CRYPTO_DB_PATH),
-                "recovery_key_configured": bool(os.getenv("MATRIX_RECOVERY_KEY", "").strip()),
+                "recovery_key_configured": bool((get_secret("MATRIX_RECOVERY_KEY", "") or "").strip()),
             },
             "policy": {
                 "allowed_user_count": len(self._allowed_user_ids),


### PR DESCRIPTION
## Summary
- Replaces `os.getenv("MATRIX_RECOVERY_KEY")` with profile-scoped `get_secret("MATRIX_RECOVERY_KEY", "")` in the Matrix adapter
- Fixes E2EE recovery key verification failure in multi-profile gateway mode

## Root Cause
In multi-profile gateway mode (`gateway.multiplex_profiles`), the Matrix adapter reads `MATRIX_RECOVERY_KEY` using `os.getenv()`. Since `os.environ` is process-global, every profile reads the default profile's recovery key from the process environment. Non-default profiles' recovery keys (stored in their `<profile>/.env`) are never read, causing "Key MAC does not match" E2EE verification failures.

## Fix
Replace `os.getenv("MATRIX_RECOVERY_KEY", "")` with `get_secret("MATRIX_RECOVERY_KEY", "")` from `agent.secret_scope`. The `get_secret` function:
- Reads from the active profile's secret scope when multiplexing is active
- Falls back to `os.environ` for single-profile deployments (backward compatible)
- Properly isolates secrets between concurrent profile turns

Changed at two call sites:
1. Line 1442: recovery key verification during startup
2. Line 1740: recovery_key_configured status in diagnostics

## Test Plan
- [ ] Existing Matrix adapter tests still pass
- [ ] Manual test: configure two profiles with different MATRIX_RECOVERY_KEY values, verify each profile uses its own key

Closes #69090