### PR TITLE
fix(agent): classify wrapped provider errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -603,7 +603,7 @@ def classify_api_error(
     # inside {"error": {"message": "Provider returned error", "metadata":
     # {"raw": "<actual error JSON>"}}} and the real error message (e.g.
     # "context length exceeded") is only in the inner JSON.
-    _raw_msg = str(error).lower()
+    _raw_msg = _extract_error_text(error).lower()
     _body_msg = ""
     _metadata_msg = ""
     if isinstance(body, dict):
@@ -1544,6 +1544,70 @@ def _classify_by_message(
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────
+
+_ERROR_TEXT_ATTRS = (
+    "message",
+    "error",
+    "error_message",
+    "errorMessage",
+    "raw_error",
+    "rawError",
+)
+
+
+def _extract_error_text(error: Exception) -> str:
+    """Collect text from a bounded graph of SDK error wrappers."""
+    pending: list[Any] = [error]
+    seen_objects: set[int] = set()
+    seen_text: set[str] = set()
+    parts: list[str] = []
+
+    while pending and len(seen_objects) < 8:
+        current = pending.pop(0)
+        if isinstance(current, str):
+            text = current.strip()
+            if text and text not in seen_text:
+                seen_text.add(text)
+                parts.append(text)
+            continue
+
+        object_id = id(current)
+        if object_id in seen_objects:
+            continue
+        seen_objects.add(object_id)
+
+        try:
+            text = str(current).strip()
+        except Exception:
+            text = ""
+        if text and text not in seen_text:
+            seen_text.add(text)
+            parts.append(text)
+
+        for attr in _ERROR_TEXT_ATTRS:
+            try:
+                value = getattr(current, attr, None)
+            except Exception:
+                continue
+            if isinstance(value, (str, BaseException)):
+                pending.append(value)
+
+        try:
+            cause = getattr(current, "__cause__", None)
+        except Exception:
+            cause = None
+        if isinstance(cause, BaseException):
+            pending.append(cause)
+        elif not getattr(current, "__suppress_context__", False):
+            try:
+                context = getattr(current, "__context__", None)
+            except Exception:
+                context = None
+            if isinstance(context, BaseException):
+                pending.append(context)
+
+    return " ".join(parts)
+
 
 def _extract_status_code(error: Exception) -> Optional[int]:
     """Walk the error and its cause chain to find an HTTP status code."""

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -687,7 +687,7 @@ def classify_api_error(
     # inside {"error": {"message": "Provider returned error", "metadata":
     # {"raw": "<actual error JSON>"}}} and the real error message (e.g.
     # "context length exceeded") is only in the inner JSON.
-    _raw_msg = str(error).lower()
+    _raw_msg = _extract_error_text(error).lower()
     _body_msg = ""
     _metadata_msg = ""
     if isinstance(body, dict):
@@ -1704,6 +1704,70 @@ def _classify_by_message(
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────
+
+_ERROR_TEXT_ATTRS = (
+    "message",
+    "error",
+    "error_message",
+    "errorMessage",
+    "raw_error",
+    "rawError",
+)
+
+
+def _extract_error_text(error: Exception) -> str:
+    """Collect text from a bounded graph of SDK error wrappers."""
+    pending: list[Any] = [error]
+    seen_objects: set[int] = set()
+    seen_text: set[str] = set()
+    parts: list[str] = []
+
+    while pending and len(seen_objects) < 8:
+        current = pending.pop(0)
+        if isinstance(current, str):
+            text = current.strip()
+            if text and text not in seen_text:
+                seen_text.add(text)
+                parts.append(text)
+            continue
+
+        object_id = id(current)
+        if object_id in seen_objects:
+            continue
+        seen_objects.add(object_id)
+
+        try:
+            text = str(current).strip()
+        except Exception:
+            text = ""
+        if text and text not in seen_text:
+            seen_text.add(text)
+            parts.append(text)
+
+        for attr in _ERROR_TEXT_ATTRS:
+            try:
+                value = getattr(current, attr, None)
+            except Exception:
+                continue
+            if isinstance(value, (str, BaseException)):
+                pending.append(value)
+
+        try:
+            cause = getattr(current, "__cause__", None)
+        except Exception:
+            cause = None
+        if isinstance(cause, BaseException):
+            pending.append(cause)
+        elif not getattr(current, "__suppress_context__", False):
+            try:
+                context = getattr(current, "__context__", None)
+            except Exception:
+                context = None
+            if isinstance(context, BaseException):
+                pending.append(context)
+
+    return " ".join(parts)
+
 
 def _extract_status_code(error: Exception) -> Optional[int]:
     """Walk the error and its cause chain to find an HTTP status code."""

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -811,6 +811,75 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.thinking_signature
         assert result.retryable is True
 
+    def test_anthropic_thinking_signature_from_wrapped_cause(self):
+        inner = Exception("thinking block has invalid signature")
+        outer = MockAPIError("Provider request failed", status_code=400)
+        outer.__cause__ = inner
+
+        result = classify_api_error(outer, provider="anthropic")
+
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_anthropic_thinking_signature_from_named_error_carrier(self):
+        e = MockAPIError("Provider request failed", status_code=400)
+        e.error_message = "thinking block has invalid signature"
+
+        result = classify_api_error(e, provider="anthropic")
+
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_anthropic_thinking_signature_at_end_of_long_error(self):
+        e = MockAPIError(
+            ("x" * 8192) + " thinking block has invalid signature",
+            status_code=400,
+        )
+
+        result = classify_api_error(e, provider="anthropic")
+
+        assert result.reason == FailoverReason.thinking_signature
+
+    def test_anthropic_thinking_signature_in_middle_of_long_error(self):
+        e = MockAPIError(
+            ("x" * 5000)
+            + " thinking block has invalid signature "
+            + ("x" * 5000),
+            status_code=400,
+        )
+
+        result = classify_api_error(e, provider="anthropic")
+
+        assert result.reason == FailoverReason.thinking_signature
+
+    def test_error_text_extraction_is_cycle_safe(self):
+        inner = Exception("thinking block has invalid signature")
+        outer = MockAPIError("Provider request failed", status_code=400)
+        outer.__cause__ = inner
+        inner.__cause__ = outer
+
+        result = classify_api_error(outer, provider="anthropic")
+
+        assert result.reason == FailoverReason.thinking_signature
+
+    def test_suppressed_exception_context_is_not_scanned(self):
+        hidden = Exception("thinking block has invalid signature")
+        outer = MockAPIError("Bad request", status_code=400)
+        outer.__context__ = hidden
+        outer.__suppress_context__ = True
+
+        result = classify_api_error(outer, provider="anthropic")
+
+        assert result.reason == FailoverReason.format_error
+
+    def test_unrelated_payload_text_is_not_scanned(self):
+        e = MockAPIError("Bad request", status_code=400)
+        e.payload = {"assistant_text": "thinking block has invalid signature"}
+
+        result = classify_api_error(e, provider="anthropic")
+
+        assert result.reason == FailoverReason.format_error
+
     def test_non_anthropic_400_with_signature_not_classified_as_thinking(self):
         """400 with 'signature' but from non-Anthropic → format error."""
         e = MockAPIError("invalid signature", status_code=400)
@@ -2169,4 +2238,3 @@ class Test408RequestTimeout:
         assert result.retryable is False
         assert result.should_fallback is True
         assert result.should_compress is False
-

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -461,6 +461,75 @@ class TestClassifyApiError:
 
     # ── Provider-specific: Anthropic thinking signature ──
 
+    def test_anthropic_thinking_signature_from_wrapped_cause(self):
+        inner = Exception("thinking block has invalid signature")
+        outer = MockAPIError("Provider request failed", status_code=400)
+        outer.__cause__ = inner
+
+        result = classify_api_error(outer, provider="anthropic")
+
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_anthropic_thinking_signature_from_named_error_carrier(self):
+        e = MockAPIError("Provider request failed", status_code=400)
+        e.error_message = "thinking block has invalid signature"
+
+        result = classify_api_error(e, provider="anthropic")
+
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_anthropic_thinking_signature_at_end_of_long_error(self):
+        e = MockAPIError(
+            ("x" * 8192) + " thinking block has invalid signature",
+            status_code=400,
+        )
+
+        result = classify_api_error(e, provider="anthropic")
+
+        assert result.reason == FailoverReason.thinking_signature
+
+    def test_anthropic_thinking_signature_in_middle_of_long_error(self):
+        e = MockAPIError(
+            ("x" * 5000)
+            + " thinking block has invalid signature "
+            + ("x" * 5000),
+            status_code=400,
+        )
+
+        result = classify_api_error(e, provider="anthropic")
+
+        assert result.reason == FailoverReason.thinking_signature
+
+    def test_error_text_extraction_is_cycle_safe(self):
+        inner = Exception("thinking block has invalid signature")
+        outer = MockAPIError("Provider request failed", status_code=400)
+        outer.__cause__ = inner
+        inner.__cause__ = outer
+
+        result = classify_api_error(outer, provider="anthropic")
+
+        assert result.reason == FailoverReason.thinking_signature
+
+    def test_suppressed_exception_context_is_not_scanned(self):
+        hidden = Exception("thinking block has invalid signature")
+        outer = MockAPIError("Bad request", status_code=400)
+        outer.__context__ = hidden
+        outer.__suppress_context__ = True
+
+        result = classify_api_error(outer, provider="anthropic")
+
+        assert result.reason == FailoverReason.format_error
+
+    def test_unrelated_payload_text_is_not_scanned(self):
+        e = MockAPIError("Bad request", status_code=400)
+        e.payload = {"assistant_text": "thinking block has invalid signature"}
+
+        result = classify_api_error(e, provider="anthropic")
+
+        assert result.reason == FailoverReason.format_error
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Preserves actionable provider diagnostics when an SDK or transport wraps an API exception with a generic outer message.

Hermes already follows exception causes for HTTP status codes and structured bodies, but message-pattern classification only inspected the outer `str(error)`. A wrapped Anthropic thinking-signature rejection could therefore become a terminal `format_error` instead of using the existing one-shot replay recovery.

The new extractor is deliberately narrow: it follows the effective Python exception chain and conventional SDK error-string fields, limits traversal to eight objects, respects suppressed contexts, and does not scan arbitrary payloads or assistant text.

## Related Issue

Fixes #70685

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/error_classifier.py`
  - collect complete diagnostic strings from explicit causes/contexts and named SDK error carriers;
  - bound and de-duplicate wrapper traversal;
  - honor `__suppress_context__` so `raise ... from None` remains authoritative.
- `tests/agent/test_error_classifier.py`
  - cover wrapped causes, named fields, long messages, cycles, suppressed contexts, and arbitrary-payload exclusion.

## How to Test

1. Run `python -m pytest tests/agent/test_error_classifier.py -q`.
2. Run `python -m ruff check agent/error_classifier.py tests/agent/test_error_classifier.py`.
3. Verify a generic HTTP 400 with `thinking block has invalid signature` in its explicit cause classifies as `thinking_signature`, while the same text in an unrelated payload does not.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused classifier suite run instead: 206 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] Documentation update ? N/A; no public API or configuration change
- [x] `cli-config.yaml.example` ? N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` ? N/A; no workflow change
- [x] Cross-platform impact considered; pure Python exception handling
- [x] Tool descriptions/schemas ? N/A

## Screenshots / Logs

```text
python -m pytest tests/agent/test_error_classifier.py -q
206 passed

python -m ruff check agent/error_classifier.py tests/agent/test_error_classifier.py
All checks passed!

PYTHONUTF8=1 autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.94)
```
