### PR TITLE
fix(mcp): enforce configured OAuth scope ceiling

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -347,6 +347,35 @@ def test_manager_builds_hermes_provider_subclass(tmp_path, monkeypatch):
     assert provider._hermes_server_name == "srv"
 
 
+@pytest.mark.asyncio
+async def test_configured_scope_is_ceiling_at_authorization(tmp_path, monkeypatch):
+    """SDK metadata discovery must not expand an explicitly configured scope."""
+    from mcp.client.auth.oauth2 import OAuthClientProvider
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+
+    reset_manager_for_tests()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+
+    manager = MCPOAuthManager()
+    provider = manager.get_or_build_provider(
+        "mesh", "https://mcp.example.com/mcp", {"scope": "openid read"}
+    )
+    provider.context.client_metadata.scope = "openid read write"
+    observed = {}
+
+    async def _capture_scope(self):
+        observed["scope"] = self.context.client_metadata.scope
+        return "authorization-request"
+
+    monkeypatch.setattr(OAuthClientProvider, "_perform_authorization", _capture_scope)
+
+    result = await provider._perform_authorization()
+
+    assert result == "authorization-request"
+    assert observed["scope"] == "openid read"
+
+
 def test_manager_fails_fast_noninteractive_without_cached_tokens(tmp_path, monkeypatch):
     """A daemon without cached MCP OAuth tokens must not enter browser auth."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -134,17 +134,25 @@ def _make_hermes_provider_class() -> Optional[type]:
             *args: Any,
             server_name: str = "",
             preregistered: bool = False,
+            scope_ceiling: Optional[str] = None,
             **kwargs: Any,
         ):
             super().__init__(*args, **kwargs)
             self._hermes_server_name = server_name
             self._hermes_home = ""
+            self._hermes_scope_ceiling = scope_ceiling
             # When the client_id comes from config.yaml (pre-registered), an
             # invalid_client rejection means the *config* is wrong — deleting
             # client.json would just be re-seeded from config and re-running
             # registration can't help. Only auto-heal dynamically-registered
             # clients. See _maybe_flag_poisoned_client.
             self._hermes_preregistered = preregistered
+
+        async def _perform_authorization(self) -> Any:
+            """Prevent SDK discovery or step-up from widening configured scopes."""
+            if self._hermes_scope_ceiling:
+                self.context.client_metadata.scope = self._hermes_scope_ceiling
+            return await super()._perform_authorization()
 
         async def _initialize(self) -> None:
             """Load stored tokens + client info AND seed token_expiry_time.
@@ -574,6 +582,7 @@ class MCPOAuthManager:
         return _HERMES_PROVIDER_CLS(
             server_name=server_name,
             preregistered=bool(cfg.get("client_id")),
+            scope_ceiling=cfg.get("scope"),
             server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,


### PR DESCRIPTION
## Summary

- treat an explicit `mcp_servers.<name>.oauth.scope` as a hard authorization ceiling
- restore the configured scope immediately before every initial or step-up authorization request
- preserve existing MCP SDK scope selection when no scope is configured

## Problem

The MCP Python SDK metadata-discovery path can replace an explicitly configured client scope with every scope advertised by protected-resource metadata. A client configured for a read-only pilot can therefore generate an authorization request containing write authority.

## Fix

Pass the configured scope into `HermesMCPOAuthProvider` as `scope_ceiling` and re-apply it in `_perform_authorization()`. This covers both initial authorization and later `insufficient_scope` step-up flows.

## Verification

- regression test reproduced SDK mutation from `openid read` to `openid read write` before the fix
- targeted regression test passes after the fix
- `tests/tools/test_mcp_oauth_manager.py` + `tests/tools/test_mcp_oauth.py`: **126 passed**
- Ruff: **all checks passed**
- independent review: no security concerns or logic errors
