### PR TITLE
fix(cli): read explicit stdin prompts in oneshot mode

### DIFF
--- a/contributors/emails/xuezhao@gmail.com
+++ b/contributors/emails/xuezhao@gmail.com
@@ -1,0 +1,1 @@
+xuezhaolan

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -167,6 +167,23 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
         pass
 
 
+def _read_stdin_prompt(prompt: str) -> tuple[str, str | None]:
+    """Resolve ``-z -`` by reading the prompt body from stdin."""
+    if prompt != "-":
+        return prompt, None
+
+    try:
+        if sys.stdin is None or sys.stdin.isatty():
+            return prompt, "hermes -z: prompt '-' requires stdin.\n"
+        stdin_content = sys.stdin.read()
+    except Exception:
+        return prompt, "hermes -z: failed to read prompt from stdin.\n"
+
+    if not stdin_content:
+        return prompt, "hermes -z: prompt '-' requires non-empty stdin.\n"
+    return stdin_content, None
+
+
 def run_oneshot(
     prompt: str,
     model: Optional[str] = None,
@@ -215,6 +232,10 @@ def run_oneshot(
         sys.stderr.write(toolsets_error)
         return 2
     use_config_toolsets = _normalize_toolsets(toolsets) is None
+    prompt, stdin_error = _read_stdin_prompt(prompt)
+    if stdin_error:
+        sys.stderr.write(stdin_error)
+        return 2
 
     # Auto-approve any shell / tool approvals.  Non-interactive by
     # definition — a prompt would hang forever.

--- a/tests/hermes_cli/test_oneshot_stdin.py
+++ b/tests/hermes_cli/test_oneshot_stdin.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import io
+
+
+class _NonTtyStdin(io.StringIO):
+    def isatty(self):
+        return False
+
+
+class _TtyStdin(io.StringIO):
+    def isatty(self):
+        return True
+
+
+class _BrokenStdin(io.StringIO):
+    def isatty(self):
+        return False
+
+    def read(self, *args, **kwargs):
+        raise OSError("broken stdin")
+
+
+def test_oneshot_dash_reads_prompt_from_stdin(monkeypatch, capsys):
+    import hermes_cli.oneshot as oneshot_mod
+
+    captured = {}
+
+    def fake_run_agent(prompt, **_kwargs):
+        captured["prompt"] = prompt
+        return ("done", {"final_response": "done"})
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", fake_run_agent)
+    monkeypatch.setattr(oneshot_mod.sys, "stdin", _NonTtyStdin("file body\n"))
+
+    assert oneshot_mod.run_oneshot("-") == 0
+    assert captured["prompt"] == "file body\n"
+    assert capsys.readouterr().out == "done\n"
+
+
+def test_oneshot_literal_prompt_does_not_drain_non_tty_stdin(monkeypatch):
+    import hermes_cli.oneshot as oneshot_mod
+
+    captured = {}
+    stdin = _NonTtyStdin("loop input\n")
+
+    def fake_run_agent(prompt, **_kwargs):
+        captured["prompt"] = prompt
+        return ("done", {"final_response": "done"})
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", fake_run_agent)
+    monkeypatch.setattr(oneshot_mod.sys, "stdin", stdin)
+
+    assert oneshot_mod.run_oneshot("literal prompt") == 0
+    assert captured["prompt"] == "literal prompt"
+    assert stdin.read() == "loop input\n"
+
+
+def test_oneshot_dash_rejects_empty_stdin(monkeypatch, capsys):
+    import hermes_cli.oneshot as oneshot_mod
+
+    monkeypatch.setattr(oneshot_mod.sys, "stdin", _NonTtyStdin(""))
+
+    assert oneshot_mod.run_oneshot("-") == 2
+    assert "requires non-empty stdin" in capsys.readouterr().err
+
+
+def test_oneshot_dash_rejects_tty_stdin(monkeypatch, capsys):
+    import hermes_cli.oneshot as oneshot_mod
+
+    monkeypatch.setattr(oneshot_mod.sys, "stdin", _TtyStdin("ignored"))
+
+    assert oneshot_mod.run_oneshot("-") == 2
+    assert "requires stdin" in capsys.readouterr().err
+
+
+def test_oneshot_dash_reports_stdin_read_failure(monkeypatch, capsys):
+    import hermes_cli.oneshot as oneshot_mod
+
+    monkeypatch.setattr(oneshot_mod.sys, "stdin", _BrokenStdin("ignored"))
+
+    assert oneshot_mod.run_oneshot("-") == 2
+    assert "failed to read prompt from stdin" in capsys.readouterr().err

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -143,7 +143,10 @@ hermes -z "What's the capital of France?"
 # → Paris.
 
 # Parent scripts can cleanly capture the response:
-answer=$(hermes -z "summarize this" < /path/to/file.txt)
+answer=$(hermes -z "What's the capital of France?")
+
+# Read the prompt body from stdin explicitly with '-':
+answer=$(hermes -z - < /path/to/prompt.txt)
 ```
 
 Per-run overrides (no mutation to `~/.hermes/config.yaml`):


### PR DESCRIPTION
## Summary
- supports `hermes -z -` to read the oneshot prompt body from stdin
- leaves literal `-z "prompt"` invocations from non-TTY parents untouched so they do not drain unrelated caller input
- documents the explicit stdin form and adds regression coverage

Fixes #70647

## Test Plan
- `python -m pytest tests/hermes_cli/test_oneshot_stdin.py tests/hermes_cli/test_oneshot_usage_file.py tests/hermes_cli/test_tui_resume_flow.py::test_oneshot_prints_nonempty_final_response tests/hermes_cli/test_tui_resume_flow.py::test_oneshot_fails_closed_on_empty_final_response tests/hermes_cli/test_tui_resume_flow.py::test_oneshot_rejects_invalid_only_toolsets -q -o 'addopts='`
- `git diff --cached --check`
- strict staged secret/security scan: no findings
- independent Codex pre-commit review: PASS, no blockers