### PR TITLE
fix(acp): accept date-form initialize versions

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -31,7 +31,9 @@ else:
 
 import argparse
 import asyncio
+import json
 import logging
+import re
 import sys
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -46,6 +48,47 @@ from hermes_constants import get_hermes_home
 # traceback is pure noise. We keep the protocol response intact and only
 # silence the stderr noise for this specific benign case.
 _BENIGN_PROBE_METHODS = frozenset({"ping", "health", "healthcheck"})
+
+
+def _normalize_initialize_frame(line: bytes, protocol_version: int) -> bytes:
+    """Normalize MCP-style ACP initialize versions before SDK validation."""
+    try:
+        message = json.loads(line)
+    except (json.JSONDecodeError, UnicodeDecodeError, TypeError, RecursionError):
+        return line
+
+    if not isinstance(message, dict) or message.get("method") != "initialize":
+        return line
+    params = message.get("params")
+    if not isinstance(params, dict):
+        return line
+
+    value = params.get("protocolVersion")
+    if not isinstance(value, str) or re.fullmatch(r"\d{4}-\d{2}-\d{2}", value) is None:
+        return line
+
+    params["protocolVersion"] = protocol_version
+    return (
+        json.dumps(message, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        + b"\n"
+    )
+
+
+class _InitializeCompatReader(asyncio.StreamReader):
+    """StreamReader facade that repairs only incompatible initialize frames."""
+
+    def __init__(self, source: asyncio.StreamReader, protocol_version: int) -> None:
+        super().__init__()
+        self._source = source
+        self._protocol_version = protocol_version
+        self._first_frame = True
+
+    async def readline(self) -> bytes:
+        line = await self._source.readline()
+        if not line or not self._first_frame:
+            return line
+        self._first_frame = False
+        return _normalize_initialize_frame(line, self._protocol_version)
 
 
 class _BenignProbeMethodFilter(logging.Filter):
@@ -214,6 +257,22 @@ def _run_setup_browser(assume_yes: bool = False) -> int:
         return 1
 
 
+async def _run_agent_with_initialize_compat(agent) -> None:
+    """Run ACP over stdio with a narrow initialize-version compatibility shim."""
+    import acp
+    from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
+    from acp.stdio import stdio_streams
+
+    reader, writer = await stdio_streams(limit=DEFAULT_STDIO_BUFFER_LIMIT_BYTES)
+    compat_reader = _InitializeCompatReader(reader, acp.PROTOCOL_VERSION)
+    await acp.run_agent(
+        agent,
+        input_stream=writer,
+        output_stream=compat_reader,
+        use_unstable_protocol=True,
+    )
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point: load env, configure logging, run the ACP agent."""
     args = _parse_args(argv)
@@ -259,7 +318,7 @@ def main(argv: list[str] | None = None) -> None:
 
     agent = HermesACPAgent()
     try:
-        asyncio.run(acp.run_agent(agent, use_unstable_protocol=True))
+        asyncio.run(_run_agent_with_initialize_compat(agent))
     except KeyboardInterrupt:
         logger.info("Shutting down (KeyboardInterrupt)")
     except Exception:

--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -31,9 +31,12 @@ else:
 
 import argparse
 import asyncio
+import json
 import logging
 import os
+import re
 import sys
+from datetime import date
 from pathlib import Path
 from hermes_constants import get_hermes_home
 
@@ -47,6 +50,51 @@ from hermes_constants import get_hermes_home
 # traceback is pure noise. We keep the protocol response intact and only
 # silence the stderr noise for this specific benign case.
 _BENIGN_PROBE_METHODS = frozenset({"ping", "health", "healthcheck"})
+
+
+def _normalize_initialize_frame(line: bytes, protocol_version: int) -> bytes:
+    """Normalize MCP-style ACP initialize versions before SDK validation."""
+    try:
+        message = json.loads(line)
+    except (ValueError, UnicodeDecodeError, TypeError, RecursionError):
+        return line
+
+    if not isinstance(message, dict) or message.get("method") != "initialize":
+        return line
+    params = message.get("params")
+    if not isinstance(params, dict):
+        return line
+
+    value = params.get("protocolVersion")
+    if not isinstance(value, str) or re.fullmatch(r"\d{4}-\d{2}-\d{2}", value) is None:
+        return line
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        return line
+
+    params["protocolVersion"] = protocol_version
+    return (
+        json.dumps(message, separators=(",", ":")).encode("utf-8")
+        + b"\n"
+    )
+
+
+class _InitializeCompatReader(asyncio.StreamReader):
+    """StreamReader facade that repairs only incompatible initialize frames."""
+
+    def __init__(self, source: asyncio.StreamReader, protocol_version: int) -> None:
+        super().__init__()
+        self._source = source
+        self._protocol_version = protocol_version
+        self._first_frame = True
+
+    async def readline(self) -> bytes:
+        line = await self._source.readline()
+        if not line or not self._first_frame:
+            return line
+        self._first_frame = False
+        return _normalize_initialize_frame(line, self._protocol_version)
 
 
 class _BenignProbeMethodFilter(logging.Filter):
@@ -217,6 +265,22 @@ def _run_setup_browser(assume_yes: bool = False) -> int:
         return 1
 
 
+async def _run_agent_with_initialize_compat(agent) -> None:
+    """Run ACP over stdio with a narrow initialize-version compatibility shim."""
+    import acp
+    from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
+    from acp.stdio import stdio_streams
+
+    reader, writer = await stdio_streams(limit=DEFAULT_STDIO_BUFFER_LIMIT_BYTES)
+    compat_reader = _InitializeCompatReader(reader, acp.PROTOCOL_VERSION)
+    await acp.run_agent(
+        agent,
+        input_stream=writer,
+        output_stream=compat_reader,
+        use_unstable_protocol=True,
+    )
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point: load env, configure logging, run the ACP agent."""
     args = _parse_args(argv)
@@ -270,7 +334,7 @@ def main(argv: list[str] | None = None) -> None:
 
     agent = HermesACPAgent()
     try:
-        asyncio.run(acp.run_agent(agent, use_unstable_protocol=True))
+        asyncio.run(_run_agent_with_initialize_compat(agent))
     except KeyboardInterrupt:
         logger.info("Shutting down (KeyboardInterrupt)")
     except Exception:

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -1,5 +1,7 @@
 """Tests for acp_adapter.entry startup wiring."""
 
+import asyncio
+import json
 import sys
 
 import acp
@@ -11,16 +13,97 @@ from acp_adapter import entry
 def test_main_enables_unstable_protocol(monkeypatch):
     calls = {}
 
-    async def fake_run_agent(agent, **kwargs):
-        calls["kwargs"] = kwargs
+    async def fake_run_agent(agent):
+        calls["agent"] = agent
 
     monkeypatch.setattr(entry, "_setup_logging", lambda: None)
     monkeypatch.setattr(entry, "_load_env", lambda: None)
-    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+    monkeypatch.setattr(entry, "_run_agent_with_initialize_compat", fake_run_agent)
 
     entry.main([])
 
-    assert calls["kwargs"]["use_unstable_protocol"] is True
+    assert calls["agent"] is not None
+
+
+def test_initialize_compat_reader_normalizes_date_protocol_version():
+    source = asyncio.StreamReader()
+    source.feed_data(
+        json.dumps({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "2025-11-25"},
+        }).encode()
+        + b"\n"
+    )
+    source.feed_eof()
+
+    line = asyncio.run(entry._InitializeCompatReader(source, 1).readline())
+
+    assert json.loads(line)["params"]["protocolVersion"] == 1
+
+
+def test_initialize_compat_reader_only_inspects_first_frame(monkeypatch):
+    initialize = (
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize",'
+        b'"params":{"protocolVersion":1}}\n'
+    )
+    subsequent = b'{"jsonrpc":"2.0","method":"session/update","params":{"large":"payload"}}\n'
+    source = asyncio.StreamReader()
+    source.feed_data(initialize + subsequent)
+    source.feed_eof()
+    reader = entry._InitializeCompatReader(source, 1)
+
+    assert asyncio.run(reader.readline()) == initialize
+    monkeypatch.setattr(entry.json, "loads", lambda _line: pytest.fail("reparsed frame"))
+    assert asyncio.run(reader.readline()) == subsequent
+
+
+def test_initialize_compat_reader_preserves_valid_integer_version():
+    line = (
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize",'
+        b'"params":{"protocolVersion":1}}\n'
+    )
+
+    assert entry._normalize_initialize_frame(line, 7) == line
+
+
+def test_initialize_compat_reader_preserves_non_initialize_frames():
+    line = (
+        b'{"jsonrpc":"2.0","id":2,"method":"session/new",'
+        b'"params":{"protocolVersion":"2025-11-25"}}\n'
+    )
+
+    assert entry._normalize_initialize_frame(line, 1) == line
+
+
+@pytest.mark.parametrize(
+    "protocol_version",
+    [None, True, {}, [], "not-a-date", 65536],
+)
+def test_initialize_compat_reader_preserves_other_invalid_versions(protocol_version):
+    line = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"protocolVersion": protocol_version},
+            }
+        ).encode()
+        + b"\n"
+    )
+
+    assert entry._normalize_initialize_frame(line, 1) == line
+
+
+def test_initialize_compat_reader_preserves_missing_protocol_version():
+    line = (
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize",'
+        b'"params":{"clientCapabilities":{}}}\n'
+    )
+
+    assert entry._normalize_initialize_frame(line, 1) == line
 
 
 def test_main_version_prints_without_starting_server(monkeypatch, capsys):

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -1,5 +1,7 @@
 """Tests for acp_adapter.entry startup wiring."""
 
+import asyncio
+import json
 import sys
 
 import acp
@@ -11,22 +13,134 @@ from acp_adapter import entry
 def test_main_enables_unstable_protocol(monkeypatch):
     calls = {}
 
-    async def fake_run_agent(agent, **kwargs):
-        calls["kwargs"] = kwargs
+    async def fake_run_agent(agent):
+        calls["agent"] = agent
 
     monkeypatch.setattr(entry, "_setup_logging", lambda: None)
     monkeypatch.setattr(entry, "_load_env", lambda: None)
-    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+    monkeypatch.setattr(entry, "_run_agent_with_initialize_compat", fake_run_agent)
 
     entry.main([])
 
+    assert calls["agent"] is not None
+
+
+def test_initialize_compat_runner_wires_stdio_and_unstable_protocol(monkeypatch):
+    from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
+
+    calls = {}
+    agent = object()
+    reader = asyncio.StreamReader()
+    writer = object()
+
+    async def fake_stdio_streams(*, limit):
+        calls["limit"] = limit
+        return reader, writer
+
+    async def fake_run_agent(actual_agent, **kwargs):
+        calls["agent"] = actual_agent
+        calls["kwargs"] = kwargs
+
+    monkeypatch.setattr("acp.stdio.stdio_streams", fake_stdio_streams)
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    asyncio.run(entry._run_agent_with_initialize_compat(agent))
+
+    assert calls["limit"] == DEFAULT_STDIO_BUFFER_LIMIT_BYTES
+    assert calls["agent"] is agent
+    assert calls["kwargs"]["input_stream"] is writer
+    compat_reader = calls["kwargs"]["output_stream"]
+    assert isinstance(compat_reader, entry._InitializeCompatReader)
+    assert compat_reader._source is reader
     assert calls["kwargs"]["use_unstable_protocol"] is True
+
+
+def test_initialize_compat_reader_normalizes_date_protocol_version():
+    source = asyncio.StreamReader()
+    source.feed_data(
+        json.dumps({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "clientInfo": {"name": "\ud800"},
+            "params": {"protocolVersion": "2025-11-25"},
+        }).encode()
+        + b"\n"
+    )
+    source.feed_eof()
+
+    line = asyncio.run(entry._InitializeCompatReader(source, 1).readline())
+
+    assert json.loads(line)["params"]["protocolVersion"] == 1
+
+
+def test_initialize_compat_reader_only_inspects_first_frame(monkeypatch):
+    initialize = (
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize",'
+        b'"params":{"protocolVersion":1}}\n'
+    )
+    subsequent = b'{"jsonrpc":"2.0","method":"session/update","params":{"large":"payload"}}\n'
+    source = asyncio.StreamReader()
+    source.feed_data(initialize + subsequent)
+    source.feed_eof()
+    reader = entry._InitializeCompatReader(source, 1)
+
+    assert asyncio.run(reader.readline()) == initialize
+    monkeypatch.setattr(entry.json, "loads", lambda _line: pytest.fail("reparsed frame"))
+    assert asyncio.run(reader.readline()) == subsequent
+
+
+def test_initialize_compat_reader_preserves_valid_integer_version():
+    line = (
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize",'
+        b'"params":{"protocolVersion":1}}\n'
+    )
+
+    assert entry._normalize_initialize_frame(line, 7) == line
+
+
+def test_initialize_compat_reader_preserves_non_initialize_frames():
+    line = (
+        b'{"jsonrpc":"2.0","id":2,"method":"session/new",'
+        b'"params":{"protocolVersion":"2025-11-25"}}\n'
+    )
+
+    assert entry._normalize_initialize_frame(line, 1) == line
+
+
+@pytest.mark.parametrize(
+    "protocol_version",
+    [None, True, {}, [], "not-a-date", "2025-99-99", "2025-02-30", 65536],
+)
+def test_initialize_compat_reader_preserves_other_invalid_versions(protocol_version):
+    line = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"protocolVersion": protocol_version},
+            }
+        ).encode()
+        + b"\n"
+    )
+
+    assert entry._normalize_initialize_frame(line, 1) == line
+
+
+def test_initialize_compat_reader_preserves_missing_protocol_version():
+    line = (
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize",'
+        b'"params":{"clientCapabilities":{}}}\n'
+    )
+
+    assert entry._normalize_initialize_frame(line, 1) == line
 
 
 def test_main_skips_configured_mcp_discovery_when_requested(monkeypatch):
     discovery_calls = []
 
-    async def fake_run_agent(agent, **kwargs):
+    async def fake_run_agent(agent):
         pass
 
     monkeypatch.setattr(entry, "_setup_logging", lambda: None)
@@ -36,7 +150,7 @@ def test_main_skips_configured_mcp_discovery_when_requested(monkeypatch):
         "tools.mcp_tool.discover_mcp_tools",
         lambda: discovery_calls.append(True),
     )
-    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+    monkeypatch.setattr(entry, "_run_agent_with_initialize_compat", fake_run_agent)
 
     entry.main([])
 


### PR DESCRIPTION
## Summary

- normalize an MCP-style date `protocolVersion` on the first ACP `initialize` frame before SDK schema validation
- preserve valid ACP integer versions and leave all other malformed values for the SDK to reject
- stop inspecting after the first frame so normal ACP session traffic is never reparsed

Fixes #70661.

## Root cause

`agent-client-protocol` 0.9.0 validates `InitializeRequest.protocol_version` as a `uint16` while decoding the stdio frame. Date-form versions therefore fail before `HermesACPAgent.initialize` can apply its existing compatibility fallback.

## Verification

- `python -m pytest tests/acp/test_entry.py tests/acp/test_server.py -q` — 107 passed
- `python -m ruff check acp_adapter/entry.py tests/acp/test_entry.py` — passed
- `git diff --check` — passed
- local autoreview — clean, no accepted/actionable findings (`patch is correct`, 0.90)

## Scope

Two files. The shim is limited to the first stdio frame and only rewrites `YYYY-MM-DD` protocol versions; later frames remain byte-for-byte passthrough, and all unrelated validation behavior is unchanged.