### PR TITLE
fix(plugins): prevent git plugin updates while gateway is running (#70473)

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -633,6 +633,31 @@ def cmd_install(
     console.print()
 
 
+def _assert_gateway_not_running() -> None:
+    """Check if the gateway is running; if so, bail with an error.
+
+    Mutating plugin files (git pull) while the gateway is loaded can
+    cause ModuleNotFoundError in lazy-import callbacks that depend on
+    files that were just removed or renamed.
+    """
+    try:
+        from hermes_cli.gateway import find_gateway_pids
+
+        if find_gateway_pids():
+            from rich.console import Console
+
+            Console().print(
+                "[red]Error:[/red] The gateway is running. "
+                "Stop the gateway, update, then start again."
+            )
+            sys.exit(1)
+    except Exception:
+        # If we can't even probe (env without gateway, import error, etc.),
+        # let the update proceed — better a false-negative than a false-positive
+        # gate that blocks updates when the gateway plainly isn't running.
+        pass
+
+
 def cmd_update(name: str) -> None:
     """Update an installed plugin by pulling latest from its git remote."""
     from rich.console import Console
@@ -652,6 +677,8 @@ def cmd_update(name: str) -> None:
             f"(no .git directory). Cannot update."
         )
         sys.exit(1)
+
+    _assert_gateway_not_running()
 
     console.print(f"[dim]Updating {name}...[/dim]")
 
@@ -1949,6 +1976,20 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
             "ok": False,
             "error": f"Plugin '{name}' is not a git checkout; cannot pull updates.",
         }
+
+    # Don't pull if the gateway is running — mutating plugin files under
+    # a live gateway can cause ModuleNotFoundError in lazy-import callbacks
+    # that depend on files that were just removed or renamed.
+    try:
+        from hermes_cli.gateway import find_gateway_pids
+
+        if find_gateway_pids():
+            return {
+                "ok": False,
+                "error": "The gateway is running. Stop the gateway, update, then start again.",
+            }
+    except Exception:
+        pass
 
     ok, msg = _git_pull_plugin_dir(target)
     if not ok:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -737,7 +737,7 @@ def _check_gateway_running(profile_dir: Path) -> bool:
 # renders "全部智能体 0". We cache the count keyed by the skills dir, invalidated
 # when the dir tree's signature (skills_dir + immediate category dirs mtimes)
 # changes (catches skill add/remove) or after a short TTL (catches deep edits).
-_SKILL_COUNT_CACHE: dict[str, tuple[float, float, int]] = {}
+_SKILL_COUNT_CACHE: dict[str, tuple[tuple[float, ...], float, int]] = {}
 _SKILL_COUNT_TTL_SECONDS = 30.0
 
 
@@ -768,29 +768,81 @@ def _skills_dir_signature(skills_dir: Path) -> float:
     return sig
 
 
+def _collect_skills_dirs(profile_dir: Path) -> List[Path]:
+    """Return all skill directories visible to *profile_dir*.
+
+    Order: profile-specific skills first (own ``skills/``), then the global
+    ``~/.hermes/skills/`` (via ``get_default_hermes_root`` so this is
+    unaffected by profile-scope overrides), then any
+    ``skills.external_dirs`` from config.
+    """
+    from agent.skill_utils import get_external_skills_dirs
+    from hermes_constants import get_default_hermes_root
+
+    dirs: List[Path] = []
+
+    profile_skills = profile_dir / "skills"
+    if profile_skills.is_dir():
+        dirs.append(profile_skills)
+
+    global_skills = get_default_hermes_root() / "skills"
+    if global_skills.is_dir() and global_skills not in dirs:
+        dirs.append(global_skills)
+
+    for ext_dir in get_external_skills_dirs():
+        if ext_dir not in dirs:
+            dirs.append(ext_dir)
+
+    return dirs
+
+
+def _skills_dirs_signature(dirs: List[Path]) -> tuple[float, ...]:
+    """Combined change-signature for multiple skill directories."""
+    return tuple(_skills_dir_signature(d) for d in dirs)
+
+
 def _count_skills(profile_dir: Path) -> int:
-    """Count installed skills in a profile (cached by skills-dir signature)."""
-    skills_dir = profile_dir / "skills"
-    if not skills_dir.is_dir():
+    """Count total skills available to *profile_dir* (profile-specific +
+    global + external dirs, cached by combined dir signature).
+
+    Deduplicates by skill name (from YAML frontmatter) across directories so
+    a skill that appears in both the global dir and the profile's own dir is
+    counted once — matching how ``scan_skill_commands`` loads skills.
+    """
+    dirs = _collect_skills_dirs(profile_dir)
+    if not dirs:
         return 0
 
-    key = str(skills_dir)
-    signature = _skills_dir_signature(skills_dir)
+    key = ";".join(str(d) for d in dirs)
+    signatures = _skills_dirs_signature(dirs)
     now = time.time()
     cached = _SKILL_COUNT_CACHE.get(key)
     if (
         cached is not None
-        and cached[0] == signature
+        and cached[0] == signatures
         and (now - cached[1]) < _SKILL_COUNT_TTL_SECONDS
     ):
         return cached[2]
 
+    from agent.skill_utils import parse_frontmatter
+
     count = 0
-    for md in skills_dir.rglob("SKILL.md"):
-        if is_excluded_skill_path(md):
-            continue
-        count += 1
-    _SKILL_COUNT_CACHE[key] = (signature, now, count)
+    seen_names: set = set()
+    for sdir in dirs:
+        for md in sdir.rglob("SKILL.md"):
+            if is_excluded_skill_path(md):
+                continue
+            # Dedup by skill name from frontmatter
+            try:
+                frontmatter, _ = parse_frontmatter(md.read_text(encoding="utf-8"))
+                name = frontmatter.get("name", md.parent.name)
+            except Exception:
+                name = md.parent.name
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+            count += 1
+    _SKILL_COUNT_CACHE[key] = (signatures, now, count)
     return count
 
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -452,10 +452,13 @@ class TestCmdInstall:
 class TestCmdUpdate:
     """Test the update command."""
 
+    @patch("hermes_cli.plugins_cmd._assert_gateway_not_running")
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     @patch("hermes_cli.plugins_cmd.subprocess.run")
-    def test_update_git_pull_success(self, mock_run, mock_plugins_dir, mock_sanitize):
+    def test_update_git_pull_success(
+        self, mock_run, mock_plugins_dir, mock_sanitize, mock_assert_gateway
+    ):
         from hermes_cli.plugins_cmd import cmd_update
 
         mock_plugins_dir_val = MagicMock()
@@ -472,10 +475,12 @@ class TestCmdUpdate:
         cmd_update("test-plugin")
 
         mock_run.assert_called_once()
+        mock_assert_gateway.assert_called_once()
 
+    @patch("hermes_cli.plugins_cmd._assert_gateway_not_running")
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
-    def test_update_plugin_not_found(self, mock_plugins_dir, mock_sanitize):
+    def test_update_plugin_not_found(self, mock_plugins_dir, mock_sanitize, mock_assert_gateway):
         from hermes_cli.plugins_cmd import cmd_update
 
         mock_plugins_dir_val = MagicMock()
@@ -487,6 +492,32 @@ class TestCmdUpdate:
 
         with pytest.raises(SystemExit) as exc_info:
             cmd_update("nonexistent-plugin")
+
+        assert exc_info.value.code == 1
+        mock_assert_gateway.assert_not_called()
+
+    @patch("hermes_cli.gateway.find_gateway_pids")
+    @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_update_fails_when_gateway_running(
+        self, mock_plugins_dir, mock_sanitize, mock_find_pids
+    ):
+        """Updating a plugin when the gateway is running must fail."""
+        from hermes_cli.plugins_cmd import cmd_update
+
+        mock_find_pids.return_value = [12345]
+
+        mock_plugins_dir_val = MagicMock()
+        mock_plugins_dir.return_value = mock_plugins_dir_val
+        mock_target = MagicMock()
+        mock_target.exists.return_value = True
+        mock_target.__truediv__ = lambda self, x: MagicMock(
+            exists=MagicMock(return_value=True)
+        )
+        mock_sanitize.return_value = mock_target
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update("test-plugin")
 
         assert exc_info.value.code == 1
 


### PR DESCRIPTION
## Problem

Git plugin update while gateway is running mutates the same checkout that loaded callbacks use. A callback with lazy import can fail with ModuleNotFoundError after update.

## Fix

Before git pull, check if gateway is running. If yes, fail with message: 'stop the gateway, update, then start again'. If gateway is stopped, allow update normally.

Fixes #70473