### PR TITLE
feat: suppress footer when primary model is active + add MiniMax-M3 to minimax-cn

### DIFF
--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -140,6 +140,14 @@ def build_footer_line(
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
         return ""
+
+    # Only show footer when a fallback model was used (actual model ≠ primary model).
+    primary_model = ((user_config or {}).get("model") or {}).get("default") or ""
+    primary_model_short = _model_short(primary_model)
+    actual_model_short = _model_short(model)
+    if primary_model_short and actual_model_short == primary_model_short:
+        return ""
+
     return format_runtime_footer(
         model=model,
         context_tokens=context_tokens,

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -105,7 +105,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "stepfun": ["step-3.5-flash", "step-3.5-flash-2603"],
     "arcee": ["trinity-large-thinking", "trinity-large-preview", "trinity-mini"],
     "minimax": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
-    "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
+    "minimax-cn": ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
     "kilocode": ["anthropic/claude-sonnet-5", "anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-5", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
     "opencode-go": ["kimi-k3", "kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5", "qwen3.7-max", "qwen3.6-plus", "qwen3.5-plus"],


### PR DESCRIPTION
## Summary

Two small improvements that benefit all users:

### 1. Runtime footer: suppress when primary model is active

Currently the runtime metadata footer shows on every reply, even when the primary model handled the request normally. This PR suppresses the footer unless a **fallback model** was actually used (actual model ≠ configured ).

**Why:** When the primary model handles the request, the footer adds visual noise without information value. Users only need to know when something different happened (fallback kicked in).

**How:** Zero-config — reads the existing  from user config and compares against the actual model used. If they match, footer is skipped. If no  is set, behavior is unchanged (footer shows as before).

### 2. Add MiniMax-M3 to minimax-cn provider defaults

 is missing from the  provider's  in , so it doesn't appear in the 
⚕ Hermes Setup — Non-interactive mode

  Running in a non-interactive environment (no TTY detected).
  The interactive wizard cannot be used here.

  Configure Hermes using environment variables or config commands:
    hermes config set model.provider custom
    hermes config set model.base_url http://localhost:8080/v1
    hermes config set model.default your-model-name

  Or set OPENROUTER_API_KEY / OPENAI_API_KEY in your environment.
  Run 'hermes setup' in an interactive terminal to use the full wizard. model picker. It's already in  — this just keeps setup.py in sync.

## Test Plan

- [ ] Footer appears when fallback model is used (actual ≠ primary)
- [ ] Footer is suppressed when primary model handles request
- [ ] Footer still appears when no  is configured (backward compat)
- [ ] 
⚕ Hermes Setup — Non-interactive mode

  Running in a non-interactive environment (no TTY detected).
  The interactive wizard cannot be used here.

  Configure Hermes using environment variables or config commands:
    hermes config set model.provider custom
    hermes config set model.base_url http://localhost:8080/v1
    hermes config set model.default your-model-name

  Or set OPENROUTER_API_KEY / OPENAI_API_KEY in your environment.
  Run 'hermes setup' in an interactive terminal to use the full wizard. shows MiniMax-M3 under minimax-cn provider