### PR TITLE
feat: add visual design companion

### DIFF
--- a/skills/creative/claude-design/SKILL.md
+++ b/skills/creative/claude-design/SKILL.md
@@ -69,7 +69,7 @@ Default deliverable:
 - exact on-disk path in the final response
 - verification using available local methods before saying it is done
 
-For two to four visual alternatives that should drive an iterative refinement, use the bundled visual companion when `open_preview` and a local terminal runtime are available. Load and follow [references/visual-companion.md](references/visual-companion.md) in full. It provides the authenticated preview, click-to-tool-result loop, stale-selection protection, decision ledger, fallback behavior, and cleanup sequence. Keep ordinary local HTML delivery as the fallback for remote backends and non-Desktop surfaces.
+For two to four visual alternatives that should drive an iterative refinement, use the bundled visual companion when `open_preview` and a local terminal runtime are available. Load and follow [references/visual-companion.md](references/visual-companion.md) in full. It provides the authenticated preview, click-to-tool-result loop, stale-selection protection, decision ledger, fallback behavior, and cleanup sequence. Its high-fidelity presentation contract is mandatory for page and product-surface decisions: show complete surfaces, a composition thesis, decision callouts, responsive proof, real product vocabulary, and a consolidated accepted board—not decorative thumbnails. Keep ordinary local HTML delivery as the fallback for remote backends and non-Desktop surfaces.
 
 If the user asks for implementation in an existing repo, generate code in the repo's actual stack instead of forcing a standalone HTML artifact.
 

--- a/skills/creative/claude-design/SKILL.md
+++ b/skills/creative/claude-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-design
-description: Design one-off HTML artifacts (landing, deck, prototype).
+description: Design HTML artifacts and iterative visual option boards.
 version: 1.1.0
 author: BadTechBandit
 license: MIT
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [design, html, prototype, ux, ui, creative, artifact, deck, motion, design-system]
-    related_skills: [design-md, popular-web-designs, excalidraw, architecture-diagram]
+    related_skills: [design-md, popular-web-designs, sketch, excalidraw, architecture-diagram]
 ---
 
 # Claude Design for CLI/API Agents
@@ -41,7 +41,7 @@ These compose: use `popular-web-designs` for the visual vocabulary, `claude-desi
 
 You are running in **CLI/API mode**, not the Claude Design hosted web UI.
 
-Ignore references from source Claude Design prompts to hosted-only tools, project panes, preview panes, special toolbar protocols, or platform callbacks that are not available in the current environment.
+Ignore references from source Claude Design prompts to hosted-only tools, project panes, special toolbar protocols, or platform callbacks that are not available in the current environment. Hermes Desktop's real `open_preview` tool is not hosted Claude plumbing: use it when available.
 
 Examples of hosted-tool concepts to ignore or remap:
 
@@ -68,6 +68,8 @@ Default deliverable:
 - self-contained CSS and JavaScript when portability matters
 - exact on-disk path in the final response
 - verification using available local methods before saying it is done
+
+For two to four visual alternatives that should drive an iterative refinement, use the bundled visual companion when `open_preview` and a local terminal runtime are available. Load and follow [references/visual-companion.md](references/visual-companion.md) in full. It provides the authenticated preview, click-to-tool-result loop, stale-selection protection, decision ledger, fallback behavior, and cleanup sequence. Keep ordinary local HTML delivery as the fallback for remote backends and non-Desktop surfaces.
 
 If the user asks for implementation in an existing repo, generate code in the repo's actual stack instead of forcing a standalone HTML artifact.
 

--- a/skills/creative/claude-design/references/visual-companion.md
+++ b/skills/creative/claude-design/references/visual-companion.md
@@ -1,0 +1,216 @@
+# Hermes Visual Companion
+
+Use this workflow when the user should compare two to four rendered design directions and a selection should drive the next design round. It is a local presentation layer for `claude-design`; it does not replace the final artifact.
+
+## Preconditions and fallback
+
+Use companion mode only when all of these are true:
+
+- the agent has `terminal`, file-writing, and `open_preview` tools;
+- Hermes Desktop and the agent runtime are on the same machine;
+- the decision is genuinely visual rather than a text-only preference;
+- a blocking wait is appropriate for the active run.
+
+For a remote backend, messaging platform, TUI-only session, preview failure, or timeout, deliver the HTML artifact normally and ask the same options through `clarify`. Never claim a click was received if the `wait` command did not return a selection event.
+
+## Resolve paths
+
+The companion is bundled with this skill. Resolve its absolute path from the `skill_dir` returned by `skill_view`, then use:
+
+```text
+<skill_dir>/scripts/visual_companion.py
+```
+
+Do not assume the repository checkout or current working directory contains the skill.
+
+Create one session directory per conversation/design exploration:
+
+```text
+${HERMES_HOME:-$HOME/.hermes}/artifacts/visual-companion/<session-id>
+```
+
+Use a stable, filesystem-safe session ID. Do not reuse a directory across unrelated chats.
+
+## The interaction loop
+
+### 1. Keep a decision ledger
+
+Maintain `decision-ledger.json` in the companion session directory. It is agent-owned state, not interpreted by the server. Keep at least:
+
+```json
+{
+  "round": 1,
+  "cursor": 0,
+  "fixed": {},
+  "rejected": [],
+  "varying": "overall direction",
+  "selected": null,
+  "user_feedback": []
+}
+```
+
+After every selection:
+
+- move accepted properties into `fixed`;
+- add explicitly rejected traits to `rejected`;
+- set `varying` to the single dimension explored next;
+- store the returned cursor;
+- preserve any free-form user correction alongside the click.
+
+A refinement round changes one meaningful design dimension. Do not silently reopen settled choices.
+
+### 2. Generate a comparison fragment
+
+Write a UTF-8 HTML fragment, not a full document. It may contain markup and inline `<style>` blocks. It must contain two to four selectable elements:
+
+```html
+<section class="directions" aria-label="Layout directions">
+  <button class="direction" data-choice="council" data-label="Council Chamber">
+    <!-- complete visual direction -->
+  </button>
+  <button class="direction" data-choice="focused" data-label="Focused Correspondence">
+    <!-- complete visual direction -->
+  </button>
+</section>
+```
+
+Rules enforced by the publisher:
+
+- the fragment is no larger than 1 MiB and contains two to four choices;
+- every option has exactly one stable, non-empty, unique `data-choice` value of at most 128 characters;
+- use at most one `data-label` of at most 256 characters for the canonical human-readable selection label;
+- no `<script>`, iframe, object, embed, base, link, or meta elements;
+- no inline `on*=` handlers or `javascript:` URLs;
+- no remote `src`, `href`, CSS `url(...)`, or `@import` assets;
+- images and fonts must be embedded data URLs when needed;
+- the host injects the only JavaScript and the baseline selection affordance;
+- generated markup and styles run inside a sandboxed iframe without same-origin access, so fixed overlays, `:host` rules, duplicate IDs, and forged inputs cannot cover or alter the trusted feedback and status controls outside the frame.
+
+Make options comparable at the same scale. Label the differentiating idea, best use, tradeoff, and recommendation without making the recommendation unselectable.
+
+### 3. Publish the first round
+
+Write the source fragment to a stable path, then run:
+
+```text
+python3 <skill_dir>/scripts/visual_companion.py publish \
+  --session-dir <session-dir> \
+  --file <round-fragment.html> \
+  --round-id <stable-round-id>
+```
+
+The command validates the fragment and the non-empty round ID (at most 128 characters), takes the session's cross-process advisory lock, writes an immutable versioned page, and atomically advances `round.json` as the active-version pointer. `current.html` is a convenience copy; serving and selection fail closed unless the immutable page named by the manifest exists. Choice recording takes the same lock, so publication cannot race a stale selection. The operating system releases advisory locks automatically if a process exits or crashes.
+
+### 4. Start and verify the local server
+
+Start one tracked long-lived background process:
+
+```text
+python3 <skill_dir>/scripts/visual_companion.py serve \
+  --session-dir <session-dir> \
+  --port 0
+```
+
+Use `terminal(background=true)` without `notify_on_complete`; this is an intentionally long-lived server. The server binds only to `127.0.0.1`, refuses a second server for the same session, creates separate random bootstrap and session credentials, and writes them only to mode-`0600` local files. `state.json` holds private lifecycle state, while `open-preview.html` is a mode-`0600` one-time launcher containing only the bootstrap capability. Standard output contains only non-secret readiness data such as `{"pid":1234,"port":54321,"status":"ready"}`.
+
+Verify readiness before opening the preview:
+
+```text
+python3 <skill_dir>/scripts/visual_companion.py status \
+  --session-dir <session-dir>
+```
+
+Expected result:
+
+```json
+{"status":"ok"}
+```
+
+### 5. Open the authenticated preview
+
+Pass the deterministic local launcher path directly to `open_preview`:
+
+```text
+<session-dir>/open-preview.html
+```
+
+Do not read `state.json` or `open-preview.html` with a file or terminal tool. The local launcher transfers the one-time capability directly into Hermes Desktop's sandboxed preview webview, so neither the capability nor the long-lived session credential enters the model context, ordinary transcript, or tool result. It posts the capability in a bounded form body to a query-free bootstrap endpoint; the loopback response exchanges it for a distinct HttpOnly, SameSite=Lax cookie and performs a same-origin transition to the randomized session route. The capability is therefore never a browser URL or history entry. Lax permits the trusted top-level local-file handoff while withholding the cookie from cross-site mutation requests.
+
+Call `open_preview` once per companion session. Later publications live-reload in the same page.
+
+### 6. Block for a structured click
+
+Use the cursor from the ledger:
+
+```text
+python3 <skill_dir>/scripts/visual_companion.py wait \
+  --session-dir <session-dir> \
+  --after <cursor> \
+  --timeout 120
+```
+
+Run this as a foreground terminal command with a timeout longer than the script timeout. Before clicking, the user may add a correction of up to 2,000 Unicode characters in the companion's optional feedback field. A click returns one JSON object:
+
+```json
+{
+  "choice_id": "council",
+  "cursor": 1,
+  "feedback": "Keep the structure, but reduce the orange accent.",
+  "label": "Council Chamber",
+  "page_version": 1,
+  "round_id": "layout-directions"
+}
+```
+
+Exit code `3` with `{"status":"timeout",...}` means no selection was made. Do not infer a choice. Fall back to `clarify`, keeping the same labels and IDs.
+
+Before sending the request, the trusted client sets a pending fence and disables every choice plus the feedback field; rapid competing clicks cannot overwrite a successful status with a later conflict. The server validates the choice ID against the active fragment, preserves optional feedback, deduplicates identical submissions, and rejects stale or conflicting clicks after a round has been selected. The complete read, validation, cursor allocation, and append transaction is protected by the same cross-process session advisory lock used by publication. Waiters also read the event stream under that lock, so they never observe a partially appended event.
+
+### 7. Refine without reopening the pane
+
+Update the ledger, generate the next fragment, and publish it to the same session directory. The preview polls `page_version` and reloads automatically. Then call `wait` with the returned cursor from the previous selection.
+
+A good sequence is:
+
+```text
+overall layout → color posture → accent system → component/detail refinement
+```
+
+Do not generate endless rounds. Once the remaining uncertainty is better resolved in implementation, summarize the accepted decisions and build the real artifact.
+
+### 8. Stop and preserve the outcome
+
+When the user accepts a direction, cancels, or the workflow cannot continue:
+
+```text
+python3 <skill_dir>/scripts/visual_companion.py stop \
+  --session-dir <session-dir>
+```
+
+Confirm the tracked background process exits. Keep the decision ledger and generated rounds as session artifacts unless the user asks to remove them. The accepted production artifact belongs in the user's requested project/output path, not only inside the companion session directory.
+
+## Security contract
+
+The companion is intentionally narrow:
+
+- loopback binding only;
+- one-time bootstrap capability distinct from the session credential;
+- private local-file handoff from `open_preview` to the one-time bootstrap capability;
+- unique HttpOnly, SameSite=Lax cookie scoped to a randomized session route;
+- one live server per session plus crash-reclaimable process leases;
+- one cross-process advisory lock shared by publication, choice recording, and event reads;
+- strict CSP with nonce-authorized host script;
+- sandboxed-iframe visual and input isolation between generated markup and trusted controls;
+- no generated JavaScript or remote assets;
+- canonical labels derived from the published fragment;
+- page-version and cursor checks for stale events;
+- bounded round IDs, choice identifiers, labels, Unicode feedback, and request bodies;
+- non-secret server readiness output and no directory-serving endpoint.
+
+Do not weaken these controls to accommodate a generated page. Change the fragment instead.
+
+## Transcript behavior
+
+After a click, state the accepted direction in ordinary assistant text before presenting or generating the next round. This keeps the decision visible in transcript replay even though the structured selection arrived as a tool result.
+
+Free-form user feedback wins over an inferred implication of the selected card. Treat a click as `selected option X`, not as consent to every incidental detail shown inside X.

--- a/skills/creative/claude-design/references/visual-companion.md
+++ b/skills/creative/claude-design/references/visual-companion.md
@@ -88,6 +88,23 @@ Rules enforced by the publisher:
 
 Make options comparable at the same scale. Label the differentiating idea, best use, tradeoff, and recommendation without making the recommendation unselectable.
 
+#### High-fidelity presentation contract
+
+A companion round is a decision board, not a gallery of decorative cards. For a page, application screen, dashboard, or other product-surface decision, every selectable direction must:
+
+- show a complete representative product surface at a readable scale, not a thumbnail, moodboard, or palette swatch;
+- pair its short direction name with a one-sentence composition thesis that explains the organizing idea rather than describing colors;
+- use actual product vocabulary, representative content, design tokens, and component patterns from the supplied source or repository instead of generic SaaS filler;
+- add numbered anatomy callouts when hierarchy, layout, or interaction structure is being judged, tying each number to a visible locus and a concise design rationale;
+- demonstrate wide and narrow behavior when the target is responsive, using the same content and accepted hierarchy rather than merely claiming that it adapts;
+- identify the differentiating idea, best use, primary tradeoff, and recommendation without making any direction harder to select.
+
+Use three to six callouts for a screen-level direction unless fewer truly cover every material decision. For a lower-level exploration such as type, accent, motion posture, or component shape, the candidate may be scoped to that dimension, but show it in representative product context rather than as an isolated token sample.
+
+Keep the comparison fair: preserve the same viewport, crop, content, and zoom wherever the varying dimension allows. Stack rich candidates vertically when side-by-side columns would make their interfaces unreadable. Do not put links, text fields, or other nested interactive controls inside a selectable direction; describe those states visually.
+
+Run the Slop Diagnostic before publication. Record the score, repair every compositional tell, and re-score. When screenshot or browser-inspection tools are available, inspect the primary wide viewport and the named narrow viewport before asking the user to choose; source validation alone is not visual acceptance.
+
 ### 3. Publish the first round
 
 Write the source fragment to a stable path, then run:
@@ -176,9 +193,21 @@ A good sequence is:
 overall layout → color posture → accent system → component/detail refinement
 ```
 
-Do not generate endless rounds. Once the remaining uncertainty is better resolved in implementation, summarize the accepted decisions and build the real artifact.
+Do not generate endless rounds. Keep every refinement at the same readable fidelity while changing only the ledger's `varying` dimension; preserve the accepted composition, content, callouts, and responsive behavior unless the user's correction explicitly reopens one of them. Once the remaining uncertainty is better resolved in implementation, summarize the accepted decisions and build the real artifact.
 
-### 8. Stop and preserve the outcome
+### 8. Consolidate the accepted direction
+
+After the final selection, create a consolidated presentation artifact outside the selectable companion fragment before treating a screen-level design review as complete. It should contain:
+
+- the accepted complete representative product surface at full readable scale;
+- the final one-sentence composition thesis;
+- numbered anatomy callouts for the decisions the user accepted;
+- wide and narrow behavior when the product is responsive;
+- a compact record of the selected direction, incorporated feedback, fixed properties, and consciously rejected tradeoffs.
+
+This artifact is the design handoff, not another vote, so it does not need `data-choice` elements. Save it in the user's requested project or artifact location, open it through the ordinary preview path, inspect its primary viewports and browser console when tools permit, and use it as the visual contract for implementation. If the user explicitly asks to proceed directly into implementation, preserve the same information in the implementation plan and verify the production surface against it.
+
+### 9. Stop and preserve the outcome
 
 When the user accepts a direction, cancels, or the workflow cannot continue:
 

--- a/skills/creative/claude-design/scripts/visual_companion.py
+++ b/skills/creative/claude-design/scripts/visual_companion.py
@@ -1,0 +1,1006 @@
+#!/usr/bin/env python3
+"""Visual companion publication utility."""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+import html
+import hmac
+import json
+import os
+import re
+import secrets
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from http import HTTPStatus
+from http.cookies import SimpleCookie
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+_CHOICE_ATTR_RE = re.compile(
+    r"\bdata-choice\s*=\s*(?:\"[^\"]+\"|'[^']+')",
+    re.IGNORECASE,
+)
+_CSS_URL_RE = re.compile(
+    r"url\s*\(\s*(?P<quote>['\"]?)(?P<value>.*?)(?P=quote)\s*\)",
+    re.IGNORECASE | re.DOTALL,
+)
+_UNSAFE_FRAGMENT_PATTERNS = (
+    (
+        re.compile(r"<(?:script|iframe|object|embed|base|link|meta)\b", re.IGNORECASE),
+        "active HTML elements",
+    ),
+    (re.compile(r"\son[a-z0-9_-]+\s*=", re.IGNORECASE), "inline event handlers"),
+    (re.compile(r"javascript\s*:", re.IGNORECASE), "javascript URLs"),
+    (
+        re.compile(
+            r"\b(?:src|href|action)\s*=\s*['\"]\s*(?:https?:)?//",
+            re.IGNORECASE,
+        ),
+        "remote asset URLs",
+    ),
+    (
+        re.compile(r"url\s*\(\s*['\"]?\s*(?:https?:)?//", re.IGNORECASE),
+        "remote CSS URLs",
+    ),
+    (re.compile(r"@import\b", re.IGNORECASE), "CSS imports"),
+)
+
+_NAVIGATION_URL_ATTRIBUTES = {"action", "formaction", "href", "xlink:href"}
+_RESOURCE_URL_ATTRIBUTES = {"poster", "src"}
+
+_COOKIE_NAME_PREFIX = "hermes_visual_companion_"
+_MAX_FRAGMENT_BYTES = 1024 * 1024
+_MAX_REQUEST_BYTES = 32 * 1024
+_MAX_BOOTSTRAP_REQUEST_BYTES = 1024
+_MAX_FEEDBACK_CHARS = 2000
+_MAX_CHOICE_ID_CHARS = 128
+_MAX_CHOICE_LABEL_CHARS = 256
+_MAX_ROUND_ID_CHARS = 128
+_PREVIEW_LAUNCHER_FILENAME = "open-preview.html"
+_POLL_SECONDS = 0.05
+_SESSION_LOCK_TIMEOUT_SECONDS = 3.0
+_SERVER_LEASE_TIMEOUT_SECONDS = 0.5
+
+
+class VisualCompanionError(ValueError):
+    """A user-facing companion configuration or content error."""
+
+
+class StalePageError(VisualCompanionError):
+    """A choice came from a superseded visual-companion round."""
+
+
+class RoundAlreadySelectedError(VisualCompanionError):
+    """A round already emitted a different choice event."""
+
+
+class _ChoiceParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.choices: dict[str, str] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        choice_metadata_attributes: set[str] = set()
+        for name, raw_value in attrs:
+            attribute = name.lower()
+            if attribute.startswith("on"):
+                raise VisualCompanionError("fragment contains disallowed inline event handlers.")
+            if attribute in {"data-choice", "data-label"}:
+                if attribute in choice_metadata_attributes:
+                    raise VisualCompanionError(
+                        f"duplicate choice metadata attribute: {attribute}"
+                    )
+                choice_metadata_attributes.add(attribute)
+            value = (raw_value or "").strip()
+            if not value:
+                continue
+            if attribute in _NAVIGATION_URL_ATTRIBUTES and not value.startswith("#"):
+                raise VisualCompanionError(
+                    f"fragment contains disallowed URL in {attribute} attribute."
+                )
+            if attribute in _RESOURCE_URL_ATTRIBUTES and not value.lower().startswith("data:"):
+                raise VisualCompanionError(
+                    f"fragment contains disallowed URL in {attribute} attribute."
+                )
+            if attribute in {"srcdoc", "srcset"}:
+                raise VisualCompanionError(f"fragment contains disallowed {attribute} attribute.")
+
+        values = dict(attrs)
+        choice_id = (values.get("data-choice") or "").strip()
+        if not choice_id:
+            return
+        if choice_id in self.choices:
+            raise VisualCompanionError(f"duplicate data-choice value: {choice_id}")
+        self.choices[choice_id] = (values.get("data-label") or choice_id).strip() or choice_id
+
+
+def _choices_from_fragment(fragment: str) -> dict[str, str]:
+    parser = _ChoiceParser()
+    parser.feed(fragment)
+    parser.close()
+    return parser.choices
+
+
+def _validated_round_id(value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise VisualCompanionError("round_id must be a non-empty string.")
+    normalized = value.strip()
+    if len(normalized) > _MAX_ROUND_ID_CHARS:
+        raise VisualCompanionError(
+            f"round_id must be {_MAX_ROUND_ID_CHARS} characters or fewer."
+        )
+    return normalized
+
+
+def _atomic_write_text(path: Path, contents: str) -> None:
+    temp_path = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            delete=False,
+        ) as tmp_file:
+            temp_path = Path(tmp_file.name)
+            tmp_file.write(contents)
+
+        temp_path.replace(path)
+    except Exception:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink(missing_ok=True)
+        raise
+
+
+def _render_preview_launcher(bootstrap_url: str, bootstrap_token: str) -> str:
+    """Build a private local-file handoff without exposing the capability to the agent."""
+    parsed = urllib.parse.urlsplit(bootstrap_url)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname != "127.0.0.1"
+        or parsed.query
+        or not bootstrap_token
+    ):
+        raise VisualCompanionError("preview launcher target must use loopback HTTP.")
+    action = html.escape(bootstrap_url, quote=True)
+    token = html.escape(bootstrap_token, quote=True)
+    origin = html.escape(f"{parsed.scheme}://{parsed.netloc}", quote=True)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="referrer" content="no-referrer">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; form-action {origin}">
+  <title>Opening visual companion</title>
+</head>
+<body>
+  <p>Opening visual companion…</p>
+  <form id="companion-bootstrap" method="post" action="{action}">
+    <input type="hidden" name="key" value="{token}">
+  </form>
+  <script>document.getElementById('companion-bootstrap').submit();</script>
+</body>
+</html>
+"""
+
+
+def _try_advisory_lock(descriptor: int) -> bool:
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        return False
+    return True
+
+
+def _release_advisory_lock(descriptor: int) -> None:
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+
+
+@contextmanager
+def _exclusive_lease(lock_path: Path, timeout: float, timeout_message: str):
+    """Hold a cross-process lease that the OS releases if its process exits."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + timeout
+    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    acquired = False
+    try:
+        if os.fstat(descriptor).st_size == 0:
+            os.write(descriptor, b"0")
+            os.fsync(descriptor)
+        if os.name != "nt":
+            os.fchmod(descriptor, 0o600)
+        while not acquired:
+            acquired = _try_advisory_lock(descriptor)
+            if acquired:
+                break
+            if time.monotonic() >= deadline:
+                raise VisualCompanionError(timeout_message)
+            time.sleep(_POLL_SECONDS)
+
+        owner = json.dumps({"pid": os.getpid()}, separators=(",", ":")).encode()
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        os.write(descriptor, owner)
+        os.ftruncate(descriptor, len(owner))
+        os.fsync(descriptor)
+        yield
+    finally:
+        if acquired:
+            _release_advisory_lock(descriptor)
+        os.close(descriptor)
+
+
+@contextmanager
+def _session_lock(session_dir: Path):
+    with _exclusive_lease(
+        session_dir / ".session.lock",
+        _SESSION_LOCK_TIMEOUT_SECONDS,
+        "timed out waiting for the companion session lock.",
+    ):
+        yield
+
+
+@contextmanager
+def _server_lease(session_dir: Path):
+    with _exclusive_lease(
+        session_dir / ".server.lock",
+        _SERVER_LEASE_TIMEOUT_SECONDS,
+        "the companion session already has a running server.",
+    ):
+        yield
+
+
+def _next_page_version(round_json_path: Path) -> int:
+    if not round_json_path.exists():
+        return 1
+
+    round_data = json.loads(round_json_path.read_text(encoding="utf-8"))
+    if not isinstance(round_data, dict):
+        raise ValueError("round.json must contain an object.")
+
+    page_version = round_data.get("page_version")
+    if type(page_version) is not int:
+        raise ValueError("round.json must include integer page_version.")
+
+    return page_version + 1
+
+
+def validate_fragment(fragment: str) -> None:
+    """Reject content that could execute code, fetch remotely, or cannot be selected."""
+    if len(fragment.encode("utf-8")) > _MAX_FRAGMENT_BYTES:
+        raise VisualCompanionError("fragment exceeds the 1 MiB limit.")
+    if not _CHOICE_ATTR_RE.search(fragment):
+        raise VisualCompanionError("fragment must include at least one non-empty data-choice attribute.")
+
+    normalized_fragment = html.unescape(fragment)
+    for pattern, description in _UNSAFE_FRAGMENT_PATTERNS:
+        if pattern.search(normalized_fragment):
+            raise VisualCompanionError(f"fragment contains disallowed {description}.")
+    for match in _CSS_URL_RE.finditer(normalized_fragment):
+        target = match.group("value").strip()
+        if target and not target.lower().startswith("data:") and not target.startswith("#"):
+            raise VisualCompanionError("fragment contains disallowed remote CSS URLs.")
+
+    choices = _choices_from_fragment(fragment)
+    if not 2 <= len(choices) <= 4:
+        raise VisualCompanionError("fragment must include two to four selectable data-choice values.")
+    for choice_id, label in choices.items():
+        if len(choice_id) > _MAX_CHOICE_ID_CHARS:
+            raise VisualCompanionError(
+                f"data-choice values must be {_MAX_CHOICE_ID_CHARS} characters or fewer."
+            )
+        if len(label) > _MAX_CHOICE_LABEL_CHARS:
+            raise VisualCompanionError(
+                f"choice labels must be {_MAX_CHOICE_LABEL_CHARS} characters or fewer."
+            )
+
+
+def _read_json_object(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise VisualCompanionError(f"{path.name} must contain a JSON object.")
+    return data
+
+
+def _active_round(session_dir: Path) -> tuple[dict, str]:
+    """Read a consistent metadata+fragment pair published via a version pointer."""
+    metadata = _read_json_object(session_dir / "round.json")
+    page_version = metadata.get("page_version")
+    if type(page_version) is not int:
+        raise VisualCompanionError("round.json must include integer page_version.")
+    metadata["round_id"] = _validated_round_id(metadata.get("round_id"))
+    versioned_fragment = session_dir / ".pages" / f"page-{page_version}.html"
+    if not versioned_fragment.is_file():
+        raise VisualCompanionError("the active round's published page is missing.")
+    fragment = versioned_fragment.read_text(encoding="utf-8")
+    validate_fragment(fragment)
+    return metadata, fragment
+
+
+def _read_events(session_dir: Path) -> list[dict]:
+    events_path = session_dir / "events.jsonl"
+    if not events_path.exists():
+        return []
+
+    events = []
+    for line_number, line in enumerate(events_path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise VisualCompanionError(
+                f"events.jsonl contains invalid JSON on line {line_number}."
+            ) from exc
+        if (
+            not isinstance(event, dict)
+            or type(event.get("cursor")) is not int
+            or event["cursor"] <= 0
+        ):
+            raise VisualCompanionError(f"events.jsonl line {line_number} is not a choice event.")
+        events.append(event)
+    return events
+
+
+def wait_for_choice(session_dir: Path, after: int, timeout: float) -> dict | None:
+    if after < 0:
+        raise VisualCompanionError("--after must be zero or greater.")
+    if timeout < 0:
+        raise VisualCompanionError("--timeout must be zero or greater.")
+
+    deadline = time.monotonic() + timeout
+    while True:
+        with _session_lock(session_dir):
+            events = _read_events(session_dir)
+        for event in events:
+            if event["cursor"] > after:
+                return event
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(min(_POLL_SECONDS, max(0.0, deadline - time.monotonic())))
+
+
+_BOARD_HELPER_SCRIPT = r"""
+document.addEventListener('click', (event) => {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const card = target.closest('[data-choice]');
+  if (!card || card.getAttribute('aria-disabled') === 'true') return;
+  event.preventDefault();
+  const choiceId = card.getAttribute('data-choice');
+  if (!choiceId) return;
+  parent.postMessage({type: 'hermes-visual-choice', choice_id: choiceId}, '*');
+});
+
+window.addEventListener('message', (event) => {
+  if (event.source !== parent) return;
+  const message = event.data;
+  if (!message || message.type !== 'hermes-visual-control') return;
+  document.querySelectorAll('[data-choice]').forEach((node) => {
+    node.toggleAttribute('data-selected', node.getAttribute('data-choice') === message.selected);
+    node.setAttribute(
+      'aria-pressed',
+      node.getAttribute('data-choice') === message.selected ? 'true' : 'false',
+    );
+    if (message.disabled) node.setAttribute('aria-disabled', 'true');
+    else node.removeAttribute('aria-disabled');
+    if ('disabled' in node) node.disabled = Boolean(message.disabled);
+  });
+});
+"""
+
+
+_HELPER_SCRIPT = r"""
+const currentVersion = __PAGE_VERSION__;
+const boardFrame = document.getElementById('__BOARD_FRAME_ID__');
+const statusNode = document.getElementById('companion-status');
+const feedbackNode = document.getElementById('companion-feedback');
+let selectionRecorded = false;
+let selectionPending = false;
+
+const setChoicesDisabled = (disabled, selected = null) => {
+  boardFrame.contentWindow?.postMessage(
+    {type: 'hermes-visual-control', disabled, selected},
+    '*',
+  );
+};
+
+const recordChoice = async (choiceId) => {
+  if (selectionRecorded || selectionPending) return;
+  if (typeof choiceId !== 'string' || !choiceId) return;
+  const feedback = feedbackNode.value;
+  selectionPending = true;
+  setChoicesDisabled(true);
+  feedbackNode.disabled = true;
+  statusNode.textContent = 'Recording selection…';
+  try {
+    const response = await fetch('__choice', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json', 'X-Visual-Companion': 'choice'},
+      body: JSON.stringify({
+        choice_id: choiceId,
+        page_version: currentVersion,
+        feedback,
+      }),
+    });
+    if (!response.ok) throw new Error(`selection failed (${response.status})`);
+    const selected = await response.json();
+    selectionPending = false;
+    selectionRecorded = true;
+    setChoicesDisabled(true, choiceId);
+    statusNode.textContent = `Selected: ${selected.label}`;
+  } catch (error) {
+    selectionPending = false;
+    setChoicesDisabled(false);
+    feedbackNode.disabled = false;
+    statusNode.textContent = error instanceof Error ? error.message : 'selection failed';
+  }
+};
+
+window.addEventListener('message', (event) => {
+  if (event.source !== boardFrame.contentWindow) return;
+  const message = event.data;
+  if (!message || message.type !== 'hermes-visual-choice') return;
+  void recordChoice(message.choice_id);
+});
+
+boardFrame.srcdoc = __BOARD_DOCUMENT_JSON__;
+
+setInterval(async () => {
+  try {
+    const response = await fetch('__version', {cache: 'no-store'});
+    if (!response.ok) return;
+    const state = await response.json();
+    if (state.page_version > currentVersion) window.location.reload();
+  } catch (_) {
+    // The agent may be replacing or stopping the local companion.
+  }
+}, 800);
+"""
+
+
+def _render_page(session_dir: Path) -> tuple[bytes, str]:
+    metadata, fragment = _active_round(session_dir)
+    page_version = metadata.get("page_version")
+    if type(page_version) is not int:
+        raise VisualCompanionError("round.json must include integer page_version.")
+
+    nonce = secrets.token_urlsafe(18)
+    board_frame_id = f"companion-board-{secrets.token_hex(12)}"
+    board_document = (
+        "<!doctype html><html><head><meta charset=\"utf-8\">"
+        "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+        "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; "
+        f"style-src 'unsafe-inline'; script-src 'nonce-{nonce}'; img-src data:; "
+        "font-src data:; form-action 'none'; base-uri 'none'\">"
+        "<style>[data-choice]{cursor:pointer}"
+        "[data-choice]:focus-visible,[data-choice][data-selected]{outline:3px solid #d7a84b;"
+        "outline-offset:4px}</style>"
+        f"<script nonce=\"{nonce}\">{_BOARD_HELPER_SCRIPT}</script>"
+        f"</head><body>{fragment}</body></html>"
+    )
+    board_document_json = (
+        json.dumps(board_document, ensure_ascii=True)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+    helper = (
+        _HELPER_SCRIPT.replace("__PAGE_VERSION__", str(page_version))
+        .replace("__BOARD_FRAME_ID__", board_frame_id)
+        .replace("__BOARD_DOCUMENT_JSON__", board_document_json)
+    )
+    page = (
+        "<!doctype html><html><head><meta charset=\"utf-8\">"
+        "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+        "<title>Hermes Visual Companion</title>"
+        "<style>"
+        "html{height:100%;color-scheme:dark}body{height:100%;margin:0;overflow:hidden;display:grid;"
+        "grid-template-rows:minmax(0,1fr) auto;background:#0b0c0f;color:#f4f2ec;"
+        "font-family:Inter,ui-sans-serif,system-ui,sans-serif}"
+        ".companion-board{display:block;width:100%;height:100%;border:0;background:#0b0c0f}"
+        "#companion-feedback-wrap{position:relative;z-index:2;display:block;padding:14px 18px 18px;"
+        "background:#0b0c0f}"
+        "#companion-feedback-label{display:block;margin:0 0 7px;color:#d7d3ca;font-size:12px}"
+        "#companion-feedback{display:block;width:min(720px,calc(100% - 32px));min-height:44px;resize:vertical;"
+        "padding:10px 12px;border:1px solid #383b45;border-radius:10px;background:#17191f;color:#f4f2ec;"
+        "font:14px/1.4 inherit}"
+        "#companion-status{position:fixed;right:16px;bottom:14px;padding:8px 12px;border-radius:999px;"
+        "background:#17191f;border:1px solid #383b45;color:#d7d3ca;font-size:12px;z-index:9999}"
+        "</style></head><body>"
+        f"<iframe id=\"{board_frame_id}\" class=\"companion-board\" sandbox=\"allow-scripts\" "
+        "title=\"Visual design choices\"></iframe>"
+        "<div id=\"companion-feedback-wrap\"><label id=\"companion-feedback-label\" "
+        "for=\"companion-feedback\">Optional correction before choosing</label>"
+        f"<textarea id=\"companion-feedback\" maxlength=\"{_MAX_FEEDBACK_CHARS}\" "
+        "placeholder=\"e.g. Keep this structure, but reduce the orange accent\"></textarea></div>"
+        "<div id=\"companion-status\" role=\"status\">Choose a direction</div>"
+        f"<script nonce=\"{nonce}\">{helper}</script>"
+        "</body></html>"
+    )
+    csp = (
+        "default-src 'none'; "
+        "style-src 'unsafe-inline'; "
+        f"script-src 'nonce-{nonce}'; "
+        "connect-src 'self'; frame-src 'self'; img-src data:; font-src data:; "
+        "form-action 'none'; frame-ancestors 'none'; base-uri 'none'"
+    )
+    return page.encode("utf-8"), csp
+
+
+class _VisualCompanionServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self,
+        session_dir: Path,
+        port: int,
+        bootstrap_token: str,
+        session_token: str,
+        cookie_name: str,
+        route_prefix: str,
+    ) -> None:
+        super().__init__(("127.0.0.1", port), _VisualCompanionHandler)
+        self.session_dir = session_dir
+        self.bootstrap_token = bootstrap_token
+        self.session_token = session_token
+        self.cookie_name = cookie_name
+        self.route_prefix = route_prefix
+        self.capability_lock = threading.Lock()
+        self.capability_consumed = False
+        self.event_lock = threading.Lock()
+
+    def route(self, suffix: str = "") -> str:
+        return f"{self.route_prefix}{suffix.lstrip('/')}"
+
+    def exchange_capability(self, supplied: str) -> bool:
+        with self.capability_lock:
+            if self.capability_consumed or not hmac.compare_digest(
+                supplied,
+                self.bootstrap_token,
+            ):
+                return False
+            self.capability_consumed = True
+            return True
+
+    def record_choice(self, choice_id: str, expected_page_version: int, feedback: str) -> dict:
+        with self.event_lock:
+            with _session_lock(self.session_dir):
+                metadata, fragment = _active_round(self.session_dir)
+                choices = _choices_from_fragment(fragment)
+                if choice_id not in choices:
+                    raise VisualCompanionError("choice_id is not present in the active round.")
+
+                page_version = metadata.get("page_version")
+                round_id = metadata.get("round_id")
+                if type(page_version) is not int or not isinstance(round_id, str):
+                    raise VisualCompanionError("round.json is missing round_id or page_version.")
+                if expected_page_version != page_version:
+                    raise StalePageError(
+                        f"active page version is {page_version}, not {expected_page_version}."
+                    )
+
+                existing = _read_events(self.session_dir)
+                prior = next(
+                    (event for event in existing if event.get("page_version") == page_version),
+                    None,
+                )
+                if prior is not None:
+                    if prior.get("choice_id") == choice_id and prior.get("feedback", "") == feedback:
+                        return prior
+                    raise RoundAlreadySelectedError(
+                        "the active round already has a recorded selection."
+                    )
+                cursor = max((event["cursor"] for event in existing), default=0) + 1
+                event = {
+                    "choice_id": choice_id,
+                    "cursor": cursor,
+                    "feedback": feedback,
+                    "label": choices[choice_id],
+                    "page_version": page_version,
+                    "round_id": round_id,
+                }
+                events_path = self.session_dir / "events.jsonl"
+                descriptor = os.open(
+                    events_path,
+                    os.O_APPEND | os.O_CREAT | os.O_WRONLY,
+                    0o600,
+                )
+                if os.name != "nt":
+                    os.fchmod(descriptor, 0o600)
+                with os.fdopen(descriptor, "a", encoding="utf-8") as event_file:
+                    event_file.write(
+                        json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
+                    )
+                    event_file.flush()
+                    os.fsync(event_file.fileno())
+                return event
+
+
+class _VisualCompanionHandler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+    def _companion_server(self) -> _VisualCompanionServer:
+        if not isinstance(self.server, _VisualCompanionServer):
+            raise RuntimeError("visual companion handler attached to an unexpected server")
+        return self.server
+
+    def _send_bytes(
+        self,
+        status: HTTPStatus,
+        body: bytes,
+        content_type: str,
+        extra_headers: dict[str, str] | None = None,
+    ) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("Referrer-Policy", "no-referrer")
+        for name, value in (extra_headers or {}).items():
+            self.send_header(name, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_json(self, status: HTTPStatus, payload: dict) -> None:
+        body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+        self._send_bytes(status, body, "application/json; charset=utf-8")
+
+    def _authorized(self) -> bool:
+        server = self._companion_server()
+        cookie = SimpleCookie(self.headers.get("Cookie", ""))
+        supplied = cookie.get(server.cookie_name)
+        return supplied is not None and hmac.compare_digest(
+            supplied.value,
+            server.session_token,
+        )
+
+    def _require_authorized(self) -> bool:
+        if self._authorized():
+            return True
+        self._send_json(HTTPStatus.FORBIDDEN, {"error": "visual companion capability required"})
+        return False
+
+    def do_GET(self) -> None:
+        parsed = urllib.parse.urlsplit(self.path)
+        server = self._companion_server()
+        if not self._require_authorized():
+            return
+
+        if parsed.path == server.route("__health"):
+            self._send_json(HTTPStatus.OK, {"status": "ok"})
+            return
+        if parsed.path == server.route():
+            page, csp = _render_page(server.session_dir)
+            self._send_bytes(
+                HTTPStatus.OK,
+                page,
+                "text/html; charset=utf-8",
+                {"Content-Security-Policy": csp},
+            )
+            return
+        if parsed.path == server.route("__version"):
+            metadata = _read_json_object(server.session_dir / "round.json")
+            self._send_json(
+                HTTPStatus.OK,
+                {
+                    "page_version": metadata.get("page_version"),
+                    "round_id": _validated_round_id(metadata.get("round_id")),
+                },
+            )
+            return
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        parsed = urllib.parse.urlsplit(self.path)
+        server = self._companion_server()
+        if parsed.path == server.route("__bootstrap"):
+            try:
+                content_length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                content_length = 0
+            if content_length <= 0:
+                self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid bootstrap request"})
+                return
+            if content_length > _MAX_BOOTSTRAP_REQUEST_BYTES:
+                self._send_json(
+                    HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                    {"error": "bootstrap request exceeds the size limit"},
+                )
+                return
+            if not self.headers.get("Content-Type", "").lower().startswith(
+                "application/x-www-form-urlencoded"
+            ):
+                self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid bootstrap request"})
+                return
+            try:
+                form = urllib.parse.parse_qs(
+                    self.rfile.read(content_length).decode("utf-8"),
+                    strict_parsing=True,
+                )
+                supplied = form.get("key", [""])[0]
+            except (UnicodeDecodeError, ValueError):
+                supplied = ""
+            if not supplied or not server.exchange_capability(supplied):
+                self._send_json(
+                    HTTPStatus.FORBIDDEN,
+                    {"error": "visual companion capability required"},
+                )
+                return
+            nonce = secrets.token_urlsafe(18)
+            route = json.dumps(server.route())
+            transition = (
+                "<!doctype html><meta charset=\"utf-8\">"
+                "<meta name=\"referrer\" content=\"no-referrer\">"
+                f"<script nonce=\"{nonce}\">location.replace({route});</script>"
+            ).encode()
+            self._send_bytes(
+                HTTPStatus.OK,
+                transition,
+                "text/html; charset=utf-8",
+                {
+                    "Content-Security-Policy": (
+                        f"default-src 'none'; script-src 'nonce-{nonce}'; base-uri 'none'"
+                    ),
+                    "Set-Cookie": (
+                        f"{server.cookie_name}={server.session_token}; "
+                        f"Path={server.route_prefix}; HttpOnly; SameSite=Lax"
+                    ),
+                },
+            )
+            return
+
+        if not self._require_authorized():
+            return
+
+        if parsed.path == server.route("__choice"):
+            if self.headers.get("X-Visual-Companion") != "choice":
+                self._send_json(HTTPStatus.BAD_REQUEST, {"error": "choice request header required"})
+                return
+            try:
+                content_length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                content_length = 0
+            if content_length <= 0:
+                self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid request body size"})
+                return
+            if content_length > _MAX_REQUEST_BYTES:
+                self._send_json(
+                    HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                    {"error": "request body exceeds the size limit"},
+                )
+                return
+            try:
+                payload = json.loads(self.rfile.read(content_length))
+                choice_id = payload.get("choice_id") if isinstance(payload, dict) else None
+                page_version = payload.get("page_version") if isinstance(payload, dict) else None
+                feedback = payload.get("feedback", "") if isinstance(payload, dict) else None
+                if not isinstance(choice_id, str) or not choice_id:
+                    raise VisualCompanionError("choice_id must be a non-empty string.")
+                if type(page_version) is not int:
+                    raise VisualCompanionError("page_version must be an integer.")
+                if not isinstance(feedback, str):
+                    raise VisualCompanionError("feedback must be a string.")
+                feedback = feedback.strip()
+                if len(feedback) > _MAX_FEEDBACK_CHARS:
+                    raise VisualCompanionError(
+                        f"feedback must be {_MAX_FEEDBACK_CHARS} characters or fewer."
+                    )
+                event = self._companion_server().record_choice(choice_id, page_version, feedback)
+            except (RoundAlreadySelectedError, StalePageError) as exc:
+                self._send_json(HTTPStatus.CONFLICT, {"error": str(exc)})
+                return
+            except (json.JSONDecodeError, VisualCompanionError) as exc:
+                self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+                return
+            self._send_json(HTTPStatus.OK, event)
+            return
+
+        if parsed.path == server.route("__shutdown"):
+            self._send_json(HTTPStatus.OK, {"status": "stopping"})
+            threading.Thread(target=self._companion_server().shutdown, daemon=True).start()
+            return
+
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+
+def publish(session_dir: Path, fragment_path: Path, round_id: str) -> int:
+    round_id = _validated_round_id(round_id)
+    fragment = fragment_path.read_text(encoding="utf-8")
+    validate_fragment(fragment)
+
+    session_dir.mkdir(parents=True, exist_ok=True)
+    with _session_lock(session_dir):
+        next_version = _next_page_version(session_dir / "round.json")
+        metadata = {"round_id": round_id, "page_version": next_version}
+        _atomic_write_text(session_dir / ".pages" / f"page-{next_version}.html", fragment)
+        _atomic_write_text(session_dir / "current.html", fragment)
+        _atomic_write_text(
+            session_dir / "round.json",
+            json.dumps(metadata, ensure_ascii=False),
+        )
+
+    print(json.dumps(metadata, ensure_ascii=False))
+    return 0
+
+
+def run_server(session_dir: Path, port: int) -> int:
+    if port < 0 or port > 65535:
+        raise VisualCompanionError("--port must be between 0 and 65535.")
+    _active_round(session_dir)
+
+    with _server_lease(session_dir):
+        bootstrap_token = secrets.token_urlsafe(32)
+        session_token = secrets.token_urlsafe(32)
+        cookie_name = f"{_COOKIE_NAME_PREFIX}{secrets.token_hex(8)}"
+        route_prefix = f"/visual-companion/{secrets.token_urlsafe(12)}/"
+        server = _VisualCompanionServer(
+            session_dir,
+            port,
+            bootstrap_token,
+            session_token,
+            cookie_name,
+            route_prefix,
+        )
+        actual_port = server.server_address[1]
+        origin = f"http://127.0.0.1:{actual_port}"
+        base_url = f"{origin}{route_prefix.rstrip('/')}"
+        state = {
+            "base_url": base_url,
+            "bootstrap_token": bootstrap_token,
+            "bootstrap_url": f"{base_url}/__bootstrap",
+            "cookie_name": cookie_name,
+            "pid": os.getpid(),
+            "port": actual_port,
+            "session_token": session_token,
+        }
+        state_path = session_dir / "state.json"
+        launcher_path = session_dir / _PREVIEW_LAUNCHER_FILENAME
+        _atomic_write_text(
+            launcher_path,
+            _render_preview_launcher(state["bootstrap_url"], state["bootstrap_token"]),
+        )
+        _atomic_write_text(state_path, json.dumps(state, ensure_ascii=False, separators=(",", ":")))
+        try:
+            state_path.chmod(0o600)
+            launcher_path.chmod(0o600)
+        except OSError:
+            pass
+
+        readiness = {"pid": os.getpid(), "port": actual_port, "status": "ready"}
+        print(json.dumps(readiness, separators=(",", ":")), flush=True)
+        try:
+            server.serve_forever(poll_interval=0.1)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            server.server_close()
+            try:
+                current_state = _read_json_object(state_path)
+                if current_state.get("session_token") == session_token:
+                    state_path.unlink(missing_ok=True)
+                    launcher_path.unlink(missing_ok=True)
+            except (FileNotFoundError, json.JSONDecodeError, VisualCompanionError):
+                pass
+    return 0
+
+
+def _request_from_state(session_dir: Path, path: str, method: str = "GET") -> dict:
+    state = _read_json_object(session_dir / "state.json")
+    base_url = state.get("base_url")
+    cookie_name = state.get("cookie_name")
+    session_token = state.get("session_token")
+    if not all(isinstance(value, str) for value in (base_url, cookie_name, session_token)):
+        raise VisualCompanionError("state.json is missing companion authentication state.")
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        method=method,
+        headers={"Cookie": f"{cookie_name}={session_token}"},
+    )
+    with urllib.request.urlopen(request, timeout=2) as response:
+        payload = json.loads(response.read())
+    if not isinstance(payload, dict):
+        raise VisualCompanionError("companion returned an invalid response.")
+    return payload
+
+
+def _command_publish(args: argparse.Namespace) -> int:
+    return publish(args.session_dir, args.file, args.round_id)
+
+
+def _command_serve(args: argparse.Namespace) -> int:
+    return run_server(args.session_dir, args.port)
+
+
+def _command_wait(args: argparse.Namespace) -> int:
+    event = wait_for_choice(args.session_dir, args.after, args.timeout)
+    if event is None:
+        print(json.dumps({"after": args.after, "status": "timeout"}, separators=(",", ":")))
+        return 3
+    print(json.dumps(event, ensure_ascii=False, separators=(",", ":")))
+    return 0
+
+
+def _command_status(args: argparse.Namespace) -> int:
+    print(json.dumps(_request_from_state(args.session_dir, "/__health"), separators=(",", ":")))
+    return 0
+
+
+def _command_stop(args: argparse.Namespace) -> int:
+    print(
+        json.dumps(
+            _request_from_state(args.session_dir, "/__shutdown", method="POST"),
+            separators=(",", ":"),
+        )
+    )
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Serve interactive visual design choices locally.")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    publish_parser = commands.add_parser("publish", help="Publish a safe design-choice fragment.")
+    publish_parser.add_argument("--session-dir", type=Path, required=True)
+    publish_parser.add_argument("--file", type=Path, required=True)
+    publish_parser.add_argument("--round-id", required=True)
+    publish_parser.set_defaults(handler=_command_publish)
+
+    serve_parser = commands.add_parser("serve", help="Serve the active round on loopback.")
+    serve_parser.add_argument("--session-dir", type=Path, required=True)
+    serve_parser.add_argument("--port", type=int, default=0)
+    serve_parser.set_defaults(handler=_command_serve)
+
+    wait_parser = commands.add_parser("wait", help="Wait for a choice newer than a cursor.")
+    wait_parser.add_argument("--session-dir", type=Path, required=True)
+    wait_parser.add_argument("--after", type=int, default=0)
+    wait_parser.add_argument("--timeout", type=float, default=120.0)
+    wait_parser.set_defaults(handler=_command_wait)
+
+    status_parser = commands.add_parser("status", help="Check a running companion.")
+    status_parser.add_argument("--session-dir", type=Path, required=True)
+    status_parser.set_defaults(handler=_command_status)
+
+    stop_parser = commands.add_parser("stop", help="Stop a running companion.")
+    stop_parser.add_argument("--session-dir", type=Path, required=True)
+    stop_parser.set_defaults(handler=_command_stop)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = _build_parser().parse_args(argv)
+        return args.handler(args)
+    except (OSError, ValueError, json.JSONDecodeError, urllib.error.URLError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_visual_companion_skill.py
+++ b/tests/skills/test_visual_companion_skill.py
@@ -1,0 +1,937 @@
+"""Tests for visual companion publish behavior."""
+
+import concurrent.futures
+import http.cookiejar
+import json
+import os
+import runpy
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/creative/claude-design/scripts/visual_companion.py"
+)
+SKILL_PATH = SCRIPT_PATH.parents[1] / "SKILL.md"
+ALTERNATIVE_CHOICE = '<button data-choice="alternate">Alternate</button>'
+
+
+def _publish(tmp_path, fragment, *, round_id="layout-directions", session_dir=None):
+    round_html = tmp_path / f"{round_id}.html"
+    round_html.write_text(fragment, encoding="utf-8")
+    session_dir = session_dir or tmp_path / "session"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "publish",
+            "--session-dir",
+            str(session_dir),
+            "--file",
+            str(round_html),
+            "--round-id",
+            round_id,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    return result, session_dir
+
+
+def _wait_for_state(session_dir, process):
+    state_path = session_dir / "state.json"
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        if state_path.exists():
+            return json.loads(state_path.read_text(encoding="utf-8"))
+        if process.poll() is not None:
+            _, stderr = process.communicate()
+            raise AssertionError(f"server exited before readiness: {stderr}")
+        time.sleep(0.02)
+    process.terminate()
+    _, stderr = process.communicate(timeout=2)
+    raise AssertionError(f"server did not write state.json: {stderr}")
+
+
+def _start_server(session_dir):
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "serve",
+            "--session-dir",
+            str(session_dir),
+            "--port",
+            "0",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return process, _wait_for_state(session_dir, process)
+
+
+def _authenticated_opener(state):
+    cookie_jar = http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookie_jar))
+    request = urllib.request.Request(
+        state["bootstrap_url"],
+        data=urllib.parse.urlencode({"key": state["bootstrap_token"]}).encode(),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    with opener.open(request, timeout=2) as response:
+        assert response.status == 200
+    with opener.open(f'{state["base_url"]}/', timeout=2) as response:
+        assert response.status == 200
+    return opener, cookie_jar
+
+
+def _post_choice(opener, base_url, choice_id, *, page_version=1, feedback=None):
+    payload = {"choice_id": choice_id, "page_version": page_version}
+    if feedback is not None:
+        payload["feedback"] = feedback
+    request = urllib.request.Request(
+        f"{base_url}/__choice",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json", "X-Visual-Companion": "choice"},
+        method="POST",
+    )
+    with opener.open(request, timeout=2) as response:
+        return json.loads(response.read())
+
+
+def test_publish_creates_versioned_round(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<section data-choice="council"><h1>Council layout</h1></section>\n'
+        + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    current_html = session_dir / "current.html"
+    assert current_html.exists()
+    assert '<section data-choice="council"' in current_html.read_text(encoding="utf-8")
+
+    round_json = session_dir / "round.json"
+    data = json.loads(round_json.read_text(encoding="utf-8"))
+    assert data["round_id"] == "layout-directions"
+    assert isinstance(data["page_version"], int)
+    assert data["page_version"] == 1
+
+    stdout_data = json.loads(result.stdout.strip())
+    assert stdout_data["round_id"] == "layout-directions"
+    assert stdout_data["page_version"] == 1
+
+
+def test_publish_increments_the_page_version(tmp_path):
+    first, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert first.returncode == 0, first.stderr
+
+    second, _ = _publish(
+        tmp_path,
+        '<button data-choice="focused">Focused</button>' + ALTERNATIVE_CHOICE,
+        round_id="focused-refinement",
+        session_dir=session_dir,
+    )
+    assert second.returncode == 0, second.stderr
+
+    metadata = json.loads((session_dir / "round.json").read_text(encoding="utf-8"))
+    assert metadata == {"round_id": "focused-refinement", "page_version": 2}
+    assert 'data-choice="focused"' in (session_dir / "current.html").read_text(encoding="utf-8")
+
+
+def test_concurrent_publish_allocates_each_page_version_once(tmp_path):
+    session_dir = tmp_path / "session"
+    publish_count = 8
+    sources = []
+    for index in range(publish_count):
+        source = tmp_path / f"round-{index}.html"
+        source.write_text(
+            f'<button data-choice="choice-{index}">Choice {index}</button>'
+            f'<button data-choice="alternate-{index}">Alternate {index}</button>',
+            encoding="utf-8",
+        )
+        sources.append(source)
+
+    barrier = threading.Barrier(publish_count)
+
+    def run_publish(index):
+        barrier.wait()
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "publish",
+                "--session-dir",
+                str(session_dir),
+                "--file",
+                str(sources[index]),
+                "--round-id",
+                f"round-{index}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=publish_count) as executor:
+        results = list(executor.map(run_publish, range(publish_count)))
+
+    assert all(result.returncode == 0 for result in results), [result.stderr for result in results]
+    versions = sorted(json.loads(result.stdout)["page_version"] for result in results)
+    assert versions == list(range(1, publish_count + 1))
+    assert json.loads((session_dir / "round.json").read_text())["page_version"] == publish_count
+
+
+def test_publish_reclaims_a_session_lease_from_an_exited_process(tmp_path):
+    first, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert first.returncode == 0, first.stderr
+
+    exited = subprocess.Popen([sys.executable, "-c", "pass"])
+    exited.wait(timeout=2)
+    (session_dir / ".session.lock").write_text(
+        json.dumps({"lease_id": "abandoned", "pid": exited.pid}),
+        encoding="utf-8",
+    )
+
+    second, _ = _publish(
+        tmp_path,
+        '<button data-choice="focused">Focused</button>' + ALTERNATIVE_CHOICE,
+        round_id="focused-refinement",
+        session_dir=session_dir,
+    )
+
+    assert second.returncode == 0, second.stderr
+    metadata = json.loads((session_dir / "round.json").read_text(encoding="utf-8"))
+    assert metadata["page_version"] == 2
+
+
+def test_publish_requires_a_selectable_choice(tmp_path):
+    result, session_dir = _publish(tmp_path, "<section>No choices here</section>")
+
+    assert result.returncode != 0
+    assert "data-choice" in result.stderr
+    assert not (session_dir / "current.html").exists()
+    assert not (session_dir / "round.json").exists()
+
+
+@pytest.mark.parametrize("choice_count", [1, 5])
+def test_publish_requires_two_to_four_comparable_choices(tmp_path, choice_count):
+    fragment = "".join(
+        f'<button data-choice="choice-{index}">Choice {index}</button>'
+        for index in range(choice_count)
+    )
+    result, session_dir = _publish(tmp_path, fragment)
+
+    assert result.returncode != 0
+    assert "two to four" in result.stderr
+    assert not (session_dir / "current.html").exists()
+
+
+@pytest.mark.parametrize(
+    "fragment",
+    [
+        f'<button data-choice="{"x" * 129}">Long ID</button>' + ALTERNATIVE_CHOICE,
+        f'<button data-choice="choice" data-label="{"界" * 257}">Choice</button>'
+        + ALTERNATIVE_CHOICE,
+    ],
+)
+def test_publish_bounds_choice_ids_and_labels(tmp_path, fragment):
+    result, session_dir = _publish(tmp_path, fragment)
+
+    assert result.returncode != 0
+    assert not (session_dir / "round.json").exists()
+
+
+def test_publish_bounds_round_ids_before_persisting_or_printing_them(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="one">One</button>' + ALTERNATIVE_CHOICE,
+        round_id="r" * 129,
+    )
+
+    assert result.returncode != 0
+    assert "128 characters or fewer" in result.stderr
+    assert result.stdout == ""
+    assert not (session_dir / "round.json").exists()
+
+
+@pytest.mark.parametrize(
+    "fragment",
+    [
+        '<button data-choice="one" data-choice="two">Ambiguous</button>'
+        + ALTERNATIVE_CHOICE,
+        '<button data-choice="one" data-label="One" data-label="Two">Ambiguous</button>'
+        + ALTERNATIVE_CHOICE,
+    ],
+)
+def test_publish_rejects_duplicate_choice_metadata_attributes(tmp_path, fragment):
+    result, session_dir = _publish(tmp_path, fragment)
+
+    assert result.returncode != 0
+    assert "duplicate choice metadata attribute" in result.stderr
+    assert not (session_dir / "round.json").exists()
+
+
+def test_publish_rejects_a_fragment_larger_than_one_mib(tmp_path):
+    fragment = (
+        '<button data-choice="one">One</button>'
+        '<button data-choice="two">Two</button>'
+        + ("x" * 1_048_576)
+    )
+    result, session_dir = _publish(tmp_path, fragment)
+
+    assert result.returncode != 0
+    assert "1 MiB" in result.stderr
+    assert not (session_dir / "current.html").exists()
+
+
+def test_publish_rejects_executable_or_remote_fragment_content(tmp_path):
+    unsafe_fragments = [
+        '<script>alert("x")</script><button data-choice="x">X</button>'
+        + ALTERNATIVE_CHOICE,
+        '<button data-choice="x" onclick="alert(1)">X</button>' + ALTERNATIVE_CHOICE,
+        '<button/data-choice="x"/onclick="alert(1)">X</button>' + ALTERNATIVE_CHOICE,
+        '<a data-choice="x" href="javascript:alert(1)">X</a>' + ALTERNATIVE_CHOICE,
+        '<a data-choice="x" href="java&#x73;cript:alert(1)">X</a>' + ALTERNATIVE_CHOICE,
+        '<a data-choice="x" href="https:example.com">X</a>' + ALTERNATIVE_CHOICE,
+        '<meta http-equiv="refresh" content="0;url=https://example.com">'
+        '<button data-choice="x">X</button>'
+        + ALTERNATIVE_CHOICE,
+        '<img data-choice="x" src="https://example.com/track.png">' + ALTERNATIVE_CHOICE,
+        '<style>.x { background: url(//example.com/track.png) }</style>'
+        '<button data-choice="x">X</button>'
+        + ALTERNATIVE_CHOICE,
+        '<style>.choice{background:url(https:example.com/image.png)}</style>'
+        '<button class="choice" data-choice="x">X</button>'
+        + ALTERNATIVE_CHOICE,
+    ]
+
+    for index, fragment in enumerate(unsafe_fragments):
+        session_dir = tmp_path / f"unsafe-{index}"
+        result, _ = _publish(tmp_path, fragment, session_dir=session_dir)
+
+        assert result.returncode != 0, fragment
+        assert not (session_dir / "current.html").exists()
+        assert not (session_dir / "round.json").exists()
+
+
+def test_round_manifest_points_to_an_immutable_published_page(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    (session_dir / "current.html").write_text(
+        '<button data-choice="partial">Partial next round</button>' + ALTERNATIVE_CHOICE,
+        encoding="utf-8",
+    )
+    server, state = _start_server(session_dir)
+    try:
+        opener, _ = _authenticated_opener(state)
+        with opener.open(f'{state["base_url"]}/', timeout=2) as response:
+            page = response.read().decode()
+        assert "Council" in page
+        assert "Partial next round" not in page
+        with pytest.raises(urllib.error.HTTPError) as invalid:
+            _post_choice(opener, state["base_url"], "partial")
+        assert invalid.value.code == 400
+    finally:
+        server.terminate()
+        server.communicate(timeout=2)
+
+
+def test_active_round_fails_closed_when_its_versioned_page_is_missing(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+    (session_dir / ".pages" / "page-1.html").unlink()
+
+    companion_module = runpy.run_path(str(SCRIPT_PATH))
+    error_type = companion_module["VisualCompanionError"]
+    with pytest.raises(error_type, match="published page is missing"):
+        companion_module["_active_round"](session_dir)
+
+
+def test_generated_fragment_is_sandboxed_from_trusted_host_controls(tmp_path):
+    fragment = (
+        '<style>:host{position:fixed;inset:0;z-index:20000}'
+        '.forged{position:fixed;inset:0;z-index:20000}</style>'
+        '<input id="companion-feedback" value="forged fragment feedback">'
+        '<div id="companion-status">forged fragment status</div>'
+        '<button data-choice="one">One</button>'
+        '<button data-choice="two">Two</button>'
+    )
+    result, session_dir = _publish(tmp_path, fragment)
+    assert result.returncode == 0, result.stderr
+
+    server, state = _start_server(session_dir)
+    try:
+        opener, _ = _authenticated_opener(state)
+        with opener.open(f'{state["base_url"]}/', timeout=2) as response:
+            page = response.read().decode()
+            csp = response.headers["Content-Security-Policy"]
+        assert page.count('id="companion-feedback"') == 1
+        assert page.count('id="companion-status"') == 1
+        assert '<input id="companion-feedback"' not in page
+        assert 'sandbox="allow-scripts"' in page
+        assert "boardFrame.srcdoc =" in page
+        assert "event.source !== boardFrame.contentWindow" in page
+        assert "attachShadow" not in page
+        assert "frame-src 'self'" in csp
+    finally:
+        server.terminate()
+        server.communicate(timeout=2)
+
+
+def test_generated_client_fences_rapid_clicks_before_sending_the_choice(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="one">One</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    companion_module = runpy.run_path(str(SCRIPT_PATH))
+    page, _ = companion_module["_render_page"](session_dir)
+    source = page.decode()
+    pending_index = source.index("selectionPending = true;")
+    disable_index = source.index("setChoicesDisabled(true);")
+    request_index = source.index("const response = await fetch")
+
+    assert "if (selectionRecorded || selectionPending) return;" in source
+    assert pending_index < request_index
+    assert disable_index < request_index
+
+
+def test_server_authenticates_preview_and_returns_a_valid_choice(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council" data-label="Council Chamber">Council</button>'
+        + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    server, state = _start_server(session_dir)
+    try:
+        with pytest.raises(urllib.error.HTTPError) as unauthenticated:
+            urllib.request.urlopen(f'{state["base_url"]}/', timeout=2)
+        assert unauthenticated.value.code == 403
+
+        opener, cookie_jar = _authenticated_opener(state)
+        cookie = next(iter(cookie_jar))
+        assert cookie.has_nonstandard_attr("HttpOnly")
+        assert cookie.get_nonstandard_attr("SameSite") == "Lax"
+
+        with pytest.raises(urllib.error.HTTPError) as reused_capability:
+            _authenticated_opener(state)
+        assert reused_capability.value.code == 403
+
+        with opener.open(f'{state["base_url"]}/', timeout=2) as response:
+            page = response.read().decode()
+            assert "default-src 'none'" in response.headers["Content-Security-Policy"]
+        assert "Council Chamber" in page
+        assert "event.preventDefault();" in page
+
+        with pytest.raises(urllib.error.HTTPError) as forged:
+            _post_choice(opener, state["base_url"], "not-an-option")
+        assert forged.value.code == 400
+
+        with pytest.raises(urllib.error.HTTPError) as boolean_version:
+            _post_choice(opener, state["base_url"], "council", page_version=True)
+        assert boolean_version.value.code == 400
+
+        with pytest.raises(urllib.error.HTTPError) as long_feedback:
+            _post_choice(opener, state["base_url"], "council", feedback="x" * 2001)
+        assert long_feedback.value.code == 400
+
+        with pytest.raises(urllib.error.HTTPError) as oversized_body:
+            _post_choice(opener, state["base_url"], "council", feedback="x" * 40_000)
+        assert oversized_body.value.code == 413
+
+        recorded = _post_choice(opener, state["base_url"], "council")
+        assert recorded == {
+            "choice_id": "council",
+            "cursor": 1,
+            "feedback": "",
+            "label": "Council Chamber",
+            "page_version": 1,
+            "round_id": "layout-directions",
+        }
+        if os.name != "nt":
+            assert (session_dir / "events.jsonl").stat().st_mode & 0o777 == 0o600
+
+        waited = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "wait",
+                "--session-dir",
+                str(session_dir),
+                "--after",
+                "0",
+                "--timeout",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert waited.returncode == 0, waited.stderr
+        assert json.loads(waited.stdout) == recorded
+    finally:
+        server.terminate()
+        server.communicate(timeout=2)
+
+
+def test_parallel_sessions_use_isolated_cookie_paths_and_tokens(tmp_path):
+    first_result, first_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+        session_dir=tmp_path / "session-a",
+    )
+    second_result, second_dir = _publish(
+        tmp_path,
+        '<button data-choice="focused">Focused</button>' + ALTERNATIVE_CHOICE,
+        session_dir=tmp_path / "session-b",
+    )
+    assert first_result.returncode == 0, first_result.stderr
+    assert second_result.returncode == 0, second_result.stderr
+
+    first_server, first_state = _start_server(first_dir)
+    second_server, second_state = _start_server(second_dir)
+    cookie_jar = http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookie_jar))
+    try:
+        for state in (first_state, second_state):
+            request = urllib.request.Request(
+                state["bootstrap_url"],
+                data=urllib.parse.urlencode({"key": state["bootstrap_token"]}).encode(),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                method="POST",
+            )
+            with opener.open(request, timeout=2) as response:
+                assert response.status == 200
+
+        with opener.open(f'{first_state["base_url"]}/', timeout=2) as response:
+            assert response.status == 200
+
+        cookies = list(cookie_jar)
+        assert len(cookies) == 2
+        assert len({cookie.name for cookie in cookies}) == 2
+        assert all(cookie.path != "/" for cookie in cookies)
+        session_tokens = {cookie.value for cookie in cookies}
+        for state in (first_state, second_state):
+            assert state["bootstrap_token"] not in session_tokens
+    finally:
+        first_server.terminate()
+        first_server.communicate(timeout=2)
+        second_server.terminate()
+        second_server.communicate(timeout=2)
+
+
+def test_wait_ignores_old_events_and_reports_timeout(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    server, state = _start_server(session_dir)
+    try:
+        opener, _ = _authenticated_opener(state)
+        first = _post_choice(opener, state["base_url"], "council")
+
+        waited = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "wait",
+                "--session-dir",
+                str(session_dir),
+                "--after",
+                str(first["cursor"]),
+                "--timeout",
+                "0.05",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert waited.returncode == 3
+        assert json.loads(waited.stdout) == {
+            "after": 1,
+            "status": "timeout",
+        }
+    finally:
+        server.terminate()
+        server.communicate(timeout=2)
+
+
+def test_wait_reads_events_under_the_session_transaction_lock(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    companion_module = runpy.run_path(str(SCRIPT_PATH))
+    events_path = session_dir / "events.jsonl"
+    observed = []
+    errors = []
+
+    def wait_for_event():
+        try:
+            observed.append(companion_module["wait_for_choice"](session_dir, 0, 1))
+        except Exception as exc:  # noqa: BLE001 - inspect cross-thread failure below
+            errors.append(exc)
+
+    with companion_module["_session_lock"](session_dir):
+        events_path.write_text('{"cursor":', encoding="utf-8")
+        waiter = threading.Thread(target=wait_for_event)
+        waiter.start()
+        time.sleep(0.1)
+        assert waiter.is_alive(), "wait read a partially written event outside the session lock"
+        events_path.write_text('{"cursor":1}\n', encoding="utf-8")
+
+    waiter.join(timeout=2)
+    assert not waiter.is_alive()
+    assert errors == []
+    assert observed == [{"cursor": 1}]
+
+
+def test_server_rejects_a_choice_from_a_stale_page_version(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    server, state = _start_server(session_dir)
+    try:
+        opener, _ = _authenticated_opener(state)
+        second, _ = _publish(
+            tmp_path,
+            '<button data-choice="saffron">Graphite &amp; Saffron</button>'
+            + ALTERNATIVE_CHOICE,
+            round_id="accent-directions",
+            session_dir=session_dir,
+        )
+        assert second.returncode == 0, second.stderr
+
+        with opener.open(f'{state["base_url"]}/__version', timeout=2) as response:
+            assert json.loads(response.read()) == {
+                "page_version": 2,
+                "round_id": "accent-directions",
+            }
+
+        with pytest.raises(urllib.error.HTTPError) as stale:
+            _post_choice(opener, state["base_url"], "saffron", page_version=1)
+        assert stale.value.code == 409
+
+        fresh = _post_choice(opener, state["base_url"], "saffron", page_version=2)
+        assert fresh["choice_id"] == "saffron"
+        assert fresh["page_version"] == 2
+    finally:
+        server.terminate()
+        server.communicate(timeout=2)
+
+
+def test_choice_transaction_uses_the_cross_process_session_lock(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    server, state = _start_server(session_dir)
+    companion_module = runpy.run_path(str(SCRIPT_PATH))
+    outcome = {}
+
+    def submit_choice():
+        try:
+            opener, _ = _authenticated_opener(state)
+            outcome["event"] = _post_choice(opener, state["base_url"], "council")
+        except Exception as exc:  # pragma: no cover - asserted through outcome below
+            outcome["error"] = exc
+
+    submitter = threading.Thread(target=submit_choice)
+    try:
+        with companion_module["_session_lock"](session_dir):
+            submitter.start()
+            time.sleep(0.2)
+            assert submitter.is_alive(), "choice transaction ignored the held session lock"
+
+        submitter.join(timeout=2)
+        assert not submitter.is_alive()
+        assert "error" not in outcome
+        assert outcome["event"]["choice_id"] == "council"
+    finally:
+        submitter.join(timeout=2)
+        server.terminate()
+        server.communicate(timeout=2)
+
+
+def test_status_and_stop_commands_manage_the_server_lifecycle(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    server, _ = _start_server(session_dir)
+    status = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "status", "--session-dir", str(session_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert status.returncode == 0, status.stderr
+    assert json.loads(status.stdout) == {"status": "ok"}
+
+    stop = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "stop", "--session-dir", str(session_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert stop.returncode == 0, stop.stderr
+    assert json.loads(stop.stdout) == {"status": "stopping"}
+    assert server.wait(timeout=2) == 0
+    assert not (session_dir / "state.json").exists()
+
+
+def test_serve_stdout_contains_only_non_secret_readiness_data(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    server, state = _start_server(session_dir)
+    try:
+        assert server.stdout is not None
+        readiness_line = server.stdout.readline()
+        assert json.loads(readiness_line) == {
+            "pid": server.pid,
+            "port": state["port"],
+            "status": "ready",
+        }
+        assert "session_token" not in readiness_line
+        assert "preview_url" not in readiness_line
+        assert "cookie_name" not in readiness_line
+        assert state["session_token"] not in readiness_line
+        assert state["bootstrap_token"] not in readiness_line
+        assert state["bootstrap_url"] not in readiness_line
+    finally:
+        server.terminate()
+        server.communicate(timeout=2)
+
+
+def test_serve_writes_a_private_preview_launcher_for_opaque_desktop_handoff(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    server, state = _start_server(session_dir)
+    try:
+        launcher_path = session_dir / "open-preview.html"
+        launcher = launcher_path.read_text(encoding="utf-8")
+
+        assert "preview_url" not in state
+        assert state["bootstrap_url"] in launcher
+        assert state["bootstrap_token"] in launcher
+        assert state["session_token"] not in launcher
+        assert 'method="post"' in launcher
+        assert "?key=" not in launcher
+        if os.name != "nt":
+            assert launcher_path.stat().st_mode & 0o777 == 0o600
+    finally:
+        server.terminate()
+        server.communicate(timeout=2)
+
+
+def test_bootstrap_cookie_allows_the_local_launcher_top_level_navigation(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    server, state = _start_server(session_dir)
+    try:
+        cookie_jar = http.cookiejar.CookieJar()
+        opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookie_jar))
+        legacy_query_url = (
+            f'{state["base_url"]}/?key='
+            f'{urllib.parse.quote(state["bootstrap_token"], safe="")}'
+        )
+        with pytest.raises(urllib.error.HTTPError) as query_bootstrap:
+            opener.open(legacy_query_url, timeout=2)
+        assert query_bootstrap.value.code == 403
+
+        request = urllib.request.Request(
+            state["bootstrap_url"],
+            data=urllib.parse.urlencode({"key": state["bootstrap_token"]}).encode(),
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            method="POST",
+        )
+        with opener.open(request, timeout=2) as response:
+            transition = response.read().decode()
+            set_cookie = response.headers["Set-Cookie"]
+
+        assert "location.replace" in transition
+        assert state["bootstrap_token"] not in transition
+        assert "HttpOnly" in set_cookie
+        assert "SameSite=Lax" in set_cookie
+        with opener.open(f'{state["base_url"]}/', timeout=2) as response:
+            assert response.status == 200
+    finally:
+        server.terminate()
+        server.communicate(timeout=2)
+
+
+def test_only_one_server_may_serve_a_session(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    first, first_state = _start_server(session_dir)
+    second = subprocess.Popen(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "serve",
+            "--session-dir",
+            str(session_dir),
+            "--port",
+            "0",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 1.5
+        while second.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.02)
+
+        assert second.poll() is not None, "second server remained active for the same session"
+        _, second_stderr = second.communicate(timeout=1)
+        assert second.returncode != 0
+        assert "already has a running server" in second_stderr
+
+        current_state = json.loads((session_dir / "state.json").read_text(encoding="utf-8"))
+        assert current_state == first_state
+    finally:
+        if second.poll() is None:
+            second.terminate()
+            second.communicate(timeout=2)
+        first.terminate()
+        first.communicate(timeout=2)
+
+
+@pytest.mark.parametrize("unicode_character", ["界", "🙂"])
+def test_feedback_accepts_two_thousand_unicode_characters(tmp_path, unicode_character):
+    result, session_dir = _publish(
+        tmp_path,
+        '<button data-choice="council">Council</button>' + ALTERNATIVE_CHOICE,
+    )
+    assert result.returncode == 0, result.stderr
+
+    server, state = _start_server(session_dir)
+    try:
+        opener, _ = _authenticated_opener(state)
+        feedback = unicode_character * 2_000
+        recorded = _post_choice(
+            opener,
+            state["base_url"],
+            "council",
+            feedback=feedback,
+        )
+        assert recorded["feedback"] == feedback
+    finally:
+        server.terminate()
+        server.communicate(timeout=2)
+
+
+def test_choice_preserves_optional_feedback_and_deduplicates_a_round(tmp_path):
+    result, session_dir = _publish(
+        tmp_path,
+        (
+            '<button data-choice="council" data-label="Council Chamber">Council</button>'
+            '<button data-choice="focused" data-label="Focused Correspondence">Focused</button>'
+        ),
+    )
+    assert result.returncode == 0, result.stderr
+
+    server, state = _start_server(session_dir)
+    try:
+        opener, _ = _authenticated_opener(state)
+        first = _post_choice(
+            opener,
+            state["base_url"],
+            "council",
+            feedback="Keep the structure, but make the accent less orange.",
+        )
+        assert first["feedback"] == "Keep the structure, but make the accent less orange."
+
+        duplicate = _post_choice(
+            opener,
+            state["base_url"],
+            "council",
+            feedback="Keep the structure, but make the accent less orange.",
+        )
+        assert duplicate == first
+
+        with pytest.raises(urllib.error.HTTPError) as conflicting:
+            _post_choice(opener, state["base_url"], "focused")
+        assert conflicting.value.code == 409
+    finally:
+        server.terminate()
+        server.communicate(timeout=2)
+
+
+def test_skill_frontmatter_links_and_visual_workflow_contract_are_valid(monkeypatch):
+    from tools import skills_tool
+    from tools.skill_manager_tool import _validate_frontmatter
+
+    skill_text = SKILL_PATH.read_text(encoding="utf-8")
+    reference_text = (SKILL_PATH.parent / "references/visual-companion.md").read_text(
+        encoding="utf-8"
+    )
+    assert _validate_frontmatter(skill_text) is None
+    assert "references/visual-companion.md" in skill_text
+
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", SKILL_PATH.parents[2])
+    viewed = json.loads(skills_tool.skill_view("claude-design", preprocess=False))
+    assert viewed["success"] is True
+    assert "references/visual-companion.md" in viewed["linked_files"]["references"]
+    assert "scripts/visual_companion.py" in viewed["linked_files"]["scripts"]
+
+    assert "Maintain `decision-ledger.json`" in reference_text
+    assert "single dimension explored next" in reference_text
+    assert "ask the same options through `clarify`" in reference_text
+    assert "state the accepted direction in ordinary assistant text" in reference_text
+    assert "open-preview.html" in reference_text
+    assert "`open_preview`" in reference_text
+    assert "Do not read `state.json`" in reference_text

--- a/tests/skills/test_visual_companion_skill.py
+++ b/tests/skills/test_visual_companion_skill.py
@@ -935,3 +935,16 @@ def test_skill_frontmatter_links_and_visual_workflow_contract_are_valid(monkeypa
     assert "open-preview.html" in reference_text
     assert "`open_preview`" in reference_text
     assert "Do not read `state.json`" in reference_text
+    assert "complete representative product surface" in reference_text
+    assert "not a thumbnail, moodboard, or palette swatch" in reference_text
+    assert "one-sentence composition thesis" in reference_text
+    assert "numbered anatomy callouts" in reference_text
+    assert "wide and narrow behavior" in reference_text
+    assert "actual product vocabulary" in reference_text
+    assert "consolidated presentation artifact" in reference_text
+    assert "Run the Slop Diagnostic before publication" in reference_text
+    assert "preserve the same viewport, crop, content, and zoom" in reference_text
+    assert "inspect the primary wide viewport and the named narrow viewport" in reference_text
+    assert "changing only the ledger's `varying` dimension" in reference_text
+    assert "This artifact is the design handoff, not another vote" in reference_text
+    assert "high-fidelity presentation contract is mandatory" in skill_text


### PR DESCRIPTION
## Summary

- extend the bundled `claude-design` skill with an iterative Hermes Desktop visual-choice workflow
- add a loopback-only companion that publishes two to four immutable visual options, collects optional corrective feedback, and returns validated structured selections
- require high-fidelity decision boards for screen and product-surface work: complete readable surfaces, composition theses, numbered anatomy callouts, wide/narrow proof, repository-faithful content, fair comparisons, and a consolidated accepted handoff instead of decorative thumbnails
- reuse the existing `open_preview` right rail through a private local launcher, with query-free one-time bootstrap exchange and a distinct scoped session cookie
- isolate generated markup and CSS in an opaque sandboxed iframe while keeping trusted feedback/status controls outside it
- document progressive one-dimension refinement, same-page reload, decision-ledger behavior, textual `clarify` fallback, lifecycle cleanup, and transcript expectations
- add focused regression coverage for authentication, limits, stale/conflicting selections, locking, singleton serving, immutable publication, Unicode feedback, trust-boundary hardening, and the presentation contract

## Security and correctness

- binds exclusively to `127.0.0.1`
- keeps capabilities and session credentials out of readiness output and ordinary tool transcripts
- uses a bounded query-free POST bootstrap rather than a capability-bearing URL
- validates round IDs, choice IDs, labels, page versions, cursors, feedback, content types, and request sizes server-side
- rejects generated scripts, inline handlers, active embeds, unsafe navigation, remote resources, duplicate metadata attributes, and malformed integer values
- serializes publication, selection transactions, and event reads with a cross-process session lock
- publishes immutable versioned pages and enforces one serving process per session

## Verification

- strict TDD for the presentation contract: focused integration assertion observed failing before the documentation change, then passed
- `scripts/run_tests.sh tests/skills/` — **388 passed**
- `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py` — **114 passed**
- Ruff 0.15.10 — passed
- `ty` 0.0.21 — passed
- Python compilation — passed
- actual Hermes frontmatter validation and `skill_view` linked-file discovery — passed
- real Chrome adversarial workflow — passed, including CSS isolation, preserved trusted feedback, truthful rapid-click behavior, one durable event, one-time bootstrap, and no capability URL in persistent history
- existing Desktop `open_preview` accepted only the opaque local launcher path
- independent implementation/correctness and product-contract reviews of the companion runtime both returned **APPROVE**
