### PR TITLE
feat(slack): support plugin-provided App Home views

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -171,6 +171,11 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Slack App Home view provider. Fired when a user opens the app's Home tab.
+    # Callbacks receive user_id, team_id, and the raw Slack event, and may return
+    # one complete ``views.publish`` home-view dict. The Slack adapter publishes
+    # the first valid result; no registered provider leaves the tab untouched.
+    "slack_app_home_opened",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -60,7 +60,7 @@ def _build_full_manifest(
 
     features = {
         "app_home": {
-            "home_tab_enabled": False,
+            "home_tab_enabled": True,
             "messages_tab_enabled": True,
             "messages_tab_read_only_enabled": False,
         },

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -90,6 +90,7 @@ def _build_full_manifest(
     ]
 
     bot_events = [
+        "app_home_opened",
         "app_mention",
         "message.channels",
         "message.groups",
@@ -116,7 +117,7 @@ def _build_full_manifest(
         # Slack includes current viewing context in Agent DM events only after
         # this subscription is enabled; the adapter consumes that context to
         # preserve the referred channel across the agent turn.
-        bot_events.extend(["app_context_changed", "app_home_opened"])
+        bot_events.append("app_context_changed")
 
     bot_scopes.sort()
     bot_events.sort()

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3530,9 +3530,11 @@ class SlackAdapter(BasePlatformAdapter):
                 if view is None:
                     return
                 client = self._team_clients.get(str(team_id or ""))
-                if client is None and self._app is not None:
-                    client = self._app.client
                 if client is None:
+                    logger.warning(
+                        "[Slack] Refusing App Home publish for unknown workspace %s",
+                        team_id or "<missing>",
+                    )
                     return
                 await client.views_publish(user_id=user_id, view=view)
             except Exception:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3500,8 +3500,46 @@ class SlackAdapter(BasePlatformAdapter):
     async def _handle_app_home_opened(
         self, event: dict, body: Optional[dict] = None
     ) -> None:
-        """Handle Slack Agent DM-open lifecycle events without producing replies."""
-        if event.get("tab") != "messages":
+        """Handle Slack App Home and Agent DM-open lifecycle events."""
+        tab = event.get("tab")
+        if tab == "home":
+            user_id = str(event.get("user") or event.get("user_id") or "")
+            team_id = self._event_team_id(event, body)
+            if not user_id:
+                return
+            try:
+                from hermes_cli.plugins import invoke_hook
+
+                views = await asyncio.to_thread(
+                    invoke_hook,
+                    "slack_app_home_opened",
+                    user_id=user_id,
+                    team_id=str(team_id or ""),
+                    event=event,
+                )
+                view = next(
+                    (
+                        candidate
+                        for candidate in views
+                        if isinstance(candidate, dict)
+                        and candidate.get("type") == "home"
+                        and isinstance(candidate.get("blocks"), list)
+                    ),
+                    None,
+                )
+                if view is None:
+                    return
+                client = self._team_clients.get(str(team_id or ""))
+                if client is None and self._app is not None:
+                    client = self._app.client
+                if client is None:
+                    return
+                await client.views_publish(user_id=user_id, view=view)
+            except Exception:
+                logger.warning("[Slack] Failed to publish plugin App Home view", exc_info=True)
+            return
+
+        if tab != "messages":
             return
 
         context = event.get("context") or event.get("app_context") or {}

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3971,6 +3971,25 @@ class TestAssistantThreadLifecycle:
         assistant_adapter.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_app_home_home_tab_unknown_workspace_never_uses_primary_client(
+        self, assistant_adapter, mock_session_store
+    ):
+        event = {
+            "type": "app_home_opened",
+            "tab": "home",
+            "team": "T_UNKNOWN",
+            "user": "U_USER",
+        }
+        view = {"type": "home", "blocks": []}
+        assistant_adapter._app.client.views_publish = AsyncMock()
+
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[view]):
+            await assistant_adapter._handle_app_home_opened(event)
+
+        assistant_adapter._app.client.views_publish.assert_not_awaited()
+        mock_session_store.get_or_create_session.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_message_uses_cached_assistant_thread_identity(
         self, assistant_adapter
     ):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3915,7 +3915,45 @@ class TestAssistantThreadLifecycle:
         assistant_adapter.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_app_home_non_messages_tab_is_ignored(
+    async def test_app_home_home_tab_publishes_first_plugin_view(
+        self, assistant_adapter, mock_session_store
+    ):
+        assistant_adapter._team_clients["T_TEAM"] = MagicMock()
+        assistant_adapter._team_clients["T_TEAM"].views_publish = AsyncMock()
+        event = {
+            "type": "app_home_opened",
+            "tab": "home",
+            "team": "T_TEAM",
+            "channel": "D123",
+            "user": "U_USER",
+        }
+
+        view = {
+            "type": "home",
+            "blocks": [{"type": "header", "text": {"type": "plain_text", "text": "Support"}}],
+        }
+
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[view, {"type": "home", "blocks": []}],
+        ) as invoke_hook:
+            await assistant_adapter._handle_app_home_opened(event)
+
+        mock_session_store.get_or_create_session.assert_not_called()
+        assistant_adapter.handle_message.assert_not_called()
+        invoke_hook.assert_called_once_with(
+            "slack_app_home_opened",
+            user_id="U_USER",
+            team_id="T_TEAM",
+            event=event,
+        )
+        assistant_adapter._team_clients["T_TEAM"].views_publish.assert_awaited_once_with(
+            user_id="U_USER",
+            view=view,
+        )
+
+    @pytest.mark.asyncio
+    async def test_app_home_home_tab_without_plugin_is_ignored(
         self, assistant_adapter, mock_session_store
     ):
         event = {
@@ -3926,7 +3964,8 @@ class TestAssistantThreadLifecycle:
             "user": "U_USER",
         }
 
-        await assistant_adapter._handle_app_home_opened(event)
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            await assistant_adapter._handle_app_home_opened(event)
 
         mock_session_store.get_or_create_session.assert_not_called()
         assistant_adapter.handle_message.assert_not_called()

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -631,6 +631,7 @@ class TestPluginHooks:
         assert "transform_terminal_output" in VALID_HOOKS
         assert "transform_tool_result" in VALID_HOOKS
         assert "transform_llm_output" in VALID_HOOKS
+        assert "slack_app_home_opened" in VALID_HOOKS
 
     def test_valid_hooks_include_pre_gateway_dispatch(self):
         assert "pre_gateway_dispatch" in VALID_HOOKS

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -41,7 +41,7 @@ class TestSlackFullManifest:
         manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
 
         assert manifest["features"]["app_home"] == {
-            "home_tab_enabled": False,
+            "home_tab_enabled": True,
             "messages_tab_enabled": True,
             "messages_tab_read_only_enabled": False,
         }

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -88,6 +88,7 @@ class TestSlackFullManifest:
         assert "assistant:write" in manifest["oauth_config"]["scopes"]["bot"]
         bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
         assert "assistant_thread_started" in bot_events
+        assert "app_home_opened" in bot_events
 
     def test_no_assistant_omits_assistant_pieces(self):
         manifest = _build_full_manifest(
@@ -102,6 +103,7 @@ class TestSlackFullManifest:
         bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
         assert "assistant_thread_started" not in bot_events
         assert "assistant_thread_context_changed" not in bot_events
+        assert "app_home_opened" in bot_events
 
     def test_agent_view_uses_agent_manifest_surface(self):
         manifest = _build_full_manifest(


### PR DESCRIPTION
## Summary
- enable Slack's Home tab in generated manifests
- expose a generic `slack_app_home_opened` plugin hook
- publish the first valid plugin-provided Block Kit home view without blocking the event loop
- preserve existing Agent Messages-tab lifecycle behavior

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_slack_cli.py tests/gateway/test_slack.py tests/hermes_cli/test_plugins.py -q`
- 402 tests passed

## Scope
The core remains vendor-neutral. Customer-specific/Pylon rendering lives in a local user plugin.