### PR TITLE
fix(hooks): guard print() against BrokenPipeError in daemon mode

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -137,10 +137,16 @@ class HookRegistry:
                     "path": str(hook_dir),
                 })
 
-                print(f"[hooks] Loaded hook '{hook_name}' for events: {events}", flush=True)
+                try:
+                    print(f"[hooks] Loaded hook '{hook_name}' for events: {events}", flush=True)
+                except BrokenPipeError:
+                    pass
 
             except Exception as e:
-                print(f"[hooks] Error loading hook {hook_dir.name}: {e}", flush=True)
+                try:
+                    print(f"[hooks] Error loading hook {hook_dir.name}: {e}", flush=True)
+                except BrokenPipeError:
+                    pass
 
     def _resolve_handlers(self, event_type: str) -> List[Callable]:
         """Return all handlers that should fire for ``event_type``.


### PR DESCRIPTION
## PR: fix(hooks): guard print() calls against BrokenPipeError in daemon mode

**Problem**
The hook system (`gateway/hooks.py:discover_and_load()`) uses `print(..., flush=True)`
to report loaded hooks and loading errors. When the gateway runs in `--replace`
background mode, or under launchd/systemd, stdout may be closed. The first
`print()` raises `BrokenPipeError`, which is caught by the hook's exception
handler — but that handler ALSO uses `print()`, which raises a second,
uncaught `BrokenPipeError` that propagates out of `discover_and_load()` and
kills the gateway startup before any platform connects.

This affects **any** hook, not a specific one. Every user running hooks in
background mode hits this.

**Fix**
Wrap both `print()` calls in `try/except BrokenPipeError: pass`. This is the
minimum change that makes the hook system daemon-safe. A more thorough fix
would replace `print()` with `logger.info()` / `logger.warning()`, but that
requires ensuring the logger is configured before hooks.discover_and_load()
runs (it currently logs nothing), making the fix larger and riskier.

**Repro**
1. Add any hook directory under `~/.hermes/hooks/` with a valid `HOOK.yaml` and `handler.py`
2. Start gateway with `--replace`: `hermes gateway run --replace`
3. Gateway crashes before connecting — check `gateway-exit-diag.log` for `BrokenPipeError`

**Relevant code**
https://github.com/NousResearch/hermes-agent/blob/main/gateway/hooks.py#L140-L143