### PR TITLE
fix(agent): surface prior-turn content as last-resort fallback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7088,10 +7088,11 @@ def run_conversation(
                         and not _has_inline_thinking  # thinking model still working — let prefill handle
                     ):
                         agent._post_tool_empty_retried = True
-                        # Clear stale narration so it doesn't resurface
-                        # on a later empty response after the nudge.
-                        agent._last_content_with_tools = None
-                        agent._last_content_tools_all_housekeeping = False
+                        # Preserve _last_content_with_tools as a last-resort
+                        # fallback.  If the nudge fails to wake the model and
+                        # all retries exhaust, we surface the captured content
+                        # instead of returning "(empty)" — a partial visible
+                        # answer is better than silence.
                         logger.info(
                             "Empty response after tool calls — nudging model "
                             "to continue processing"
@@ -7249,6 +7250,28 @@ def run_conversation(
                     # Surface the buffered retry/fallback trace so the
                     # user can see what was attempted before "(empty)".
                     agent._flush_status_buffer()
+
+                    # ── Last-resort fallback: prior-turn content ──
+                    # If the model delivered visible text alongside
+                    # tool calls in a prior turn (e.g. "Let me check
+                    # the config...") but then went silent, surface
+                    # that text as the final response.  A partial
+                    # visible answer is better than "(empty)".
+                    _last_resort = getattr(agent, '_last_content_with_tools', None)
+                    if _last_resort:
+                        logger.info(
+                            "Empty response exhausted — using prior-turn "
+                            "content as last-resort fallback"
+                        )
+                        agent._emit_status(
+                            "↻ Model went silent — using earlier content as final answer"
+                        )
+                        agent._last_content_with_tools = None
+                        agent._last_content_tools_all_housekeeping = False
+                        final_response = agent._strip_think_blocks(_last_resort).strip()
+                        agent._response_was_previewed = True
+                        _turn_exit_reason = "fallback_prior_turn_content"
+                        break
                     _turn_exit_reason = "empty_response_exhausted"
                     reasoning_text = agent._extract_reasoning(assistant_message)
                     agent._drop_trailing_empty_response_scaffolding(messages)

--- a/tests/run_agent/test_conversation_fallback_state.py
+++ b/tests/run_agent/test_conversation_fallback_state.py
@@ -205,3 +205,69 @@ def test_bare_tool_marker_is_not_reused_as_final_response():
         f"Expected 3 API calls (including nudge), got: {result['api_calls']}."
     )
 
+
+def test_last_resort_fallback_surfaces_prior_content_after_exhaustion():
+    """E2E: when nudge fails, prior-turn content is surfaced as last-resort.
+
+    Sequence:
+    1. Content + terminal (substantive) → cached, not housekeeping
+    2. Empty → enters nudge path (housekeeping shortcut skipped)
+    3. Empty after nudge → retries exhausted
+    4. Last-resort fallback surfaces prior-turn content
+    """
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs("terminal")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1/",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.valid_tool_names = {"terminal"}
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.side_effect = [
+        # Turn 1: Content + substantive tool (sets _last_content_with_tools,
+        # but NOT housekeeping because terminal is substantive).
+        _response(
+            content="Let me check the config...",
+            finish_reason="tool_calls",
+            tool_calls=[_tool_call("terminal", "term1")],
+        ),
+        # Turn 2: Empty → enters nudge path (housekeeping shortcut skipped).
+        _response(content="", finish_reason="stop"),
+        # Turn 3: Nudge response also empty → empty-content retry 1/3
+        _response(content="", finish_reason="stop"),
+        # Turn 4: Retry 2/3
+        _response(content="", finish_reason="stop"),
+        # Turn 5: Retry 3/3
+        _response(content="", finish_reason="stop"),
+        # Turn 6: After exhaustion → last-resort fires
+        _response(content="", finish_reason="stop"),
+    ]
+
+    with (
+        patch("run_agent.handle_function_call", return_value="ok"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("check the server config")
+
+    assert result["final_response"] == "Let me check the config...", (
+        f"Expected last-resort fallback to surface prior-turn content, "
+        f"got: {result['final_response']!r}"
+    )
+    assert result["turn_exit_reason"] == "fallback_prior_turn_content", (
+        f"Expected fallback_prior_turn_content exit reason, "
+        f"got: {result['turn_exit_reason']}"
+    )
+


### PR DESCRIPTION
## Problem

When the model delivers visible text alongside tool calls (e.g. "Let me check the config...") and then goes silent after exhausting all retries, nudge, and fallback chain — the user sees `(empty)` instead of the text the model already produced.

Two root causes:
1. `_last_content_with_tools` is cleared during the post-tool nudge path, destroying the fallback
2. The `(empty)` terminal has no last-resort check for captured prior-turn content

## Fix

1. Preserve `_last_content_with_tools` through the nudge — don't clear it
2. Last-resort fallback before `(empty)` — if prior-turn content is still available when all retries are exhausted, use it as the final response