### PR TITLE
fix(proxy): stop httpx from reparsing NO_PROXY for OpenAI clients

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -196,6 +196,7 @@ def build_keepalive_http_client(
             proxy=proxy,
             mounts=mounts or None,
             verify=verify,
+            trust_env=False,
         )
     except Exception:
         return None

--- a/run_agent.py
+++ b/run_agent.py
@@ -4337,6 +4337,7 @@ class AIAgent:
                 proxy=_proxy,
                 mounts=_mounts or None,
                 verify=verify,
+                trust_env=False,
             )
         except Exception:
             return None

--- a/tests/agent/test_auxiliary_client_proxy_env.py
+++ b/tests/agent/test_auxiliary_client_proxy_env.py
@@ -96,3 +96,23 @@ def test_openai_http_client_kwargs_async_mode():
         async_mode=True,
     )
     assert isinstance(kwargs["http_client"], httpx.AsyncClient)
+
+
+@patch("agent.auxiliary_client.OpenAI")
+def test_create_openai_client_ignores_ipv6_no_proxy_entries(mock_openai, monkeypatch):
+    """httpx must not parse bare IPv6/CIDR NO_PROXY entries itself."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1,localhost,::1,fe80::/10,64:ff9b::/96")
+
+    _create_openai_client(
+        api_key="test-key",
+        base_url="https://litellm.internal.example.com/v1",
+    )
+
+    http_client = mock_openai.call_args.kwargs.get("http_client")
+    assert isinstance(http_client, httpx.Client)
+    assert http_client.trust_env is False
+    http_client.close()

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -232,3 +232,31 @@ def test_create_openai_client_bypasses_proxy_for_no_proxy_host(mock_openai, monk
         "NO_PROXY host must not route through HTTPProxy; pools were %r" % (pool_types,)
     )
     http_client.close()
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_ignores_ipv6_no_proxy_entries(mock_openai, monkeypatch):
+    """httpx 0.28 URLPattern rejects bare IPv6/CIDR NO_PROXY entries.
+
+    Hermes resolves env proxy policy before constructing httpx.Client, so the
+    explicit keepalive client must not let httpx re-read NO_PROXY via
+    trust_env=True.
+    """
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy",
+                "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1,localhost,::1,fe80::/10,64:ff9b::/96")
+
+    agent = _make_agent()
+    kwargs = {
+        "api_key": "***",
+        "base_url": "https://api.openai.com/v1",
+    }
+    agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    http_client = _extract_http_client(mock_openai.call_args.kwargs)
+    assert isinstance(http_client, httpx.Client)
+    assert http_client.trust_env is False
+    http_client.close()


### PR DESCRIPTION
## What does this PR do?

  Fixes OpenAI client initialization when `NO_PROXY` contains IPv6 CIDR entries such as `fe80::/10` or `64:ff9b::/96`.

  Hermes already resolves proxy policy explicitly before constructing the OpenAI SDK httpx clients. The managed clients still used httpx's default `trust_env=True`, which let httpx read `NO_PROXY` a
  second time. With httpx 0.28.1, IPv6 CIDR entries can become URLPattern keys like `all://[fe80::/10]` and fail during client initialization with `Invalid port: ':'`.

  This sets `trust_env=False` on the main and auxiliary OpenAI keepalive clients so Hermes's proxy decision is the single source of truth.

  ## Related Issue

  No issue filed.

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Set `trust_env=False` for the main OpenAI keepalive httpx client in `run_agent.py`.
  - Set `trust_env=False` for auxiliary OpenAI keepalive httpx clients in `agent/process_bootstrap.py`.
  - Added regression coverage for IPv6 `NO_PROXY` entries in:
    - `tests/run_agent/test_create_openai_client_proxy_env.py`
    - `tests/agent/test_auxiliary_client_proxy_env.py`

  ## How to Test

  1. Reproduce with an environment like:
     ```bash
     export HTTPS_PROXY=http://127.0.0.1:7897
     export NO_PROXY='127.0.0.1,localhost,::1,fe80::/10,64:ff9b::/96'

  2. Start Hermes with a custom/OpenAI-compatible endpoint.
  3. Confirm the OpenAI client initializes instead of failing with Invalid port: ':'.

  Tested with:

  python -m compileall -q run_agent.py agent/process_bootstrap.py \
    tests/run_agent/test_create_openai_client_proxy_env.py \
    tests/agent/test_auxiliary_client_proxy_env.py

  uv run --python /usr/bin/python3.11 --extra dev pytest \
    tests/run_agent/test_create_openai_client_proxy_env.py \
    tests/agent/test_auxiliary_client_proxy_env.py \
    tests/agent/test_proxy_and_url_validation.py

  Result: 32 passed.

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Linux, Python 3.11

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## For New Skills

  N/A

  ## Screenshots / Logs

  Before:

  Failed to initialize OpenAI client: Invalid port: ':'

  After: covered by regression tests for main and auxiliary OpenAI client construction paths.