### PR TITLE
feat(plugins): pre_goal_turn hook at the kanban goal-loop turn boundary

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -47,6 +47,9 @@ Wire protocol
     # Inject context for pre_llm_call:
     {"context": "Today is Friday"}
 
+    # Rewrite the kanban goal loop's next continuation turn (pre_goal_turn):
+    {"prompt": "Checkpoint your state, then continue", "handed_off": true}
+
     # Silent no-op:
     <empty or any non-matching JSON object>
 
@@ -92,6 +95,21 @@ emitted by each built-in hook site.
     interrupted     – bool, True when the user interrupted
     model           – model name
     platform        – platform identifier
+
+``pre_goal_turn`` (emitted from ``hermes_cli/goals.py``)::
+
+    prompt          – the continuation prompt about to be sent
+    task_id         – kanban task id the goal loop is driving
+    goal_text       – the goal being pursued
+    progress        – the worker's response from the previous turn
+    next_step       – the judge's stated reason for continuing
+    turns_used      – turns spent so far
+    max_turns       – the loop's hard turn budget
+    handoffs_done   – handoffs a hook has reported so far this loop
+    runtime         – resolved probes: context_occupancy (0..1 or absent),
+                      compaction_active (bool).  The loop's session id is
+                      lifted to the top-level ``session_id`` field; control
+                      callables are Python-only and are not exposed here.
 
 ``subagent_stop`` (emitted from ``tools/delegate_tool.py``)::
 
@@ -533,10 +551,51 @@ def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]
     return _callback
 
 
+# ``pre_goal_turn`` hands its callbacks a ``runtime`` dict of best-effort
+# callables.  A subprocess cannot call a Python function, so the read-only
+# probes below are evaluated while rendering the payload and delivered as
+# plain values — without this a shell hook would receive a dict of
+# stringified function reprs and could not see the context budget the hook
+# exists to react to.  Only these keys are ever invoked; control callables
+# (``reset_session_fn``) have no shell equivalent and are dropped rather
+# than called for a side effect the script never asked for.
+_GOAL_TURN_RUNTIME_PROBES = {
+    "context_occupancy_fn": "context_occupancy",
+    "compaction_active_fn": "compaction_active",
+    "session_id_fn": "session_id",
+}
+
+
+def _resolve_goal_turn_runtime(runtime: Any) -> Dict[str, Any]:
+    """Evaluate the read-only ``pre_goal_turn`` runtime probes.
+
+    Each probe is best-effort: a missing, non-callable, or raising entry
+    yields no key at all rather than failing the payload, so a script sees
+    "the loop could not tell me" as an absent field.
+    """
+    if not isinstance(runtime, dict):
+        return {}
+    resolved: Dict[str, Any] = {}
+    for fn_key, value_key in _GOAL_TURN_RUNTIME_PROBES.items():
+        probe = runtime.get(fn_key)
+        if not callable(probe):
+            continue
+        try:
+            resolved[value_key] = probe()
+        except Exception as exc:
+            logger.debug("pre_goal_turn runtime probe %s failed: %s", fn_key, exc)
+    return resolved
+
+
 def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
     """Render the stdin JSON payload.  Unserialisable values are
     stringified via ``default=str`` rather than dropped."""
     extras = {k: v for k, v in kwargs.items() if k not in _TOP_LEVEL_PAYLOAD_KEYS}
+    session_id = kwargs.get("session_id") or kwargs.get("parent_session_id") or ""
+    if event == "pre_goal_turn":
+        runtime = _resolve_goal_turn_runtime(extras.get("runtime"))
+        session_id = session_id or str(runtime.pop("session_id", "") or "")
+        extras["runtime"] = runtime
     try:
         cwd = str(Path.cwd())
     except OSError:
@@ -545,7 +604,7 @@ def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
         "hook_event_name": event,
         "tool_name": kwargs.get("tool_name"),
         "tool_input": kwargs.get("args") if isinstance(kwargs.get("args"), dict) else None,
-        "session_id": kwargs.get("session_id") or kwargs.get("parent_session_id") or "",
+        "session_id": session_id,
         "cwd": cwd,
         "extra": extras,
     }
@@ -576,6 +635,9 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
 
     For ``pre_llm_call``, ``{"context": "..."}`` is passed through
     unchanged to match the existing plugin-hook contract.
+
+    For ``pre_goal_turn``, ``{"prompt": "...", "handed_off": bool}`` is
+    normalised to the shape ``goals.run_kanban_goal_loop`` consumes.
 
     Anything else returns ``None``.
     """
@@ -611,6 +673,17 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
             message = data.get("message") or data.get("reason")
             if isinstance(message, str) and message.strip():
                 return {"action": "continue", "message": message.strip()}
+        return None
+
+    if event == "pre_goal_turn":
+        # Rewrite the goal loop's next continuation prompt.  ``handed_off``
+        # is the hook's own bookkeeping — it is fed back as ``handoffs_done``
+        # on later firings so a hook can bound how often it intervenes.  A
+        # directive without a prompt is a no-op: the loop keeps the prompt it
+        # already had and spends the turn normally.
+        prompt = data.get("prompt")
+        if isinstance(prompt, str) and prompt.strip():
+            return {"prompt": prompt, "handed_off": bool(data.get("handed_off"))}
         return None
 
     context = data.get("context")

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -53,6 +53,9 @@ Wire protocol
     # Modify tool input for pre_tool_call (Claude-Code-style):
     {"decision": "modify", "tool_input": {"new_string": "fixed content"}}
 
+    # Rewrite the kanban goal loop's next continuation turn (pre_goal_turn):
+    {"prompt": "Checkpoint your state, then continue", "handed_off": true}
+
     # Silent no-op:
     <empty or any non-matching JSON object>
 
@@ -120,6 +123,21 @@ emitted by each built-in hook site.
     interrupted     – bool, True when the user interrupted
     model           – model name
     platform        – platform identifier
+
+``pre_goal_turn`` (emitted from ``hermes_cli/goals.py``)::
+
+    prompt          – the continuation prompt about to be sent
+    task_id         – kanban task id the goal loop is driving
+    goal_text       – the goal being pursued
+    progress        – the worker's response from the previous turn
+    next_step       – the judge's stated reason for continuing
+    turns_used      – turns spent so far
+    max_turns       – the loop's hard turn budget
+    handoffs_done   – handoffs a hook has reported so far this loop
+    runtime         – resolved probes: context_occupancy (0..1 or absent),
+                      compaction_active (bool).  The loop's session id is
+                      lifted to the top-level ``session_id`` field; control
+                      callables are Python-only and are not exposed here.
 
 ``subagent_stop`` (emitted from ``tools/delegate_tool.py``)::
 
@@ -739,10 +757,51 @@ def _evaluate_result(
     return parsed
 
 
+# ``pre_goal_turn`` hands its callbacks a ``runtime`` dict of best-effort
+# callables.  A subprocess cannot call a Python function, so the read-only
+# probes below are evaluated while rendering the payload and delivered as
+# plain values — without this a shell hook would receive a dict of
+# stringified function reprs and could not see the context budget the hook
+# exists to react to.  Only these keys are ever invoked; control callables
+# (``reset_session_fn``) have no shell equivalent and are dropped rather
+# than called for a side effect the script never asked for.
+_GOAL_TURN_RUNTIME_PROBES = {
+    "context_occupancy_fn": "context_occupancy",
+    "compaction_active_fn": "compaction_active",
+    "session_id_fn": "session_id",
+}
+
+
+def _resolve_goal_turn_runtime(runtime: Any) -> Dict[str, Any]:
+    """Evaluate the read-only ``pre_goal_turn`` runtime probes.
+
+    Each probe is best-effort: a missing, non-callable, or raising entry
+    yields no key at all rather than failing the payload, so a script sees
+    "the loop could not tell me" as an absent field.
+    """
+    if not isinstance(runtime, dict):
+        return {}
+    resolved: Dict[str, Any] = {}
+    for fn_key, value_key in _GOAL_TURN_RUNTIME_PROBES.items():
+        probe = runtime.get(fn_key)
+        if not callable(probe):
+            continue
+        try:
+            resolved[value_key] = probe()
+        except Exception as exc:
+            logger.debug("pre_goal_turn runtime probe %s failed: %s", fn_key, exc)
+    return resolved
+
+
 def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
     """Render the stdin JSON payload.  Unserialisable values are
     stringified via ``default=str`` rather than dropped."""
     extras = {k: v for k, v in kwargs.items() if k not in _TOP_LEVEL_PAYLOAD_KEYS}
+    session_id = kwargs.get("session_id") or kwargs.get("parent_session_id") or ""
+    if event == "pre_goal_turn":
+        runtime = _resolve_goal_turn_runtime(extras.get("runtime"))
+        session_id = session_id or str(runtime.pop("session_id", "") or "")
+        extras["runtime"] = runtime
     try:
         cwd = str(Path.cwd())
     except OSError:
@@ -751,7 +810,7 @@ def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
         "hook_event_name": event,
         "tool_name": kwargs.get("tool_name"),
         "tool_input": kwargs.get("args") if isinstance(kwargs.get("args"), dict) else None,
-        "session_id": kwargs.get("session_id") or kwargs.get("parent_session_id") or "",
+        "session_id": session_id,
         "cwd": cwd,
         "extra": extras,
     }
@@ -788,6 +847,9 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
 
     For ``pre_llm_call``, ``{"context": "..."}`` is passed through
     unchanged to match the existing plugin-hook contract.
+
+    For ``pre_goal_turn``, ``{"prompt": "...", "handed_off": bool}`` is
+    normalised to the shape ``goals.run_kanban_goal_loop`` consumes.
 
     Anything else returns ``None``.
     """
@@ -832,6 +894,17 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
             message = data.get("message") or data.get("reason")
             if isinstance(message, str) and message.strip():
                 return {"action": "continue", "message": message.strip()}
+        return None
+
+    if event == "pre_goal_turn":
+        # Rewrite the goal loop's next continuation prompt.  ``handed_off``
+        # is the hook's own bookkeeping — it is fed back as ``handoffs_done``
+        # on later firings so a hook can bound how often it intervenes.  A
+        # directive without a prompt is a no-op: the loop keeps the prompt it
+        # already had and spends the turn normally.
+        prompt = data.get("prompt")
+        if isinstance(prompt, str) and prompt.strip():
+            return {"prompt": prompt, "handed_off": bool(data.get("handed_off"))}
         return None
 
     context = data.get("context")

--- a/cli.py
+++ b/cli.py
@@ -16083,6 +16083,26 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
             except Exception:
                 pass
 
+    # Generic runtime surface for the goal loop's pre_goal_turn plugin hook:
+    # live context-window occupancy and fresh-session control on the running
+    # agent. All best-effort — consumers treat a None/raising callable as
+    # "unknown" and skip whatever depends on it.
+    def _context_occupancy() -> "float | None":
+        cc = getattr(cli.agent, "context_compressor", None)
+        if cc is None:
+            return None
+        prompt_tokens = getattr(cc, "last_prompt_tokens", 0) or 0
+        window = getattr(cc, "context_length", 0) or 0
+        # <=0 prompt tokens means unknown (stale, or -1 right after a
+        # compaction reset) — report occupancy as unknown, not 0%.
+        if prompt_tokens <= 0 or window <= 0:
+            return None
+        return float(prompt_tokens) / float(window)
+
+    def _compaction_active() -> bool:
+        cc = getattr(cli.agent, "context_compressor", None)
+        return bool(getattr(cc, "awaiting_real_usage_after_compression", False))
+
     _run_loop(
         task_id=task_id,
         goal_text=goal_text,
@@ -16092,6 +16112,12 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
         max_turns=max_turns,
         first_response=first_response or "",
         log=lambda m: logger.info("%s", m),
+        runtime={
+            "context_occupancy_fn": _context_occupancy,
+            "compaction_active_fn": _compaction_active,
+            "reset_session_fn": lambda: cli.new_session(silent=True),
+            "session_id_fn": lambda: getattr(cli, "session_id", None),
+        },
     )
 
 

--- a/cli.py
+++ b/cli.py
@@ -21040,6 +21040,26 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
             except Exception:
                 pass
 
+    # Generic runtime surface for the goal loop's pre_goal_turn plugin hook:
+    # live context-window occupancy and fresh-session control on the running
+    # agent. All best-effort — consumers treat a None/raising callable as
+    # "unknown" and skip whatever depends on it.
+    def _context_occupancy() -> "float | None":
+        cc = getattr(cli.agent, "context_compressor", None)
+        if cc is None:
+            return None
+        prompt_tokens = getattr(cc, "last_prompt_tokens", 0) or 0
+        window = getattr(cc, "context_length", 0) or 0
+        # <=0 prompt tokens means unknown (stale, or -1 right after a
+        # compaction reset) — report occupancy as unknown, not 0%.
+        if prompt_tokens <= 0 or window <= 0:
+            return None
+        return float(prompt_tokens) / float(window)
+
+    def _compaction_active() -> bool:
+        cc = getattr(cli.agent, "context_compressor", None)
+        return bool(getattr(cc, "awaiting_real_usage_after_compression", False))
+
     _run_loop(
         task_id=task_id,
         goal_text=goal_text,
@@ -21049,6 +21069,12 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
         max_turns=max_turns,
         first_response=first_response or "",
         log=lambda m: logger.info("%s", m),
+        runtime={
+            "context_occupancy_fn": _context_occupancy,
+            "compaction_active_fn": _compaction_active,
+            "reset_session_fn": lambda: cli.new_session(silent=True),
+            "session_id_fn": lambda: getattr(cli, "session_id", None),
+        },
     )
 
 

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1669,6 +1669,7 @@ def run_kanban_goal_loop(
     max_turns: int = DEFAULT_MAX_TURNS,
     first_response: str = "",
     log=None,
+    runtime=None,
 ) -> Dict[str, Any]:
     """Drive a kanban worker through a Ralph-style goal loop.
 
@@ -1693,6 +1694,16 @@ def run_kanban_goal_loop(
     (str -> str), ``task_status_fn`` (() -> str|None), and ``block_fn``
     (reason: str -> None).
 
+    ``runtime`` is an optional dict of best-effort introspection/control
+    callables supplied by the caller (e.g. ``context_occupancy_fn``,
+    ``compaction_active_fn``, ``reset_session_fn``, ``session_id_fn``). It is
+    passed verbatim to the ``pre_goal_turn`` plugin hook, which fires before
+    each continuation turn and may return ``{"prompt": str, "handed_off":
+    bool}`` to rewrite the continuation prompt and/or note that it moved the
+    loop to a fresh session (a context-budget handoff). The finalize nudge is
+    a one-shot and is never intercepted; every hook failure degrades to a
+    normal in-session turn.
+
     Returns a decision dict: ``{"outcome", "turns_used", "reason"}`` where
     outcome is one of ``"completed_by_worker"``, ``"blocked_budget"``,
     ``"blocked_by_worker"``, or ``"stopped"``.
@@ -1713,6 +1724,7 @@ def run_kanban_goal_loop(
     # The first turn already consumed one unit of budget.
     turns_used = 1
     nudged_to_finalize = False
+    handoffs_done = 0
 
     while True:
         # Did the worker terminate the task itself this turn?
@@ -1773,7 +1785,41 @@ def run_kanban_goal_loop(
                 _log(f"kanban goal loop: block_fn failed ({exc})")
             return {"outcome": "blocked_budget", "turns_used": turns_used, "reason": "turn budget exhausted"}
 
-        # Run another turn in the same session.
+        # Plugin turn-boundary hook: before spending another CONTINUATION
+        # turn, let a plugin rewrite the continuation prompt and/or move the
+        # loop to a fresh session (e.g. a context-budget handoff that
+        # checkpoints worker state when the live window nears capacity, so
+        # the loop resumes with a clean window instead of riding this one
+        # down into repeated compaction). The finalize nudge (verdict ==
+        # "done") is a one-shot and is never intercepted. Fail-open: any
+        # hook error leaves ``prompt`` unchanged and runs the turn in the
+        # same session — the turn budget above stays the hard last line.
+        if verdict != "done":
+            try:
+                from hermes_cli.plugins import has_hook, invoke_hook
+                if has_hook("pre_goal_turn"):
+                    for ret in invoke_hook(
+                        "pre_goal_turn",
+                        prompt=prompt,
+                        task_id=task_id,
+                        goal_text=goal_text,
+                        progress=last_response,
+                        next_step=reason,
+                        turns_used=turns_used,
+                        max_turns=max_turns,
+                        handoffs_done=handoffs_done,
+                        runtime=runtime or {},
+                    ):
+                        if isinstance(ret, dict) and ret.get("prompt"):
+                            prompt = str(ret["prompt"])
+                            if ret.get("handed_off"):
+                                handoffs_done += 1
+                            break
+            except Exception as exc:
+                _log(f"kanban goal loop: pre_goal_turn hook failed ({exc}); continuing in-session")
+
+        # Run another turn (in the same session, or the fresh one a hook
+        # switched to).
         try:
             last_response = run_turn(prompt) or ""
         except Exception as exc:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -2175,6 +2175,7 @@ def run_kanban_goal_loop(
     max_turns: int = DEFAULT_MAX_TURNS,
     first_response: str = "",
     log=None,
+    runtime=None,
 ) -> Dict[str, Any]:
     """Drive a kanban worker through a Ralph-style goal loop.
 
@@ -2199,6 +2200,16 @@ def run_kanban_goal_loop(
     (str -> str), ``task_status_fn`` (() -> str|None), and ``block_fn``
     (reason: str -> None).
 
+    ``runtime`` is an optional dict of best-effort introspection/control
+    callables supplied by the caller (e.g. ``context_occupancy_fn``,
+    ``compaction_active_fn``, ``reset_session_fn``, ``session_id_fn``). It is
+    passed verbatim to the ``pre_goal_turn`` plugin hook, which fires before
+    each continuation turn and may return ``{"prompt": str, "handed_off":
+    bool}`` to rewrite the continuation prompt and/or note that it moved the
+    loop to a fresh session (a context-budget handoff). The finalize nudge is
+    a one-shot and is never intercepted; every hook failure degrades to a
+    normal in-session turn.
+
     Returns a decision dict: ``{"outcome", "turns_used", "reason"}`` where
     outcome is one of ``"completed_by_worker"``, ``"review_requested_by_worker"``,
     ``"changes_requested_by_reviewer"``, ``"blocked_budget"``,
@@ -2220,6 +2231,7 @@ def run_kanban_goal_loop(
     # The first turn already consumed one unit of budget.
     turns_used = 1
     nudged_to_finalize = False
+    handoffs_done = 0
 
     while True:
         # Did the worker terminate the task itself this turn?
@@ -2289,7 +2301,41 @@ def run_kanban_goal_loop(
                 _log(f"kanban goal loop: block_fn failed ({exc})")
             return {"outcome": "blocked_budget", "turns_used": turns_used, "reason": "turn budget exhausted"}
 
-        # Run another turn in the same session.
+        # Plugin turn-boundary hook: before spending another CONTINUATION
+        # turn, let a plugin rewrite the continuation prompt and/or move the
+        # loop to a fresh session (e.g. a context-budget handoff that
+        # checkpoints worker state when the live window nears capacity, so
+        # the loop resumes with a clean window instead of riding this one
+        # down into repeated compaction). The finalize nudge (verdict ==
+        # "done") is a one-shot and is never intercepted. Fail-open: any
+        # hook error leaves ``prompt`` unchanged and runs the turn in the
+        # same session — the turn budget above stays the hard last line.
+        if verdict != "done":
+            try:
+                from hermes_cli.plugins import has_hook, invoke_hook
+                if has_hook("pre_goal_turn"):
+                    for ret in invoke_hook(
+                        "pre_goal_turn",
+                        prompt=prompt,
+                        task_id=task_id,
+                        goal_text=goal_text,
+                        progress=last_response,
+                        next_step=reason,
+                        turns_used=turns_used,
+                        max_turns=max_turns,
+                        handoffs_done=handoffs_done,
+                        runtime=runtime or {},
+                    ):
+                        if isinstance(ret, dict) and ret.get("prompt"):
+                            prompt = str(ret["prompt"])
+                            if ret.get("handed_off"):
+                                handoffs_done += 1
+                            break
+            except Exception as exc:
+                _log(f"kanban goal loop: pre_goal_turn hook failed ({exc}); continuing in-session")
+
+        # Run another turn (in the same session, or the fresh one a hook
+        # switched to).
         try:
             last_response = run_turn(prompt) or ""
         except Exception as exc:

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -166,6 +166,24 @@ _DEFAULT_PAYLOADS = {
         "final_response": "All done — the change is applied.",
         "changed_paths": ["src/app.tsx"],
     },
+    "pre_goal_turn": {
+        "prompt": "Continue working toward the goal.",
+        "task_id": "test-task",
+        "goal_text": "Ship the feature",
+        "progress": "Wrote the module; two tests still failing.",
+        "next_step": "Fix the failing tests.",
+        "turns_used": 3,
+        "max_turns": 12,
+        "handoffs_done": 0,
+        # Callables, exactly as the live goal loop passes them — the
+        # serializer resolves the read-only probes, so a dry run shows the
+        # script the same resolved values it will see at runtime.
+        "runtime": {
+            "context_occupancy_fn": lambda: 0.62,
+            "compaction_active_fn": lambda: False,
+            "session_id_fn": lambda: "test-session",
+        },
+    },
     "on_session_start": {"session_id": "test-session"},
     "on_session_end": {
         "session_id": "test-session",

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -148,6 +148,24 @@ _DEFAULT_PAYLOADS = {
         "final_response": "All done — the change is applied.",
         "changed_paths": ["src/app.tsx"],
     },
+    "pre_goal_turn": {
+        "prompt": "Continue working toward the goal.",
+        "task_id": "test-task",
+        "goal_text": "Ship the feature",
+        "progress": "Wrote the module; two tests still failing.",
+        "next_step": "Fix the failing tests.",
+        "turns_used": 3,
+        "max_turns": 12,
+        "handoffs_done": 0,
+        # Callables, exactly as the live goal loop passes them — the
+        # serializer resolves the read-only probes, so a dry run shows the
+        # script the same resolved values it will see at runtime.
+        "runtime": {
+            "context_occupancy_fn": lambda: 0.62,
+            "compaction_active_fn": lambda: False,
+            "session_id_fn": lambda: "test-session",
+        },
+    },
     "on_session_start": {"session_id": "test-session"},
     "on_session_end": {"session_id": "test-session"},
     "on_session_finalize": {"session_id": "test-session"},

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -154,6 +154,17 @@ VALID_HOOKS: Set[str] = {
     # verification-stop nudge; this hook is for user/plugin policy and is
     # bounded by agent.max_verify_nudges.
     "pre_verify",
+    # Kanban goal-loop turn boundary. Fired by goals.run_kanban_goal_loop
+    # before each CONTINUATION turn (never the one-shot finalize nudge).
+    # Kwargs: prompt, task_id, goal_text, progress, next_step, turns_used,
+    # max_turns, handoffs_done, runtime (caller-supplied dict of best-effort
+    # callables: context_occupancy_fn, compaction_active_fn,
+    # reset_session_fn, session_id_fn). A callback may return
+    #   {"prompt": "<replacement continuation prompt>", "handed_off": bool}
+    # to rewrite the prompt and/or record that it moved the loop to a fresh
+    # session (context-budget handoff). First such dict wins; None/other
+    # shapes leave the turn unchanged.
+    "pre_goal_turn",
     "pre_api_request",
     "post_api_request",
     "api_request_error",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -187,6 +187,17 @@ VALID_HOOKS: Set[str] = {
     # verification-stop nudge; this hook is for user/plugin policy and is
     # bounded by agent.max_verify_nudges.
     "pre_verify",
+    # Kanban goal-loop turn boundary. Fired by goals.run_kanban_goal_loop
+    # before each CONTINUATION turn (never the one-shot finalize nudge).
+    # Kwargs: prompt, task_id, goal_text, progress, next_step, turns_used,
+    # max_turns, handoffs_done, runtime (caller-supplied dict of best-effort
+    # callables: context_occupancy_fn, compaction_active_fn,
+    # reset_session_fn, session_id_fn). A callback may return
+    #   {"prompt": "<replacement continuation prompt>", "handed_off": bool}
+    # to rewrite the prompt and/or record that it moved the loop to a fresh
+    # session (context-budget handoff). First such dict wins; None/other
+    # shapes leave the turn unchanged.
+    "pre_goal_turn",
     "pre_api_request",
     "post_api_request",
     "api_request_error",

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -64,6 +64,32 @@ class TestParseResponse:
 
 
 
+    def test_pre_goal_turn_prompt_rewrite(self):
+        r = shell_hooks._parse_response(
+            "pre_goal_turn", '{"prompt": "checkpoint, then continue"}',
+        )
+        assert r == {"prompt": "checkpoint, then continue", "handed_off": False}
+
+    def test_pre_goal_turn_handoff_flag_preserved(self):
+        r = shell_hooks._parse_response(
+            "pre_goal_turn", '{"prompt": "fresh start", "handed_off": true}',
+        )
+        assert r == {"prompt": "fresh start", "handed_off": True}
+
+    def test_pre_goal_turn_without_prompt_is_noop(self):
+        # Nothing to rewrite the turn with — the loop keeps its own prompt.
+        assert shell_hooks._parse_response("pre_goal_turn", '{"handed_off": true}') is None
+        assert shell_hooks._parse_response("pre_goal_turn", '{"prompt": "  "}') is None
+        assert shell_hooks._parse_response("pre_goal_turn", '{"prompt": 42}') is None
+
+    def test_pre_goal_turn_prompt_ignored_for_other_events(self):
+        """Only pre_goal_turn honors prompt directives."""
+        assert shell_hooks._parse_response("pre_llm_call", '{"prompt": "x"}') is None
+
+    def test_block_action_without_message_uses_default(self):
+        """Block is honored even when message/reason is absent."""
+        r = shell_hooks._parse_response("pre_tool_call", '{"action": "block"}')
+        assert r == {"action": "block", "message": shell_hooks._DEFAULT_BLOCK_MESSAGE}
 
 
 
@@ -102,6 +128,69 @@ class TestSerializePayload:
         assert payload["tool_input"] is None
 
 
+    def test_pre_goal_turn_runtime_probes_resolved(self):
+        """A subprocess can't call a Python callable, so the read-only
+        probes are evaluated into plain values and the session id is
+        lifted to the top-level payload field."""
+        raw = shell_hooks._serialize_payload(
+            "pre_goal_turn",
+            {
+                "prompt": "keep going",
+                "turns_used": 3,
+                "runtime": {
+                    "context_occupancy_fn": lambda: 0.82,
+                    "compaction_active_fn": lambda: False,
+                    "session_id_fn": lambda: "sess-goal",
+                },
+            },
+        )
+        payload = json.loads(raw)
+        assert payload["session_id"] == "sess-goal"
+        assert payload["extra"]["prompt"] == "keep going"
+        assert payload["extra"]["turns_used"] == 3
+        assert payload["extra"]["runtime"] == {
+            "context_occupancy": 0.82,
+            "compaction_active": False,
+        }
+
+    def test_pre_goal_turn_control_callables_not_invoked(self):
+        """Only read-only probes are called while rendering the payload —
+        rendering must never reset the caller's session."""
+        called = []
+        raw = shell_hooks._serialize_payload(
+            "pre_goal_turn",
+            {"runtime": {"reset_session_fn": lambda: called.append("reset")}},
+        )
+        assert called == []
+        assert json.loads(raw)["extra"]["runtime"] == {}
+
+    def test_pre_goal_turn_failing_probe_omits_key(self):
+        def boom():
+            raise RuntimeError("no compressor")
+
+        raw = shell_hooks._serialize_payload(
+            "pre_goal_turn",
+            {"runtime": {"context_occupancy_fn": boom,
+                         "compaction_active_fn": lambda: True}},
+        )
+        runtime = json.loads(raw)["extra"]["runtime"]
+        assert "context_occupancy" not in runtime
+        assert runtime["compaction_active"] is True
+
+    def test_pre_goal_turn_missing_runtime_is_empty_dict(self):
+        raw = shell_hooks._serialize_payload("pre_goal_turn", {"prompt": "go"})
+        assert json.loads(raw)["extra"]["runtime"] == {}
+
+    def test_unserialisable_extras_stringified(self):
+        class Weird:
+            def __repr__(self) -> str:
+                return "<weird>"
+
+        raw = shell_hooks._serialize_payload(
+            "on_session_start", {"obj": Weird()},
+        )
+        payload = json.loads(raw)
+        assert payload["extra"]["obj"] == "<weird>"
 
 
 # ── Matcher behaviour ─────────────────────────────────────────────────────

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -115,6 +115,28 @@ class TestParseResponse:
         assert shell_hooks._parse_response("pre_verify", '{"action": "continue"}') is None
         assert shell_hooks._parse_response("pre_verify", '{"decision": "allow"}') is None
 
+    def test_pre_goal_turn_prompt_rewrite(self):
+        r = shell_hooks._parse_response(
+            "pre_goal_turn", '{"prompt": "checkpoint, then continue"}',
+        )
+        assert r == {"prompt": "checkpoint, then continue", "handed_off": False}
+
+    def test_pre_goal_turn_handoff_flag_preserved(self):
+        r = shell_hooks._parse_response(
+            "pre_goal_turn", '{"prompt": "fresh start", "handed_off": true}',
+        )
+        assert r == {"prompt": "fresh start", "handed_off": True}
+
+    def test_pre_goal_turn_without_prompt_is_noop(self):
+        # Nothing to rewrite the turn with — the loop keeps its own prompt.
+        assert shell_hooks._parse_response("pre_goal_turn", '{"handed_off": true}') is None
+        assert shell_hooks._parse_response("pre_goal_turn", '{"prompt": "  "}') is None
+        assert shell_hooks._parse_response("pre_goal_turn", '{"prompt": 42}') is None
+
+    def test_pre_goal_turn_prompt_ignored_for_other_events(self):
+        """Only pre_goal_turn honors prompt directives."""
+        assert shell_hooks._parse_response("pre_llm_call", '{"prompt": "x"}') is None
+
     def test_block_action_without_message_uses_default(self):
         """Block is honored even when message/reason is absent."""
         r = shell_hooks._parse_response("pre_tool_call", '{"action": "block"}')
@@ -178,6 +200,59 @@ class TestSerializePayload:
         )
         payload = json.loads(raw)
         assert payload["session_id"] == "p-1"
+
+    def test_pre_goal_turn_runtime_probes_resolved(self):
+        """A subprocess can't call a Python callable, so the read-only
+        probes are evaluated into plain values and the session id is
+        lifted to the top-level payload field."""
+        raw = shell_hooks._serialize_payload(
+            "pre_goal_turn",
+            {
+                "prompt": "keep going",
+                "turns_used": 3,
+                "runtime": {
+                    "context_occupancy_fn": lambda: 0.82,
+                    "compaction_active_fn": lambda: False,
+                    "session_id_fn": lambda: "sess-goal",
+                },
+            },
+        )
+        payload = json.loads(raw)
+        assert payload["session_id"] == "sess-goal"
+        assert payload["extra"]["prompt"] == "keep going"
+        assert payload["extra"]["turns_used"] == 3
+        assert payload["extra"]["runtime"] == {
+            "context_occupancy": 0.82,
+            "compaction_active": False,
+        }
+
+    def test_pre_goal_turn_control_callables_not_invoked(self):
+        """Only read-only probes are called while rendering the payload —
+        rendering must never reset the caller's session."""
+        called = []
+        raw = shell_hooks._serialize_payload(
+            "pre_goal_turn",
+            {"runtime": {"reset_session_fn": lambda: called.append("reset")}},
+        )
+        assert called == []
+        assert json.loads(raw)["extra"]["runtime"] == {}
+
+    def test_pre_goal_turn_failing_probe_omits_key(self):
+        def boom():
+            raise RuntimeError("no compressor")
+
+        raw = shell_hooks._serialize_payload(
+            "pre_goal_turn",
+            {"runtime": {"context_occupancy_fn": boom,
+                         "compaction_active_fn": lambda: True}},
+        )
+        runtime = json.loads(raw)["extra"]["runtime"]
+        assert "context_occupancy" not in runtime
+        assert runtime["compaction_active"] is True
+
+    def test_pre_goal_turn_missing_runtime_is_empty_dict(self):
+        raw = shell_hooks._serialize_payload("pre_goal_turn", {"prompt": "go"})
+        assert json.loads(raw)["extra"]["runtime"] == {}
 
     def test_unserialisable_extras_stringified(self):
         class Weird:

--- a/tests/hermes_cli/test_goals_pre_goal_turn.py
+++ b/tests/hermes_cli/test_goals_pre_goal_turn.py
@@ -1,0 +1,97 @@
+"""``pre_goal_turn`` hook at the kanban goal-loop turn boundary.
+
+Fired before each CONTINUATION turn (never the one-shot finalize nudge) with
+the loop's state and the caller's runtime dict. A callback may return
+``{"prompt": ..., "handed_off": bool}`` to rewrite the continuation prompt
+and/or record a context-budget handoff to a fresh session; a raising hook
+degrades to a normal in-session turn.
+"""
+from hermes_cli import goals
+from hermes_cli.plugins import VALID_HOOKS, get_plugin_manager
+
+
+def test_pre_goal_turn_is_a_valid_hook():
+    assert "pre_goal_turn" in VALID_HOOKS
+
+
+def _run_loop(monkeypatch, verdicts, hook, max_turns=6, statuses=None):
+    """Drive the loop with scripted judge verdicts and a test hook."""
+    state = {"prompts": [], "judge_i": 0, "turn_i": 0}
+
+    def fake_judge(goal_text, response):
+        i = min(state["judge_i"], len(verdicts) - 1)
+        state["judge_i"] += 1
+        # (verdict, reason, parse_failed, wait, transport_failed)
+        return verdicts[i], f"scripted verdict #{i}", False, False, False
+
+    def fake_status():
+        state["turn_i"] += 1
+        if statuses:
+            return statuses[min(state["turn_i"] - 1, len(statuses) - 1)]
+        return "done" if state["judge_i"] >= len(verdicts) else "running"
+
+    monkeypatch.setattr(goals, "judge_goal", fake_judge)
+    mgr = get_plugin_manager()
+    saved = list(mgr._hooks.get("pre_goal_turn", []))
+    mgr._hooks["pre_goal_turn"] = [hook] if hook else []
+    try:
+        result = goals.run_kanban_goal_loop(
+            task_id="t_test", goal_text="do the thing",
+            run_turn=lambda p: state["prompts"].append(p) or "worked on it",
+            task_status_fn=fake_status, block_fn=lambda r: None,
+            max_turns=max_turns, first_response="first",
+            runtime={"marker": "RUNTIME-OK"},
+        )
+    finally:
+        mgr._hooks["pre_goal_turn"] = saved
+    return result, state
+
+
+def test_hook_fires_per_continuation_turn_with_state(monkeypatch):
+    captured = []
+    result, _state = _run_loop(
+        monkeypatch, ["continue", "continue"],
+        lambda **kw: captured.append(kw))
+
+    assert result["outcome"] == "completed_by_worker"
+    assert len(captured) == 2
+    payload = captured[0]
+    assert payload["task_id"] == "t_test"
+    assert payload["goal_text"] == "do the thing"
+    assert payload["progress"] == "first"
+    assert payload["handoffs_done"] == 0
+    assert payload["runtime"]["marker"] == "RUNTIME-OK"
+
+
+def test_finalize_nudge_is_never_intercepted(monkeypatch):
+    captured = []
+    _run_loop(monkeypatch, ["done"], lambda **kw: captured.append(kw),
+              statuses=["running", "done"])
+    assert captured == []
+
+
+def test_prompt_rewrite_and_handoff_accounting(monkeypatch):
+    captured = []
+
+    def handoff_hook(**kw):
+        captured.append(kw)
+        if len(captured) == 1:
+            return {"prompt": "FRESH-SESSION PROMPT", "handed_off": True}
+        return None
+
+    _result, state = _run_loop(
+        monkeypatch, ["continue", "continue"], handoff_hook)
+
+    assert state["prompts"][0] == "FRESH-SESSION PROMPT"
+    assert len(captured) == 2
+    assert captured[1]["handoffs_done"] == 1
+
+
+def test_raising_hook_degrades_to_in_session_turn(monkeypatch):
+    def boom(**kw):
+        raise RuntimeError("boom")
+
+    result, state = _run_loop(monkeypatch, ["continue", "continue"], boom)
+    assert result["outcome"] == "completed_by_worker"
+    assert len(state["prompts"]) >= 1
+    assert state["prompts"][0] != "FRESH-SESSION PROMPT"

--- a/tests/hermes_cli/test_goals_pre_goal_turn.py
+++ b/tests/hermes_cli/test_goals_pre_goal_turn.py
@@ -1,0 +1,176 @@
+"""``pre_goal_turn`` hook at the kanban goal-loop turn boundary.
+
+Fired before each CONTINUATION turn (never the one-shot finalize nudge) with
+the loop's state and the caller's runtime dict. A callback may return
+``{"prompt": ..., "handed_off": bool}`` to rewrite the continuation prompt
+and/or record a context-budget handoff to a fresh session; a raising hook
+degrades to a normal in-session turn.
+
+The last test drives the same loop through a real configured shell hook —
+subprocess, JSON wire protocol and all — so the Python-plugin and shell-hook
+surfaces are proven to reach the loop the same way.
+"""
+import sys
+
+from hermes_cli import goals
+from hermes_cli.plugins import VALID_HOOKS, get_plugin_manager
+
+# Sentinel for _run_loop: leave whatever is already registered in place
+# (as opposed to None, which clears the hook for the duration of the run).
+_KEEP_REGISTERED = object()
+
+
+def test_pre_goal_turn_is_a_valid_hook():
+    assert "pre_goal_turn" in VALID_HOOKS
+
+
+def _run_loop(monkeypatch, verdicts, hook, max_turns=6, statuses=None,
+              runtime=None):
+    """Drive the loop with scripted judge verdicts and a test hook."""
+    state = {"prompts": [], "judge_i": 0, "turn_i": 0}
+
+    def fake_judge(goal_text, response):
+        i = min(state["judge_i"], len(verdicts) - 1)
+        state["judge_i"] += 1
+        # (verdict, reason, parse_failed, wait, transport_failed)
+        return verdicts[i], f"scripted verdict #{i}", False, False, False
+
+    def fake_status():
+        state["turn_i"] += 1
+        if statuses:
+            return statuses[min(state["turn_i"] - 1, len(statuses) - 1)]
+        return "done" if state["judge_i"] >= len(verdicts) else "running"
+
+    monkeypatch.setattr(goals, "judge_goal", fake_judge)
+    mgr = get_plugin_manager()
+    saved = list(mgr._hooks.get("pre_goal_turn", []))
+    if hook is not _KEEP_REGISTERED:
+        mgr._hooks["pre_goal_turn"] = [hook] if hook else []
+    try:
+        result = goals.run_kanban_goal_loop(
+            task_id="t_test", goal_text="do the thing",
+            run_turn=lambda p: state["prompts"].append(p) or "worked on it",
+            task_status_fn=fake_status, block_fn=lambda r: None,
+            max_turns=max_turns, first_response="first",
+            runtime=runtime if runtime is not None else {"marker": "RUNTIME-OK"},
+        )
+    finally:
+        mgr._hooks["pre_goal_turn"] = saved
+    return result, state
+
+
+def test_hook_fires_per_continuation_turn_with_state(monkeypatch):
+    captured = []
+    result, _state = _run_loop(
+        monkeypatch, ["continue", "continue"],
+        lambda **kw: captured.append(kw))
+
+    assert result["outcome"] == "completed_by_worker"
+    assert len(captured) == 2
+    payload = captured[0]
+    assert payload["task_id"] == "t_test"
+    assert payload["goal_text"] == "do the thing"
+    assert payload["progress"] == "first"
+    assert payload["handoffs_done"] == 0
+    assert payload["runtime"]["marker"] == "RUNTIME-OK"
+
+
+def test_finalize_nudge_is_never_intercepted(monkeypatch):
+    captured = []
+    _run_loop(monkeypatch, ["done"], lambda **kw: captured.append(kw),
+              statuses=["running", "done"])
+    assert captured == []
+
+
+def test_prompt_rewrite_and_handoff_accounting(monkeypatch):
+    captured = []
+
+    def handoff_hook(**kw):
+        captured.append(kw)
+        if len(captured) == 1:
+            return {"prompt": "FRESH-SESSION PROMPT", "handed_off": True}
+        return None
+
+    _result, state = _run_loop(
+        monkeypatch, ["continue", "continue"], handoff_hook)
+
+    assert state["prompts"][0] == "FRESH-SESSION PROMPT"
+    assert len(captured) == 2
+    assert captured[1]["handoffs_done"] == 1
+
+
+def test_raising_hook_degrades_to_in_session_turn(monkeypatch):
+    def boom(**kw):
+        raise RuntimeError("boom")
+
+    result, state = _run_loop(monkeypatch, ["continue", "continue"], boom)
+    assert result["outcome"] == "completed_by_worker"
+    assert len(state["prompts"]) >= 1
+    assert state["prompts"][0] != "FRESH-SESSION PROMPT"
+
+
+_HANDOFF_SCRIPT = '''#!/usr/bin/env python3
+"""Context-budget handoff hook, written the way a user would write one."""
+import json
+import sys
+
+payload = json.load(sys.stdin)
+extra = payload["extra"]
+occupancy = extra["runtime"].get("context_occupancy")
+
+if occupancy is not None and occupancy >= 0.8 and not extra["handoffs_done"]:
+    print(json.dumps({
+        "prompt": "HANDOFF session=%s occupancy=%.2f turn=%d :: %s" % (
+            payload["session_id"], occupancy, extra["turns_used"],
+            extra["next_step"],
+        ),
+        "handed_off": True,
+    }))
+'''
+
+
+def test_configured_shell_hook_steers_the_loop(monkeypatch, tmp_path):
+    """A `hooks:` entry in config.yaml reaches the goal loop.
+
+    Real subprocess, real JSON wire protocol, real registration path — the
+    script reads the resolved context occupancy out of the payload and its
+    stdout directive replaces the loop's next continuation prompt.
+    """
+    from agent import shell_hooks
+    from hermes_cli import plugins
+
+    script = tmp_path / "handoff.py"
+    script.write_text(_HANDOFF_SCRIPT)
+    script.chmod(0o755)
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("HERMES_ACCEPT_HOOKS", "1")
+    monkeypatch.setattr(plugins, "_plugin_manager", plugins.PluginManager())
+    shell_hooks.reset_for_tests()
+
+    registered = shell_hooks.register_from_config(
+        {"hooks": {"pre_goal_turn": [
+            {"command": f"{sys.executable} {script}"},
+        ]}},
+        accept_hooks=True,
+    )
+    assert len(registered) == 1
+
+    try:
+        _result, state = _run_loop(
+            monkeypatch, ["continue", "continue"], _KEEP_REGISTERED,
+            runtime={
+                "context_occupancy_fn": lambda: 0.91,
+                "compaction_active_fn": lambda: False,
+                "session_id_fn": lambda: "sess-goal",
+                "reset_session_fn": lambda: None,
+            },
+        )
+    finally:
+        shell_hooks.reset_for_tests()
+
+    assert state["prompts"][0] == (
+        "HANDOFF session=sess-goal occupancy=0.91 turn=1 :: scripted verdict #0"
+    )
+    # handoffs_done fed back to the script, which then stands down.
+    assert not state["prompts"][1].startswith("HANDOFF")

--- a/tests/hermes_cli/test_goals_pre_goal_turn.py
+++ b/tests/hermes_cli/test_goals_pre_goal_turn.py
@@ -5,16 +5,27 @@ the loop's state and the caller's runtime dict. A callback may return
 ``{"prompt": ..., "handed_off": bool}`` to rewrite the continuation prompt
 and/or record a context-budget handoff to a fresh session; a raising hook
 degrades to a normal in-session turn.
+
+The last test drives the same loop through a real configured shell hook —
+subprocess, JSON wire protocol and all — so the Python-plugin and shell-hook
+surfaces are proven to reach the loop the same way.
 """
+import sys
+
 from hermes_cli import goals
 from hermes_cli.plugins import VALID_HOOKS, get_plugin_manager
+
+# Sentinel for _run_loop: leave whatever is already registered in place
+# (as opposed to None, which clears the hook for the duration of the run).
+_KEEP_REGISTERED = object()
 
 
 def test_pre_goal_turn_is_a_valid_hook():
     assert "pre_goal_turn" in VALID_HOOKS
 
 
-def _run_loop(monkeypatch, verdicts, hook, max_turns=6, statuses=None):
+def _run_loop(monkeypatch, verdicts, hook, max_turns=6, statuses=None,
+              runtime=None):
     """Drive the loop with scripted judge verdicts and a test hook."""
     state = {"prompts": [], "judge_i": 0, "turn_i": 0}
 
@@ -33,14 +44,15 @@ def _run_loop(monkeypatch, verdicts, hook, max_turns=6, statuses=None):
     monkeypatch.setattr(goals, "judge_goal", fake_judge)
     mgr = get_plugin_manager()
     saved = list(mgr._hooks.get("pre_goal_turn", []))
-    mgr._hooks["pre_goal_turn"] = [hook] if hook else []
+    if hook is not _KEEP_REGISTERED:
+        mgr._hooks["pre_goal_turn"] = [hook] if hook else []
     try:
         result = goals.run_kanban_goal_loop(
             task_id="t_test", goal_text="do the thing",
             run_turn=lambda p: state["prompts"].append(p) or "worked on it",
             task_status_fn=fake_status, block_fn=lambda r: None,
             max_turns=max_turns, first_response="first",
-            runtime={"marker": "RUNTIME-OK"},
+            runtime=runtime if runtime is not None else {"marker": "RUNTIME-OK"},
         )
     finally:
         mgr._hooks["pre_goal_turn"] = saved
@@ -95,3 +107,70 @@ def test_raising_hook_degrades_to_in_session_turn(monkeypatch):
     assert result["outcome"] == "completed_by_worker"
     assert len(state["prompts"]) >= 1
     assert state["prompts"][0] != "FRESH-SESSION PROMPT"
+
+
+_HANDOFF_SCRIPT = '''#!/usr/bin/env python3
+"""Context-budget handoff hook, written the way a user would write one."""
+import json
+import sys
+
+payload = json.load(sys.stdin)
+extra = payload["extra"]
+occupancy = extra["runtime"].get("context_occupancy")
+
+if occupancy is not None and occupancy >= 0.8 and not extra["handoffs_done"]:
+    print(json.dumps({
+        "prompt": "HANDOFF session=%s occupancy=%.2f turn=%d :: %s" % (
+            payload["session_id"], occupancy, extra["turns_used"],
+            extra["next_step"],
+        ),
+        "handed_off": True,
+    }))
+'''
+
+
+def test_configured_shell_hook_steers_the_loop(monkeypatch, tmp_path):
+    """A `hooks:` entry in config.yaml reaches the goal loop.
+
+    Real subprocess, real JSON wire protocol, real registration path — the
+    script reads the resolved context occupancy out of the payload and its
+    stdout directive replaces the loop's next continuation prompt.
+    """
+    from agent import shell_hooks
+    from hermes_cli import plugins
+
+    script = tmp_path / "handoff.py"
+    script.write_text(_HANDOFF_SCRIPT)
+    script.chmod(0o755)
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("HERMES_ACCEPT_HOOKS", "1")
+    monkeypatch.setattr(plugins, "_plugin_manager", plugins.PluginManager())
+    shell_hooks.reset_for_tests()
+
+    registered = shell_hooks.register_from_config(
+        {"hooks": {"pre_goal_turn": [
+            {"command": f"{sys.executable} {script}"},
+        ]}},
+        accept_hooks=True,
+    )
+    assert len(registered) == 1
+
+    try:
+        _result, state = _run_loop(
+            monkeypatch, ["continue", "continue"], _KEEP_REGISTERED,
+            runtime={
+                "context_occupancy_fn": lambda: 0.91,
+                "compaction_active_fn": lambda: False,
+                "session_id_fn": lambda: "sess-goal",
+                "reset_session_fn": lambda: None,
+            },
+        )
+    finally:
+        shell_hooks.reset_for_tests()
+
+    assert state["prompts"][0] == (
+        "HANDOFF session=sess-goal occupancy=0.91 turn=1 :: scripted verdict #0"
+    )
+    # handoffs_done fed back to the script, which then stands down.
+    assert not state["prompts"][1].startswith("HANDOFF")

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -111,6 +111,31 @@ class TestHooksTest:
         assert seen["tool_name"] is None
         assert seen["tool_input"] is None
 
+    def test_pre_goal_turn_dry_run_resolves_runtime_probes(self, tmp_path):
+        """A goal-turn hook must be dry-runnable: the synthetic payload
+        carries the same callables the live loop passes, so the script sees
+        resolved values rather than function reprs it can't read."""
+        capture = tmp_path / "goal.json"
+        script = _hook_script(
+            tmp_path,
+            f"#!/usr/bin/env bash\ncat - > {capture}\nprintf '{{}}\\n'\n",
+            name="goal.sh",
+        )
+        cfg = {"hooks": {"pre_goal_turn": [{"command": str(script)}]}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            _run(SimpleNamespace(
+                hooks_action="test", event="pre_goal_turn",
+                for_tool=None, payload_file=None,
+            ))
+
+        seen = json.loads(capture.read_text())
+        assert seen["session_id"] == "test-session"
+        runtime = seen["extra"]["runtime"]
+        assert isinstance(runtime["context_occupancy"], float)
+        assert runtime["compaction_active"] is False
+        assert seen["extra"]["handoffs_done"] == 0
+        assert seen["extra"]["prompt"]
+
     def test_fires_real_subprocess_and_parses_block(self, tmp_path):
         block_script = _hook_script(
             tmp_path,

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -373,7 +373,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Most hooks are fire-and-forget observers, but some have behavior-changing return values: [`pre_tool_call`](#pre_tool_call) can **block** the tool, [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call, [`pre_verify`](#pre_verify) can **keep the agent going**, [`pre_goal_turn`](#pre_goal_turn) can **rewrite the goal loop's next turn**, [`pre_gateway_dispatch`](#pre_gateway_dispatch) can **skip or rewrite** an incoming gateway message, and the three `transform_*` hooks can **replace** text on its way through. The **Returns** column in the table below is the authoritative list — anything marked *ignored* is an observer.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
@@ -385,6 +385,7 @@ def register(ctx):
 | [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context to the user message |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
 | [`pre_verify`](#pre_verify) | Once per turn when the agent edited code, before it verifies/finishes | `{"action": "continue", "message": str}` to keep going |
+| [`pre_goal_turn`](#pre_goal_turn) | Before each continuation turn of a `goal_mode` kanban worker's loop | `{"prompt": str, "handed_off": bool}` to rewrite the next turn's prompt |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
 | [`on_session_end`](#on_session_end) | Session ends | ignored |
 | [`on_session_finalize`](#on_session_finalize) | CLI/gateway tears down an active session (flush, save, stats) | ignored |
@@ -717,6 +718,69 @@ def register(ctx):
 ```
 
 For standing guidance that should shape the built-in missing-evidence nudge, use `agent.verify_guidance`. For broader coding posture rules that don't need to *gate* verification, prefer `agent.coding_instructions` in `config.yaml` — it rides the coding brief and costs no extra turn.
+
+---
+
+### `pre_goal_turn`
+
+Fires **before each continuation turn** of the kanban goal loop: the Ralph-style loop a dispatcher-spawned `goal_mode` kanban worker runs in, re-prompting itself until an auxiliary judge agrees the card is done, the worker finalizes the task, or the turn budget runs out. The one-shot finalize nudge — the turn sent after the judge has already returned `done` — is never intercepted.
+
+**Callback signature:**
+
+```python
+def my_callback(prompt: str, task_id: str, goal_text: str, progress: str,
+                next_step: str, turns_used: int, max_turns: int,
+                handoffs_done: int, runtime: dict, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `prompt` | `str` | The continuation prompt the loop is about to send |
+| `task_id` | `str` | Kanban task id the loop is driving |
+| `goal_text` | `str` | The goal being pursued |
+| `progress` | `str` | The worker's response from the previous turn |
+| `next_step` | `str` | The judge's stated reason for continuing |
+| `turns_used` | `int` | Turns spent so far |
+| `max_turns` | `int` | The loop's hard turn budget |
+| `handoffs_done` | `int` | Handoffs a hook has already reported this loop — self-throttle on this |
+| `runtime` | `dict` | Caller-supplied best-effort callables (see below) |
+
+**Fires:** In `hermes_cli/goals.py` (`run_kanban_goal_loop`), after the turn-budget check and before the next turn is run.
+
+**The `runtime` dict** is supplied by whoever drives the loop; from the CLI it carries `context_occupancy_fn()` (live prompt tokens ÷ context window, or `None` when unknown), `compaction_active_fn()`, `session_id_fn()`, and `reset_session_fn()` (start a fresh session). Every entry is best-effort — treat a missing or raising callable as "unknown" and skip whatever depended on it.
+
+**Return value — rewrite the next turn:**
+
+```python
+return {"prompt": "Checkpoint your state to the task, then continue.", "handed_off": True}
+```
+
+The first returned dict with a non-empty `prompt` wins; later callbacks are not consulted. `handed_off` is bookkeeping — set it when the directive represents a handoff (state checkpointed, loop moved on) and it comes back as `handoffs_done` on later firings so a hook can bound how often it intervenes. Any other return leaves the turn untouched.
+
+**Bounded:** the loop's `max_turns` budget is checked *before* the hook and is unaffected by it, so a hook that rewrites every prompt can never extend the loop past its budget. A callback that raises is logged and the turn runs unchanged.
+
+**Use cases:** soft context-budget handoff (checkpoint the worker and restart on a clean window before the live one rides down into repeated compaction), injecting fresh external state into every continuation, escalating instructions as the turn budget runs low.
+
+**Example — hand off to a fresh session when the context window fills up:**
+
+```python
+def context_budget_handoff(prompt, runtime, handoffs_done, **kwargs):
+    if handoffs_done >= 2:
+        return None  # don't loop on handoffs
+    occupancy = (runtime.get("context_occupancy_fn") or (lambda: None))()
+    if occupancy is None or occupancy < 0.8:
+        return None
+    (runtime.get("reset_session_fn") or (lambda: None))()
+    return {
+        "prompt": "Fresh session — re-read the task, then continue:\n" + prompt,
+        "handed_off": True,
+    }
+
+def register(ctx):
+    ctx.register_hook("pre_goal_turn", context_budget_handoff)
+```
+
+**Shell hooks:** a shell hook returns the same `{"prompt": ..., "handed_off": ...}` JSON on stdout. It receives the resolved probe *values* — `extra.runtime.context_occupancy` and `extra.runtime.compaction_active`, with the loop's session id in the top-level `session_id` field — because a subprocess cannot call a Python callable. The control callables have no shell equivalent, so a shell hook cannot switch the loop to a fresh session; it influences the loop by rewriting the prompt.
 
 ---
 
@@ -1292,6 +1356,7 @@ Use shell hooks when you want a drop-in, single-file script (Bash, Python, anyth
 - **Block a tool call** — reject dangerous `terminal` commands, enforce per-directory policies, require approval for destructive `write_file` / `patch` operations.
 - **Run after a tool call** — auto-format Python or TypeScript files that the agent just wrote, log API calls, trigger a CI workflow.
 - **Inject context into the next LLM turn** — prepend `git status` output, the current weekday, or retrieved documents to the user message (see [`pre_llm_call`](#pre_llm_call)).
+- **Steer a long-running goal loop** — rewrite the next continuation prompt when the context window fills up or the turn budget runs low (see [`pre_goal_turn`](#pre_goal_turn)).
 - **Observe lifecycle events** — write a log line when a subagent completes (`subagent_stop`) or a session starts (`on_session_start`).
 
 Shell hooks are registered by calling `agent.shell_hooks.register_from_config(cfg)` at both CLI startup (`hermes_cli/main.py`) and gateway startup (`gateway/run.py`). They compose naturally with Python plugin hooks — both flow through the same dispatcher.
@@ -1307,6 +1372,7 @@ Shell hooks are registered by calling `agent.shell_hooks.register_from_config(cf
 | Events | `VALID_HOOKS` (incl. `subagent_stop`) | `VALID_HOOKS` | Gateway lifecycle (`gateway:startup`, `agent:*`, `command:*`) |
 | Can block a tool call | Yes (`pre_tool_call`) | Yes (`pre_tool_call`) | No |
 | Can inject LLM context | Yes (`pre_llm_call`) | Yes (`pre_llm_call`) | No |
+| Can steer the goal loop | Prompt only (`pre_goal_turn`) | Yes (`pre_goal_turn`) | No |
 | Consent | First-use prompt per `(event, command)` pair | Implicit (Python plugin trust) | Implicit (dir trust) |
 | Inter-process isolation | Yes (subprocess) | No (in-process) | No (in-process) |
 
@@ -1341,7 +1407,7 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
 }
 ```
 
-`tool_name` and `tool_input` are `null` for non-tool events (`pre_llm_call`, `subagent_stop`, session lifecycle). The `extra` dict carries all event-specific kwargs (`user_message`, `conversation_history`, `child_role`, `duration_ms`, …). Unserialisable values are stringified rather than omitted.
+`tool_name` and `tool_input` are `null` for non-tool events (`pre_llm_call`, `subagent_stop`, session lifecycle). The `extra` dict carries all event-specific kwargs (`user_message`, `conversation_history`, `child_role`, `duration_ms`, …). Unserialisable values are stringified rather than omitted — the one exception is [`pre_goal_turn`](#pre_goal_turn), whose `runtime` callables are evaluated into plain values so a script can read them.
 
 **stdout — optional response:**
 
@@ -1356,6 +1422,9 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
 // Keep the agent going at the verify gate (pre_verify); both shapes accepted:
 {"action": "continue", "message": "Run the formatter, then finish."}
 {"decision": "block",  "reason":  "Run the formatter, then finish."}
+
+// Rewrite the goal loop's next continuation turn (pre_goal_turn):
+{"prompt": "Checkpoint your state to the task, then continue.", "handed_off": true}
 
 // Silent no-op — any empty / non-matching output is fine:
 ```

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -446,6 +446,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `post_llm_call` | Observer | Successful, non-interrupted turn finalization; return ignored. | `session_id`, `task_id`, `turn_id`, `user_message`, `assistant_response`, `conversation_history`, `model`, `platform` | Full prompt, response, and history. |
 | `transform_llm_output` | Transform | Before `post_llm_call` and final delivery; first non-empty string replaces the response. | `response_text`, `session_id`, `model`, `platform` | Full final assistant text. |
 | `pre_verify` | Directive/control | At the bounded edited-code verify gate; first valid continue/block-stop directive keeps the turn going. | `session_id`, `platform`, `model`, `coding`, `attempt`, `final_response`, `changed_paths` | Draft response and changed paths. |
+| [`pre_goal_turn`](#pre_goal_turn) | Directive/control | Before each continuation turn of the kanban goal loop (never the one-shot finalize nudge); the first valid `{"prompt": ...}` rewrites the turn, `handed_off` sends it on a fresh session. | `prompt`, `task_id`, `goal_text`, `progress`, `next_step`, `turns_used`, `max_turns`, `handoffs_done`, `runtime` | Goal text, worker progress, and the continuation prompt. |
 | `pre_api_request` | Observer | Per provider attempt, immediately before the request; return ignored. | `task_id`, `turn_id`, `api_request_id`, `session_id`, `user_message`, `conversation_history`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `retry_count`, `request_messages`, `message_count`, `tool_count`, `approx_input_tokens`, `request_char_count`, `max_tokens`, `started_at`, `middleware_trace`, `request` | High sensitivity: legacy `user_message`, `conversation_history`, and `request_messages` are intentionally raw; prefer sanitized `request`. |
 | `post_api_request` | Observer | After normalized provider success; return ignored. | `task_id`, `turn_id`, `api_request_id`, `session_id`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `api_duration`, `started_at`, `ended_at`, `finish_reason`, `message_count`, `response_model`, `response`, `usage`, `assistant_message`, `assistant_content_chars`, `assistant_tool_call_count` | Sanitized `response` is available, but raw normalized `assistant_message` may contain model/user content; `usage` is accounting data. |
 | `api_request_error` | Observer | On each failed provider attempt; return ignored. | `task_id`, `turn_id`, `api_request_id`, `session_id`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `api_duration`, `started_at`, `ended_at`, `status_code`, `retry_count`, `max_retries`, `retryable`, `reason`, `error`, `request` | Error text may contain provider/user data; `request` is intended to be sanitized. |
@@ -877,6 +878,67 @@ return {"reason": "model_not_found",   # required: a FailoverReason name
 Dispatch is run-all-then-pick-first: every callback runs, failures are isolated, and the first valid result in registration order wins (valid-but-losing results log a runtime warning). Invalid dicts and unknown reasons are skipped, so a broken plugin can never break classification.
 
 **Privacy:** `error_message` and `error_body` may carry unredacted provider data. **Python plugins only** — shell registrations are refused at config parse with a warning.
+
+### `pre_goal_turn`
+
+Fires **before each continuation turn** of the kanban goal loop: the Ralph-style loop a dispatcher-spawned `goal_mode` kanban worker runs in, re-prompting itself until an auxiliary judge agrees the card is done, the worker finalizes the task, or the turn budget runs out. The one-shot finalize nudge — the turn sent after the judge has already returned `done` — is never intercepted.
+
+**Callback signature:**
+
+```python
+def my_callback(prompt: str, task_id: str, goal_text: str, progress: str,
+                next_step: str, turns_used: int, max_turns: int,
+                handoffs_done: int, runtime: dict, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `prompt` | `str` | The continuation prompt the loop is about to send |
+| `task_id` | `str` | Kanban task id the loop is driving |
+| `goal_text` | `str` | The goal being pursued |
+| `progress` | `str` | The worker's response from the previous turn |
+| `next_step` | `str` | The judge's stated reason for continuing |
+| `turns_used` | `int` | Turns spent so far |
+| `max_turns` | `int` | The loop's hard turn budget |
+| `handoffs_done` | `int` | Handoffs a hook has already reported this loop — self-throttle on this |
+| `runtime` | `dict` | Caller-supplied best-effort callables (see below) |
+
+**Fires:** In `hermes_cli/goals.py` (`run_kanban_goal_loop`), after the turn-budget check and before the next turn is run.
+
+**The `runtime` dict** is supplied by whoever drives the loop; from the CLI it carries `context_occupancy_fn()` (live prompt tokens ÷ context window, or `None` when unknown), `compaction_active_fn()`, `session_id_fn()`, and `reset_session_fn()` (start a fresh session). Every entry is best-effort — treat a missing or raising callable as "unknown" and skip whatever depended on it.
+
+**Return value — rewrite the next turn:**
+
+```python
+return {"prompt": "Checkpoint your state to the task, then continue.", "handed_off": True}
+```
+
+The first returned dict with a non-empty `prompt` wins; later callbacks are not consulted. `handed_off` is bookkeeping — set it when the directive represents a handoff (state checkpointed, loop moved on) and it comes back as `handoffs_done` on later firings so a hook can bound how often it intervenes. Any other return leaves the turn untouched.
+
+**Bounded:** the loop's `max_turns` budget is checked *before* the hook and is unaffected by it, so a hook that rewrites every prompt can never extend the loop past its budget. A callback that raises is logged and the turn runs unchanged.
+
+**Use cases:** soft context-budget handoff (checkpoint the worker and restart on a clean window before the live one rides down into repeated compaction), injecting fresh external state into every continuation, escalating instructions as the turn budget runs low.
+
+**Example — hand off to a fresh session when the context window fills up:**
+
+```python
+def context_budget_handoff(prompt, runtime, handoffs_done, **kwargs):
+    if handoffs_done >= 2:
+        return None  # don't loop on handoffs
+    occupancy = (runtime.get("context_occupancy_fn") or (lambda: None))()
+    if occupancy is None or occupancy < 0.8:
+        return None
+    (runtime.get("reset_session_fn") or (lambda: None))()
+    return {
+        "prompt": "Fresh session — re-read the task, then continue:\n" + prompt,
+        "handed_off": True,
+    }
+
+def register(ctx):
+    ctx.register_hook("pre_goal_turn", context_budget_handoff)
+```
+
+**Shell hooks:** a shell hook returns the same `{"prompt": ..., "handed_off": ...}` JSON on stdout. It receives the resolved probe *values* — `extra.runtime.context_occupancy` and `extra.runtime.compaction_active`, with the loop's session id in the top-level `session_id` field — because a subprocess cannot call a Python callable. The control callables have no shell equivalent, so a shell hook cannot switch the loop to a fresh session; it influences the loop by rewriting the prompt.
 
 ---
 
@@ -1581,6 +1643,7 @@ Use shell hooks when you want a drop-in, single-file script (Bash, Python, anyth
 - **Block or modify a tool call** — reject dangerous `terminal` commands, enforce per-directory policies, require approval for destructive `write_file` / `patch` operations, or rewrite arguments (sanitize paths, inject defaults) before the tool runs.
 - **Run after a tool call** — auto-format Python or TypeScript files that the agent just wrote, log API calls, trigger a CI workflow.
 - **Inject context into the next LLM turn** — prepend `git status` output, the current weekday, or retrieved documents to the user message (see [`pre_llm_call`](#pre_llm_call)).
+- **Steer a long-running goal loop** — rewrite the next continuation prompt when the context window fills up or the turn budget runs low (see [`pre_goal_turn`](#pre_goal_turn)).
 - **Observe lifecycle events** — write a log line when a subagent completes (`subagent_stop`) or a session starts (`on_session_start`).
 
 Shell hooks are registered by calling `agent.shell_hooks.register_from_config(cfg)` at both CLI startup (`hermes_cli/main.py`) and gateway startup (`gateway/run.py`). They compose naturally with Python plugin hooks — both flow through the same dispatcher.
@@ -1596,6 +1659,7 @@ Shell hooks are registered by calling `agent.shell_hooks.register_from_config(cf
 | Events | `VALID_HOOKS` (incl. `subagent_stop`) | `VALID_HOOKS` | Gateway lifecycle (`gateway:startup`, `agent:*`, `command:*`) |
 | Can block a tool call | Yes (`pre_tool_call`) | Yes (`pre_tool_call`) | No |
 | Can inject LLM context | Yes (`pre_llm_call`) | Yes (`pre_llm_call`) | No |
+| Can steer the goal loop | Prompt only (`pre_goal_turn`) | Yes (`pre_goal_turn`) | No |
 | Consent | First-use prompt per `(event, command)` pair | Implicit (Python plugin trust) | Implicit (dir trust) |
 | Inter-process isolation | Yes (subprocess) | No (in-process) | No (in-process) |
 
@@ -1632,7 +1696,7 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
 }
 ```
 
-`tool_name` and `tool_input` are `null` for non-tool events (`pre_llm_call`, `subagent_stop`, session lifecycle). The `extra` dict carries all event-specific kwargs (`user_message`, `conversation_history`, `child_role`, `duration_ms`, …). Unserialisable values are stringified rather than omitted.
+`tool_name` and `tool_input` are `null` for non-tool events (`pre_llm_call`, `subagent_stop`, session lifecycle). The `extra` dict carries all event-specific kwargs (`user_message`, `conversation_history`, `child_role`, `duration_ms`, …). Unserialisable values are stringified rather than omitted — the one exception is [`pre_goal_turn`](#pre_goal_turn), whose `runtime` callables are evaluated into plain values so a script can read them.
 
 **stdout — optional response:**
 
@@ -1651,6 +1715,9 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
 // Keep the agent going at the verify gate (pre_verify); both shapes accepted:
 {"action": "continue", "message": "Run the formatter, then finish."}
 {"decision": "block",  "reason":  "Run the formatter, then finish."}
+
+// Rewrite the goal loop's next continuation turn (pre_goal_turn):
+{"prompt": "Checkpoint your state to the task, then continue.", "handed_off": true}
 
 // Silent no-op — any empty / non-matching output is fine:
 ```


### PR DESCRIPTION
## Summary
`run_kanban_goal_loop` (the Ralph-style goal loop kanban workers run in) has no plugin extension point at its turn boundary. The hook system covers the LLM-call level (`pre_llm_call` / `post_llm_call`) but not the loop's own decision point — so a plugin cannot observe goal progress or intervene in the continuation prompt without forking the loop.

This adds a `pre_goal_turn` hook fired before each CONTINUATION turn (never the one-shot finalize nudge). The motivating consumer is context-budget management: with the caller-supplied `runtime` dict (occupancy/compaction/reset callables), a plugin can detect a nearly-full context and hand the loop off to a fresh session by returning `{"prompt": <replacement>, "handed_off": True}` — instead of the worker degrading through repeated compaction. Return `None` (or raise) and the turn proceeds exactly as before.

## Changes
- `hermes_cli/plugins.py`: `pre_goal_turn` added to `VALID_HOOKS` with contract docs (kwargs: `prompt`, `task_id`, `goal_text`, `progress`, `next_step`, `turns_used`, `max_turns`, `handoffs_done`, `runtime`; first dict return wins)
- `hermes_cli/goals.py`: fire the hook before continuation turns; apply a `{"prompt", "handed_off"}` return (prompt rewrite + `handoffs_done` accounting); a raising hook degrades to a normal in-session turn
- `cli.py`: pass the runtime dict (context-occupancy / compaction-active / reset-session callables) from the quiet-mode kanban path
- `tests/hermes_cli/test_goals_pre_goal_turn.py`: 5 new tests — VALID_HOOKS membership, per-continuation firing with state payload, finalize-nudge exclusion, prompt rewrite + handoff accounting, raising-hook degradation

## Validation
| | Result |
|---|---|
| `pytest tests/hermes_cli/test_goals_pre_goal_turn.py -q` | 5/5 pass |
| `pytest tests/hermes_cli/test_goals.py -q` | 101/101 pass |
| Platform | macOS 15 (Apple Silicon), Python 3.11 |
