### PR TITLE
fix(classifier): recognize Moonshot/Kimi billing exhaustion for provider fallback

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -121,6 +121,13 @@ _BILLING_PATTERNS = [
     "balance_depleted",
     "model_not_supported_on_free_tier",
     "not available on the free tier",
+    "account balance is exhausted",
+    "billing exhausted",
+    "账户余额",
+    "余额不足",
+    "额度已用完",
+    "调用额度",
+    "额度耗尽",
 ]
 
 # Patterns that indicate rate limiting (transient, will resolve)
@@ -1036,6 +1043,18 @@ def _classify_by_status(
             return result_fn(
                 FailoverReason.format_error,
                 retryable=False,
+                should_fallback=True,
+            )
+        # Some providers (notably Moonshot/Kimi) proxy billing/credit
+        # exhaustion through HTTP 500 when an intermediate gateway can't
+        # map the upstream payment error to a 402. Treat the explicit
+        # billing message as a non-retryable billing failure so fallback
+        # can activate instead of retrying a dead account.
+        if any(p in error_msg for p in _BILLING_PATTERNS):
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
                 should_fallback=True,
             )
         # Some local inference servers (notably llama.cpp / llama-server)


### PR DESCRIPTION
## Problem

When Moonshot/Kimi (kimi-coding provider) credits are exhausted, the provider may return the exhaustion message in Chinese or through an intermediate gateway as HTTP 400/500. The existing error classifier did not recognize these patterns, so the failure was classified as `format_error` or `server_error` and the configured `fallback_providers` chain was never activated.

## Changes

- Extend `_BILLING_PATTERNS` with common Moonshot/Kimi English and Chinese billing-exhaustion phrases.
- In the HTTP 500/502 classifier path, check `_BILLING_PATTERNS` before falling through to retryable `server_error`, so proxied billing failures trigger `FailoverReason.billing` and activate fallback.

## Tested

Verified with simulated Kimi errors that 400/500 messages containing billing-exhaustion text now classify as `billing` with `should_fallback=True`, while generic 400/500 errors keep their existing behavior.