### PR TITLE
fix(cron): tick every served profile's cron store under multiplex_profiles (#69377)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -816,15 +816,20 @@ def record_ticker_heartbeat(success: bool = False) -> None:
     (both fresh) — a ticker stuck failing every tick would otherwise keep the
     plain heartbeat fresh and falsely report healthy (#32612, #32895).
 
+    Resolution uses ``_current_cron_store()`` so the heartbeat is correctly
+    scoped to the active profile's store — critical under multiplex_profiles
+    where each profile needs its own liveness signal (#69377).
+
     Best-effort: a write failure must never disrupt the tick loop.
     """
+    store = _current_cron_store()
     try:
-        _atomic_write_epoch(TICKER_HEARTBEAT_FILE)
+        _atomic_write_epoch(store.cron_dir / "ticker_heartbeat")
     except Exception:
         pass
     if success:
         try:
-            _atomic_write_epoch(TICKER_SUCCESS_FILE)
+            _atomic_write_epoch(store.cron_dir / "ticker_last_success")
         except Exception:
             pass
 
@@ -842,13 +847,24 @@ def get_ticker_heartbeat_age() -> Optional[float]:
 
     None = heartbeat file missing/unreadable (older build, never ran, or a
     torn read). Callers treat None as "cannot determine", not "dead".
+
+    Resolution uses ``_current_cron_store()`` so the heartbeat is correctly
+    scoped to the active profile — critical under multiplex_profiles where
+    ``hermes cron status`` must report per-profile liveness (#69377).
     """
-    return _epoch_file_age(TICKER_HEARTBEAT_FILE)
+    store = _current_cron_store()
+    return _epoch_file_age(store.cron_dir / "ticker_heartbeat")
 
 
 def get_ticker_success_age() -> Optional[float]:
-    """Seconds since the ticker last completed a tick WITHOUT raising, or None."""
-    return _epoch_file_age(TICKER_SUCCESS_FILE)
+    """Seconds since the ticker last completed a tick WITHOUT raising, or None.
+
+    Resolution uses ``_current_cron_store()`` so the heartbeat is correctly
+    scoped to the active profile — critical under multiplex_profiles where
+    ``hermes cron status`` must report per-profile liveness (#69377).
+    """
+    store = _current_cron_store()
+    return _epoch_file_age(store.cron_dir / "ticker_last_success")
 
 
 # =============================================================================

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -259,13 +259,16 @@ class InProcessCronScheduler(CronScheduler):
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
-        Each profile uses ``use_cron_store()`` to scope its tick, heartbeat,
-        and recovery to that profile's own ``cron/jobs.json`` — mirroring how
-        the multiplexer already scopes config/SOUL/memory per turn.
+        Each profile uses ``set_hermes_home_override()`` + ``use_cron_store()``
+        to scope its tick, heartbeat, recovery, lock file, config/.env, and
+        agent execution to that profile's home — mirroring how
+        ``_profile_runtime_scope`` scopes the multiplexed inbound path and
+        ``web_server.py`` scopes per-profile cron API calls.
         """
         import logging
         from cron.scheduler import tick as cron_tick
         from cron.jobs import record_ticker_heartbeat, use_cron_store
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
 
         logger = logging.getLogger("cron.scheduler_provider")
         logger.info(
@@ -277,15 +280,19 @@ class InProcessCronScheduler(CronScheduler):
         # Recovery + initial heartbeat for every profile.
         for entry in profile_homes:
             home = entry[1] if isinstance(entry, tuple) else entry
-            with use_cron_store(home):
-                recovered = self.recover_interrupted()
-                if recovered:
-                    logger.warning(
-                        "Marked %d interrupted cron execution(s) for profile at %s",
-                        recovered,
-                        home,
-                    )
-                record_ticker_heartbeat()
+            home_token = set_hermes_home_override(str(home))
+            try:
+                with use_cron_store(home):
+                    recovered = self.recover_interrupted()
+                    if recovered:
+                        logger.warning(
+                            "Marked %d interrupted cron execution(s) for profile at %s",
+                            recovered,
+                            home,
+                        )
+                    record_ticker_heartbeat()
+            finally:
+                reset_hermes_home_override(home_token)
 
         while not stop_event.is_set():
             ok = False
@@ -295,20 +302,28 @@ class InProcessCronScheduler(CronScheduler):
                 else:
                     for entry in profile_homes:
                         home = entry[1] if isinstance(entry, tuple) else entry
-                        with use_cron_store(home):
-                            cron_tick(
-                                verbose=False,
-                                adapters=adapters,
-                                loop=loop,
-                                sync=False,
-                                can_dispatch=can_dispatch,
-                            )
+                        home_token = set_hermes_home_override(str(home))
+                        try:
+                            with use_cron_store(home):
+                                cron_tick(
+                                    verbose=False,
+                                    adapters=adapters,
+                                    loop=loop,
+                                    sync=False,
+                                    can_dispatch=can_dispatch,
+                                )
+                        finally:
+                            reset_hermes_home_override(home_token)
                 ok = True
             except BaseException as e:
                 logger.error("Cron tick error: %s", e, exc_info=True)
             # Record per-profile heartbeat after each tick cycle.
             for entry in profile_homes:
                 home = entry[1] if isinstance(entry, tuple) else entry
-                with use_cron_store(home):
-                    record_ticker_heartbeat(success=ok)
+                home_token = set_hermes_home_override(str(home))
+                try:
+                    with use_cron_store(home):
+                        record_ticker_heartbeat(success=ok)
+                finally:
+                    reset_hermes_home_override(home_token)
             stop_event.wait(interval)

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -173,13 +173,42 @@ class InProcessCronScheduler(CronScheduler):
     def name(self) -> str:
         return "builtin"
 
-    def start(self, stop_event, *, adapters=None, loop=None, interval=60, can_dispatch=None):
+    def start(
+        self,
+        stop_event,
+        *,
+        adapters=None,
+        loop=None,
+        interval=60,
+        can_dispatch=None,
+        profile_homes=None,
+    ):
         import logging
         from cron.scheduler import tick as cron_tick
         from cron.jobs import record_ticker_heartbeat
 
         logger = logging.getLogger("cron.scheduler_provider")
         logger.info("In-process cron scheduler started (interval=%ds)", interval)
+
+        # ── Multiplex profiles ────────────────────────────────────────────
+        # When profile_homes is set (multiplex_profiles on), tick EACH profile's
+        # cron store on every tick cycle so secondary-profile jobs actually fire
+        # instead of languishing in a store no ticker owns (#69377). Without this,
+        # only the process-global HERMES_HOME (the default profile) is ticked.
+        # Heartbeats and recovery are also scoped per profile so `hermes cron
+        # status` reflects liveness for every profile independently.
+        if profile_homes:
+            self._start_multiplex(
+                stop_event,
+                profile_homes=profile_homes,
+                adapters=adapters,
+                loop=loop,
+                interval=interval,
+                can_dispatch=can_dispatch,
+            )
+            return
+
+        # ── Single-profile (legacy) path ──────────────────────────────────
         recovered = self.recover_interrupted()
         if recovered:
             logger.warning(
@@ -216,4 +245,70 @@ class InProcessCronScheduler(CronScheduler):
             # clean tick, so status can tell "alive but failing every tick" from
             # "actually firing jobs" (#32612, #32895).
             record_ticker_heartbeat(success=ok)
+            stop_event.wait(interval)
+
+    def _start_multiplex(
+        self,
+        stop_event,
+        *,
+        profile_homes,
+        adapters=None,
+        loop=None,
+        interval=60,
+        can_dispatch=None,
+    ):
+        """Tick every served profile's cron store when multiplex_profiles is on.
+
+        Each profile uses ``use_cron_store()`` to scope its tick, heartbeat,
+        and recovery to that profile's own ``cron/jobs.json`` — mirroring how
+        the multiplexer already scopes config/SOUL/memory per turn.
+        """
+        import logging
+        from cron.scheduler import tick as cron_tick
+        from cron.jobs import record_ticker_heartbeat, use_cron_store
+
+        logger = logging.getLogger("cron.scheduler_provider")
+        logger.info(
+            "Multiplex cron scheduler started for %d profile(s): %s",
+            len(profile_homes),
+            [p[0] if isinstance(p, tuple) else p for p in profile_homes],
+        )
+
+        # Recovery + initial heartbeat for every profile.
+        for entry in profile_homes:
+            home = entry[1] if isinstance(entry, tuple) else entry
+            with use_cron_store(home):
+                recovered = self.recover_interrupted()
+                if recovered:
+                    logger.warning(
+                        "Marked %d interrupted cron execution(s) for profile at %s",
+                        recovered,
+                        home,
+                    )
+                record_ticker_heartbeat()
+
+        while not stop_event.is_set():
+            ok = False
+            try:
+                if can_dispatch is not None and not can_dispatch():
+                    logger.debug("Cron dispatch paused while gateway drains existing work")
+                else:
+                    for entry in profile_homes:
+                        home = entry[1] if isinstance(entry, tuple) else entry
+                        with use_cron_store(home):
+                            cron_tick(
+                                verbose=False,
+                                adapters=adapters,
+                                loop=loop,
+                                sync=False,
+                                can_dispatch=can_dispatch,
+                            )
+                ok = True
+            except BaseException as e:
+                logger.error("Cron tick error: %s", e, exc_info=True)
+            # Record per-profile heartbeat after each tick cycle.
+            for entry in profile_homes:
+                home = entry[1] if isinstance(entry, tuple) else entry
+                with use_cron_store(home):
+                    record_ticker_heartbeat(success=ok)
             stop_event.wait(interval)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23973,7 +23973,35 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     from cron.scheduler_provider import InProcessCronScheduler, resolve_cron_scheduler
     cron_stop = threading.Event()
     cron_provider = resolve_cron_scheduler()
-    cron_start_kwargs = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
+    cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
+
+    # Multiplex profiles: tell the built-in ticker which profile homes to
+    # tick so secondary-profile cron jobs actually fire (#69377).
+    # Without this, only the process-global HERMES_HOME (default profile)
+    # is iterated and every secondary profile's cron store is silently
+    # ignored — jobs show as "scheduled" with a valid next_run_at but
+    # never execute because no ticker owns that store.
+    if (
+        isinstance(cron_provider, InProcessCronScheduler)
+        and getattr(runner.config, "multiplex_profiles", False)
+    ):
+        try:
+            from hermes_cli.profiles import profiles_to_serve
+
+            profile_homes = list(profiles_to_serve(multiplex=True))
+            if profile_homes:
+                cron_start_kwargs["profile_homes"] = profile_homes
+                logger.info(
+                    "Cron scheduler will tick %d profile(s) under multiplex: %s",
+                    len(profile_homes),
+                    [p[0] if isinstance(p, tuple) else p for p in profile_homes],
+                )
+        except Exception as exc:
+            logger.warning(
+                "Could not resolve profile homes for multiplex cron: %s",
+                exc,
+            )
+
     # External cron providers own their remote scheduling contract. Only the
     # in-process ticker polls local due jobs, so only it receives the local
     # external-drain dispatch gate.

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -691,3 +691,103 @@ class TestGuardJobCredentialExfil:
 
         monkeypatch.setattr(ct, "_validate_cron_base_url", _boom)
         assert _guard_job_credential_exfil({"id": "j8", "provider": "anthropic"}) is None
+
+
+# ── Multiplex profiles: cron per secondary profile (issue #69377) ─────────
+
+
+def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
+    """The multiplex cron scheduler calls tick() once per profile home,
+    scoped via use_cron_store, so secondary-profile jobs actually fire
+    instead of languishing in an unticked store."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    # Set up two profile directories.
+    p1 = tmp_path / "default"
+    p2 = tmp_path / "home-ops"
+    for d in (p1, p2):
+        (d / "cron").mkdir(parents=True)
+
+    profile_homes = [("default", p1), ("home-ops", p2)]
+
+    # Count tick() calls — should be called once per profile per iteration.
+    tick_count: list[int] = []
+
+    def _tracking_tick(*args, **kwargs):
+        tick_count.append(1)
+        return 0
+
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+
+    with patch("cron.scheduler.tick", side_effect=_tracking_tick), \
+         patch("cron.jobs.record_ticker_heartbeat", lambda **kw: None):
+        t = threading.Thread(
+            target=prov.start,
+            args=(stop,),
+            kwargs={"interval": 0, "profile_homes": profile_homes},
+            daemon=True,
+        )
+        t.start()
+        # Wait for at least len(profile_homes) tick calls (one full cycle).
+        deadline = time.monotonic() + 10
+        while len(tick_count) < len(profile_homes) and time.monotonic() < deadline:
+            time.sleep(0.005)
+        # Give one more cycle to ensure it keeps ticking.
+        deadline = time.monotonic() + 3
+        while len(tick_count) < len(profile_homes) * 2 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+    # The ticker called tick() at least once per profile per iteration.
+    # With 2 profiles and multiple iterations, we should have seen at least 2 calls.
+    assert len(tick_count) >= len(profile_homes), \
+        f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
+
+
+def test_multiplex_heartbeat_scoped_per_profile(tmp_path, monkeypatch):
+    """record_ticker_heartbeat is scoped to each profile's store under
+    multiplex, so 'hermes cron status' can report liveness per profile."""
+    from cron.scheduler_provider import InProcessCronScheduler
+    from cron.jobs import record_ticker_heartbeat as _real_heartbeat
+
+    p_default = tmp_path / "default"
+    p_sec = tmp_path / "home-ops"
+    for d in (p_default, p_sec):
+        (d / "cron").mkdir(parents=True)
+    profile_homes = [("default", p_default), ("home-ops", p_sec)]
+
+    beat_log: list[str] = []
+
+    def _track_beat(*, success=False):
+        beat_log.append(str(success))
+        # Write the real heartbeat files so we can check them after.
+        _real_heartbeat(success=success)
+
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+
+    with patch("cron.scheduler.tick", return_value=0), \
+         patch("cron.jobs.record_ticker_heartbeat", side_effect=_track_beat):
+        t = threading.Thread(
+            target=prov.start,
+            args=(stop,),
+            kwargs={"interval": 0, "profile_homes": profile_homes},
+            daemon=True,
+        )
+        t.start()
+        deadline = time.monotonic() + 10
+        # Wait for at least 2 tick iterations over all profiles (2 profiles).
+        while len(beat_log) < len(profile_homes) * 2 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+    # Every profile should have a heartbeat file.
+    assert (p_default / "cron" / "ticker_heartbeat").exists(), \
+        "default profile heartbeat file missing"
+    assert (p_sec / "cron" / "ticker_heartbeat").exists(), \
+        "secondary profile heartbeat file missing"


### PR DESCRIPTION
## Summary
Under `multiplex_profiles: true`, the gateway's in-process cron ticker only ticked the default profile's cron store, so secondary-profile jobs were silently never executed.

Root cause: `InProcessCronScheduler.start()` was bound to the process-global `HERMES_HOME`. Secondary-profile jobs landed in `<profile>/cron/jobs.json` and showed valid `next_run_at` but never fired because no ticker owned that store.

## Changes
- `cron/scheduler_provider.py`: add `_start_multiplex()` that iterates `profile_homes`, scoping each profile's tick/heartbeat/recovery via `set_hermes_home_override()` + `use_cron_store()` (matching the `web_server.py` and `_profile_runtime_scope` patterns)
- `gateway/run.py`: resolve `profiles_to_serve(multiplex=True)` and pass `profile_homes` to the built-in scheduler
- `cron/jobs.py`: heartbeat functions now resolve via `_current_cron_store()` instead of module-level constants, so per-profile heartbeats are correctly scoped
- `tests/cron/test_scheduler_provider.py`: 2 new tests for multiplex tick-per-profile and heartbeat scoping

## Follow-up fix (on top of contributor's commit)
The original PR only used `use_cron_store()` to scope storage paths. But `cron/scheduler.py`'s `_get_lock_paths()` and agent execution path resolve via `get_hermes_home()` → `_HERMES_HOME_OVERRIDE` (a separate ContextVar). Without `set_hermes_home_override()`, the `.tick.lock`, `config.yaml`, `.env`, and secrets all resolved to the default profile — a security boundary violation. Fixed by adding `set_hermes_home_override()`/`reset_hermes_home_override()` alongside each `use_cron_store()` block, matching `web_server.py:11994`.

Salvage of #69529 by @webtecnica — cherry-picked with authorship preserved.

## Validation
| | Before | After |
|---|---|---|
| Secondary profile cron jobs | never fire | ticked per-profile |
| .tick.lock under multiplex | default profile only | correctly per-profile |
| Config/.env under multiplex | default profile only | correctly per-profile |
| Tests (test_scheduler_provider.py) | 38 | 40/40 pass |
| Tests (test_jobs.py + test_scheduler.py) | — | 418/418 pass |
| Lint (ruff) | — | clean |
