### PR TITLE
fix(cli): downgrade paste file gone log from warning to debug

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6541,7 +6541,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             try:
                 return path.read_text(encoding="utf-8")
             except (OSError, IOError):
-                logger.warning("Paste file gone or unreadable, returning placeholder: %s", path)
+                logger.debug("Paste file gone or unreadable, returning placeholder: %s", path)
                 return match.group(0)
 
         return paste_ref_re.sub(_expand_ref, text)

--- a/tests/cli/test_cli_external_editor.py
+++ b/tests/cli/test_cli_external_editor.py
@@ -99,14 +99,24 @@ def test_inline_pastes_stores_full_content(tmp_path):
 
 def test_inline_pastes_missing_file_keeps_placeholder(tmp_path, caplog):
     """A recalled reference whose file is gone stays as the placeholder."""
+    import logging
+
     cli_obj = _make_cli()
     placeholder = f"[Pasted text #1: 2 lines \u2192 {tmp_path / 'gone.txt'}]"
     buffer = _FakeBuffer(text=placeholder)
 
-    import logging
     with caplog.at_level(logging.DEBUG):
         cli_obj._inline_pastes(buffer)
 
     assert buffer.text == placeholder
     assert cli_obj._skip_paste_collapse is False
-    assert "Paste file gone or unreadable" in caplog.text
+    matching = [
+        r for r in caplog.records if "Paste file gone or unreadable" in r.getMessage()
+    ]
+    assert matching, "expected paste-gone log record"
+    assert matching[0].levelno == logging.DEBUG
+    assert not any(
+        r.levelno >= logging.WARNING
+        and "Paste file gone or unreadable" in r.getMessage()
+        for r in caplog.records
+    )

--- a/tests/cli/test_cli_external_editor.py
+++ b/tests/cli/test_cli_external_editor.py
@@ -97,13 +97,16 @@ def test_inline_pastes_stores_full_content(tmp_path):
 
 
 
-def test_inline_pastes_missing_file_keeps_placeholder(tmp_path):
+def test_inline_pastes_missing_file_keeps_placeholder(tmp_path, caplog):
     """A recalled reference whose file is gone stays as the placeholder."""
     cli_obj = _make_cli()
     placeholder = f"[Pasted text #1: 2 lines \u2192 {tmp_path / 'gone.txt'}]"
     buffer = _FakeBuffer(text=placeholder)
 
-    cli_obj._inline_pastes(buffer)
+    import logging
+    with caplog.at_level(logging.DEBUG):
+        cli_obj._inline_pastes(buffer)
 
     assert buffer.text == placeholder
     assert cli_obj._skip_paste_collapse is False
+    assert "Paste file gone or unreadable" in caplog.text


### PR DESCRIPTION
Fixes log spam when a temporary paste file is unreadable or deleted, which is expected behavior for old sessions.

- [x] Tested locally
- [x] Includes tests for regression prevention