### PR TITLE
fix(state): hydrate display_metadata in get_messages/get_messages_around/get_anchored_view

### DIFF
--- a/contributors/emails/iborazzi@users.noreply.github.com
+++ b/contributors/emails/iborazzi@users.noreply.github.com
@@ -1,0 +1,1 @@
+iborazzi

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6169,6 +6169,12 @@ class SessionDB:
                 except (json.JSONDecodeError, TypeError):
                     logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
                     msg["tool_calls"] = []
+            if msg.get("display_metadata") and isinstance(msg["display_metadata"], str):
+                try:
+                    msg["display_metadata"] = json.loads(msg["display_metadata"])
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning("Failed to deserialize display_metadata in get_messages, dropping it")
+                    msg["display_metadata"] = None
             result.append(msg)
         return result
 
@@ -6238,6 +6244,14 @@ class SessionDB:
                         "Failed to deserialize tool_calls in get_messages_around, falling back to []"
                     )
                     msg["tool_calls"] = []
+            if msg.get("display_metadata") and isinstance(msg["display_metadata"], str):
+                try:
+                    msg["display_metadata"] = json.loads(msg["display_metadata"])
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning(
+                        "Failed to deserialize display_metadata in get_messages_around, dropping it"
+                    )
+                    msg["display_metadata"] = None
             result.append(msg)
 
         # before_rows includes the anchor itself; subtract 1 for the count of
@@ -6360,6 +6374,14 @@ class SessionDB:
                         "Failed to deserialize tool_calls in get_anchored_view, falling back to []"
                     )
                     msg["tool_calls"] = []
+            if msg.get("display_metadata") and isinstance(msg["display_metadata"], str):
+                try:
+                    msg["display_metadata"] = json.loads(msg["display_metadata"])
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning(
+                        "Failed to deserialize display_metadata in get_anchored_view, dropping it"
+                    )
+                    msg["display_metadata"] = None
             return msg
 
         return {

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6122,6 +6122,43 @@ class SessionDB:
 
         return self._execute_write(_do)
 
+    def _hydrate_message_row(self, row, *, caller: str) -> Dict[str, Any]:
+        """Turn a raw ``messages`` row into a JSON-hydrated dict.
+
+        Shared by :meth:`get_messages`, :meth:`get_messages_around`, and
+        :meth:`get_anchored_view` — the three read paths that return the raw
+        row shape (all columns, dict(row)) rather than the trimmed OpenAI
+        conversation shape :meth:`_rows_to_conversation` builds. Decodes
+        ``content`` and JSON-deserializes the ``tool_calls`` /
+        ``display_metadata`` TEXT columns, dropping either to a safe empty
+        value (``[]`` / ``None``) on a decode failure instead of handing the
+        caller a raw string. ``caller`` is folded into the warning log line
+        so a bad row is traceable to the read path that hit it.
+
+        Before ``display_metadata`` was added here, only ``tool_calls`` was
+        hydrated in these three paths — the drift that produced #70586
+        (the desktop renderer's ``'task_count' in message.display_metadata``
+        check crashing on the un-hydrated string). Route every new
+        JSON-TEXT column through this helper rather than adding another
+        one-off block per read path.
+        """
+        msg = dict(row)
+        if "content" in msg:
+            msg["content"] = self._decode_content(msg["content"])
+        if msg.get("tool_calls"):
+            try:
+                msg["tool_calls"] = json.loads(msg["tool_calls"])
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Failed to deserialize tool_calls in %s, falling back to []", caller)
+                msg["tool_calls"] = []
+        if msg.get("display_metadata") and isinstance(msg["display_metadata"], str):
+            try:
+                msg["display_metadata"] = json.loads(msg["display_metadata"])
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Failed to deserialize display_metadata in %s, dropping it", caller)
+                msg["display_metadata"] = None
+        return msg
+
     def get_messages(
         self,
         session_id: str,
@@ -6160,22 +6197,7 @@ class SessionDB:
             rows = cursor.fetchall()
         result = []
         for row in rows:
-            msg = dict(row)
-            if "content" in msg:
-                msg["content"] = self._decode_content(msg["content"])
-            if msg.get("tool_calls"):
-                try:
-                    msg["tool_calls"] = json.loads(msg["tool_calls"])
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
-                    msg["tool_calls"] = []
-            if msg.get("display_metadata") and isinstance(msg["display_metadata"], str):
-                try:
-                    msg["display_metadata"] = json.loads(msg["display_metadata"])
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning("Failed to deserialize display_metadata in get_messages, dropping it")
-                    msg["display_metadata"] = None
-            result.append(msg)
+            result.append(self._hydrate_message_row(row, caller="get_messages"))
         return result
 
     def get_messages_around(
@@ -6231,28 +6253,7 @@ class SessionDB:
 
         # before_rows is DESC; reverse so it's ASC, then concatenate after_rows.
         rows = list(reversed(before_rows)) + list(after_rows)
-        result = []
-        for row in rows:
-            msg = dict(row)
-            if "content" in msg:
-                msg["content"] = self._decode_content(msg["content"])
-            if msg.get("tool_calls"):
-                try:
-                    msg["tool_calls"] = json.loads(msg["tool_calls"])
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning(
-                        "Failed to deserialize tool_calls in get_messages_around, falling back to []"
-                    )
-                    msg["tool_calls"] = []
-            if msg.get("display_metadata") and isinstance(msg["display_metadata"], str):
-                try:
-                    msg["display_metadata"] = json.loads(msg["display_metadata"])
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning(
-                        "Failed to deserialize display_metadata in get_messages_around, dropping it"
-                    )
-                    msg["display_metadata"] = None
-            result.append(msg)
+        result = [self._hydrate_message_row(row, caller="get_messages_around") for row in rows]
 
         # before_rows includes the anchor itself; subtract 1 for the count of
         # messages strictly before the anchor in the returned slice.
@@ -6362,34 +6363,12 @@ class SessionDB:
                 # End rows came back DESC for the LIMIT cap; flip to ASC.
                 bookend_end_rows = list(reversed(bookend_end_rows))
 
-        def _hydrate(row) -> Dict[str, Any]:
-            msg = dict(row)
-            if "content" in msg:
-                msg["content"] = self._decode_content(msg["content"])
-            if msg.get("tool_calls"):
-                try:
-                    msg["tool_calls"] = json.loads(msg["tool_calls"])
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning(
-                        "Failed to deserialize tool_calls in get_anchored_view, falling back to []"
-                    )
-                    msg["tool_calls"] = []
-            if msg.get("display_metadata") and isinstance(msg["display_metadata"], str):
-                try:
-                    msg["display_metadata"] = json.loads(msg["display_metadata"])
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning(
-                        "Failed to deserialize display_metadata in get_anchored_view, dropping it"
-                    )
-                    msg["display_metadata"] = None
-            return msg
-
         return {
             "window": filtered_window,
             "messages_before": primitive["messages_before"],
             "messages_after": primitive["messages_after"],
-            "bookend_start": [_hydrate(r) for r in bookend_start_rows],
-            "bookend_end": [_hydrate(r) for r in bookend_end_rows],
+            "bookend_start": [self._hydrate_message_row(r, caller="get_anchored_view") for r in bookend_start_rows],
+            "bookend_end": [self._hydrate_message_row(r, caller="get_anchored_view") for r in bookend_end_rows],
         }
 
     def resolve_resume_session_id(self, session_id: str) -> str:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -7235,3 +7235,65 @@ class TestDisplayMetadataPersistence:
         assert len(switched) == 1
         assert switched[0]["display_metadata"] == meta
 
+    # Regression tests for #70586: display_metadata is stored as JSON TEXT and
+    # must be hydrated to a dict by every read path, mirroring the existing
+    # tool_calls handling. Before the fix, get_messages/get_messages_around/
+    # get_anchored_view returned the raw string, which crashed the desktop
+    # renderer's `'task_count' in message.display_metadata` check on reload.
+
+    def test_get_messages_hydrates_display_metadata(self, db):
+        db.create_session("s1", source="cli")
+        meta = {"delegation_id": "deleg_1", "task_count": 5, "completed_count": 5}
+        db.append_message(
+            "s1", "assistant", "done",
+            display_kind="async_delegation_complete",
+            display_metadata=meta,
+        )
+        msg = db.get_messages("s1")[0]
+        assert isinstance(msg["display_metadata"], dict)
+        assert msg["display_metadata"] == meta
+
+    def test_get_messages_around_hydrates_display_metadata(self, db):
+        db.create_session("s1", source="cli")
+        meta = {"delegation_id": "deleg_1", "task_count": 5, "completed_count": 5}
+        db.append_message("s1", "user", "before")
+        anchor_id = db.append_message(
+            "s1", "assistant", "done",
+            display_kind="async_delegation_complete",
+            display_metadata=meta,
+        )
+        db.append_message("s1", "user", "after")
+        result = db.get_messages_around("s1", anchor_id, window=2)
+        anchored = [m for m in result["window"] if m["id"] == anchor_id][0]
+        assert isinstance(anchored["display_metadata"], dict)
+        assert anchored["display_metadata"] == meta
+
+    def test_get_anchored_view_hydrates_display_metadata(self, db):
+        db.create_session("s1", source="cli")
+        meta = {"delegation_id": "deleg_1", "task_count": 5, "completed_count": 5}
+        db.append_message("s1", "user", "before")
+        anchor_id = db.append_message(
+            "s1", "assistant", "done",
+            display_kind="async_delegation_complete",
+            display_metadata=meta,
+        )
+        db.append_message("s1", "user", "after")
+        result = db.get_anchored_view("s1", anchor_id, window=2, bookend=2)
+        all_rows = result["window"] + result["bookend_start"] + result["bookend_end"]
+        anchored = [m for m in all_rows if m.get("id") == anchor_id]
+        assert anchored, "anchor message missing from anchored view"
+        assert isinstance(anchored[0]["display_metadata"], dict)
+        assert anchored[0]["display_metadata"] == meta
+
+    def test_get_messages_drops_corrupt_display_metadata(self, db, caplog):
+        db.create_session("s1", source="cli")
+        db.append_message("s1", "assistant", "done", display_kind="model_switch")
+        with db._lock:
+            db._conn.execute(
+                "UPDATE messages SET display_metadata = ? WHERE session_id = ?",
+                ("{not valid json", "s1"),
+            )
+            db._conn.commit()
+        msg = db.get_messages("s1")[0]
+        assert msg["display_metadata"] is None
+


### PR DESCRIPTION
Closes #70586

## Root cause

`display_metadata` is stored as JSON TEXT in `messages`. Three of the four
read paths — `get_messages`, `get_messages_around`, and
`get_anchored_view`'s internal hydration — deserialized `tool_calls` with
`json.loads` but returned `display_metadata` as the raw string; only
`_rows_to_conversation` decoded it correctly.

The desktop history path (`tui_gateway -> get_messages`) therefore handed
the renderer a string where `SessionMessage` declares `display_metadata`
as an object. `timelineDisplayContent()`'s `'task_count' in
message.display_metadata` check then threw a `TypeError` on reload,
blanking the whole transcript for any session containing an
`async_delegation_complete` message. The live-delivery path was
unaffected since the realtime event already carries a dict — the bug
only bit on session reload.

## Fix

- Hydrate `display_metadata` in all three read paths, mirroring the
  existing `tool_calls` pattern: `json.loads` if it's a string, log +
  drop to `None` on decode failure instead of propagating a broken
  string to the renderer.
- Extracted the now-duplicated hydration logic into a single
  `_hydrate_message_row(row, caller=...)` helper used by all three read
  paths, to prevent the next JSON-TEXT column from drifting the same
  way (this is what caused #70586 in the first place — `tool_calls` was
  hydrated in 3/4 paths, `display_metadata` in only 1/4).
  `_rows_to_conversation` is intentionally left as-is since it builds a
  different, trimmed OpenAI-conversation shape rather than the raw
  `dict(row)` shape the other three share.

## Testing

- Added regression tests: dict hydration in `get_messages`,
  `get_messages_around`, and `get_anchored_view`, plus a corrupt-JSON
  case verifying the field is dropped instead of raising.
- Full `tests/test_hermes_state.py` suite: 417 passed.