### PR TITLE
fix(tui): refuse empty truncation on prompt.submit to prevent silent session wipe (#70516)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3239,6 +3239,77 @@ def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
         server._sessions.pop("trunc-sid", None)
 
 
+def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
+    """prompt.submit with truncate_before_user_ordinal=0 must be REFUSED
+    unless confirm_empty_truncate=true is explicitly passed. Without this guard
+    a stale ordinal from a desynced frontend silently wipes the session DB."""
+    replaced = []
+    started = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "done"},
+    ]
+    server._sessions["empty-trunc-sid"] = _session(history=list(history))
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: started.append(True)
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: started.append(True)
+    )
+
+    try:
+        # --- Case 1: ordinal=0 without confirm_empty_truncate → REFUSED ---
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "empty-trunc-sid",
+                    "text": "next",
+                    "truncate_before_user_ordinal": 0,
+                },
+            }
+        )
+        assert resp.get("error"), f"expected error but got result: {resp.get('result')}"
+        assert resp["error"]["code"] == 4025, (
+            f"expected code 4025 (empty-truncation guard), got {resp['error']['code']}"
+        )
+        # History and DB must be untouched — no data loss.
+        assert server._sessions["empty-trunc-sid"]["history"] == history
+        assert server._sessions["empty-trunc-sid"]["running"] is False
+        assert replaced == [], f"replace_messages was called: {replaced}"
+        assert started == [], "no turn should have started"
+
+        # --- Case 2: ordinal=0 with confirm_empty_truncate=true → ALLOWED ---
+        resp = server.handle_request(
+            {
+                "id": "2",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "empty-trunc-sid",
+                    "text": "next",
+                    "truncate_before_user_ordinal": 0,
+                    "confirm_empty_truncate": True,
+                },
+            }
+        )
+        # With confirm_empty_truncate, the truncation goes through (the turn
+        # may still error on the agent build, but the history is truncated).
+        assert server._sessions["empty-trunc-sid"]["history"] == []
+        assert server._sessions["empty-trunc-sid"]["history_version"] == 1
+        assert replaced == [("session-key", [])]
+    finally:
+        server._sessions.pop("empty-trunc-sid", None)
+
+
 class _StopAfterOneNotificationPoll:
     def __init__(self):
         self._checks = 0

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10045,6 +10045,27 @@ def _(rid, params: dict) -> dict:
             if ordinal < 0 or ordinal >= len(user_indices):
                 return _err(rid, 4018, "target user message is no longer in session history")
             truncated = history[: user_indices[ordinal]]
+            # Guard: refuse an empty truncation (truncated == []) unless the
+            # client explicitly passes confirm_empty_truncate=true. A stale
+            # ordinal from a desynced frontend (e.g. ordinal=0 on an ordinary
+            # prompt.submit) would otherwise silently wipe the entire session
+            # transcript via replace_messages() — unrecoverable data loss.
+            if not truncated and not params.get("confirm_empty_truncate"):
+                logger.warning(
+                    "prompt.submit: REFUSED empty truncation of session %s "
+                    "(%d messages would be wiped; ordinal=%d).",
+                    sid, len(history), ordinal,
+                )
+                return _err(
+                    rid, 4025,
+                    "truncation would erase the entire session transcript; "
+                    "resubmit with confirm_empty_truncate=true if this is intended",
+                )
+            # Log every truncation so future incidents are traceable in agent.log.
+            logger.warning(
+                "prompt.submit: truncating session %s history %d -> %d messages (ordinal=%d)",
+                sid, len(history), len(truncated), ordinal,
+            )
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
             if (db := _get_db()) is not None:


### PR DESCRIPTION
## Problem

Stale truncate_before_user_ordinal=0 from a desynced frontend causes replace_messages() to DELETE all session messages silently (observed: 308 messages lost). No log, no confirmation.

## Fix

- Empty-truncation guard: refuse truncation when truncated==[] unless confirm_empty_truncate=true is passed (error 4025)
- Logging: every truncation logged at WARNING (session id, history N→M, ordinal)
- Covers the exact wipe reported: ordinal=0 on an ordinary submit from stale frontend

Fixes #70516