### PR TITLE
fix(tui): complete local slash commands

### DIFF
--- a/ui-tui/src/__tests__/useCompletion.test.ts
+++ b/ui-tui/src/__tests__/useCompletion.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, it } from 'vitest'
 
-import { completionRequestForInput } from '../hooks/useCompletion.js'
+import { completionRequestForInput, mergeLocalSlashItems } from '../hooks/useCompletion.js'
+
+describe('mergeLocalSlashItems', () => {
+  it('adds TUI-local commands from the dispatch registry', () => {
+    expect(mergeLocalSlashItems('/wid', []).map(item => item.text)).toContain('/widgets-reload')
+  })
+
+  it('preserves gateway entries and does not suggest commands after arguments', () => {
+    const gatewayItem = {
+      display: '/widgets-reload',
+      meta: 'gateway metadata',
+      text: '/widgets-reload'
+    }
+
+    const widgetAppItem = {
+      display: '/widget-usage',
+      meta: 'widget app metadata',
+      text: '/widget-usage'
+    }
+
+    expect(mergeLocalSlashItems('/wid', [gatewayItem, widgetAppItem])).toEqual([gatewayItem, widgetAppItem])
+    expect(mergeLocalSlashItems('/wid reload', [])).toEqual([])
+  })
+})
 
 describe('completionRequestForInput', () => {
   it('routes real slash commands to slash completion', () => {

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
 import type { CompletionItem } from '../app/interfaces.js'
+import { SLASH_COMMANDS } from '../app/slash/registry.js'
 import { looksLikeSlashCommand } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { CompletionResponse } from '../gatewayTypes.js'
@@ -20,6 +21,41 @@ export function mergeWidgetAppItems(input: string, items: CompletionItem[]): Com
     .filter(app => `/${app.id}`.startsWith(input.toLowerCase()))
     .filter(app => !items.some(item => item.text === `/${app.id}`))
     .map(app => ({ display: `/${app.id}`, meta: app.help, text: `/${app.id}` }))
+
+  return [...items, ...local]
+}
+
+/** TUI-local slash commands dispatch without passing through the gateway, so
+ *  expose the same registry here while preserving gateway results as canonical. */
+export function mergeLocalSlashItems(input: string, items: CompletionItem[]): CompletionItem[] {
+  // Only complete the command NAME position (no args typed yet).
+  if (input.includes(' ')) {
+    return items
+  }
+
+  const knownNames = new Set(items.map(item => item.text.toLowerCase()))
+  const prefix = input.toLowerCase()
+
+  const local = SLASH_COMMANDS.flatMap(command =>
+    [command.name, ...(command.aliases ?? [])].map(name => ({
+      display: `/${name}`,
+      meta: command.help,
+      text: `/${name}`
+    }))
+  )
+    .filter(item => item.text.toLowerCase().startsWith(prefix))
+    .filter(item => {
+
+      const name = item.text.toLowerCase()
+
+      if (knownNames.has(name)) {
+        return false
+      }
+
+      knownNames.add(name)
+
+      return true
+    })
 
   return [...items, ...local]
 }
@@ -104,7 +140,9 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
           const r = asRpcResult<CompletionResponse>(raw)
 
           const items =
-            request.method === 'complete.slash' ? mergeWidgetAppItems(input, r?.items ?? []) : (r?.items ?? [])
+            request.method === 'complete.slash'
+              ? mergeLocalSlashItems(input, mergeWidgetAppItems(input, r?.items ?? []))
+              : (r?.items ?? [])
 
           setCompletions(items)
           setCompIdx(0)


### PR DESCRIPTION
## What does this PR do?

Makes TUI-local slash commands available in the completion popover. Commands such as `/widgets-reload`, `/heapdump`, `/theme-info`, and `/mem` already dispatch locally but were absent from gateway-backed completion.

## Related Issue

Fixes #70649

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Merge the TUI `SLASH_COMMANDS` registry into top-level completion results.
- Preserve gateway-provided completions when a command name is duplicated.
- Keep dynamic widget-app completion and argument completion behavior unchanged.
- Add focused coverage for local command visibility, de-duplication, and argument handling.

## How to Test

1. Run `npm --prefix ui-tui test -- useCompletion`.
2. Verify `/wid` includes `/widgets-reload`.
3. Verify a gateway-provided `/widgets-reload` result appears only once.
4. Verify `/wid reload` receives no top-level command suggestions.

## Validation

- `npm --prefix ui-tui test -- useCompletion` — passed (6 tests)
- `npm --prefix ui-tui run typecheck` — passed
- `npm --prefix ui-tui run lint` — passed
- `npm --prefix ui-tui test` — 1,351 passed; 8 unrelated Windows-environment failures in editor/terminal setup tests.

## Checklist

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs.
- [x] This PR contains only changes related to this fix.
- [x] I've added tests for my changes.
- [x] I've tested on Windows.