### PR TITLE
feat(gateway): support channel workspace routing

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -513,7 +513,7 @@ class SessionResetPolicy:
 @dataclass
 class ChannelOverride:
     """
-    Per-channel override for model, provider, and system prompt.
+    Per-channel override for model, provider, system prompt, and working directory.
 
     Used in config under platforms.<name>.channel_overrides[channel_id].
     Enables different channels (e.g. Discord #daily vs #dev) to use different
@@ -522,6 +522,7 @@ class ChannelOverride:
     model: Optional[str] = None
     provider: Optional[str] = None
     system_prompt: Optional[str] = None
+    workdir: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {}
@@ -531,6 +532,8 @@ class ChannelOverride:
             out["provider"] = self.provider
         if self.system_prompt is not None:
             out["system_prompt"] = self.system_prompt
+        if self.workdir is not None:
+            out["workdir"] = self.workdir
         return out
 
     @classmethod
@@ -541,6 +544,7 @@ class ChannelOverride:
             model=data.get("model"),
             provider=data.get("provider"),
             system_prompt=data.get("system_prompt"),
+            workdir=data.get("workdir"),
         )
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -505,7 +505,7 @@ import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
+from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union, Sequence
 from enum import Enum
 
 from pathlib import Path as _Path
@@ -5782,6 +5782,7 @@ class BasePlatformAdapter(ABC):
         scope_id: Optional[str] = None,
         guild_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None,
+        ancestor_chat_ids: Optional[Sequence[str]] = None,
         message_id: Optional[str] = None,
         role_authorized: bool = False,
         auto_thread_created: bool = False,
@@ -5820,6 +5821,7 @@ class BasePlatformAdapter(ABC):
                         scope_id=str(scope_id) if scope_id else None,
                         guild_id=str(guild_id) if guild_id else None,
                         parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
+                        ancestor_chat_ids=tuple(str(value) for value in (ancestor_chat_ids or ())),
                         message_id=str(message_id) if message_id else None,
                     )
                 )
@@ -5844,6 +5846,7 @@ class BasePlatformAdapter(ABC):
             scope_id=str(scope_id) if scope_id else None,
             guild_id=str(guild_id) if guild_id else None,
             parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
+            ancestor_chat_ids=tuple(str(value) for value in (ancestor_chat_ids or ())),
             message_id=str(message_id) if message_id else None,
             profile=profile,
             role_authorized=role_authorized,

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -193,6 +193,10 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
         chat_id_alt=src.get("chat_id_alt"),
         scope_id=src.get("scope_id"),
         parent_chat_id=src.get("parent_chat_id"),
+        ancestor_chat_ids=tuple(
+            str(value) for value in (src.get("ancestor_chat_ids") or ())
+            if value is not None
+        ),
         message_id=src.get("message_id"),
         # The HERMES profile this event is routed to (multiplex mode). The
         # connector stamps it on the wire source when NAS resolves the target

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -44,7 +44,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Awaitable, Callable, Dict, Optional, Any, List, Union, cast
+from typing import Awaitable, Callable, Dict, Optional, Any, List, Union, Sequence, cast
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
@@ -2227,6 +2227,12 @@ _CONVERSATION_SCOPED_STATE: tuple = (
     # and run_sync) must not leak into a future conversation's first user
     # message — session keys are source-derived and REUSED.
     "_pending_turn_sidecar_notes",
+    # The selected channel workspace is pinned for the conversation so a
+    # config edit cannot silently change project context mid-session.
+    "_session_workdirs",
+    # session_key -> {task/session id: gateway-installed cwd}. Kept separately
+    # from the pin because terminal overrides are keyed by session_id.
+    "_session_workdir_task_overrides",
 )
 
 # Sentinel for "caller did not pass metadata" vs "caller passed None".
@@ -2853,15 +2859,16 @@ def _channel_override_lookup_keys(
     *,
     thread_id: Optional[str] = None,
     parent_id: Optional[str] = None,
+    ancestor_ids: Optional[Sequence[str]] = None,
 ) -> list[str]:
     """Ordered, de-duplicated keys for ``channel_overrides`` lookup.
 
-    Matches ``resolve_channel_prompt`` semantics: exact thread/channel id first,
-    then parent channel/forum id (Discord threads inherit parent overrides).
+    Exact thread/channel ID wins, followed by the immediate parent and then
+    platform-supplied ancestors from nearest to farthest.
     """
     keys: list[str] = []
     seen: set[str] = set()
-    for key in (chat_id, thread_id, parent_id):
+    for key in (chat_id, thread_id, parent_id, *(ancestor_ids or ())):
         if not key:
             continue
         sk = str(key)
@@ -2879,11 +2886,12 @@ def _get_channel_override(
     *,
     thread_id: Optional[str] = None,
     parent_id: Optional[str] = None,
+    ancestor_ids: Optional[Sequence[str]] = None,
 ) -> Optional[ChannelOverride]:
     """Return per-channel override for this platform/chat_id, or None.
 
-    Looks up ``channel_overrides`` by ``chat_id``, then ``thread_id``, then
-    ``parent_id`` (forum threads / child channels inherit the parent entry).
+    Looks up ``channel_overrides`` by exact ID, immediate parent, then ordered
+    platform-supplied ancestors (for example a Discord category).
     """
     platforms = getattr(config, "platforms", None)
     if not platforms:
@@ -2893,7 +2901,8 @@ def _get_channel_override(
         return None
     overrides = platform_config.channel_overrides
     for key in _channel_override_lookup_keys(
-        chat_id, thread_id=thread_id, parent_id=parent_id
+        chat_id, thread_id=thread_id, parent_id=parent_id,
+        ancestor_ids=ancestor_ids,
     ):
         ov = overrides.get(key)
         if ov is not None:
@@ -4411,6 +4420,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_id,
                 thread_id=thread_id,
                 parent_id=parent_id,
+                ancestor_ids=getattr(source, "ancestor_chat_ids", ()),
             )
             if ch:
                 if ch.model:
@@ -5435,6 +5445,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_config: Optional[dict] = None,
         thread_id: Optional[str] = None,
         parent_id: Optional[str] = None,
+        ancestor_ids: Optional[Sequence[str]] = None,
     ) -> str:
         """Resolve model for this channel: channel_overrides else global default."""
         config = getattr(self, "config", None)
@@ -5445,6 +5456,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_id,
                 thread_id=thread_id,
                 parent_id=parent_id,
+                ancestor_ids=ancestor_ids,
             )
             if override and override.model:
                 return override.model
@@ -5457,6 +5469,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         *,
         thread_id: Optional[str] = None,
         parent_id: Optional[str] = None,
+        ancestor_ids: Optional[Sequence[str]] = None,
     ) -> str:
         """Ephemeral system prompt for this channel/thread.
 
@@ -5473,10 +5486,60 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_id,
                 thread_id=thread_id,
                 parent_id=parent_id,
+                ancestor_ids=ancestor_ids,
             )
             if override and override.system_prompt:
                 return (override.system_prompt or "").strip()
         return getattr(self, "_ephemeral_system_prompt", None) or ""
+
+    def _resolve_workdir_for_session(
+        self,
+        source: SessionSource,
+        session_key: str,
+    ) -> str:
+        """Return the validated, conversation-pinned channel workdir.
+
+        A missing override is represented by ``""``. Config changes take
+        effect only after a conversation boundary clears the pin.
+        """
+        pinned = getattr(self, "_session_workdirs", None)
+        if not isinstance(pinned, dict):
+            pinned = {}
+            self._session_workdirs = pinned
+        if session_key in pinned:
+            return pinned[session_key]
+
+        override = _get_channel_override(
+            self.config,
+            source.platform,
+            str(source.chat_id or ""),
+            thread_id=getattr(source, "thread_id", None),
+            parent_id=getattr(source, "parent_chat_id", None),
+            ancestor_ids=getattr(source, "ancestor_chat_ids", ()),
+        )
+        configured = (override.workdir or "").strip() if override else ""
+        if not configured:
+            pinned[session_key] = ""
+            return ""
+
+        path = Path(configured)
+        if not path.is_absolute():
+            raise ValueError(
+                f"channel override workdir must be an absolute path: {configured!r}"
+            )
+        try:
+            resolved = path.resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
+            raise ValueError(
+                f"channel override workdir does not exist: {configured!r}"
+            ) from exc
+        if not resolved.is_dir():
+            raise ValueError(
+                f"channel override workdir is not a directory: {configured!r}"
+            )
+        value = str(resolved)
+        pinned[session_key] = value
+        return value
 
     @staticmethod
     def _load_reasoning_config(model: str = "") -> dict | None:
@@ -12782,9 +12845,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # Build session context
         context = build_session_context(source, self.config, session_entry)
+
+        # Resolve once per conversation before binding any tool context. An
+        # invalid override must stop the turn rather than fall through to the
+        # gateway process cwd.
+        try:
+            session_workdir = self._resolve_workdir_for_session(source, session_key)
+        except ValueError as exc:
+            logger.error(
+                "Refusing gateway turn with invalid channel workdir for %s: %s",
+                session_key,
+                exc,
+            )
+            adapter = self._adapter_for_source(source)
+            if adapter:
+                metadata = (
+                    {"thread_id": source.thread_id}
+                    if getattr(source, "thread_id", None)
+                    else None
+                )
+                await adapter.send(
+                    source.chat_id,
+                    f"⚠️ Invalid channel workspace configuration: {exc}",
+                    metadata=metadata,
+                )
+            return None
+        if session_workdir:
+            # Tool calls use the conversation's session_id as task_id. Seed
+            # the existing per-task terminal/file cwd registry; no process
+            # cwd or global TERMINAL_CWD mutation is involved.
+            from tools.terminal_tool import update_task_env_overrides
+
+            update_task_env_overrides(
+                session_entry.session_id,
+                {"cwd": session_workdir},
+            )
+            owned = getattr(self, "_session_workdir_task_overrides", None)
+            if not isinstance(owned, dict):
+                owned = {}
+                self._session_workdir_task_overrides = owned
+            owned.setdefault(session_key, {})[session_entry.session_id] = session_workdir
         
         # Set session context variables for tools (task-local, concurrency-safe)
-        _session_env_tokens = self._set_session_env(context)
+        _session_env_tokens = self._set_session_env(context, cwd=session_workdir)
         
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
@@ -17149,7 +17252,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return delivered
 
-    def _set_session_env(self, context: SessionContext) -> list:
+    def _set_session_env(self, context: SessionContext, *, cwd: str = "") -> list:
         """Set session context variables for the current async task.
 
         Uses ``contextvars`` instead of ``os.environ`` so that concurrent
@@ -17180,6 +17283,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,
+            cwd=cwd,
         )
 
     def _clear_session_env(self, tokens: list) -> None:
@@ -18678,6 +18782,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not session_key:
             return
+        owned_workdirs = getattr(self, "_session_workdir_task_overrides", None)
+        if isinstance(owned_workdirs, dict):
+            task_overrides = owned_workdirs.get(session_key, {})
+            if isinstance(task_overrides, dict):
+                from tools.terminal_tool import clear_task_env_override_cwd
+
+                for task_id, expected_cwd in tuple(task_overrides.items()):
+                    clear_task_env_override_cwd(
+                        task_id,
+                        expected_cwd=expected_cwd,
+                    )
         for attr in _CONVERSATION_SCOPED_STATE:
             store = getattr(self, attr, None)
             if isinstance(store, dict):
@@ -21003,6 +21118,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 source.chat_id or "",
                 thread_id=getattr(source, "thread_id", None),
                 parent_id=getattr(source, "parent_chat_id", None),
+                ancestor_ids=getattr(source, "ancestor_chat_ids", ()),
             )
             if cfg_channel_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + cfg_channel_prompt).strip()

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -175,6 +175,10 @@ class SessionSource:
     scope_id: Optional[str] = None
     guild_id: Optional[str] = None  # @deprecated legacy alias for scope_id (D-Q2.5)
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
+    # Ordered nearest-to-farthest stable ancestor IDs. Platform adapters fill
+    # this when their hierarchy is deeper than parent_chat_id (Discord
+    # category ancestry, for example).
+    ancestor_chat_ids: tuple[str, ...] = ()
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
     role_authorized: bool = False  # True when adapter granted access via role (not user ID)
     # Profile this inbound message is routed to in a multiplexing gateway
@@ -260,6 +264,8 @@ class SessionSource:
             d["guild_id"] = scope
         if self.parent_chat_id:
             d["parent_chat_id"] = self.parent_chat_id
+        if self.ancestor_chat_ids:
+            d["ancestor_chat_ids"] = list(self.ancestor_chat_ids)
         if self.message_id:
             d["message_id"] = self.message_id
         if self.profile:
@@ -287,6 +293,10 @@ class SessionSource:
             # deprecated `guild_id` alias (a peer not yet migrated still sends it).
             scope_id=data.get("scope_id", data.get("guild_id")),
             parent_chat_id=data.get("parent_chat_id"),
+            ancestor_chat_ids=tuple(
+                str(value) for value in (data.get("ancestor_chat_ids") or ())
+                if value is not None
+            ),
             message_id=data.get("message_id"),
             profile=data.get("profile"),
             auto_thread_created=bool(data.get("auto_thread_created", False)),

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5548,6 +5548,8 @@ class DiscordAdapter(BasePlatformAdapter):
         # For forum threads, inherit the parent forum's topic.
         chat_topic = self._get_effective_topic(interaction.channel, is_thread=is_thread)
 
+        interaction_channel = getattr(interaction, "channel", None)
+        parent_id = self._get_parent_channel_id(interaction_channel) if is_thread else None
         source = self.build_source(
             chat_id=str(interaction.channel_id),
             chat_name=chat_name,
@@ -5556,11 +5558,13 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            parent_chat_id=parent_id,
+            ancestor_chat_ids=self._channel_ancestor_ids(interaction_channel),
         )
 
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
         channel_id = str(interaction.channel_id)
-        parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
+        parent_id = parent_id or ""
         return MessageEvent(
             text=text,
             message_type=msg_type,
@@ -5641,6 +5645,12 @@ class DiscordAdapter(BasePlatformAdapter):
         # Inherit forum topic when the thread was created inside a forum channel.
         _chan = getattr(interaction, "channel", None)
         chat_topic = self._get_effective_topic(_chan, is_thread=True) if _chan else None
+        _parent_channel = (
+            self._thread_parent_channel(_chan)
+            if isinstance(_chan, discord.Thread)
+            else _chan
+        )
+        _parent_id = str(getattr(_parent_channel, "id", "") or "")
 
         source = self.build_source(
             chat_id=thread_id,
@@ -5650,10 +5660,10 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            parent_chat_id=_parent_id or None,
+            ancestor_chat_ids=self._channel_ancestor_ids(_parent_channel),
         )
 
-        _parent_channel = self._thread_parent_channel(getattr(interaction, "channel", None))
-        _parent_id = str(getattr(_parent_channel, "id", "") or "")
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(thread_id, _parent_id or None)
         event = MessageEvent(
@@ -6934,6 +6944,33 @@ class DiscordAdapter(BasePlatformAdapter):
             return str(parent_id)
         return None
 
+    def _channel_ancestor_ids(self, channel: Any) -> tuple[str, ...]:
+        """Return stable Discord ancestor IDs, nearest first.
+
+        ``parent_chat_id`` carries a thread's immediate parent separately.
+        This list includes every more-distant Discord parent (notably the
+        category) and is deterministically de-duplicated by the gateway.
+        """
+        ids: list[str] = []
+        seen: set[str] = set()
+        current = channel
+        while current is not None:
+            parent = (
+                getattr(current, "parent", None)
+                or getattr(current, "category", None)
+            )
+            if parent is None:
+                category_id = str(getattr(current, "category_id", "") or "")
+                if category_id and category_id not in seen:
+                    ids.append(category_id)
+                break
+            parent_id = str(getattr(parent, "id", "") or "")
+            if parent_id and parent_id not in seen:
+                seen.add(parent_id)
+                ids.append(parent_id)
+            current = parent
+        return tuple(ids)
+
     def _is_forum_parent(self, channel: Any) -> bool:
         """Best-effort check for whether a Discord channel is a forum channel."""
         if channel is None:
@@ -7327,6 +7364,7 @@ class DiscordAdapter(BasePlatformAdapter):
             is_bot=getattr(message.author, "bot", False),
             guild_id=str(guild.id) if guild else None,
             parent_chat_id=parent_channel_id,
+            ancestor_chat_ids=self._channel_ancestor_ids(effective_channel),
             message_id=str(message.id),
             role_authorized=role_authorized,
             auto_thread_created=auto_threaded_channel is not None,

--- a/tests/gateway/test_channel_override_workdir.py
+++ b/tests/gateway/test_channel_override_workdir.py
@@ -1,0 +1,273 @@
+"""Channel-override workspace routing and isolation contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import pytest
+
+from agent.prompt_builder import build_context_files_prompt
+from agent.runtime_cwd import resolve_context_cwd
+from gateway.config import ChannelOverride, GatewayConfig, Platform, PlatformConfig
+from gateway.run import GatewayRunner, _get_channel_override
+from gateway.session import SessionContext, SessionSource
+from tools.file_tools import read_file_tool
+from tools.terminal_tool import terminal_tool
+
+
+def _config(overrides: dict[str, ChannelOverride]) -> GatewayConfig:
+    return GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                channel_overrides=overrides,
+            ),
+            Platform.SLACK: PlatformConfig(
+                enabled=True,
+                channel_overrides=overrides,
+            ),
+        }
+    )
+
+
+def _runner(config: GatewayConfig) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner.adapters = {}
+    return runner
+
+
+def _source(
+    platform: Platform = Platform.DISCORD,
+    *,
+    chat_id: str = "333",
+    parent_id: str | None = "222",
+    ancestors: tuple[str, ...] = ("222", "111"),
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        chat_type="thread",
+        thread_id=chat_id,
+        parent_chat_id=parent_id,
+        ancestor_chat_ids=ancestors,
+        user_id="user-1",
+    )
+
+
+def test_generic_direct_channel_workdir_resolution(tmp_path):
+    config = _config({"222": ChannelOverride(workdir=str(tmp_path))})
+    source = SessionSource(platform=Platform.SLACK, chat_id="222")
+
+    assert _runner(config)._resolve_workdir_for_session(source, "session-1") == str(
+        tmp_path.resolve()
+    )
+
+
+def test_discord_category_channel_thread_precedence(tmp_path):
+    category = tmp_path / "category"
+    channel = tmp_path / "channel"
+    thread = tmp_path / "thread"
+    for path in (category, channel, thread):
+        path.mkdir()
+    source = _source()
+
+    category_only = _config({"111": ChannelOverride(workdir=str(category))})
+    assert _runner(category_only)._resolve_workdir_for_session(source, "s1") == str(category)
+
+    channel_override = _config(
+        {
+            "111": ChannelOverride(workdir=str(category)),
+            "222": ChannelOverride(workdir=str(channel)),
+        }
+    )
+    assert _runner(channel_override)._resolve_workdir_for_session(source, "s2") == str(channel)
+
+    thread_override = _config(
+        {
+            "111": ChannelOverride(workdir=str(category)),
+            "222": ChannelOverride(workdir=str(channel)),
+            "333": ChannelOverride(workdir=str(thread)),
+        }
+    )
+    assert _runner(thread_override)._resolve_workdir_for_session(source, "s3") == str(thread)
+
+
+def test_override_lookup_is_deterministic_deduplicated_and_preserves_other_fields():
+    category = ChannelOverride(
+        model="model-category",
+        provider="provider-category",
+        system_prompt="category prompt",
+    )
+    channel = ChannelOverride(
+        model="model-channel",
+        provider="provider-channel",
+        system_prompt="channel prompt",
+    )
+    config = _config({"111": category, "222": channel})
+
+    selected = _get_channel_override(
+        config,
+        Platform.DISCORD,
+        "333",
+        thread_id="333",
+        parent_id="222",
+        ancestor_ids=("222", "111", "111"),
+    )
+
+    assert selected is channel
+    assert selected.model == "model-channel"
+    assert selected.provider == "provider-channel"
+    assert selected.system_prompt == "channel prompt"
+
+
+@pytest.mark.parametrize("configured", ["relative/project", "/missing/hermes-workdir"])
+def test_invalid_workdir_fails_clearly(configured):
+    runner = _runner(_config({"222": ChannelOverride(workdir=configured)}))
+    source = SessionSource(platform=Platform.SLACK, chat_id="222")
+
+    with pytest.raises(ValueError, match="absolute path|does not exist"):
+        runner._resolve_workdir_for_session(source, "session-invalid")
+
+
+def test_existing_file_is_not_accepted_as_workdir(tmp_path):
+    configured = tmp_path / "not-a-directory"
+    configured.write_text("content", encoding="utf-8")
+    runner = _runner(_config({"222": ChannelOverride(workdir=str(configured))}))
+    source = SessionSource(platform=Platform.SLACK, chat_id="222")
+
+    with pytest.raises(ValueError, match="not a directory"):
+        runner._resolve_workdir_for_session(source, "session-file")
+
+
+def test_workdir_mapping_is_pinned_until_conversation_scope_clears(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    override = ChannelOverride(workdir=str(first))
+    runner = _runner(_config({"222": override}))
+    source = SessionSource(platform=Platform.SLACK, chat_id="222")
+
+    assert runner._resolve_workdir_for_session(source, "session-1") == str(first)
+    override.workdir = str(second)
+    assert runner._resolve_workdir_for_session(source, "session-1") == str(first)
+
+    runner._clear_session_boundary_security_state = lambda _key: None
+    runner._clear_conversation_scope("session-1", reason="test reset")
+    assert runner._resolve_workdir_for_session(source, "session-1") == str(second)
+
+
+def test_conversation_boundary_clears_only_owned_workspace_cwd(tmp_path, monkeypatch):
+    import tools.terminal_tool as terminal_module
+
+    workspace = str(tmp_path.resolve())
+    monkeypatch.setattr(
+        terminal_module,
+        "_task_env_overrides",
+        {"task-1": {"docker_image": "neutral:latest", "cwd": workspace}},
+    )
+    monkeypatch.setattr(
+        terminal_module,
+        "_session_cwd",
+        {"task-1": workspace},
+    )
+    runner = _runner(_config({}))
+    runner._session_workdirs = {"session-1": workspace}
+    runner._session_workdir_task_overrides = {
+        "session-1": {"task-1": workspace},
+    }
+    runner._clear_session_boundary_security_state = lambda _key: None
+
+    runner._clear_conversation_scope("session-1", reason="test boundary")
+
+    assert terminal_module._task_env_overrides == {
+        "task-1": {"docker_image": "neutral:latest"}
+    }
+    assert terminal_module.get_session_cwd("task-1") is None
+    assert "session-1" not in runner._session_workdirs
+    assert "session-1" not in runner._session_workdir_task_overrides
+
+
+def test_session_source_ancestor_ids_roundtrip():
+    restored = SessionSource.from_dict(_source().to_dict())
+    assert restored.ancestor_chat_ids == ("222", "111")
+
+
+def test_relay_wire_preserves_ancestor_ids():
+    from gateway.relay.ws_transport import _event_from_wire
+
+    event = _event_from_wire(
+        {
+            "text": "hello",
+            "source": _source().to_dict(),
+        }
+    )
+
+    assert event.source.ancestor_chat_ids == ("222", "111")
+
+
+def test_concurrent_workdirs_isolate_context_file_terminal_and_file_tools(tmp_path):
+    workspaces = []
+    for name in ("alpha", "docs"):
+        workspace = tmp_path / name
+        workspace.mkdir()
+        (workspace / "AGENTS.md").write_text(f"workspace-context:{name}", encoding="utf-8")
+        (workspace / "marker.txt").write_text(f"workspace-file:{name}", encoding="utf-8")
+        workspaces.append((name, workspace))
+
+    async def observe(name: str, workspace) -> tuple[str, str, str]:
+        runner = _runner(_config({}))
+        source = SessionSource(platform=Platform.SLACK, chat_id=name)
+        context = SessionContext(
+            source=source,
+            connected_platforms=[Platform.SLACK],
+            home_channels={},
+            session_key=f"session-{name}",
+            session_id=f"id-{name}",
+        )
+        tokens = runner._set_session_env(context, cwd=str(workspace))
+        task_id = f"id-{name}"
+        try:
+            await asyncio.sleep(0)
+            prompt = build_context_files_prompt(cwd=resolve_context_cwd())
+            from tools.terminal_tool import register_task_env_overrides
+
+            register_task_env_overrides(task_id, {"cwd": str(workspace)})
+            file_result = read_file_tool("marker.txt", task_id=task_id)
+            from tools.code_execution_tool import _resolve_child_cwd
+
+            code_cwd = _resolve_child_cwd(
+                "project",
+                str(tmp_path),
+                task_id=task_id,
+            )
+            terminal_result = await asyncio.to_thread(
+                terminal_tool,
+                "pwd",
+                task_id=task_id,
+            )
+            terminal_data = json.loads(terminal_result)
+            assert code_cwd == str(workspace)
+            return prompt, file_result, terminal_data["output"].strip()
+        finally:
+            from tools.terminal_tool import clear_task_env_overrides
+
+            clear_task_env_overrides(task_id)
+            runner._clear_session_env(tokens)
+
+    async def run_both():
+        return await asyncio.gather(
+            *(observe(name, workspace) for name, workspace in workspaces)
+        )
+
+    alpha, docs = asyncio.run(run_both())
+
+    assert "workspace-context:alpha" in alpha[0]
+    assert "workspace-context:docs" not in alpha[0]
+    assert "workspace-file:alpha" in alpha[1]
+    assert alpha[2] == str(workspaces[0][1])
+    assert "workspace-context:docs" in docs[0]
+    assert "workspace-context:alpha" not in docs[0]
+    assert "workspace-file:docs" in docs[1]
+    assert docs[2] == str(workspaces[1][1])

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -129,6 +129,7 @@ class TestPlatformConfigRoundtrip:
                     model="openrouter/healer-alpha",
                     provider="openrouter",
                     system_prompt="You are a daily news summarizer.",
+                    workdir="/srv/projects/alpha",
                 ),
                 "9876543210": ChannelOverride(
                     model="anthropic/claude-opus-4.6",
@@ -141,9 +142,11 @@ class TestPlatformConfigRoundtrip:
         assert "channel_overrides" in d
         assert d["channel_overrides"]["1234567890"]["model"] == "openrouter/healer-alpha"
         assert d["channel_overrides"]["9876543210"]["system_prompt"] == "You are a coding assistant."
+        assert d["channel_overrides"]["1234567890"]["workdir"] == "/srv/projects/alpha"
         restored = PlatformConfig.from_dict(d)
         assert restored.channel_overrides["1234567890"].model == "openrouter/healer-alpha"
         assert restored.channel_overrides["9876543210"].provider == "anthropic"
+        assert restored.channel_overrides["1234567890"].workdir == "/srv/projects/alpha"
 
     def test_channel_overrides_from_dict_normalizes_channel_id_to_str(self):
         """YAML may have numeric channel IDs; we store as str."""
@@ -1668,7 +1671,8 @@ class TestLoadGatewayConfig:
             '    "1234567890":\n'
             "      model: openrouter/healer-alpha\n"
             "      provider: openrouter\n"
-            "      system_prompt: Daily news summarizer\n",
+            "      system_prompt: Daily news summarizer\n"
+            "      workdir: /srv/projects/alpha\n",
             encoding="utf-8",
         )
 
@@ -1682,6 +1686,7 @@ class TestLoadGatewayConfig:
         assert ov.model == "openrouter/healer-alpha"
         assert ov.provider == "openrouter"
         assert ov.system_prompt == "Daily news summarizer"
+        assert ov.workdir == "/srv/projects/alpha"
 
     def test_bridges_discord_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -102,6 +102,15 @@ def _make_source() -> SessionSource:
 
 
 class TestResolveChannelPrompts:
+    def test_channel_ancestor_ids_include_category_for_channel_and_thread(self):
+        adapter = _make_adapter()
+        category = SimpleNamespace(id=111, parent=None, category=None)
+        channel = SimpleNamespace(id=222, parent=None, category=category)
+        thread = SimpleNamespace(id=333, parent=channel, category=None)
+
+        assert adapter._channel_ancestor_ids(channel) == ("111",)
+        assert adapter._channel_ancestor_ids(thread) == ("222", "111")
+
     def test_no_prompt_returns_none(self):
         adapter = _make_adapter()
         assert adapter._resolve_channel_prompt("123") is None
@@ -145,9 +154,16 @@ class TestResolveChannelPrompts:
         adapter.config.extra = {"channel_prompts": {"321": "Command prompt"}}
         adapter.build_source = MagicMock(return_value=SimpleNamespace())
 
+        category = SimpleNamespace(id=111, parent=None)
         interaction = SimpleNamespace(
             channel_id=321,
-            channel=SimpleNamespace(name="general", guild=None, parent_id=None),
+            channel=SimpleNamespace(
+                id=321,
+                name="general",
+                guild=None,
+                parent_id=111,
+                parent=category,
+            ),
             user=SimpleNamespace(id=1, display_name="Brenner"),
         )
         adapter._get_effective_topic = MagicMock(return_value=None)
@@ -155,6 +171,7 @@ class TestResolveChannelPrompts:
         event = adapter._build_slash_event(interaction, "/retry")
 
         assert event.channel_prompt == "Command prompt"
+        assert adapter.build_source.call_args.kwargs["ancestor_chat_ids"] == ("111",)
 
     @pytest.mark.asyncio
     async def test_dispatch_thread_session_inherits_parent_channel_prompt(self):
@@ -164,15 +181,20 @@ class TestResolveChannelPrompts:
         adapter._get_effective_topic = MagicMock(return_value=None)
         adapter.handle_message = AsyncMock()
 
+        category = SimpleNamespace(id=111, parent=None)
+        parent = SimpleNamespace(id=200, parent=category)
         interaction = SimpleNamespace(
             guild=SimpleNamespace(name="Wetlands"),
-            channel=SimpleNamespace(id=200, parent=None),
+            channel=parent,
             user=SimpleNamespace(id=1, display_name="Brenner"),
         )
 
         await adapter._dispatch_thread_session(interaction, "999", "new-thread", "hello")
 
         dispatched_event = adapter.handle_message.await_args.args[0]
+        source_kwargs = adapter.build_source.call_args.kwargs
+        assert source_kwargs["parent_chat_id"] == "200"
+        assert source_kwargs["ancestor_chat_ids"] == ("111",)
         assert dispatched_event.channel_prompt == "Parent prompt"
 
     def test_blank_prompts_are_ignored(self):

--- a/tests/tools/test_session_cwd_store.py
+++ b/tests/tools/test_session_cwd_store.py
@@ -63,6 +63,36 @@ class TestDualWriteSites:
         tt.clear_task_env_overrides("desktop-sess")
         assert tt.get_session_cwd("desktop-sess") is None
 
+    def test_update_task_env_overrides_merges_without_changing_register_contract(self):
+        tt.register_task_env_overrides("session", {"docker_image": "neutral:latest"})
+        tt.update_task_env_overrides("session", {"cwd": "/work/neutral"})
+        assert tt._task_env_overrides["session"] == {
+            "docker_image": "neutral:latest",
+            "cwd": "/work/neutral",
+        }
+
+        tt.register_task_env_overrides("session", {"modal_image": "neutral:v2"})
+        assert tt._task_env_overrides["session"] == {"modal_image": "neutral:v2"}
+
+    def test_clear_task_env_override_cwd_preserves_other_keys_and_newer_cwd(self):
+        tt.register_task_env_overrides(
+            "session",
+            {"docker_image": "neutral:latest", "cwd": "/work/first"},
+        )
+        assert not tt.clear_task_env_override_cwd(
+            "session",
+            expected_cwd="/work/stale",
+        )
+        assert tt._task_env_overrides["session"]["cwd"] == "/work/first"
+
+        assert tt.clear_task_env_override_cwd(
+            "session",
+            expected_cwd="/work/first",
+        )
+        assert tt._task_env_overrides["session"] == {
+            "docker_image": "neutral:latest"
+        }
+
     def test_reregistration_updates_the_record(self):
         """ACP session/load switching project roots mid-session."""
         tt.register_task_env_overrides("acp-sess", {"cwd": "/proj/one"})

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1162,6 +1162,40 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
             env.cwd = new_cwd
 
 
+def update_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
+    """Merge *overrides* into a task's existing environment overrides.
+
+    Unlike :func:`register_task_env_overrides`, this helper preserves keys
+    already registered by another caller.  The registration API intentionally
+    retains its replacement semantics for rollout callers that depend on it.
+    """
+    merged = dict(_task_env_overrides.get(task_id, {}))
+    merged.update(overrides)
+    register_task_env_overrides(task_id, merged)
+
+
+def clear_task_env_override_cwd(task_id: str, *, expected_cwd: str) -> bool:
+    """Remove a caller-owned cwd override without disturbing sibling keys.
+
+    The expected-value guard prevents a stale conversation-boundary cleanup
+    from deleting a cwd installed later by another owner.  Live environment
+    objects are deliberately left untouched so an already-running turn keeps
+    its cwd; subsequent resolution no longer sees the stale registry entry.
+    """
+    current = _task_env_overrides.get(task_id)
+    if not isinstance(current, dict) or current.get("cwd") != expected_cwd:
+        return False
+    remaining = dict(current)
+    remaining.pop("cwd", None)
+    if remaining:
+        _task_env_overrides[task_id] = remaining
+    else:
+        _task_env_overrides.pop(task_id, None)
+    if get_session_cwd(task_id) == expected_cwd:
+        clear_session_cwd(task_id)
+    return True
+
+
 def clear_task_env_overrides(task_id: str):
     """
     Clear environment overrides for a task after rollout completes.

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -475,6 +475,35 @@ Behavior:
 - If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
 - Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
 
+#### Channel workspace overrides
+
+The existing `channel_overrides` mapping supports an optional `workdir` on
+every messaging platform. The value must be an existing absolute directory.
+Hermes uses it for project context discovery and as the base directory for
+terminal, file, and code-execution tools.
+
+```yaml
+discord:
+  channel_overrides:
+    "111":
+      workdir: /srv/projects/alpha
+    "222":
+      workdir: /home/user/projects/docs
+      model: example/model
+```
+
+Keys are stable platform IDs, not names. On Discord, an override on category
+ID `111` applies to its child channels and threads. A child channel override
+such as `222` wins over its category, and a thread override such as `333` wins
+over both. Lookup always proceeds from the exact thread/channel to its parent,
+then through more distant ancestors.
+
+The selected workspace is pinned for the lifetime of a conversation to keep
+the system prompt cache stable. After changing a mapping, start a new/reset
+session (or restart the gateway) before expecting the new workspace to apply.
+Invalid, relative, missing, or non-directory paths reject the turn with a
+configuration error instead of falling back to another working directory.
+
 #### `discord.history_backfill`
 
 **Type:** boolean — **Default:** `true`
@@ -904,5 +933,3 @@ Leave `everyone` and `roles` at `false` unless you know exactly why you need the
 :::
 
 For more information on securing your Hermes Agent deployment, see the [Security Guide](../security.md).
-
-


### PR DESCRIPTION
## Summary

- add an optional `workdir` field to platform `channel_overrides`
- resolve Discord overrides from thread to parent channel to category ancestry, preserving existing model/provider/prompt precedence
- pin each resolved workspace to its conversation scope and clear owned CWD state at conversation boundaries
- propagate ancestor IDs through session persistence and relay transport
- route context discovery, terminal commands, and file tools through the isolated session workspace
- validate configured paths as absolute, existing directories and fail clearly on invalid mappings

## Motivation

Messaging work often spans several repositories or workspace directories. Stable platform IDs already support per-channel model and prompt overrides; extending that mechanism to workspace selection lets a category, channel, or thread open in the correct project context without process-global `chdir()` calls or cross-session leakage.

## Behavior

```yaml
discord:
  channel_overrides:
    "123456789012345678":
      workdir: /absolute/path/to/workspace
```

For Discord, the most specific configured ID wins:

1. thread
2. parent channel
3. category/remaining ancestors

An exact override with no `workdir` can intentionally stop inherited workspace routing. Other platforms continue to support direct channel overrides without Discord-specific assumptions.

## Validation

- `scripts/run_tests.sh -j 4 tests/gateway/test_channel_override_workdir.py tests/gateway/test_config.py tests/gateway/test_discord_channel_prompts.py tests/tools/test_session_cwd_store.py tests/tools/test_terminal_task_cwd.py` — 203 passed
- Python compilation for all modified Python modules and focused tests
- `git diff --check`
- local configuration load exercised category inheritance, channel exception behavior, and four distinct existing workspace directories
