### PR TITLE
feat(plugins): fire post_api_request for Codex app-server turns

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -152,6 +152,26 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     agent.session_cost_status = cost_result.status
     agent.session_cost_source = cost_result.source
 
+    # Mirror conversation_loop's post_api_request firing so plugin-side
+    # accounting (spend guards, usage ledgers) sees Codex app-server turns
+    # too — without this, subscription-billed codex sessions are invisible
+    # to every post_api_request consumer.
+    try:
+        from hermes_cli.plugins import has_hook, invoke_hook as _invoke_hook
+        if has_hook("post_api_request"):
+            _invoke_hook(
+                "post_api_request",
+                session_id=agent.session_id or "",
+                platform=getattr(agent, "platform", "") or "",
+                model=agent.model,
+                provider=agent.provider,
+                base_url=agent.base_url,
+                api_mode=getattr(agent, "api_mode", "") or "",
+                usage=dict(usage_dict),
+            )
+    except Exception:
+        logger.debug("codex post_api_request hook failed", exc_info=True)
+
     if agent._session_db and agent.session_id:
         try:
             if not agent._session_db_created:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -152,26 +152,6 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     agent.session_cost_status = cost_result.status
     agent.session_cost_source = cost_result.source
 
-    # Mirror conversation_loop's post_api_request firing so plugin-side
-    # accounting (spend guards, usage ledgers) sees Codex app-server turns
-    # too — without this, subscription-billed codex sessions are invisible
-    # to every post_api_request consumer.
-    try:
-        from hermes_cli.plugins import has_hook, invoke_hook as _invoke_hook
-        if has_hook("post_api_request"):
-            _invoke_hook(
-                "post_api_request",
-                session_id=agent.session_id or "",
-                platform=getattr(agent, "platform", "") or "",
-                model=agent.model,
-                provider=agent.provider,
-                base_url=agent.base_url,
-                api_mode=getattr(agent, "api_mode", "") or "",
-                usage=dict(usage_dict),
-            )
-    except Exception:
-        logger.debug("codex post_api_request hook failed", exc_info=True)
-
     if agent._session_db and agent.session_id:
         try:
             if not agent._session_db_created:
@@ -635,6 +615,219 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
     return on_event
 
 
+# ---------------------------------------------------------------------------
+# App-server turn lifecycle
+#
+# One app-server turn is one provider request as far as Hermes is concerned,
+# so it carries the same lifecycle the ordinary loop dispatches around a
+# chat-completions call (conversation_loop's pre_api_request /
+# post_api_request / api_request_error sites).  Dispatch goes through
+# hermes_cli.lifecycle rather than hermes_cli.plugins so first-party
+# observability is notified before the compatibility plugin hooks.
+#
+# The pairing is what makes the events usable: consumers key a model call on
+# api_request_id and DROP a terminal event whose start they never saw
+# (observability/relay_shared_metrics.end_model_call, the langfuse plugin's
+# generation lookup).  So every path out of the turn — success, empty usage,
+# codex never returning — has to emit exactly one terminal event under the
+# same identity the pre hook opened.
+# ---------------------------------------------------------------------------
+
+_HOOK_USAGE_KEYS = (
+    "prompt_tokens", "completion_tokens", "total_tokens", "input_tokens",
+    "output_tokens", "cache_read_tokens", "cache_write_tokens",
+    "reasoning_tokens",
+)
+
+
+def _codex_hook_identity(agent, task_id: str) -> Dict[str, Any]:
+    """Identity + runtime fields every hook of one turn repeats verbatim."""
+    turn_id = str(getattr(agent, "_current_turn_id", "") or "")
+    return {
+        "task_id": task_id,
+        "turn_id": turn_id,
+        # The ordinary loop numbers requests within a turn as
+        # f"{turn_id}:api:{api_call_count}"; an app-server turn is always
+        # exactly one request, so the ordinal is fixed at 1.
+        "api_request_id": f"{turn_id}:api:1" if turn_id else "",
+        "session_id": getattr(agent, "session_id", "") or "",
+        "platform": getattr(agent, "platform", "") or "",
+        "model": getattr(agent, "model", "") or "",
+        "provider": getattr(agent, "provider", "") or "",
+        "base_url": getattr(agent, "base_url", "") or "",
+        "api_mode": getattr(agent, "api_mode", "") or "",
+        "api_call_count": 1,
+    }
+
+
+def _codex_hook_usage(usage_result: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Token buckets only — the contract's ``usage`` carries no cost fields."""
+    usage = {
+        key: usage_result[key]
+        for key in _HOOK_USAGE_KEYS
+        if key in usage_result
+    }
+    return usage or None
+
+
+def _codex_request_payload(agent, user_message: str) -> Any:
+    """Sanitized view of what Hermes actually handed the app server."""
+    return agent._sanitize_hook_payload({
+        "method": "codex_app_server/run_turn",
+        "body": {
+            "model": getattr(agent, "model", "") or "",
+            "input": user_message,
+        },
+    })
+
+
+def _codex_projected_tool_calls(turn) -> List[Any]:
+    """Tool calls the app server made while serving this turn."""
+    calls: List[Any] = []
+    for message in getattr(turn, "projected_messages", None) or []:
+        if isinstance(message, dict):
+            calls.extend(message.get("tool_calls") or [])
+    return calls
+
+
+def _codex_finish_reason(turn) -> str:
+    if getattr(turn, "error", None):
+        return "error"
+    if getattr(turn, "interrupted", False):
+        return "interrupt"
+    return "stop"
+
+
+def _fire_codex_pre_api_request(
+    agent,
+    identity: Dict[str, Any],
+    *,
+    user_message: str,
+    original_user_message: Any,
+    messages: List[Dict[str, Any]],
+    started_at: float,
+) -> None:
+    """Open the model call before codex is asked to serve the turn."""
+    try:
+        from hermes_cli import lifecycle as _lifecycle
+
+        if not _lifecycle.has_hook("pre_api_request"):
+            return
+        _lifecycle.invoke_hook(
+            "pre_api_request",
+            **identity,
+            user_message=original_user_message,
+            conversation_history=list(messages),
+            # Hermes hands the app server this turn's user input only —
+            # codex holds the rest of the thread on its side.
+            request_messages=[{"role": "user", "content": user_message}],
+            retry_count=0,
+            message_count=len(messages),
+            # Codex serves the turn with its own tools, and neither Hermes
+            # tokenization nor max_tokens governs this request.
+            tool_count=0,
+            approx_input_tokens=None,
+            request_char_count=len(user_message or ""),
+            max_tokens=None,
+            started_at=started_at,
+            request=_codex_request_payload(agent, user_message),
+        )
+    except Exception:
+        logger.debug(
+            "codex app-server pre_api_request hook failed", exc_info=True
+        )
+
+
+def _fire_codex_post_api_request(
+    agent,
+    identity: Dict[str, Any],
+    *,
+    turn,
+    usage: Dict[str, Any] | None,
+    message_count: int,
+    started_at: float,
+    ended_at: float,
+) -> None:
+    """Close the model call with the contract the ordinary loop delivers."""
+    try:
+        from hermes_cli import lifecycle as _lifecycle
+
+        if not _lifecycle.has_hook("post_api_request"):
+            return
+        finish_reason = _codex_finish_reason(turn)
+        tool_calls = _codex_projected_tool_calls(turn)
+        assistant_text = getattr(turn, "final_text", "") or ""
+        _lifecycle.invoke_hook(
+            "post_api_request",
+            **identity,
+            api_duration=ended_at - started_at,
+            started_at=started_at,
+            ended_at=ended_at,
+            finish_reason=finish_reason,
+            message_count=message_count,
+            # The app-server protocol never echoes the model that served the
+            # turn, so there is no honest response_model to report.
+            response_model=None,
+            response=agent._sanitize_hook_payload({
+                "model": None,
+                "finish_reason": finish_reason,
+                "assistant_message": {
+                    "role": "assistant",
+                    "content": assistant_text,
+                    "tool_calls": tool_calls,
+                },
+                "usage": usage,
+            }),
+            usage=usage,
+            # No normalized provider message object exists on this path;
+            # consumers fall back to the assistant_* summary fields.
+            assistant_message=None,
+            assistant_content_chars=len(assistant_text),
+            assistant_tool_call_count=len(tool_calls),
+        )
+    except Exception:
+        logger.debug(
+            "codex app-server post_api_request hook failed", exc_info=True
+        )
+
+
+def _fire_codex_api_request_error(
+    agent,
+    identity: Dict[str, Any],
+    *,
+    user_message: str,
+    error: BaseException,
+    started_at: float,
+    ended_at: float,
+) -> None:
+    """Terminate the model call when codex never returned a turn at all."""
+    try:
+        from hermes_cli import lifecycle as _lifecycle
+
+        if not _lifecycle.has_hook("api_request_error"):
+            return
+        _lifecycle.invoke_hook(
+            "api_request_error",
+            **identity,
+            api_duration=ended_at - started_at,
+            started_at=started_at,
+            ended_at=ended_at,
+            status_code=None,
+            # This path has no retry loop of its own: the session is retired
+            # and the failure is handed straight back to the caller.
+            retry_count=0,
+            max_retries=0,
+            retryable=False,
+            reason="codex_app_server_turn_failed",
+            error={"type": type(error).__name__, "message": str(error)},
+            request=_codex_request_payload(agent, user_message),
+        )
+    except Exception:
+        logger.debug(
+            "codex app-server api_request_error hook failed", exc_info=True
+        )
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -714,9 +907,35 @@ def run_codex_app_server_turn(
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
 
+    _hook_identity = _codex_hook_identity(agent, effective_task_id)
+    # conversation_loop stamps this per API request so tool-level hooks fired
+    # during the turn correlate to the request that caused them; this runtime
+    # bypasses that loop, so stamp it here.
+    agent._current_api_request_id = _hook_identity["api_request_id"]
+    # Both hooks must report the request the same way, and `messages` grows
+    # once projected messages are spliced in below.
+    _request_message_count = len(messages)
+    _api_started_at = time.time()
+    _fire_codex_pre_api_request(
+        agent,
+        _hook_identity,
+        user_message=user_message,
+        original_user_message=original_user_message,
+        messages=messages,
+        started_at=_api_started_at,
+    )
+
     try:
         turn = agent._codex_session.run_turn(user_input=user_message)
     except Exception as exc:
+        _fire_codex_api_request_error(
+            agent,
+            _hook_identity,
+            user_message=user_message,
+            error=exc,
+            started_at=_api_started_at,
+            ended_at=time.time(),
+        )
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn
         # respawns from scratch instead of reusing a dead client.
@@ -752,6 +971,8 @@ def run_codex_app_server_turn(
             ),
             "error": str(exc),
         }
+
+    _api_ended_at = time.time()
 
     # This runtime bypasses the normal conversation-loop finalizer. Mirror its
     # interrupt handoff/cleanup so a hard stop cannot poison the next turn and a
@@ -837,6 +1058,19 @@ def run_codex_app_server_turn(
     _record_codex_app_server_compaction(agent, turn)
     usage_result = _record_codex_app_server_usage(agent, turn)
     api_calls = 1
+
+    # Fires for every turn codex returned, including the ones it reported no
+    # token usage for — those still cost an API call, and an observer that
+    # opened this model call needs its terminal event either way.
+    _fire_codex_post_api_request(
+        agent,
+        _hook_identity,
+        turn=turn,
+        usage=_codex_hook_usage(usage_result),
+        message_count=_request_message_count,
+        started_at=_api_started_at,
+        ended_at=_api_ended_at,
+    )
 
     # Now check the skill nudge AFTER iters were incremented — same
     # pattern the chat_completions path uses (line ~15432).

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -160,6 +160,14 @@ API hooks describe provider attempts inside the agent loop:
 The sanitized `request`, `response`, and `error` fields are the canonical
 observer inputs for new consumers.
 
+The `codex_app_server` runtime hands a whole turn to a Codex subprocess, so it
+reports that turn as one API request with the same fields. Two of them have no
+equivalent in the app-server protocol and are always `None` there:
+`response_model` (Codex never echoes the model it served the turn with) and the
+`assistant_message` compatibility object (no provider message object is
+normalized on that path — read `assistant_content_chars` /
+`assistant_tool_call_count`, or `response`, instead).
+
 ### Tool Lifecycle
 
 Tool hooks describe individual tool calls:

--- a/tests/agent/test_codex_runtime_post_api_request.py
+++ b/tests/agent/test_codex_runtime_post_api_request.py
@@ -1,0 +1,93 @@
+"""Codex app-server turns must reach ``post_api_request`` consumers.
+
+The ordinary conversation loop fires ``post_api_request`` for every API turn,
+but Codex app-server sessions record usage through
+``_record_codex_app_server_usage`` and bypassed the hook — so plugin-side
+accounting (usage ledgers, spend guards) was blind to subscription-billed
+Codex turns.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from agent.codex_runtime import _record_codex_app_server_usage
+from hermes_cli.plugins import get_plugin_manager
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.model = "gpt-5.1-codex"
+        self.provider = "openai-codex"
+        self.base_url = ""
+        self.api_key = ""
+        self.api_mode = "codex-app-server"
+        self.platform = "cli"
+        self.session_id = "codex-test-session"
+        self.context_compressor = None
+        self._session_db = None
+        self._session_db_created = False
+        for attr in (
+            "session_api_calls", "session_prompt_tokens",
+            "session_completion_tokens", "session_total_tokens",
+            "session_input_tokens", "session_output_tokens",
+            "session_cache_read_tokens", "session_cache_write_tokens",
+            "session_reasoning_tokens",
+        ):
+            setattr(self, attr, 0)
+        self.session_estimated_cost_usd = 0.0
+        self.session_cost_status = ""
+        self.session_cost_source = ""
+
+
+def _turn():
+    return SimpleNamespace(
+        token_usage_last={
+            "inputTokens": 12000, "cachedInputTokens": 3000,
+            "outputTokens": 800, "reasoningOutputTokens": 200,
+            "totalTokens": 16000,
+        },
+        model_context_window=None,
+    )
+
+
+@pytest.fixture()
+def hook_capture():
+    mgr = get_plugin_manager()
+    saved = list(mgr._hooks.get("post_api_request", []))
+    captured = []
+    mgr._hooks["post_api_request"] = [lambda **kw: captured.append(kw)]
+    try:
+        yield captured
+    finally:
+        mgr._hooks["post_api_request"] = saved
+
+
+def test_codex_app_server_turn_fires_post_api_request(hook_capture):
+    agent = _FakeAgent()
+    result = _record_codex_app_server_usage(agent, _turn())
+
+    assert len(hook_capture) == 1
+    payload = hook_capture[0]
+    assert payload["provider"] == "openai-codex"
+    assert payload["model"] == "gpt-5.1-codex"
+    # canonical usage buckets, same shape conversation_loop delivers
+    assert payload["usage"]["input_tokens"] == 12000
+    assert payload["usage"]["cache_read_tokens"] == 3000
+    assert payload["usage"]["output_tokens"] == 800
+    # session accounting and the returned usage dict are unchanged
+    assert agent.session_api_calls == 1
+    assert agent.session_total_tokens == 16000
+    assert result.get("total_tokens") == 16000
+
+
+def test_broken_hook_never_breaks_usage_recording():
+    mgr = get_plugin_manager()
+    saved = list(mgr._hooks.get("post_api_request", []))
+    mgr._hooks["post_api_request"] = [
+        lambda **kw: (_ for _ in ()).throw(RuntimeError("boom"))]
+    try:
+        agent = _FakeAgent()
+        _record_codex_app_server_usage(agent, _turn())
+        assert agent.session_api_calls == 1
+    finally:
+        mgr._hooks["post_api_request"] = saved

--- a/tests/agent/test_codex_runtime_post_api_request.py
+++ b/tests/agent/test_codex_runtime_post_api_request.py
@@ -1,93 +1,292 @@
-"""Codex app-server turns must reach ``post_api_request`` consumers.
+"""Codex app-server turns must carry the ordinary loop's API lifecycle.
 
-The ordinary conversation loop fires ``post_api_request`` for every API turn,
-but Codex app-server sessions record usage through
-``_record_codex_app_server_usage`` and bypassed the hook — so plugin-side
-accounting (usage ledgers, spend guards) was blind to subscription-billed
-Codex turns.
+The chat-completions loop wraps every provider request in
+``pre_api_request`` → ``post_api_request`` / ``api_request_error``, dispatched
+through ``hermes_cli.lifecycle`` so first-party observability is notified
+ahead of the compatibility plugin hooks.  The codex app-server runtime is an
+early-return path that bypasses that loop entirely, so subscription-billed
+codex turns reached no API-hook consumer at all: usage ledgers, spend guards
+and the built-in Relay shared-metrics observer were blind to them.
+
+Consumers key a model call on ``api_request_id`` and drop a terminal event
+whose start they never observed, so the pre/post pair — and one terminal
+event on every exit path — is the actual contract, not just the post hook.
 """
-from types import SimpleNamespace
+import time
 
 import pytest
 
-from agent.codex_runtime import _record_codex_app_server_usage
-from hermes_cli.plugins import get_plugin_manager
+from agent.codex_runtime import run_codex_app_server_turn
+from agent.transports.codex_app_server_session import TurnResult
+from run_agent import AIAgent
+
+_API_HOOKS = ("pre_api_request", "post_api_request", "api_request_error")
+
+# docs/observability/README.md — "Request-Scoped API Hooks".  post_api_request
+# delivers the identity/runtime fields plus these.  A field with no honest
+# app-server equivalent is reported as None, never fabricated or omitted.
+_POST_CONTRACT_FIELDS = (
+    "session_id", "task_id", "turn_id", "api_request_id",
+    "platform", "model", "provider", "base_url", "api_mode",
+    "api_duration", "started_at", "ended_at",
+    "finish_reason", "message_count", "response_model",
+    "usage", "assistant_content_chars", "assistant_tool_call_count",
+    "response", "assistant_message",
+)
 
 
-class _FakeAgent:
-    def __init__(self):
-        self.model = "gpt-5.1-codex"
-        self.provider = "openai-codex"
-        self.base_url = ""
-        self.api_key = ""
-        self.api_mode = "codex-app-server"
-        self.platform = "cli"
-        self.session_id = "codex-test-session"
-        self.context_compressor = None
-        self._session_db = None
-        self._session_db_created = False
-        for attr in (
-            "session_api_calls", "session_prompt_tokens",
-            "session_completion_tokens", "session_total_tokens",
-            "session_input_tokens", "session_output_tokens",
-            "session_cache_read_tokens", "session_cache_write_tokens",
-            "session_reasoning_tokens",
-        ):
-            setattr(self, attr, 0)
-        self.session_estimated_cost_usd = 0.0
-        self.session_cost_status = ""
-        self.session_cost_source = ""
+class _FakeCodexSession:
+    """Stands in for the codex subprocess client, without spawning one."""
+
+    def __init__(self, turn=None, raises=None):
+        self._turn = turn
+        self._raises = raises
+        self.closed = False
+
+    def run_turn(self, *, user_input):
+        self.user_input = user_input
+        if self._raises is not None:
+            raise self._raises
+        return self._turn
+
+    def close(self):
+        self.closed = True
 
 
-def _turn():
-    return SimpleNamespace(
+def _turn(**overrides):
+    turn = TurnResult(
+        final_text="codex answer",
+        projected_messages=[
+            {
+                "role": "assistant",
+                "content": "codex answer",
+                "tool_calls": [{"id": "call_1", "function": {"name": "shell"}}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ],
+        tool_iterations=1,
+        thread_id="thread-1",
+        turn_id="codex-turn-1",
         token_usage_last={
-            "inputTokens": 12000, "cachedInputTokens": 3000,
-            "outputTokens": 800, "reasoningOutputTokens": 200,
+            "inputTokens": 12000,
+            "cachedInputTokens": 3000,
+            "outputTokens": 800,
+            "reasoningOutputTokens": 200,
             "totalTokens": 16000,
         },
-        model_context_window=None,
+    )
+    for name, value in overrides.items():
+        setattr(turn, name, value)
+    return turn
+
+
+def _agent(session):
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.model = "gpt-5.1-codex"
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_app_server"
+    agent.platform = "cli"
+    agent.session_id = "sess-codex"
+    # Stamped by turn_context before the runtime is handed the turn.
+    agent._current_turn_id = "turn-abc"
+    agent._codex_session = session
+    agent.tool_progress_callback = None
+    return agent
+
+
+def _run(agent, messages=None):
+    return run_codex_app_server_turn(
+        agent,
+        user_message="hello codex",
+        original_user_message="hello codex",
+        messages=messages if messages is not None else [
+            {"role": "user", "content": "hello codex"},
+        ],
+        effective_task_id="task-1",
     )
 
 
 @pytest.fixture()
-def hook_capture():
-    mgr = get_plugin_manager()
-    saved = list(mgr._hooks.get("post_api_request", []))
-    captured = []
-    mgr._hooks["post_api_request"] = [lambda **kw: captured.append(kw)]
+def lifecycle_events(monkeypatch):
+    """Record what the real lifecycle dispatcher hands each kind of consumer.
+
+    Nothing here stubs ``hermes_cli.lifecycle`` itself: the runtime has to go
+    through it for either consumer to be reached at all.
+    """
+    from hermes_cli import observability, plugins
+
+    events = []
+
+    monkeypatch.setattr(
+        observability, "handles_hook", lambda hook_name: hook_name in _API_HOOKS
+    )
+    monkeypatch.setattr(
+        observability,
+        "observe_lifecycle",
+        lambda hook_name, **kwargs: events.append(("builtin", hook_name, kwargs)),
+    )
+
+    manager = plugins.get_plugin_manager()
+    saved = {hook: list(manager._hooks.get(hook, [])) for hook in _API_HOOKS}
+    for hook in _API_HOOKS:
+        manager._hooks[hook] = [
+            lambda _hook=hook, **kwargs: events.append(("plugin", _hook, kwargs))
+        ]
     try:
-        yield captured
+        yield events
     finally:
-        mgr._hooks["post_api_request"] = saved
+        for hook, callbacks in saved.items():
+            manager._hooks[hook] = callbacks
 
 
-def test_codex_app_server_turn_fires_post_api_request(hook_capture):
-    agent = _FakeAgent()
-    result = _record_codex_app_server_usage(agent, _turn())
+def _of(events, kind, hook_name):
+    return [
+        kwargs
+        for got_kind, got_hook, kwargs in events
+        if got_kind == kind and got_hook == hook_name
+    ]
 
-    assert len(hook_capture) == 1
-    payload = hook_capture[0]
-    assert payload["provider"] == "openai-codex"
-    assert payload["model"] == "gpt-5.1-codex"
-    # canonical usage buckets, same shape conversation_loop delivers
-    assert payload["usage"]["input_tokens"] == 12000
-    assert payload["usage"]["cache_read_tokens"] == 3000
-    assert payload["usage"]["output_tokens"] == 800
-    # session accounting and the returned usage dict are unchanged
+
+def test_turn_reaches_builtin_observability_and_plugins(lifecycle_events):
+    """Both lifecycle consumers see the turn, built-in observer first."""
+    _run(_agent(_FakeCodexSession(_turn())))
+
+    assert [(kind, hook) for kind, hook, _ in lifecycle_events] == [
+        ("builtin", "pre_api_request"),
+        ("plugin", "pre_api_request"),
+        ("builtin", "post_api_request"),
+        ("plugin", "post_api_request"),
+    ]
+
+
+def test_pre_and_post_correlate_on_one_api_request_id(lifecycle_events):
+    """A terminal event is dropped by consumers unless it matches its start."""
+    _run(_agent(_FakeCodexSession(_turn())))
+
+    pre = _of(lifecycle_events, "builtin", "pre_api_request")[0]
+    post = _of(lifecycle_events, "builtin", "post_api_request")[0]
+
+    assert pre["turn_id"] == "turn-abc"
+    assert pre["api_request_id"].startswith("turn-abc")
+    for field in ("task_id", "turn_id", "api_request_id", "session_id",
+                  "platform", "model", "provider", "base_url", "api_mode",
+                  "api_call_count"):
+        assert post[field] == pre[field], field
+
+
+def test_tool_hooks_inside_the_turn_share_the_request_id(lifecycle_events):
+    """Tool-level hooks correlate to the request that caused them."""
+    agent = _agent(_FakeCodexSession(_turn()))
+    _run(agent)
+
+    pre = _of(lifecycle_events, "builtin", "pre_api_request")[0]
+    assert agent._current_api_request_id == pre["api_request_id"]
+
+
+def test_post_reports_the_documented_contract(lifecycle_events):
+    """Payload parity with the ordinary loop, honest values only."""
+    started = time.time()
+    _run(_agent(_FakeCodexSession(_turn())))
+
+    post = _of(lifecycle_events, "builtin", "post_api_request")[0]
+    for field in _POST_CONTRACT_FIELDS:
+        assert field in post, field
+
+    assert post["finish_reason"] == "stop"
+    assert post["api_call_count"] == 1
+    assert post["message_count"] == 1
+    assert post["started_at"] >= started
+    assert post["ended_at"] >= post["started_at"]
+    assert post["api_duration"] == pytest.approx(
+        post["ended_at"] - post["started_at"]
+    )
+    assert post["assistant_content_chars"] == len("codex answer")
+    assert post["assistant_tool_call_count"] == 1
+    # The app server never echoes the model it served the turn with, and no
+    # normalized provider message object exists on this path.
+    assert post["response_model"] is None
+    assert post["assistant_message"] is None
+    assert post["response"]["assistant_message"]["content"] == "codex answer"
+    assert post["response"]["finish_reason"] == "stop"
+
+    usage = post["usage"]
+    assert usage["input_tokens"] == 12000
+    assert usage["cache_read_tokens"] == 3000
+    assert usage["output_tokens"] == 800
+    assert usage["total_tokens"] == 16000
+    # ``usage`` is token buckets; cost belongs to the turn result, not here.
+    assert "estimated_cost_usd" not in usage
+
+
+def test_turn_without_token_usage_still_ends_the_model_call(lifecycle_events):
+    """Codex omits usage on some turns; they still cost an API call."""
+    agent = _agent(_FakeCodexSession(_turn(token_usage_last=None)))
+    _run(agent)
+
+    post = _of(lifecycle_events, "builtin", "post_api_request")
+    assert len(post) == 1
+    assert post[0]["usage"] is None
+    assert post[0]["api_call_count"] == 1
+    assert agent.session_api_calls == 1
+
+
+def test_interrupted_turn_reports_its_finish_reason(lifecycle_events):
+    _run(_agent(_FakeCodexSession(_turn(interrupted=True, final_text=""))))
+
+    post = _of(lifecycle_events, "builtin", "post_api_request")[0]
+    assert post["finish_reason"] == "interrupt"
+
+
+def test_failed_turn_terminates_the_model_call(lifecycle_events):
+    """A turn codex never returned must not leave a start hanging open."""
+    session = _FakeCodexSession(raises=RuntimeError("app-server died"))
+    result = _run(_agent(session))
+
+    assert result["completed"] is False
+    hooks = [hook for kind, hook, _ in lifecycle_events if kind == "builtin"]
+    assert hooks == ["pre_api_request", "api_request_error"]
+
+    pre = _of(lifecycle_events, "builtin", "pre_api_request")[0]
+    err = _of(lifecycle_events, "builtin", "api_request_error")[0]
+    assert err["api_request_id"] == pre["api_request_id"]
+    assert err["retryable"] is False
+    assert err["error"] == {
+        "type": "RuntimeError",
+        "message": "app-server died",
+    }
+
+
+def test_pre_describes_the_request_hermes_actually_sent(lifecycle_events):
+    _run(_agent(_FakeCodexSession(_turn())))
+
+    pre = _of(lifecycle_events, "builtin", "pre_api_request")[0]
+    assert pre["request"]["body"]["input"] == "hello codex"
+    assert pre["request_char_count"] == len("hello codex")
+    assert pre["request_messages"] == [
+        {"role": "user", "content": "hello codex"},
+    ]
+
+
+def test_broken_lifecycle_dispatch_never_breaks_the_turn(monkeypatch):
+    """Observability is best-effort; the turn and its accounting survive it."""
+    from hermes_cli import lifecycle
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("dispatch exploded")
+
+    monkeypatch.setattr(lifecycle, "has_hook", lambda hook_name: True)
+    monkeypatch.setattr(lifecycle, "invoke_hook", _boom)
+
+    agent = _agent(_FakeCodexSession(_turn()))
+    result = _run(agent)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "codex answer"
     assert agent.session_api_calls == 1
     assert agent.session_total_tokens == 16000
-    assert result.get("total_tokens") == 16000
-
-
-def test_broken_hook_never_breaks_usage_recording():
-    mgr = get_plugin_manager()
-    saved = list(mgr._hooks.get("post_api_request", []))
-    mgr._hooks["post_api_request"] = [
-        lambda **kw: (_ for _ in ()).throw(RuntimeError("boom"))]
-    try:
-        agent = _FakeAgent()
-        _record_codex_app_server_usage(agent, _turn())
-        assert agent.session_api_calls == 1
-    finally:
-        mgr._hooks["post_api_request"] = saved


### PR DESCRIPTION
## Summary
The ordinary conversation loop fires the `post_api_request` plugin hook for every API turn, but Codex **app-server** sessions record usage through `_record_codex_app_server_usage` and bypassed the hook entirely. Any plugin doing usage accounting (ledgers, spend guards, telemetry) is blind to subscription-billed Codex turns — they see OpenRouter/Anthropic/API-key turns but a Codex session contributes zero events.

This mirrors `conversation_loop.py`'s existing firing on the app-server path: same hook, same canonical usage buckets (`input_tokens` / `cache_read_tokens` / `output_tokens`), so a consumer written against the conversation loop works unchanged for Codex.

## Changes
- `agent/codex_runtime.py`: `_record_codex_app_server_usage` fires `post_api_request` after session accounting, payload matching the conversation-loop shape; a raising hook is swallowed (same contract as `PluginManager.invoke_hook` everywhere else) so a broken plugin can never break usage recording
- `tests/agent/test_codex_runtime_post_api_request.py`: 2 new tests — payload shape + accounting unchanged, and broken-hook isolation

## Validation
| | Result |
|---|---|
| `pytest tests/agent/test_codex_runtime_post_api_request.py -q` | 2/2 pass |
| `pytest tests/agent/test_codex_runtime_live_events.py tests/hermes_cli/test_codex_runtime_switch.py -q` | 37/37 pass |
| Platform | macOS 15 (Apple Silicon), Python 3.11 |
