### PR TITLE
fix(gateway): block self-targeting start operations

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -1,7 +1,8 @@
 """Gateway lifecycle guard for cron job creation (#30719).
 
 An agent running inside a gateway can schedule a cron job that calls
-``hermes gateway restart`` (or ``launchctl kickstart ai.hermes.gateway``
+``hermes gateway start`` or ``hermes gateway restart`` (or
+``launchctl kickstart ai.hermes.gateway``
 or ``systemctl restart hermes-gateway``).  When the cron fires, the
 gateway dies, the supervisor (launchd KeepAlive / systemd Restart=)
 revives it, auto-resume picks up the offending session, and the resumed
@@ -25,7 +26,7 @@ command shape.
 
 This is a defence-in-depth layer.  ``tools/terminal_tool.py`` already
 blocks these commands at *execution* time when ``_HERMES_GATEWAY=1``, and
-``hermes gateway stop|restart`` refuse to self-target from inside the
+``hermes gateway start|stop|restart`` refuse to self-target from inside the
 gateway.  Blocking at *creation* time as well means the agent gets an
 immediate, informative rejection instead of scheduling a job that will
 only fail (silently) when it fires.
@@ -47,11 +48,10 @@ class GatewayLifecycleBlocked(ValueError):
 # actual shell-command-shaped strings, not on prose.
 _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"(?i)"
-    # Branch A: `hermes gateway restart|stop` — the canonical foot-gun.
-    # `start` is intentionally excluded: starting a gateway from inside a
-    # gateway is benign (a no-op or "already running" error), and a
-    # legitimate cron job might start a sibling profile's gateway.
-    r"(?:hermes\s+gateway\s+(?:restart|stop))"
+    # Branch A: `hermes gateway start|restart|stop` — canonical lifecycle
+    # operations. Even `start` may reload supervisor state and terminate the
+    # currently running gateway before the command completes.
+    r"(?:hermes\s+gateway\s+(?:start|restart|stop))"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.
@@ -134,8 +134,8 @@ def check_gateway_lifecycle(
     if contains_gateway_lifecycle_command(combined):
         raise GatewayLifecycleBlocked(
             "Blocked: cron job contains a gateway lifecycle command "
-            "(restart/stop/kill). This is blocked to prevent agent-driven "
+            "(start/stop/restart/kill). This is blocked to prevent agent-driven "
             "SIGTERM-respawn loops under launchd/systemd supervision "
-            "(#30719). Run `hermes gateway restart` from a shell outside "
+            "(#30719). Run gateway lifecycle commands from a shell outside "
             "the running gateway instead."
         )

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6878,6 +6878,18 @@ def _gateway_command_inner(args):
             sys.exit(1)
 
     elif subcmd == "start":
+        # Refuse all self-targeting lifecycle operations before service
+        # dispatch or service-file mutation. Starting an already-running
+        # supervised gateway may reload it rather than behave as a no-op.
+        if os.getenv("_HERMES_GATEWAY") == "1":
+            print_error(
+                "Refusing to start the gateway from inside the gateway process.\n"
+                "This command was blocked because gateway lifecycle operations "
+                "may interrupt the running gateway.\n"
+                "Use `hermes gateway start` from a shell outside the running gateway."
+            )
+            sys.exit(1)
+
         system = getattr(args, "system", False)
         start_all = getattr(args, "all", False)
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1,7 +1,7 @@
 """Tests for gateway restart-loop defenses (#30719).
 
 Covers:
-- Defense 1: gateway stop/restart refuse when _HERMES_GATEWAY=1
+- Defense 1: gateway start/stop/restart refuse when _HERMES_GATEWAY=1
 - Defense 2: cron create rejects prompts containing gateway lifecycle commands
 - _contains_gateway_lifecycle_command pattern matching
 """
@@ -28,6 +28,8 @@ class TestGatewayLifecyclePattern:
     @pytest.mark.parametrize("text", [
         "hermes gateway restart",
         "hermes gateway stop",
+        "hermes gateway start",
+        "  HeRmEs   GaTeWaY   StArT  ",
         "hermes  gateway  restart",         # double spaces
         "Hermez Gateway Restart".lower().replace("z", "s"),  # case handled
         "HERMES GATEWAY RESTART",           # uppercase
@@ -62,12 +64,6 @@ class TestGatewayLifecyclePattern:
         "echo 'just a normal cron job'",
         "run the backup script",
         "gateway is running fine",
-        # `hermes gateway start` is benign — starting a gateway from inside a
-        # gateway is a no-op / "already running", and a legit cron job may
-        # start a sibling profile's gateway. Only restart/stop/kill are the
-        # foot-gun (#30719 lists only those).
-        "hermes gateway start",
-        "hermes gateway start --all",
         # Tightened launchctl/systemctl branches: ops on NON-gateway hermes
         # services must not be falsely blocked (the old `.*hermes` matched any
         # hermes token).
@@ -87,6 +83,16 @@ class TestGatewayLifecyclePattern:
     ])
     def test_safe_commands(self, text):
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
+
+    def test_start_is_dangerous_command_metadata(self):
+        from tools.approval import detect_dangerous_command
+
+        is_dangerous, _pattern, description = detect_dangerous_command(
+            "hermes gateway start"
+        )
+
+        assert is_dangerous
+        assert description == "start/stop/restart hermes gateway (kills running agents)"
 
 
 class TestCronCreateLifecycleBlock:
@@ -213,11 +219,25 @@ class TestCronCreateLifecycleBlock:
 
 
 # ---------------------------------------------------------------------------
-# Defense 1: gateway stop/restart refuse inside gateway
+# Defense 1: gateway start/stop/restart refuse inside gateway
 # ---------------------------------------------------------------------------
 
 class TestGatewaySelfTargetingGuard:
-    """Verify hermes gateway stop/restart refuse when _HERMES_GATEWAY=1."""
+    """Verify gateway lifecycle commands refuse when _HERMES_GATEWAY=1."""
+
+    def test_start_refuses_inside_gateway_before_service_mutation(self, monkeypatch):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        import hermes_cli.gateway as gw
+
+        def _must_not_run(*args, **kwargs):
+            raise AssertionError("service mutation must not be reached")
+
+        monkeypatch.setattr(gw, "_dispatch_via_service_manager_if_s6", _must_not_run)
+        monkeypatch.setattr(gw, "launchd_start", _must_not_run)
+        args = Namespace(gateway_command="start", all=False, system=False)
+        with pytest.raises(SystemExit) as exc_info:
+            gw.gateway_command(args)
+        assert exc_info.value.code == 1
 
     def test_stop_refuses_inside_gateway(self, monkeypatch):
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
@@ -252,6 +272,21 @@ class TestGatewaySelfTargetingGuard:
         monkeypatch.setattr(gw, "_dispatch_via_service_manager_if_s6", _sentinel)
         monkeypatch.setattr(gw, "_dispatch_all_via_service_manager_if_s6", _sentinel)
         args = Namespace(gateway_command="stop", all=False, system=False)
+        with pytest.raises(_Reached):
+            gw.gateway_command(args)
+
+    def test_start_allows_outside_gateway(self, monkeypatch):
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        import hermes_cli.gateway as gw
+
+        class _Reached(Exception):
+            pass
+
+        def _sentinel(*args, **kwargs):
+            raise _Reached()
+
+        monkeypatch.setattr(gw, "_dispatch_via_service_manager_if_s6", _sentinel)
+        args = Namespace(gateway_command="start", all=False, system=False)
         with pytest.raises(_Reached):
             gw.gateway_command(args)
 
@@ -315,6 +350,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         "systemctl --user restart hermes-gateway",
         "systemctl stop hermes-gateway.service",
         "hermes gateway restart",
+        "hermes gateway start",
         "launchctl kickstart gui/501/ai.hermes.gateway",
         "pkill -f hermes.*gateway",
     ])
@@ -332,7 +368,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
         result = json.loads(tt.terminal_tool(
-            command="systemctl restart hermes-gateway", force=True
+            command="hermes gateway start", force=True
         ))
 
         assert result["exit_code"] == 1

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -679,11 +679,11 @@ DANGEROUS_PATTERNS = [
     (r'\bfind\b.*-exec(?:dir)?\s+(/\S*/)?rm\b', "find -exec/-execdir rm"),
     (r'\bfind\b.*-delete\b', "find -delete"),
     # Gateway lifecycle protection: prevent the agent from killing its own
-    # gateway process.  These commands trigger a gateway restart/stop that
-    # terminates all running agents mid-work.  Allow global flags between
+    # gateway process. These commands trigger gateway lifecycle operations that
+    # terminate all running agents mid-work. Allow global flags between
     # `hermes` and `gateway` (e.g. `hermes -p ade gateway restart`) so a
     # profile flag can't slip the agent past the guard.
-    (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
+    (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*gateway\s+(start|stop|restart)\b', "start/stop/restart hermes gateway (kills running agents)"),
     (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
     # Docker container lifecycle — any user with docker.sock mounted (a common
     # Docker Compose pattern) gives the agent the ability to restart/stop/kill

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2349,10 +2349,10 @@ def terminal_tool(
             }, ensure_ascii=False)
 
         # Hard-block: gateway lifecycle commands (systemctl/launchctl/hermes
-        # restart|stop targeting hermes-gateway) must never run inside the
-        # gateway process itself. The restart would SIGTERM the gateway, which
-        # kills this very subprocess before it can complete — the service may
-        # never restart. This mirrors the `hermes gateway restart` guard in
+        # start|stop|restart targeting hermes-gateway) must never run inside
+        # the gateway process itself. A lifecycle operation may SIGTERM the
+        # gateway, which kills this very subprocess before it can complete —
+        # the service may never restart. This mirrors the gateway lifecycle guard in
         # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
         # but applies unconditionally (force=True cannot help here).
         if os.environ.get("_HERMES_GATEWAY") == "1":
@@ -2362,10 +2362,10 @@ def terminal_tool(
                     "output": "",
                     "exit_code": 1,
                     "error": (
-                        "Blocked: cannot restart or stop the gateway from inside the "
-                        "gateway process. The gateway would kill this command before "
+                        "Blocked: cannot start, stop, or restart the gateway from inside "
+                        "the gateway process. The gateway may kill this command before "
                         "it could complete (SIGTERM propagates to child processes). "
-                        "Run `hermes gateway restart` from a separate shell outside "
+                        "Run gateway lifecycle commands from a separate shell outside "
                         "the running gateway."
                     ),
                     "status": "error",


### PR DESCRIPTION
## Summary

- treat `hermes gateway start` as a gateway lifecycle operation in the existing self-targeting guards
- refuse direct in-gateway CLI starts before service dispatch or service-file mutation
- extend cron, terminal hard-block, and dangerous-command coverage to include start
- preserve ordinary external-shell start behavior

## Problem

`hermes gateway start` is not always a benign no-op when invoked from a running gateway. A supervisor may refresh or reload its service definition, terminating the active gateway and interrupting the agent turn. Existing safeguards covered stop and restart but allowed this path.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py` — 69 passed
- `python -m py_compile cron/lifecycle_guard.py hermes_cli/gateway.py tools/approval.py tools/terminal_tool.py tests/hermes_cli/test_gateway_restart_loop.py`
- `git diff --check`
- live subprocess check confirmed an in-gateway start exits 1 before mutation while the supervised PID remains unchanged
