### PR TITLE
fix(verification): skip clean workspaces when building nudge

### DIFF
--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -153,7 +153,15 @@ def _verification_snapshot(
     session_id: str | None,
     changed_paths: list[str],
 ) -> tuple[dict[str, Any], dict[str, Any]] | None:
-    """Return ``(status, facts)`` for the first edited workspace needing proof."""
+    """Return ``(status, facts)`` for the first edited workspace needing proof.
+
+    A workspace that reports ``"passed"`` (verification ran and no subsequent
+    edits) or ``"unverified"`` with an empty ``changed_paths`` list (no edits
+    were ever recorded, so there is nothing to verify) is treated as
+    proof-complete — the snapshot is skipped.  Only workspaces with actual
+    outstanding changes (``"unverified"`` with non-empty changed_paths,
+    ``"stale"``, or ``"failed"``) are returned.
+    """
     try:
         from agent.coding_context import project_facts_for
         from agent.verification_evidence import verification_status
@@ -169,9 +177,23 @@ def _verification_snapshot(
         snapshot = (status, facts)
         if first_snapshot is None:
             first_snapshot = snapshot
-        if str(status.get("status") or "unverified") != "passed":
-            return snapshot
-    return first_snapshot
+
+        state = str(status.get("status") or "unverified")
+
+        # Passed → fully verified, nothing to do.
+        if state == "passed":
+            continue
+
+        # Unverified with no changed paths → nothing concrete to verify.
+        if state == "unverified":
+            workspace_paths = status.get("changed_paths") or []
+            if not workspace_paths:
+                continue
+
+        return snapshot
+
+    # No workspace needs verification — all passed or have no recorded edits.
+    return None
 
 
 def _format_changed_paths(paths: list[str]) -> str:

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -154,6 +154,11 @@ def test_no_suite_nudge_uses_canonical_temp_dir(tmp_path, monkeypatch):
     linked_temp = tmp_path / "linked-temp"
     linked_temp.symlink_to(real_temp, target_is_directory=True)
     monkeypatch.setattr(tempfile, "gettempdir", lambda: str(linked_temp))
+    # The workspace must have recorded edits in the DB for a nudge to fire.
+    # An unverified workspace with empty changed_paths is now skipped entirely.
+    mark_workspace_edited(
+        session_id="s1", cwd=project, paths=[str(project / "src" / "app.ts")]
+    )
 
     nudge = build_verify_on_stop_nudge(
         session_id="s1",
@@ -233,3 +238,62 @@ def test_is_non_code_path_classification():
     assert _is_non_code_path("src/app.ts") is False
     assert _is_non_code_path("config.yaml") is False
     assert _is_non_code_path("run_agent.py") is False
+
+
+def test_snapshot_returns_none_for_clean_unverified_workspace(tmp_path, monkeypatch):
+    """Lone workspace with unverified status and empty changed_paths →
+    _verification_snapshot returns None.  No nudge should fire."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    project = tmp_path / "project"
+    _make_project(project)
+    changed_path = str(project / "src" / "app.ts")
+
+    from agent.verification_stop import _verification_snapshot
+
+    # Workspace was edited but verification has never recorded any paths
+    # (the DB entry exists but changed_paths_json is '[]').
+    mark_workspace_edited(session_id="s2", cwd=project, paths=[])
+
+    # Build a non-empty changed_paths list (these came from the IDE event)
+    # to exercise the join of [changed from editor] ∪ [stored in DB].
+    snapshot = _verification_snapshot(
+        session_id="s2",
+        changed_paths=[changed_path],
+    )
+    assert snapshot is None, (
+        f"expected None for clean unverified workspace, got {snapshot}"
+    )
+
+
+def test_snapshot_none_when_all_skipped_passed_or_empty(tmp_path, monkeypatch):
+    """Multiple workspaces, all either passed or unverified-empty →
+    _verification_snapshot returns None."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    proj_a = tmp_path / "a"
+    proj_b = tmp_path / "b"
+    _make_project(proj_a)
+    _make_project(proj_b)
+
+    changed_a = str(proj_a / "src" / "app.ts")
+    changed_b = str(proj_b / "src" / "app.ts")
+
+    # proj_a: verified with record_terminal_result
+    record_terminal_result(
+        command="pnpm test",
+        cwd=proj_a,
+        session_id="s3",
+        exit_code=0,
+        output="green",
+    )
+    # proj_b: unverified with no recorded paths
+    mark_workspace_edited(session_id="s3", cwd=proj_b, paths=[])
+
+    from agent.verification_stop import _verification_snapshot
+
+    snapshot = _verification_snapshot(
+        session_id="s3",
+        changed_paths=[changed_a, changed_b],
+    )
+    assert snapshot is None, (
+        f"expected None when all workspaces are passed/clean, got {snapshot}"
+    )


### PR DESCRIPTION
## Problem

\_verification_snapshot() triggers a verification nudge for any non-passed status. This causes spurious [System: You edited code...] messages when:

1. The workspace is unverified but has zero changed_paths — nothing concrete to verify
2. The first workspace is clean, but first_snapshot from a later workspace was returned

## Fix

In \_verification_snapshot():
- Skip workspaces with status == passed — already verified
- Skip workspaces with status == unverified and empty changed_paths — nothing to verify
- Only return a snapshot when there are actual outstanding changes

Closes #70094 (superseded by this clean PR).