### PR TITLE
fix(anthropic): detect DeepSeek endpoint by model name for proxied gateways

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -531,7 +531,7 @@ def _is_kimi_family_endpoint(base_url: str | None, model: str | None = None) -> 
     return False
 
 
-def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
+def _is_deepseek_anthropic_endpoint(base_url: str | None, model: str | None = None) -> bool:
     """Return True for DeepSeek's Anthropic-compatible endpoint.
 
     DeepSeek's ``/anthropic`` route speaks the Anthropic Messages protocol
@@ -548,9 +548,17 @@ def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
     policy used for Kimi's ``/coding`` endpoint.  The match is pinned to
     the ``/anthropic`` path so the OpenAI-compatible ``api.deepseek.com``
     base URL (which never reaches this adapter) is not misclassified.
+
+    When the base_url does not match api.deepseek.com, fall back to
+    model-name detection so proxied endpoints (e.g. LiteLLM) that front
+    DeepSeek models preserve unsigned thinking blocks.  Model-based
+    detection follows the same pattern as Kimi's ``_model_name_is_kimi_family``.
     See hermes-agent#16748.
     """
     if not base_url_host_matches(base_url or "", "api.deepseek.com"):
+        # Fall back to model-name detection for proxied endpoints
+        if model and model.lower().startswith("deepseek"):
+            return True
         return False
     normalized = _normalize_base_url_text(base_url)
     if not normalized:
@@ -2524,7 +2532,7 @@ def _manage_thinking_signatures(
             # Kimi does not enforce thinking signatures — replay as-is
             # (shared cleanup below still strips cache markers + the internal flag).
             pass
-        elif _is_deepseek_anthropic_endpoint(base_url):
+        elif _is_deepseek_anthropic_endpoint(base_url, model):
             # DeepSeek: strip signed, preserve unsigned.
             new_content = []
             for b in m["content"]:

--- a/tests/agent/test_deepseek_anthropic_thinking.py
+++ b/tests/agent/test_deepseek_anthropic_thinking.py
@@ -105,3 +105,60 @@ class TestDeepSeekAnthropicPreservesThinking:
                     assert "cache_control" not in b
 
 
+class TestDeepSeekCustomRelay:
+    """Custom relay host with DeepSeek model — model-name detection path."""
+
+    def test_model_name_detection_for_custom_relay(self) -> None:
+        """When base_url is NOT api.deepseek.com but model starts with 'deepseek',
+        the endpoint is detected via model-name fallback."""
+        from agent.anthropic_adapter import _is_deepseek_anthropic_endpoint
+
+        result = _is_deepseek_anthropic_endpoint(
+            "https://llm-gateway.example.com/v1",
+            "deepseek-deepseek-v4-pro",
+        )
+        assert result is True, (
+            "Custom relay with deepseek model should be detected via model-name fallback"
+        )
+
+    def test_custom_relay_preserves_unsigned_thinking_blocks(self) -> None:
+        """Unsigned thinking blocks from reasoning_content must be preserved on
+        custom relay when model-name detection triggers the DeepSeek path."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "reasoning_content": "Looking at the config...",
+                "content": "Let me check.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "config data"},
+        ]
+        _system, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://llm-gateway.example.com/anthropic",
+            model="deepseek-deepseek-v4-pro",
+        )
+
+        # Find the assistant message with tool_calls
+        assistant_msgs = [m for m in converted if m["role"] == "assistant"]
+        assert len(assistant_msgs) == 1, "Expected one assistant message"
+        thinking_blocks = [
+            b for b in assistant_msgs[0]["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert len(thinking_blocks) >= 1, (
+            "Unsigned thinking blocks from reasoning_content must be "
+            "preserved on custom DeepSeek relays"
+        )
+        assert thinking_blocks[0]["thinking"] == "Looking at the config..."
+
+


### PR DESCRIPTION
## Problem

\_is_deepseek_anthropic_endpoint() only matches by base_url (api.deepseek.com). When DeepSeek is behind a proxy (LiteLLM, aiproxy, etc.), the URL doesn't match → thinking blocks are stripped → HTTP 400:

> The content[].thinking in the thinking mode must be passed back to the API.

## Fix

- Add optional model parameter to \_is_deepseek_anthropic_endpoint()
- Fall back to model-name detection when base_url doesn't match: if model starts with deepseek, treat as DeepSeek endpoint
- Update call site in \_manage_thinking_signatures() to pass model

Same pattern as \_is_kimi_family_endpoint().