### PR TITLE
fix(telegram): gate model picker callbacks on user authorization

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5546,7 +5546,23 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _handle_model_picker_callback(
         self, query, data: str, chat_id: str
     ) -> None:
-        """Handle model picker inline keyboard callbacks (mp:/mm:/mc:/mb:/mx:/mg:)."""
+        """Handle authorized model picker inline keyboard callbacks (mp:/mm:/mc:/mb:/mx:/mg:)."""
+        query_message = getattr(query, "message", None)
+        query_chat = getattr(query_message, "chat", None)
+        query_thread_id = getattr(query_message, "message_thread_id", None)
+        query_user = getattr(query, "from_user", None)
+        caller_id = str(getattr(query_user, "id", ""))
+        query_user_name = getattr(query_user, "first_name", None)
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=chat_id,
+            chat_type=str(getattr(query_chat, "type", "")) or None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to change the model.")
+            return
+
         state = self._model_picker_state.get(chat_id)
         if not state:
             await query.answer(text="Picker expired — use /model again.")

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -37,6 +37,7 @@ from plugins.platforms.telegram.adapter import TelegramAdapter
 
 def _make_adapter():
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
     adapter._bot = AsyncMock()
     adapter._app = MagicMock()
     return adapter
@@ -322,6 +323,43 @@ class TestTelegramModelPicker:
 
         callback.assert_awaited_once_with("12345", "openai/gpt-5.5-pro", "openrouter")
         assert "12345" not in adapter._model_picker_state
+
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_callback_cannot_mutate_model_picker_state(self):
+        """The shared picker handler authenticates before model selection or cancellation."""
+        adapter = _make_adapter()
+        callback = AsyncMock()
+        adapter._is_callback_user_authorized = MagicMock(return_value=False)
+        adapter._model_picker_state["12345"] = {
+            "providers": [{"slug": "openai", "name": "OpenAI", "total_models": 1}],
+            "current_model": "model_1",
+            "current_provider": "openai",
+            "session_key": "s",
+            "on_model_selected": callback,
+            "selected_provider": "openai",
+            "model_list": ["gpt-5"],
+            "msg_id": 42,
+        }
+        query = SimpleNamespace(
+            message=SimpleNamespace(
+                chat_id=12345,
+                chat=SimpleNamespace(type="private"),
+                message_thread_id=None,
+            ),
+            from_user=SimpleNamespace(id=999, first_name="Unauthorized"),
+            answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
+        )
+
+        await adapter._handle_model_picker_callback(query, "mm:0", "12345")
+
+        callback.assert_not_awaited()
+        query.edit_message_text.assert_not_awaited()
+        assert "12345" in adapter._model_picker_state
+        query.answer.assert_awaited_once_with(
+            text="⛔ You are not authorized to change the model."
+        )
 
     @pytest.mark.asyncio
     async def test_retries_without_thread_when_thread_not_found(self):


### PR DESCRIPTION
## Summary

Telegram's model picker (`/model` inline keyboard) dispatches `mp:`, `mpg:`, `mpv:`, `mm:`, `mc:`, `mb`, `mx`, and `mg:` callbacks straight to `_handle_model_picker_callback` without re-validating the caller. In a shared chat, any user who can see the picker message can press its buttons and switch the bot's session model, even when they are not in `allowed_users`.

This ports the guard from #33859 to the plugin adapter at `plugins/platforms/telegram/adapter.py`, as requested in maintainer review (the Telegram implementation moved out of `gateway/platforms/telegram.py` in the plugin migration, so the original hunk no longer applies).

## What changed

- `_handle_model_picker_callback` now calls `_is_callback_user_authorized(...)` — the same check used by approval and slash-confirm callbacks — before touching picker state, and fails closed with `⛔ You are not authorized to change the model.`
- The guard lives inside the handler rather than at the dispatch site, so it holds on any future invocation path.
- Existing picker tests mock the gate open; a new regression test covers an unauthorized `mm:` callback.

## Security impact

- Unauthorized users in shared/group chats can no longer switch the session model through picker buttons.
- Chat/session routing state is no longer treated as authorization, aligning the picker with the existing approval-button trust model.

## Tests

RED before the fix on current `main` (unauthorized `mm:` callback reached the model-selection path); after the fix:

```bash
pytest -q tests/gateway/test_telegram_model_picker.py \
  tests/gateway/test_telegram_auth_check.py \
  tests/gateway/test_telegram_callback_auth_fail_closed.py \
  tests/gateway/test_telegram_approval_buttons.py
# 54 passed
```

Supersedes / closes #33859 (same fix, ported to the current adapter per maintainer request; original author credited via Co-authored-by).
