### PR TITLE
fix(anthropic): honor disabled thinking on replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -262,6 +262,49 @@ def _supports_adaptive_thinking(model: str) -> bool:
     return not any(v in m for v in _LEGACY_MANUAL_THINKING_CLAUDE_SUBSTRINGS)
 
 
+_ALWAYS_ON_ADAPTIVE_THINKING_MODELS = (
+    "claude-fable-5",
+    "claude-mythos-5",
+    "claude-mythos-preview",
+)
+
+
+def _uses_always_on_adaptive_thinking(model: str) -> bool:
+    """Return whether Anthropic rejects attempts to disable thinking."""
+    model_lower = model.lower()
+    return any(name in model_lower for name in _ALWAYS_ON_ADAPTIVE_THINKING_MODELS)
+
+
+def _resolve_anthropic_replay_thinking_enabled(
+    model: str,
+    request_kwargs: Dict[str, Any],
+) -> bool | None:
+    """Resolve thinking from the final request payload.
+
+    ``None`` means the behavior of a third-party Anthropic-compatible endpoint
+    is unknown, so replayed thinking should be preserved conservatively.
+    """
+    model_lower = model.lower()
+
+    if _uses_always_on_adaptive_thinking(model):
+        return True
+
+    thinking = request_kwargs.get("thinking")
+    if isinstance(thinking, dict):
+        thinking_type = str(thinking.get("type", "")).strip().lower()
+        if thinking_type == "disabled":
+            return False
+        if thinking_type in {"adaptive", "enabled"}:
+            return True
+
+    if _is_claude_model(model):
+        # Sonnet 5 defaults to adaptive thinking when the field is omitted.
+        # Other current Claude models default to thinking off.
+        return "claude-sonnet-5" in model_lower
+
+    return None
+
+
 def _supports_xhigh_effort(model: str) -> bool:
     """Return True for models that accept the 'xhigh' adaptive effort level.
 
@@ -2308,8 +2351,50 @@ def _merge_consecutive_roles(result: List[Dict[str, Any]]) -> List[Dict[str, Any
     return fixed
 
 
+def _find_active_anthropic_tool_turn_assistant_index(
+    result: List[Dict[str, Any]],
+) -> int | None:
+    """Return the assistant turn continued by trailing tool results."""
+    if len(result) < 2:
+        return None
+
+    trailing_user = result[-1]
+    trailing_content = trailing_user.get("content")
+    if trailing_user.get("role") != "user" or not isinstance(trailing_content, list):
+        return None
+
+    tool_result_ids = {
+        block.get("tool_use_id")
+        for block in trailing_content
+        if isinstance(block, dict) and block.get("type") == "tool_result"
+    }
+    if not tool_result_ids or any(
+        not isinstance(block, dict) or block.get("type") != "tool_result"
+        for block in trailing_content
+    ):
+        return None
+
+    assistant_idx = len(result) - 2
+    assistant = result[assistant_idx]
+    assistant_content = assistant.get("content")
+    if assistant.get("role") != "assistant" or not isinstance(assistant_content, list):
+        return None
+
+    tool_use_ids = {
+        block.get("id")
+        for block in assistant_content
+        if isinstance(block, dict) and block.get("type") == "tool_use"
+    }
+    if tool_result_ids.issubset(tool_use_ids):
+        return assistant_idx
+    return None
+
+
 def _manage_thinking_signatures(
-    result: List[Dict[str, Any]], base_url: str | None, model: str | None
+    result: List[Dict[str, Any]],
+    base_url: str | None,
+    model: str | None,
+    thinking_enabled: bool | None = None,
 ) -> None:
     """Strip or preserve thinking blocks based on endpoint type.
 
@@ -2330,6 +2415,7 @@ def _manage_thinking_signatures(
     """
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
+    active_tool_turn_idx = _find_active_anthropic_tool_turn_assistant_index(result)
 
     last_assistant_idx = None
     for i in range(len(result) - 1, -1, -1):
@@ -2357,7 +2443,11 @@ def _manage_thinking_signatures(
                     continue
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
-        elif _is_third_party or idx != last_assistant_idx:
+        elif (
+            _is_third_party
+            or idx != last_assistant_idx
+            or (thinking_enabled is False and idx != active_tool_turn_idx)
+        ):
             # Third-party: strip ALL thinking blocks (signatures are proprietary).
             # Direct Anthropic: strip from non-latest assistant messages only.
             stripped = [
@@ -2468,6 +2558,7 @@ def convert_messages_to_anthropic(
     messages: List[Dict],
     base_url: str | None = None,
     model: str | None = None,
+    thinking_enabled: bool | None = None,
 ) -> Tuple[Optional[Any], List[Dict]]:
     """Convert OpenAI-format messages to Anthropic format.
 
@@ -2523,7 +2614,12 @@ def convert_messages_to_anthropic(
     _strip_orphaned_tool_blocks(result)
     result = _merge_consecutive_roles(result)
     _ensure_leading_user_turn(result)
-    _manage_thinking_signatures(result, base_url, model)
+    _manage_thinking_signatures(
+        result,
+        base_url,
+        model,
+        thinking_enabled=thinking_enabled,
+    )
     _evict_old_screenshots(result)
 
     return system, result
@@ -2542,6 +2638,7 @@ def build_anthropic_kwargs(
     base_url: str | None = None,
     fast_mode: bool = False,
     drop_context_1m_beta: bool = False,
+    extra_body: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build kwargs for anthropic.messages.create().
 
@@ -2582,7 +2679,9 @@ def build_anthropic_kwargs(
     compatible ones).
     """
     system, anthropic_messages = convert_messages_to_anthropic(
-        messages, base_url=base_url, model=model
+        messages,
+        base_url=base_url,
+        model=model,
     )
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
 
@@ -2731,6 +2830,13 @@ def build_anthropic_kwargs(
                 # Anthropic requires temperature=1 when thinking is enabled on older models
                 kwargs["temperature"] = 1
                 kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
+        elif (
+            "claude-sonnet-5" in model.lower()
+            and not _uses_always_on_adaptive_thinking(model)
+        ):
+            # Sonnet 5 defaults to adaptive thinking when omitted, so disabling
+            # it requires an explicit wire parameter.
+            kwargs["thinking"] = {"type": "disabled"}
 
     # ── Strip sampling params on 4.7+ ─────────────────────────────────
     # Opus 4.7 rejects any non-default temperature/top_p/top_k with a 400.
@@ -2763,6 +2869,34 @@ def build_anthropic_kwargs(
             betas.extend(_OAUTH_ONLY_BETAS)
         betas.append(_FAST_MODE_BETA)
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
+
+    if isinstance(extra_body, dict):
+        passthrough = {
+            key: value
+            for key, value in extra_body.items()
+            if key != "reasoning" and not str(key).startswith("_")
+        }
+        override_thinking = passthrough.pop("thinking", None)
+        if isinstance(override_thinking, dict):
+            override_type = str(override_thinking.get("type", "")).strip().lower()
+            if not (
+                override_type == "disabled"
+                and _uses_always_on_adaptive_thinking(model)
+            ):
+                kwargs["thinking"] = dict(override_thinking)
+        if passthrough:
+            existing = kwargs.get("extra_body") or {}
+            if not isinstance(existing, dict):
+                existing = {}
+            kwargs["extra_body"] = {**existing, **passthrough}
+
+    thinking_enabled = _resolve_anthropic_replay_thinking_enabled(model, kwargs)
+    _manage_thinking_signatures(
+        kwargs["messages"],
+        base_url,
+        model,
+        thinking_enabled=thinking_enabled,
+    )
 
     return kwargs
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1356,6 +1356,7 @@ class _AnthropicCompletionsAdapter:
             reasoning_config=_reasoning_cfg,
             tool_choice=normalized_tool_choice,
             is_oauth=self._is_oauth,
+            extra_body=kwargs.get("extra_body"),
         )
         # Opus 4.7+ rejects any non-default temperature/top_p/top_k; only set
         # temperature for models that still accept it. build_anthropic_kwargs
@@ -1364,31 +1365,6 @@ class _AnthropicCompletionsAdapter:
             from agent.anthropic_adapter import _forbids_sampling_params
             if not _forbids_sampling_params(model):
                 anthropic_kwargs["temperature"] = temperature
-
-        # Pass through caller-supplied extra_body so providers behind
-        # Anthropic-compatible gateways receive their per-vendor request
-        # fields (thinking control, metadata, portal tags, ...). The dict
-        # form is the documented Anthropic SDK passthrough for non-standard
-        # request body keys; merge on top of whatever build_anthropic_kwargs
-        # already produced (e.g. fast-mode ``speed``) so call-time settings
-        # survive. Two exclusions:
-        #   - ``reasoning``: the OpenAI-shaped config dict is TRANSLATED into
-        #     the native ``thinking`` field above (build_anthropic_kwargs);
-        #     forwarding the raw field alongside would double-specify
-        #     reasoning and 400 on strict gateways.
-        #   - ``_``-prefixed keys: private Hermes plumbing (_reasoning_config
-        #     et al.), never wire fields.
-        caller_extra_body = kwargs.get("extra_body")
-        if caller_extra_body and isinstance(caller_extra_body, dict):
-            passthrough = {
-                k: v for k, v in caller_extra_body.items()
-                if k != "reasoning" and not str(k).startswith("_")
-            }
-            if passthrough:
-                existing = anthropic_kwargs.get("extra_body") or {}
-                if not isinstance(existing, dict):
-                    existing = {}
-                anthropic_kwargs["extra_body"] = {**existing, **passthrough}
 
         response = create_anthropic_message(self._client, anthropic_kwargs)
         _transport = get_transport("anthropic_messages")

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1005,6 +1005,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             base_url=getattr(agent, "_anthropic_base_url", None),
             fast_mode=(agent.request_overrides or {}).get("speed") == "fast",
             drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
+            extra_body=(agent.request_overrides or {}).get("extra_body"),
         )
 
     # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.
@@ -2093,7 +2094,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 _ant_kw = _tsum.build_kwargs(model=agent.model, messages=api_messages, tools=None,
                                max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
                                is_oauth=agent._is_anthropic_oauth,
-                               preserve_dots=agent._anthropic_preserve_dots())
+                               preserve_dots=agent._anthropic_preserve_dots(),
+                               extra_body=(agent.request_overrides or {}).get("extra_body"))
                 summary_response = agent._anthropic_messages_create(_ant_kw)
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_summary_result.content or "").strip()
@@ -2123,7 +2125,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 _ant_kw2 = _tretry.build_kwargs(model=agent.model, messages=api_messages, tools=None,
                                 is_oauth=agent._is_anthropic_oauth,
                                 max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
-                                preserve_dots=agent._anthropic_preserve_dots())
+                                preserve_dots=agent._anthropic_preserve_dots(),
+                                extra_body=(agent.request_overrides or {}).get("extra_body"))
                 retry_response = agent._anthropic_messages_create(_ant_kw2)
                 _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_retry_result.content or "").strip()

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -75,6 +75,7 @@ class AnthropicTransport(ProviderTransport):
             base_url=params.get("base_url"),
             fast_mode=params.get("fast_mode", False),
             drop_context_1m_beta=params.get("drop_context_1m_beta", False),
+            extra_body=params.get("extra_body"),
         )
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -2444,6 +2444,361 @@ class TestThinkingBlockSignatureManagement:
         assert thinking[0]["signature"] == "sig_live"
         assert "_thinking_signature_invalidated" not in assistant
 
+    def test_disabled_thinking_strips_completed_latest_turn(self):
+        """A new non-thinking request must not replay completed native thinking."""
+        messages = [
+            {"role": "user", "content": "Think about this."},
+            {
+                "role": "assistant",
+                "content": "The answer is 42.",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Signed prior reasoning.",
+                        "signature": "sig_prior",
+                    },
+                    {
+                        "type": "redacted_thinking",
+                        "data": "redacted_prior",
+                    },
+                ],
+            },
+            {"role": "user", "content": "Answer briefly now."},
+        ]
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+        )
+
+        assistant = next(m for m in kwargs["messages"] if m["role"] == "assistant")
+        assert [b["type"] for b in assistant["content"]] == ["text"]
+        assert assistant["content"][0]["text"] == "The answer is 42."
+
+    def test_omitted_thinking_strips_latest_turn_for_default_off_model(self):
+        """Sonnet 4.6 runs without thinking when the field is omitted."""
+        messages = [
+            {"role": "user", "content": "Think about this."},
+            {
+                "role": "assistant",
+                "content": "Done.",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Signed prior reasoning.",
+                        "signature": "sig_prior",
+                    },
+                ],
+            },
+            {"role": "user", "content": "Continue."},
+        ]
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+        )
+
+        assistant = next(m for m in kwargs["messages"] if m["role"] == "assistant")
+        assert assistant["content"] == [{"type": "text", "text": "Done."}]
+
+    def test_sonnet_5_omitted_thinking_preserves_latest_turn(self):
+        """Sonnet 5 defaults to adaptive thinking when the field is omitted."""
+        messages = [
+            {"role": "user", "content": "Think about this."},
+            {
+                "role": "assistant",
+                "content": "Done.",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Signed prior reasoning.",
+                        "signature": "sig_prior",
+                    },
+                ],
+            },
+            {"role": "user", "content": "Continue."},
+        ]
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-5",
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+        )
+
+        assistant = next(m for m in kwargs["messages"] if m["role"] == "assistant")
+        thinking = [
+            block for block in assistant["content"] if block.get("type") == "thinking"
+        ]
+        assert len(thinking) == 1
+        assert thinking[0]["signature"] == "sig_prior"
+        assert "thinking" not in kwargs
+
+    def test_sonnet_5_disabled_thinking_is_explicit_and_strips_latest_turn(self):
+        """Sonnet 5 needs type=disabled because omission defaults to adaptive."""
+        messages = [
+            {"role": "user", "content": "Think about this."},
+            {
+                "role": "assistant",
+                "content": "Done.",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Signed prior reasoning.",
+                        "signature": "sig_prior",
+                    },
+                ],
+            },
+            {"role": "user", "content": "Continue briefly."},
+        ]
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-5",
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+        )
+
+        assistant = next(m for m in kwargs["messages"] if m["role"] == "assistant")
+        assert assistant["content"] == [{"type": "text", "text": "Done."}]
+        assert kwargs["thinking"] == {"type": "disabled"}
+
+    def test_extra_body_enabled_thinking_preserves_latest_turn(self):
+        """The final wire override wins over a disabled reasoning config."""
+        messages = [
+            {"role": "user", "content": "Think about this."},
+            {
+                "role": "assistant",
+                "content": "Done.",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Signed prior reasoning.",
+                        "signature": "sig_prior",
+                    },
+                ],
+            },
+            {"role": "user", "content": "Continue."},
+        ]
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+            extra_body={"thinking": {"type": "adaptive"}},
+        )
+
+        assistant = next(m for m in kwargs["messages"] if m["role"] == "assistant")
+        thinking = [
+            block for block in assistant["content"] if block.get("type") == "thinking"
+        ]
+        assert len(thinking) == 1
+        assert thinking[0]["signature"] == "sig_prior"
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert "thinking" not in kwargs.get("extra_body", {})
+
+    def test_extra_body_disabled_thinking_strips_latest_turn(self):
+        """The final wire override wins over an enabled reasoning config."""
+        messages = [
+            {"role": "user", "content": "Think about this."},
+            {
+                "role": "assistant",
+                "content": "Done.",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Signed prior reasoning.",
+                        "signature": "sig_prior",
+                    },
+                ],
+            },
+            {"role": "user", "content": "Continue."},
+        ]
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-5",
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "high"},
+            extra_body={"thinking": {"type": "disabled"}},
+        )
+
+        assistant = next(m for m in kwargs["messages"] if m["role"] == "assistant")
+        assert assistant["content"] == [{"type": "text", "text": "Done."}]
+        assert kwargs["thinking"] == {"type": "disabled"}
+        assert "thinking" not in kwargs.get("extra_body", {})
+
+    def test_primary_request_path_honors_extra_body_thinking_override(self):
+        """Profile extra_body must reach the final main-agent wire decision."""
+        from agent.chat_completion_helpers import build_api_kwargs
+
+        messages = [
+            {"role": "user", "content": "Think about this."},
+            {
+                "role": "assistant",
+                "content": "Done.",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Signed prior reasoning.",
+                        "signature": "sig_prior",
+                    },
+                ],
+            },
+            {"role": "user", "content": "Continue."},
+        ]
+        agent = SimpleNamespace(
+            api_mode="anthropic_messages",
+            tools=None,
+            model="claude-sonnet-5",
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+            request_overrides={
+                "extra_body": {"thinking": {"type": "adaptive"}}
+            },
+            _is_anthropic_oauth=False,
+            _ephemeral_max_output_tokens=None,
+            _anthropic_base_url=None,
+            _oauth_1m_beta_disabled=False,
+            _get_transport=lambda: get_transport("anthropic_messages"),
+            _prepare_anthropic_messages_for_api=lambda value: value,
+            _anthropic_preserve_dots=lambda: False,
+        )
+
+        kwargs = build_api_kwargs(agent, messages)
+
+        assistant = next(m for m in kwargs["messages"] if m["role"] == "assistant")
+        thinking = [
+            block for block in assistant["content"] if block.get("type") == "thinking"
+        ]
+        assert len(thinking) == 1
+        assert thinking[0]["signature"] == "sig_prior"
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert "thinking" not in kwargs.get("extra_body", {})
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-fable-5",
+            "claude-mythos-5",
+            "claude-mythos-preview",
+        ],
+    )
+    def test_always_on_models_preserve_thinking_when_disabled_requested(self, model):
+        """Always-on models reject type=disabled and still require replay."""
+        messages = [
+            {"role": "user", "content": "Think about this."},
+            {
+                "role": "assistant",
+                "content": "Done.",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Signed prior reasoning.",
+                        "signature": "sig_prior",
+                    },
+                ],
+            },
+            {"role": "user", "content": "Continue."},
+        ]
+
+        kwargs = build_anthropic_kwargs(
+            model=model,
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+        )
+
+        assistant = next(m for m in kwargs["messages"] if m["role"] == "assistant")
+        thinking = [
+            block for block in assistant["content"] if block.get("type") == "thinking"
+        ]
+        assert len(thinking) == 1
+        assert thinking[0]["signature"] == "sig_prior"
+        assert "thinking" not in kwargs
+
+    def test_disabled_thinking_preserves_active_tool_turn_signature(self):
+        """Tool-result continuation still needs the original signed thinking."""
+        messages = [
+            {"role": "user", "content": "Inspect the file."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc_read",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    },
+                ],
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "I should inspect it.",
+                        "signature": "sig_tool",
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_read", "content": "contents"},
+        ]
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+        )
+
+        assistant = next(m for m in kwargs["messages"] if m["role"] == "assistant")
+        thinking = [
+            block for block in assistant["content"] if block.get("type") == "thinking"
+        ]
+        assert len(thinking) == 1
+        assert thinking[0]["signature"] == "sig_tool"
+
+    def test_disabled_thinking_keeps_placeholder_for_thinking_only_turn(self):
+        """Stripping a completed thinking-only turn must not make it empty."""
+        messages = [
+            {"role": "user", "content": "Think."},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Only reasoning.",
+                        "signature": "sig_only",
+                    },
+                ],
+            },
+            {"role": "user", "content": "Continue without thinking."},
+        ]
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=messages,
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+        )
+
+        assistant = next(m for m in kwargs["messages"] if m["role"] == "assistant")
+        assert assistant["content"] == [
+            {"type": "text", "text": "(thinking elided)"}
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Tool choice

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3860,19 +3860,28 @@ class TestAuxiliaryTaskExtraBody:
         assert mock_bak.call_args.kwargs["reasoning_config"] == {
             "enabled": True, "effort": "low",
         }
+        assert mock_bak.call_args.kwargs["extra_body"] == {
+            "reasoning": {"enabled": True, "effort": "low"},
+        }
         mock_create.assert_called_once()
 
     def _run_anthropic_adapter(self, *, call_extra_body=None, bak_result=None):
         """Drive _AnthropicCompletionsAdapter.create() with mocked SDK layers;
         return the api_kwargs handed to create_anthropic_message."""
+        from contextlib import nullcontext
+
         from agent.auxiliary_client import _AnthropicCompletionsAdapter
 
         adapter = _AnthropicCompletionsAdapter(MagicMock(), "claude-sonnet-4-6", is_oauth=False)
-        bak_result = bak_result or {
-            "model": "claude-sonnet-4-6", "messages": [], "max_tokens": 64,
-        }
-        with patch("agent.anthropic_adapter.build_anthropic_kwargs",
-                   return_value=dict(bak_result)), \
+        builder_context = (
+            patch(
+                "agent.anthropic_adapter.build_anthropic_kwargs",
+                return_value=dict(bak_result),
+            )
+            if bak_result is not None
+            else nullcontext()
+        )
+        with builder_context, \
              patch("agent.anthropic_adapter.create_anthropic_message") as mock_create, \
              patch("agent.transports.get_transport") as mock_gt:
             mock_gt.return_value.normalize_response.return_value = MagicMock(
@@ -3894,9 +3903,8 @@ class TestAuxiliaryTaskExtraBody:
         api_kwargs = self._run_anthropic_adapter(
             call_extra_body={"thinking": {"type": "disabled"}, "metadata": {"user_id": "u1"}},
         )
-        assert api_kwargs["extra_body"] == {
-            "thinking": {"type": "disabled"}, "metadata": {"user_id": "u1"},
-        }
+        assert api_kwargs["thinking"] == {"type": "disabled"}
+        assert api_kwargs["extra_body"] == {"metadata": {"user_id": "u1"}}
 
     def test_anthropic_aux_extra_body_excludes_reasoning_and_private_keys(self):
         """The OpenAI-shaped reasoning dict is translated (not forwarded), and
@@ -3910,14 +3918,12 @@ class TestAuxiliaryTaskExtraBody:
         )
         assert api_kwargs["extra_body"] == {"metadata": {"user_id": "u1"}}
 
-    def test_anthropic_aux_extra_body_merges_over_existing(self):
-        """Caller extra_body merges on top of what build_anthropic_kwargs
-        already emitted (fast-mode speed) instead of clobbering it."""
+    def test_anthropic_aux_extra_body_preserves_multiple_vendor_fields(self):
+        """All non-private vendor fields survive the centralized merge."""
         api_kwargs = self._run_anthropic_adapter(
-            call_extra_body={"metadata": {"user_id": "u1"}},
-            bak_result={
-                "model": "claude-sonnet-4-6", "messages": [], "max_tokens": 64,
-                "extra_body": {"speed": "fast"},
+            call_extra_body={
+                "speed": "fast",
+                "metadata": {"user_id": "u1"},
             },
         )
         assert api_kwargs["extra_body"] == {

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3880,6 +3880,36 @@ class TestHandleMaxIterations:
         assert "error" in result.lower()
         assert "API down" in result
 
+    def test_anthropic_summary_and_retry_keep_request_extra_body(self, agent):
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
+        agent.request_overrides = {
+            "extra_body": {
+                "thinking": {"type": "disabled"},
+                "metadata": {"tenant": "test"},
+            }
+        }
+        agent._cached_system_prompt = "You are helpful."
+
+        transport = MagicMock()
+        transport.build_kwargs.side_effect = lambda **kwargs: kwargs
+        transport.normalize_response.side_effect = [
+            SimpleNamespace(content=""),
+            SimpleNamespace(content="Summary"),
+        ]
+        agent._get_transport = MagicMock(return_value=transport)
+        agent._anthropic_messages_create = MagicMock(return_value=object())
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            60,
+        )
+
+        assert result == "Summary"
+        assert transport.build_kwargs.call_count == 2
+        for call in transport.build_kwargs.call_args_list:
+            assert call.kwargs["extra_body"] == agent.request_overrides["extra_body"]
+
     def test_summary_skips_reasoning_for_unsupported_openrouter_model(self, agent):
         agent.base_url = "https://openrouter.ai/api/v1"
         agent.model = "minimax/minimax-m2.5"


### PR DESCRIPTION
## What does this PR do?

Makes Anthropic thinking-history replay follow the final effective wire request rather than a model default computed before provider/profile overrides are applied.

When a session has stored signed thinking and a later request disables thinking through `extra_body`, Hermes can currently replay the stale signed block while sending `thinking.type = "disabled"`. This patch strips completed thinking in that case, preserves signed blocks during active tool continuations, and keeps always-on model behavior intact.

It also forwards the same request `extra_body` through auxiliary and max-iteration summary/retry paths so one session does not change reasoning behavior depending on which request path runs.

## Related Issue

Fixes #70726

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- resolve Anthropic thinking from the final effective request payload;
- strip stale completed thinking blocks when wire thinking is disabled;
- preserve signed thinking during active tool-use continuations;
- retain always-on thinking for models that require it;
- propagate request `extra_body` through normal, auxiliary, summary, and retry paths;
- add regression coverage for disabled overrides, Sonnet 5 defaults, tool continuations, auxiliary requests, and max-iteration retry/summary behavior.

## How to Test

1. Run the focused Anthropic/transport suite shown below.
2. Run Ruff on the touched files.
3. Start with a signed thinking block in history, send a later request with `extra_body={"thinking": {"type": "disabled"}}`, and verify completed thinking is absent unless the request is an active tool continuation.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused Anthropic/transport suite run instead: 329 passed, 1 skipped)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] Documentation update - N/A; no public API or configuration change
- [x] `cli-config.yaml.example` - N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` - N/A; no workflow change
- [x] Cross-platform impact considered; provider request normalization is pure Python
- [x] Tool descriptions/schemas - N/A

## Screenshots / Logs

```text
python -m pytest tests/agent/test_anthropic_adapter.py tests/agent/test_auxiliary_client.py tests/agent/test_kimi_coding_anthropic_thinking.py tests/providers/test_transport_parity.py tests/agent/test_anthropic_mcp_prefix_strip.py tests/run_agent/test_run_agent.py -q -k "anthropic or thinking or transport_parity or mcp_prefix_strip"
329 passed, 1 skipped, 718 deselected

python -m ruff check <touched files>
All checks passed!

autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.92)
```
