### PR TITLE
fix(desktop): align model rows with provider labels

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -133,6 +133,15 @@ describe('ModelMenuPanel provider collapse', () => {
     expect(content.queryByText('Deepseek Chat')).not.toBeNull()
   })
 
+  it('reserves the provider disclosure column for model rows', async () => {
+    const { content } = renderPanel()
+
+    const model = await content.findByText('Deepseek V4 Pro')
+    const row = model.closest('[data-slot="dropdown-menu-sub-trigger"]')
+
+    expect(row?.getAttribute('data-inset')).toBe('true')
+  })
+
   it('collapses provider models when header is clicked', async () => {
     const { content } = renderPanel()
 

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -326,6 +326,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
                         <DropdownMenuSubTrigger
                           className={dropdownMenuRow}
                           hideChevron
+                          inset
                           onClick={activate}
                           onKeyDown={event => {
                             if (event.key === 'Enter' || event.key === ' ') {


### PR DESCRIPTION
## What does this PR do?

Aligns model rows with their provider labels in the desktop model picker. Provider headers reserve space for the disclosure chevron, but model rows previously started at the menu's base padding. Using the existing `inset` behavior gives both labels the same 28px start position without adding a one-off spacing override.

## Related Issue

Fixes #70628

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Set `inset` on model submenu triggers in `apps/desktop/src/app/shell/model-menu-panel.tsx`.
- Added a focused regression test that checks model rows reserve the provider disclosure column.

## How to Test

1. Open the desktop model picker with at least one expanded provider.
2. Confirm provider and model labels start on the same vertical grid line.
3. Run `npx vitest run src/app/shell/model-menu-panel.test.tsx src/app/shell/model-edit-submenu.test.tsx` from `apps/desktop`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- Focused model picker tests: 16 passed.
- Desktop TypeScript checks: passed.
- Targeted ESLint: passed.
- Renderer production build: passed.
- Full UI suite: 2,043 passed, 1 skipped, 7 unrelated failures in Billing, Messaging, and Skills. None of those files differ from `upstream/main`; the two Billing failures also reproduce when run alone.
- Python tests were not run because this is a desktop-only TypeScript change.
