### PR TITLE
fix: expose custom provider models in ACP picker

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -588,6 +588,12 @@ class HermesACPAgent(acp.Agent):
         """Return the ACP model selector payload for editors like Zed."""
         model = str(state.model or getattr(state.agent, "model", "") or "").strip()
         provider = getattr(state.agent, "provider", None) or detect_provider() or "openrouter"
+        # For custom providers, use the original requested_provider name
+        # (e.g., "litellm") for encoding so model switches can re-resolve
+        # to the correct custom_providers entry.
+        encode_provider = (
+            getattr(state.agent, "requested_provider", None) or provider
+        )
 
         try:
             from hermes_cli.models import curated_models_for_provider, normalize_provider, provider_label
@@ -601,7 +607,7 @@ class HermesACPAgent(acp.Agent):
                 rendered_model = str(model_id or "").strip()
                 if not rendered_model:
                     continue
-                choice_id = self._encode_model_choice(normalized_provider, rendered_model)
+                choice_id = self._encode_model_choice(encode_provider, rendered_model)
                 if choice_id in seen_ids:
                     continue
                 desc_parts = [f"Provider: {provider_name}"]
@@ -618,7 +624,7 @@ class HermesACPAgent(acp.Agent):
                 )
                 seen_ids.add(choice_id)
 
-            current_model_id = self._encode_model_choice(normalized_provider, model)
+            current_model_id = self._encode_model_choice(encode_provider, model)
             if current_model_id and current_model_id not in seen_ids:
                 available_models.insert(
                     0,
@@ -640,7 +646,7 @@ class HermesACPAgent(acp.Agent):
         if not model:
             return None
 
-        fallback_choice = self._encode_model_choice(provider, model)
+        fallback_choice = self._encode_model_choice(encode_provider, model)
         return SessionModelState(
             available_models=[ModelInfo(model_id=fallback_choice, name=model)],
             current_model_id=fallback_choice,
@@ -656,6 +662,16 @@ class HermesACPAgent(acp.Agent):
             from hermes_cli.models import detect_provider_for_model, parse_model_input
 
             target_provider, new_model = parse_model_input(new_model, current_provider)
+            # parse_model_input only splits on colon for _KNOWN_PROVIDER_NAMES.
+            # Custom provider names (e.g., "litellm") aren't in that set, so
+            # "litellm:model" is returned as the full model name.  Detect this
+            # by checking if the result still has a colon prefix matching the
+            # current_provider and split it manually.
+            if target_provider == current_provider and ":" in new_model:
+                prefix = new_model.split(":", 1)[0].strip().lower()
+                remainder = new_model.split(":", 1)[1].strip()
+                if prefix == current_provider and remainder:
+                    new_model = remainder
             if target_provider == current_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
@@ -2141,12 +2157,18 @@ class HermesACPAgent(acp.Agent):
         state = self.session_manager.get_session(session_id)
         if state:
             current_provider = getattr(state.agent, "provider", None)
+            # For custom providers, use the original requested_provider name
+            # (e.g., "litellm") instead of the canonicalized "custom" so that
+            # resolve_runtime_provider can re-find the custom_providers entry.
+            effective_provider = (
+                getattr(state.agent, "requested_provider", None) or current_provider
+            )
             requested_provider, resolved_model = self._resolve_model_selection(
                 model_id,
-                current_provider or "openrouter",
+                effective_provider or "openrouter",
             )
             state.model = resolved_model
-            provider_changed = bool(current_provider and requested_provider != current_provider)
+            provider_changed = bool(effective_provider and requested_provider != effective_provider)
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
             state.agent = self.session_manager._make_agent(

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -637,6 +637,7 @@ class SessionManager:
             kwargs.update(
                 {
                     "provider": runtime.get("provider"),
+                    "requested_provider": runtime.get("requested_provider"),
                     "api_mode": api_mode or runtime.get("api_mode"),
                     "base_url": base_url or runtime.get("base_url"),
                     "api_key": runtime.get("api_key"),

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2018,9 +2018,27 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
 
 
 def _get_custom_base_url() -> str:
-    """Get the custom endpoint base_url from config.yaml."""
+    """Get the custom endpoint base_url from config.yaml.
+
+    Checks model.base_url first (legacy), then falls back to the first
+    custom_providers entry if available.
+    """
     model_cfg = _get_model_config_dict()
-    return str(model_cfg.get("base_url", "")).strip()
+    base_url = str(model_cfg.get("base_url", "")).strip()
+    if base_url:
+        return base_url
+
+    # Fall back to custom_providers list
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config_readonly
+        config = load_config_readonly()
+        custom_providers = get_compatible_custom_providers(config)
+        if custom_providers:
+            return str(custom_providers[0].get("base_url", "")).strip()
+    except Exception:
+        pass
+
+    return ""
 
 
 def _get_model_config_dict() -> dict[str, Any]:
@@ -2725,10 +2743,39 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                 or os.getenv("OPENAI_API_KEY", "")
                 or os.getenv("OPENROUTER_API_KEY", "")
             )
+            # Fall back to custom_providers list for API key
+            if not api_key:
+                try:
+                    from hermes_cli.config import get_compatible_custom_providers, load_config_readonly
+                    config = load_config_readonly()
+                    custom_providers = get_compatible_custom_providers(config)
+                    if custom_providers:
+                        api_key = str(custom_providers[0].get("api_key", "") or "").strip()
+                except Exception:
+                    pass
             api_mode = "anthropic_messages" if _base_url_looks_like_anthropic_messages(base_url) else None
             live = fetch_api_models(api_key, base_url, api_mode=api_mode)
             if live:
                 return live
+    # Check if this is a named custom provider from config.yaml
+    # (e.g., liteLLM, vLLM, etc.) — query their /v1/models endpoint
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config_readonly
+        config = load_config_readonly()
+        custom_providers = get_compatible_custom_providers(config)
+        for cp in custom_providers:
+            cp_name = (cp.get("name") or "").strip().lower()
+            if cp_name == normalized:
+                base_url = (cp.get("base_url") or "").strip()
+                api_key = (cp.get("api_key") or "").strip()
+                if base_url:
+                    api_mode = "anthropic_messages" if _base_url_looks_like_anthropic_messages(base_url) else None
+                    live = fetch_api_models(api_key, base_url, api_mode=api_mode)
+                    if live:
+                        return live
+                break
+    except Exception:
+        pass
     # Bedrock uses live discovery keyed by the resolved AWS region so that
     # EU/AP users see eu.*/ap.* model IDs instead of the static us.* list.
     # Note: early return intentionally skips _MODELS_DEV_PREFERRED merge


### PR DESCRIPTION
## Problem
When using custom providers (liteLLM, vLLM, etc.) with ACP clients like VSCode, only the default model appears in the model picker instead of all available models.

## Root Cause
The ACP adapter calls `curated_models_for_provider()` which eventually calls `provider_model_ids()`. This function had no handler for custom providers, so it returned an empty list. Additionally, `_get_custom_base_url()` only checked `model.base_url` in config, not the `custom_providers[]` list where the actual base_url and api_key are stored.

## Solution
- Modified `_get_custom_base_url()` to fall back to `custom_providers[0].base_url` when `model.base_url` is empty
- Modified the `custom` handler in `provider_model_ids()` to also check `custom_providers[0].api_key` when no API key is found in model config or environment
- Added a fallback handler that matches custom provider names (e.g., 'litellm') against the `custom_providers` list and queries their `/v1/models` endpoint

## Testing
Verified with a liteLLM instance serving 48 models. Before fix: ACP picker showed 1 model. After fix: ACP picker shows all 48 models.

## Impact
- Fixes ACP model picker for all custom OpenAI-compatible providers
- Also improves `/model` slash command to show custom provider models
- No breaking changes — existing behavior preserved when custom_providers is not configured