### PR TITLE
fix(curator): cap max_iterations at 200 instead of 9999

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1929,7 +1929,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             # API calls against hundreds of candidate skills. The
             # single-session review path caps itself at a much smaller
             # number because it's not doing a curation sweep.
-            max_iterations=9999,
+            max_iterations=200,
             quiet_mode=True,
             platform="curator",
             skip_context_files=True,

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -757,6 +757,9 @@ def test_review_fork_forwards_runtime_pool_and_overrides(curator_env, monkeypatc
     assert meta.get("error") is None, meta.get("error")
     assert captured["kwargs"]["credential_pool"] is fake_pool
     assert captured["kwargs"]["request_overrides"] == fake_overrides
+    assert captured["kwargs"]["max_iterations"] == 200, (
+        f"expected max_iterations=200, got {captured['kwargs']['max_iterations']}"
+    )
 
 
 def test_review_fork_uses_runtime_model_and_output_cap(curator_env, monkeypatch):


### PR DESCRIPTION
## Problem

curator.\_run_llm_review() uses max_iterations=9999. If the model gets stuck in a loop during skill review, it consumes the entire quota before the run is interrupted.

## Fix

Cap max_iterations at 200 — enough for any reasonable skill-review sweep while preventing runaway billing.