### PR TITLE
fix(acp): snapshots, unified diffs, parent_session_id support

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -117,6 +117,7 @@ def make_tool_progress_cb(
     loop: asyncio.AbstractEventLoop,
     tool_call_ids: Dict[str, Deque[str]],
     tool_call_meta: Dict[str, Dict[str, Any]],
+    read_snapshots_cache: Dict[str, str | None] | None = None,
     edit_approval_policy_getter: Callable[[], tuple[str, str | None]] | None = None,
 ) -> Callable:
     """Create a ``tool_progress_callback`` for AIAgent.
@@ -154,7 +155,7 @@ def make_tool_progress_cb(
         queue.append(tc_id)
 
         snapshot = None
-        if name in {"write_file", "patch", "skill_manage"}:
+        if name in {"read_file", "write_file", "patch", "skill_manage", "terminal"}:
             try:
                 from agent.display import capture_local_edit_snapshot
 
@@ -162,6 +163,34 @@ def make_tool_progress_cb(
             except Exception:
                 logger.debug("Failed to capture ACP edit snapshot for %s", name, exc_info=True)
         tool_call_meta[tc_id] = {"args": args, "snapshot": snapshot}
+
+        # Cross-turn snapshot cache — so terminal in later API calls can build
+        # composite snapshots.  All keys are absolute resolved paths.
+        # write_file / patch / skill_manage: save before-state (only if path
+        #   not already cached — first writer wins, preserving the original
+        #   baseline across multiple edits).
+        # read_file: save current disk content (only if path not cached).
+        if read_snapshots_cache is not None and name in {"write_file", "patch", "skill_manage"}:
+            if snapshot is not None and snapshot.before is not None:
+                from pathlib import Path as _P
+                for rp, before_text in snapshot.before.items():
+                    rk = str(_P(rp).resolve())
+                    if rk not in read_snapshots_cache:
+                        read_snapshots_cache[rk] = before_text
+        elif read_snapshots_cache is not None and name == "read_file":
+            rp = args.get("path", "")
+            if rp and isinstance(rp, str):
+                from pathlib import Path as _P
+                try:
+                    rk = str(_P(rp).resolve())
+                except (TypeError, OSError):
+                    pass
+                else:
+                    if rk not in read_snapshots_cache:
+                        try:
+                            read_snapshots_cache[rk] = _P(rk).read_text(encoding="utf-8")
+                        except (FileNotFoundError, OSError):
+                            read_snapshots_cache[rk] = None
 
         edit_diff = None
         if name in {"write_file", "patch"} and edit_approval_policy_getter is not None:
@@ -212,6 +241,7 @@ def make_step_cb(
     loop: asyncio.AbstractEventLoop,
     tool_call_ids: Dict[str, Deque[str]],
     tool_call_meta: Dict[str, Dict[str, Any]],
+    read_snapshots_cache: Dict[str, str | None] | None = None,
 ) -> Callable:
     """Create a ``step_callback`` for AIAgent.
 
@@ -221,7 +251,9 @@ def make_step_cb(
     """
 
     def _step(api_call_count: int, prev_tools: Any = None) -> None:
+
         if prev_tools and isinstance(prev_tools, list):
+            from pathlib import Path
             for tool_info in prev_tools:
                 tool_name = None
                 result = None
@@ -240,6 +272,24 @@ def make_step_cb(
                     tool_call_ids[tool_name] = queue
                 if tool_name and queue:
                     tc_id = queue.popleft()
+
+                    # Build composite snapshot from cross-turn cache for terminal.
+                    # The cache persists across API calls — read_file in call #1
+                    # fills it, terminal in call #4 reads it.  No ordering bug
+                    # because entries are never popped from the cache.
+                    if tool_name == "terminal" and read_snapshots_cache:
+                        from agent.display import LocalEditSnapshot
+                        known = {p: b for p, b in read_snapshots_cache.items() if b is not None}
+                        if known:
+                            tool_call_meta.setdefault(tc_id, {})["snapshot"] = LocalEditSnapshot(
+                                paths=[Path(p) for p in known.keys()],
+                                before=known,
+                            )
+                            logger.debug(
+                                "terminal composite snapshot: %d paths from cache",
+                                len(known),
+                            )
+
                     meta = tool_call_meta.pop(tc_id, {})
                     update = build_tool_complete(
                         tc_id,
@@ -255,6 +305,36 @@ def make_step_cb(
                             _send_update(conn, session_id, loop, plan_update)
                     if not queue:
                         tool_call_ids.pop(tool_name, None)
+
+                    # Refresh cross-turn cache from disk after tool completes.
+                    # After terminal: update all cached paths so the next
+                    # terminal starts from post-change state.
+                    # After write_file/patch/skill_manage: update the affected
+                    # path so approve/reject reset works correctly.
+                    if tool_name == "terminal" and read_snapshots_cache is not None:
+                        for p in list(read_snapshots_cache.keys()):
+                            try:
+                                disk = Path(p).read_text(encoding="utf-8")
+                                read_snapshots_cache[p] = disk
+                            except FileNotFoundError:
+                                read_snapshots_cache.pop(p, None)
+                            except Exception as e:
+                                logger.warning(
+                                    "Failed to refresh snapshot cache for %s: %s", p, e
+                                )
+                    elif tool_name in {"write_file", "patch", "skill_manage"} and read_snapshots_cache is not None:
+                        path_arg = (function_args or {}).get("path", "")
+                        if path_arg:
+                            rk = str(Path(path_arg).resolve())
+                            try:
+                                read_snapshots_cache[rk] = Path(rk).read_text(encoding="utf-8")
+                            except FileNotFoundError:
+                                read_snapshots_cache.pop(rk, None)
+                            except Exception as e:
+                                logger.warning(
+                                    "Failed to refresh snapshot cache for %s after %s: %s",
+                                    rk, tool_name, e,
+                                )
 
     return _step
 

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1438,7 +1438,8 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
-        state = self.session_manager.create_session(cwd=cwd)
+        parent_session_id = kwargs.get("parent_session_id") or None
+        state = self.session_manager.create_session(cwd=cwd, parent_session_id=parent_session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
@@ -1777,6 +1778,7 @@ class HermesACPAgent(acp.Agent):
 
         tool_call_ids: dict[str, Deque[str]] = defaultdict(deque)
         tool_call_meta: dict[str, dict[str, Any]] = {}
+        read_snapshots_cache: dict[str, str | None] = state.read_snapshots_cache
         previous_approval_cb = None
         edit_approval_requester = None
 
@@ -1789,10 +1791,12 @@ class HermesACPAgent(acp.Agent):
                 loop,
                 tool_call_ids,
                 tool_call_meta,
+                read_snapshots_cache,
                 edit_approval_policy_getter=lambda: self._edit_approval_policy_for_state(state),
             )
             reasoning_cb = make_thinking_cb(conn, session_id, loop)
-            step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
+            step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta,
+                                    read_snapshots_cache)
             message_cb = make_message_cb(conn, session_id, loop)
 
             def stream_delta_cb(text: str) -> None:

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -170,6 +170,7 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    read_snapshots_cache: dict = field(default_factory=dict)
 
 
 class SessionManager:
@@ -196,13 +197,23 @@ class SessionManager:
 
     # ---- public API ---------------------------------------------------------
 
-    def create_session(self, cwd: str = ".") -> SessionState:
-        """Create a new session with a unique ID and a fresh AIAgent."""
+    def create_session(self, cwd: str = ".", parent_session_id: str | None = None) -> SessionState:
+        """Create a new session with a unique ID and a fresh AIAgent.
+
+        Args:
+            cwd: Working directory for the session.
+            parent_session_id: If set, the new session becomes a branch
+                (child) of the given parent session.
+        """
         import threading
 
         cwd = _translate_acp_cwd(cwd)
         session_id = str(uuid.uuid4())
-        agent = self._make_agent(session_id=session_id, cwd=cwd)
+        agent = self._make_agent(
+            session_id=session_id,
+            cwd=cwd,
+            parent_session_id=parent_session_id or "",
+        )
         state = SessionState(
             session_id=session_id,
             agent=agent,
@@ -213,8 +224,9 @@ class SessionManager:
         with self._lock:
             self._sessions[session_id] = state
         _register_task_cwd(session_id, cwd)
-        self._persist(state)
-        logger.info("Created ACP session %s (cwd=%s)", session_id, cwd)
+        self._persist(state, parent_session_id=parent_session_id)
+        logger.info("Created ACP session %s (cwd=%s%s)", session_id, cwd,
+                     ", parent=%s" % parent_session_id if parent_session_id else "")
         return state
 
     def get_session(self, session_id: str) -> Optional[SessionState]:
@@ -409,7 +421,7 @@ class SessionManager:
             logger.debug("SessionDB unavailable for ACP persistence", exc_info=True)
             return None
 
-    def _persist(self, state: SessionState) -> None:
+    def _persist(self, state: SessionState, parent_session_id: str | None = None) -> None:
         """Write session state to the database.
 
         Creates the session record if it doesn't exist, then replaces all
@@ -442,6 +454,7 @@ class SessionManager:
                     source="acp",
                     model=model_str,
                     model_config={"cwd": state.cwd},
+                    parent_session_id=parent_session_id,
                 )
             else:
                 # Update model_config (contains cwd) if changed.
@@ -597,6 +610,7 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        parent_session_id: str | None = None,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -631,6 +645,7 @@ class SessionManager:
             "session_id": session_id,
             "session_db": self._get_db(),
             "model": model or default_model,
+            "parent_session_id": parent_session_id or "",
         }
 
         try:


### PR DESCRIPTION
## What

ACP (IDE integration) improvements:

- Unified diffs for terminal — when terminal writes files, ACP shows the diff inline
- Cross-turn snapshot cache — read_snapshots_cache persists across API calls
- parent_session_id support — enables session branching in the IDE

## Review fixes from #64930

1. read_snapshots_cache is now optional (| None = None) — callers without snapshots don't need to pass empty dict
2. Validate read_file path argument is a string before Path() — guards against malformed model-provided args
3. Path(rp).resolve() wrapped in try/except for malformed paths

Closes #64930.