### PR TITLE
fix(mcp): scope privileged servers by runtime

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -123,6 +123,99 @@ class TestLoadMCPConfig:
             assert result == {}
 
 
+class TestMCPRuntimeScopes:
+    def test_detects_gateway_run_with_profile_flag_before_command(self):
+        from tools.mcp_tool import _detect_mcp_runtime_context
+
+        argv = [
+            "hermes",
+            "--profile",
+            "vision",
+            "gateway",
+            "run",
+            "--replace",
+        ]
+        assert _detect_mcp_runtime_context(argv) == "gateway"
+
+    def test_ordinary_cli_is_not_misclassified_as_gateway(self):
+        from tools.mcp_tool import _detect_mcp_runtime_context
+
+        assert _detect_mcp_runtime_context(["hermes", "chat", "-q", "hello"]) == "cli"
+
+    @pytest.mark.parametrize(
+        ("scope", "expected"),
+        [
+            ("gateway", True),
+            (["gateway"], True),
+            ("*", True),
+            (["*"], True),
+            ("cli", False),
+            ([], False),
+            ("   ", False),
+            (["gateway", 7], False),
+            ("not-a-runtime", False),
+        ],
+    )
+    def test_runtime_scope_matching_is_backward_compatible_and_fail_closed(
+        self, scope, expected
+    ):
+        from tools.mcp_tool import _mcp_server_allowed_in_runtime
+
+        assert (
+            _mcp_server_allowed_in_runtime(
+                {"command": "xcrun", "runtime_contexts": scope},
+                runtime_context="gateway",
+            )
+            is expected
+        )
+        assert _mcp_server_allowed_in_runtime(
+            {"command": "xcrun"}, runtime_context="cli"
+        ) is True
+
+    def test_discovery_filters_scoped_servers_before_registration(self):
+        import tools.mcp_tool as mcp_tool
+
+        servers = {
+            "xcode": {"command": "xcrun", "runtime_contexts": ["gateway"]},
+            "filesystem": {"command": "npx"},
+        }
+        with patch.object(mcp_tool, "_MCP_AVAILABLE", True), \
+             patch.object(mcp_tool, "_load_mcp_config", return_value=servers), \
+             patch.object(mcp_tool, "_detect_mcp_runtime_context", return_value="cli"), \
+             patch.object(mcp_tool, "register_mcp_servers", return_value=[]) as register:
+            assert mcp_tool.discover_mcp_tools() == []
+
+        register.assert_called_once_with({"filesystem": {"command": "npx"}})
+
+    def test_direct_registration_cannot_bypass_runtime_scope(self):
+        import tools.mcp_tool as mcp_tool
+
+        servers = {
+            "xcode": {"command": "xcrun", "runtime_contexts": ["gateway"]},
+        }
+        with patch.object(mcp_tool, "_MCP_AVAILABLE", True), \
+             patch.object(mcp_tool, "_detect_mcp_runtime_context", return_value="cli"), \
+             patch.object(mcp_tool, "_ensure_mcp_loop") as ensure_loop, \
+             patch.object(mcp_tool, "_existing_tool_names", return_value=[]):
+            assert mcp_tool.register_mcp_servers(servers) == []
+
+        ensure_loop.assert_not_called()
+
+    def test_probe_cannot_bypass_runtime_scope(self):
+        import tools.mcp_tool as mcp_tool
+
+        servers = {
+            "xcode": {"command": "xcrun", "runtime_contexts": ["gateway"]},
+        }
+        with patch.object(mcp_tool, "_MCP_AVAILABLE", True), \
+             patch.object(mcp_tool, "_load_mcp_config", return_value=servers), \
+             patch.object(mcp_tool, "_detect_mcp_runtime_context", return_value="cli"), \
+             patch.object(mcp_tool, "_ensure_mcp_loop") as ensure_loop:
+            assert mcp_tool.probe_mcp_server_tools() == {}
+
+        ensure_loop.assert_not_called()
+
+
 class TestMCPStatus:
     def test_status_distinguishes_configured_connecting_failed_and_disabled(
         self, monkeypatch

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4455,6 +4455,96 @@ def _load_mcp_config() -> Dict[str, dict]:
         return {}
 
 
+_MCP_RUNTIME_CONTEXTS = frozenset({"gateway", "cli", "cron", "tui", "acp"})
+
+
+def _detect_mcp_runtime_context(argv: Optional[List[str]] = None) -> str:
+    """Return the current Hermes runtime class without granting gateway by default.
+
+    The gateway check deliberately uses the real launcher argv rather than
+    ``HERMES_GATEWAY_SESSION``. TUI/dashboard workers also set that environment
+    marker for approval routing, but they are short-lived processes and must not
+    inherit privileged, long-lived gateway MCP connections.
+    """
+    args = [str(arg) for arg in (sys.argv if argv is None else argv)]
+    if any(
+        args[index] == "gateway" and args[index + 1] == "run"
+        for index in range(len(args) - 1)
+    ):
+        return "gateway"
+
+    lowered = [arg.lower() for arg in args]
+    if any("acp_adapter" in arg for arg in lowered) or any(
+        os.path.basename(arg) == "hermes-acp" for arg in lowered
+    ):
+        return "acp"
+    if "dashboard" in lowered or any("tui_gateway" in arg for arg in lowered):
+        return "tui"
+    if "cron" in lowered or os.getenv("HERMES_CRON_SESSION", "").strip().lower() in {
+        "1", "true", "yes", "on"
+    }:
+        return "cron"
+    # Unknown/ordinary launchers fail away from the privileged gateway lane.
+    return "cli"
+
+
+def _mcp_server_allowed_in_runtime(
+    config: dict,
+    *,
+    runtime_context: Optional[str] = None,
+) -> bool:
+    """Return whether one MCP server is eligible in the current runtime.
+
+    Omitting ``runtime_contexts`` preserves the historical all-runtime behavior.
+    An explicit scope accepts one string, a list of strings, or ``*``. Empty,
+    malformed, and unknown explicit scopes fail closed so a typo cannot launch a
+    privileged server in every Hermes process.
+    """
+    if "runtime_contexts" not in config:
+        return True
+
+    raw_scopes = config.get("runtime_contexts")
+    if isinstance(raw_scopes, str):
+        scopes = [raw_scopes.strip()]
+    elif isinstance(raw_scopes, (list, tuple, set)):
+        if not raw_scopes or any(not isinstance(item, str) for item in raw_scopes):
+            return False
+        scopes = [item.strip() for item in raw_scopes]
+    else:
+        return False
+
+    if not scopes or any(not scope for scope in scopes):
+        return False
+    if any(scope != "*" and scope not in _MCP_RUNTIME_CONTEXTS for scope in scopes):
+        return False
+
+    current = runtime_context or _detect_mcp_runtime_context()
+    return "*" in scopes or current in scopes
+
+
+def _filter_mcp_servers_for_runtime(
+    servers: Dict[str, dict],
+    *,
+    runtime_context: Optional[str] = None,
+) -> Dict[str, dict]:
+    """Filter explicit/configured servers through the runtime-scope contract."""
+    current = runtime_context or _detect_mcp_runtime_context()
+    eligible: Dict[str, dict] = {}
+    for name, config in servers.items():
+        if not isinstance(config, dict):
+            continue
+        if _mcp_server_allowed_in_runtime(config, runtime_context=current):
+            eligible[name] = config
+        else:
+            logger.debug(
+                "Skipping MCP server '%s' in runtime context '%s' (runtime_contexts=%r)",
+                name,
+                current,
+                config.get("runtime_contexts"),
+            )
+    return eligible
+
+
 # ---------------------------------------------------------------------------
 # Server connection helper
 # ---------------------------------------------------------------------------
@@ -5616,7 +5706,12 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         logger.debug("MCP SDK not available -- skipping explicit MCP registration")
         return []
 
-    servers = _filter_suspicious_mcp_servers(servers)
+    # Apply runtime scoping here as well as in config discovery. ACP and other
+    # callers can register explicit server maps directly; without this gate they
+    # could bypass a gateway-only scope and spawn a fresh privileged process.
+    servers = _filter_mcp_servers_for_runtime(
+        _filter_suspicious_mcp_servers(servers)
+    )
     if not servers:
         logger.debug("No explicit MCP servers provided")
         return []
@@ -5750,7 +5845,7 @@ def discover_mcp_tools() -> List[str]:
         logger.debug("MCP SDK not available -- skipping MCP tool discovery")
         return []
 
-    servers = _load_mcp_config()
+    servers = _filter_mcp_servers_for_runtime(_load_mcp_config())
     if not servers:
         logger.debug("No MCP servers configured")
         return []
@@ -5895,7 +5990,7 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     if not _MCP_AVAILABLE:
         return {}
 
-    servers_config = _load_mcp_config()
+    servers_config = _filter_mcp_servers_for_runtime(_load_mcp_config())
     if not servers_config:
         return {}
 


### PR DESCRIPTION
## Summary
- add explicit per-server `runtime_contexts` scoping for MCP servers
- filter configured and directly registered MCP servers before any process/loop spawn
- fail closed for malformed or unknown explicit scopes while preserving backward compatibility when the key is absent
- cover gateway, CLI, cron, TUI/dashboard and ACP runtime detection

## Problem
Privileged MCP servers such as Xcode were being spawned by short-lived non-gateway Hermes processes, causing repeated macOS permission prompts.

## Local activation
The live default profile already has:

```yaml
mcp_servers:
  xcode:
    runtime_contexts: [gateway]
```

The active launchd gateway command is `python -m hermes_cli.main gateway run --replace`, which is detected as the `gateway` runtime. The configuration remains inert on old code and becomes effective once this change is applied.

## Verification
- `uv run --extra dev python -m pytest -q tests/tools/test_mcp_tool.py tests/cron/test_scheduler_mcp_init.py tests/test_tui_entry_mcp_owner.py`
- Result: **236 passed**
- `git diff --check origin/main...HEAD`
- Independent Claude Code / Opus 4.8 / high read-only review: approve; verified all spawn paths are gated. Its two operational concerns were checked: the local Xcode config is already gateway-scoped and the production gateway launch argv contains adjacent `gateway run` tokens.

## Risk
Backward-compatible by default: servers without `runtime_contexts` retain historical all-runtime behaviour. Invalid explicit scopes fail closed.
