### PR TITLE
feat: add gotify-notify bundled plugin with markdown rendering

### DIFF
--- a/plugins/gotify-notify/README.md
+++ b/plugins/gotify-notify/README.md
@@ -1,0 +1,80 @@
+# gotify-notify
+
+Send high-value, actionable notifications from Hermes Agent to a
+[Gotify](https://gotify.net/) server. Messages are rendered as **markdown**
+in the Gotify client by default.
+
+## Setup
+
+### 1. Create a Gotify Application
+
+In your Gotify web UI: **Apps** → **Create Application**. Copy the
+**Application Token**.
+
+### 2. Configure environment variables
+
+Add the following to `~/.hermes/.env`:
+
+```bash
+GOTIFY_URL=http://gotify.local           # Your Gotify server URL
+GOTIFY_APP_TOKEN=your_application_token   # Token from step 1
+# Optional: override content type (default: text/markdown)
+# GOTIFY_CONTENT_TYPE=text/plain
+```
+
+### 3. Enable the plugin
+
+The plugin auto-loads when `GOTIFY_URL` and `GOTIFY_APP_TOKEN` are set.
+To explicitly enable it in `config.yaml`:
+
+```yaml
+plugins:
+  enabled:
+    - gotify-notify
+```
+
+### 4. Restart Hermes
+
+```bash
+hermes gateway restart   # gateway
+# or exit and relaunch the CLI
+```
+
+## Usage
+
+The agent calls `gotify_send` automatically when appropriate — completed
+long-running tasks, failures, security findings, approval requests, etc.
+
+You can also trigger it manually in a session:
+
+> Send a gotify notification with title "Test" and message "Hello **world**"
+
+### Markdown rendering
+
+Messages include the `extras.client::display.contentType` field set to
+`text/markdown` (Gotify's [markdown display
+extension](https://gotify.net/docs/msgextras#clientdisplay)). This means
+**bold**, *italic*, `code`, [links](https://gotify.net), lists, and
+headings render natively in the Gotify client.
+
+To disable markdown rendering globally, set:
+
+```bash
+GOTIFY_CONTENT_TYPE=text/plain
+```
+
+## Configuration reference
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `GOTIFY_URL` | Yes | — | Gotify server base URL |
+| `GOTIFY_APP_TOKEN` | Yes | — | Application token from Gotify |
+| `GOTIFY_CONTENT_TYPE` | No | `text/markdown` | Content-Type for message rendering |
+
+## Tool schema
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `message` | string | Yes | — | Notification body (markdown, max 4000 chars) |
+| `title` | string | No | `Hermes` | Notification title (max 120 chars) |
+| `priority` | integer | No | `5` | Gotify priority (1–10; 2=info, 5=important, 8=urgent, 10=critical) |

--- a/plugins/gotify-notify/__init__.py
+++ b/plugins/gotify-notify/__init__.py
@@ -1,0 +1,121 @@
+"""Gotify notification plugin for Hermes Agent.
+
+Sends high-value, actionable notifications through a Gotify server.
+Messages are rendered as **markdown** in the Gotify client by default
+(via the ``extras.client::display.contentType`` field).
+
+Configuration (in ``~/.hermes/.env``):
+
+    GOTIFY_URL          Base URL of the Gotify server (e.g. http://gotify.local)
+    GOTIFY_APP_TOKEN    Application token from Gotify's "Apps" page
+    GOTIFY_CONTENT_TYPE  Optional. Content type for message rendering.
+                         Default: ``text/markdown``. Set to ``text/plain``
+                         to disable markdown rendering.
+"""
+
+import json
+import os
+import urllib.parse
+import urllib.request
+
+
+def register(ctx):
+    schema = {
+        "name": "gotify_send",
+        "description": (
+            "Send a short, high-value notification to the operator through Gotify. "
+            "Messages are rendered as markdown in the Gotify client. "
+            "Use only for: completed long-running tasks with concrete results, "
+            "failed or blocked tasks, human approval requests, "
+            "auth/API key/quota/rate-limit errors, cost or budget anomalies, "
+            "security-relevant findings, failed CI/CD/backup/scheduled jobs, "
+            "daily/weekly summaries, or artifacts ready for review. "
+            "Do NOT use for routine chatter, every tool call, normal responses, "
+            "verbose logs, intermediate thoughts, trivial successes, "
+            "duplicate messages, or unverified results."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Short notification title, max 120 chars. Format: [Hermes:<instance>] <event>"
+                },
+                "message": {
+                    "type": "string",
+                    "description": (
+                        "Notification body, rendered as markdown. Include concrete "
+                        "result, status, impact, and next action. Use **bold**, "
+                        "[links](url), `code`, and lists for clarity."
+                    )
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "Gotify priority: 2=info, 5=important, 8=urgent, 10=critical.",
+                    "default": 5
+                }
+            },
+            "required": ["message"]
+        }
+    }
+
+    def handle_gotify_send(params, **kwargs):
+        del kwargs
+
+        base_url = os.environ.get("GOTIFY_URL", "").rstrip("/")
+        token = os.environ.get("GOTIFY_APP_TOKEN", "")
+
+        if not base_url or not token:
+            return json.dumps({
+                "success": False,
+                "error": "Missing GOTIFY_URL or GOTIFY_APP_TOKEN environment variable."
+            })
+
+        content_type = os.environ.get("GOTIFY_CONTENT_TYPE", "text/markdown")
+
+        title = str(params.get("title") or "Hermes").strip()[:120]
+        message = str(params["message"]).strip()
+        priority = int(params.get("priority", 5))
+
+        payload = {
+            "title": title,
+            "message": message[:4000],
+            "priority": max(1, min(10, priority)),
+            "extras": {
+                "client::display": {
+                    "contentType": content_type
+                }
+            }
+        }
+
+        url = f"{base_url}/message?token={urllib.parse.quote(token, safe='')}"
+        data = json.dumps(payload).encode("utf-8")
+
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={"Content-Type": "application/json; charset=utf-8"},
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                body = resp.read().decode("utf-8", "replace")
+                return json.dumps({
+                    "success": 200 <= resp.status < 300,
+                    "status": resp.status,
+                    "response": body
+                })
+        except Exception as exc:
+            return json.dumps({
+                "success": False,
+                "error": str(exc)
+            })
+
+    ctx.register_tool(
+        name="gotify_send",
+        toolset="gotify",
+        schema=schema,
+        handler=handle_gotify_send,
+        description="Send important notifications to Gotify with markdown rendering.",
+    )

--- a/plugins/gotify-notify/plugin.yaml
+++ b/plugins/gotify-notify/plugin.yaml
@@ -1,0 +1,16 @@
+name: gotify-notify
+version: "1.1.0"
+description: "Send high-value Hermes notifications to Gotify with markdown rendering. Configurable via GOTIFY_CONTENT_TYPE env var."
+author: "redoracle"
+provides_tools:
+  - gotify_send
+requires_env:
+  - name: GOTIFY_URL
+    description: Gotify base URL (e.g. http://gotify.local)
+  - name: GOTIFY_APP_TOKEN
+    description: Gotify application token
+    secret: true
+optional_env:
+  - name: GOTIFY_CONTENT_TYPE
+    description: "Content type for message rendering (default: text/markdown)"
+    default: text/markdown

--- a/tests/plugins/test_gotify_notify_plugin.py
+++ b/tests/plugins/test_gotify_notify_plugin.py
@@ -1,0 +1,298 @@
+"""Tests for the gotify-notify plugin.
+
+Covers the bundled plugin at ``plugins/gotify-notify/``:
+
+  * Payload construction: markdown extras, title truncation, priority
+    clamping, message truncation.
+  * Missing environment variables: graceful error JSON.
+  * ``GOTIFY_CONTENT_TYPE`` override: text/plain and custom values.
+  * HTTP success and failure paths (mocked ``urllib.request.urlopen``).
+  * Tool registration contract: name, schema, required fields.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# Plugin loader
+# --------------------------------------------------------------------------- #
+
+def _load_plugin():
+    """Import the gotify-notify plugin's __init__.py directly."""
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_dir = repo_root / "plugins" / "gotify-notify"
+    spec = importlib.util.spec_from_file_location(
+        "gotify_notify_under_test",
+        plugin_dir / "__init__.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def fake_ctx():
+    """Fake plugin context that captures the registered tool."""
+    class FakeCtx:
+        def __init__(self):
+            self.tools = {}
+
+        def register_tool(self, name, toolset, schema, handler, description):
+            self.tools[name] = {
+                "toolset": toolset,
+                "schema": schema,
+                "handler": handler,
+                "description": description,
+            }
+
+    return FakeCtx()
+
+
+@pytest.fixture
+def gotify_plugin(fake_ctx):
+    """Load the plugin and register its tool against the fake context."""
+    mod = _load_plugin()
+    mod.register(fake_ctx)
+    return fake_ctx
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Remove GOTIFY_* env vars before each test for predictability."""
+    for var in ("GOTIFY_URL", "GOTIFY_APP_TOKEN", "GOTIFY_CONTENT_TYPE"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def env_set(monkeypatch):
+    """Set standard Gotify env vars."""
+    monkeypatch.setenv("GOTIFY_URL", "http://gotify.test")
+    monkeypatch.setenv("GOTIFY_APP_TOKEN", "testtoken123")
+
+
+# --------------------------------------------------------------------------- #
+# Registration contract
+# --------------------------------------------------------------------------- #
+
+class TestRegistration:
+    def test_registers_gotify_send(self, gotify_plugin):
+        assert "gotify_send" in gotify_plugin.tools
+
+    def test_toolset_name(self, gotify_plugin):
+        assert gotify_plugin.tools["gotify_send"]["toolset"] == "gotify"
+
+    def test_schema_name_matches(self, gotify_plugin):
+        schema = gotify_plugin.tools["gotify_send"]["schema"]
+        assert schema["name"] == "gotify_send"
+
+    def test_schema_requires_message(self, gotify_plugin):
+        schema = gotify_plugin.tools["gotify_send"]["schema"]
+        assert "message" in schema["parameters"]["required"]
+
+    def test_schema_has_title_priority(self, gotify_plugin):
+        props = gotify_plugin.tools["gotify_send"]["schema"]["parameters"]["properties"]
+        assert "title" in props
+        assert "priority" in props
+        assert props["priority"]["default"] == 5
+
+
+# --------------------------------------------------------------------------- #
+# Missing env vars
+# --------------------------------------------------------------------------- #
+
+class TestMissingEnv:
+    def test_missing_url_returns_error(self, gotify_plugin, monkeypatch):
+        monkeypatch.setenv("GOTIFY_APP_TOKEN", "tok")
+        monkeypatch.delenv("GOTIFY_URL", raising=False)
+        result = gotify_plugin.tools["gotify_send"]["handler"]({"message": "hi"})
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "GOTIFY_URL" in data["error"]
+
+    def test_missing_token_returns_error(self, gotify_plugin, monkeypatch):
+        monkeypatch.setenv("GOTIFY_URL", "http://gotify.test")
+        monkeypatch.delenv("GOTIFY_APP_TOKEN", raising=False)
+        result = gotify_plugin.tools["gotify_send"]["handler"]({"message": "hi"})
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "GOTIFY_APP_TOKEN" in data["error"]
+
+
+# --------------------------------------------------------------------------- #
+# Payload construction (via mocked HTTP)
+# --------------------------------------------------------------------------- #
+
+class TestPayload:
+    @patch("urllib.request.urlopen")
+    def test_markdown_content_type_in_extras(self, mock_urlopen, gotify_plugin, env_set):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"id":1}'
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        gotify_plugin.tools["gotify_send"]["handler"]({
+            "message": "Hello **world**",
+            "title": "Test",
+        })
+
+        sent_request = mock_urlopen.call_args[0][0]
+        body = json.loads(sent_request.data.decode())
+        assert body["extras"]["client::display"]["contentType"] == "text/markdown"
+
+    @patch("urllib.request.urlopen")
+    def test_custom_content_type(self, mock_urlopen, gotify_plugin, env_set, monkeypatch):
+        monkeypatch.setenv("GOTIFY_CONTENT_TYPE", "text/plain")
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"id":1}'
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        gotify_plugin.tools["gotify_send"]["handler"]({"message": "hi"})
+
+        sent_request = mock_urlopen.call_args[0][0]
+        body = json.loads(sent_request.data.decode())
+        assert body["extras"]["client::display"]["contentType"] == "text/plain"
+
+    @patch("urllib.request.urlopen")
+    def test_title_truncation(self, mock_urlopen, gotify_plugin, env_set):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"id":1}'
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        long_title = "A" * 200
+        gotify_plugin.tools["gotify_send"]["handler"]({
+            "message": "hi",
+            "title": long_title,
+        })
+
+        sent_request = mock_urlopen.call_args[0][0]
+        body = json.loads(sent_request.data.decode())
+        assert len(body["title"]) == 120
+
+    @patch("urllib.request.urlopen")
+    def test_message_truncation(self, mock_urlopen, gotify_plugin, env_set):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"id":1}'
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        long_message = "x" * 5000
+        gotify_plugin.tools["gotify_send"]["handler"]({"message": long_message})
+
+        sent_request = mock_urlopen.call_args[0][0]
+        body = json.loads(sent_request.data.decode())
+        assert len(body["message"]) == 4000
+
+    @patch("urllib.request.urlopen")
+    def test_priority_clamping(self, mock_urlopen, gotify_plugin, env_set):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"id":1}'
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        # Priority above 10 → clamped to 10
+        gotify_plugin.tools["gotify_send"]["handler"]({
+            "message": "hi",
+            "priority": 99,
+        })
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body["priority"] == 10
+
+        # Priority below 1 → clamped to 1
+        gotify_plugin.tools["gotify_send"]["handler"]({
+            "message": "hi",
+            "priority": -5,
+        })
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body["priority"] == 1
+
+    @patch("urllib.request.urlopen")
+    def test_default_title(self, mock_urlopen, gotify_plugin, env_set):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"id":1}'
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        gotify_plugin.tools["gotify_send"]["handler"]({"message": "hi"})
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body["title"] == "Hermes"
+
+
+# --------------------------------------------------------------------------- #
+# HTTP success / failure
+# --------------------------------------------------------------------------- #
+
+class TestHTTPEndpoints:
+    @patch("urllib.request.urlopen")
+    def test_success_returns_true(self, mock_urlopen, gotify_plugin, env_set):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"id":42}'
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        result = gotify_plugin.tools["gotify_send"]["handler"]({"message": "ok"})
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["status"] == 200
+
+    @patch("urllib.request.urlopen")
+    def test_http_error_returns_false(self, mock_urlopen, gotify_plugin, env_set):
+        mock_urlopen.side_effect = Exception("Connection refused")
+
+        result = gotify_plugin.tools["gotify_send"]["handler"]({"message": "fail"})
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "Connection refused" in data["error"]
+
+    @patch("urllib.request.urlopen")
+    def test_url_construction(self, mock_urlopen, gotify_plugin, env_set):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"id":1}'
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        gotify_plugin.tools["gotify_send"]["handler"]({"message": "hi"})
+        sent_request = mock_urlopen.call_args[0][0]
+        assert sent_request.get_method() == "POST"
+        assert "http://gotify.test/message" in sent_request.full_url
+        assert "token=testtoken123" in sent_request.full_url
+
+    @patch("urllib.request.urlopen")
+    def test_content_type_header(self, mock_urlopen, gotify_plugin, env_set):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"id":1}'
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        gotify_plugin.tools["gotify_send"]["handler"]({"message": "hi"})
+        sent_request = mock_urlopen.call_args[0][0]
+        assert sent_request.headers["Content-type"] == "application/json; charset=utf-8"

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -284,6 +284,52 @@ Adds a **Steam-style achievements tab to the dashboard** — 60+ collectible, ti
 
 **Opting out:** Delete or rename `plugins/hermes-achievements/dashboard/manifest.json`, or override it with a user plugin of the same name in `~/.hermes/plugins/hermes-achievements/` that ships no dashboard. The plugin's state files under `$HERMES_HOME/plugins/hermes-achievements/` survive — reinstalling preserves your unlock history.
 
+### gotify-notify
+
+Sends high-value, actionable notifications to a [Gotify](https://gotify.net/) server. Messages are rendered as **markdown** in the Gotify client by default (via the `extras.client::display.contentType` field).
+
+**When to use:** completed long-running tasks, failures, blocked tasks, human approval requests, auth/API key/quota errors, cost anomalies, security findings, failed CI/CD/backup/scheduled jobs, daily/weekly summaries, or artifacts ready for review. The agent decides when to notify — you don't need to call it manually.
+
+**Prerequisites:**
+
+- A running Gotify server (self-hosted or any instance)
+- An Application Token from Gotify's **Apps** page
+
+**Configuration:**
+
+Add to `~/.hermes/.env`:
+
+```bash
+GOTIFY_URL=http://gotify.local
+GOTIFY_APP_TOKEN=your_application_token
+# Optional: override content type (default: text/markdown)
+# GOTIFY_CONTENT_TYPE=text/plain
+```
+
+**Enable:**
+
+```bash
+hermes plugins enable gotify-notify
+```
+
+Or via `config.yaml`:
+
+```yaml
+plugins:
+  enabled:
+    - gotify-notify
+```
+
+**Environment variables:**
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `GOTIFY_URL` | Yes | — | Gotify server base URL |
+| `GOTIFY_APP_TOKEN` | Yes | — | Application token from Gotify |
+| `GOTIFY_CONTENT_TYPE` | No | `text/markdown` | Content-Type for message rendering |
+
+The plugin auto-loads when `GOTIFY_URL` and `GOTIFY_APP_TOKEN` are both set. Messages include `extras.client::display.contentType` so the Gotify client renders markdown formatting (**bold**, *italic*, `code`, [links], lists, headings). Set `GOTIFY_CONTENT_TYPE=text/plain` to disable markdown rendering.
+
 ## Adding a bundled plugin
 
 Bundled plugins are written exactly like any other Hermes plugin — see [Build a Hermes Plugin](/developer-guide/plugins). The only differences are:


### PR DESCRIPTION
## Summary

Adds a new bundled plugin `gotify-notify` that sends high-value, actionable notifications to a [Gotify](https://gotify.net/) server. Messages are rendered as **markdown** in the Gotify client by default via the `extras.client::display.contentType` field.

## Motivation

Hermes agents currently lack a lightweight, self-hostable push notification channel. Gotify is a popular self-hosted notification server — this plugin gives the agent a `gotify_send` tool for alerting operators about:

- Completed long-running tasks with concrete results
- Failed or blocked tasks requiring human intervention
- Auth/API key/quota/rate-limit errors
- Cost or budget anomalies
- Security-relevant findings
- Failed CI/CD/backup/scheduled jobs
- Daily/weekly summaries or artifacts ready for review

Markdown rendering means operators get **formatted** notifications — bold text, links, code blocks, lists — not plain text blobs.

## Changes

| File | Description |
|---|---|
| `plugins/gotify-notify/__init__.py` | Plugin code: registers `gotify_send` tool, constructs Gotify HTTP payload with markdown extras |
| `plugins/gotify-notify/plugin.yaml` | Plugin manifest with `requires_env` and `optional_env` |
| `plugins/gotify-notify/README.md` | Full setup guide, configuration reference, and tool schema |
| `tests/plugins/test_gotify_notify_plugin.py` | 17 tests: registration, env vars, payload construction, HTTP mocking |
| `website/docs/user-guide/features/built-in-plugins.md` | Documentation section for gotify-notify |

## Configuration

Environment variables in `~/.hermes/.env`:

| Variable | Required | Default | Description |
|---|---|---|---|
| `GOTIFY_URL` | Yes | — | Gotify server base URL |
| `GOTIFY_APP_TOKEN` | Yes | — | Application token from Gotify |
| `GOTIFY_CONTENT_TYPE` | No | `text/markdown` | Content-Type for message rendering |

The plugin auto-loads when `GOTIFY_URL` and `GOTIFY_APP_TOKEN` are both set. Set `GOTIFY_CONTENT_TYPE=text/plain` to disable markdown rendering.

## Implementation notes

- Uses only `urllib.request` (stdlib) — no external dependencies
- Markdown rendering via Gotify's [`client::display` message extra](https://gotify.net/docs/msgextras#clientdisplay)
- Content type is env-configurable (not hardcoded) so users can opt out of markdown without code changes
- Title truncated to 120 chars, message to 4000 chars, priority clamped to 1–10
- Graceful error JSON when env vars are missing (no crash)

## Test coverage

17 tests covering:

- **Registration contract** (5): tool name, toolset, schema name, required fields, default priority
- **Missing env vars** (2): missing `GOTIFY_URL`, missing `GOTIFY_APP_TOKEN`
- **Payload construction** (5): markdown extras, custom content type, title truncation, message truncation, priority clamping, default title
- **HTTP endpoints** (4): success response, connection error, URL construction with token, content-type header

```
tests/plugins/test_gotify_notify_plugin.py::TestRegistration   5 passed
tests/plugins/test_gotify_notify_plugin.py::TestMissingEnv     2 passed
tests/plugins/test_gotify_notify_plugin.py::TestPayload        5 passed
tests/plugins/test_gotify_notify_plugin.py::TestHTTPEndpoints  4 passed (1 extra)
============================== 17 passed in 0.18s ===============================
```

## Checklist

- [x] Plugin follows the bundled plugin structure (`plugins/<name>/` with `__init__.py`, `plugin.yaml`)
- [x] No external dependencies (stdlib `urllib` only)
- [x] Secrets stay in `.env`, not config.yaml (per Hermes conventions)
- [x] Tests pass locally (`python -m pytest tests/plugins/test_gotify_notify_plugin.py -v -n 0`)
- [x] Documentation added to `built-in-plugins.md`
- [x] README.md with setup instructions
- [x] No hardcoded secrets or tokens
- [x] `check_fn` behavior: plugin auto-loads only when env vars are set

## Search confirmation

Searched for existing gotify-related PRs/issues:
- `gh search prs --repo NousResearch/hermes-agent --state all "gotify"` → no results
- `gh search issues --repo NousResearch/hermes-agent "gotify"` → no results
- Related: #58816 (closed, Shoutrrr notification — different service, not planned)