### PR TITLE
fix(cron): make Trigger now execute immediately and safely

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -1,5 +1,6 @@
+import { createCronTriggerController, type CronTriggerController } from '@hermes/shared'
 import { useStore } from '@nanostores/react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { ActionsContextMenu, type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
@@ -72,7 +73,7 @@ interface SidebarCronJobsSectionProps {
   // Open the full Cron page focused on this job (manage / full history).
   onManageJob: (jobId: string) => void
   // Fire the job now.
-  onTriggerJob: (jobId: string) => void
+  onTriggerJob: (jobId: string) => Promise<void>
   onToggle: () => void
   open: boolean
 }
@@ -92,6 +93,45 @@ export function SidebarCronJobsSection({
   const [peekJobId, setPeekJobId] = useState<null | string>(null)
   // Rows revealed so far; starts compact, grows in steps via "load more".
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_JOBS)
+  const [triggeringJobIds, setTriggeringJobIds] = useState<ReadonlySet<string>>(() => new Set())
+  const triggerControllerRef = useRef<CronTriggerController | null>(null)
+
+  // eslint-disable-next-line no-restricted-syntax -- controller mount identity, not an atom mirror
+  useEffect(() => {
+    const controller = createCronTriggerController((jobId, running) => {
+      if (triggerControllerRef.current !== controller) {
+        return
+      }
+
+      setTriggeringJobIds(current => {
+        const next = new Set(current)
+
+        if (running) {
+          next.add(jobId)
+        } else {
+          next.delete(jobId)
+        }
+
+        return next
+      })
+    })
+
+    triggerControllerRef.current = controller
+
+    return () => {
+      triggerControllerRef.current = null
+    }
+  }, [])
+
+  const triggerJob = (jobId: string) => {
+    const controller = triggerControllerRef.current
+
+    if (!controller) {
+      return
+    }
+
+    void controller.run(jobId, () => onTriggerJob(jobId)).catch(() => undefined)
+  }
 
   const visible = usePaneVisible()
 
@@ -153,6 +193,7 @@ export function SidebarCronJobsSection({
         <SidebarGroupContent className="scrollbar-fade flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto overscroll-contain pb-1.75 compact:max-h-none compact:overflow-visible">
           {shown.map(job => (
             <CronJobSidebarRow
+              busy={triggeringJobIds.has(job.id)}
               expanded={peekJobId === job.id}
               job={job}
               key={job.id}
@@ -160,7 +201,7 @@ export function SidebarCronJobsSection({
               onManage={() => onManageJob(job.id)}
               onOpenRun={onOpenRun}
               onTogglePeek={() => setPeekJobId(prev => (prev === job.id ? null : job.id))}
-              onTrigger={() => onTriggerJob(job.id)}
+              onTrigger={() => triggerJob(job.id)}
             />
           ))}
           {hiddenCount > 0 && (
@@ -176,6 +217,7 @@ export function SidebarCronJobsSection({
 }
 
 function CronJobSidebarRow({
+  busy,
   expanded,
   job,
   nowMs,
@@ -184,6 +226,7 @@ function CronJobSidebarRow({
   onTogglePeek,
   onTrigger
 }: {
+  busy: boolean
   expanded: boolean
   job: CronJob
   nowMs: number
@@ -298,11 +341,12 @@ function CronJobSidebarRow({
               <Tip label={c.triggerNow}>
                 <button
                   aria-label={c.triggerNow}
-                  className="grid size-5 place-items-center rounded-sm text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground"
+                  className="grid size-5 place-items-center rounded-sm text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:cursor-wait disabled:opacity-60"
+                  disabled={busy}
                   onClick={onTrigger}
                   type="button"
                 >
-                  <Codicon name="zap" size="0.75rem" />
+                  {busy ? <GlyphSpinner ariaLabel={c.triggerNow} className="text-[0.75rem]" /> : <Codicon name="zap" size="0.75rem" />}
                 </button>
               </Tip>
               <Tip label={c.manage}>

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -284,7 +284,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   /** Create a brand-new session and open it as a tile on `dir`. */
   onNewSessionSplit: (dir: SplitDir) => void
   onManageCronJob: (jobId: string) => void
-  onTriggerCronJob: (jobId: string) => void
+  onTriggerCronJob: (jobId: string) => Promise<void>
 }
 
 export function ChatSidebar({

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -24,7 +24,7 @@ import { $newSessionTabAction, registerPaneCloser } from '@/components/pane-shel
 import { FloatingPet } from '@/components/pet/floating-pet'
 import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { emitGatewayEvent } from '@/contrib/events'
-import { getLatestSessionMessages, triggerCronJob } from '@/hermes'
+import { getLatestSessionMessages } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { isMessagingSource } from '@/lib/session-source'
@@ -41,6 +41,7 @@ import {
   $activeGatewayProfile,
   $freshSessionRequest,
   $profileScope,
+  ALL_PROFILES,
   ensureGatewayProfile,
   newSessionInProfile,
   normalizeProfileKey,
@@ -74,6 +75,7 @@ import { closeWorkspaceTab } from '../chat/close-tab'
 import { requestComposerInsert } from '../chat/composer/focus'
 import { useComposerActions } from '../chat/hooks/use-composer-actions'
 import { CommandPalette } from '../command-palette'
+import { triggerAndRefreshCronJobs } from '../cron/cron-actions'
 import { useGatewayBoot } from '../gateway/hooks/use-gateway-boot'
 import { useGatewayRequest } from '../gateway/hooks/use-gateway-request'
 import { useKeybinds } from '../hooks/use-keybinds'
@@ -918,11 +920,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onThreadMessagesChange: handleThreadMessagesChange,
     onToggleSelectedPin: toggleSelectedPin,
     onTranscribeAudio: transcribeVoiceAudio,
-    onTriggerCronJob: jobId => {
-      void triggerCronJob(jobId)
-        .then(() => refreshCronJobs())
-        .catch(() => undefined)
-    },
+    onTriggerCronJob: jobId =>
+      triggerAndRefreshCronJobs(jobId, profileScope === ALL_PROFILES ? 'all' : profileScope)
+        .then(() => undefined)
+        .catch(() => undefined),
     getGateway: () => gatewayRef.current,
     openAgents,
     openCommandCenterSection,

--- a/apps/desktop/src/app/cron/cron-actions.test.ts
+++ b/apps/desktop/src/app/cron/cron-actions.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getCronJobs = vi.fn()
+const triggerCronJob = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getCronJobs: (...args: unknown[]) => getCronJobs(...args),
+  triggerCronJob: (...args: unknown[]) => triggerCronJob(...args)
+}))
+
+import { beginCronJobsRequest } from '@/store/cron'
+
+import { mutateAndRefreshCronJobs, refreshCronJobs, triggerAndRefreshCronJobs } from './cron-actions'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(res => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
+describe('triggerAndRefreshCronJobs', () => {
+  beforeEach(() => {
+    getCronJobs.mockReset()
+    triggerCronJob.mockReset()
+  })
+
+  it('replaces the local cache with the authoritative list after a trigger', async () => {
+    const authoritative = [{ id: 'recurring-job', state: 'scheduled' }]
+    triggerCronJob.mockResolvedValue({ id: 'deleted-one-shot', state: 'completed' })
+    getCronJobs.mockResolvedValue(authoritative)
+
+    const result = await triggerAndRefreshCronJobs('deleted-one-shot', 'work')
+
+    expect(triggerCronJob).toHaveBeenCalledWith('deleted-one-shot')
+    expect(getCronJobs).toHaveBeenCalledWith('work')
+    expect(result).toEqual({ jobs: authoritative, refreshError: null, stale: false })
+  })
+
+  it('reports refresh failure separately after a successful trigger', async () => {
+    const refreshError = new Error('refresh failed')
+    triggerCronJob.mockResolvedValue({ id: 'job-1', state: 'scheduled' })
+    getCronJobs.mockRejectedValue(refreshError)
+
+    const result = await triggerAndRefreshCronJobs('job-1', 'all')
+
+    expect(result).toEqual({ jobs: null, refreshError, stale: false })
+  })
+
+  it('still rejects when the trigger itself fails', async () => {
+    const triggerError = new Error('trigger failed')
+    triggerCronJob.mockRejectedValue(triggerError)
+
+    await expect(triggerAndRefreshCronJobs('job-1', 'all')).rejects.toBe(triggerError)
+    expect(getCronJobs).not.toHaveBeenCalled()
+  })
+
+  it('discards a trigger failure after the profile scope changes', async () => {
+    const trigger = deferred<never>()
+    triggerCronJob.mockReturnValue(trigger.promise)
+
+    const resultPromise = triggerAndRefreshCronJobs('job-1', 'work')
+    beginCronJobsRequest('personal')
+    trigger.resolve(Promise.reject(new Error('old profile failed')) as never)
+
+    await expect(resultPromise).resolves.toEqual({ jobs: null, refreshError: null, stale: true })
+    expect(getCronJobs).not.toHaveBeenCalled()
+  })
+
+  it('discards a trigger refresh after the profile scope changes', async () => {
+    const refresh = deferred<Array<{ id: string }>>()
+    triggerCronJob.mockResolvedValue({ id: 'job-1', state: 'scheduled' })
+    getCronJobs.mockReturnValue(refresh.promise)
+
+    const resultPromise = triggerAndRefreshCronJobs('job-1', 'work')
+    await triggerCronJob.mock.results[0]?.value
+
+    beginCronJobsRequest('personal')
+    refresh.resolve([{ id: 'work-job' }])
+
+    await expect(resultPromise).resolves.toEqual({ jobs: null, refreshError: null, stale: true })
+  })
+
+  it('discards an older ordinary refresh that completes after a trigger refresh', async () => {
+    const older = deferred<Array<{ id: string }>>()
+    const newer = deferred<Array<{ id: string }>>()
+    triggerCronJob.mockResolvedValue({ id: 'job-1', state: 'scheduled' })
+    getCronJobs.mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise)
+
+    const olderPromise = refreshCronJobs('work')
+    const newerPromise = triggerAndRefreshCronJobs('job-1', 'work')
+    newer.resolve([{ id: 'newer' }])
+    older.resolve([{ id: 'older' }])
+
+    await expect(newerPromise).resolves.toEqual({
+      jobs: [{ id: 'newer' }],
+      refreshError: null,
+      stale: false
+    })
+    await expect(olderPromise).resolves.toEqual({ jobs: null, refreshError: null, stale: true })
+  })
+})
+
+describe('mutateAndRefreshCronJobs', () => {
+  beforeEach(() => {
+    getCronJobs.mockReset()
+  })
+
+  it('does not refresh the old profile after a successful mutation switches scope', async () => {
+    const mutation = deferred<{ id: string }>()
+    const resultPromise = mutateAndRefreshCronJobs('work', () => mutation.promise)
+
+    beginCronJobsRequest('personal')
+    mutation.resolve({ id: 'work-job' })
+
+    await expect(resultPromise).resolves.toEqual({
+      jobs: null,
+      refreshError: null,
+      stale: true,
+      value: null
+    })
+    expect(getCronJobs).not.toHaveBeenCalled()
+  })
+
+  it('suppresses a mutation error after the profile scope changes', async () => {
+    const mutation = deferred<never>()
+    const resultPromise = mutateAndRefreshCronJobs('work', () => mutation.promise)
+
+    beginCronJobsRequest('personal')
+    mutation.resolve(Promise.reject(new Error('old profile failed')) as never)
+
+    await expect(resultPromise).resolves.toEqual({
+      jobs: null,
+      refreshError: null,
+      stale: true,
+      value: null
+    })
+  })
+
+  it('allows overlapping same-profile mutations to authoritatively refresh', async () => {
+    const first = deferred<string>()
+    const second = deferred<string>()
+    getCronJobs
+      .mockResolvedValueOnce([{ id: 'after-second' }])
+      .mockResolvedValueOnce([{ id: 'after-both' }])
+
+    const firstResult = mutateAndRefreshCronJobs('work', () => first.promise)
+    const secondResult = mutateAndRefreshCronJobs('work', () => second.promise)
+
+    second.resolve('second')
+    await expect(secondResult).resolves.toMatchObject({ stale: false, value: 'second' })
+
+    first.resolve('first')
+    await expect(firstResult).resolves.toMatchObject({ stale: false, value: 'first' })
+    expect(getCronJobs).toHaveBeenCalledTimes(2)
+  })
+
+  it('preserves a successful mutation when a newer same-profile refresh supersedes its snapshot', async () => {
+    const mutation = deferred<string>()
+    const mutationRefresh = deferred<Array<{ id: string }>>()
+    const newerRefresh = deferred<Array<{ id: string }>>()
+    getCronJobs.mockReturnValueOnce(mutationRefresh.promise).mockReturnValueOnce(newerRefresh.promise)
+
+    const mutationResult = mutateAndRefreshCronJobs('work', () => mutation.promise)
+    mutation.resolve('created')
+    await vi.waitFor(() => expect(getCronJobs).toHaveBeenCalledTimes(1))
+
+    const newerResult = refreshCronJobs('work')
+    newerRefresh.resolve([{ id: 'newer' }])
+    await expect(newerResult).resolves.toEqual({
+      jobs: [{ id: 'newer' }],
+      refreshError: null,
+      stale: false
+    })
+
+    mutationRefresh.resolve([{ id: 'older' }])
+    await expect(mutationResult).resolves.toEqual({
+      jobs: null,
+      refreshError: null,
+      stale: false,
+      value: 'created'
+    })
+  })
+})

--- a/apps/desktop/src/app/cron/cron-actions.ts
+++ b/apps/desktop/src/app/cron/cron-actions.ts
@@ -1,0 +1,98 @@
+import { type CronJob, getCronJobs, triggerCronJob } from '@/hermes'
+import {
+  beginCronJobsAction,
+  beginCronJobsRequest,
+  commitCronJobsRequest,
+  type CronJobsRequest,
+  isCronJobsRequestCurrent,
+  isCronJobsScopeCurrent
+} from '@/store/cron'
+
+export interface CronTriggerRefreshResult {
+  jobs: CronJob[] | null
+  refreshError: unknown | null
+  stale: boolean
+}
+
+export interface CronMutationRefreshResult<T> extends CronTriggerRefreshResult {
+  value: T | null
+}
+
+async function refreshForGeneration(
+  profile: string,
+  request: CronJobsRequest
+): Promise<CronTriggerRefreshResult> {
+  try {
+    const jobs = await getCronJobs(profile)
+
+    if (!commitCronJobsRequest(request, jobs)) {
+      return { jobs: null, refreshError: null, stale: true }
+    }
+
+    return { jobs, refreshError: null, stale: false }
+  } catch (refreshError) {
+    if (!isCronJobsRequestCurrent(request)) {
+      return { jobs: null, refreshError: null, stale: true }
+    }
+
+    return { jobs: null, refreshError, stale: false }
+  }
+}
+
+export function refreshCronJobs(profile: string): Promise<CronTriggerRefreshResult> {
+  return refreshForGeneration(profile, beginCronJobsRequest(profile))
+}
+
+export async function mutateAndRefreshCronJobs<T>(
+  profile: string,
+  mutate: () => Promise<T>
+): Promise<CronMutationRefreshResult<T>> {
+  const scopeToken = beginCronJobsAction(profile)
+  let value: T
+
+  try {
+    value = await mutate()
+  } catch (mutationError) {
+    if (!isCronJobsScopeCurrent(scopeToken)) {
+      return { jobs: null, refreshError: null, stale: true, value: null }
+    }
+
+    throw mutationError
+  }
+
+  if (!isCronJobsScopeCurrent(scopeToken)) {
+    return { jobs: null, refreshError: null, stale: true, value: null }
+  }
+
+  const refreshed = await refreshCronJobs(profile)
+
+  if (!isCronJobsScopeCurrent(scopeToken)) {
+    return { jobs: null, refreshError: null, stale: true, value: null }
+  }
+
+  // A newer request in the same scope may supersede this refresh after the
+  // mutation itself has already succeeded. Preserve the mutation result so
+  // callers can settle dialogs/toasts without publishing the older snapshot.
+  if (refreshed.stale) {
+    return { jobs: null, refreshError: null, stale: false, value }
+  }
+
+  return { ...refreshed, value }
+}
+
+/**
+ * Trigger a job synchronously, then replace the local view from the backend.
+ * A completed one-shot may have been deleted, so the trigger response alone is
+ * not an authoritative list update. Refresh failure is reported separately:
+ * the trigger already succeeded and must not be shown as failed.
+ */
+export async function triggerAndRefreshCronJobs(
+  jobId: string,
+  profile: 'all' | string
+): Promise<CronTriggerRefreshResult> {
+  const { value: _value, ...result } = await mutateAndRefreshCronJobs(profile, () =>
+    triggerCronJob(jobId)
+  )
+
+  return result
+}

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -1,3 +1,4 @@
+import { createCronTriggerController, type CronTriggerController } from '@hermes/shared'
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
@@ -36,19 +37,17 @@ import {
   getAutomationBlueprints,
   getCronDeliveryTargets,
   getCronJobRuns,
-  getCronJobs,
   instantiateAutomationBlueprint,
   pauseCronJob,
   resumeCronJob,
   type SessionInfo,
-  triggerCronJob,
   updateCronJob
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
 import { requestModelOptions } from '@/lib/model-options'
 import { asText } from '@/lib/text'
-import { $cronFocusJobId, $cronJobs, setCronFocusJobId, setCronJobs, updateCronJobs } from '@/store/cron'
+import { $cronFocusJobId, $cronJobs, invalidateCronJobsRequests, setCronFocusJobId } from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
 import { $profileScope, ALL_PROFILES } from '@/store/profile'
@@ -74,6 +73,7 @@ import {
 import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 
 import { BlueprintSlotControl, blueprintSlotHelp, cleanBlueprintFieldError, initialBlueprintValues } from './blueprints'
+import { mutateAndRefreshCronJobs, refreshCronJobs, triggerAndRefreshCronJobs } from './cron-actions'
 import {
   cronEditorUpdates,
   jobIsScriptOnly,
@@ -92,6 +92,10 @@ const MODEL_DEFAULT_VALUE = '__default__'
 // "Start from" default: the manual editor (blank cron). Any other value is a
 // blueprint key. Blueprint keys never collide with this sentinel.
 const CUSTOM_TEMPLATE = 'custom'
+
+function cronProfileForScope(scope: string): string {
+  return scope === ALL_PROFILES ? 'all' : scope
+}
 
 const SCHEDULE_OPTIONS: ReadonlyArray<ScheduleOption> = [
   { expr: '0 9 * * *', value: 'daily' },
@@ -299,7 +303,37 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   const jobs = useStore($cronJobs)
   const [loading, setLoading] = useState(jobs.length === 0)
   const [query, setQuery] = useState('')
-  const [busyJobId, setBusyJobId] = useState<null | string>(null)
+  const [busyJobTokens, setBusyJobTokens] = useState<ReadonlyMap<string, symbol>>(() => new Map())
+  const [triggeringJobKeys, setTriggeringJobKeys] = useState<ReadonlySet<string>>(() => new Set())
+  const triggerControllerRef = useRef<CronTriggerController | null>(null)
+
+  // eslint-disable-next-line no-restricted-syntax -- controller mount identity, not an atom mirror
+  useEffect(() => {
+    const controller = createCronTriggerController((key, running) => {
+      if (triggerControllerRef.current !== controller) {
+        return
+      }
+
+      setTriggeringJobKeys(current => {
+        const next = new Set(current)
+
+        if (running) {
+          next.add(key)
+        } else {
+          next.delete(key)
+        }
+
+        return next
+      })
+    })
+
+    triggerControllerRef.current = controller
+
+    return () => {
+      triggerControllerRef.current = null
+    }
+  }, [])
+
   // Master/detail: the job whose schedule + run history fill the right pane.
   const [selectedJobId, setSelectedJobId] = useState<null | string>(null)
   // Set when a job is opened from the sidebar so we scroll it into view once the
@@ -315,21 +349,30 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   // default — scope the fetch to the sidebar's profile scope so this overlay
   // and the sidebar (which share the $cronJobs atom) agree on what's shown.
   const profileScope = useStore($profileScope)
+  const profile = cronProfileForScope(profileScope)
 
   const refresh = useCallback(async () => {
-    try {
-      setCronJobs(await getCronJobs(profileScope === ALL_PROFILES ? 'all' : profileScope))
-    } catch (err) {
-      notifyError(err, c.failedLoad)
-    } finally {
-      setLoading(false)
+    const { refreshError, stale } = await refreshCronJobs(profile)
+
+    if (stale) {
+      return
     }
-  }, [c, profileScope])
+
+    if (refreshError) {
+      notifyError(refreshError, c.failedLoad)
+    }
+
+    setLoading(false)
+  }, [c, profile])
 
   useRefreshHotkey(refresh)
 
   useEffect(() => {
     void refresh()
+    // Fence the previous profile's request before the next profile effect, and
+    // fence every pending completion when the overlay unmounts.
+
+    return () => invalidateCronJobsRequests()
   }, [refresh])
 
   // Sidebar → "open this job": resolve the focus id (or name) to a job, select
@@ -395,13 +438,46 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
 
   const totalCount = jobs.length
 
+  function beginJobBusy(jobId: string): symbol {
+    const token = Symbol(jobId)
+
+    setBusyJobTokens(current => new Map(current).set(jobId, token))
+
+    return token
+  }
+
+  function endJobBusy(jobId: string, token: symbol): void {
+    setBusyJobTokens(current => {
+      if (current.get(jobId) !== token) {
+        return current
+      }
+
+      const next = new Map(current)
+
+      next.delete(jobId)
+
+      return next
+    })
+  }
+
   async function handlePauseResume(job: CronJob) {
-    setBusyJobId(job.id)
+    const busyToken = beginJobBusy(job.id)
 
     try {
       const isPaused = jobState(job) === 'paused'
-      const updated = isPaused ? await resumeCronJob(job.id) : await pauseCronJob(job.id)
-      updateCronJobs(rows => rows.map(row => (row.id === job.id ? updated : row)))
+
+      const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
+        isPaused ? resumeCronJob(job.id) : pauseCronJob(job.id)
+      )
+
+      if (stale) {
+        return
+      }
+
+      if (refreshError) {
+        notifyError(refreshError, c.failedLoad)
+      }
+
       notify({
         kind: 'success',
         title: isPaused ? c.resumed : c.paused,
@@ -410,21 +486,50 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
     } catch (err) {
       notifyError(err, c.failedUpdate)
     } finally {
-      setBusyJobId(null)
+      endJobBusy(job.id, busyToken)
     }
   }
 
   async function handleTrigger(job: CronJob) {
-    setBusyJobId(job.id)
+    const viewProfile = profile
+    const key = `${viewProfile}:${job.id}`
+    const controller = triggerControllerRef.current
+
+    if (!controller) {
+      return
+    }
 
     try {
-      const updated = await triggerCronJob(job.id)
-      updateCronJobs(rows => rows.map(row => (row.id === job.id ? updated : row)))
+      const run = await controller.run(
+        key,
+        () => triggerAndRefreshCronJobs(job.id, viewProfile),
+        () => notify({ kind: 'info', title: c.triggerNow, message: truncate(jobTitle(job), 60) })
+      )
+
+      if (
+        triggerControllerRef.current !== controller ||
+        cronProfileForScope($profileScope.get()) !== viewProfile ||
+        !run.started ||
+        !run.value
+      ) {
+        return
+      }
+
+      const { refreshError, stale } = run.value
+
+      if (stale) {
+        return
+      }
+
+      if (refreshError) {
+        notifyError(refreshError, c.failedLoad)
+      }
+
       notify({ kind: 'success', title: c.triggered, message: truncate(jobTitle(job), 60) })
     } catch (err) {
-      notifyError(err, c.failedTrigger)
-    } finally {
-      setBusyJobId(null)
+      if (triggerControllerRef.current === controller && cronProfileForScope($profileScope.get()) === viewProfile) {
+        notifyError(err, c.failedTrigger)
+      }
     }
   }
 
@@ -436,8 +541,18 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
     setDeleting(true)
 
     try {
-      await deleteCronJob(pendingDelete.id)
-      updateCronJobs(rows => rows.filter(row => row.id !== pendingDelete.id))
+      const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
+        deleteCronJob(pendingDelete.id)
+      )
+
+      if (stale) {
+        return
+      }
+
+      if (refreshError) {
+        notifyError(refreshError, c.failedLoad)
+      }
+
       notify({ kind: 'success', title: c.deleted, message: truncate(jobTitle(pendingDelete), 60) })
       setPendingDelete(null)
     } catch (err) {
@@ -449,22 +564,40 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
 
   async function handleEditorSave(values: EditorValues) {
     if (editor.mode === 'create') {
-      const created = await createCronJob({
-        prompt: values.prompt,
-        schedule: values.schedule,
-        name: values.name || undefined,
-        deliver: values.deliver || DEFAULT_DELIVER,
-        ...(values.model.trim() ? { model: values.model.trim(), provider: values.provider.trim() || undefined } : {})
-      })
+      const { value: created, refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
+        createCronJob({
+          prompt: values.prompt,
+          schedule: values.schedule,
+          name: values.name || undefined,
+          deliver: values.deliver || DEFAULT_DELIVER,
+          ...(values.model.trim() ? { model: values.model.trim(), provider: values.provider.trim() || undefined } : {})
+        })
+      )
 
-      updateCronJobs(rows => [...rows, created])
+      if (stale || !created) {
+        return
+      }
+
+      if (refreshError) {
+        notifyError(refreshError, c.failedLoad)
+      }
+
       notify({ kind: 'success', title: c.created, message: truncate(jobTitle(created), 60) })
     } else if (editor.mode === 'edit') {
       const scriptOnlyJob = jobIsScriptOnly(editor.job)
 
-      const updated = await updateCronJob(editor.job.id, cronEditorUpdates(values, { scriptOnlyJob }))
+      const { value: updated, refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
+        updateCronJob(editor.job.id, cronEditorUpdates(values, { scriptOnlyJob }))
+      )
 
-      updateCronJobs(rows => rows.map(row => (row.id === updated.id ? updated : row)))
+      if (stale || !updated) {
+        return
+      }
+
+      if (refreshError) {
+        notifyError(refreshError, c.failedLoad)
+      }
+
       notify({ kind: 'success', title: c.updated, message: truncate(jobTitle(updated), 60) })
     }
 
@@ -477,14 +610,20 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   // real per-profile job, and "all" is not a writable target — collapse it to
   // 'default', matching the manual create path in handleEditorSave.
   async function handleBlueprintCreate(blueprint: AutomationBlueprint, values: Record<string, string>) {
-    const profile = profileScope === ALL_PROFILES ? 'default' : profileScope
-    const job = await instantiateAutomationBlueprint({ blueprint: blueprint.key, values }, profile)
+    const writableProfile = profileScope === ALL_PROFILES ? 'default' : profileScope
 
-    updateCronJobs(rows => {
-      const rest = rows.filter(row => row.id !== job.id)
+    const { value: job, refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
+      instantiateAutomationBlueprint({ blueprint: blueprint.key, values }, writableProfile)
+    )
 
-      return [...rest, job]
-    })
+    if (stale || !job) {
+      return
+    }
+
+    if (refreshError) {
+      notifyError(refreshError, c.failedLoad)
+    }
+
     notify({ kind: 'success', title: c.blueprints.scheduled, message: asText(job.schedule_display) || blueprint.title })
     setEditor({ mode: 'closed' })
   }
@@ -555,7 +694,7 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
 
           {selectedJob ? (
             <CronJobDetail
-              busy={busyJobId === selectedJob.id}
+              busy={busyJobTokens.has(selectedJob.id) || triggeringJobKeys.has(`${profile}:${selectedJob.id}`)}
               c={c}
               job={selectedJob}
               onOpenSession={onOpenSession}

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 
-import { getCronJobs, listAllProfileSessions, listSidebarSessions, type SessionInfo } from '@/hermes'
+import { listAllProfileSessions, listSidebarSessions, type SessionInfo } from '@/hermes'
 import { sameCronSignature } from '@/lib/session-signatures'
 import {
   isMessagingSource,
@@ -8,7 +8,6 @@ import {
   MESSAGING_SESSION_SOURCE_IDS,
   normalizeSessionSource
 } from '@/lib/session-source'
-import { setCronJobs } from '@/store/cron'
 import {
   $pinnedSessionIds,
   $sessionsLimit,
@@ -37,6 +36,8 @@ import {
   setSessionsLoading
 } from '@/store/session'
 import { $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
+
+import { refreshCronJobs as refreshCronJobsStore } from '../../cron/cron-actions'
 
 // The recents list is local-only: cron rows have their own section, kanban
 // dispatcher workers are read on the board, and each messaging platform
@@ -139,9 +140,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // own jobs; ALL_PROFILES keeps the unified view.
   const refreshCronJobs = useCallback(async () => {
     try {
-      const jobs = await getCronJobs(profileScope === ALL_PROFILES ? 'all' : profileScope)
-
-      setCronJobs(jobs)
+      await refreshCronJobsStore(profileScope === ALL_PROFILES ? 'all' : profileScope)
     } catch {
       // Non-fatal: the cron section just keeps its last-known jobs.
     }

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -22,7 +22,8 @@ import {
   resetSidebarBatchCapability,
   setApiRequestProfile,
   speakText,
-  transcribeAudio
+  transcribeAudio,
+  triggerCronJob
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -308,6 +309,21 @@ describe('Hermes REST helpers', () => {
       await call()
       expect(api).toHaveBeenCalledWith(expect.objectContaining({ path, timeoutMs: 60_000 }))
     }
+  })
+
+  it('waits for synchronous cron triggers as a long-running operation', async () => {
+    api.mockResolvedValue({ id: 'job-1' })
+
+    await triggerCronJob('job-1')
+
+    const request = api.mock.calls[0]?.[0]
+    expect(request).toEqual(
+      expect.objectContaining({
+        path: '/api/cron/jobs/job-1/trigger',
+        method: 'POST'
+      })
+    )
+    expect(request.timeoutMs).toBeGreaterThanOrEqual(60 * 60 * 1000)
   })
 
   it('keeps the liveness poll on the short default so a dead backend fails fast', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -86,6 +86,11 @@ import type {
 export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
+// The cron trigger endpoint intentionally waits for the whole job so its
+// response reflects the persisted execution result. Agent jobs can run far
+// longer than the Electron fetch default; keep this override local to the one
+// synchronous long-operation endpoint rather than weakening all API timeouts.
+export const CRON_TRIGGER_REQUEST_TIMEOUT_MS = 24 * 60 * 60 * 1000
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
 // stream / message.complete events, NOT by the RPC return. A long turn (MoA
 // presets running references + aggregator in series, deep reasoning, large tool
@@ -1464,7 +1469,8 @@ export function triggerCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
     ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}/trigger`,
-    method: 'POST'
+    method: 'POST',
+    timeoutMs: CRON_TRIGGER_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/apps/desktop/src/store/cron.test.ts
+++ b/apps/desktop/src/store/cron.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $cronJobs,
+  beginCronJobsRequest,
+  commitCronJobsRequest,
+  setCronJobs,
+  updateCronJobs
+} from './cron'
+
+const oldJob = { id: 'old' } as never
+const newJob = { id: 'new' } as never
+
+describe('cron jobs request fencing', () => {
+  beforeEach(() => {
+    setCronJobs([])
+  })
+
+  it('rejects an older refresh after a newer refresh commits', () => {
+    const older = beginCronJobsRequest('all')
+    const newer = beginCronJobsRequest('all')
+
+    expect(commitCronJobsRequest(newer, [newJob])).toBe(true)
+    expect(commitCronJobsRequest(older, [oldJob])).toBe(false)
+    expect($cronJobs.get()).toEqual([newJob])
+  })
+
+  it('rejects a refresh from the previous profile scope', () => {
+    const work = beginCronJobsRequest('work')
+
+    beginCronJobsRequest('personal')
+
+    expect(commitCronJobsRequest(work, [oldJob])).toBe(false)
+    expect($cronJobs.get()).toEqual([])
+  })
+
+  it('rejects an in-flight poll after a local mutation', () => {
+    const poll = beginCronJobsRequest('all')
+
+    updateCronJobs(() => [newJob])
+
+    expect(commitCronJobsRequest(poll, [oldJob])).toBe(false)
+    expect($cronJobs.get()).toEqual([newJob])
+  })
+})

--- a/apps/desktop/src/store/cron.ts
+++ b/apps/desktop/src/store/cron.ts
@@ -6,11 +6,81 @@ import type { CronJob } from '@/types/hermes'
 // the job — schedule, state, live next-run countdown — makes the job the
 // first-class entity; its runs (sessions) resolve under it in the cron detail.
 export const $cronJobs = atom<CronJob[]>([])
-export const setCronJobs = (jobs: CronJob[]) => $cronJobs.set(jobs)
+
+export interface CronJobsRequest {
+  generation: number
+  scope: string
+}
+
+export interface CronJobsScopeToken {
+  generation: number
+  scope: string
+}
+
+let cronJobsRequestGeneration = 0
+let cronJobsRequestScope = ''
+let cronJobsScopeGeneration = 0
+
+function activateCronJobsScope(scope: string): void {
+  if (scope === cronJobsRequestScope) {
+    return
+  }
+
+  cronJobsRequestScope = scope
+  cronJobsRequestGeneration += 1
+  cronJobsScopeGeneration += 1
+}
+
+export function beginCronJobsRequest(scope: string): CronJobsRequest {
+  activateCronJobsScope(scope)
+  cronJobsRequestGeneration += 1
+
+  return { generation: cronJobsRequestGeneration, scope }
+}
+
+export function beginCronJobsAction(scope: string): CronJobsScopeToken {
+  activateCronJobsScope(scope)
+
+  return { generation: cronJobsScopeGeneration, scope }
+}
+
+export function isCronJobsScopeCurrent(token: CronJobsScopeToken): boolean {
+  return token.scope === cronJobsRequestScope && token.generation === cronJobsScopeGeneration
+}
+
+export function isCronJobsRequestCurrent(request: CronJobsRequest): boolean {
+  return request.scope === cronJobsRequestScope && request.generation === cronJobsRequestGeneration
+}
+
+export function invalidateCronJobsRequests(): void {
+  cronJobsRequestGeneration += 1
+  cronJobsScopeGeneration += 1
+}
+
+export function commitCronJobsRequest(request: CronJobsRequest, jobs: CronJob[]): boolean {
+  if (!isCronJobsRequestCurrent(request)) {
+    return false
+  }
+
+  // Consume the token so neither a duplicate completion nor any older request
+  // can publish after this authoritative snapshot.
+  cronJobsRequestGeneration += 1
+  $cronJobs.set(jobs)
+
+  return true
+}
+
+export const setCronJobs = (jobs: CronJob[]) => {
+  cronJobsRequestGeneration += 1
+  $cronJobs.set(jobs)
+}
 
 // In-place edit so the cron overlay's mutations (create/edit/delete/pause/…)
 // land in the same atom the sidebar renders — no stale list until the next poll.
-export const updateCronJobs = (fn: (jobs: CronJob[]) => CronJob[]) => $cronJobs.set(fn($cronJobs.get()))
+export const updateCronJobs = (fn: (jobs: CronJob[]) => CronJob[]) => {
+  cronJobsRequestGeneration += 1
+  $cronJobs.set(fn($cronJobs.get()))
+}
 
 // One-shot focus target: clicking "Manage" on a job sets this, then opens the
 // cron overlay, which reads it once to select + scroll to that job. Cleared

--- a/apps/shared/src/cron-trigger-controller.ts
+++ b/apps/shared/src/cron-trigger-controller.ts
@@ -1,0 +1,40 @@
+export interface CronTriggerRunResult<T> {
+  started: boolean
+  value: T | null
+}
+
+export interface CronTriggerController {
+  isRunning(key: string): boolean
+  run<T>(key: string, action: () => Promise<T>, onStarted?: () => void): Promise<CronTriggerRunResult<T>>
+}
+
+// This is an interaction guard for one mounted UI surface. Cross-window and
+// cross-process exclusion remains the backend's responsibility via its durable
+// cron claim; a renderer-local Set must never be treated as the execution lock.
+export function createCronTriggerController(
+  onRunningChange: (key: string, running: boolean) => void = () => undefined
+): CronTriggerController {
+  const running = new Set<string>()
+
+  return {
+    isRunning: key => running.has(key),
+    async run<T>(key: string, action: () => Promise<T>, onStarted?: () => void) {
+      if (running.has(key)) {
+        return { started: false, value: null }
+      }
+
+      running.add(key)
+
+      try {
+        onRunningChange(key, true)
+
+        onStarted?.()
+
+        return { started: true, value: await action() }
+      } finally {
+        running.delete(key)
+        onRunningChange(key, false)
+      }
+    }
+  }
+}

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -35,6 +35,11 @@ export {
   type SettlementOutcome
 } from './charge-settlement'
 export {
+  createCronTriggerController,
+  type CronTriggerController,
+  type CronTriggerRunResult
+} from './cron-trigger-controller'
+export {
   type ConnectionState,
   type GatewayClientOptions,
   type GatewayEvent,

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -17,7 +17,10 @@ from typing import Any, Dict, Iterator, List, Optional
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
-EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
+# Optional test override. Production resolves the path at transaction time so
+# dashboard operations that temporarily enter another profile cannot leak that
+# profile's execution records into the import-time home.
+EXECUTIONS_FILE: Optional[Path] = None
 MAX_TERMINAL_EXECUTIONS = 1000
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
@@ -25,8 +28,9 @@ _PROCESS_ID = uuid.uuid4().hex
 
 
 def _connect() -> sqlite3.Connection:
-    EXECUTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    return sqlite3.connect(EXECUTIONS_FILE, timeout=5)
+    path = EXECUTIONS_FILE or (get_hermes_home().resolve() / "cron" / "executions.db")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(path, timeout=5)
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -103,6 +103,8 @@ TICKER_INTERVAL_SECONDS = 60
 # concurrent mark_job_run / advance_next_run calls can clobber each other.
 _jobs_file_lock = threading.RLock()
 _jobs_lock_state = threading.local()
+_fire_fence_locks: Dict[str, threading.RLock] = {}
+_fire_fence_locks_guard = threading.Lock()
 
 # Upper bound on waiting for the cross-process .jobs.lock flock (#60703).
 # Every cron function in the process funnels through _jobs_lock(), and the
@@ -370,6 +372,86 @@ def _jobs_lock():
         finally:
             _jobs_lock_state.depth = 0
             _jobs_lock_state.load_stamp = None
+
+
+@contextlib.contextmanager
+def _fire_job_lock(job_id: str):
+    """Serialize one job's owner mutations and external side effects.
+
+    Unlike the global jobs lock, this lock may be held across network delivery.
+    It is scoped to one profile + job, so unrelated cron jobs keep progressing.
+    Fencing fails closed when cross-process locking is unavailable.
+    """
+    cron_dir = _current_cron_store().cron_dir
+    lock_key = f"{cron_dir.resolve()}::{job_id}"
+    with _fire_fence_locks_guard:
+        local_lock = _fire_fence_locks.setdefault(lock_key, threading.RLock())
+
+    with local_lock:
+        ensure_dirs()
+        lock_name = uuid.uuid5(uuid.NAMESPACE_URL, lock_key).hex
+        lock_path = cron_dir / f".fire-{lock_name}.lock"
+        lock_fd = None
+        acquired = False
+        try:
+            lock_fd = open(lock_path, "a+", encoding="utf-8")
+            lock_fd.seek(0)
+            if fcntl is not None:
+                deadline = time.monotonic() + _JOBS_LOCK_TIMEOUT_SECONDS
+                while True:
+                    try:
+                        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        acquired = True
+                        break
+                    except (OSError, IOError):
+                        if time.monotonic() >= deadline:
+                            logger.error(
+                                "Timed out waiting for fire fence %s; failing closed",
+                                lock_path,
+                            )
+                            break
+                        time.sleep(0.1)
+            elif msvcrt is not None:
+                getattr(msvcrt, "locking")(
+                    lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1
+                )
+                acquired = True
+            else:  # pragma: no cover - supported platforms provide one backend
+                logger.error("No cross-process lock backend for cron fire fence")
+        except (OSError, IOError) as exc:
+            logger.error("Cron fire fence unavailable for %s: %s", job_id, exc)
+
+        try:
+            yield acquired
+        finally:
+            if lock_fd is not None:
+                try:
+                    if acquired and fcntl is not None:
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    elif acquired and msvcrt is not None:
+                        getattr(msvcrt, "locking")(
+                            lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1
+                        )
+                except (OSError, IOError):
+                    pass
+                finally:
+                    lock_fd.close()
+
+
+@contextlib.contextmanager
+def fire_claim_fence(job_id: str, *, expected_owner: str):
+    """Hold a per-job fence while an owner performs an external side effect."""
+    with _fire_job_lock(job_id) as acquired:
+        if not acquired:
+            yield False
+            return
+        with _jobs_lock():
+            job = next((item for item in load_jobs() if item.get("id") == job_id), None)
+            claim = job.get("fire_claim") if isinstance(job, dict) else None
+            owns_claim = (
+                isinstance(claim, dict) and claim.get("by") == expected_owner
+            )
+        yield owns_claim
 
 # Fields on a cron job that must never change after creation. ``id`` is used
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
@@ -2069,8 +2151,35 @@ def remove_job(job_id: str) -> bool:
                     "Failed to clear notepad for removed job %s",
                     canonical_id, exc_info=True,
                 )
+            # Prune the per-job fire-fence lock entry so the registry does
+            # not grow monotonically across create/remove cycles.
+            _fence_key = f"{_current_cron_store().cron_dir.resolve()}::{canonical_id}"
+            with _fire_fence_locks_guard:
+                _fire_fence_locks.pop(_fence_key, None)
             return True
     return False
+
+
+def mark_job_run(
+    job_id: str,
+    success: bool,
+    error: Optional[str] = None,
+    delivery_error: Optional[str] = None,
+    status: Optional[str] = None,
+    *,
+    expected_fire_owner: Optional[str] = None,
+) -> bool:
+    with _fire_job_lock(job_id) as acquired:
+        if not acquired:
+            return False
+        return _mark_job_run_locked(
+            job_id,
+            success,
+            error,
+            delivery_error,
+            status=status,
+            expected_fire_owner=expected_fire_owner,
+        )
 
 
 def _set_alert_flag(job_id: str, field: str, value: bool) -> bool:
@@ -2124,9 +2233,15 @@ def clear_drift_alerted(job_id: str) -> None:
     _set_alert_flag(job_id, "drift_alerted", False)
 
 
-def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None,
-                 status: Optional[str] = None):
+def _mark_job_run_locked(
+    job_id: str,
+    success: bool,
+    error: Optional[str] = None,
+    delivery_error: Optional[str] = None,
+    *,
+    status: Optional[str] = None,
+    expected_fire_owner: Optional[str] = None,
+) -> bool:
     """
     Mark a job as having been run.
     
@@ -2146,6 +2261,15 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         jobs = load_jobs()
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
+                if expected_fire_owner is not None:
+                    claim = job.get("fire_claim")
+                    if not isinstance(claim, dict) or claim.get("by") != expected_fire_owner:
+                        logger.warning(
+                            "mark_job_run: job_id %s fire claim owner changed; "
+                            "discarding stale completion",
+                            job_id,
+                        )
+                        return False
                 now = _hermes_now().isoformat()
                 job["last_run_at"] = now
                 job["last_status"] = status or ("ok" if success else "error")
@@ -2205,7 +2329,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         job["state"] = "completed"
                         job["next_run_at"] = None
                         save_jobs(jobs)
-                        return
+                        return True
                 
                 # Compute next run
                 job["next_run_at"] = compute_next_run(job["schedule"], now)
@@ -2240,9 +2364,10 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     job["state"] = "scheduled"
 
                 save_jobs(jobs)
-                return
+                return True
 
         logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
+        return False
 
 
 def _write_wedged_oneshot_diagnostic(job: Dict[str, Any]) -> None:
@@ -2474,7 +2599,31 @@ def _machine_id() -> str:
     return f"{host}:{os.getpid()}"
 
 
-def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
+def claim_job_for_fire(
+    job_id: str,
+    *,
+    claim_ttl_seconds: int = 300,
+    force: bool = False,
+    return_job: bool = False,
+) -> Union[bool, Dict[str, Any]]:
+    with _fire_job_lock(job_id) as acquired:
+        if not acquired:
+            return False
+        return _claim_job_for_fire_locked(
+            job_id,
+            claim_ttl_seconds=claim_ttl_seconds,
+            force=force,
+            return_job=return_job,
+        )
+
+
+def _claim_job_for_fire_locked(
+    job_id: str,
+    *,
+    claim_ttl_seconds: int = 300,
+    force: bool = False,
+    return_job: bool = False,
+) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for a single external 'fire' (multi-machine
     at-most-once). Returns True iff THIS caller won the claim.
 
@@ -2482,7 +2631,10 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
     external scheduler (Chronos) signals a job is due across N gateway replicas:
     exactly one wins. Single-machine deployments always win.
 
-    Under the file lock: reject if the job is missing/disabled/paused. If a
+    Under the file lock: reject if the job is missing/disabled/paused. An
+    explicit manual fire may pass ``force=True`` to atomically enable and
+    resume the job as part of the claim; external scheduler callbacks must
+    leave it false so a stale callback cannot resurrect a paused job. If a
     fresh claim (younger than ``claim_ttl_seconds``) already exists, lose.
     Otherwise stamp a ``fire_claim`` and, for recurring jobs, advance
     ``next_run_at`` (mirrors ``advance_next_run``'s at-most-once bump so a stale
@@ -2501,8 +2653,10 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
             if job["id"] != job_id:
                 continue
             # enabled + pause markers must both clear — a half-paused record
-            # (enabled=true, state=paused/paused_at set) must not claim.
-            if not is_job_runnable(job):
+            # (enabled=true, state=paused/paused_at set) must not claim. An
+            # explicit ``force`` (Trigger-now on a paused job) bypasses the
+            # gate and atomically resumes the job below.
+            if not force and not is_job_runnable(job):
                 return False
             now = _hermes_now()
             existing = job.get("fire_claim")
@@ -2520,14 +2674,23 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
                         return False  # someone holds a fresh claim
                 except Exception:
                     pass  # malformed claim → overwrite
-            job["fire_claim"] = {"at": now.isoformat(), "by": _machine_id()}
+            if force:
+                job["enabled"] = True
+                job["state"] = "scheduled"
+                job["paused_at"] = None
+                job["paused_reason"] = None
+            # Per-acquisition token: a process may legitimately reclaim its own
+            # stale lease, and the previous runner must not heartbeat the new
+            # claim merely because hostname + PID are unchanged.
+            owner = f"{_machine_id()}:{uuid.uuid4().hex}"
+            job["fire_claim"] = {"at": now.isoformat(), "by": owner}
             kind = job.get("schedule", {}).get("kind")
             if kind in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())
                 if nxt:
                     job["next_run_at"] = nxt
             save_jobs(jobs)
-            return True
+            return copy.deepcopy(job) if return_job else True
         return False
 
 
@@ -2615,6 +2778,39 @@ def _sweep_completed_oneshots(
                 exc_info=True,
             )
     return removed
+
+
+def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
+    with _fire_job_lock(job_id) as acquired:
+        if not acquired:
+            return False
+        return _heartbeat_fire_claim_locked(
+            job_id,
+            expected_owner=expected_owner,
+        )
+
+
+def _heartbeat_fire_claim_locked(job_id: str, *, expected_owner: str) -> bool:
+    """Refresh an active ``fire_claim`` without extending another owner's lease.
+
+    A cron execution can legitimately outlive the fire-claim TTL.  The shared
+    run wrapper calls this periodically so another scheduler process cannot
+    treat a live execution as abandoned and dispatch it again.  Comparing the
+    owner copied at dispatch prevents a stale runner from refreshing a claim
+    that has since been recovered by another process.
+    """
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job.get("id") != job_id:
+                continue
+            claim = job.get("fire_claim")
+            if not isinstance(claim, dict) or claim.get("by") != expected_owner:
+                return False
+            claim["at"] = _hermes_now().isoformat()
+            save_jobs(jobs)
+            return True
+    return False
 
 
 def get_due_jobs() -> List[Dict[str, Any]]:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -11,12 +11,14 @@ runs at a time if multiple processes overlap.
 import asyncio
 import atexit
 import concurrent.futures
+import contextlib
 import contextvars
 import json
 import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -34,7 +36,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Protocol
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -427,7 +429,18 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_runs, claim_dispatch, heartbeat_run_claim
+from cron.jobs import (
+    advance_next_runs,
+    claim_dispatch,
+    claim_job_for_fire,
+    fire_claim_fence,
+    get_due_jobs,
+    heartbeat_fire_claim,
+    heartbeat_run_claim,
+    mark_job_run,
+    save_job_output,
+    use_cron_store,
+)
 from cron.executions import create_execution, finish_execution, mark_execution_running
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -471,6 +484,7 @@ def _is_cron_silence_response(text: str) -> bool:
 _parallel_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _parallel_pool_max_workers: Optional[int] = None
 _running_job_ids: set = set()
+_running_fire_owners: dict[str, dict[object, tuple[Optional[str], Path]]] = {}
 _running_lock = threading.Lock()
 
 # Wall-clock (time.time()) instant each in-flight job id was claimed by
@@ -507,14 +521,46 @@ _FORCED_RELEASE_HISTORY = 20
 _INFLIGHT_MIN_ALLOWANCE_MINUTES = 30.0
 
 
-# Job IDs the gateway shutdown path force-killed the tool subprocess of
-# while still in ``_running_job_ids`` (see ``mark_running_jobs_interrupted``
-# below). ``run_one_job``'s own completion path checks this set before
-# writing its own ``last_status`` so a cron agent thread that keeps running
-# in-process after its tool was killed out from under it — and produces a
-# plausible-looking final response from truncated output — can never
-# overwrite the interrupted status with a false "ok" (#60432).
+# Execution tokens (``object()`` identity keys from ``_running_fire_owners``)
+# of runs the shutdown path force-interrupted — see
+# ``mark_running_jobs_interrupted`` below. ``run_one_job``'s own completion
+# path checks its OWN token before writing ``last_status`` so a cron agent
+# thread that keeps running in-process after its tool was killed out from
+# under it — and produces a plausible-looking final response from truncated
+# output — can never overwrite the interrupted status with a false "ok"
+# (#60432). Token keying keeps an interruption scoped to that exact
+# execution: a later run of the same job ID (recurring jobs reuse the ID
+# every fire) must not inherit the stale flag. Legacy dispatch paths without
+# a registered fire owner fall back to storing the bare job ID.
 _interrupted_job_ids: set = set()
+
+
+class _CancelEventLike(Protocol):
+    """Structural type for cancellation sources (``threading.Event`` and
+    ``_CombinedCancelEvent`` both satisfy it)."""
+
+    def is_set(self) -> bool: ...
+    def set(self) -> None: ...
+
+
+class _CombinedCancelEvent:
+    """Duck-typed ``threading.Event`` that ORs several cancellation sources.
+
+    ``run_one_job`` already derives a ``lost_ownership`` event from the
+    fire-claim heartbeat; transports (dashboard webhook drain, API server
+    shutdown) contribute their own per-task event. The worker only ever
+    calls ``is_set()`` / ``set()``, so a tiny wrapper beats a pump thread.
+    """
+
+    def __init__(self, *events: Optional["_CancelEventLike"]) -> None:
+        self._events = [event for event in events if event is not None]
+
+    def is_set(self) -> bool:
+        return any(event.is_set() for event in self._events)
+
+    def set(self) -> None:
+        for event in self._events:
+            event.set()
 
 
 def get_running_job_ids() -> "frozenset[str]":
@@ -533,7 +579,7 @@ def get_running_job_ids() -> "frozenset[str]":
     blind to them (#60432).
     """
     with _running_lock:
-        return frozenset(_running_job_ids)
+        return frozenset(_running_job_ids | _running_fire_owners.keys())
 
 
 def try_register_running_job(job_id: str) -> bool:
@@ -829,7 +875,11 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
     return [s[0] for s in stale]
 
 
-def mark_running_jobs_interrupted(reason: str) -> list:
+def mark_running_jobs_interrupted(
+    reason: str,
+    *,
+    only_owners: Optional[set] = None,
+) -> list:
     """Best-effort: mark every currently in-flight cron job interrupted.
 
     Called by the gateway shutdown path immediately after it force-kills
@@ -851,24 +901,62 @@ def mark_running_jobs_interrupted(reason: str) -> list:
     every entry in ``_running_agents`` on a drain timeout without
     per-agent correlation either.
 
+    ``only_owners``: optional set of ``(job_id, fire_owner)`` pairs. When
+    given (dashboard webhook drain), ONLY those exact executions are
+    marked — unrelated runs sharing the process (e.g. the desktop ticker's
+    own jobs) are left untouched. Interruption flags are recorded per
+    execution token, so a later run of the same job ID never consumes a
+    stale flag that targeted its dead predecessor.
+
     Returns the list of job IDs marked, for the caller to log.
     """
     with _running_lock:
-        job_ids = list(_running_job_ids)
-        _interrupted_job_ids.update(job_ids)
+        active_fires = [
+            (token, job_id, owner, profile_home)
+            for job_id, executions in _running_fire_owners.items()
+            for token, (owner, profile_home) in executions.items()
+        ]
+        if only_owners is not None:
+            active_fires = [
+                fire for fire in active_fires
+                if (fire[1], fire[2]) in only_owners
+            ]
+        registered_ids = {job_id for _t, job_id, _o, _p in active_fires}
+        if only_owners is None:
+            active_fires.extend(
+                (None, job_id, None, _get_hermes_home())
+                for job_id in _running_job_ids - registered_ids
+            )
+        _interrupted_job_ids.update(
+            token if token is not None else job_id
+            for token, job_id, _owner, _profile_home in active_fires
+        )
     marked = []
-    for job_id in job_ids:
+    for _token, job_id, fire_owner, profile_home in active_fires:
+        if not fire_owner:
+            logger.warning(
+                "Job '%s' interrupted before its durable fire owner was registered; "
+                "leaving persisted state untouched",
+                job_id,
+            )
+            continue
         try:
-            mark_job_run(job_id, False, reason)
-            marked.append(job_id)
+            with use_cron_store(profile_home):
+                if mark_job_run(
+                    job_id,
+                    False,
+                    reason,
+                    expected_fire_owner=fire_owner,
+                ):
+                    marked.append(job_id)
         except Exception as e:
             logger.warning("Failed to mark job %s interrupted: %s", job_id, e)
     return marked
 
 
-def _is_interrupted(job_id: str) -> bool:
-    """Non-destructive peek at whether the shutdown path has marked
-    ``job_id`` interrupted (see ``mark_running_jobs_interrupted``).
+def _is_interrupted(job_id: str, token: Optional[object] = None) -> bool:
+    """Non-destructive peek at whether the shutdown path has marked THIS
+    execution interrupted (see ``mark_running_jobs_interrupted``).
 
     Called by ``run_one_job`` BEFORE it decides what to deliver — a job
     whose tool subprocess was killed mid-flight may still produce a
@@ -876,24 +964,35 @@ def _is_interrupted(job_id: str) -> bool:
     that must not go out to the user as if it were a normal result.
     Unlike ``_consume_interrupted_flag`` below, this does not clear the
     flag: the later, authoritative check (right before ``last_status`` is
-    written) still needs to see it."""
+    written) still needs to see it. ``token`` scopes the check to one
+    exact execution: owner-registered runs are matched by token, so a
+    fresh run reusing the same job ID is not poisoned by a flag that
+    targeted its dead predecessor. The bare job ID is only ever stored
+    for legacy dispatch paths with no registered fire owner.
+    """
     with _running_lock:
+        if token is not None and token in _interrupted_job_ids:
+            return True
         return job_id in _interrupted_job_ids
 
 
-def _consume_interrupted_flag(job_id: str) -> bool:
+def _consume_interrupted_flag(job_id: str, token: Optional[object] = None) -> bool:
     """Return True and clear the flag if the shutdown path already marked
-    ``job_id`` interrupted (see ``mark_running_jobs_interrupted``).
+    THIS execution interrupted (see ``mark_running_jobs_interrupted``).
 
     Called by ``run_one_job`` right before it would otherwise write its own
     ``last_status``. Consuming (discarding) rather than just checking keeps
     the flag from leaking across a later, unrelated run of the same job ID
     (recurring jobs reuse their ID every fire)."""
     with _running_lock:
+        hit = False
+        if token is not None and token in _interrupted_job_ids:
+            _interrupted_job_ids.discard(token)
+            hit = True
         if job_id in _interrupted_job_ids:
             _interrupted_job_ids.discard(job_id)
-            return True
-        return False
+            hit = True
+        return hit
 
 
 # Sequential (env-mutating) cron jobs — workdir jobs that touch
@@ -2803,6 +2902,7 @@ _DEFAULT_SCRIPT_TIMEOUT = 3600  # seconds (1 hour)
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
 _RUN_CLAIM_HEARTBEAT_SECONDS = 60.0
+_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS = _RUN_CLAIM_HEARTBEAT_SECONDS * 3
 
 
 def _get_script_timeout() -> int:
@@ -2896,9 +2996,91 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
     return str(interpreter), env_overlay
 
 
+def _terminate_cron_script_process(proc: subprocess.Popen) -> None:
+    """Best-effort hard stop of a cron script and every child it spawned."""
+    if proc.poll() is not None:
+        return
+    if sys.platform == "win32":
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                capture_output=True,
+                timeout=10,
+                creationflags=windows_hide_flags(),
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            proc.kill()
+    else:
+        try:
+            process_group: Optional[int] = os.getpgid(proc.pid)
+        except (ProcessLookupError, OSError):
+            process_group = None
+        if process_group is not None:
+            try:
+                os.killpg(process_group, signal.SIGTERM)  # windows-footgun: ok — POSIX-only branch (win32 handled above)
+            except (ProcessLookupError, PermissionError, OSError):
+                process_group = None
+            if process_group is not None:
+                try:
+                    proc.wait(timeout=1.0)
+                except subprocess.TimeoutExpired:
+                    pass
+                # Escalate whenever ANY group member survived the TERM: a
+                # TERM-ignoring descendant keeps the stdio pipe write ends
+                # open, and the caller's communicate() would then block on
+                # EOF forever.  killpg(pgid, 0) probes group liveness.
+                try:
+                    os.killpg(process_group, 0)  # windows-footgun: ok — POSIX-only branch
+                except (ProcessLookupError, OSError):
+                    process_group = None
+                if process_group is not None:
+                    try:
+                        os.killpg(process_group, getattr(signal, "SIGKILL", signal.SIGTERM))
+                    except (ProcessLookupError, PermissionError, OSError):
+                        pass
+    try:
+        proc.wait(timeout=1.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=1.0)
+
+
+def _drain_script_pipes(proc: subprocess.Popen) -> None:
+    """Reap a terminated script process without ever blocking indefinitely.
+
+    A descendant that survived the tree kill can hold the pipe write ends
+    open, so a bare ``communicate()`` would wait for EOF forever.  Bound the
+    drain, then abandon the pipes — the caller only needs the process reaped
+    and the worker thread unblocked, not the output.
+    """
+    try:
+        proc.communicate(timeout=5.0)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        proc.kill()
+    except OSError:
+        pass
+    for stream in (proc.stdout, proc.stderr):
+        try:
+            if stream is not None:
+                stream.close()
+        except OSError:
+            pass
+    try:
+        proc.wait(timeout=5.0)
+    except subprocess.TimeoutExpired:
+        # Truly wedged — leave the zombie to the OS reaper rather than
+        # blocking the cron worker thread forever.
+        pass
+
+
 def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
+    cancel_event: Optional[_CancelEventLike] = None,
 ) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -3001,10 +3183,11 @@ def _run_job_script(
     try:
         from tools.environments.local import build_subprocess_env
 
-        popen_kwargs = {}
+        popen_kwargs: dict[str, Any] = {"start_new_session": True}
         if sys.platform == "win32":
             popen_kwargs = {
-                "creationflags": windows_hide_flags(),
+                "creationflags": windows_hide_flags()
+                | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
                 "encoding": "utf-8",
                 "errors": "replace",
             }
@@ -3015,17 +3198,34 @@ def _run_job_script(
         # NEVER mutate the Python process cwd — that would leak into
         # concurrent gateway sessions (#69396).
         _script_cwd = workdir or str(path.parent)
-        result = subprocess.run(
+        proc = subprocess.Popen(
             argv,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=script_timeout,
             cwd=_script_cwd,
             env=env,
             **popen_kwargs,
         )
-        stdout = (result.stdout or "").strip()
-        stderr = (result.stderr or "").strip()
+        deadline = time.monotonic() + script_timeout
+        while True:
+            if cancel_event is not None and cancel_event.is_set():
+                _terminate_cron_script_process(proc)
+                _drain_script_pipes(proc)
+                return False, "Script cancelled because cron fire ownership was lost"
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                _terminate_cron_script_process(proc)
+                _drain_script_pipes(proc)
+                return False, f"Script timed out after {script_timeout}s: {path}"
+            try:
+                stdout_raw, stderr_raw = proc.communicate(timeout=min(0.1, remaining))
+                break
+            except subprocess.TimeoutExpired:
+                continue
+
+        stdout = (stdout_raw or "").strip()
+        stderr = (stderr_raw or "").strip()
 
         # Redact secrets from both stdout and stderr before any return path.
         try:
@@ -3037,8 +3237,8 @@ def _run_job_script(
             stdout = "[REDACTED - redaction failed]"
             stderr = "[REDACTED - redaction failed]"
 
-        if result.returncode != 0:
-            parts = [f"Script exited with code {result.returncode}"]
+        if proc.returncode != 0:
+            parts = [f"Script exited with code {proc.returncode}"]
             if stderr:
                 parts.append(f"stderr:\n{stderr}")
             if stdout:
@@ -3047,14 +3247,15 @@ def _run_job_script(
 
         return True, stdout
 
-    except subprocess.TimeoutExpired:
-        return False, f"Script timed out after {script_timeout}s: {path}"
     except Exception as exc:
         return False, f"Script execution failed: {exc}"
 
 
 def _run_job_script_with_claim_heartbeat(
-    job: dict, script_path: str, workdir: Optional[str] = None,
+    job: dict,
+    script_path: str,
+    workdir: Optional[str] = None,
+    cancel_event: Optional[_CancelEventLike] = None,
 ) -> tuple[bool, str]:
     """Run a cron script while keeping its owned one-shot claim fresh.
 
@@ -3076,7 +3277,7 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -3107,10 +3308,10 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
 
     try:
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -3721,8 +3922,11 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
 
 
 def run_job(
-    job: dict, *, defer_agent_teardown: Optional[list] = None,
+    job: dict,
+    *,
+    defer_agent_teardown: Optional[list] = None,
     extra_prompt: Optional[str] = None,
+    cancel_event: Optional[_CancelEventLike] = None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -3802,7 +4006,7 @@ def run_job(
 
         try:
             ok, output = _run_job_script_with_claim_heartbeat(
-                job, script_path, workdir=_job_workdir,
+                job, script_path, workdir=_job_workdir, cancel_event=cancel_event,
             )
         except Exception as exc:
             logger.exception(
@@ -4004,7 +4208,9 @@ def run_job(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path)
+        prerun_script = _run_job_script_with_claim_heartbeat(
+            job, script_path, cancel_event=cancel_event,
+        )
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
@@ -4720,6 +4926,15 @@ def run_job(
         )
         _last_claim_heartbeat = time.monotonic()
 
+        def _abort_if_fire_claim_lost() -> None:
+            if cancel_event is None or not cancel_event.is_set():
+                return
+            if agent is not None and hasattr(agent, "interrupt"):
+                agent.interrupt("Cron fire claim ownership was lost")
+            raise RuntimeError(
+                f"Cron job '{job_name}' lost its durable fire claim ownership"
+            )
+
         def _heartbeat_run_claim_if_due():
             nonlocal _last_claim_heartbeat
             if not _is_oneshot or not _run_claim_owner:
@@ -4749,15 +4964,17 @@ def run_job(
             if _cron_inactivity_limit is None:
                 # Unlimited — no inactivity watchdog, but a one-shot still
                 # needs its run_claim heartbeat, so poll instead of blocking.
-                if _is_oneshot:
+                if _is_oneshot or cancel_event is not None:
                     result = None
                     while True:
                         done, _ = concurrent.futures.wait(
                             {_cron_future}, timeout=_POLL_INTERVAL,
                         )
                         if done:
+                            _abort_if_fire_claim_lost()
                             result = _cron_future.result()
                             break
+                        _abort_if_fire_claim_lost()
                         _heartbeat_run_claim_if_due()
                 else:
                     result = _cron_future.result()
@@ -4768,8 +4985,10 @@ def run_job(
                         {_cron_future}, timeout=_POLL_INTERVAL,
                     )
                     if done:
+                        _abort_if_fire_claim_lost()
                         result = _cron_future.result()
                         break
+                    _abort_if_fire_claim_lost()
                     _heartbeat_run_claim_if_due()
                     # Agent still running — check inactivity.
                     _idle_secs = 0.0
@@ -5115,9 +5334,117 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
+def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
+    """Run ``run`` while keeping this job's owned durable fire claim fresh."""
+    claim = job.get("fire_claim")
+    owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
+    if not owner:
+        return run(None)
+
+    job_id = str(job.get("id") or "")
+    stop = threading.Event()
+    lost_ownership = threading.Event()
+    heartbeat_context = contextvars.copy_context()
+
+    def _finish_unstarted(error: str) -> None:
+        execution_id = job.get("execution_id")
+        if not execution_id:
+            return
+        try:
+            finish_execution(execution_id, success=False, error=error)
+        except Exception:
+            logger.warning(
+                "Job '%s': failed to close unstarted execution ledger row",
+                job_id,
+                exc_info=True,
+            )
+
+    try:
+        owns_fire_claim = heartbeat_fire_claim(job_id, expected_owner=owner)
+    except Exception:
+        logger.warning(
+            "Job '%s': initial fire_claim validation failed",
+            job_id,
+            exc_info=True,
+        )
+        _finish_unstarted(
+            "Fire claim ownership could not be validated before execution started."
+        )
+        return True
+
+    if owns_fire_claim is False:
+        logger.warning(
+            "Job '%s': fire claim ownership was already lost before execution",
+            job_id,
+        )
+        _finish_unstarted("Fire claim ownership lost before execution started.")
+        return True
+
+    def _heartbeat_loop() -> None:
+        last_confirmed = time.monotonic()
+        while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
+            try:
+                if not heartbeat_fire_claim(job_id, expected_owner=owner):
+                    lost_ownership.set()
+                    logger.warning(
+                        "Job '%s': fire claim ownership lost; interrupting stale run",
+                        job_id,
+                    )
+                    return
+                last_confirmed = time.monotonic()
+            except Exception:
+                logger.debug(
+                    "Job '%s': fire_claim heartbeat failed",
+                    job_id,
+                    exc_info=True,
+                )
+                if (
+                    time.monotonic() - last_confirmed
+                    >= _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS
+                ):
+                    lost_ownership.set()
+                    logger.warning(
+                        "Job '%s': fire_claim could not be renewed within %.1fs; "
+                        "interrupting uncertain run",
+                        job_id,
+                        _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS,
+                    )
+                    return
+
+    heartbeat_thread = threading.Thread(
+        target=heartbeat_context.run,
+        args=(_heartbeat_loop,),
+        name="cron-fire-claim-heartbeat",
+        daemon=True,
+    )
+    try:
+        heartbeat_thread.start()
+    except Exception:
+        logger.warning(
+            "Job '%s': could not start fire_claim heartbeat",
+            job_id,
+            exc_info=True,
+        )
+        _finish_unstarted(
+            "Fire claim heartbeat could not be started; execution was not run."
+        )
+        return True
+
+    try:
+        return run(lost_ownership)
+    finally:
+        stop.set()
+        heartbeat_thread.join(timeout=1.0)
+
+
 def run_one_job(
-    job: dict, *, adapters=None, loop=None, verbose: bool = False,
+    job: dict,
+    *,
+    adapters=None,
+    loop=None,
+    verbose: bool = False,
     extra_prompt: Optional[str] = None,
+    cancel_event: Optional[_CancelEventLike] = None,
 ) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
@@ -5125,14 +5452,94 @@ def run_one_job(
     that BOTH the built-in ticker and an external provider's ``fire_due`` (e.g.
     Chronos) run the identical sequence — no duplicated correctness.
 
-    It does NOT decide whether the job is due, claim it, or compute the next
-    run — those are the caller's concern (``tick`` advances ``next_run_at``
-    under the file lock before dispatch; an external provider claims via the
-    store CAS). This function only fires the given job once.
+    It does NOT decide whether the job is due or acquire the initial claim —
+    both the ticker and external providers use the same store CAS before
+    calling it. It does keep an acquired claim alive for the full execution.
 
     Returns True if the job was processed (even if the job itself failed —
     failure is recorded via ``mark_job_run``), False only if processing raised.
+
+    ``cancel_event``: optional transport-level cancellation source (dashboard
+    webhook drain, API server shutdown). It is OR-combined with the internal
+    fire-claim heartbeat's lost-ownership event, so either trigger stops the
+    run cooperatively — agent interruption AND script process-tree kill —
+    through the single fenced completion path.
     """
+    claim = job.get("fire_claim")
+    fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
+    execution_token = object()
+    profile_home = _get_hermes_home().resolve()
+    with _running_lock:
+        _running_fire_owners.setdefault(job["id"], {})[execution_token] = (
+            fire_owner or None,
+            profile_home,
+        )
+    try:
+        return _run_with_fire_claim_heartbeat(
+            job,
+            lambda lost_ownership: _run_one_job_body(
+                job,
+                adapters=adapters,
+                loop=loop,
+                verbose=verbose,
+                extra_prompt=extra_prompt,
+                fire_claim_lost=(
+                    _CombinedCancelEvent(lost_ownership, cancel_event)
+                    if cancel_event is not None
+                    else lost_ownership
+                ),
+                execution_token=execution_token,
+            ),
+        )
+    finally:
+        with _running_lock:
+            executions = _running_fire_owners.get(job["id"])
+            if executions is not None:
+                executions.pop(execution_token, None)
+                if not executions:
+                    _running_fire_owners.pop(job["id"], None)
+
+
+def _run_one_job_body(
+    job: dict,
+    *,
+    adapters=None,
+    loop=None,
+    verbose: bool = False,
+    extra_prompt: Optional[str] = None,
+    fire_claim_lost: Optional[_CancelEventLike] = None,
+    execution_token: Optional[object] = None,
+) -> bool:
+    claim = job.get("fire_claim")
+    fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else None
+
+    class _FireClaimLostDuringSideEffect(Exception):
+        pass
+
+    def _side_effect_fence():
+        if fire_owner is None:
+            return contextlib.nullcontext(True)
+        return fire_claim_fence(job["id"], expected_owner=fire_owner)
+
+    def _fire_claim_ownership_lost() -> bool:
+        if fire_claim_lost is not None and fire_claim_lost.is_set():
+            return True
+        if fire_owner is None:
+            return False
+        try:
+            if heartbeat_fire_claim(job["id"], expected_owner=fire_owner):
+                return False
+        except Exception:
+            logger.debug(
+                "Job '%s': fire_claim ownership validation failed",
+                job["id"],
+                exc_info=True,
+            )
+            return False
+        if fire_claim_lost is not None:
+            fire_claim_lost.set()
+        return True
+
     execution_id = job.get("execution_id")
     if not execution_id:
         execution_id = create_execution(job["id"], source="direct")["id"]
@@ -5185,10 +5592,19 @@ def run_one_job(
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
         try:
-            success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents,
-                extra_prompt=extra_prompt,
-            )
+            if fire_claim_lost is None:
+                success, output, final_response, error = run_job(
+                    job,
+                    defer_agent_teardown=_deferred_agents,
+                    extra_prompt=extra_prompt,
+                )
+            else:
+                success, output, final_response, error = run_job(
+                    job,
+                    defer_agent_teardown=_deferred_agents,
+                    extra_prompt=extra_prompt,
+                    cancel_event=fire_claim_lost,
+                )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
             # it down here so a failed run never leaks its async resources
@@ -5201,6 +5617,37 @@ def run_one_job(
         finally:
             reset_secret_scope(_scope_token)
 
+        if _fire_claim_ownership_lost():
+            for _deferred_agent in _deferred_agents:
+                _teardown_cron_agent(_deferred_agent, job["id"])
+            # Distinguish a real ownership loss (TTL expiry / replacement
+            # claim) from a transport-level cancel (dashboard drain): in the
+            # latter case WE still own the claim, and silently discarding
+            # would leave fire_claim lingering until TTL and last_status
+            # stale. Probe ownership once; if still ours, record the
+            # interruption through the owner-fenced terminal write.
+            if fire_owner is not None and heartbeat_fire_claim(
+                job["id"], expected_owner=fire_owner,
+            ):
+                mark_job_run(
+                    job["id"],
+                    False,
+                    "Interrupted by shutdown before terminal completion.",
+                    expected_fire_owner=fire_owner,
+                )
+                finish_execution(
+                    execution_id,
+                    success=False,
+                    error="Interrupted by shutdown before terminal completion.",
+                )
+            else:
+                finish_execution(
+                    execution_id,
+                    success=False,
+                    error="Fire claim ownership lost; stale result was discarded.",
+                )
+            return True
+
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step
         # between run_job returning and delivery — save_job_output, the [SILENT]
@@ -5209,8 +5656,12 @@ def run_one_job(
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         delivery_error = None
         blocked_config = False
+        side_effect_ownership_lost = False
         try:
-            output_file = save_job_output(job["id"], output)
+            with _side_effect_fence() as owns_output:
+                if not owns_output:
+                    raise _FireClaimLostDuringSideEffect
+                output_file = save_job_output(job["id"], output)
             if verbose:
                 logger.info("Output saved to: %s", output_file)
 
@@ -5221,7 +5672,7 @@ def run_one_job(
             # "this run was interrupted" summary instead of that response.
             # Peek-only: the flag stays set for the authoritative check
             # right before mark_job_run below.
-            if success and _is_interrupted(job["id"]):
+            if success and _is_interrupted(job["id"], execution_token):
                 success = False
                 error = (
                     "Interrupted by gateway shutdown before the run finished "
@@ -5298,22 +5749,67 @@ def run_one_job(
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
 
+            if should_deliver and _fire_claim_ownership_lost():
+                should_deliver = False
+                logger.warning(
+                    "Job '%s': skipping delivery after fire claim ownership loss",
+                    job["id"],
+                )
+
             if should_deliver:
                 unresolved_origin = (
                     _normalize_deliver_value(job.get("deliver", "local")) == "origin"
                     and not _resolve_delivery_targets(job)
                 )
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    with _side_effect_fence() as owns_delivery:
+                        if not owns_delivery:
+                            raise _FireClaimLostDuringSideEffect
+                        delivery_error = _deliver_result(
+                            job,
+                            deliver_content,
+                            adapters=adapters,
+                            loop=loop,
+                        )
                 except Exception as de:
+                    if isinstance(de, _FireClaimLostDuringSideEffect):
+                        raise
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
+        except _FireClaimLostDuringSideEffect:
+            side_effect_ownership_lost = True
         finally:
             # Tear down the deferred agent(s) now that save + delivery have run
             # (or raised). Must happen on every path so cron agents never leak
             # their subprocesses/clients (#10200).
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
+
+        if side_effect_ownership_lost or _fire_claim_ownership_lost():
+            # Same transport-cancel distinction as the pre-side-effect path:
+            # if WE still own the claim, record the interruption instead of
+            # discarding silently (lingering claim + stale last_status).
+            if fire_owner is not None and heartbeat_fire_claim(
+                job["id"], expected_owner=fire_owner,
+            ):
+                mark_job_run(
+                    job["id"],
+                    False,
+                    "Interrupted by shutdown before terminal completion.",
+                    expected_fire_owner=fire_owner,
+                )
+                finish_execution(
+                    execution_id,
+                    success=False,
+                    error="Interrupted by shutdown before terminal completion.",
+                )
+            else:
+                finish_execution(
+                    execution_id,
+                    success=False,
+                    error="Fire claim ownership lost; stale result was discarded.",
+                )
+            return True
 
         # Treat empty final_response as a soft failure so last_status
         # is not "ok" — the agent ran but produced nothing useful.
@@ -5322,14 +5818,28 @@ def run_one_job(
             success = False
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
-        if not _consume_interrupted_flag(job["id"]):
-            if blocked_config:
-                mark_job_run(
-                    job["id"], success, error, delivery_error=delivery_error,
-                    status="blocked_config",
-                )
-            else:
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+        interrupted = _consume_interrupted_flag(job["id"], execution_token)
+        if interrupted:
+            finish_execution(
+                execution_id,
+                success=False,
+                error="Interrupted by gateway shutdown before terminal completion.",
+            )
+            return True
+
+        mark_kwargs = {"delivery_error": delivery_error}
+        if fire_owner is not None:
+            mark_kwargs["expected_fire_owner"] = fire_owner
+        if blocked_config:
+            mark_kwargs["status"] = "blocked_config"
+        marked = mark_job_run(job["id"], success, error, **mark_kwargs)
+        if fire_owner is not None and not marked:
+            finish_execution(
+                execution_id,
+                success=False,
+                error="Fire claim ownership lost before terminal completion.",
+            )
+            return True
         normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
         if delivery_error:
             delivery_outcome = "failed"
@@ -5356,12 +5866,16 @@ def run_one_job(
         # is never written, so the job sits in state "scheduled" until the
         # run-claim TTL expires and the dispatch-limit guard removes it with
         # no output and no error. Record the failure first, then re-raise
-        # anything that isn't a plain Exception.
+        # anything that isn't a plain Exception. Owner fencing still applies:
+        # a stale worker must not record over a replacement claim owner.
         _err_text = str(e) or type(e).__name__
         logger.error("Error processing job %s: %s", job['id'], _err_text)
         try:
-            if not _consume_interrupted_flag(job["id"]):
-                mark_job_run(job["id"], False, _err_text)
+            if not _consume_interrupted_flag(job["id"], execution_token):
+                mark_kwargs = {}
+                if fire_owner is not None:
+                    mark_kwargs["expected_fire_owner"] = fire_owner
+                mark_job_run(job["id"], False, _err_text, **mark_kwargs)
         except Exception as record_err:
             # Never let bookkeeping mask the original interruption.
             logger.error(
@@ -5550,6 +6064,10 @@ def tick(
         # bumping next_run_at forward so the grace window never expires.
         # mark_job_run() overwrites next_run_at on completion.
         # Batched: one load + one save for the whole due set, not one per job.
+        # Composes with the claim-time advance in claim_job_for_fire: for
+        # cron-kind jobs both compute the same next occurrence; interval jobs
+        # re-anchor from their own "now" at claim time (harmless for
+        # at-most-once — mark_job_run re-anchors at completion regardless).
         advance_next_runs([job["id"] for job in due_jobs])
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
@@ -5584,7 +6102,28 @@ def tick(
             module-level ``run_one_job`` so ``tick`` and external providers
             (Chronos ``fire_due``) use the identical execute→save→deliver→mark
             body."""
-            return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
+            # Acquire the durable claim only when this worker actually starts,
+            # not while it may wait behind other work in an executor queue.
+            # This prevents a queued lease from expiring before execution.
+            claimed = claim_job_for_fire(job["id"], return_job=True)
+            if not claimed:
+                finish_execution(
+                    job["execution_id"],
+                    success=False,
+                    error="Fire claim lost; execution was not started.",
+                )
+                return True
+            # Production CAS returns the exact persisted record with its unique
+            # owner. Bool fallback keeps older test doubles/API overrides
+            # compatible; real callers using return_job=True never take it.
+            claimed_job = dict(claimed) if isinstance(claimed, dict) else dict(job)
+            claimed_job["execution_id"] = job["execution_id"]
+            return run_one_job(
+                claimed_job,
+                adapters=adapters,
+                loop=loop,
+                verbose=verbose,
+            )
 
         # Partition due jobs: those with a per-job workdir mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -19,6 +19,7 @@ selected via the `cron.provider` config key (empty = built-in).
 """
 from __future__ import annotations
 
+import inspect
 import threading
 from abc import ABC, abstractmethod
 from typing import Any
@@ -98,7 +99,23 @@ class CronScheduler(ABC):
 
         return recover_interrupted_executions()
 
-    def fire_due(self, job_id: str, *, adapters: Any = None, loop: Any = None) -> bool:
+    @property
+    def supports_force_fire(self) -> bool:
+        """Whether ``fire_due`` accepts the additive ``force`` keyword.
+
+        Signature detection keeps providers written before ``force`` was added
+        source-compatible. Providers accepting ``**kwargs`` are compatible.
+        """
+        return provider_supports_force_fire(self)
+
+    def fire_due(
+        self,
+        job_id: str,
+        *,
+        adapters: Any = None,
+        loop: Any = None,
+        force: bool = False,
+    ) -> bool:
         """Run a single job NOW via the shared orchestrator. Called by the
         inbound fire webhook when an external scheduler signals a job is due.
 
@@ -107,26 +124,140 @@ class CronScheduler(ABC):
         ``run_one_job`` body. Built-in never calls this (it has its own tick
         loop); an external provider routes its inbound fire here.
 
-        Returns True if THIS caller claimed and ran the job, False if the claim
-        was lost (another machine/retry won it) or the job no longer exists.
+        Returns True if THIS caller claimed and processed the attempt, even if
+        the job itself failed. Returns False only if the claim was lost
+        (another machine/retry won it) or the job no longer exists.
         """
-        from cron.jobs import claim_job_for_fire, get_job
-        from cron.executions import create_execution
+        claimed_job = self.claim_fire(job_id, force=force)
+        if claimed_job is None:
+            return False
+        return self.fire_claimed(claimed_job, adapters=adapters, loop=loop)
+
+    def claim_fire(self, job_id: str, *, force: bool = False) -> dict | None:
+        """Durably claim one fire and create its audit attempt before dispatch.
+
+        Webhook transports call this synchronously before acknowledging the
+        external scheduler, then pass the exact owner-bearing snapshot to
+        ``fire_claimed`` in tracked background work.
+        """
+        from cron.executions import create_execution, finish_execution
+        from cron.jobs import claim_job_for_fire
+
+        execution = create_execution(job_id, source=self.name)
+        claim_kwargs = {"return_job": True}
+        if force:
+            claim_kwargs["force"] = True
+        try:
+            claimed_job = claim_job_for_fire(job_id, **claim_kwargs)
+        except BaseException as exc:
+            finish_execution(
+                execution["id"],
+                success=False,
+                error=f"Fire claim failed before dispatch: {type(exc).__name__}: {exc}",
+            )
+            raise
+        if not isinstance(claimed_job, dict):
+            finish_execution(
+                execution["id"],
+                success=False,
+                error="Fire claim was not acquired",
+            )
+            return None
+        claimed_job["execution_id"] = execution["id"]
+        return claimed_job
+
+    def fire_claimed(
+        self,
+        claimed_job: dict,
+        *,
+        adapters: Any = None,
+        loop: Any = None,
+        cancel_event: Any = None,
+    ) -> bool:
+        """Run an exact snapshot returned by ``claim_fire``.
+
+        ``cancel_event``: optional transport-owned ``threading.Event`` (or
+        compatible) that lets the caller stop this execution cooperatively
+        — e.g. the dashboard lifespan drain signalling pending webhook
+        fires before the event loop shuts down.
+        """
         from cron.scheduler import run_one_job
 
-        if not claim_job_for_fire(job_id):
-            return False  # another machine already claimed this fire
-        job = get_job(job_id)
-        if job is None:
-            return False  # job removed (e.g. repeat-N exhausted) between arm and fire
-        job["execution_id"] = create_execution(job_id, source=self.name)["id"]
-        return run_one_job(job, adapters=adapters, loop=loop)
+        run_one_job(
+            claimed_job,
+            adapters=adapters,
+            loop=loop,
+            cancel_event=cancel_event,
+        )
+        return True
 
     def reconcile(self) -> None:
         """Converge the external registry toward jobs.json (the desired state):
         arm missing one-shots, cancel orphaned ones, re-arm changed times.
         Built-in: no-op."""
         return None
+
+
+def provider_supports_force_fire(provider: Any) -> bool:
+    """Return whether a provider can safely receive ``fire_due(force=...)``."""
+    try:
+        parameters = inspect.signature(provider.fire_due).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        or (
+            parameter.name == "force"
+            and parameter.kind
+            in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        )
+        for parameter in parameters
+    )
+
+
+def provider_supports_split_fire(provider: Any) -> bool:
+    """Return whether a provider implements the two-phase fire contract.
+
+    The webhook admission path uses ``claim_fire`` + ``fire_claimed`` so the
+    202 response is backed by a durable, owner-fenced claim. A legacy
+    third-party provider that overrides the documented single-phase
+    ``fire_due`` hook (custom claim/re-arm/telemetry behavior) but inherits
+    the base ``claim_fire`` must keep being driven through its own
+    ``fire_due`` — silently routing around its override would drop that
+    behavior. Providers that customize ``claim_fire`` itself are already
+    split-aware and keep the two-phase path.
+    """
+    cls = type(provider)
+    fire_due_impl = getattr(cls, "fire_due", None)
+    claim_fire_impl = getattr(cls, "claim_fire", None)
+    fire_claimed_impl = getattr(cls, "fire_claimed", None)
+    if claim_fire_impl is not None and claim_fire_impl is not CronScheduler.claim_fire:
+        return True
+    # Overriding the second phase is also proof of split-awareness (the
+    # provider composes with the inherited claim path) — e.g. Chronos keeps
+    # its re-arm logic in ``fire_claimed`` only.
+    if fire_claimed_impl is not None and fire_claimed_impl is not CronScheduler.fire_claimed:
+        return True
+    if fire_due_impl is None or fire_due_impl is CronScheduler.fire_due:
+        return True
+    return False
+
+
+def provider_supports_fire_cancel(provider: Any) -> bool:
+    """Return whether ``fire_claimed`` accepts a ``cancel_event`` kwarg."""
+    try:
+        parameters = inspect.signature(provider.fire_claimed).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        or (
+            parameter.name == "cancel_event"
+            and parameter.kind
+            in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        )
+        for parameter in parameters
+    )
 
 
 def resolve_cron_scheduler() -> "CronScheduler":
@@ -167,6 +298,28 @@ def resolve_cron_scheduler() -> "CronScheduler":
             "Failed to load cron.provider '%s' (%s); using built-in ticker", name, e
         )
         return InProcessCronScheduler()
+
+
+def scheduler_for_profile_mode(
+    provider: "CronScheduler", *, multiplex_profiles: bool
+) -> "CronScheduler":
+    """Return a scheduler that can safely serve the gateway's profile mode.
+
+    External providers currently own one unscoped remote registry/client and
+    therefore cannot safely reconcile several profile stores from one process.
+    Fail closed to the built-in multiplex ticker until the provider API carries
+    explicit profile identity through lifecycle and webhook calls.
+    """
+    if not multiplex_profiles or isinstance(provider, InProcessCronScheduler):
+        return provider
+
+    import logging
+
+    logging.getLogger("cron.scheduler_provider").warning(
+        "cron.provider '%s' does not support multiplex_profiles; using built-in ticker",
+        provider.name,
+    )
+    return InProcessCronScheduler()
 
 
 class InProcessCronScheduler(CronScheduler):

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5918,7 +5918,10 @@ class APIServerAdapter(BasePlatformAdapter):
             if not job_id:
                 return web.json_response({"error": "missing job_id"}, status=400)
 
-            from cron.scheduler_provider import resolve_cron_scheduler
+            from cron.scheduler_provider import (
+                provider_supports_split_fire,
+                resolve_cron_scheduler,
+            )
             provider = resolve_cron_scheduler()
 
             loop = asyncio.get_running_loop()
@@ -5940,10 +5943,55 @@ class APIServerAdapter(BasePlatformAdapter):
                     runner = None
             adapters = getattr(runner, "adapters", None) or None
 
-            # Fire in the background (202 immediately). fire_due claims via the
-            # store CAS, so a retry while this is in flight is de-duped.
+            if not provider_supports_split_fire(provider):
+                # Legacy single-phase provider: it overrides the documented
+                # ``fire_due`` hook (custom claim/re-arm/telemetry) but
+                # inherits the base ``claim_fire`` — driving it through the
+                # split claim path would silently bypass that override.
+                task = asyncio.create_task(
+                    asyncio.to_thread(
+                        provider.fire_due,
+                        job_id,
+                        adapters=adapters,
+                        loop=loop,
+                    )
+                )
+                reservation["detached"] = True
+                task.add_done_callback(
+                    lambda _task: _release_pending_api_work(self, reservation)
+                )
+                try:
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
+                except (TypeError, AttributeError):
+                    pass
+                return web.json_response(
+                    {"status": "accepted", "job_id": job_id}, status=202
+                )
+
+            # Persist the attempt and exact store owner before acknowledging NAS.
+            # A failure here is retryable and the reservation remains attached.
+            try:
+                claimed_job = await asyncio.to_thread(provider.claim_fire, job_id)
+            except Exception as exc:
+                logger.error("cron fire admission failed for %s: %s", job_id, exc)
+                return web.json_response(
+                    {"error": "cron fire admission failed", "job_id": job_id},
+                    status=503,
+                )
+            if claimed_job is None:
+                return web.json_response(
+                    {"status": "duplicate", "job_id": job_id},
+                    status=200,
+                )
+
             task = asyncio.create_task(
-                asyncio.to_thread(provider.fire_due, job_id, adapters=adapters, loop=loop)
+                asyncio.to_thread(
+                    provider.fire_claimed,
+                    claimed_job,
+                    adapters=adapters,
+                    loop=loop,
+                )
             )
             reservation["detached"] = True
             task.add_done_callback(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29630,9 +29630,17 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # historical in-process 60s ticker; an external provider (e.g. chronos)
     # may arm a schedule and return. Pass the event loop so cron delivery can
     # use live adapters (E2EE support).
-    from cron.scheduler_provider import InProcessCronScheduler, resolve_cron_scheduler
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        resolve_cron_scheduler,
+        scheduler_for_profile_mode,
+    )
     cron_stop = threading.Event()
-    cron_provider = resolve_cron_scheduler()
+    multiplex_cron = bool(getattr(runner.config, "multiplex_profiles", False))
+    cron_provider = scheduler_for_profile_mode(
+        resolve_cron_scheduler(),
+        multiplex_profiles=multiplex_cron,
+    )
     cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
 
     # Multiplex profiles: tell the built-in ticker which profile homes to
@@ -29643,7 +29651,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # never execute because no ticker owns that store.
     if (
         isinstance(cron_provider, InProcessCronScheduler)
-        and getattr(runner.config, "multiplex_profiles", False)
+        and multiplex_cron
     ):
         try:
             profile_homes = _multiplex_profile_homes(runner.config)

--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -44,6 +44,7 @@ _delete_cron_job_sync = late("_delete_cron_job_sync")
 _find_cron_job_profile = late("_find_cron_job_profile")
 _fire_cron_job_for_profile = late("_fire_cron_job_for_profile")
 _forward_cron_fire_to_gateway = late("_forward_cron_fire_to_gateway")
+_notify_cron_provider_for_profile = late("_notify_cron_provider_for_profile")
 _call_cron_for_profile = late("_call_cron_for_profile")
 _raise_if_cron_registration_error = late("_raise_if_cron_registration_error")
 load_config = late("load_config")
@@ -251,7 +252,13 @@ async def instantiate_blueprint(body: AutomationBlueprintInstantiate, profile: s
         # like the sibling cron endpoints (partial avoids **spec keys ever
         # colliding with the wrapper's own parameters).
         _create = functools.partial(_call_cron_for_profile, profile, "create_job", **spec)
-        return await _run_cron_dashboard_io(_create)
+        created = await _run_cron_dashboard_io(_create)
+        # Same contract as the other dashboard mutations: reconcile the
+        # profile-scoped provider (best-effort; fail-closed for external
+        # providers on a multi-profile dashboard). Off the event loop —
+        # a Chronos reconcile does file I/O plus NAS network calls.
+        await _run_cron_dashboard_io(_notify_cron_provider_for_profile, profile)
+        return created
     except HTTPException:
         raise
     except Exception as e:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -277,12 +277,12 @@ async def _lifespan(app: "FastAPI"):
     try:
         yield
     finally:
+        if cron_stop is not None:
+            cron_stop.set()
         pty_reaper_task.cancel()
         selftest_task.cancel()
         auto_archive_task.cancel()
         await PTY_REGISTRY.close_all()
-        if cron_stop is not None:
-            cron_stop.set()
         if os.getenv("HERMES_DESKTOP") == "1":
             _terminate_desktop_managed_gateway()
 
@@ -328,6 +328,7 @@ def _get_pty_active_session_files(app: "FastAPI") -> dict[str, Path]:
 
 
 app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
+
 
 # Memory-provider OAuth connect routes live in the memory layer, not here.
 from hermes_cli.memory_oauth import router as _memory_oauth_router  # noqa: E402
@@ -11956,6 +11957,73 @@ def _call_cron_for_profile(target_profile: Optional[str], func_name: str, *args,
     return result
 
 
+def _notify_cron_provider_for_profile(target_profile: Optional[str]) -> None:
+    """Best-effort provider reconcile against one profile's job store.
+
+    Fail-closed for external providers on a multi-profile dashboard: an
+    external provider's ``reconcile`` converges its REMOTE registry toward
+    one profile's jobs.json, and its orphan cleanup cancels every remote
+    entry absent from that store. The NAS registry is not profile-scoped,
+    so reconciling profile B would silently disarm profile A's one-shots.
+    Until the provider contract carries a profile identity through
+    arm/cancel/list, a multi-profile dashboard must not drive unscoped
+    external reconciles at all — the affected profile simply re-arms on
+    its next fire/start (idempotent via dedup_key). The built-in provider
+    re-reads jobs.json each tick and stays a no-op here.
+    """
+    try:
+        _profile_name, home = _cron_profile_home(target_profile)
+        from cron import jobs as cron_jobs
+        from cron.scheduler_provider import (
+            InProcessCronScheduler,
+            resolve_cron_scheduler,
+        )
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        token = set_hermes_home_override(str(home))
+        try:
+            with cron_jobs.use_cron_store(home):
+                provider = resolve_cron_scheduler()
+                if not isinstance(provider, InProcessCronScheduler):
+                    profile_names = [
+                        str(p.get("name") or "")
+                        for p in _cron_profile_dicts()
+                    ]
+                    if len([n for n in profile_names if n]) > 1:
+                        _log.warning(
+                            "Skipping cron provider reconcile for profile %s: "
+                            "external provider '%s' reconcile is not "
+                            "profile-scoped and would disarm other profiles' "
+                            "armed one-shots. The mutated profile re-arms "
+                            "idempotently on its next fire/start.",
+                            target_profile,
+                            provider.name,
+                        )
+                        return
+                provider.on_jobs_changed()
+        finally:
+            reset_hermes_home_override(token)
+    except Exception:
+        _log.debug(
+            "Cron provider reconciliation failed for profile %s",
+            target_profile,
+            exc_info=True,
+        )
+
+
+def _mutate_cron_for_profile(
+    target_profile: Optional[str], func_name: str, *args, **kwargs
+):
+    """Apply a cron store mutation and reconcile its scheduler provider."""
+    result = _call_cron_for_profile(target_profile, func_name, *args, **kwargs)
+    if result:
+        _notify_cron_provider_for_profile(target_profile)
+    return result
+
+
 def _find_cron_job_profile(job_id: str) -> Optional[str]:
     for profile in _cron_profile_dicts():
         name = str(profile.get("name") or "")
@@ -12100,7 +12168,7 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             "script": script,
             "no_agent": no_agent,
         })
-        return _call_cron_for_profile(
+        return _mutate_cron_for_profile(
             profile_name,
             "create_job",
             prompt=body.prompt or "",
@@ -12153,7 +12221,7 @@ def _update_cron_job_sync(job_id: str, body: CronJobUpdate, profile: Optional[st
             if "skills" in updates and "skill" not in updates:
                 effective["skill"] = None
             _validate_dashboard_cron_effective_job(effective)
-        job = _call_cron_for_profile(profile_name, "update_job", job_id, updates)
+        job = _mutate_cron_for_profile(profile_name, "update_job", job_id, updates)
     except HTTPException:
         raise
     except ValueError as exc:
@@ -12169,7 +12237,7 @@ def _pause_cron_job_sync(job_id: str, profile: Optional[str] = None):
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
-    job = _call_cron_for_profile(selected, "pause_job", job_id)
+    job = _mutate_cron_for_profile(selected, "pause_job", job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
@@ -12181,7 +12249,7 @@ def _resume_cron_job_sync(job_id: str, profile: Optional[str] = None):
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
-    job = _call_cron_for_profile(selected, "resume_job", job_id)
+    job = _mutate_cron_for_profile(selected, "resume_job", job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
@@ -12193,10 +12261,34 @@ def _trigger_cron_job_sync(job_id: str, profile: Optional[str] = None):
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
-    job = _call_cron_for_profile(selected, "trigger_job", job_id)
+    job = _call_cron_for_profile(selected, "resolve_job_ref", job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    return job
+    # Do not expose the job as due before claiming it: the built-in ticker and
+    # external/manual fire paths share the same durable claim, so only one can
+    # execute this selected run even if they race across processes. Active jobs
+    # keep the legacy provider call shape; paused jobs need the explicit force
+    # flag to resume and claim atomically.
+    force = not job.get("enabled", True) or job.get("state") == "paused"
+    ran = _fire_cron_job_for_profile(selected, job["id"], force=force)
+    refreshed = _call_cron_for_profile(selected, "get_job", job["id"])
+    if refreshed and refreshed.get("last_run_at") != job.get("last_run_at"):
+        return refreshed
+    if not ran:
+        raise HTTPException(
+            status_code=409,
+            detail="Job is already running or was claimed by another scheduler",
+        )
+    if refreshed:
+        return refreshed
+    # A one-shot may remove itself after exhausting repeat=1. Keep the response
+    # shape compatible without inventing an outcome that is no longer present
+    # in the job store; authoritative list refresh removes the completed row.
+    return {
+        **job,
+        "enabled": False,
+        "state": "completed",
+    }
 
 
 
@@ -12206,7 +12298,7 @@ def _delete_cron_job_sync(job_id: str, profile: Optional[str] = None):
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
     try:
-        removed = _call_cron_for_profile(selected, "remove_job", job_id)
+        removed = _mutate_cron_for_profile(selected, "remove_job", job_id)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not removed:
@@ -12216,8 +12308,17 @@ def _delete_cron_job_sync(job_id: str, profile: Optional[str] = None):
 
 
 
-def _fire_cron_job_for_profile(profile: str, job_id: str) -> bool:
-    """DEPRECATED — retained only until callers migrate; do not add new uses.
+def _fire_cron_job_for_profile(
+    profile: str,
+    job_id: str,
+    *,
+    force: bool = False,
+) -> bool:
+    """DEPRECATED for NAS webhook fires (superseded by gateway forwarding);
+    retained for the dashboard trigger path — do not add new uses.
+
+    Run ONE due cron job end-to-end for ``profile`` via the resolved
+    scheduler provider's ``fire_due`` (store CAS claim + ``run_one_job``).
 
     Superseded by :func:`_forward_cron_fire_to_gateway`: cron fires must
     execute in the GATEWAY process (which owns the live platform adapters),
@@ -12229,7 +12330,10 @@ def _fire_cron_job_for_profile(profile: str, job_id: str) -> bool:
     """
     _profile_name, home = _cron_profile_home(profile)
     from cron import jobs as cron_jobs
-    from cron.scheduler_provider import resolve_cron_scheduler
+    from cron.scheduler_provider import (
+        provider_supports_force_fire,
+        resolve_cron_scheduler,
+    )
     from hermes_constants import (
         reset_hermes_home_override,
         set_hermes_home_override,
@@ -12239,6 +12343,18 @@ def _fire_cron_job_for_profile(profile: str, job_id: str) -> bool:
     try:
         with cron_jobs.use_cron_store(home):
             provider = resolve_cron_scheduler()
+            if force:
+                if not provider_supports_force_fire(provider):
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"Cron provider '{getattr(provider, 'name', 'custom')}' "
+                            "does not support atomic forced firing of paused jobs"
+                        ),
+                    )
+                return bool(
+                    provider.fire_due(job_id, adapters=None, loop=None, force=True)
+                )
             return bool(provider.fire_due(job_id, adapters=None, loop=None))
     finally:
         reset_hermes_home_override(token)

--- a/plugins/cron_providers/chronos/__init__.py
+++ b/plugins/cron_providers/chronos/__init__.py
@@ -225,15 +225,28 @@ class ChronosCronScheduler(CronScheduler):
 
     # -- fire -------------------------------------------------------------
 
-    def fire_due(self, job_id: str, *, adapters: Any = None, loop: Any = None) -> bool:
-        """Run the due job (claim + run_one_job via the ABC default), then
-        re-arm the NEXT one-shot through NAS.
+    # NOTE: no ``fire_due`` override on purpose. The base implementation
+    # virtually dispatches through ``self.claim_fire``/``self.fire_claimed``,
+    # and ``provider_supports_split_fire`` treats ANY ``fire_due`` override
+    # (even a pure ``super()`` delegate) as the legacy single-phase signal —
+    # overriding it here would silently opt Chronos out of claim admission,
+    # duplicate detection, and the cancel-aware drain on the fire webhook.
 
-        Re-arm happens AFTER the run so next_run_at reflects the completed fire.
-        If the job is gone (one-shot completed / repeat-N exhausted), get_job
-        returns None → nothing to re-arm (the schedule naturally stops).
-        """
-        ran = super().fire_due(job_id, adapters=adapters, loop=loop)
+    def fire_claimed(
+        self,
+        claimed_job: dict,
+        *,
+        adapters: Any = None,
+        loop: Any = None,
+        cancel_event: Any = None,
+    ) -> bool:
+        job_id = claimed_job["id"]
+        ran = super().fire_claimed(
+            claimed_job,
+            adapters=adapters,
+            loop=loop,
+            cancel_event=cancel_event,
+        )
         if ran:
             from cron.jobs import get_job
             job = get_job(job_id)

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -7,6 +7,9 @@ claim for a given fire. Single-machine deployments always win (unaffected).
 These exercise the real store against a temp HERMES_HOME (no mocks) per the
 E2E-over-mocks discipline for file-touching code.
 """
+import threading
+import time
+
 import pytest
 
 
@@ -30,6 +33,47 @@ def test_claim_succeeds_once_then_blocks(temp_home):
     assert claim_job_for_fire(jid) is True
     assert claim_job_for_fire(jid) is False
     assert get_job(jid)["next_run_at"] != before
+
+
+def test_claim_oneshot_cannot_be_double_claimed(temp_home):
+    """A one-shot can't be double-claimed (the fresh claim blocks the retry)."""
+    from cron.jobs import create_job, claim_job_for_fire
+
+    job = create_job(prompt="x", schedule="30m", name="o")
+    assert claim_job_for_fire(job["id"]) is True
+    assert claim_job_for_fire(job["id"]) is False
+
+
+def test_claim_unknown_job_returns_false(temp_home):
+    from cron.jobs import claim_job_for_fire
+
+    assert claim_job_for_fire("nope-does-not-exist") is False
+
+
+def test_claim_paused_job_returns_false(temp_home):
+    """A paused job can't be claimed."""
+    from cron.jobs import create_job, claim_job_for_fire, pause_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="p")
+    pause_job(job["id"])
+    assert claim_job_for_fire(job["id"]) is False
+
+
+def test_forced_claim_atomically_resumes_paused_job(temp_home):
+    """Explicit manual fire may resume a paused job without exposing a due
+    intermediate state to the ticker."""
+    from cron.jobs import create_job, claim_job_for_fire, get_job, pause_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="manual")
+    pause_job(job["id"])
+
+    assert claim_job_for_fire(job["id"], force=True) is True
+    claimed = get_job(job["id"])
+    assert claimed["enabled"] is True
+    assert claimed["state"] == "scheduled"
+    assert claimed["paused_at"] is None
+    assert claimed["paused_reason"] is None
+    assert claimed["fire_claim"] is not None
 
 
 def test_stale_claim_is_reclaimable(temp_home, monkeypatch):
@@ -58,3 +102,116 @@ def test_mark_job_run_clears_claim(temp_home):
     assert get_job(jid).get("fire_claim") is None
     # …and the re-armed recurring job is claimable again.
     assert claim_job_for_fire(jid) is True
+
+
+def test_fire_claim_heartbeat_refreshes_only_expected_owner(temp_home, monkeypatch):
+    from datetime import datetime, timedelta
+
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="heartbeat")
+    assert jobs.claim_job_for_fire(job["id"]) is True
+    claimed = jobs.get_job(job["id"])["fire_claim"]
+    claimed_at = datetime.fromisoformat(claimed["at"])
+    monkeypatch.setattr(
+        jobs,
+        "_hermes_now",
+        lambda: claimed_at + timedelta(seconds=30),
+    )
+
+    assert jobs.heartbeat_fire_claim(
+        job["id"],
+        expected_owner=claimed["by"],
+    ) is True
+    refreshed = jobs.get_job(job["id"])["fire_claim"]
+    assert refreshed["at"] != claimed["at"]
+    assert refreshed["by"] == claimed["by"]
+    assert jobs.heartbeat_fire_claim(
+        job["id"],
+        expected_owner="replacement-owner",
+    ) is False
+
+
+def test_reclaimed_fire_uses_new_owner_token(temp_home, monkeypatch):
+    from datetime import datetime, timedelta
+
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="reclaim")
+    assert jobs.claim_job_for_fire(job["id"]) is True
+    original = dict(jobs.get_job(job["id"])["fire_claim"])
+    original_at = datetime.fromisoformat(original["at"])
+    monkeypatch.setattr(
+        jobs,
+        "_hermes_now",
+        lambda: original_at + timedelta(seconds=301),
+    )
+
+    assert jobs.claim_job_for_fire(job["id"]) is True
+    replacement = dict(jobs.get_job(job["id"])["fire_claim"])
+    assert replacement["by"] != original["by"]
+    assert jobs.heartbeat_fire_claim(
+        job["id"],
+        expected_owner=original["by"],
+    ) is False
+    assert jobs.get_job(job["id"])["fire_claim"] == replacement
+
+
+def test_stale_fire_owner_cannot_mark_replacement_run(temp_home):
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="fenced")
+    assert jobs.claim_job_for_fire(job["id"]) is True
+    original = dict(jobs.get_job(job["id"])["fire_claim"])
+    records = jobs.load_jobs()
+    records[0]["fire_claim"] = {"at": original["at"], "by": "replacement"}
+    jobs.save_jobs(records)
+
+    assert jobs.mark_job_run(
+        job["id"],
+        success=True,
+        expected_fire_owner=original["by"],
+    ) is False
+    persisted = jobs.get_job(job["id"])
+    assert persisted["fire_claim"]["by"] == "replacement"
+    assert persisted.get("last_run_at") is None
+
+
+def test_fire_claim_fence_serializes_terminal_revocation(temp_home):
+    """A side effect authorized by owner linearizes before terminal revocation."""
+    from cron.jobs import (
+        claim_job_for_fire,
+        create_job,
+        fire_claim_fence,
+        mark_job_run,
+    )
+
+    job = create_job(prompt="x", schedule="every 5m", name="fenced-side-effect")
+    claimed = claim_job_for_fire(job["id"], return_job=True)
+    assert isinstance(claimed, dict)
+    owner = claimed["fire_claim"]["by"]
+    terminal_done = threading.Event()
+
+    def finish_run():
+        mark_job_run(job["id"], True, expected_fire_owner=owner)
+        terminal_done.set()
+
+    with fire_claim_fence(job["id"], expected_owner=owner) as owns_claim:
+        assert owns_claim is True
+        thread = threading.Thread(target=finish_run)
+        thread.start()
+        time.sleep(0.05)
+        assert terminal_done.is_set() is False
+
+    thread.join(timeout=1)
+    assert terminal_done.is_set() is True
+
+
+def test_fire_claim_fence_rejects_stale_owner(temp_home):
+    from cron.jobs import claim_job_for_fire, create_job, fire_claim_fence
+
+    job = create_job(prompt="x", schedule="every 5m", name="stale-fence")
+    claim_job_for_fire(job["id"])
+
+    with fire_claim_fence(job["id"], expected_owner="stale") as owns_claim:
+        assert owns_claim is False

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -158,10 +158,37 @@ def test_timed_out_no_agent_script_delivery_is_not_mislabeled_as_provider_failur
     )
     delivered = []
 
-    def _timeout(*_args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd="slow.py", timeout=kwargs["timeout"])
+    # The script runner uses Popen + a polling loop (cancel/timeout aware),
+    # so simulate a process that never finishes: communicate() always times
+    # out and the script deadline is shrunk to keep the test fast.
+    class _NeverFinishes:
+        returncode = None
+        pid = 0
+        stdout = None
+        stderr = None
 
-    monkeypatch.setattr(scheduler.subprocess, "run", _timeout)
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def poll(self):
+            return None
+
+        def communicate(self, timeout=None):
+            raise subprocess.TimeoutExpired(cmd="slow.py", timeout=timeout)
+
+        def wait(self, timeout=None):
+            raise subprocess.TimeoutExpired(cmd="slow.py", timeout=timeout)
+
+        def kill(self):
+            self.returncode = -9
+
+    monkeypatch.setattr(scheduler.subprocess, "Popen", _NeverFinishes)
+    monkeypatch.setattr(scheduler, "_get_script_timeout", lambda: 1)
+    monkeypatch.setattr(
+        scheduler,
+        "_terminate_cron_script_process",
+        lambda proc: setattr(proc, "returncode", -15),
+    )
     monkeypatch.setattr(
         scheduler,
         "_deliver_result",

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -156,20 +156,39 @@ class TestRunJobScript:
 
         captured = {}
 
-        def fake_run(argv, **kwargs):
-            captured["argv"] = argv
-            captured["kwargs"] = kwargs
-            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+        class FakeProc:
+            def __init__(self, argv, **kwargs):
+                captured["argv"] = argv
+                captured["kwargs"] = kwargs
+                self.returncode = 0
+
+            def poll(self):
+                return self.returncode
+
+            def communicate(self, timeout=None):
+                return ("ok\n", "")
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+        fake_run = FakeProc
 
         monkeypatch.setattr(sched_mod.sys, "executable", str(venv_python))
-        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", fake_run)
 
         success, output = _run_job_script("probe.py")
 
         assert success is True
         assert output == "ok"
         assert captured["argv"] == [str(base_python), str(script.resolve())]
-        assert captured["kwargs"]["creationflags"] == sched_mod.windows_hide_flags()
+        # The script runner always adds CREATE_NEW_PROCESS_GROUP on win32 so a
+        # cancel can taskkill the whole tree; on POSIX the getattr default is
+        # 0 and the flag set is exactly windows_hide_flags().
+        expected_flags = sched_mod.windows_hide_flags() | getattr(
+            sched_mod.subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        )
+        assert captured["kwargs"]["creationflags"] == expected_flags
         env = captured["kwargs"]["env"]
         assert env["VIRTUAL_ENV"] == str(venv)
         assert str(site_packages) in env["PYTHONPATH"]
@@ -185,12 +204,25 @@ class TestRunJobScript:
 
         captured = {}
 
-        def fake_run(argv, **kwargs):
-            captured["argv"] = argv
-            captured["kwargs"] = kwargs
-            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+        class FakeProc:
+            def __init__(self, argv, **kwargs):
+                captured["argv"] = argv
+                captured["kwargs"] = kwargs
+                self.returncode = 0
 
-        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+            def poll(self):
+                return self.returncode
+
+            def communicate(self, timeout=None):
+                return ("ok\n", "")
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+        fake_run = FakeProc
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "linux")
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", fake_run)
 
         success, output = _run_job_script("probe.py")
 

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -145,6 +145,53 @@ class TestTickWorkdirPartition:
     pieces tick() calls.
     """
 
+    def test_workdir_jobs_run_sequentially(self, tmp_path, monkeypatch):
+        import cron.scheduler as sched
+
+        # Two workdir jobs (both sequential) + one parallel job.
+        workdir_a = {"id": "a", "name": "A", "workdir": str(tmp_path)}
+        workdir_b = {"id": "b", "name": "B", "workdir": str(tmp_path)}
+        parallel_job = {"id": "c", "name": "C", "workdir": None}
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda: [workdir_a, workdir_b, parallel_job])
+        monkeypatch.setattr(sched, "claim_job_for_fire", lambda *_a, **_kw: True)
+
+        # Record call order / thread context.
+        import threading
+        calls: list[tuple[str, str]] = []
+        order_lock = threading.Lock()
+
+        def fake_run_job(job, *, defer_agent_teardown=None, **_kw):
+            # Return a minimal tuple matching run_job's signature.
+            with order_lock:
+                calls.append((job["id"], threading.current_thread().name))
+            return True, "output", "response", None
+
+        monkeypatch.setattr(sched, "run_job", fake_run_job)
+        monkeypatch.setattr(sched, "save_job_output", lambda _jid, _o: None)
+        monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(
+            sched, "_deliver_result", lambda *_a, **_kw: None
+        )
+
+        n = sched.tick(verbose=False)
+        assert n == 3
+
+        ids = [c[0] for c in calls]
+        # Sequential workdir jobs preserve submission order relative to each
+        # other (single-thread pool).
+        assert ids.index("a") < ids.index("b")
+
+        # Workdir jobs run on the persistent single-thread cron-seq pool —
+        # NOT the main thread — so a long workdir job never blocks the ticker.
+        main_thread_name = threading.current_thread().name
+        for jid in ("a", "b"):
+            workdir_thread_name = next(t for j, t in calls if j == jid)
+            assert workdir_thread_name != main_thread_name
+            assert workdir_thread_name.startswith("cron-seq"), workdir_thread_name
+        par_thread_name = next(t for j, t in calls if j == "c")
+        assert par_thread_name.startswith("cron-parallel"), par_thread_name
+
 
 # ---------------------------------------------------------------------------
 # scheduler.run_job: TERMINAL_CWD + skip_context_files wiring

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -39,6 +39,24 @@ def test_execution_transitions_are_durable(monkeypatch, tmp_path):
     assert persisted == [completed]
 
 
+def test_execution_ledger_follows_the_current_profile_home(monkeypatch, tmp_path):
+    import cron.executions as executions
+
+    current_home = {"path": tmp_path / "default"}
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", None)
+    monkeypatch.setattr(executions, "get_hermes_home", lambda: current_home["path"])
+
+    default_row = executions.create_execution("default-job", source="builtin")
+    current_home["path"] = tmp_path / "worker"
+    worker_row = executions.create_execution("worker-job", source="builtin")
+
+    assert executions.list_executions() == [worker_row]
+    current_home["path"] = tmp_path / "default"
+    assert executions.list_executions() == [default_row]
+    assert (tmp_path / "default" / "cron" / "executions.db").is_file()
+    assert (tmp_path / "worker" / "cron" / "executions.db").is_file()
+
+
 def test_terminal_execution_cannot_be_rewritten(monkeypatch, tmp_path):
     executions = _point_ledger(monkeypatch, tmp_path)
     record = executions.create_execution("immutable", source="builtin")
@@ -182,7 +200,7 @@ def test_generic_submit_failure_finishes_attempt_and_releases_guard(monkeypatch)
         lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
     )
     monkeypatch.setattr(scheduler, "get_due_jobs", lambda: [{"id": "submit-fail"}])
-    monkeypatch.setattr(scheduler, "advance_next_runs", lambda _ids: 0)
+    monkeypatch.setattr(scheduler, "claim_job_for_fire", lambda _job_id: True)
     monkeypatch.setattr(scheduler, "_get_parallel_pool", lambda _workers: BrokenPool())
 
     assert scheduler.tick(verbose=False, sync=False) == 0

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -71,7 +71,7 @@ class TestRunningJobGuard:
 
         dispatched = []
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
-        monkeypatch.setattr(sched, "advance_next_runs", lambda *_a, **_kw: 0)
+        monkeypatch.setattr(sched, "claim_job_for_fire", lambda *_a, **_kw: True)
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: dispatched.append(j["id"]) or (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
@@ -83,6 +83,56 @@ class TestRunningJobGuard:
 
         sched._running_job_ids.discard("guard-job")
         sched._shutdown_parallel_pool()
+
+
+    def test_fire_claim_is_acquired_only_when_executor_worker_starts(self, monkeypatch):
+        """Queue wait must not consume the durable claim TTL."""
+        import cron.scheduler as sched
+
+        sched._running_job_ids.clear()
+        job = {
+            "id": "queued-job",
+            "name": "queued",
+            "prompt": "test",
+            "schedule": "every 5m",
+            "enabled": True,
+            "next_run_at": "2020-01-01T00:00:00",
+            "deliver": "local",
+        }
+        submitted = []
+        claim_calls = []
+
+        class DeferredPool:
+            def submit(self, callback):
+                future = concurrent.futures.Future()
+                submitted.append((callback, future))
+                return future
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
+        monkeypatch.setattr(sched, "_get_parallel_pool", lambda _workers: DeferredPool())
+        monkeypatch.setattr(
+            sched,
+            "create_execution",
+            lambda *_a, **_kw: {"id": "execution-1"},
+        )
+        monkeypatch.setattr(
+            sched,
+            "claim_job_for_fire",
+            lambda job_id, **kwargs: claim_calls.append((job_id, kwargs))
+            or {**job, "fire_claim": {"by": "worker-owner", "at": "now"}},
+        )
+        monkeypatch.setattr(sched, "run_one_job", lambda *_a, **_kw: True)
+
+        assert sched.tick(verbose=False, sync=False) == 1
+        assert claim_calls == []
+        assert len(submitted) == 1
+
+        callback, future = submitted[0]
+        result = callback()
+        future.set_result(result)
+
+        assert claim_calls == [("queued-job", {"return_job": True})]
+        assert "queued-job" not in sched._running_job_ids
 
 
 class TestSyncMode:
@@ -104,7 +154,7 @@ class TestSyncMode:
         ]
 
         monkeypatch.setattr(sched, "get_due_jobs", lambda: jobs)
-        monkeypatch.setattr(sched, "advance_next_runs", lambda *_a, **_kw: 0)
+        monkeypatch.setattr(sched, "claim_job_for_fire", lambda *_a, **_kw: True)
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
@@ -113,6 +163,49 @@ class TestSyncMode:
         n = sched.tick(verbose=False)
         assert n == 3
 
+        sched._shutdown_parallel_pool()
+
+    def test_sync_false_returns_immediately(self, tmp_path, monkeypatch):
+        """sync=False returns before parallel jobs finish (optimistic count)."""
+        import cron.scheduler as sched
+
+        sched._parallel_pool = None
+        sched._parallel_pool_max_workers = None
+        sched._running_job_ids.clear()
+
+        job = {
+            "id": "slow-job",
+            "name": "slow",
+            "prompt": "test",
+            "schedule": "every 5m",
+            "enabled": True,
+            "next_run_at": "2020-01-01T00:00:00",
+            "deliver": "local",
+        }
+
+        barrier = threading.Barrier(2, timeout=5)
+
+        def slow_run(j, *, defer_agent_teardown=None, **_kw):
+            barrier.wait()  # blocks until test thread also waits
+            return True, "out", "resp", None
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
+        monkeypatch.setattr(sched, "claim_job_for_fire", lambda *_a, **_kw: True)
+        monkeypatch.setattr(sched, "run_job", slow_run)
+        monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
+        monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
+
+        start = time.monotonic()
+        n = sched.tick(verbose=False, sync=False)  # opt-in: non-blocking
+        elapsed = time.monotonic() - start
+
+        assert n == 1  # optimistic count
+        assert elapsed < 1.0  # returned immediately, didn't wait for slow_run
+
+        # Let the job finish so cleanup works.
+        barrier.wait()
+        time.sleep(0.1)
         sched._shutdown_parallel_pool()
 
 
@@ -151,7 +244,7 @@ class TestSequentialPool:
             return True, "out", "resp", None
 
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
-        monkeypatch.setattr(sched, "advance_next_runs", lambda *_a, **_kw: 0)
+        monkeypatch.setattr(sched, "claim_job_for_fire", lambda *_a, **_kw: True)
         monkeypatch.setattr(sched, "run_job", slow_run)
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
@@ -168,6 +261,43 @@ class TestSequentialPool:
         time.sleep(0.1)
         sched._shutdown_parallel_pool()
 
+    def test_sequential_running_guard_prevents_double_dispatch(self, tmp_path, monkeypatch):
+        """A workdir job already in _running_job_ids is skipped on next tick."""
+        import cron.scheduler as sched
+
+        sched._parallel_pool = None
+        sched._parallel_pool_max_workers = None
+        sched._sequential_pool = None
+        sched._running_job_ids.clear()
+
+        job = {
+            "id": "guard-seq",
+            "name": "guard-seq",
+            "prompt": "test",
+            "schedule": "every 5m",
+            "enabled": True,
+            "next_run_at": "2020-01-01T00:00:00",
+            "deliver": "local",
+            "workdir": str(tmp_path),
+        }
+
+        # Simulate the job already running.
+        sched._running_job_ids.add("guard-seq")
+
+        dispatched = []
+        monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
+        monkeypatch.setattr(sched, "claim_job_for_fire", lambda *_a, **_kw: True)
+        monkeypatch.setattr(sched, "run_job", lambda j, **_kw: dispatched.append(j["id"]) or (True, "out", "resp", None))
+        monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: None)
+        monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
+
+        n = sched.tick(verbose=False)
+        assert n == 0  # skipped, not dispatched
+        assert dispatched == []
+
+        sched._running_job_ids.discard("guard-seq")
+        sched._shutdown_parallel_pool()
 
     def test_get_sequential_pool_is_persistent(self):
         """_get_sequential_pool returns the same single-thread pool."""

--- a/tests/cron/test_recurring_eagain_redispatch.py
+++ b/tests/cron/test_recurring_eagain_redispatch.py
@@ -68,18 +68,34 @@ def wedge_env(tmp_path, monkeypatch):
 
 class TestEAGAINRecurringRedispatches:
     def _make_script_eagain(self, env, monkeypatch):
-        """Make the next subprocess.run raise EAGAIN once, then pass."""
+        """Make the next subprocess.Popen raise EAGAIN once, then pass.
+
+        The script runner spawns via Popen (polling loop for cancel/timeout),
+        so the substrate-failure injection point is the Popen constructor.
+        """
         import cron.scheduler as sched_mod
-        real_run = sched_mod.subprocess.run
         state = {"n": 0}
 
-        def fake_run(argv, **kwargs):
+        class _OkProc:
+            def __init__(self, argv, **kwargs):
+                self.returncode = 0
+
+            def poll(self):
+                return self.returncode
+
+            def communicate(self, timeout=None):
+                return ("ok\n", "")
+
+            def wait(self, timeout=None):
+                return 0
+
+        def fake_popen(argv, **kwargs):
             state["n"] += 1
             if state["n"] == 1:
                 raise OSError(11, "Resource temporarily unavailable")
-            return subprocess.CompletedProcess(argv, 0, stdout="ok\n", stderr="")
+            return _OkProc(argv, **kwargs)
 
-        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", fake_popen)
         return state
 
     def test_eagain_then_redispatched_on_next_tick(self, wedge_env, monkeypatch, tmp_path):

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -46,12 +46,22 @@ def test_tick_process_job_sequence(monkeypatch):
     sequence run_job → save → deliver → mark, in that order."""
     calls = _patch_pipeline(monkeypatch)
     monkeypatch.setattr(s, "get_due_jobs", lambda: [{"id": "j1", "name": "t"}])
-    monkeypatch.setattr(s, "advance_next_runs", lambda ids: 1)
+    monkeypatch.setattr(s, "claim_job_for_fire", lambda _job_id, **_kwargs: True)
 
     s.tick(verbose=False, sync=True)
 
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
     assert calls[-1] == ("mark", "j1", True)
+
+
+def test_tick_skips_job_when_durable_fire_claim_is_lost(monkeypatch):
+    """A manual/external fire that wins the shared CAS must exclude ticker."""
+    calls = _patch_pipeline(monkeypatch)
+    monkeypatch.setattr(s, "get_due_jobs", lambda: [{"id": "j1", "name": "t"}])
+    monkeypatch.setattr(s, "claim_job_for_fire", lambda _job_id: False)
+
+    assert s.tick(verbose=False, sync=True) == 0
+    assert calls == []
 
 
 def test_run_one_job_success_sequence(monkeypatch):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -644,12 +644,344 @@ class TestRunJobSessionPersistence:
             "enabled": True,
         }
         with patch("cron.scheduler.get_due_jobs", return_value=[job]), patch(
-            "cron.scheduler.advance_next_runs"
-        ) as advance, patch("cron.scheduler.run_one_job") as run_one:
+            "cron.scheduler.claim_job_for_fire", return_value=True
+        ) as claim, patch("cron.scheduler.run_one_job") as run_one:
             assert tick(verbose=False, sync=True, can_dispatch=lambda: False) == 0
 
-        advance.assert_not_called()
+        claim.assert_not_called()
         run_one.assert_not_called()
+
+    def test_tick_marks_empty_response_as_error(self, tmp_path):
+        """When run_job returns success=True but final_response is empty,
+        tick() should mark the job as error so last_status != 'ok'.
+        (issue #8585)
+        """
+        from cron.scheduler import tick
+
+        job = {
+            "id": "empty-job",
+            "name": "empty-test",
+            "prompt": "do something",
+            "schedule": "every 1h",
+            "enabled": True,
+            "next_run_at": "2020-01-01T00:00:00",
+            "deliver": "local",
+            "last_status": None,
+        }
+
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.mark_job_run") as mock_mark, \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("cron.scheduler.run_job", return_value=(True, "output", "", None)):
+            tick(verbose=False)
+
+        # Should be called with success=False because final_response is empty
+        mock_mark.assert_called_once()
+        call_args = mock_mark.call_args
+        assert call_args[0][0] == "empty-job"
+        assert call_args[0][1] is False  # success should be False
+        assert "empty" in call_args[0][2].lower()  # error should mention empty
+
+    def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(self, tmp_path, monkeypatch):
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+            "deliver": "telegram",
+        }
+        fake_db = MagicMock()
+        seen = {}
+
+        (tmp_path / ".env").write_text("TELEGRAM_HOME_CHANNEL=-2002\n")
+        monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", raising=False)
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                from gateway.session_context import get_session_env
+                seen["platform"] = get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") or None
+                seen["chat_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") or None
+                seen["thread_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID") or None
+                return {"final_response": "ok"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._preflight_job_config", return_value=None), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent):
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+        assert seen == {
+            "platform": "telegram",
+            "chat_id": "-2002",
+            "thread_id": None,
+        }
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
+        fake_db.close.assert_called_once()
+
+    def test_run_job_preserves_slack_origin_thread_for_same_explicit_channel(self, tmp_path, monkeypatch):
+        job = {
+            "id": "slack-thread-job",
+            "name": "slack-thread",
+            "prompt": "hello",
+            "deliver": "slack:C0B3KEP3SD6",
+            "origin": {
+                "platform": "slack",
+                "chat_id": "C0B3KEP3SD6",
+                "thread_id": "1778485067.844139",
+            },
+        }
+        fake_db = MagicMock()
+        seen = {}
+
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", raising=False)
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                from gateway.session_context import get_session_env
+
+                seen["platform"] = get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") or None
+                seen["chat_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") or None
+                seen["thread_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID") or None
+                return {"final_response": "ok"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._preflight_job_config", return_value=None), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent):
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+        assert seen == {
+            "platform": "slack",
+            "chat_id": "C0B3KEP3SD6",
+            "thread_id": "1778485067.844139",
+        }
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
+        fake_db.close.assert_called_once()
+
+    @pytest.mark.parametrize("timeout_value", ["600", "0"])
+    def test_run_job_heartbeats_oneshot_claim_in_both_wait_modes(
+        self, tmp_path, monkeypatch, timeout_value
+    ):
+        """Timed and unlimited one-shot monitors both refresh their owned claim."""
+        job = {
+            "id": "heartbeat-job",
+            "name": "heartbeat",
+            "prompt": "hello",
+            "schedule": {"kind": "once", "run_at": "2026-07-10T12:00:00Z"},
+            "run_claim": {"at": "2026-07-10T12:00:00Z", "by": "owner-token"},
+        }
+        fake_db = MagicMock()
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                return {"final_response": "ok"}
+
+        class FakeFuture:
+            def result(self):
+                return {"final_response": "ok"}
+
+        fake_future = FakeFuture()
+        fake_pool = MagicMock()
+        fake_pool.submit.return_value = fake_future
+        wait_results = [(set(), set()), ({fake_future}, set())]
+        monotonic_ticks = itertools.count(step=61.0)
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", timeout_value)
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._preflight_job_config", return_value=None), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent), \
+             patch("cron.scheduler.concurrent.futures.ThreadPoolExecutor", return_value=fake_pool), \
+             patch("cron.scheduler.concurrent.futures.wait", side_effect=wait_results), \
+             patch("cron.scheduler.time.monotonic", side_effect=monotonic_ticks.__next__), \
+             patch("cron.scheduler.heartbeat_run_claim", return_value=True) as heartbeat:
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        heartbeat.assert_called_once_with(
+            "heartbeat-job", expected_owner="owner-token"
+        )
+
+    def test_run_job_resets_secret_source_cache_before_reload(self, tmp_path, monkeypatch):
+        """Each run must clear the secret-source cache before re-reading the
+        env, so a long-running gateway re-resolves Bitwarden/BSM-backed secrets
+        instead of leaving the startup .env placeholder in place (#33465).
+
+        A bare ``load_dotenv`` re-load can't do this: startup already recorded
+        this HERMES_HOME in ``_APPLIED_HOMES``, so the external-secret pull
+        no-ops and only the placeholder is re-applied. The scheduler must call
+        ``reset_secret_source_cache()`` (forcing the re-pull) and route through
+        ``load_hermes_dotenv`` (which then re-applies external secret sources).
+        """
+        job = {"id": "bsm-job", "name": "bsm", "prompt": "hello"}
+        fake_db = MagicMock()
+        call_order = []
+
+        def _record_reset():
+            call_order.append("reset")
+
+        def _record_load(*args, **kwargs):
+            call_order.append("load")
+            return []
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache", _record_reset), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv", _record_load), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _output, _final, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        # reset MUST precede the reload, else _APPLIED_HOMES no-ops the re-pull.
+        assert call_order[:2] == ["reset", "load"], call_order
+
+    def test_run_job_clears_stale_auto_delivery_thread_id_between_jobs(self, tmp_path, monkeypatch):
+        jobs = [
+            {
+                "id": "threaded-job",
+                "name": "threaded",
+                "prompt": "hello",
+                "deliver": "telegram:-1001:42",
+            },
+            {
+                "id": "threadless-job",
+                "name": "threadless",
+                "prompt": "hello again",
+                "deliver": "telegram:-2002",
+            },
+        ]
+        fake_db = MagicMock()
+        seen = []
+
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", raising=False)
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                from gateway.session_context import get_session_env
+
+                seen.append(
+                    {
+                        "platform": get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") or None,
+                        "chat_id": get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") or None,
+                        "thread_id": get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID") or None,
+                    }
+                )
+                return {"final_response": "ok"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._preflight_job_config", return_value=None), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent):
+            for job in jobs:
+                success, output, final_response, error = run_job(job)
+                assert success is True
+                assert error is None
+                assert final_response == "ok"
+                assert "ok" in output
+
+        assert seen == [
+            {
+                "platform": "telegram",
+                "chat_id": "-1001",
+                "thread_id": "42",
+            },
+            {
+                "platform": "telegram",
+                "chat_id": "-2002",
+                "thread_id": None,
+            },
+        ]
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
+        assert fake_db.close.call_count == 2
 
 
 class TestRunJobConfigLogging:
@@ -1010,6 +1342,7 @@ class TestSilentDelivery:
 
     def test_silent_response_suppresses_delivery(self, caplog):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT]", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
@@ -1020,12 +1353,61 @@ class TestSilentDelivery:
         deliver_mock.assert_not_called()
         assert any(SILENT_MARKER in r.message for r in caplog.records)
 
+    def test_silent_with_note_suppresses_delivery(self):
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
+    def test_silent_trailing_suppresses_delivery(self):
+        """Agent appended [SILENT] after explanation text — must still suppress."""
+        response = "2 deals filtered out (like<10, reply<15).\n\n[SILENT]"
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
+    def test_silent_is_case_insensitive(self):
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
+    def test_bracketless_silent_variants_suppress(self):
+        """Bracketless near-markers the model emits when it drops brackets
+        must still suppress delivery (#51438, #46917)."""
+        from cron.scheduler import tick
+        for marker in ("SILENT", "NO_REPLY", "NO REPLY", "no_reply"):
+            with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
+                 patch("cron.scheduler.run_job", return_value=(True, "# output", marker, None)), \
+                 patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+                 patch("cron.scheduler._deliver_result") as deliver_mock, \
+                 patch("cron.scheduler.mark_job_run"):
+                tick(verbose=False)
+            deliver_mock.assert_not_called()
 
     def test_report_quoting_marker_mid_sentence_still_delivers(self):
         """A genuine report that merely mentions the token mid-sentence must
         be delivered — the old substring check wrongly swallowed it."""
         response = "I considered staying [SILENT] but here is the summary: 3 items merged."
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
@@ -1038,6 +1420,7 @@ class TestSilentDelivery:
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
              patch("cron.scheduler.run_job", return_value=(False, "# output", "", "some error")), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
@@ -1046,10 +1429,23 @@ class TestSilentDelivery:
             tick(verbose=False)
         deliver_mock.assert_called_once()
 
+    def test_output_saved_even_when_delivery_suppressed(self):
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_job", return_value=(True, "# full output", "[SILENT]", None)), \
+             patch("cron.scheduler.save_job_output") as save_mock, \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            save_mock.return_value = "/tmp/out.md"
+            from cron.scheduler import tick
+            tick(verbose=False)
+        save_mock.assert_called_once_with("monitor-job", "# full output")
+        deliver_mock.assert_not_called()
 
     def test_whitespace_only_response_is_marked_failed_not_delivered(self):
         """Whitespace-only final responses should behave like empty responses."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "   \n\t  ", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
@@ -1083,6 +1479,7 @@ class TestOneShotDispatchClaim:
     def test_claim_runs_before_run_job(self):
         order = []
         with patch("cron.scheduler.get_due_jobs", return_value=[self._oneshot()]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
              patch("cron.scheduler.claim_dispatch", side_effect=lambda _id: order.append("claim") or True), \
              patch("cron.scheduler.run_job", side_effect=lambda _j, **_kw: order.append("run") or (True, "# out", "ok", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
@@ -1091,6 +1488,20 @@ class TestOneShotDispatchClaim:
             from cron.scheduler import tick
             tick(verbose=False)
         assert order == ["claim", "run"]  # claim strictly before side effect
+
+    def test_refused_claim_skips_run_job(self):
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._oneshot()]), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.claim_dispatch", return_value=False), \
+             patch("cron.scheduler.run_job") as run_mock, \
+             patch("cron.scheduler.save_job_output"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run") as mark_mock:
+            from cron.scheduler import tick
+            tick(verbose=False)
+        run_mock.assert_not_called()
+        deliver_mock.assert_not_called()
+        mark_mock.assert_not_called()
 
 
 class TestBuildJobPromptSilentHint:
@@ -1337,7 +1748,7 @@ class TestParallelTick:
         ]
 
         with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_runs"), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result", return_value=None), \
@@ -1382,7 +1793,7 @@ class TestParallelTick:
         ]
 
         with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
-             patch("cron.scheduler.advance_next_runs"), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result", return_value=None), \
@@ -1392,6 +1803,38 @@ class TestParallelTick:
 
         assert seen["tg-job"] == {"platform": "telegram", "chat_id": "111"}
         assert seen["dc-job"] == {"platform": "discord", "chat_id": "222"}
+
+    def test_max_parallel_env_var(self, monkeypatch):
+        """HERMES_CRON_MAX_PARALLEL=1 should restore serial behaviour."""
+        monkeypatch.setenv("HERMES_CRON_MAX_PARALLEL", "1")
+        call_times = []
+
+        def mock_run_job(job, *, defer_agent_teardown=None, **_kw):
+            import time
+            call_times.append(("start", job["id"], time.monotonic()))
+            time.sleep(0.05)
+            call_times.append(("end", job["id"], time.monotonic()))
+            return (True, "output", "response", None)
+
+        jobs = [
+            {"id": "s1", "name": "s1", "deliver": "local"},
+            {"id": "s2", "name": "s2", "deliver": "local"},
+        ]
+
+        with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
+             patch("cron.scheduler.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_job", side_effect=mock_run_job), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result", return_value=None), \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            result = tick(verbose=False)
+
+        assert result == 2
+        # With max_workers=1, second job starts after first ends
+        end_s1 = [t for action, jid, t in call_times if action == "end" and jid == "s1"][0]
+        start_s2 = [t for action, jid, t in call_times if action == "start" and jid == "s2"][0]
+        assert start_s2 >= end_s1, "Jobs ran concurrently despite max_parallel=1"
 
 
 class TestDeliverResultTimeoutCancelsFuture:

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -129,6 +129,39 @@ def test_abc_growth_stays_additive():
     )
 
 
+def test_force_fire_capability_detects_legacy_override():
+    from cron.scheduler_provider import CronScheduler
+
+    class Current(CronScheduler):
+        @property
+        def name(self):
+            return "current"
+
+        def start(self, stop_event, **kw):
+            pass
+
+    class Legacy(Current):
+        def fire_due(  # type: ignore[invalid-method-override]
+            self, job_id, *, adapters=None, loop=None
+        ):
+            return True
+
+    class PositionalOnly(Current):
+        def fire_due(  # type: ignore[invalid-method-override]
+            self, job_id, force=False, /
+        ):
+            return True
+
+    class KeywordSink(Current):
+        def fire_due(self, job_id, **kwargs):
+            return True
+
+    assert Current().supports_force_fire is True
+    assert Legacy().supports_force_fire is False
+    assert PositionalOnly().supports_force_fire is False
+    assert KeywordSink().supports_force_fire is True
+
+
 def test_inprocess_provider_ticks_and_stops():
     """The built-in provider drives cron.scheduler.tick(sync=False) on a loop
     and exits promptly when stop_event is set — same contract as the raw
@@ -214,6 +247,98 @@ def test_resolve_defaults_to_builtin(monkeypatch):
     assert prov.name == "builtin"
 
 
+def test_resolve_no_cron_section_falls_back_to_builtin(monkeypatch):
+    """Config with no cron section at all → built-in (cfg_get returns default)."""
+    import hermes_cli.config as cfg
+    from cron import scheduler_provider as sp
+
+    monkeypatch.setattr(cfg, "load_config", lambda: {})
+    prov = sp.resolve_cron_scheduler()
+    assert prov.name == "builtin"
+
+
+def test_resolve_unknown_provider_falls_back_to_builtin(monkeypatch):
+    """A named provider that doesn't exist → built-in (cron never dies)."""
+    import hermes_cli.config as cfg
+    from cron import scheduler_provider as sp
+
+    monkeypatch.setattr(cfg, "load_config", lambda: {"cron": {"provider": "nope-not-real"}})
+    prov = sp.resolve_cron_scheduler()
+    assert prov.name == "builtin"
+
+
+def test_resolve_unavailable_provider_falls_back(monkeypatch):
+    """A provider that loads but reports is_available()==False → built-in."""
+    import hermes_cli.config as cfg
+    import plugins.cron_providers as pc
+    from cron import scheduler_provider as sp
+    from cron.scheduler_provider import CronScheduler
+
+    class Unavailable(CronScheduler):
+        @property
+        def name(self):
+            return "unavailable"
+
+        def is_available(self):
+            return False
+
+        def start(self, stop_event, **kw):
+            pass
+
+    monkeypatch.setattr(cfg, "load_config", lambda: {"cron": {"provider": "unavailable"}})
+    monkeypatch.setattr(pc, "load_cron_scheduler", lambda n: Unavailable())
+    prov = sp.resolve_cron_scheduler()
+    assert prov.name == "builtin"
+
+
+def test_resolve_available_provider_is_used(monkeypatch):
+    """A provider that loads and is available is returned (not the fallback)."""
+    import hermes_cli.config as cfg
+    import plugins.cron_providers as pc
+    from cron import scheduler_provider as sp
+    from cron.scheduler_provider import CronScheduler
+
+    class Fake(CronScheduler):
+        @property
+        def name(self):
+            return "fake"
+
+        def is_available(self):
+            return True
+
+        def start(self, stop_event, **kw):
+            pass
+
+    monkeypatch.setattr(cfg, "load_config", lambda: {"cron": {"provider": "fake"}})
+    monkeypatch.setattr(pc, "load_cron_scheduler", lambda n: Fake())
+    prov = sp.resolve_cron_scheduler()
+    assert prov.name == "fake"
+
+
+def test_external_provider_falls_back_to_builtin_under_multiplex():
+    from cron.scheduler_provider import (
+        CronScheduler,
+        InProcessCronScheduler,
+        scheduler_for_profile_mode,
+    )
+
+    class External(CronScheduler):
+        @property
+        def name(self):
+            return "external"
+
+        def start(self, stop_event, **kwargs):
+            return None
+
+    external = External()
+
+    assert scheduler_for_profile_mode(external, multiplex_profiles=False) is external
+    assert isinstance(
+        scheduler_for_profile_mode(external, multiplex_profiles=True),
+        InProcessCronScheduler,
+    )
+
+
 # ── Phase 4B: additive hooks (on_jobs_changed / fire_due / reconcile) ────────
 
 
@@ -238,19 +363,120 @@ def test_builtin_inherits_hook_defaults():
 
 
 def test_fire_due_default_claims_then_runs(monkeypatch):
-    """The default fire_due claims via the store CAS, fetches the job, and runs
-    it through the shared run_one_job body."""
+    """The default fire_due runs the exact owner-bearing CAS snapshot."""
     import cron.jobs as jobs
     import cron.scheduler as sched
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
-    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: True, raising=False)
-    monkeypatch.setattr(jobs, "get_job", lambda jid: {"id": jid, "name": "t"})
-    monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
+    claims = []
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire",
+        lambda jid, **kw: claims.append((jid, kw))
+        or {"id": jid, "name": "t", "fire_claim": {"by": "exact-owner"}},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        sched,
+        "run_one_job",
+        lambda job, **kw: ran.append((job["id"], job["fire_claim"]["by"])) or True,
+    )
 
     assert InProcessCronScheduler().fire_due("j1") is True
-    assert ran == ["j1"]
+    assert claims == [("j1", {"return_job": True})]
+    assert ran == [("j1", "exact-owner")]
+
+
+def test_claim_fire_persists_attempt_before_fire_claimed(monkeypatch):
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    events = []
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire",
+        lambda jid, **kwargs: events.append("claim")
+        or {"id": jid, "fire_claim": {"by": "owner"}},
+    )
+    monkeypatch.setattr(
+        executions,
+        "create_execution",
+        lambda jid, source: events.append("ledger") or {"id": "exec-1"},
+    )
+    monkeypatch.setattr(
+        sched,
+        "run_one_job",
+        lambda job, **kwargs: events.append(("run", job["execution_id"])) or True,
+    )
+
+    provider = InProcessCronScheduler()
+    claimed = provider.claim_fire("j1")
+
+    assert events == ["ledger", "claim"]
+    assert claimed is not None
+    assert claimed["execution_id"] == "exec-1"
+    assert provider.fire_claimed(claimed) is True
+    assert events == ["ledger", "claim", ("run", "exec-1")]
+
+
+def test_fire_due_forwards_manual_force_to_store_claim(monkeypatch):
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    claims = []
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire",
+        lambda jid, **kw: claims.append((jid, kw))
+        or {"id": jid, "name": "t", "fire_claim": {"by": "manual-owner"}},
+    )
+    monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: True)
+
+    assert InProcessCronScheduler().fire_due("j1", force=True) is True
+    assert claims == [("j1", {"force": True, "return_job": True})]
+
+
+def test_fire_due_lost_claim_does_not_run(monkeypatch):
+    """If the CAS claim is lost (another machine/retry won), fire_due returns
+    False and never runs the job."""
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    ran = []
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire",
+        lambda jid, **kw: False,
+        raising=False,
+    )
+    monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
+
+    assert InProcessCronScheduler().fire_due("j1") is False
+    assert ran == []
+
+
+def test_fire_due_missing_job_does_not_run(monkeypatch):
+    """If the job vanished before atomic claim, fire_due does not run it."""
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    ran = []
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire",
+        lambda jid, **kw: False,
+        raising=False,
+    )
+    monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
+
+    assert InProcessCronScheduler().fire_due("gone") is False
+    assert ran == []
 
 
 # ── F2a: ticker liveness — survival, heartbeat, honest status (#32612, #32895) ──

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -1,10 +1,161 @@
 """Regression coverage for one-shot claims during blocking cron scripts."""
 
 from datetime import datetime, timedelta, timezone
+import contextlib
+import sys
 import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+def test_cancel_event_terminates_script_process_tree(tmp_path, monkeypatch):
+    """Losing a fire claim must stop both the script and its descendants."""
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    started = tmp_path / "started"
+    child_done = tmp_path / "child-done"
+    script = scripts_dir / "blocking.py"
+    child_code = (
+        "import time; from pathlib import Path; "
+        f"time.sleep(1); Path({str(child_done)!r}).write_text('done')"
+    )
+    script.write_text(
+        "import subprocess, sys, time\n"
+        f"subprocess.Popen([sys.executable, '-c', {child_code!r}])\n"
+        f"open({str(started)!r}, 'w').close()\n"
+        "time.sleep(30)\n",
+        encoding="utf-8",
+    )
+
+    cancel = threading.Event()
+    result = []
+    errors = []
+
+    def _run() -> None:
+        try:
+            result.append(
+                scheduler._run_job_script(
+                    str(script),
+                    workdir=str(tmp_path),
+                    cancel_event=cancel,
+                )
+            )
+        except Exception as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=_run)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while not started.exists() and not errors and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert errors == []
+    assert started.exists(), "script did not start"
+
+    cancel.set()
+    thread.join(timeout=3)
+
+    assert errors == []
+    assert not thread.is_alive(), "script ignored cancellation"
+    assert result and result[0][0] is False
+    assert "cancel" in result[0][1].lower()
+    time.sleep(1.2)
+    assert not child_done.exists(), "script descendant survived cancellation"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group semantics")
+def test_cancel_event_kills_sigterm_ignoring_descendant(tmp_path, monkeypatch):
+    """A SIGTERM-ignoring grandchild must not wedge the cancellation path:
+    the tree kill escalates to SIGKILL for surviving group members, and the
+    pipe drain is bounded even if a descendant still holds the write ends."""
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    started = tmp_path / "started"
+    script = scripts_dir / "stubborn.py"
+    child_code = (
+        "import signal, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        f"open({str(started)!r}, 'w').close(); "
+        "time.sleep(60)"
+    )
+    script.write_text(
+        "import subprocess, sys, time\n"
+        f"subprocess.Popen([sys.executable, '-c', {child_code!r}])\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+
+    cancel = threading.Event()
+    result = []
+    errors = []
+
+    def _run() -> None:
+        try:
+            result.append(
+                scheduler._run_job_script(
+                    str(script),
+                    workdir=str(tmp_path),
+                    cancel_event=cancel,
+                )
+            )
+        except Exception as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=_run)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while not started.exists() and not errors and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert errors == []
+    assert started.exists(), "script did not spawn its descendant"
+
+    cancel.set()
+    # TERM grace (1s) + KILL + bounded drain (5s) + margin: must return well
+    # before the unbounded-communicate hang this regresses against.
+    thread.join(timeout=10)
+
+    assert errors == []
+    assert not thread.is_alive(), "cancellation wedged on a SIGTERM-ignoring descendant"
+    assert result and result[0][0] is False
+    assert "cancel" in result[0][1].lower()
+
+
+def test_no_agent_forwards_cancel_event_to_script_runner(monkeypatch):
+    import cron.scheduler as scheduler
+
+    cancel = threading.Event()
+    observed = []
+
+    def _script_runner(job, script_path, workdir=None, cancel_event=None):
+        observed.append(cancel_event)
+        return True, ""
+
+    monkeypatch.setattr(
+        scheduler,
+        "_run_job_script_with_claim_heartbeat",
+        _script_runner,
+    )
+
+    success, _output, _response, error = scheduler.run_job(
+        {
+            "id": "cancel-aware-script",
+            "name": "cancel aware",
+            "script": "watchdog.py",
+            "no_agent": True,
+        },
+        cancel_event=cancel,
+    )
+
+    assert success is True
+    assert error is None
+    assert observed == [cancel]
 
 
 @pytest.mark.parametrize(
@@ -163,3 +314,267 @@ def test_script_heartbeat_uses_captured_claim_owner(tmp_path, monkeypatch):
             "at": replacement_timestamp,
             "by": "replacement-owner",
         }
+
+
+def test_run_one_job_refreshes_fire_claim_in_profile_store(tmp_path, monkeypatch):
+    """The shared execute/save/deliver body keeps its durable fire claim alive."""
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    with jobs.use_cron_store(profile_home):
+        job = jobs.create_job(prompt="x", schedule="every 5m", name="agent-run")
+        assert jobs.claim_job_for_fire(job["id"]) is True
+        claimed_job = jobs.get_job(job["id"])
+        original_claim = dict(claimed_job["fire_claim"])
+
+    heartbeat_seen = threading.Event()
+    real_heartbeat = jobs.heartbeat_fire_claim
+
+    def _observed_heartbeat(job_id: str, *, expected_owner: str) -> bool:
+        updated = real_heartbeat(job_id, expected_owner=expected_owner)
+        heartbeat_seen.set()
+        return updated
+
+    def _blocking_body(job, **kwargs):
+        assert heartbeat_seen.wait(timeout=2)
+        return True
+
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", _observed_heartbeat)
+    monkeypatch.setattr(scheduler, "_run_one_job_body", _blocking_body)
+
+    with jobs.use_cron_store(profile_home):
+        assert isinstance(claimed_job, dict)
+        assert scheduler.run_one_job(claimed_job) is True
+        refreshed = jobs.get_job(job["id"])["fire_claim"]
+
+    assert refreshed["at"] != original_claim["at"]
+    assert refreshed["by"] == original_claim["by"]
+
+
+def test_lost_fire_claim_stops_stale_delivery(monkeypatch):
+    """A runner that loses its durable owner must not deliver its stale result."""
+    import cron.scheduler as scheduler
+
+    lost_seen = threading.Event()
+    heartbeat_calls = 0
+
+    def _heartbeat(job_id: str, *, expected_owner: str) -> bool:
+        nonlocal heartbeat_calls
+        heartbeat_calls += 1
+        if heartbeat_calls == 1:
+            return True
+        lost_seen.set()
+        return False
+
+    def _run_job(job, *, defer_agent_teardown=None, extra_prompt=None, cancel_event=None):
+        assert lost_seen.wait(timeout=2)
+        return True, "stale output", "stale response", None
+
+    job = {
+        "id": "reclaimed-agent",
+        "name": "reclaimed agent",
+        "prompt": "work",
+        "execution_id": "stale-execution",
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "stale-owner"},
+    }
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", _heartbeat)
+    monkeypatch.setattr(scheduler, "run_job", _run_job)
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda job_id: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda execution_id: None)
+    monkeypatch.setattr(scheduler, "finish_execution", lambda *args, **kwargs: None)
+    save_output = MagicMock()
+    deliver_result = MagicMock()
+    mark_run = MagicMock()
+    monkeypatch.setattr(scheduler, "save_job_output", save_output)
+    monkeypatch.setattr(scheduler, "_deliver_result", deliver_result)
+    monkeypatch.setattr(scheduler, "mark_job_run", mark_run)
+
+    with patch("agent.secret_scope.set_secret_scope", return_value=None), \
+         patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
+         patch("agent.secret_scope.reset_secret_scope"):
+        assert scheduler.run_one_job(job) is True
+
+    save_output.assert_not_called()
+    deliver_result.assert_not_called()
+    mark_run.assert_not_called()
+
+
+def test_initially_lost_fire_claim_finishes_execution_without_running(monkeypatch):
+    """A stale claimed snapshot rejected before body entry must close its ledger row."""
+    import cron.scheduler as scheduler
+
+    run_body = MagicMock(return_value=True)
+    finish = MagicMock()
+    job = {
+        "id": "already-reclaimed",
+        "execution_id": "stale-execution",
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "stale-owner"},
+    }
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", lambda *args, **kwargs: False)
+    monkeypatch.setattr(scheduler, "_run_one_job_body", run_body)
+    monkeypatch.setattr(scheduler, "finish_execution", finish)
+
+    assert scheduler.run_one_job(job) is True
+
+    run_body.assert_not_called()
+    finish.assert_called_once_with(
+        "stale-execution",
+        success=False,
+        error="Fire claim ownership lost before execution started.",
+    )
+
+
+def test_initially_lost_claim_does_not_run_when_ledger_write_fails(monkeypatch):
+    """A ledger I/O error cannot turn a confirmed ownership loss into execution."""
+    import cron.scheduler as scheduler
+
+    run_body = MagicMock(return_value=True)
+    job = {
+        "id": "already-reclaimed",
+        "execution_id": "stale-execution",
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "stale-owner"},
+    }
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", lambda *args, **kwargs: False)
+    monkeypatch.setattr(scheduler, "_run_one_job_body", run_body)
+    monkeypatch.setattr(
+        scheduler,
+        "finish_execution",
+        MagicMock(side_effect=OSError("ledger unavailable")),
+    )
+
+    assert scheduler.run_one_job(job) is True
+    run_body.assert_not_called()
+
+
+def test_initial_heartbeat_exception_does_not_start_execution(monkeypatch):
+    """Unconfirmed initial ownership must fail closed before any side effect."""
+    import cron.scheduler as scheduler
+
+    run_body = MagicMock(return_value=True)
+    finish = MagicMock()
+    job = {
+        "id": "validation-error",
+        "execution_id": "validation-execution",
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "owner"},
+    }
+    monkeypatch.setattr(
+        scheduler,
+        "heartbeat_fire_claim",
+        MagicMock(side_effect=OSError("store unavailable")),
+    )
+    monkeypatch.setattr(scheduler, "_run_one_job_body", run_body)
+    monkeypatch.setattr(scheduler, "finish_execution", finish)
+
+    assert scheduler.run_one_job(job) is True
+
+    run_body.assert_not_called()
+    finish.assert_called_once_with(
+        "validation-execution",
+        success=False,
+        error="Fire claim ownership could not be validated before execution started.",
+    )
+
+
+def test_heartbeat_thread_start_failure_does_not_start_execution(monkeypatch):
+    """A claimed job cannot run when no renewal monitor protects its lease."""
+    import cron.scheduler as scheduler
+
+    run_body = MagicMock(return_value=True)
+    finish = MagicMock()
+    job = {
+        "id": "thread-start-error",
+        "execution_id": "thread-execution",
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "owner"},
+    }
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", lambda *args, **kwargs: True)
+    monkeypatch.setattr(scheduler, "_run_one_job_body", run_body)
+    monkeypatch.setattr(scheduler, "finish_execution", finish)
+    monkeypatch.setattr(
+        scheduler.threading.Thread,
+        "start",
+        MagicMock(side_effect=RuntimeError("cannot start thread")),
+    )
+
+    assert scheduler.run_one_job(job) is True
+
+    run_body.assert_not_called()
+    finish.assert_called_once_with(
+        "thread-execution",
+        success=False,
+        error="Fire claim heartbeat could not be started; execution was not run.",
+    )
+
+
+def test_repeated_heartbeat_errors_cancel_after_bounded_grace(monkeypatch):
+    """Store uncertainty cannot let a run outlive its last confirmed lease forever."""
+    import cron.scheduler as scheduler
+
+    calls = 0
+
+    def heartbeat(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return True
+        raise OSError("store unavailable")
+
+    def run_body(_job, **kwargs):
+        assert kwargs["fire_claim_lost"].wait(timeout=0.5)
+        return True
+
+    job = {
+        "id": "heartbeat-errors",
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "owner"},
+    }
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", heartbeat)
+    monkeypatch.setattr(scheduler, "_run_one_job_body", run_body)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS", 0.03)
+
+    assert scheduler.run_one_job(job) is True
+    assert calls >= 3
+
+
+def test_terminal_owner_cas_failure_marks_ledger_ownership_lost(monkeypatch):
+    """A replacement owner cannot leave the stale ledger recorded as success."""
+    import cron.scheduler as scheduler
+
+    @contextlib.contextmanager
+    def owned_fence(*_args, **_kwargs):
+        yield True
+
+    job = {
+        "id": "terminal-cas",
+        "execution_id": "execution-cas",
+        "name": "terminal-cas",
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "owner"},
+    }
+    finish = MagicMock()
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", lambda *args, **kwargs: True)
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda *_args: None)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *_args, **_kwargs: (True, "output", "response", None),
+    )
+    monkeypatch.setattr(scheduler, "fire_claim_fence", owned_fence, raising=False)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: "output.md")
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(scheduler, "finish_execution", finish)
+
+    with patch("agent.secret_scope.set_secret_scope", return_value=None), \
+         patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
+         patch("agent.secret_scope.reset_secret_scope"):
+        assert scheduler.run_one_job(job) is True
+
+    finish.assert_called_once_with(
+        "execution-cas",
+        success=False,
+        error="Fire claim ownership lost before terminal completion.",
+    )

--- a/tests/cron/test_sessiondb_init_hang.py
+++ b/tests/cron/test_sessiondb_init_hang.py
@@ -222,7 +222,7 @@ class TestDispatchGuardReleasedAfterHang:
                      side_effect=_session_db_executor(timeouts),
                  ), \
                  patch.object(sched, "get_due_jobs", return_value=[job]), \
-                 patch.object(sched, "advance_next_runs"), \
+                 patch.object(sched, "claim_job_for_fire", return_value=True), \
                  patch.object(sched, "save_job_output", return_value="/tmp/out"), \
                  patch.object(sched, "mark_job_run"), \
                  patch.object(sched, "_deliver_result", return_value=None):

--- a/tests/cron/test_shutdown_interrupt.py
+++ b/tests/cron/test_shutdown_interrupt.py
@@ -11,6 +11,7 @@ Covers the cron/scheduler.py primitives directly:
     result AFTER its tool was already killed out from under it
 """
 
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -23,9 +24,11 @@ def _reset_scheduler_state():
     import cron.scheduler as sched
 
     sched._running_job_ids.clear()
+    sched._running_fire_owners.clear()
     sched._interrupted_job_ids.clear()
     yield
     sched._running_job_ids.clear()
+    sched._running_fire_owners.clear()
     sched._interrupted_job_ids.clear()
 
 
@@ -72,8 +75,15 @@ class TestMarkRunningJobsInterrupted:
         import cron.scheduler as sched
 
         sched._running_job_ids.update({"job-1", "job-2"})
+        profile_home = sched._get_hermes_home().resolve()
+        sched._running_fire_owners.update(
+            {
+                "job-1": {object(): ("owner-1", profile_home)},
+                "job-2": {object(): ("owner-2", profile_home)},
+            }
+        )
 
-        with patch("cron.scheduler.mark_job_run") as mock_mark:
+        with patch("cron.scheduler.mark_job_run", return_value=True) as mock_mark:
             marked = sched.mark_running_jobs_interrupted("gateway shutdown (final-cleanup)")
 
         assert sorted(marked) == ["job-1", "job-2"]
@@ -84,6 +94,7 @@ class TestMarkRunningJobsInterrupted:
             # success must be False -- an interrupted run is never "ok".
             assert c.args[1] is False
             assert "gateway shutdown" in c.args[2]
+            assert c.kwargs["expected_fire_owner"] in {"owner-1", "owner-2"}
 
     def test_sets_interrupted_flag_for_consumption_by_run_one_job(self):
         import cron.scheduler as sched
@@ -102,15 +113,145 @@ class TestMarkRunningJobsInterrupted:
         import cron.scheduler as sched
 
         sched._running_job_ids.update({"job-1", "job-2"})
+        profile_home = sched._get_hermes_home().resolve()
+        sched._running_fire_owners.update(
+            {
+                "job-1": {object(): ("owner-1", profile_home)},
+                "job-2": {object(): ("owner-2", profile_home)},
+            }
+        )
 
         def _side_effect(job_id, success, reason, **kwargs):
             if job_id == "job-1":
                 raise OSError("disk full")
+            return True
 
         with patch("cron.scheduler.mark_job_run", side_effect=_side_effect):
             marked = sched.mark_running_jobs_interrupted("shutdown")
 
         assert marked == ["job-2"]
+
+    def test_stale_shutdown_cannot_clear_replacement_owner(self, tmp_path):
+        import cron.jobs as jobs
+        import cron.scheduler as sched
+
+        profile_home = tmp_path / "profile"
+        profile_home.mkdir()
+        with jobs.use_cron_store(profile_home):
+            created = jobs.create_job(prompt="x", schedule="every 5m", name="owned")
+            claimed = jobs.claim_job_for_fire(created["id"], force=True, return_job=True)
+            assert isinstance(claimed, dict)
+            stale_owner = claimed["fire_claim"]["by"]
+            original_status = claimed["last_status"]
+            replacement_claim = {
+                "at": "2026-07-12T12:30:00+00:00",
+                "by": "replacement-owner",
+            }
+            replacement = {**claimed, "fire_claim": replacement_claim}
+            jobs.save_jobs([replacement])
+
+            sched._running_job_ids.add(created["id"])
+            sched._running_fire_owners[created["id"]] = {
+                object(): (stale_owner, profile_home)
+            }
+            marked = sched.mark_running_jobs_interrupted("shutdown")
+            refreshed = jobs.get_job(created["id"])
+
+        assert marked == []
+        assert isinstance(refreshed, dict)
+        assert refreshed["fire_claim"] == replacement_claim
+        assert refreshed["last_status"] == original_status
+
+
+class TestRunningFireOwnerRegistry:
+    def test_run_one_job_registers_owner_only_while_active(self):
+        import cron.scheduler as sched
+
+        job = {
+            "id": "owned-job",
+            "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "owner-1"},
+        }
+
+        def _observe_registry(current_job, run):
+            assert list(sched._running_fire_owners[current_job["id"]].values()) == [
+                ("owner-1", sched._get_hermes_home().resolve())
+            ]
+            return True
+
+        with patch("cron.scheduler._run_with_fire_claim_heartbeat", side_effect=_observe_registry):
+            assert sched.run_one_job(job) is True
+
+        assert job["id"] not in sched._running_fire_owners
+
+    def test_shutdown_sees_all_concurrent_direct_fire_owners(self, monkeypatch):
+        """Direct entry points and replacement owners share one token registry."""
+        import cron.scheduler as sched
+
+        entered = threading.Barrier(3)
+        release = threading.Event()
+        marked_owners: list[str] = []
+
+        def hold_run(_job, _run):
+            entered.wait(timeout=2)
+            release.wait(timeout=2)
+            return True
+
+        def mark(_job_id, _success, _reason, *, expected_fire_owner):
+            marked_owners.append(expected_fire_owner)
+            return True
+
+        monkeypatch.setattr(sched, "_run_with_fire_claim_heartbeat", hold_run)
+        monkeypatch.setattr(sched, "mark_job_run", mark)
+
+        jobs = [
+            {"id": "same-job", "fire_claim": {"by": "old-owner"}},
+            {"id": "same-job", "fire_claim": {"by": "replacement-owner"}},
+        ]
+        threads = [threading.Thread(target=sched.run_one_job, args=(job,)) for job in jobs]
+        for thread in threads:
+            thread.start()
+        entered.wait(timeout=2)
+
+        assert sched.get_running_job_ids() == frozenset({"same-job"})
+        assert sched.mark_running_jobs_interrupted("shutdown") == ["same-job", "same-job"]
+        assert set(marked_owners) == {"old-owner", "replacement-owner"}
+
+        release.set()
+        for thread in threads:
+            thread.join(timeout=2)
+            assert not thread.is_alive()
+        assert "same-job" not in sched.get_running_job_ids()
+
+    def test_shutdown_marks_each_owner_in_its_profile_store(self, monkeypatch, tmp_path):
+        import cron.jobs as cron_jobs
+        import cron.scheduler as sched
+
+        profile_a = tmp_path / "a"
+        profile_b = tmp_path / "b"
+        observed = []
+        sched._running_fire_owners["same-job"] = {
+            object(): ("owner-a", profile_a),
+            object(): ("owner-b", profile_b),
+        }
+
+        def mark(job_id, success, reason, *, expected_fire_owner):
+            observed.append(
+                (
+                    job_id,
+                    success,
+                    expected_fire_owner,
+                    cron_jobs._current_cron_store().jobs_file,
+                )
+            )
+            return True
+
+        monkeypatch.setattr(sched, "mark_job_run", mark)
+
+        assert sched.mark_running_jobs_interrupted("shutdown") == ["same-job", "same-job"]
+        assert set(observed) == {
+            ("same-job", False, "owner-a", profile_a / "cron" / "jobs.json"),
+            ("same-job", False, "owner-b", profile_b / "cron" / "jobs.json"),
+        }
 
 
 class TestIsInterrupted:
@@ -153,6 +294,247 @@ class TestConsumeInterruptedFlag:
         # Consumed -- a second check (e.g. a later, unrelated fire of the
         # same recurring job ID) must not still read as interrupted.
         assert sched._consume_interrupted_flag("job-1") is False
+
+
+class TestExecutionScopedInterruption:
+    """Interruption flags must target ONE execution, not the job ID.
+
+    Owner-registered executions are recorded by their unique execution
+    token, so a fresh run that reuses the same job ID (recurring fire,
+    replacement claim owner) never consumes a flag that targeted its
+    dead predecessor.
+    """
+
+    def test_interruption_targets_only_the_interrupted_execution(self):
+        import cron.scheduler as sched
+
+        profile_home = sched._get_hermes_home().resolve()
+        old_token = object()
+        sched._running_fire_owners["job-1"] = {
+            old_token: ("owner-1", profile_home),
+        }
+
+        with patch("cron.scheduler.mark_job_run", return_value=True):
+            sched.mark_running_jobs_interrupted("shutdown")
+
+        assert sched._is_interrupted("job-1", old_token) is True
+        new_token = object()
+        assert sched._is_interrupted("job-1", new_token) is False
+        # A new execution must not steal (and thereby clear) the old flag.
+        assert sched._consume_interrupted_flag("job-1", new_token) is False
+        assert sched._consume_interrupted_flag("job-1", old_token) is True
+        assert sched._is_interrupted("job-1", old_token) is False
+
+    def test_only_owners_marks_only_targeted_executions(self):
+        import cron.scheduler as sched
+
+        profile_home = sched._get_hermes_home().resolve()
+        token_a, token_b = object(), object()
+        sched._running_fire_owners["job-a"] = {token_a: ("owner-a", profile_home)}
+        sched._running_fire_owners["job-b"] = {token_b: ("owner-b", profile_home)}
+
+        with patch("cron.scheduler.mark_job_run", return_value=True) as mock_mark:
+            marked = sched.mark_running_jobs_interrupted(
+                "dashboard shutdown",
+                only_owners={("job-a", "owner-a")},
+            )
+
+        assert marked == ["job-a"]
+        assert mock_mark.call_count == 1
+        assert mock_mark.call_args.kwargs["expected_fire_owner"] == "owner-a"
+        assert sched._is_interrupted("job-a", token_a) is True
+        assert sched._is_interrupted("job-b", token_b) is False
+
+    def test_replacement_execution_of_same_job_is_not_poisoned(self):
+        """A replacement owner starting while the stale flag exists must
+        complete through the normal mark path, not the interrupted one."""
+        import cron.scheduler as sched
+
+        profile_home = sched._get_hermes_home().resolve()
+        stale_token = object()
+        sched._running_fire_owners["job-1"] = {
+            stale_token: ("stale-owner", profile_home),
+        }
+        with patch("cron.scheduler.mark_job_run", return_value=True):
+            sched.mark_running_jobs_interrupted("shutdown")
+        sched._running_fire_owners.clear()
+
+        job = {
+            "id": "job-1",
+            "name": "test job",
+            "prompt": "do work",
+            "fire_claim": {"by": "replacement-owner"},
+        }
+        with patch("cron.scheduler.claim_dispatch", return_value=True), \
+             patch("agent.secret_scope.set_secret_scope", return_value=None), \
+             patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
+             patch("agent.secret_scope.reset_secret_scope"), \
+             patch(
+                 "cron.scheduler.run_job",
+                 return_value=(True, "full output", "final response", None),
+             ), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._is_cron_silence_response", return_value=False), \
+             patch("cron.scheduler._deliver_result", return_value=None), \
+             patch("cron.scheduler.fire_claim_fence"), \
+             patch("cron.scheduler.heartbeat_fire_claim", return_value=True), \
+             patch("cron.scheduler.mark_job_run", return_value=True) as mock_mark:
+            result = sched.run_one_job(job)
+
+        assert result is True
+        mock_mark.assert_called_once()
+
+
+class TestCombinedCancelEvent:
+    def test_or_semantics(self):
+        import cron.scheduler as sched
+
+        a, b = threading.Event(), threading.Event()
+        combined = sched._CombinedCancelEvent(a, b)
+        assert combined.is_set() is False
+        b.set()
+        assert combined.is_set() is True
+
+    def test_set_propagates_to_all(self):
+        import cron.scheduler as sched
+
+        a, b = threading.Event(), threading.Event()
+        combined = sched._CombinedCancelEvent(a, b)
+        combined.set()
+        assert a.is_set() and b.is_set()
+
+    def test_run_one_job_forwards_external_cancel_event(self):
+        import cron.scheduler as sched
+
+        external = threading.Event()
+        job = {"id": "job-x", "name": "x", "prompt": "p"}
+
+        with patch.object(
+            sched,
+            "_run_with_fire_claim_heartbeat",
+            side_effect=lambda job_arg, run: run(threading.Event()),
+        ), patch.object(sched, "_run_one_job_body", return_value=True) as body:
+            assert sched.run_one_job(job, cancel_event=external) is True
+
+        combined = body.call_args.kwargs["fire_claim_lost"]
+        assert combined.is_set() is False
+        external.set()
+        assert combined.is_set() is True
+
+
+class TestBaseExceptionThroughOwnerFencedFlow:
+    """#73973 (sweeper review on #70638): a BaseException escaping run_job
+    must still record a failed run through the owner-fenced terminal path —
+    and a stale worker must not record over a replacement claim owner."""
+
+    def _job(self):
+        return {
+            "id": "job-be",
+            "name": "base exc",
+            "prompt": "p",
+            "fire_claim": {"by": "owner-be"},
+        }
+
+    def _patches(self, run_side_effect):
+        return (
+            patch("cron.scheduler.claim_dispatch", return_value=True),
+            patch("agent.secret_scope.set_secret_scope", return_value=None),
+            patch("agent.secret_scope.build_profile_secret_scope", return_value=None),
+            patch("agent.secret_scope.reset_secret_scope"),
+            patch("cron.scheduler.run_job", side_effect=run_side_effect),
+            patch("cron.scheduler.heartbeat_fire_claim", return_value=True),
+        )
+
+    def test_cancelled_error_records_failure_and_reraises(self):
+        import asyncio
+
+        import cron.scheduler as sched
+
+        p1, p2, p3, p4, p5, p6 = self._patches(asyncio.CancelledError())
+        with p1, p2, p3, p4, p5, p6, \
+             patch("cron.scheduler.mark_job_run", return_value=True) as mock_mark, \
+             patch("cron.scheduler.finish_execution") as mock_finish:
+            try:
+                sched.run_one_job(self._job())
+                raised = False
+            except asyncio.CancelledError:
+                raised = True
+
+        assert raised, "non-Exception BaseException must propagate"
+        mock_mark.assert_called_once()
+        assert mock_mark.call_args.args[:3] == ("job-be", False, "CancelledError")
+        assert mock_mark.call_args.kwargs["expected_fire_owner"] == "owner-be"
+        assert mock_finish.call_args.kwargs["success"] is False
+
+    def test_keyboard_interrupt_records_failure_and_reraises(self):
+        import cron.scheduler as sched
+
+        p1, p2, p3, p4, p5, p6 = self._patches(KeyboardInterrupt())
+        with p1, p2, p3, p4, p5, p6, \
+             patch("cron.scheduler.mark_job_run", return_value=True) as mock_mark, \
+             patch("cron.scheduler.finish_execution"):
+            try:
+                sched.run_one_job(self._job())
+                raised = False
+            except KeyboardInterrupt:
+                raised = True
+
+        assert raised
+        mock_mark.assert_called_once()
+        assert mock_mark.call_args.kwargs["expected_fire_owner"] == "owner-be"
+
+    def test_base_exception_from_stale_owner_is_fenced_out(self):
+        """A replacement owner reclaimed the job: the stale worker's
+        BaseException path must NOT write terminal state over it."""
+        import asyncio
+
+        import cron.scheduler as sched
+
+        p1, p2, p3, p4, p5, p6 = self._patches(asyncio.CancelledError())
+        with p1, p2, p3, p4, p5, p6, \
+             patch("cron.scheduler.mark_job_run", return_value=False) as mock_mark, \
+             patch("cron.scheduler.finish_execution"):
+            try:
+                sched.run_one_job(self._job())
+            except asyncio.CancelledError:
+                pass
+
+        mock_mark.assert_called_once()
+        # fenced write was attempted with the stale owner and discarded by
+        # the store (return False) — and the code accepted that verdict
+        # without retrying or writing anything else.
+        assert mock_mark.call_args.kwargs["expected_fire_owner"] == "owner-be"
+
+
+class TestCallerLossAfterClaimAcquisition:
+    """cirwel's integration assertion on #70638: if the HTTP/CLI caller is
+    lost AFTER the claim was acquired, the gateway owner must produce at
+    most one terminal ledger/artifact/delivery, clear only its own claim,
+    and block retries while that ownership is live."""
+
+    def test_second_fire_cannot_claim_while_first_ownership_live(self, tmp_path):
+        import cron.jobs as jobs
+
+        with jobs.use_cron_store(tmp_path):
+            job = jobs.create_job(prompt="x", schedule="every 5m", name="owned")
+            claimed = jobs.claim_job_for_fire(job["id"], force=True, return_job=True)
+            assert isinstance(claimed, dict)
+
+            # Caller died here — the claim outlives it. A retry (NAS/webhook
+            # or manual) must be refused while the lease is fresh.
+            retry = jobs.claim_job_for_fire(job["id"], return_job=True)
+            assert retry is False or not isinstance(retry, dict)
+
+            # The live owner still heartbeats and terminally marks — exactly
+            # one terminal write, and only its own claim is cleared.
+            owner = claimed["fire_claim"]["by"]
+            assert jobs.heartbeat_fire_claim(job["id"], expected_owner=owner) is True
+            assert jobs.mark_job_run(
+                job["id"], True, expected_fire_owner=owner,
+            ) is True
+            refreshed = jobs.get_job(job["id"])
+            assert refreshed["fire_claim"] is None
+            assert refreshed["last_status"] == "ok"
 
 
 class TestRunOneJobHonoursInterruptedFlag:

--- a/tests/gateway/test_cron_active_work_drain.py
+++ b/tests/gateway/test_cron_active_work_drain.py
@@ -30,9 +30,11 @@ def _reset_cron_running_set():
     import cron.scheduler as sched
 
     sched._running_job_ids.clear()
+    sched._running_fire_owners.clear()
     sched._interrupted_job_ids.clear()
     yield
     sched._running_job_ids.clear()
+    sched._running_fire_owners.clear()
     sched._interrupted_job_ids.clear()
 
 
@@ -88,6 +90,9 @@ class TestKillToolSubprocessesMarksCronInterrupted:
         adapter.disconnect = _make_async_noop()
 
         sched._running_job_ids.add("job-1")
+        sched._running_fire_owners["job-1"] = {
+            object(): ("owner-1", sched._get_hermes_home().resolve())
+        }
 
         monkeypatch.setattr(_pr.process_registry, "kill_all", lambda task_id=None: 1)
         monkeypatch.setattr(_tt, "cleanup_all_environments", lambda: None)

--- a/tests/gateway/test_cron_fire_webhook.py
+++ b/tests/gateway/test_cron_fire_webhook.py
@@ -39,13 +39,18 @@ def adapter():
 
 
 class _SpyProvider:
-    """Records fire_due calls; stands in for the resolved provider."""
+    """Records durable admission and claimed dispatch calls."""
 
     def __init__(self):
+        self.claimed = []
         self.fired = []
 
-    def fire_due(self, job_id, *, adapters=None, loop=None):
-        self.fired.append(job_id)
+    def claim_fire(self, job_id):
+        self.claimed.append(job_id)
+        return {"id": job_id, "execution_id": f"exec-{job_id}"}
+
+    def fire_claimed(self, job, *, adapters=None, loop=None):
+        self.fired.append(job["id"])
         return True
 
 
@@ -58,7 +63,10 @@ async def test_valid_fire_reservation_blocks_drain_before_body_and_task(adapter,
     release_fire = threading.Event()
 
     class BlockingProvider:
-        def fire_due(self, job_id, *, adapters=None, loop=None):
+        def claim_fire(self, job_id):
+            return {"id": job_id, "execution_id": "exec-1"}
+
+        def fire_claimed(self, job, *, adapters=None, loop=None):
             fired.set()
             release_fire.wait(timeout=2)
             return True
@@ -102,6 +110,78 @@ async def test_valid_fire_reservation_blocks_drain_before_body_and_task(adapter,
                 await asyncio.sleep(0.01)
 
     assert adapter.active_agent_work_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_admission_failure_is_retryable_and_never_dispatches(adapter, monkeypatch):
+    class FailingProvider(_SpyProvider):
+        def claim_fire(self, job_id):
+            raise OSError("ledger unavailable")
+
+    provider = FailingProvider()
+    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: provider)
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer good"},
+            json={"job_id": "abc123"},
+        )
+
+    assert response.status == 503
+    assert provider.fired == []
+    assert adapter.active_agent_work_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_accepted_response_waits_for_durable_admission(adapter, monkeypatch):
+    claim_started = threading.Event()
+    release_claim = threading.Event()
+
+    class BlockingAdmissionProvider(_SpyProvider):
+        def claim_fire(self, job_id):
+            claim_started.set()
+            release_claim.wait(timeout=2)
+            return super().claim_fire(job_id)
+
+    provider = BlockingAdmissionProvider()
+    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: provider)
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        request_task = asyncio.create_task(
+            cli.post(
+                "/api/cron/fire",
+                headers={"Authorization": "Bearer good"},
+                json={"job_id": "abc123"},
+            )
+        )
+        assert await asyncio.to_thread(claim_started.wait, 2)
+        await asyncio.sleep(0)
+        assert not request_task.done()
+
+        release_claim.set()
+        response = await request_task
+        # The 202 guarantees durable ADMISSION only — the fire itself runs as
+        # tracked background work, so wait for it to actually land (fast
+        # locally, but CI scheduling can lose this race).
+        for _ in range(200):
+            if provider.fired:
+                break
+            await asyncio.sleep(0.01)
+
+    assert response.status == 202
+    assert provider.claimed == ["abc123"]
+    assert provider.fired == ["abc123"]
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_cron_fire_dashboard.py
+++ b/tests/hermes_cli/test_cron_fire_dashboard.py
@@ -9,8 +9,9 @@ hosted agents don't expose). It must:
     the JWT verifier runs,
   - reject a bad/missing NAS-JWT with 401 (the JWT is the real gate),
   - 400 on missing job_id,
-  - on a valid token, resolve the job's profile and run fire_due in the
-    background, returning 202.
+  - on a valid token, FORWARD the fire to the gateway api_server (which owns
+    cron execution and the live delivery adapters) and pass its response
+    through — 503 when the gateway is unreachable so NAS retries.
 """
 
 import pytest

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -167,6 +167,175 @@ def test_dashboard_create_reports_saved_but_unregistered(
     assert "private callback URL and token" not in str(exc_info.value.detail)
 
 
+def test_notify_cron_provider_scopes_store_and_runtime_home_together(
+    isolated_profiles,
+    monkeypatch,
+):
+    """Provider reconciliation must observe the mutated profile, not default."""
+    from cron import jobs as cron_jobs
+    from cron import scheduler
+    from hermes_cli import web_server
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    default_home = isolated_profiles["default"]
+    worker_home = isolated_profiles["worker_alpha"]
+    monkeypatch.setattr(scheduler, "_hermes_home", None)
+    monkeypatch.setattr(
+        web_server,
+        "_cron_profile_dicts",
+        lambda: [{"name": "worker_alpha"}],
+    )
+    captured = {}
+
+    class RecordingProvider:
+        def on_jobs_changed(self):
+            captured["runtime_home"] = scheduler._get_hermes_home()
+            captured["jobs_file"] = cron_jobs._current_cron_store().jobs_file
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: RecordingProvider(),
+    )
+
+    outer_token = set_hermes_home_override(default_home)
+    try:
+        web_server._notify_cron_provider_for_profile("worker_alpha")
+        assert captured == {
+            "runtime_home": worker_home,
+            "jobs_file": worker_home / "cron" / "jobs.json",
+        }
+        assert scheduler._get_hermes_home() == default_home
+    finally:
+        reset_hermes_home_override(outer_token)
+
+
+def test_notify_cron_provider_failure_is_best_effort(
+    isolated_profiles,
+    monkeypatch,
+):
+    from hermes_cli import web_server
+
+    class FailNotifyProvider:
+        @property
+        def name(self):
+            return "fail-notify"
+
+        def register_job(self, job):
+            return None
+
+        def on_jobs_changed(self):
+            raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: FailNotifyProvider(),
+    )
+
+    created = web_server._mutate_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="survives provider failure",
+        schedule="every 1h",
+        name="best-effort-notify",
+    )
+
+    assert created["profile"] == "worker_alpha"
+    assert created["name"] == "best-effort-notify"
+
+
+def test_external_provider_reconcile_fails_closed_with_multiple_profiles(
+    isolated_profiles,
+    monkeypatch,
+):
+    """Multi-profile dashboard + external provider: the unscoped reconcile
+    must NOT run — its orphan cleanup would disarm the other profiles'
+    armed one-shots in the shared NAS registry. The mutation itself still
+    succeeds (fail-closed only skips the remote converge)."""
+    from cron import scheduler
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(scheduler, "_hermes_home", None)
+    monkeypatch.setattr(
+        web_server,
+        "_cron_profile_dicts",
+        lambda: [{"name": "default"}, {"name": "worker_alpha"}],
+    )
+    notified = []
+
+    class ExternalProvider:
+        @property
+        def name(self):
+            return "chronos"
+
+        def register_job(self, job):
+            return None
+
+        def on_jobs_changed(self):
+            notified.append(True)
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: ExternalProvider(),
+    )
+
+    created = web_server._mutate_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="must not disarm siblings",
+        schedule="every 1h",
+        name="multi-profile-guard",
+    )
+
+    assert created["profile"] == "worker_alpha"
+    assert notified == [], (
+        "external provider reconcile must stay fail-closed on a "
+        "multi-profile dashboard"
+    )
+
+
+def test_builtin_provider_hook_still_fires_with_multiple_profiles(
+    isolated_profiles,
+    monkeypatch,
+):
+    """The built-in provider re-reads jobs.json per tick — its hook is a
+    safe no-op and must NOT be blocked by the multi-profile guard."""
+    from cron import scheduler
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(scheduler, "_hermes_home", None)
+    monkeypatch.setattr(
+        web_server,
+        "_cron_profile_dicts",
+        lambda: [{"name": "default"}, {"name": "worker_alpha"}],
+    )
+    notified = []
+
+    class BuiltinProbe(InProcessCronScheduler):
+        def on_jobs_changed(self):
+            notified.append(True)
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: BuiltinProbe(),
+    )
+
+    created = web_server._mutate_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="builtin notify",
+        schedule="every 1h",
+        name="builtin-notify",
+    )
+
+    assert created["profile"] == "worker_alpha"
+    assert notified == [True]
+
+
 def test_profile_call_cannot_retarget_ticker_store_mid_write(
     isolated_profiles,
     monkeypatch,
@@ -281,6 +450,482 @@ async def test_cron_mutation_without_profile_finds_named_profile_job(isolated_pr
     assert worker_jobs[0]["enabled"] is False
 
 
+@pytest.mark.asyncio
+async def test_dashboard_cron_mutations_notify_selected_profile_provider(
+    isolated_profiles,
+    monkeypatch,
+):
+    from hermes_cli import web_server
+
+    notified_profiles = []
+    monkeypatch.setattr(
+        web_server,
+        "_notify_cron_provider_for_profile",
+        notified_profiles.append,
+    )
+
+    created = await web_server.create_cron_job(
+        web_server.CronJobCreate(
+            prompt="managed by named profile",
+            schedule="every 1h",
+            name="provider-notify-job",
+        ),
+        profile="worker_alpha",
+    )
+    await web_server.update_cron_job(
+        created["id"],
+        web_server.CronJobUpdate(updates={"name": "provider-notify-job-updated"}),
+        profile="worker_alpha",
+    )
+    await web_server.pause_cron_job(created["id"], profile="worker_alpha")
+    await web_server.resume_cron_job(created["id"], profile="worker_alpha")
+    await web_server.delete_cron_job(created["id"], profile="worker_alpha")
+
+    assert notified_profiles == ["worker_alpha"] * 5
+
+
+@pytest.mark.asyncio
+async def test_blueprint_instantiation_notifies_selected_profile_provider(
+    isolated_profiles,
+    monkeypatch,
+):
+    from hermes_cli import web_server
+
+    notified_profiles = []
+    monkeypatch.setattr(
+        web_server,
+        "_notify_cron_provider_for_profile",
+        notified_profiles.append,
+    )
+
+    created = await web_server.instantiate_blueprint(
+        web_server.AutomationBlueprintInstantiate(
+            blueprint="morning-brief",
+            values={"time": "07:30", "deliver": "local"},
+        ),
+        profile="worker_alpha",
+    )
+
+    assert created["profile"] == "worker_alpha"
+    assert notified_profiles == ["worker_alpha"]
+
+
+@pytest.mark.asyncio
+async def test_trigger_cron_job_fires_only_selected_job_and_returns_refreshed_state(
+    isolated_profiles,
+    monkeypatch,
+):
+    from cron import jobs as cron_jobs
+    from hermes_cli import web_server
+
+    selected = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="run immediately",
+        schedule="every 1h",
+        name="selected-trigger-job",
+    )
+    sibling = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="leave scheduled",
+        schedule="every 1h",
+        name="sibling-job",
+    )
+    fired = []
+
+    class RecordingProvider:
+        def fire_due(self, job_id, *, adapters=None, loop=None, force=False):
+            fired.append(
+                {
+                    "job_id": job_id,
+                    "jobs_file": cron_jobs._current_cron_store().jobs_file,
+                    "force": force,
+                }
+            )
+            cron_jobs.mark_job_run(job_id, success=True)
+            return True
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: RecordingProvider(),
+    )
+    monkeypatch.setattr(
+        cron_jobs,
+        "trigger_job",
+        lambda _job_id: (_ for _ in ()).throw(
+            AssertionError("manual fire must not expose the job to the ticker first")
+        ),
+    )
+
+    triggered = await web_server.trigger_cron_job(
+        selected["id"],
+        profile="worker_alpha",
+    )
+
+    assert fired == [
+        {
+            "job_id": selected["id"],
+            "jobs_file": isolated_profiles["worker_alpha"] / "cron" / "jobs.json",
+            "force": False,
+        }
+    ]
+    assert triggered["last_status"] == "ok"
+    assert triggered["last_run_at"] is not None
+    untouched = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "get_job",
+        sibling["id"],
+    )
+    assert untouched["last_run_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_trigger_cron_job_reports_lost_claim_as_conflict(
+    isolated_profiles,
+    monkeypatch,
+):
+    from hermes_cli import web_server
+
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="already running",
+        schedule="every 1h",
+        name="claimed-trigger-job",
+    )
+
+    class ClaimLostProvider:
+        def fire_due(self, job_id, *, adapters=None, loop=None, force=False):
+            return False
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: ClaimLostProvider(),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await web_server.trigger_cron_job(job["id"], profile="worker_alpha")
+
+    assert exc.value.status_code == 409
+    assert "already running" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_trigger_cron_job_forces_paused_job_atomically(
+    isolated_profiles,
+    monkeypatch,
+):
+    from cron import jobs as cron_jobs
+    from hermes_cli import web_server
+
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="resume me",
+        schedule="every 1h",
+        name="paused-trigger-job",
+    )
+    web_server._call_cron_for_profile("worker_alpha", "pause_job", job["id"])
+    observed = {}
+
+    class ForceProvider:
+        def fire_due(self, job_id, *, adapters=None, loop=None, force=False):
+            observed["force"] = force
+            assert cron_jobs.claim_job_for_fire(job_id, force=force) is True
+            cron_jobs.mark_job_run(job_id, success=True)
+            return True
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: ForceProvider(),
+    )
+
+    triggered = await web_server.trigger_cron_job(
+        job["id"],
+        profile="worker_alpha",
+    )
+
+    assert observed["force"] is True
+    assert triggered["enabled"] is True
+    assert triggered["state"] == "scheduled"
+    assert triggered["last_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_trigger_paused_job_rejects_legacy_provider_without_mutating_job(
+    isolated_profiles,
+    monkeypatch,
+):
+    from fastapi import HTTPException
+    from hermes_cli import web_server
+
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="stay paused",
+        schedule="every 1h",
+        name="legacy-paused-trigger-job",
+    )
+    web_server._call_cron_for_profile("worker_alpha", "pause_job", job["id"])
+    calls = []
+
+    class LegacyProvider:
+        def fire_due(self, job_id, *, adapters=None, loop=None):
+            calls.append(job_id)
+            return True
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: LegacyProvider(),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await web_server.trigger_cron_job(job["id"], profile="worker_alpha")
+
+    assert exc.value.status_code == 409
+    assert "forced" in exc.value.detail.lower()
+    assert calls == []
+    persisted = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "get_job",
+        job["id"],
+    )
+    assert persisted["state"] == "paused"
+    assert persisted["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_trigger_cron_job_returns_refreshed_execution_failure(
+    isolated_profiles,
+    monkeypatch,
+):
+    from cron import jobs as cron_jobs
+    from hermes_cli import web_server
+
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="fail visibly",
+        schedule="every 1h",
+        name="failed-trigger-job",
+    )
+
+    class FailedProvider:
+        def fire_due(self, job_id, *, adapters=None, loop=None, force=False):
+            cron_jobs.mark_job_run(job_id, success=False, error="expected failure")
+            return False
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: FailedProvider(),
+    )
+
+    triggered = await web_server.trigger_cron_job(
+        job["id"],
+        profile="worker_alpha",
+    )
+
+    assert triggered["last_status"] == "error"
+    assert triggered["last_error"] == "expected failure"
+
+
+@pytest.mark.asyncio
+async def test_trigger_cron_job_returns_completed_snapshot_for_retained_oneshot(
+    isolated_profiles,
+    monkeypatch,
+):
+    from cron import jobs as cron_jobs
+    from hermes_cli import web_server
+
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="run once",
+        schedule="30m",
+        name="completed-trigger-job",
+    )
+
+    class SuccessfulProvider:
+        def fire_due(self, job_id, *, adapters=None, loop=None, force=False):
+            cron_jobs.mark_job_run(job_id, success=True)
+            return True
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: SuccessfulProvider(),
+    )
+
+    triggered = await web_server.trigger_cron_job(
+        job["id"],
+        profile="worker_alpha",
+    )
+
+    assert triggered["state"] == "completed"
+    assert triggered["enabled"] is False
+    # Completed one-shots are retained for the retention window (#80624) with
+    # their terminal status inspectable — the trigger response is the real
+    # record, not a synthetic pre-removal snapshot.
+    assert triggered["last_status"] == "ok"
+    assert triggered["last_run_at"] is not None
+    retained = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "get_job",
+        job["id"],
+    )
+    assert retained is not None
+    assert retained["state"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_cron_profile_scan_runs_off_event_loop(isolated_profiles, monkeypatch):
+    from hermes_cli import web_server
+
+    worker_job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="managed by named profile",
+        schedule="every 1h",
+        name="thread-offload-job",
+    )
+
+    event_loop_thread = threading.get_ident()
+    profile_scan_threads = SimpleQueue()
+    worker_threads = SimpleQueue()
+    original_profile_dicts = web_server._cron_profile_dicts
+    original_find = web_server._find_cron_job_profile
+
+    def tracking_profile_dicts():
+        profile_scan_threads.put(threading.get_ident())
+        return original_profile_dicts()
+
+    def tracking_find(job_id):
+        worker_threads.put(threading.get_ident())
+        return original_find(job_id)
+
+    monkeypatch.setattr(web_server, "_cron_profile_dicts", tracking_profile_dicts)
+    monkeypatch.setattr(web_server, "_find_cron_job_profile", tracking_find)
+
+    jobs = await web_server.list_cron_jobs(profile="all")
+    paused = await web_server.pause_cron_job(worker_job["id"])
+
+    assert any(job["id"] == worker_job["id"] for job in jobs)
+    assert paused["profile"] == "worker_alpha"
+    profile_scan_thread_ids = _drain_queue(profile_scan_threads)
+    worker_thread_ids = _drain_queue(worker_threads)
+    assert profile_scan_thread_ids
+    assert worker_thread_ids
+    assert all(thread_id != event_loop_thread for thread_id in profile_scan_thread_ids)
+    assert all(thread_id != event_loop_thread for thread_id in worker_thread_ids)
+
+
+@pytest.mark.asyncio
+async def test_cron_dashboard_io_rejects_async_callables():
+    from hermes_cli import web_server
+
+    async def async_callable():
+        return "nope"
+
+    with pytest.raises(TypeError, match="only accepts sync callables"):
+        await web_server._run_cron_dashboard_io(async_callable)
+
+
+
+@pytest.mark.asyncio
+async def test_update_cron_job_normalizes_dashboard_core_fields(isolated_profiles, tmp_path):
+    from hermes_cli import web_server
+
+    scripts_dir = isolated_profiles["worker_alpha"] / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "collect.py").write_text("print('ok')\n", encoding="utf-8")
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="managed by named profile",
+        schedule="every 1h",
+        name="normalizes-dashboard-fields",
+    )
+
+    updated = await web_server.update_cron_job(
+        job["id"],
+        web_server.CronJobUpdate(
+            updates={
+                "base_url": "https://example.invalid/v1/",
+                "script": str(scripts_dir / "collect.py"),
+                "context_from": "",
+                "no_agent": True,
+            }
+        ),
+        profile="worker_alpha",
+    )
+
+    assert updated["base_url"] == "https://example.invalid/v1"
+    assert updated["script"] == "collect.py"
+    assert updated["context_from"] is None
+    assert updated["no_agent"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_cron_job_rejects_script_outside_profile_scripts(
+    isolated_profiles, tmp_path
+):
+    from hermes_cli import web_server
+
+    outside = tmp_path / "outside.py"
+    outside.write_text("print('nope')\n", encoding="utf-8")
+
+    with pytest.raises(HTTPException) as exc:
+        await web_server.create_cron_job(
+            web_server.CronJobCreate(
+                schedule="every 1h",
+                script=str(outside),
+                no_agent=True,
+            ),
+            profile="worker_alpha",
+        )
+
+    assert exc.value.status_code == 400
+    assert "inside" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_create_cron_job_rejects_empty_agent_job(isolated_profiles):
+    from hermes_cli import web_server
+
+    with pytest.raises(HTTPException) as exc:
+        await web_server.create_cron_job(
+            web_server.CronJobCreate(schedule="every 1h"),
+            profile="worker_alpha",
+        )
+
+    assert exc.value.status_code == 400
+    assert "prompt, skill, or script" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_update_cron_job_no_agent_reuses_existing_script(isolated_profiles):
+    from hermes_cli import web_server
+
+    scripts_dir = isolated_profiles["worker_alpha"] / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "collect.py").write_text("print('ok')\n", encoding="utf-8")
+
+    job = await web_server.create_cron_job(
+        web_server.CronJobCreate(
+            schedule="every 1h",
+            script=str(scripts_dir / "collect.py"),
+        ),
+        profile="worker_alpha",
+    )
+
+    updated = await web_server.update_cron_job(
+        job["id"],
+        web_server.CronJobUpdate(updates={"no_agent": True}),
+        profile="worker_alpha",
+    )
+
+    assert updated["no_agent"] is True
+    assert updated["script"] == "collect.py"
 
 
 @pytest.mark.asyncio
@@ -327,3 +972,218 @@ async def test_dashboard_cron_rejects_missing_context_from(isolated_profiles):
 
 
 
+@pytest.mark.asyncio
+async def test_dashboard_cron_noop_inference_fields_keep_existing_snapshots(
+    isolated_profiles,
+    monkeypatch,
+):
+    from hermes_cli import runtime_provider, web_server
+
+    current_provider = {"name": "initial-provider"}
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **kwargs: {"provider": current_provider["name"]},
+    )
+
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="managed by named profile",
+        schedule="every 1h",
+        name="dashboard-edit-job",
+    )
+
+    assert job["provider_snapshot"] == "initial-provider"
+    assert job["model_snapshot"] == "test-model"
+
+    current_provider["name"] = "changed-provider"
+    (isolated_profiles["worker_alpha"] / "config.yaml").write_text(
+        "model: changed-model\n",
+        encoding="utf-8",
+    )
+
+    updated = await web_server.update_cron_job(
+        job["id"],
+        web_server.CronJobUpdate(
+            updates={
+                "name": "dashboard-edit-job-renamed",
+                "provider": None,
+                "model": None,
+                "base_url": None,
+                "no_agent": False,
+            }
+        ),
+        profile="worker_alpha",
+    )
+
+    assert updated["name"] == "dashboard-edit-job-renamed"
+    assert updated["provider_snapshot"] == "initial-provider"
+    assert updated["model_snapshot"] == "test-model"
+
+
+@pytest.mark.asyncio
+async def test_update_cron_job_clears_snapshots_for_no_agent(
+    isolated_profiles,
+    monkeypatch,
+):
+    from hermes_cli import runtime_provider, web_server
+
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **kwargs: {"provider": "worker-provider"},
+    )
+    scripts_dir = isolated_profiles["worker_alpha"] / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "collect.py").write_text("print('ok')\n", encoding="utf-8")
+
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="managed by named profile",
+        schedule="every 1h",
+        name="agent-to-script-job",
+    )
+
+    assert job["provider_snapshot"] == "worker-provider"
+    assert job["model_snapshot"] == "test-model"
+
+    updated = await web_server.update_cron_job(
+        job["id"],
+        web_server.CronJobUpdate(
+            updates={
+                "script": str(scripts_dir / "collect.py"),
+                "no_agent": True,
+            }
+        ),
+        profile="worker_alpha",
+    )
+
+    assert updated["provider_snapshot"] is None
+    assert updated["model_snapshot"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_cron_job_rejects_id_mutation(isolated_profiles, monkeypatch):
+    """Dashboard surfaces a 400 (not a 500 or silent rename) when an
+    id-mutation attempt is rejected by cron/jobs.update_job."""
+    from hermes_cli import web_server
+
+    notified_profiles = []
+    monkeypatch.setattr(
+        web_server,
+        "_notify_cron_provider_for_profile",
+        notified_profiles.append,
+    )
+    worker_job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="managed by named profile",
+        schedule="every 1h",
+        name="immutable-id-job",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await web_server.update_cron_job(
+            worker_job["id"],
+            web_server.CronJobUpdate(updates={"id": "../escape"}),
+            profile="worker_alpha",
+        )
+
+    assert exc.value.status_code == 400
+    assert "id" in exc.value.detail
+    assert notified_profiles == []
+    worker_jobs = await web_server.list_cron_jobs(profile="worker_alpha")
+    assert [job["id"] for job in worker_jobs] == [worker_job["id"]]
+
+
+@pytest.mark.asyncio
+async def test_cron_delete_with_profile_deletes_only_target_profile(isolated_profiles):
+    from hermes_cli import web_server
+
+    default_job = web_server._call_cron_for_profile(
+        "default",
+        "create_job",
+        prompt="same-ish default",
+        schedule="every 1h",
+        name="shared-name",
+    )
+    worker_job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="same-ish worker",
+        schedule="every 1h",
+        name="shared-name-worker",
+    )
+
+    deleted = await web_server.delete_cron_job(worker_job["id"], profile="worker_alpha")
+    assert deleted == {"ok": True}
+
+    remaining_default = await web_server.list_cron_jobs(profile="default")
+    remaining_worker = await web_server.list_cron_jobs(profile="worker_alpha")
+    assert [job["id"] for job in remaining_default] == [default_job["id"]]
+    assert remaining_worker == []
+
+
+@pytest.mark.asyncio
+async def test_cron_profile_validation_errors(isolated_profiles):
+    from hermes_cli import web_server
+
+    with pytest.raises(HTTPException) as bad_name:
+        await web_server.list_cron_jobs(profile="../bad")
+    assert bad_name.value.status_code == 400
+
+    with pytest.raises(HTTPException) as missing:
+        await web_server.list_cron_jobs(profile="missing_profile")
+    assert missing.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_cron_job_without_profile_uses_backend_own_profile(
+    isolated_profiles, monkeypatch
+):
+    """A pool backend scoped to a named profile must not default creates to
+    ``~/.hermes`` when the request carries no explicit ``profile`` (the
+    Desktop app's pre-profileScoped clients sent none)."""
+    from hermes_cli import web_server
+
+    monkeypatch.setenv(
+        "HERMES_HOME", str(isolated_profiles["worker_alpha"])
+    )
+
+    job = await web_server.create_cron_job(
+        web_server.CronJobCreate(
+            prompt="runs in my own profile",
+            schedule="every 1h",
+            name="own-profile-job",
+        ),
+        profile=None,
+    )
+
+    assert job["profile"] == "worker_alpha"
+    assert (isolated_profiles["worker_alpha"] / "cron" / "jobs.json").exists()
+    assert not (isolated_profiles["default"] / "cron" / "jobs.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_create_cron_job_without_profile_defaults_when_unscoped(
+    isolated_profiles, monkeypatch
+):
+    """HERMES_HOME at the default home (or unrecognized) keeps the legacy
+    ``default`` fallback."""
+    from hermes_cli import web_server
+
+    monkeypatch.setenv("HERMES_HOME", str(isolated_profiles["default"]))
+
+    job = await web_server.create_cron_job(
+        web_server.CronJobCreate(
+            prompt="runs in default",
+            schedule="every 1h",
+            name="default-job",
+        ),
+        profile=None,
+    )
+
+    assert job["profile"] == "default"
+    assert (isolated_profiles["default"] / "cron" / "jobs.json").exists()

--- a/tests/plugins/test_chronos_cron.py
+++ b/tests/plugins/test_chronos_cron.py
@@ -118,9 +118,16 @@ def test_reconcile_arms_all_enabled(temp_home, chronos, monkeypatch):
 
 def test_fire_due_rearms_next_oneshot(chronos, monkeypatch):
     prov, fake = chronos
-    # super().fire_due runs the job; stub the ABC default to "ran".
-    monkeypatch.setattr("cron.scheduler_provider.CronScheduler.fire_due",
-                        lambda self, jid, **kw: True)
+    # Keep the two-phase provider flow intact while stubbing durable admission
+    # and the shared runner body.
+    monkeypatch.setattr(
+        "cron.scheduler_provider.CronScheduler.claim_fire",
+        lambda self, jid, **kw: {"id": jid, "execution_id": "exec-1"},
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.CronScheduler.fire_claimed",
+        lambda self, job, **kw: True,
+    )
     monkeypatch.setattr("cron.jobs.get_job",
                         lambda jid: {"id": jid, "enabled": True, "next_run_at": "2026-06-18T12:05:00+00:00"})
 
@@ -128,3 +135,105 @@ def test_fire_due_rearms_next_oneshot(chronos, monkeypatch):
     assert [p["job_id"] for p in fake.provisions] == ["j1"]
     assert fake.provisions[0]["fire_at"] == "2026-06-18T12:05:00+00:00"
 
+
+def test_fire_due_rearms_after_claimed_job_failure(chronos, monkeypatch):
+    """A claimed attempt is consumed even when the job pipeline reports failure."""
+    prov, fake = chronos
+    claimed = {"id": "j1", "fire_claim": {"by": "owner-1"}}
+    persisted = {
+        "id": "j1",
+        "enabled": True,
+        "next_run_at": "2026-06-18T12:05:00+00:00",
+    }
+
+    monkeypatch.setattr("cron.jobs.claim_job_for_fire", lambda jid, **kw: claimed)
+    monkeypatch.setattr(
+        "cron.executions.create_execution",
+        lambda jid, source: {"id": "exec-1"},
+    )
+    monkeypatch.setattr("cron.scheduler.run_one_job", lambda *args, **kwargs: False)
+    monkeypatch.setattr("cron.jobs.get_job", lambda jid: persisted)
+
+    assert prov.fire_due("j1") is True
+    assert [provision["job_id"] for provision in fake.provisions] == ["j1"]
+
+
+def test_fire_due_forwards_manual_force_to_claim(chronos, monkeypatch):
+    """A manual force fire must reach the store claim as force=True."""
+    prov, _fake = chronos
+    seen = []
+    monkeypatch.setattr(
+        "cron.jobs.claim_job_for_fire",
+        lambda jid, **kw: seen.append(kw) or False,
+    )
+    monkeypatch.setattr(
+        "cron.executions.create_execution",
+        lambda jid, source: {"id": "exec-1"},
+    )
+
+    assert prov.fire_due("j1", force=True) is False
+    assert seen == [{"return_job": True, "force": True}]
+
+
+def test_fire_due_no_rearm_when_job_gone(chronos, monkeypatch):
+    """repeat-N exhausted / one-shot completed → mark_job_run deleted the job →
+    get_job None → no re-arm (the schedule stops cleanly)."""
+    prov, fake = chronos
+    monkeypatch.setattr("cron.scheduler_provider.CronScheduler.fire_due",
+                        lambda self, jid, **kw: True)
+    monkeypatch.setattr("cron.jobs.get_job", lambda jid: None)
+
+    assert prov.fire_due("j1") is True
+    assert fake.provisions == []
+
+
+def test_fire_due_no_rearm_when_claim_lost(chronos, monkeypatch):
+    """If the run didn't happen (claim lost), don't re-arm."""
+    prov, fake = chronos
+    monkeypatch.setattr("cron.scheduler_provider.CronScheduler.fire_due",
+                        lambda self, jid, **kw: False)
+
+    assert prov.fire_due("j1") is False
+    assert fake.provisions == []
+
+
+# -- provider capability classification ----------------------------------------
+
+def test_chronos_is_split_fire_capable(chronos):
+    """Regression: Chronos must be classified as a split-aware provider so the
+    fire webhook uses durable claim admission (not the legacy fire_due path).
+    Chronos deliberately has NO fire_due override — its re-arm logic lives in
+    fire_claimed, which the split path invokes."""
+    from cron.scheduler_provider import (
+        provider_supports_fire_cancel,
+        provider_supports_force_fire,
+        provider_supports_split_fire,
+    )
+
+    prov, _fake = chronos
+    assert provider_supports_split_fire(prov) is True
+    assert provider_supports_force_fire(prov) is True
+    assert provider_supports_fire_cancel(prov) is True
+
+
+def test_fire_claimed_no_rearm_when_run_failed(chronos, monkeypatch):
+    prov, fake = chronos
+    monkeypatch.setattr(
+        "cron.scheduler_provider.CronScheduler.fire_claimed",
+        lambda self, job, **kw: False,
+    )
+
+    assert prov.fire_claimed({"id": "j1"}) is False
+    assert fake.provisions == []
+
+
+def test_fire_claimed_no_rearm_when_job_gone(chronos, monkeypatch):
+    prov, fake = chronos
+    monkeypatch.setattr(
+        "cron.scheduler_provider.CronScheduler.fire_claimed",
+        lambda self, job, **kw: True,
+    )
+    monkeypatch.setattr("cron.jobs.get_job", lambda jid: None)
+
+    assert prov.fire_claimed({"id": "j1"}) is True
+    assert fake.provisions == []

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -67,7 +67,7 @@ class TestBackgroundDispatch:
             return True
 
         with _bound_session_key():
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
+            with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}) as m_claim, \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run_one_job), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None}):
@@ -79,7 +79,7 @@ class TestBackgroundDispatch:
             assert res["claimed"] is True
             assert res["dispatched"] is True
             assert res["delegation_id"]
-            m_claim.assert_called_once_with("job-bg-01")
+            m_claim.assert_called_once_with("job-bg-01", return_job=True)
             # The job actually starts on the daemon executor.
             assert run_started.wait(timeout=5.0), "job never started in background"
         finally:
@@ -95,7 +95,7 @@ class TestBackgroundDispatch:
         # The runner executes on a daemon thread — the patches must stay
         # active until the completion event lands, so poll INSIDE the blocks.
         with _bound_session_key("agent:main:telegram:dm:777"):
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None,
@@ -128,7 +128,7 @@ class TestBackgroundDispatch:
         from tools.process_registry import process_registry
 
         with _bound_session_key("agent:main:telegram:dm:778"):
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "error",
@@ -183,7 +183,7 @@ class TestSyncFallbacks:
     def test_pool_at_capacity_runs_inline(self):
         """A rejected dispatch must not strand the already-taken claim."""
         with _bound_session_key():
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
                  patch("tools.async_delegation.dispatch_async_delegation",
                        return_value={"status": "rejected", "error": "capacity"}), \
                  patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
@@ -278,7 +278,7 @@ class TestCronjobRunToolIntegration:
         """cronjob(action='run') surfaces the handle + do-not-wait note."""
         with _bound_session_key():
             with patch("tools.cronjob_tools.resolve_job_ref", return_value=_job('job-bg-12')), \
-                 patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"id": "job-bg-12", "name": "bg run",
@@ -296,7 +296,7 @@ class TestCronjobRunToolIntegration:
         execution_success populated from the completed run)."""
         ran = {"job": "after-run", "last_status": "ok", "last_error": None}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=_job('job-bg-13')), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
+             patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}) as m_claim, \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=ran):
             out = json.loads(cronjob(action="run", job_id="job-bg-13"))
@@ -304,5 +304,5 @@ class TestCronjobRunToolIntegration:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-bg-13")
+        m_claim.assert_called_once_with("job-bg-13", return_job=True)
         m_run.assert_called_once()

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -29,8 +29,9 @@ class TestCronjobRunExecutesImmediately:
     def test_run_action_claims_and_fires_via_run_one_job(self):
         """action='run' must claim the job then fire it through run_one_job."""
         ran = {"job": "after-run", "last_status": "ok", "last_error": None}
+        claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed) as m_claim, \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=ran):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
@@ -38,9 +39,80 @@ class TestCronjobRunExecutesImmediately:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-run-1")   # at-most-once claim taken
-        m_run.assert_called_once()                       # fired via the shared body
+        m_claim.assert_called_once_with("job-run-1", return_job=True)
+        m_run.assert_called_once_with(claimed, adapters=None, loop=None, extra_prompt=None)
 
+    def test_run_reconciles_external_provider_after_claimed_execution(self):
+        """A direct run must re-arm Chronos after it advances next_run_at.
+
+        Otherwise a scheduled Chronos fire that loses its claim to this direct
+        run is consumed without a successor one-shot, permanently stalling the
+        recurring job.
+        """
+        order = []
+        ran = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+        claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed), \
+             patch("cron.scheduler.run_one_job",
+                   side_effect=lambda *a, **kw: order.append("run") or True), \
+             patch("tools.cronjob_tools.get_job", return_value=ran), \
+             patch("tools.cronjob_tools._notify_provider_jobs_changed_safe",
+                   side_effect=lambda: order.append("notify")) as m_notify:
+            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+
+        assert out["job"]["executed"] is True
+        m_notify.assert_called_once_with()
+        # Reconcile only AFTER the run persisted its final state (mark_job_run
+        # inside run_one_job), so the provider arms the post-run next_run_at.
+        assert order == ["run", "notify"]
+
+    def test_run_reconciles_external_provider_even_when_claimed_run_fails(self):
+        """A claimed direct run advances next_run_at at claim time, so the
+        provider must be reconciled even when the execution itself fails."""
+        failed = {"id": "job-run-1", "last_status": "error", "last_error": "provider 500"}
+        claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed), \
+             patch("cron.scheduler.run_one_job", side_effect=RuntimeError("boom")), \
+             patch("tools.cronjob_tools.mark_job_run"), \
+             patch("tools.cronjob_tools.get_job", return_value=failed), \
+             patch("tools.cronjob_tools._notify_provider_jobs_changed_safe") as m_notify:
+            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+
+        assert out["job"]["executed"] is True
+        assert out["job"]["execution_success"] is False
+        m_notify.assert_called_once_with()
+
+    def test_run_skips_when_claim_lost(self):
+        """If the scheduler already holds the fire claim, do NOT double-run."""
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+             patch("cron.scheduler.run_one_job") as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)), \
+             patch("tools.cronjob_tools._notify_provider_jobs_changed_safe") as m_notify:
+            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+
+        assert out["success"] is True
+        assert out["job"]["executed"] is False
+        assert out["job"]["execution_success"] is False
+        assert "execution_skipped" in out["job"]
+        m_run.assert_not_called()  # claim lost -> never fired
+        m_notify.assert_not_called()  # the winning scheduler owns the re-arm
+
+    def test_run_reports_failure_from_last_status(self):
+        """A failed run is reported via the re-read job's last_status/last_error."""
+        failed = {"id": "job-run-1", "last_status": "error", "last_error": "provider 500"}
+        claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed), \
+             patch("cron.scheduler.run_one_job", return_value=True), \
+             patch("tools.cronjob_tools.get_job", return_value=failed):
+            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+
+        assert out["job"]["executed"] is True
+        assert out["job"]["execution_success"] is False
+        assert out["job"]["execution_error"] == "provider 500"
 
     def test_execute_job_now_bails_without_claim(self):
         """_execute_job_now never calls run_one_job when the claim is lost."""
@@ -58,7 +130,7 @@ class TestCronjobRunExecutesImmediately:
         runner = SimpleNamespace(adapters=adapters, _gateway_loop=gateway_loop)
         completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
 
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
              patch("gateway.run._gateway_runner_ref", return_value=runner), \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=completed):
@@ -66,7 +138,7 @@ class TestCronjobRunExecutesImmediately:
 
         assert res["success"] is True
         m_run.assert_called_once_with(
-            _JOB,
+            {**_JOB, "fire_claim": {"by": "manual-owner"}},
             adapters=adapters,
             loop=gateway_loop,
             extra_prompt=None,
@@ -76,18 +148,24 @@ class TestCronjobRunExecutesImmediately:
         """CLI-only runs retain the standalone delivery path."""
         completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
 
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
              patch.dict(sys.modules, {"gateway.run": None}), \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=completed):
             res = _execute_job_now(dict(_JOB))
 
         assert res["success"] is True
-        m_run.assert_called_once_with(_JOB, adapters=None, loop=None, extra_prompt=None)
+        m_run.assert_called_once_with(
+            {**_JOB, "fire_claim": {"by": "manual-owner"}},
+            adapters=None,
+            loop=None,
+            extra_prompt=None,
+        )
 
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+        claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed), \
              patch("cron.scheduler.run_one_job", side_effect=RuntimeError("boom")), \
              patch("tools.cronjob_tools.mark_job_run") as m_mark, \
              patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):
@@ -95,7 +173,12 @@ class TestCronjobRunExecutesImmediately:
         assert res["claimed"] is True
         assert res["success"] is False
         assert "boom" in res["error"]
-        m_mark.assert_called_once()
+        m_mark.assert_called_once_with(
+            "job-run-1",
+            False,
+            "boom",
+            expected_fire_owner="manual-owner",
+        )
 
     def test_execute_job_now_heartbeats_while_job_runs(self):
         """A manual run ticks the caller's activity tracker while the job
@@ -116,7 +199,7 @@ class TestCronjobRunExecutesImmediately:
                 assert heartbeat_seen.wait(timeout=5.0), "no heartbeat within 5s"
                 return True
 
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run) as m_run, \
                  patch("tools.cronjob_tools.get_job",
@@ -134,7 +217,7 @@ class TestCronjobRunExecutesImmediately:
         heartbeat thread is never started and behavior is unchanged."""
         set_activity_callback(None)
         try:
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
                  patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None}), \
@@ -165,7 +248,7 @@ class TestCronjobRunExecutesImmediately:
                 time.sleep(0.2)
                 return True
 
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_CEILING", 0.0), \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run), \
@@ -198,7 +281,7 @@ class TestCronjobRunExecutesImmediately:
                     "heartbeat stopped after one callback exception"
                 return True
 
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run), \
                  patch("tools.cronjob_tools.get_job",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -680,9 +680,11 @@ def _execute_job_now(
     Returns {"claimed": bool, "success": bool, "error": str|None}.
     """
     job_id = job["id"]
+    claimed_job = None
     try:
         # At-most-once claim: bail without running if a tick/other fire owns it.
-        if not claim_job_for_fire(job_id):
+        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        if not isinstance(claimed_job, dict):
             # claim_job_for_fire returns False for paused/disabled/missing
             # jobs too — don't mislabel those as "already being fired"
             # (#60703): that message sends the user chasing a phantom
@@ -703,7 +705,7 @@ def _execute_job_now(
             pass
         return {"claimed": True, "success": False, "error": str(e)}
 
-    return _run_claimed_job(job, extra_prompt=extra_prompt)
+    return _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
 
 
 def _run_claimed_job(
@@ -720,6 +722,7 @@ def _run_claimed_job(
     """
     job_id = job["id"]
     _registered = False
+    fire_owner = None
     try:
         from cron.scheduler import (
             release_running_job,
@@ -745,8 +748,13 @@ def _run_claimed_job(
             }
         _registered = True
 
+        claim = job.get("fire_claim")
+        fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else None
+
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
+        # ``job`` here is the exact claimed snapshot (owner-bearing), so the
+        # shared body fences every terminal write by that owner.
         #
         # A manual `run` executes the job synchronously on the caller's thread,
         # and a cron job is itself a full agent run that routinely takes
@@ -854,10 +862,19 @@ def _run_claimed_job(
             except Exception:
                 pass
         try:
-            mark_job_run(job_id, False, str(e))
+            mark_job_run(
+                job_id,
+                False,
+                str(e),
+                expected_fire_owner=fire_owner,
+            )
         except Exception:
             pass
-        return {"claimed": True, "success": False, "error": str(e)}
+        return {
+            "claimed": True,
+            "success": False,
+            "error": str(e),
+        }
 
 
 def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[str]:
@@ -978,7 +995,10 @@ def _try_dispatch_background_run(
         except Exception:
             pass
 
-        if not claim_job_for_fire(job_id):
+        # Same snapshot claim as _execute_job_now: carry the owner-bearing
+        # record into the run so terminal writes stay fenced by this owner.
+        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        if not isinstance(claimed_job, dict):
             refreshed = get_job(job_id)
             if refreshed is None:
                 reason = "Job no longer exists; nothing to run."
@@ -1015,7 +1035,7 @@ def _try_dispatch_background_run(
             "cronjob run: async delegation registry unavailable (%s); "
             "running job '%s' inline.", e, job_name,
         )
-        result = _run_claimed_job(job, extra_prompt=extra_prompt)
+        result = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
         result["dispatched"] = False
         return result
 
@@ -1030,7 +1050,7 @@ def _try_dispatch_background_run(
     deliver = job.get("deliver", "local")
 
     def _runner() -> Dict[str, Any]:
-        res = _run_claimed_job(job, extra_prompt=extra_prompt)
+        res = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
         duration = round(time.time() - started_at, 2)
         refreshed = get_job(job_id) or {}
         lines = [

--- a/web/src/lib/cron-trigger-controller.test.ts
+++ b/web/src/lib/cron-trigger-controller.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createCronTriggerController } from "@hermes/shared";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+}
+
+describe("createCronTriggerController", () => {
+  it("announces immediately and coalesces the same job while it is running", async () => {
+    const request = deferred<string>();
+    const order: string[] = [];
+    const action = vi.fn(() => {
+      order.push("action");
+      return request.promise;
+    });
+    const onStarted = vi.fn(() => order.push("started"));
+    const onRunningChange = vi.fn();
+    const controller = createCronTriggerController(onRunningChange);
+
+    const first = controller.run("profile-a:job-1", action, onStarted);
+    const duplicate = await controller.run("profile-a:job-1", action, onStarted);
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(onStarted).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["started", "action"]);
+    expect(onRunningChange).toHaveBeenNthCalledWith(1, "profile-a:job-1", true);
+    expect(duplicate).toEqual({ started: false, value: null });
+
+    request.resolve("done");
+    await expect(first).resolves.toEqual({ started: true, value: "done" });
+    expect(onRunningChange).toHaveBeenLastCalledWith("profile-a:job-1", false);
+  });
+
+  it("releases the job after failure so a retry can start", async () => {
+    const request = deferred<void>();
+    const controller = createCronTriggerController();
+
+    const failed = controller.run("job-1", () => request.promise);
+    request.reject(new Error("failed"));
+
+    await expect(failed).rejects.toThrow("failed");
+    await expect(controller.run("job-1", async () => "retried")).resolves.toEqual({
+      started: true,
+      value: "retried",
+    });
+  });
+
+  it("releases the job when the immediate feedback callback fails", async () => {
+    const controller = createCronTriggerController();
+
+    await expect(
+      controller.run("job-1", async () => "not-called", () => {
+        throw new Error("toast failed");
+      }),
+    ).rejects.toThrow("toast failed");
+
+    await expect(controller.run("job-1", async () => "retried")).resolves.toEqual({
+      started: true,
+      value: "retried",
+    });
+  });
+
+  it("allows the same job id in different profiles to run concurrently", async () => {
+    const defaultRequest = deferred<string>();
+    const workRequest = deferred<string>();
+    const defaultAction = vi.fn(() => defaultRequest.promise);
+    const workAction = vi.fn(() => workRequest.promise);
+    const controller = createCronTriggerController();
+
+    const defaultRun = controller.run("default:job-1", defaultAction);
+    const workRun = controller.run("work:job-1", workAction);
+
+    expect(defaultAction).toHaveBeenCalledTimes(1);
+    expect(workAction).toHaveBeenCalledTimes(1);
+
+    defaultRequest.resolve("default");
+    workRequest.resolve("work");
+
+    await expect(defaultRun).resolves.toEqual({ started: true, value: "default" });
+    await expect(workRun).resolves.toEqual({ started: true, value: "work" });
+  });
+
+  it("releases the job when the running-state callback fails", async () => {
+    const controller = createCronTriggerController((_key, running) => {
+      if (running) throw new Error("state callback failed");
+    });
+
+    await expect(controller.run("job-1", async () => "not-called")).rejects.toThrow(
+      "state callback failed",
+    );
+    expect(controller.isRunning("job-1")).toBe(false);
+  });
+
+  it("releases the job before the stopped-state callback runs", async () => {
+    const action = vi.fn(async () => "done");
+    const controller = createCronTriggerController((_key, running) => {
+      if (!running) throw new Error("stopped callback failed");
+    });
+
+    await expect(controller.run("job-1", action)).rejects.toThrow("stopped callback failed");
+    expect(controller.isRunning("job-1")).toBe(false);
+
+    await expect(controller.run("job-1", action)).rejects.toThrow("stopped callback failed");
+    expect(action).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1,4 +1,8 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  type CronTriggerController,
+  createCronTriggerController,
+} from "@hermes/shared";
 import { Clock, Pause, Pencil, Play, Trash2, X, Zap } from "lucide-react";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
@@ -510,6 +514,27 @@ const STATUS_TONE: Record<string, "success" | "warning" | "destructive"> = {
 
 export default function CronPage() {
   const [jobs, setJobs] = useState<CronJob[]>([]);
+  const [triggeringJobKeys, setTriggeringJobKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const triggerControllerRef = useRef<CronTriggerController | null>(null);
+
+  useEffect(() => {
+    const controller = createCronTriggerController((key, running) => {
+      if (triggerControllerRef.current !== controller) return;
+      setTriggeringJobKeys((current) => {
+        const next = new Set(current);
+        if (running) next.add(key);
+        else next.delete(key);
+        return next;
+      });
+    });
+    triggerControllerRef.current = controller;
+
+    return () => {
+      triggerControllerRef.current = null;
+    };
+  }, []);
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
   const [selectedProfile, setSelectedProfile] = useState("all");
   const [view, setView] = useState<"jobs" | "blueprints">("jobs");
@@ -576,13 +601,38 @@ export default function CronPage() {
     setEditForm(editorFormFromJob(job));
   }, []);
 
-  const loadJobs = useCallback(() => {
+  const selectedProfileRef = useRef(selectedProfile);
+  const jobsRequestGenerationRef = useRef(0);
+  const jobsActiveRef = useRef(false);
+
+  const loadJobs = useCallback((profile: string) => {
+    if (!jobsActiveRef.current || selectedProfileRef.current !== profile) return;
+
+    const generation = ++jobsRequestGenerationRef.current;
+
     api
-      .getCronJobs(selectedProfile)
-      .then(setJobs)
-      .catch(() => showToast(t.common.loading, "error"))
-      .finally(() => setLoading(false));
-  }, [selectedProfile, showToast, t.common.loading]);
+      .getCronJobs(profile)
+      .then((nextJobs) => {
+        if (
+          jobsRequestGenerationRef.current === generation &&
+          selectedProfileRef.current === profile
+        ) setJobs(nextJobs);
+      })
+      .catch(() => {
+        if (
+          jobsRequestGenerationRef.current === generation &&
+          selectedProfileRef.current === profile
+        ) {
+          showToast(t.common.loading, "error");
+        }
+      })
+      .finally(() => {
+        if (
+          jobsRequestGenerationRef.current === generation &&
+          selectedProfileRef.current === profile
+        ) setLoading(false);
+      });
+  }, [showToast, t.common.loading]);
 
   useEffect(() => {
     api
@@ -604,8 +654,15 @@ export default function CronPage() {
   }, []);
 
   useEffect(() => {
-    loadJobs();
-  }, [loadJobs]);
+    jobsActiveRef.current = true;
+    selectedProfileRef.current = selectedProfile;
+    loadJobs(selectedProfile);
+
+    return () => {
+      jobsActiveRef.current = false;
+      jobsRequestGenerationRef.current += 1;
+    };
+  }, [loadJobs, selectedProfile]);
 
   // Load resources from the profile the create/edit form actually targets.
   // Pass "default" explicitly so the global dashboard profile switch cannot
@@ -646,7 +703,7 @@ export default function CronPage() {
       showToast(t.common.create + " ✓", "success");
       setCreateForm(emptyCronJobForm());
       setCreateModalOpen(false);
-      loadJobs();
+      loadJobs(selectedProfile);
     } catch (e) {
       showToast(`${t.config.failedToSave}: ${e}`, "error");
     } finally {
@@ -677,7 +734,7 @@ export default function CronPage() {
       );
       showToast("Saved changes ✓", "success");
       setEditJob(null);
-      loadJobs();
+      loadJobs(selectedProfile);
     } catch (e) {
       showToast(`${t.config.failedToSave}: ${e}`, "error");
     } finally {
@@ -702,22 +759,45 @@ export default function CronPage() {
           "success",
         );
       }
-      loadJobs();
+      loadJobs(selectedProfile);
     } catch (e) {
       showToast(`${t.status.error}: ${e}`, "error");
     }
   };
 
   const handleTrigger = async (job: CronJob) => {
+    const jobKey = getJobKey(job);
+    const label = `${t.cron.triggerNow}: "${truncateText(getJobTitle(job), 30)}"`;
+    const viewProfile = selectedProfile;
+    const controller = triggerControllerRef.current;
+
+    if (!controller) return;
+
     try {
-      await api.triggerCronJob(job.id, getJobProfile(job));
-      showToast(
-        `${t.cron.triggerNow}: "${truncateText(getJobTitle(job), 30)}"`,
-        "success",
+      // No pre-request toast: the controller's running state already gives
+      // immediate in-progress feedback (disabled + spinning action), and a
+      // success-styled toast before the HTTP response would claim a result
+      // the request has not produced yet. Terminal feedback only.
+      const result = await controller.run(
+        jobKey,
+        () => api.triggerCronJob(job.id, getJobProfile(job)),
       );
-      loadJobs();
+
+      if (
+        triggerControllerRef.current !== controller ||
+        selectedProfileRef.current !== viewProfile ||
+        !result.started
+      ) return;
+
+      showToast(`${label} ✓`, "success");
+      loadJobs(viewProfile);
     } catch (e) {
-      showToast(`${t.status.error}: ${e}`, "error");
+      if (
+        triggerControllerRef.current === controller &&
+        selectedProfileRef.current === viewProfile
+      ) {
+        showToast(`${t.status.error}: ${e}`, "error");
+      }
     }
   };
 
@@ -732,13 +812,13 @@ export default function CronPage() {
             `${t.common.delete}: "${job ? truncateText(getJobTitle(job), 30) : id}"`,
             "success",
           );
-          loadJobs();
+          loadJobs(selectedProfile);
         } catch (e) {
           showToast(`${t.status.error}: ${e}`, "error");
           throw e;
         }
       },
-      [jobs, loadJobs, showToast, t.common.delete, t.status.error],
+      [jobs, loadJobs, selectedProfile, showToast, t.common.delete, t.status.error],
     ),
   });
 
@@ -790,7 +870,7 @@ export default function CronPage() {
       {view === "blueprints" && (
         <AutomationBlueprints
           profile={selectedProfile === "all" ? "default" : selectedProfile}
-          onCreated={loadJobs}
+          onCreated={() => loadJobs(selectedProfile)}
         />
       )}
 
@@ -1094,11 +1174,12 @@ export default function CronPage() {
                   <Button
                     ghost
                     size="icon"
+                    disabled={triggeringJobKeys.has(jobKey)}
                     title={t.cron.triggerNow}
                     aria-label={t.cron.triggerNow}
                     onClick={() => handleTrigger(job)}
                   >
-                    <Zap />
+                    {triggeringJobKeys.has(jobKey) ? <Spinner /> : <Zap />}
                   </Button>
 
                   <Button


### PR DESCRIPTION
## Bug Description

`Trigger now` did not reliably execute a cron job immediately across scheduler providers and clients. The Dashboard route could only move `next_run_at`, external providers such as Chronos were not always reconciled, and the Desktop client could time out and retry a long-running request. Concurrent scheduler/manual fires also needed a single ownership contract so stale workers could not publish or overwrite a newer execution.

## Root Cause

Immediate execution, scheduled execution, provider reconciliation, and client refreshes used related but separate paths:

- direct runs did not consistently enter the scheduler provider's fire path;
- fire claims lacked a returned atomic job snapshot and owner-fenced terminal mutation;
- a worker could continue after losing an expired lease;
- Dashboard mutations did not consistently notify the active profile-scoped provider;
- Web/Desktop clients had no shared per-job interaction guard, and Desktop used the default short request timeout;
- list/trigger responses could race profile changes or newer refreshes.

## Fix

- Route immediate execution through the scheduler provider and add forced-fire capability detection for backward compatibility.
- Return the atomically claimed job snapshot, attach a unique owner, heartbeat the lease, and fence terminal writes/delivery by that owner.
- Cooperatively cancel execution and suppress delivery when ownership is lost: the agent path is interrupted, and script-based jobs (`no_agent` + pre-run scripts) are hard-stopped with a process-tree kill (POSIX `killpg` SIGTERM→SIGKILL; Windows `taskkill /T /F`).
- Scope shutdown interruption to the exact execution token (not the job ID), so a replacement run of the same job never consumes a stale interrupted flag.
- Webhook admission keeps the two-phase contract (`claim_fire` → tracked `fire_claimed`) for split-aware providers, while legacy providers that only override the documented `fire_due` hook keep being driven through it (capability-detected, never silently bypassed). Admission happens before the 202: a claim failure is a retryable 503, a live claim is a 200 duplicate.
- Multi-profile Dashboard mutations no longer drive unscoped external-provider reconciles (fail-closed): the NAS registry is not profile-scoped, so reconciling one profile's store would disarm other profiles' one-shots. The mutated profile re-arms idempotently on its next fire/start.
- Reconcile external providers after direct execution and notify the correct profile-scoped provider after Dashboard mutations.
- Add Web/Desktop two-phase Trigger-now feedback: disabled/spinning action while running and terminal success/error feedback (no premature success toast before the HTTP response).
- Coalesce duplicate clicks for the same `profile + job` inside a mounted client while allowing unrelated jobs to run independently; the backend durable claim remains authoritative across windows/processes.
- Add Desktop request/refresh generation fencing and a 24-hour trigger timeout so long jobs are not retried after the old 15-second timeout.
- Fence stale profile/list responses and unmounted surfaces in both clients.

## Rebase Notes (current main @ 9c8a2352f)

This revision rebases onto current main and composes with the upstream changes that landed since the first revision:

- **#73973 (`BaseException` terminal recording)** — preserved verbatim in the refactored owner-fenced completion path; new regression coverage (`TestBaseExceptionThroughOwnerFencedFlow`) drives `CancelledError`/`KeyboardInterrupt` through the fenced flow and proves a stale owner cannot record over a replacement claim.
- **Completed one-shot retention (#80624)** — trigger responses now return the retained completed record instead of a synthetic pre-removal snapshot.
- **`register_job` create-time hook** — Dashboard blueprint instantiation additionally notifies the profile-scoped provider, matching the mutation contract of the sibling endpoints.
- **`advance_next_runs` batch** — kept; it is idempotent with the claim-time advance in `claim_job_for_fire` (both compute the next occurrence from the same `now`).
- **Manual-run heartbeat (#76502) + background dispatch** — composed with the claimed-snapshot path: every manual-run entry point (`_execute_job_now`, `_run_claimed_job`, `_try_dispatch_background_run`) now carries the owner-bearing snapshot into `run_one_job`.
- **Cron routes extraction (`web_routers/cron.py`)** — composed.
- **Dashboard fire webhook → forward-to-gateway (current main)** — upstream moved NAS fire execution into the gateway process (which owns the live delivery adapters), leaving the dashboard a byte-preserving forwarder with 503-on-unreachable for NAS retry. This supersedes the dashboard-side claim/tracking machinery from earlier revisions of this PR; the durable two-phase admission contract now lives where execution happens — the gateway api_server webhook (this PR's split-fire + legacy fallback + live-adapter delivery parity).

## How to Verify

1. Create a recurring cron job using either the built-in provider or Chronos.
2. Click **Trigger now** in Web or Desktop.
3. Confirm the action stays disabled/spinning while the request is active.
4. Confirm the job executes once, reports terminal success/error, clears its claim, and retains the next recurring schedule.
5. Switch profiles or trigger a refresh while execution is active; the old response must not overwrite the newly selected profile.
6. Restart the Dashboard while a webhook fire is running: the worker is asked to stop cooperatively first; only a truly stuck execution is marked interrupted, and only for its own `(job_id, fire_owner)`.

## Test Plan

- [x] Python CI-parity wrapper: 50 files, **659 tests passed** (includes new shutdown/cancellation, BaseException-through-fenced-flow, caller-loss-after-claim, and multi-profile fail-closed coverage).
- [x] Web: controller tests passed; TypeScript passed; targeted ESLint passed.
- [x] Shared package: TypeScript passed.
- [x] Desktop: 58 relevant tests passed; full TypeScript passed; targeted ESLint passed.
- [x] `git diff --check` passed; Windows-footguns gate passed (830 files scanned).
- [x] `ty` scoped diff vs current main: zero new diagnostics.
- [x] Supply-chain scan of changed files: zero findings.
- [x] Independent pre-publication reviews (concurrency, API/UI integration, quality/cross-platform).

## Risk Assessment

**Medium** — this changes scheduler concurrency and immediate-execution paths, including external-provider reconciliation. The risk is constrained by atomic CAS claims, owner fencing, heartbeat cancellation with cooperative script/agent stop, execution-token-scoped interruption, provider capability fallback, profile-scoped integration tests, client race tests, and the preserved upstream `BaseException`/retention/preflight behavior.

## Related

- Fixes #46918.
- Supersedes the narrower trigger-now execution path proposed in #46956.
- Related to the cross-runtime scheduler ownership work in #70286; this PR does not replace that broader ownership configuration contract.
