### PR TITLE
test(kanban): preserve non-zero exit for delegated-child refusals

### DIFF
--- a/tests/hermes_cli/test_kanban_cli_exit_status.py
+++ b/tests/hermes_cli/test_kanban_cli_exit_status.py
@@ -1,0 +1,59 @@
+"""Regression coverage for Kanban CLI process exit status propagation."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+
+
+def _run_hermes(home: Path, *args: str, marker: bool = False) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["HERMES_KANBAN_HOME"] = str(home)
+    for name in (
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+    ):
+        env.pop(name, None)
+    env["PYTHONPATH"] = str(ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    if marker:
+        env["HERMES_DELEGATED_CHILD_CONTEXT"] = "1"
+    else:
+        env.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", *args],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_delegated_child_kanban_cli_refusal_returns_nonzero_exit_status(tmp_path):
+    """A printed Kanban mutation refusal must not look like CLI success."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    created = _run_hermes(home, "kanban", "create", "exit status probe", "--json")
+    assert created.returncode == 0, created.stderr
+    task_id = json.loads(created.stdout)["id"]
+
+    refused = _run_hermes(
+        home,
+        "kanban",
+        "comment",
+        task_id,
+        "must be refused",
+        marker=True,
+    )
+
+    assert refused.returncode == 1
+    assert "delegate_task child contexts cannot mutate Kanban tasks via the CLI" in refused.stderr

--- a/tests/hermes_cli/test_kanban_cli_exit_status.py
+++ b/tests/hermes_cli/test_kanban_cli_exit_status.py
@@ -34,6 +34,7 @@ def _run_hermes(home: Path, *args: str, marker: bool = False) -> subprocess.Comp
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Add regression coverage for the Kanban CLI process boundary so a delegated-child refusal remains a non-zero process exit instead of being interpreted as successful automation.

## Observed behavior and root cause

The production fix for propagating non-zero command-handler results is already on upstream `main`. The remaining contribution is test coverage at the subprocess boundary: the CLI test must observe a refused delegated-child operation as a failure, not merely inspect an in-process return value.

Without this regression coverage, an automation caller could treat a rejected Kanban mutation as success even though the user-facing command had refused the operation.

## Changes Made

- Added coverage in `tests/hermes_cli/test_kanban_cli_exit_status.py` for delegated-child refusal exit status.
- Kept the PR test-only: no production behavior, dependency, configuration, or platform adapter changes.
- Bound the subprocess helper with an explicit timeout so a broken CLI path cannot hang the regression test indefinitely.
- The current series contains two focused test commits and one changed test file.

## Related Issue

No standalone issue. The production behavior is already present on upstream `main`; this PR preserves the missing regression contract.

## How to Test

### Current exact-head verification

Published head: `7a22b9036f3aab34833e8fba5d025883750517a4`  
Rebased base: `8911e2e0edf750b104edbdc106d63d6cdac88524`

The repository's canonical isolated test wrapper was run from a clean checkout of that exact head:

```text
scripts/run_tests.sh -q tests/hermes_cli/test_kanban_cli_exit_status.py
1 passed, 0 failed

git diff --check 8911e2e0edf750b104edbdc106d63d6cdac88524 7a22b9036f3aab34833e8fba5d025883750517a4
passed
```

This covers the delegated-child Kanban CLI process-exit regression. The candidate checkout remained clean after the run. The full repository suite was not run and is not claimed as passing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this regression coverage
- [ ] I've run `pytest tests/ -q` and all tests pass — focused canonical coverage was run instead
- [x] I've added tests or improved test coverage
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] No user documentation change is required
- [x] No config keys changed; `cli-config.yaml.example` is unaffected
- [x] No architecture or workflow change; `CONTRIBUTING.md` and `AGENTS.md` are unaffected
- [x] The change is test-only and has no additional cross-platform behavior
- [x] No tool descriptions or schemas changed

## Provenance

- Published head: `2416fee97f9c2d8950ffa674148841b2595b73c0`
- PR base: `main` at `de0abc0617794a8c4ae661d2f67f4b23d4ab51fe`
- Source fork: `vadelma-agent/hermes-agent`
