### PR TITLE
fix: mount images/ dir into Docker sandboxes for desktop uploads (#69575)

### DIFF
--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -395,6 +395,7 @@ _CACHE_DIRS: list[tuple[str, str]] = [
     ("cache/screenshots", "browser_screenshots"),
     ("cache/web", "web_cache"),
     ("cache/delegation", "delegation_cache"),
+    ("images", "images"),  # desktop/clipboard uploads (#69575)
 ]
 
 


### PR DESCRIPTION
## Summary
- Adds `images/` directory to Docker sandbox cache mounts
- Desktop and clipboard uploads land in `HERMES_HOME/images/` but Docker sandboxes only mounted `cache/images`

## Root Cause
`_CACHE_DIRS` in `tools/credential_files.py` defines which host directories are bind-mounted into Docker sandbox containers. The `images/` directory (where desktop uploads, clipboard pastes, and `image.attach` files land) was not included. Only `cache/images` (used by image generation) was mounted.

This caused `vision_analyze` on desktop-uploaded images to fail with:
```
'~/.hermes/images/upload_*.png' is not reachable inside the sandbox
```

## Fix
Add `("images", "images")` to `_CACHE_DIRS` so the `images/` directory is automatically mounted into Docker containers alongside the existing cache directories.

## Test Plan
- [ ] Existing credential_files tests still pass
- [ ] Manual test: upload image via desktop app, verify vision_analyze works in Docker sandbox

Closes #69575