### PR TITLE
feat(plugins): register_aux_provider — plugin-supplied auxiliary providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -322,6 +322,50 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
     return _PROVIDER_ALIASES.get(normalized, normalized)
 
 
+# ── Plugin-registered auxiliary providers ────────────────────────────────
+# Plugins can contribute whole auxiliary providers (e.g. a subprocess-backed
+# subscription pool) without touching this file. A registered name is valid
+# anywhere a provider name is accepted: ``auxiliary.<task>.provider`` and
+# ``auxiliary.<task>.fallback_chain`` entries both route through
+# :func:`resolve_provider_client`, which checks this registry first.
+_PLUGIN_AUX_PROVIDERS: Dict[str, Any] = {}
+
+# Provider names with dedicated resolution branches (or magic meaning) that a
+# plugin must not shadow. Alias keys/values are folded in at check time.
+_RESERVED_AUX_PROVIDERS = {
+    "auto", "custom", "main", "local", "codex", "openrouter", "nous",
+    "openai-codex", "xai-oauth", "azure-foundry", "anthropic", "copilot",
+    "gemini", "copilot-acp",
+}
+
+
+def register_aux_provider(name: str, builder, *, aliases: Tuple[str, ...] = ()) -> None:
+    """Register a plugin-supplied auxiliary provider under *name*.
+
+    ``builder(model, task=None)`` must return ``(client, resolved_model)``
+    where the client exposes ``.chat.completions.create()``, or
+    ``(None, None)`` when its credentials are unavailable on this host (the
+    caller's fallback chain then continues instead of hard-failing).
+
+    Async-native clients (subprocess/IPC facades with no httpx transport to
+    swap) should set ``aux_async_passthrough = True`` on themselves; async
+    callers then receive them unchanged instead of an AsyncOpenAI wrapper
+    around a non-HTTP base URL.
+    """
+    key = (name or "").strip().lower()
+    reserved = (_RESERVED_AUX_PROVIDERS
+                | set(_PROVIDER_ALIASES) | set(_PROVIDER_ALIASES.values()))
+    if not key or key in reserved:
+        raise ValueError(f"aux provider name {name!r} is empty or reserved")
+    if not callable(builder):
+        raise ValueError(f"aux provider {name!r} builder must be callable")
+    _PLUGIN_AUX_PROVIDERS[key] = builder
+    for alias in aliases:
+        alias_key = (alias or "").strip().lower()
+        if alias_key and alias_key not in reserved and alias_key != key:
+            _PROVIDER_ALIASES[alias_key] = key
+
+
 # Sentinel: when returned by _fixed_temperature_for_model(), callers must
 # strip the ``temperature`` key from API kwargs entirely so the provider's
 # server-side default applies.  Kimi/Moonshot models manage temperature
@@ -4676,6 +4720,12 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     """
     from openai import AsyncOpenAI
 
+    # Async-native facades (subprocess/IPC-backed plugin clients): nothing to
+    # swap — wrapping their marker base_url in AsyncOpenAI would HTTP a bogus
+    # URL. Duck-typed so plugin classes never need an isinstance here.
+    if getattr(sync_client, "aux_async_passthrough", False):
+        return sync_client, model
+
     if isinstance(sync_client, CodexAuxiliaryClient):
         return AsyncCodexAuxiliaryClient(sync_client), model
     if isinstance(sync_client, AnthropicAuxiliaryClient):
@@ -4915,6 +4965,24 @@ def resolve_provider_client(
         return _maybe_wrap_anthropic(
             client_obj, final_model_str, api_key_str, base_url_str, api_mode,
         )
+
+    # ── Plugin-registered providers ──────────────────────────────────
+    if provider in _PLUGIN_AUX_PROVIDERS:
+        try:
+            client, default = _PLUGIN_AUX_PROVIDERS[provider](model, task=task)
+        except Exception:
+            logger.warning(
+                "resolve_provider_client: plugin aux provider %r failed to "
+                "build", provider, exc_info=True)
+            return None, None
+        if client is None:
+            logger.debug(
+                "resolve_provider_client: plugin aux provider %r has no "
+                "credentials on this host", provider)
+            return None, None
+        final_model = default or model
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
 
     # ── Auto: try all providers in priority order ────────────────────
     if provider == "auto":

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -52,7 +52,7 @@ import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urlparse, parse_qs, urlunparse
 
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
@@ -328,10 +328,29 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
 # anywhere a provider name is accepted: ``auxiliary.<task>.provider`` and
 # ``auxiliary.<task>.fallback_chain`` entries both route through
 # :func:`resolve_provider_client`, which checks this registry first.
-_PLUGIN_AUX_PROVIDERS: Dict[str, Any] = {}
+#
+# Registrations carry their owner (the plugin name; ``None`` for direct API
+# callers) so one plugin cannot silently take over a route another plugin
+# already serves. The whole registry is torn down by forced plugin discovery
+# — see :func:`clear_plugin_aux_providers`.
+
+
+class _AuxProviderRegistration(NamedTuple):
+    builder: Any
+    owner: Optional[str]
+
+
+_PLUGIN_AUX_PROVIDERS: Dict[str, _AuxProviderRegistration] = {}
+
+# Aliases contributed by registrations: alias → provider name. Mirrored into
+# _PROVIDER_ALIASES so _normalize_aux_provider() resolves them, but tracked
+# separately so teardown removes exactly what plugins added and the built-in
+# alias table survives untouched.
+_PLUGIN_AUX_ALIASES: Dict[str, str] = {}
 
 # Provider names with dedicated resolution branches (or magic meaning) that a
-# plugin must not shadow. Alias keys/values are folded in at check time.
+# plugin must not shadow. Built-in aliases and the auth PROVIDER_REGISTRY are
+# folded in at check time — see _reserved_aux_names().
 _RESERVED_AUX_PROVIDERS = {
     "auto", "custom", "main", "local", "codex", "openrouter", "nous",
     "openai-codex", "xai-oauth", "azure-foundry", "anthropic", "copilot",
@@ -339,7 +358,50 @@ _RESERVED_AUX_PROVIDERS = {
 }
 
 
-def register_aux_provider(name: str, builder, *, aliases: Tuple[str, ...] = ()) -> None:
+def _reserved_aux_names() -> set:
+    """Names a plugin may not claim: every built-in provider and alias.
+
+    Plugin-contributed aliases live in ``_PROVIDER_ALIASES`` too, so they are
+    excluded here — they are guarded by ownership, not by reservation.
+    """
+    builtin_aliases = {k: v for k, v in _PROVIDER_ALIASES.items()
+                       if k not in _PLUGIN_AUX_ALIASES}
+    reserved = set(_RESERVED_AUX_PROVIDERS)
+    reserved |= set(builtin_aliases) | set(builtin_aliases.values())
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        reserved |= set(PROVIDER_REGISTRY)
+    except Exception:
+        logger.debug("aux provider registry: hermes_cli.auth unavailable",
+                     exc_info=True)
+    return reserved
+
+
+def _check_alias_available(alias_key: str, key: str, owner: Optional[str],
+                           reserved: set) -> None:
+    """Raise ValueError if *alias_key* is not *owner*'s to point at *key*."""
+    if alias_key in reserved:
+        raise ValueError(
+            f"aux provider alias {alias_key!r} is reserved by a built-in provider")
+    # An alias that matches a registered *name* would rewrite that provider's
+    # route away from itself — never allowed, not even for its own owner.
+    shadowed = _PLUGIN_AUX_PROVIDERS.get(alias_key)
+    if shadowed is not None:
+        raise ValueError(
+            f"aux provider alias {alias_key!r} would rewrite the provider "
+            f"registered under that name by {shadowed.owner or 'a direct caller'}")
+    target = _PLUGIN_AUX_ALIASES.get(alias_key)
+    if target is not None and target != key:
+        holder = _PLUGIN_AUX_PROVIDERS.get(target)
+        holder_owner = holder.owner if holder is not None else None
+        if holder_owner != owner:
+            raise ValueError(
+                f"aux provider alias {alias_key!r} is already registered for "
+                f"{target!r} by {holder_owner or 'a direct caller'}")
+
+
+def register_aux_provider(name: str, builder, *, aliases: Tuple[str, ...] = (),
+                          owner: Optional[str] = None) -> None:
     """Register a plugin-supplied auxiliary provider under *name*.
 
     ``builder(model, task=None)`` must return ``(client, resolved_model)``
@@ -351,19 +413,58 @@ def register_aux_provider(name: str, builder, *, aliases: Tuple[str, ...] = ()) 
     swap) should set ``aux_async_passthrough = True`` on themselves; async
     callers then receive them unchanged instead of an AsyncOpenAI wrapper
     around a non-HTTP base URL.
+
+    *owner* identifies the registrant (``PluginContext`` passes the plugin
+    name). An owner may re-register its own provider — the builder is
+    replaced and the alias set rewritten — but claiming a name or an alias
+    that belongs to a different owner raises ``ValueError`` instead of
+    silently rerouting it. Nothing is mutated unless every check passes.
     """
     key = (name or "").strip().lower()
-    reserved = (_RESERVED_AUX_PROVIDERS
-                | set(_PROVIDER_ALIASES) | set(_PROVIDER_ALIASES.values()))
+    reserved = _reserved_aux_names()
     if not key or key in reserved:
         raise ValueError(f"aux provider name {name!r} is empty or reserved")
     if not callable(builder):
         raise ValueError(f"aux provider {name!r} builder must be callable")
-    _PLUGIN_AUX_PROVIDERS[key] = builder
+    existing = _PLUGIN_AUX_PROVIDERS.get(key)
+    if existing is not None and existing.owner != owner:
+        raise ValueError(
+            f"aux provider {key!r} is already registered by "
+            f"{existing.owner or 'a direct caller'}")
+
+    alias_keys = []
     for alias in aliases:
         alias_key = (alias or "").strip().lower()
-        if alias_key and alias_key not in reserved and alias_key != key:
-            _PROVIDER_ALIASES[alias_key] = key
+        if not alias_key or alias_key == key:
+            continue
+        _check_alias_available(alias_key, key, owner, reserved)
+        alias_keys.append(alias_key)
+
+    # Re-registration narrows: aliases this provider carried before but no
+    # longer declares are dropped rather than left dangling.
+    for stale in [a for a, t in _PLUGIN_AUX_ALIASES.items()
+                  if t == key and a not in alias_keys]:
+        _PLUGIN_AUX_ALIASES.pop(stale, None)
+        _PROVIDER_ALIASES.pop(stale, None)
+
+    _PLUGIN_AUX_PROVIDERS[key] = _AuxProviderRegistration(builder, owner)
+    for alias_key in alias_keys:
+        _PROVIDER_ALIASES[alias_key] = key
+        _PLUGIN_AUX_ALIASES[alias_key] = key
+
+
+def clear_plugin_aux_providers() -> None:
+    """Drop every registered aux provider and the aliases they contributed.
+
+    Called from ``PluginManager.discover_and_load(force=True)`` alongside the
+    manager's own registries: plugins that survive the rescan re-register in
+    the same sweep, while a disabled or uninstalled plugin's provider stops
+    resolving without waiting for a restart.
+    """
+    _PLUGIN_AUX_PROVIDERS.clear()
+    for alias in _PLUGIN_AUX_ALIASES:
+        _PROVIDER_ALIASES.pop(alias, None)
+    _PLUGIN_AUX_ALIASES.clear()
 
 
 # Sentinel: when returned by _fixed_temperature_for_model(), callers must
@@ -4969,7 +5070,8 @@ def resolve_provider_client(
     # ── Plugin-registered providers ──────────────────────────────────
     if provider in _PLUGIN_AUX_PROVIDERS:
         try:
-            client, default = _PLUGIN_AUX_PROVIDERS[provider](model, task=task)
+            client, default = _PLUGIN_AUX_PROVIDERS[provider].builder(
+                model, task=task)
         except Exception:
             logger.warning(
                 "resolve_provider_client: plugin aux provider %r failed to "

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -621,6 +621,176 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
     return _PROVIDER_ALIASES.get(normalized, normalized)
 
 
+# ── Plugin-registered auxiliary providers ────────────────────────────────
+# Plugins can contribute whole auxiliary providers (e.g. a subprocess-backed
+# subscription pool) without touching this file. A registered name is valid
+# anywhere a provider name is accepted: ``auxiliary.<task>.provider`` and
+# ``auxiliary.<task>.fallback_chain`` entries both route through
+# :func:`resolve_provider_client`, which checks this registry first.
+#
+# Registrations carry their owner (the plugin name; ``None`` for direct API
+# callers) so one plugin cannot silently take over a route another plugin
+# already serves. Each one is released through the ``PluginRegistration``
+# handle its plugin received — see :func:`unregister_aux_provider` — so a
+# plugin unload or forced re-discovery drops it with the rest of that
+# plugin's state.
+
+
+class _AuxProviderRegistration(NamedTuple):
+    builder: Any
+    owner: Optional[str]
+
+
+_PLUGIN_AUX_PROVIDERS: Dict[str, _AuxProviderRegistration] = {}
+
+# Aliases contributed by registrations: alias → provider name. Mirrored into
+# _PROVIDER_ALIASES so _normalize_aux_provider() resolves them, but tracked
+# separately so teardown removes exactly what plugins added and the built-in
+# alias table survives untouched.
+_PLUGIN_AUX_ALIASES: Dict[str, str] = {}
+
+# Provider names with dedicated resolution branches (or magic meaning) that a
+# plugin must not shadow. Built-in aliases and the auth PROVIDER_REGISTRY are
+# folded in at check time — see _reserved_aux_names().
+_RESERVED_AUX_PROVIDERS = {
+    "auto", "custom", "main", "local", "codex", "openrouter", "nous",
+    "openai-codex", "xai-oauth", "azure-foundry", "anthropic", "copilot",
+    "gemini", "copilot-acp",
+}
+
+
+def _reserved_aux_names() -> set:
+    """Names a plugin may not claim: every built-in provider and alias.
+
+    Plugin-contributed aliases live in ``_PROVIDER_ALIASES`` too, so they are
+    excluded here — they are guarded by ownership, not by reservation.
+    """
+    builtin_aliases = {k: v for k, v in _PROVIDER_ALIASES.items()
+                       if k not in _PLUGIN_AUX_ALIASES}
+    reserved = set(_RESERVED_AUX_PROVIDERS)
+    reserved |= set(builtin_aliases) | set(builtin_aliases.values())
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        reserved |= set(PROVIDER_REGISTRY)
+    except Exception:
+        logger.debug("aux provider registry: hermes_cli.auth unavailable",
+                     exc_info=True)
+    return reserved
+
+
+def _check_alias_available(alias_key: str, key: str, owner: Optional[str],
+                           reserved: set) -> None:
+    """Raise ValueError if *alias_key* is not *owner*'s to point at *key*."""
+    if alias_key in reserved:
+        raise ValueError(
+            f"aux provider alias {alias_key!r} is reserved by a built-in provider")
+    # An alias that matches a registered *name* would rewrite that provider's
+    # route away from itself — never allowed, not even for its own owner.
+    shadowed = _PLUGIN_AUX_PROVIDERS.get(alias_key)
+    if shadowed is not None:
+        raise ValueError(
+            f"aux provider alias {alias_key!r} would rewrite the provider "
+            f"registered under that name by {shadowed.owner or 'a direct caller'}")
+    target = _PLUGIN_AUX_ALIASES.get(alias_key)
+    if target is not None and target != key:
+        holder = _PLUGIN_AUX_PROVIDERS.get(target)
+        holder_owner = holder.owner if holder is not None else None
+        if holder_owner != owner:
+            raise ValueError(
+                f"aux provider alias {alias_key!r} is already registered for "
+                f"{target!r} by {holder_owner or 'a direct caller'}")
+
+
+def register_aux_provider(name: str, builder, *, aliases: Tuple[str, ...] = (),
+                          owner: Optional[str] = None) -> _AuxProviderRegistration:
+    """Register a plugin-supplied auxiliary provider under *name*.
+
+    ``builder(model, task=None)`` must return ``(client, resolved_model)``
+    where the client exposes ``.chat.completions.create()``, or
+    ``(None, None)`` when its credentials are unavailable on this host (the
+    caller's fallback chain then continues instead of hard-failing).
+
+    Async-native clients (subprocess/IPC facades with no httpx transport to
+    swap) should set ``aux_async_passthrough = True`` on themselves; async
+    callers then receive them unchanged instead of an AsyncOpenAI wrapper
+    around a non-HTTP base URL.
+
+    *owner* identifies the registrant (``PluginContext`` passes the plugin
+    name). An owner may re-register its own provider — the builder is
+    replaced and the alias set rewritten — but claiming a name or an alias
+    that belongs to a different owner raises ``ValueError`` instead of
+    silently rerouting it. Nothing is mutated unless every check passes.
+
+    Returns the installed registration record, which
+    :func:`unregister_aux_provider` accepts as *expect* so a stale handle
+    cannot tear down a newer registration made under the same name.
+    """
+    key = (name or "").strip().lower()
+    reserved = _reserved_aux_names()
+    if not key or key in reserved:
+        raise ValueError(f"aux provider name {name!r} is empty or reserved")
+    if not callable(builder):
+        raise ValueError(f"aux provider {name!r} builder must be callable")
+    existing = _PLUGIN_AUX_PROVIDERS.get(key)
+    if existing is not None and existing.owner != owner:
+        raise ValueError(
+            f"aux provider {key!r} is already registered by "
+            f"{existing.owner or 'a direct caller'}")
+
+    alias_keys = []
+    for alias in aliases:
+        alias_key = (alias or "").strip().lower()
+        if not alias_key or alias_key == key:
+            continue
+        _check_alias_available(alias_key, key, owner, reserved)
+        alias_keys.append(alias_key)
+
+    # Re-registration narrows: aliases this provider carried before but no
+    # longer declares are dropped rather than left dangling.
+    for stale in [a for a, t in _PLUGIN_AUX_ALIASES.items()
+                  if t == key and a not in alias_keys]:
+        _PLUGIN_AUX_ALIASES.pop(stale, None)
+        _PROVIDER_ALIASES.pop(stale, None)
+
+    registration = _AuxProviderRegistration(builder, owner)
+    _PLUGIN_AUX_PROVIDERS[key] = registration
+    for alias_key in alias_keys:
+        _PROVIDER_ALIASES[alias_key] = key
+        _PLUGIN_AUX_ALIASES[alias_key] = key
+    return registration
+
+
+def unregister_aux_provider(name: str, *, owner: Optional[str] = None,
+                            expect: Optional[_AuxProviderRegistration] = None
+                            ) -> bool:
+    """Remove one registered provider and the aliases it contributed.
+
+    This is the release half of a registration: ``PluginContext``'s handle
+    calls it, so a plugin's provider is dropped by the same reverse-order
+    teardown that unwinds every other plugin-owned registration — a disabled
+    or uninstalled plugin stops resolving without waiting for a restart.
+
+    Idempotent, and never removes someone else's route: the call is a no-op
+    unless *owner* matches and — when *expect* is given — the registration
+    still in place is the very one that handle installed. A later
+    re-registration by the same owner therefore supersedes the older handle
+    instead of being torn down by it.
+
+    Returns whether this call removed a registration.
+    """
+    key = (name or "").strip().lower()
+    current = _PLUGIN_AUX_PROVIDERS.get(key)
+    if current is None or current.owner != owner:
+        return False
+    if expect is not None and current is not expect:
+        return False
+    _PLUGIN_AUX_PROVIDERS.pop(key, None)
+    for alias in [a for a, target in _PLUGIN_AUX_ALIASES.items() if target == key]:
+        _PLUGIN_AUX_ALIASES.pop(alias, None)
+        _PROVIDER_ALIASES.pop(alias, None)
+    return True
+
+
 # Sentinel: when returned by _fixed_temperature_for_model(), callers must
 # strip the ``temperature`` key from API kwargs entirely so the provider's
 # server-side default applies.  Kimi/Moonshot models manage temperature
@@ -6164,6 +6334,13 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
 
     if isinstance(sync_client, _AuxProbeClientStub):
         return sync_client, model
+
+    # Async-native facades (subprocess/IPC-backed plugin clients): nothing to
+    # swap — wrapping their marker base_url in AsyncOpenAI would HTTP a bogus
+    # URL. Duck-typed so plugin classes never need an isinstance here.
+    if getattr(sync_client, "aux_async_passthrough", False):
+        return sync_client, model
+
     if isinstance(sync_client, CodexAuxiliaryClient):
         return AsyncCodexAuxiliaryClient(sync_client), model
     if isinstance(sync_client, AnthropicAuxiliaryClient):
@@ -6418,6 +6595,25 @@ def resolve_provider_client(
         return _maybe_wrap_anthropic(
             client_obj, final_model_str, api_key_str, base_url_str, api_mode,
         )
+
+    # ── Plugin-registered providers ──────────────────────────────────
+    if provider in _PLUGIN_AUX_PROVIDERS:
+        try:
+            client, default = _PLUGIN_AUX_PROVIDERS[provider].builder(
+                model, task=task)
+        except Exception:
+            logger.warning(
+                "resolve_provider_client: plugin aux provider %r failed to "
+                "build", provider, exc_info=True)
+            return None, None
+        if client is None:
+            logger.debug(
+                "resolve_provider_client: plugin aux provider %r has no "
+                "credentials on this host", provider)
+            return None, None
+        final_model = default or model
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
 
     # ── Auto: try all providers in priority order ────────────────────
     if provider == "auto":

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1155,6 +1155,38 @@ class PluginContext:
             display_name,
         )
 
+    def register_aux_provider(
+        self,
+        name: str,
+        builder: Callable,
+        *,
+        aliases: tuple = (),
+    ) -> None:
+        """Register an auxiliary LLM *provider* (a client factory, not a task).
+
+        Complements :meth:`register_auxiliary_task`: tasks declare LLM-backed
+        side jobs, providers supply the clients that serve them. The
+        registered name becomes valid anywhere a provider name is accepted —
+        ``auxiliary.<task>.provider`` and ``auxiliary.<task>.fallback_chain``
+        in ``config.yaml`` — via ``agent.auxiliary_client``.
+
+        ``builder(model, task=None)`` must return ``(client, resolved_model)``
+        where the client exposes ``.chat.completions.create()``, or
+        ``(None, None)`` when its credentials are unavailable on this host.
+        Async-native clients (subprocess/IPC facades) should set
+        ``aux_async_passthrough = True`` on themselves.
+
+        Raises:
+            ValueError: if *name* is empty or shadows a built-in provider.
+        """
+        from agent.auxiliary_client import register_aux_provider as _register
+
+        _register(name, builder, aliases=tuple(aliases))
+        logger.info(
+            "Plugin '%s' registered aux provider: %s",
+            self.manifest.name, name,
+        )
+
     def register_hook(self, hook_name: str, callback: Callable) -> None:
         """Register a lifecycle hook callback.
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1176,12 +1176,21 @@ class PluginContext:
         Async-native clients (subprocess/IPC facades) should set
         ``aux_async_passthrough = True`` on themselves.
 
+        Registrations are owned by the registering plugin. Re-registering the
+        same name from the same plugin replaces the builder and rewrites its
+        aliases; a *different* plugin claiming that name — or aliasing onto
+        it — is rejected rather than allowed to reroute it silently.
+        Registrations are dropped on forced re-discovery and re-made by the
+        plugins that survive it.
+
         Raises:
-            ValueError: if *name* is empty or shadows a built-in provider.
+            ValueError: if *name* is empty, shadows a built-in provider, or
+                collides with a name/alias owned by another plugin.
         """
         from agent.auxiliary_client import register_aux_provider as _register
 
-        _register(name, builder, aliases=tuple(aliases))
+        _register(name, builder, aliases=tuple(aliases),
+                  owner=self.manifest.name)
         logger.info(
             "Plugin '%s' registered aux provider: %s",
             self.manifest.name, name,
@@ -1277,6 +1286,20 @@ class PluginContext:
 # PluginManager
 # ---------------------------------------------------------------------------
 
+def _clear_plugin_aux_providers() -> None:
+    """Drop aux providers registered via :meth:`PluginContext.register_aux_provider`.
+
+    Their registry is a module global in ``agent.auxiliary_client`` rather than
+    a manager attribute, so it needs an explicit hand in the force-rediscover
+    teardown. Nothing can be registered without that module being imported
+    first, so an unimported module means an empty registry — worth skipping,
+    since plugin discovery runs on every startup and that module is heavy.
+    """
+    aux = sys.modules.get("agent.auxiliary_client")
+    if aux is not None:
+        aux.clear_plugin_aux_providers()
+
+
 class PluginManager:
     """Central manager that discovers, loads, and invokes plugins."""
 
@@ -1333,6 +1356,7 @@ class PluginManager:
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
             self._context_engine = None
+            _clear_plugin_aux_providers()
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
         # raises so a failed scan is NOT cached as "discovered with an empty

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -3127,6 +3127,62 @@ class PluginContext:
         )
         return count
 
+    def register_aux_provider(
+        self,
+        name: str,
+        builder: Callable,
+        *,
+        aliases: tuple = (),
+    ) -> PluginRegistration:
+        """Register an auxiliary LLM *provider* (a client factory, not a task).
+
+        Complements :meth:`register_auxiliary_task`: tasks declare LLM-backed
+        side jobs, providers supply the clients that serve them. The
+        registered name becomes valid anywhere a provider name is accepted —
+        ``auxiliary.<task>.provider`` and ``auxiliary.<task>.fallback_chain``
+        in ``config.yaml`` — via ``agent.auxiliary_client``.
+
+        ``builder(model, task=None)`` must return ``(client, resolved_model)``
+        where the client exposes ``.chat.completions.create()``, or
+        ``(None, None)`` when its credentials are unavailable on this host.
+        Async-native clients (subprocess/IPC facades) should set
+        ``aux_async_passthrough = True`` on themselves.
+
+        Registrations are owned by the registering plugin. Re-registering the
+        same name from the same plugin replaces the builder and rewrites its
+        aliases; a *different* plugin claiming that name — or aliasing onto
+        it — is rejected rather than allowed to reroute it silently.
+
+        The registry is a module global in ``agent.auxiliary_client`` rather
+        than a manager attribute, so the returned handle carries its release:
+        a plugin unload or a forced re-discovery unwinds the provider with the
+        rest of that plugin's registrations instead of leaving a disabled
+        plugin's route reachable for the life of the process.
+
+        Raises:
+            ValueError: if *name* is empty, shadows a built-in provider, or
+                collides with a name/alias owned by another plugin.
+        """
+        from agent.auxiliary_client import (
+            register_aux_provider as _register,
+            unregister_aux_provider as _unregister,
+        )
+
+        owner = self.manifest.key or self.manifest.name
+        key = (name or "").strip().lower()
+        registration = _register(name, builder, aliases=tuple(aliases),
+                                 owner=owner)
+        handle = self._track(
+            "aux_provider",
+            key,
+            lambda: _unregister(key, owner=owner, expect=registration),
+        )
+        logger.info(
+            "Plugin '%s' registered aux provider: %s",
+            self.manifest.name, name,
+        )
+        return handle
+
     def register_hook(self, hook_name: str, callback: Callable) -> PluginRegistration:
         """Register a lifecycle hook callback.
 

--- a/tests/agent/test_auxiliary_client_plugin_providers.py
+++ b/tests/agent/test_auxiliary_client_plugin_providers.py
@@ -1,0 +1,100 @@
+"""Plugin-registered auxiliary providers (``register_aux_provider``).
+
+A plugin can contribute a whole auxiliary provider (e.g. a subprocess-backed
+subscription pool) without editing this module: the registered name is valid
+anywhere a provider name is accepted — explicit ``auxiliary.<task>.provider``,
+aliases, and ``fallback_chain`` entries — and resolution degrades to
+``(None, None)`` instead of hard-failing when the builder has no credentials.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from agent import auxiliary_client as aux
+from hermes_cli.plugins import PluginContext
+
+
+class _FakePoolClient:
+    aux_async_passthrough = True
+
+    def __init__(self, model):
+        self.model = model
+        self.base_url = "acp://test-pool"
+        self.api_key = "test-pool"
+
+
+def _good_builder(model=None, *, task=None):
+    return _FakePoolClient(model or "pool-default"), model or "pool-default"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Registration mutates both the registry and the alias map."""
+    saved_providers = dict(aux._PLUGIN_AUX_PROVIDERS)
+    saved_aliases = dict(aux._PROVIDER_ALIASES)
+    try:
+        yield
+    finally:
+        aux._PLUGIN_AUX_PROVIDERS.clear()
+        aux._PLUGIN_AUX_PROVIDERS.update(saved_providers)
+        aux._PROVIDER_ALIASES.clear()
+        aux._PROVIDER_ALIASES.update(saved_aliases)
+
+
+def test_reserved_and_invalid_registrations_are_rejected():
+    with pytest.raises(ValueError):
+        aux.register_aux_provider("openrouter", _good_builder)
+    with pytest.raises(ValueError):
+        aux.register_aux_provider("claude", _good_builder)  # anthropic alias
+    with pytest.raises(ValueError):
+        aux.register_aux_provider("test-pool", "not-callable")
+
+
+def test_registered_provider_resolves_by_name_and_alias():
+    aux.register_aux_provider("test-pool", _good_builder, aliases=("test-subs",))
+
+    client, model = aux.resolve_provider_client("test-pool", model="m1")
+    assert isinstance(client, _FakePoolClient) and model == "m1"
+
+    client, model = aux.resolve_provider_client("test-subs", model="m2")
+    assert isinstance(client, _FakePoolClient) and model == "m2"
+
+
+def test_async_passthrough_client_is_returned_unwrapped():
+    aux.register_aux_provider("test-pool", _good_builder)
+    client, model = aux.resolve_provider_client(
+        "test-pool", model="m3", async_mode=True)
+    assert isinstance(client, _FakePoolClient) and model == "m3"
+
+
+def test_builder_degradation_never_raises():
+    aux.register_aux_provider(
+        "empty-pool", lambda model=None, *, task=None: (None, None))
+    assert aux.resolve_provider_client("empty-pool") == (None, None)
+
+    def boom(model=None, *, task=None):
+        raise RuntimeError("boom")
+
+    aux.register_aux_provider("broken-pool", boom)
+    assert aux.resolve_provider_client("broken-pool") == (None, None)
+
+
+def test_fallback_chain_reaches_registered_provider():
+    aux.register_aux_provider("test-pool", _good_builder)
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "auxiliary:\n"
+        "  compression:\n"
+        "    fallback_chain:\n"
+        "      - provider: test-pool\n"
+        "        model: haiku\n"
+    )
+    client, model, label = aux._try_configured_fallback_chain(
+        "compression", "openrouter")
+    assert isinstance(client, _FakePoolClient)
+    assert model == "haiku"
+
+
+def test_plugin_context_exposes_registration():
+    assert callable(getattr(PluginContext, "register_aux_provider", None))

--- a/tests/agent/test_auxiliary_client_plugin_providers.py
+++ b/tests/agent/test_auxiliary_client_plugin_providers.py
@@ -1,0 +1,276 @@
+"""Plugin-registered auxiliary providers (``register_aux_provider``).
+
+A plugin can contribute a whole auxiliary provider (e.g. a subprocess-backed
+subscription pool) without editing this module: the registered name is valid
+anywhere a provider name is accepted — explicit ``auxiliary.<task>.provider``,
+aliases, and ``fallback_chain`` entries — and resolution degrades to
+``(None, None)`` instead of hard-failing when the builder has no credentials.
+
+Registrations are owned by the plugin that made them: a second plugin cannot
+take over a name or reroute one through an alias, and forced re-discovery
+tears the registry down so a disabled plugin's provider stops resolving.
+"""
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from agent import auxiliary_client as aux
+from hermes_cli.plugins import PluginContext, PluginManager
+
+
+class _FakePoolClient:
+    aux_async_passthrough = True
+
+    def __init__(self, model):
+        self.model = model
+        self.base_url = "acp://test-pool"
+        self.api_key = "test-pool"
+
+
+def _good_builder(model=None, *, task=None):
+    return _FakePoolClient(model or "pool-default"), model or "pool-default"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Registration mutates the registry and both alias maps."""
+    saved_providers = dict(aux._PLUGIN_AUX_PROVIDERS)
+    saved_aliases = dict(aux._PROVIDER_ALIASES)
+    saved_plugin_aliases = dict(aux._PLUGIN_AUX_ALIASES)
+    try:
+        yield
+    finally:
+        aux._PLUGIN_AUX_PROVIDERS.clear()
+        aux._PLUGIN_AUX_PROVIDERS.update(saved_providers)
+        aux._PROVIDER_ALIASES.clear()
+        aux._PROVIDER_ALIASES.update(saved_aliases)
+        aux._PLUGIN_AUX_ALIASES.clear()
+        aux._PLUGIN_AUX_ALIASES.update(saved_plugin_aliases)
+
+
+def test_reserved_and_invalid_registrations_are_rejected():
+    with pytest.raises(ValueError):
+        aux.register_aux_provider("openrouter", _good_builder)
+    with pytest.raises(ValueError):
+        aux.register_aux_provider("claude", _good_builder)  # anthropic alias
+    with pytest.raises(ValueError):
+        # Provider with no dedicated branch, resolved through the auth
+        # PROVIDER_REGISTRY catch-all — shadowing it is just as breaking.
+        aux.register_aux_provider("deepseek", _good_builder)
+    with pytest.raises(ValueError):
+        aux.register_aux_provider("test-pool", "not-callable")
+
+
+def test_registered_provider_resolves_by_name_and_alias():
+    aux.register_aux_provider("test-pool", _good_builder, aliases=("test-subs",))
+
+    client, model = aux.resolve_provider_client("test-pool", model="m1")
+    assert isinstance(client, _FakePoolClient) and model == "m1"
+
+    client, model = aux.resolve_provider_client("test-subs", model="m2")
+    assert isinstance(client, _FakePoolClient) and model == "m2"
+
+
+def test_async_passthrough_client_is_returned_unwrapped():
+    aux.register_aux_provider("test-pool", _good_builder)
+    client, model = aux.resolve_provider_client(
+        "test-pool", model="m3", async_mode=True)
+    assert isinstance(client, _FakePoolClient) and model == "m3"
+
+
+def test_builder_degradation_never_raises():
+    aux.register_aux_provider(
+        "empty-pool", lambda model=None, *, task=None: (None, None))
+    assert aux.resolve_provider_client("empty-pool") == (None, None)
+
+    def boom(model=None, *, task=None):
+        raise RuntimeError("boom")
+
+    aux.register_aux_provider("broken-pool", boom)
+    assert aux.resolve_provider_client("broken-pool") == (None, None)
+
+
+def test_fallback_chain_reaches_registered_provider():
+    aux.register_aux_provider("test-pool", _good_builder)
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "auxiliary:\n"
+        "  compression:\n"
+        "    fallback_chain:\n"
+        "      - provider: test-pool\n"
+        "        model: haiku\n"
+    )
+    client, model, label = aux._try_configured_fallback_chain(
+        "compression", "openrouter")
+    assert isinstance(client, _FakePoolClient)
+    assert model == "haiku"
+
+
+def test_plugin_context_exposes_registration():
+    assert callable(getattr(PluginContext, "register_aux_provider", None))
+
+
+# ── Ownership ──────────────────────────────────────────────────────────────
+
+
+def _other_builder(model=None, *, task=None):
+    client = _FakePoolClient(model or "other-default")
+    client.api_key = "other-pool"
+    return client, model or "other-default"
+
+
+def test_another_owner_cannot_take_over_a_registered_name():
+    aux.register_aux_provider("shared-pool", _good_builder, owner="alpha")
+
+    with pytest.raises(ValueError, match="alpha"):
+        aux.register_aux_provider("shared-pool", _other_builder, owner="beta")
+
+    client, _ = aux.resolve_provider_client("shared-pool", model="m")
+    assert client.api_key == "test-pool"
+
+
+def test_owner_may_re_register_its_own_provider():
+    aux.register_aux_provider("shared-pool", _good_builder, owner="alpha",
+                              aliases=("shared-subs", "shared-legacy"))
+    aux.register_aux_provider("shared-pool", _other_builder, owner="alpha",
+                              aliases=("shared-subs",))
+
+    client, _ = aux.resolve_provider_client("shared-subs", model="m")
+    assert client.api_key == "other-pool"
+    # The dropped alias stops resolving instead of dangling on the old builder.
+    assert "shared-legacy" not in aux._PROVIDER_ALIASES
+    assert aux.resolve_provider_client("shared-legacy", model="m") == (None, None)
+
+
+def test_alias_owned_by_another_plugin_is_rejected():
+    aux.register_aux_provider("alpha-pool", _good_builder, owner="alpha",
+                              aliases=("subs",))
+
+    with pytest.raises(ValueError, match="alpha"):
+        aux.register_aux_provider("beta-pool", _other_builder, owner="beta",
+                                  aliases=("subs",))
+
+    client, _ = aux.resolve_provider_client("subs", model="m")
+    assert client.api_key == "test-pool"
+    # A rejected registration leaves nothing behind — not even its name.
+    assert "beta-pool" not in aux._PLUGIN_AUX_PROVIDERS
+
+
+def test_alias_cannot_rewrite_an_existing_provider_name():
+    aux.register_aux_provider("alpha-pool", _good_builder, owner="alpha")
+
+    with pytest.raises(ValueError, match="alpha"):
+        aux.register_aux_provider("beta-pool", _other_builder, owner="beta",
+                                  aliases=("alpha-pool",))
+
+    client, _ = aux.resolve_provider_client("alpha-pool", model="m")
+    assert client.api_key == "test-pool"
+
+
+# ── Release ────────────────────────────────────────────────────────────────
+
+
+def test_unregister_drops_the_provider_and_its_aliases():
+    aux.register_aux_provider("test-pool", _good_builder, aliases=("test-subs",),
+                              owner="alpha")
+
+    assert aux.unregister_aux_provider("test-pool", owner="alpha") is True
+
+    assert aux.resolve_provider_client("test-pool", model="m") == (None, None)
+    assert "test-subs" not in aux._PROVIDER_ALIASES
+    # Idempotent: releasing an already-released registration is a no-op.
+    assert aux.unregister_aux_provider("test-pool", owner="alpha") is False
+
+
+def test_unregister_refuses_to_drop_another_owners_provider():
+    aux.register_aux_provider("shared-pool", _good_builder, owner="alpha")
+
+    assert aux.unregister_aux_provider("shared-pool", owner="beta") is False
+
+    client, _ = aux.resolve_provider_client("shared-pool", model="m")
+    assert client is not None
+
+
+def test_a_superseded_handle_does_not_release_the_newer_registration():
+    """Re-registering hands the route to the new record; the old handle is inert.
+
+    PluginContext keeps one release handle per registration call, so an owner
+    that re-registers under the same name leaves an older handle behind. That
+    handle must not tear down the live route when it is finally disposed.
+    """
+    first = aux.register_aux_provider("shared-pool", _good_builder, owner="alpha")
+    aux.register_aux_provider("shared-pool", _other_builder, owner="alpha")
+
+    assert aux.unregister_aux_provider("shared-pool", owner="alpha",
+                                       expect=first) is False
+
+    client, _ = aux.resolve_provider_client("shared-pool", model="m")
+    assert client.api_key == "other-pool"
+
+
+# ── Plugin lifecycle ───────────────────────────────────────────────────────
+
+
+_AUX_PLUGIN_SOURCE = textwrap.dedent('''\
+    class _PluginClient:
+        aux_async_passthrough = True
+        api_key = "plugin-pool"
+
+
+    def _build(model=None, *, task=None):
+        return _PluginClient(), model or "plugin-default"
+
+
+    def register(ctx):
+        ctx.register_aux_provider("plugin-pool", _build, aliases=("plugin-subs",))
+''')
+
+
+def _install_aux_plugin(hermes_home: Path, *, enabled: bool) -> None:
+    """Write a plugin that registers an aux provider, opted in or out."""
+    plugin_dir = hermes_home / "plugins" / "aux_pool_plugin"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: aux_pool_plugin\nversion: 0.1.0\ndescription: aux provider\n")
+    (plugin_dir / "__init__.py").write_text(_AUX_PLUGIN_SOURCE)
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n  enabled: [aux_pool_plugin]\n" if enabled
+        else "plugins:\n  enabled: []\n")
+
+
+def test_forced_rediscovery_drops_a_disabled_plugins_provider():
+    """A provider must stop routing once its plugin is gone.
+
+    The registry is a module global rather than a PluginManager attribute, so
+    without an explicit hand in the force-rediscover teardown the builder of a
+    disabled plugin stays reachable for the life of the process.
+    """
+    home = Path(os.environ["HERMES_HOME"])
+    _install_aux_plugin(home, enabled=True)
+
+    manager = PluginManager()
+    manager.discover_and_load()
+    client, model = aux.resolve_provider_client("plugin-pool", model="m")
+    assert client.api_key == "plugin-pool"
+    assert model == "m"
+
+    _install_aux_plugin(home, enabled=False)
+    manager.discover_and_load(force=True)
+
+    assert aux.resolve_provider_client("plugin-pool", model="m") == (None, None)
+    assert aux.resolve_provider_client("plugin-subs", model="m") == (None, None)
+
+
+def test_rediscovery_re_registers_a_still_enabled_plugin():
+    """The teardown must not outlive the sweep that follows it."""
+    home = Path(os.environ["HERMES_HOME"])
+    _install_aux_plugin(home, enabled=True)
+
+    manager = PluginManager()
+    manager.discover_and_load()
+    manager.discover_and_load(force=True)
+
+    client, _ = aux.resolve_provider_client("plugin-subs", model="m")
+    assert client.api_key == "plugin-pool"

--- a/tests/agent/test_auxiliary_client_plugin_providers.py
+++ b/tests/agent/test_auxiliary_client_plugin_providers.py
@@ -5,14 +5,19 @@ subscription pool) without editing this module: the registered name is valid
 anywhere a provider name is accepted — explicit ``auxiliary.<task>.provider``,
 aliases, and ``fallback_chain`` entries — and resolution degrades to
 ``(None, None)`` instead of hard-failing when the builder has no credentials.
+
+Registrations are owned by the plugin that made them: a second plugin cannot
+take over a name or reroute one through an alias, and forced re-discovery
+tears the registry down so a disabled plugin's provider stops resolving.
 """
 import os
+import textwrap
 from pathlib import Path
 
 import pytest
 
 from agent import auxiliary_client as aux
-from hermes_cli.plugins import PluginContext
+from hermes_cli.plugins import PluginContext, PluginManager
 
 
 class _FakePoolClient:
@@ -30,9 +35,10 @@ def _good_builder(model=None, *, task=None):
 
 @pytest.fixture(autouse=True)
 def _clean_registry():
-    """Registration mutates both the registry and the alias map."""
+    """Registration mutates the registry and both alias maps."""
     saved_providers = dict(aux._PLUGIN_AUX_PROVIDERS)
     saved_aliases = dict(aux._PROVIDER_ALIASES)
+    saved_plugin_aliases = dict(aux._PLUGIN_AUX_ALIASES)
     try:
         yield
     finally:
@@ -40,6 +46,8 @@ def _clean_registry():
         aux._PLUGIN_AUX_PROVIDERS.update(saved_providers)
         aux._PROVIDER_ALIASES.clear()
         aux._PROVIDER_ALIASES.update(saved_aliases)
+        aux._PLUGIN_AUX_ALIASES.clear()
+        aux._PLUGIN_AUX_ALIASES.update(saved_plugin_aliases)
 
 
 def test_reserved_and_invalid_registrations_are_rejected():
@@ -47,6 +55,10 @@ def test_reserved_and_invalid_registrations_are_rejected():
         aux.register_aux_provider("openrouter", _good_builder)
     with pytest.raises(ValueError):
         aux.register_aux_provider("claude", _good_builder)  # anthropic alias
+    with pytest.raises(ValueError):
+        # Provider with no dedicated branch, resolved through the auth
+        # PROVIDER_REGISTRY catch-all — shadowing it is just as breaking.
+        aux.register_aux_provider("deepseek", _good_builder)
     with pytest.raises(ValueError):
         aux.register_aux_provider("test-pool", "not-callable")
 
@@ -98,3 +110,126 @@ def test_fallback_chain_reaches_registered_provider():
 
 def test_plugin_context_exposes_registration():
     assert callable(getattr(PluginContext, "register_aux_provider", None))
+
+
+# ── Ownership ──────────────────────────────────────────────────────────────
+
+
+def _other_builder(model=None, *, task=None):
+    client = _FakePoolClient(model or "other-default")
+    client.api_key = "other-pool"
+    return client, model or "other-default"
+
+
+def test_another_owner_cannot_take_over_a_registered_name():
+    aux.register_aux_provider("shared-pool", _good_builder, owner="alpha")
+
+    with pytest.raises(ValueError, match="alpha"):
+        aux.register_aux_provider("shared-pool", _other_builder, owner="beta")
+
+    client, _ = aux.resolve_provider_client("shared-pool", model="m")
+    assert client.api_key == "test-pool"
+
+
+def test_owner_may_re_register_its_own_provider():
+    aux.register_aux_provider("shared-pool", _good_builder, owner="alpha",
+                              aliases=("shared-subs", "shared-legacy"))
+    aux.register_aux_provider("shared-pool", _other_builder, owner="alpha",
+                              aliases=("shared-subs",))
+
+    client, _ = aux.resolve_provider_client("shared-subs", model="m")
+    assert client.api_key == "other-pool"
+    # The dropped alias stops resolving instead of dangling on the old builder.
+    assert "shared-legacy" not in aux._PROVIDER_ALIASES
+    assert aux.resolve_provider_client("shared-legacy", model="m") == (None, None)
+
+
+def test_alias_owned_by_another_plugin_is_rejected():
+    aux.register_aux_provider("alpha-pool", _good_builder, owner="alpha",
+                              aliases=("subs",))
+
+    with pytest.raises(ValueError, match="alpha"):
+        aux.register_aux_provider("beta-pool", _other_builder, owner="beta",
+                                  aliases=("subs",))
+
+    client, _ = aux.resolve_provider_client("subs", model="m")
+    assert client.api_key == "test-pool"
+    # A rejected registration leaves nothing behind — not even its name.
+    assert "beta-pool" not in aux._PLUGIN_AUX_PROVIDERS
+
+
+def test_alias_cannot_rewrite_an_existing_provider_name():
+    aux.register_aux_provider("alpha-pool", _good_builder, owner="alpha")
+
+    with pytest.raises(ValueError, match="alpha"):
+        aux.register_aux_provider("beta-pool", _other_builder, owner="beta",
+                                  aliases=("alpha-pool",))
+
+    client, _ = aux.resolve_provider_client("alpha-pool", model="m")
+    assert client.api_key == "test-pool"
+
+
+# ── Plugin lifecycle ───────────────────────────────────────────────────────
+
+
+_AUX_PLUGIN_SOURCE = textwrap.dedent('''\
+    class _PluginClient:
+        aux_async_passthrough = True
+        api_key = "plugin-pool"
+
+
+    def _build(model=None, *, task=None):
+        return _PluginClient(), model or "plugin-default"
+
+
+    def register(ctx):
+        ctx.register_aux_provider("plugin-pool", _build, aliases=("plugin-subs",))
+''')
+
+
+def _install_aux_plugin(hermes_home: Path, *, enabled: bool) -> None:
+    """Write a plugin that registers an aux provider, opted in or out."""
+    plugin_dir = hermes_home / "plugins" / "aux_pool_plugin"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: aux_pool_plugin\nversion: 0.1.0\ndescription: aux provider\n")
+    (plugin_dir / "__init__.py").write_text(_AUX_PLUGIN_SOURCE)
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n  enabled: [aux_pool_plugin]\n" if enabled
+        else "plugins:\n  enabled: []\n")
+
+
+def test_forced_rediscovery_drops_a_disabled_plugins_provider():
+    """A provider must stop routing once its plugin is gone.
+
+    The registry is a module global rather than a PluginManager attribute, so
+    without an explicit hand in the force-rediscover teardown the builder of a
+    disabled plugin stays reachable for the life of the process.
+    """
+    home = Path(os.environ["HERMES_HOME"])
+    _install_aux_plugin(home, enabled=True)
+
+    manager = PluginManager()
+    manager.discover_and_load()
+    client, model = aux.resolve_provider_client("plugin-pool", model="m")
+    assert client.api_key == "plugin-pool"
+    assert model == "m"
+
+    _install_aux_plugin(home, enabled=False)
+    manager.discover_and_load(force=True)
+
+    assert aux.resolve_provider_client("plugin-pool", model="m") == (None, None)
+    assert aux.resolve_provider_client("plugin-subs", model="m") == (None, None)
+
+
+def test_rediscovery_re_registers_a_still_enabled_plugin():
+    """The teardown must not outlive the sweep that follows it."""
+    home = Path(os.environ["HERMES_HOME"])
+    _install_aux_plugin(home, enabled=True)
+
+    manager = PluginManager()
+    manager.discover_and_load()
+    manager.discover_and_load(force=True)
+
+    client, _ = aux.resolve_provider_client("plugin-subs", model="m")
+    assert client.api_key == "plugin-pool"

--- a/tests/hermes_cli/test_plugin_ownership_ledger.py
+++ b/tests/hermes_cli/test_plugin_ownership_ledger.py
@@ -58,6 +58,11 @@ def _write_plugin(hermes_home: Path) -> None:
         "    )\n"
         "    ctx.register_hook('pre_tool_call', _hook)\n"
         "    ctx.register_middleware('tool_request', _middleware)\n"
+        "    ctx.register_aux_provider(\n"
+        "        'ledger_probe_provider',\n"
+        "        lambda model=None, *, task=None: (None, None),\n"
+        "        aliases=('ledger-probe-alias',),\n"
+        "    )\n"
         "    ctx.register_auxiliary_task(\n"
         "        key='ledger_probe_task',\n"
         "        display_name='Ledger probe task',\n"
@@ -118,6 +123,7 @@ def test_load_force_reload_and_unload_remove_every_manager_registration(
 ):
     """A real temporary plugin has one live registration after each reload."""
     import hermes_cli.plugins as plugins_mod
+    from agent import auxiliary_client
     from gateway.platform_registry import platform_registry
     from hermes_cli.plugins import PluginManager
     from tools.registry import registry
@@ -154,6 +160,7 @@ def test_load_force_reload_and_unload_remove_every_manager_registration(
         "hook",
         "middleware",
         "auxiliary_task",
+        "aux_provider",
         "skill",
         "tool_override_policy",
         "system_prompt_section",
@@ -186,6 +193,10 @@ def test_load_force_reload_and_unload_remove_every_manager_registration(
 
     assert manager.unload("ledger_probe") is True
     assert registry.get_entry("ledger_probe_tool") is None
+    assert auxiliary_client.resolve_provider_client(
+        "ledger_probe_provider", model="m"
+    ) == (None, None)
+    assert "ledger-probe-alias" not in auxiliary_client._PROVIDER_ALIASES
     assert not platform_registry.is_registered("ledger_probe_platform")
     assert "pre_tool_call" not in manager._hooks
     assert "tool_request" not in manager._middleware

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -466,6 +466,12 @@ class TestPluginDiscovery:
         mgr._plugin_skills["p:skill"] = {}
         mgr._aux_tasks["task"] = {"plugin": "p"}
         mgr._slack_action_handlers.append(("aid", lambda **_: None, "p"))
+        # Aux providers live in a module global rather than on the manager,
+        # but they are plugin-owned state and must clear with the rest.
+        from agent import auxiliary_client as aux
+        aux.register_aux_provider(
+            "force-test-pool", lambda model=None, *, task=None: (None, None),
+            aliases=("force-test-subs",), owner="p")
         mgr._discovered = True
 
         monkeypatch.setattr(PluginManager, "_discover_and_load_inner", lambda self_inner: None)
@@ -483,6 +489,8 @@ class TestPluginDiscovery:
         assert mgr._plugin_skills == {}
         assert mgr._aux_tasks == {}
         assert mgr._slack_action_handlers == []
+        assert aux._PLUGIN_AUX_PROVIDERS == {}
+        assert "force-test-subs" not in aux._PROVIDER_ALIASES
 
 
 # ── TestPluginLoading ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Auxiliary-task provider resolution is a closed list: the candidate chain in `auxiliary_client.py` is hardcoded (`openrouter`, `nous`, `local/custom`, …), and while plugins can already register auxiliary *tasks* (`PluginContext.register_auxiliary_task`), they cannot contribute a *provider*. A plugin that manages its own credentialed backend (e.g. a subprocess-backed subscription pool) has no way to make `auxiliary.<task>.provider: my-pool` or a `fallback_chain` entry route to it.

This adds `register_aux_provider(name, builder, *, aliases=())` as the provider-side complement of `register_auxiliary_task`. A registered name is valid anywhere a provider name is accepted; resolution checks the registry first. Builders degrade gracefully: `(None, None)` (or an exception) means "no credentials on this host" and the caller's fallback chain simply continues.

Related: #41544 touches the adjacent resolve path for plugin registries; this PR adds the registration API itself and routes explicit names, aliases, fallback-chain entries, and async mode through it.

## Changes
- `agent/auxiliary_client.py`: `_PLUGIN_AUX_PROVIDERS` registry + `register_aux_provider()` (reserved/builtin names and non-callable builders rejected); `resolve_provider_client` consults the registry first; clients marked `aux_async_passthrough = True` are returned unchanged in async mode instead of being wrapped in `AsyncOpenAI` (for subprocess/IPC facades with no httpx transport)
- `hermes_cli/plugins.py`: `PluginContext.register_aux_provider` delegation so plugins register during `register(ctx)`
- `tests/agent/test_auxiliary_client_plugin_providers.py`: 6 new tests — rejection rules, name+alias resolution, async passthrough, credential-less/raising builder degradation, fallback-chain routing, PluginContext surface

## Validation
| | Result |
|---|---|
| `pytest tests/agent/test_auxiliary_client_plugin_providers.py -q` | 6/6 pass |
| `pytest tests/agent/ -k auxiliary -q` | 565 pass; the 15 failures are pre-existing on main in the same environment (verified on an unpatched checkout) |
| Platform | macOS 15 (Apple Silicon), Python 3.11 |
