### PR TITLE
fix(goals): preserve tail evidence in judge prompts

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -627,6 +627,21 @@ def _truncate(text: str, limit: int) -> str:
     return text[:limit] + "… [truncated]"
 
 
+def _truncate_judge_response(text: str, limit: int) -> str:
+    """Keep the response head and tail without exceeding the judge budget."""
+    if not text or limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+    marker = "\n\n… [response middle truncated] …\n\n"
+    available = limit - len(marker)
+    if available < 2:
+        return text[:limit]
+    head_chars = available // 2
+    tail_chars = available - head_chars
+    return f"{text[:head_chars]}{marker}{text[-tail_chars:]}"
+
+
 def _pid_alive(pid: int) -> bool:
     """Return True if a process with ``pid`` is currently alive.
 
@@ -920,7 +935,7 @@ def judge_goal(
         prompt = JUDGE_USER_PROMPT_WITH_CONTRACT_TEMPLATE.format(
             goal=_truncate(goal, 2000),
             contract_block=_truncate(contract_block, 2500),
-            response=_truncate(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
+            response=_truncate_judge_response(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
             background_block=background_block,
             current_time=current_time,
         )
@@ -931,14 +946,14 @@ def judge_goal(
         prompt = JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE.format(
             goal=_truncate(goal, 2000),
             subgoals_block=_truncate(subgoals_block, 2000),
-            response=_truncate(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
+            response=_truncate_judge_response(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
             background_block=background_block,
             current_time=current_time,
         )
     else:
         prompt = JUDGE_USER_PROMPT_TEMPLATE.format(
             goal=_truncate(goal, 2000),
-            response=_truncate(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
+            response=_truncate_judge_response(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
             background_block=background_block,
             current_time=current_time,
         )

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -210,6 +210,26 @@ class TestJudgeGoal:
         assert verdict == "continue"
         assert reason == "not yet"
 
+    def test_judge_response_excerpt_is_bounded_and_omits_middle(self):
+        from hermes_cli import goals
+
+        truncate_response = getattr(goals, "_truncate_judge_response")
+        response = "HEAD" + ("A" * 2500) + "MIDDLE-SENTINEL" + ("B" * 2500) + "TAIL"
+        excerpt = truncate_response(response, 4000)
+
+        assert len(excerpt) == 4000
+        assert excerpt.startswith("HEAD")
+        assert excerpt.endswith("TAIL")
+        assert "… [response middle truncated] …" in excerpt
+        assert "MIDDLE-SENTINEL" not in excerpt
+
+    @pytest.mark.parametrize("limit", [0, 1, 2, 34, 35, 36])
+    def test_judge_response_excerpt_never_exceeds_tiny_limit(self, limit):
+        from hermes_cli import goals
+
+        truncate_response = getattr(goals, "_truncate_judge_response")
+        assert len(truncate_response("x" * 100, limit)) <= limit
+
 
 # ──────────────────────────────────────────────────────────────────────
 # GoalManager lifecycle + persistence
@@ -770,6 +790,51 @@ class TestJudgeGoalWithSubgoals:
         assert "2. update docs" in user_msg
         assert "every additional criterion" in user_msg
         assert verdict == "done"
+
+    @pytest.mark.parametrize("prompt_kind", ["plain", "subgoals", "contract"])
+    def test_judge_preserves_completion_evidence_at_end_of_long_response(
+        self, hermes_home, prompt_kind
+    ):
+        """Every judge prompt must retain tail evidence within the response budget."""
+        from unittest.mock import patch
+        from hermes_cli import goals
+
+        captured = {}
+
+        class _FakeMsg:
+            content = '{"done": true, "reason": "all evidence visible"}'
+        class _FakeChoice:
+            message = _FakeMsg()
+        class _FakeResp:
+            choices = [_FakeChoice()]
+        def _fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return _FakeResp()
+
+        response = (
+            "HEAD-EVIDENCE\n"
+            + ("leading filler " * 250)
+            + "MIDDLE-SENTINEL"
+            + ("trailing filler " * 250)
+            + "\nTAIL-COMPLETION-EVIDENCE"
+        )
+        judge_kwargs = {}
+        if prompt_kind == "subgoals":
+            judge_kwargs["subgoals"] = ["include the completion evidence"]
+        elif prompt_kind == "contract":
+            judge_kwargs["contract"] = goals.GoalContract(
+                verification="include the completion evidence"
+            )
+
+        with patch("agent.auxiliary_client.call_llm", side_effect=_fake_call_llm):
+            goals.judge_goal("ship the feature", response, **judge_kwargs)
+
+        sent_messages = captured.get("messages") or []
+        user_msg = next((m["content"] for m in sent_messages if m["role"] == "user"), "")
+        assert "HEAD-EVIDENCE" in user_msg
+        assert "TAIL-COMPLETION-EVIDENCE" in user_msg
+        assert "… [response middle truncated] …" in user_msg
+        assert "MIDDLE-SENTINEL" not in user_msg
 
     def test_judge_uses_original_template_when_no_subgoals(self, hermes_home):
         from unittest.mock import patch


### PR DESCRIPTION
## What does this PR do?

Prevents false standing-goal continuations when completion evidence appears after the first 4,000 characters of an agent response.

The goal judge currently applies head-only `_truncate()` to `last_response`. This change introduces a response-specific head-and-tail excerpt that:

- preserves the existing 4,000-character budget;
- keeps both the response opening and completion/verification evidence at the end;
- inserts an explicit middle-truncation marker;
- applies consistently to plain, subgoal, and contract judge prompts.

## Related Issue

Fixes #70699

Related but distinct: #34197 and #63180.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/goals.py`: add `_truncate_judge_response()` and use it for all three goal-judge response prompt variants.
- `tests/hermes_cli/test_goals.py`: add regressions across plain, subgoal, and contract prompts; assert the 4,000-character bound, explicit marker, omitted middle, retained head/tail, and strict tiny-limit behavior.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_goals.py -q`.
2. Confirm all 46 goal tests pass.
3. The regression fails on `origin/main` because `TAIL-COMPLETION-EVIDENCE` is absent from the judge prompt; it passes with this branch.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched open/closed issues and PRs for duplicates.
- [x] My PR contains only changes related to this fix.
- [x] I've added a regression test for the bug.
- [x] Focused suite passes: `46 passed` via the canonical runner.
- [x] Reverified on Linux 7.1.3, Python 3.13.5.

### Documentation & Housekeeping

- [x] Documentation update: N/A; internal judge excerpt behavior only.
- [x] `cli-config.yaml.example`: N/A; no config changes.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow or architecture change.
- [x] Cross-platform impact considered: pure Python string slicing, platform-independent.
- [x] Tool descriptions/schemas: N/A.

## Verification

```text
scripts/run_tests.sh tests/hermes_cli/test_goals.py -q
46 tests passed, 0 failed
```

`git diff --check` passes. An independent review found no blocking issues and verified the production excerpt remains exactly 4,000 characters with both head and tail retained.
