### PR TITLE
fix(cli): guard SSH setup test against a missing or hanging ssh client (supersedes #7477)

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1600,19 +1600,39 @@ def setup_terminal_backend(config: dict):
             print_info("  Testing connection...")
             import subprocess
 
-            ssh_cmd = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5"]
-            if ssh_key:
-                ssh_cmd.extend(["-i", ssh_key])
-            if port and port != "22":
-                ssh_cmd.extend(["-p", port])
-            ssh_cmd.append(f"{user}@{host}" if user else host)
-            ssh_cmd.append("echo ok")
-            result = subprocess.run(ssh_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10)
-            if result.returncode == 0:
-                print_success("  SSH connection successful!")
+            if shutil.which("ssh") is None:
+                print_warning(
+                    "  SSH client not found on PATH — install OpenSSH to test the connection."
+                )
             else:
-                print_warning(f"  SSH connection failed: {result.stderr.strip()}")
-                print_info("  Check your SSH key and host settings.")
+                ssh_cmd = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5"]
+                if ssh_key:
+                    ssh_cmd.extend(["-i", ssh_key])
+                if port and port != "22":
+                    ssh_cmd.extend(["-p", port])
+                ssh_cmd.append(f"{user}@{host}" if user else host)
+                ssh_cmd.append("echo ok")
+                try:
+                    result = subprocess.run(
+                        ssh_cmd,
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
+                        timeout=10,
+                    )
+                except subprocess.TimeoutExpired:
+                    print_warning(
+                        "  SSH connection test timed out after 10s. Check the host and network."
+                    )
+                except OSError as exc:
+                    print_warning(f"  Could not run the SSH client: {exc}")
+                else:
+                    if result.returncode == 0:
+                        print_success("  SSH connection successful!")
+                    else:
+                        print_warning(f"  SSH connection failed: {result.stderr.strip()}")
+                        print_info("  Check your SSH key and host settings.")
 
     # Sync terminal backend to .env so terminal_tool picks it up directly.
     # config.yaml is the source of truth, but terminal_tool reads TERMINAL_ENV.

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -250,3 +250,79 @@ def test_vercel_setup_prefills_project_and_team_from_link_file(tmp_path, monkeyp
     assert os.environ["VERCEL_TEAM_ID"] == "linked-team"
     assert defaults["    Vercel project ID"] == "linked-project"
     assert defaults["    Vercel team ID"] == "linked-team"
+
+
+def _drive_ssh_backend(monkeypatch, tmp_path):
+    """Route setup_terminal_backend through the SSH branch with the
+    'Test SSH connection?' prompt answered yes.
+
+    Backend index 3 == ssh (idx_to_backend). Returns the config so callers can
+    invoke setup_terminal_backend(config)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = load_config()
+
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt_choice", lambda *a, **kw: 3
+    )
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt",
+        lambda message, *a, **kw: "example.com" if "SSH host" in message else "",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt_yes_no", lambda *a, **kw: True
+    )
+    return config
+
+
+def test_ssh_setup_warns_when_ssh_client_missing(tmp_path, monkeypatch, capsys):
+    """When no ssh client is on PATH the wizard must warn and skip the test,
+    not crash with an uncaught FileNotFoundError from subprocess.run."""
+    config = _drive_ssh_backend(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+    def _boom(*_a, **_k):
+        raise AssertionError("subprocess.run must not run when ssh is absent")
+
+    monkeypatch.setattr("subprocess.run", _boom)
+
+    setup_mod.setup_terminal_backend(config)
+
+    out = capsys.readouterr().out
+    assert "SSH client not found" in out
+
+
+def test_ssh_setup_warns_on_timeout(tmp_path, monkeypatch, capsys):
+    """A hung/unreachable host makes subprocess.run raise TimeoutExpired under
+    timeout=10; the wizard must warn instead of crashing. This is the path
+    #7477 misses."""
+    import subprocess
+
+    config = _drive_ssh_backend(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/ssh")
+
+    def _timeout(*_a, **_k):
+        raise subprocess.TimeoutExpired(cmd=["ssh"], timeout=10)
+
+    monkeypatch.setattr("subprocess.run", _timeout)
+
+    setup_mod.setup_terminal_backend(config)
+
+    out = capsys.readouterr().out
+    assert "timed out" in out
+
+
+def test_ssh_setup_reports_success(tmp_path, monkeypatch, capsys):
+    """Positive control: a returncode==0 result still reports success, so the
+    warning-path tests cannot pass vacuously."""
+    config = _drive_ssh_backend(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/ssh")
+
+    def _ok(*_a, **_k):
+        return types.SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr("subprocess.run", _ok)
+
+    setup_mod.setup_terminal_backend(config)
+
+    out = capsys.readouterr().out
+    assert "SSH connection successful" in out

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -311,6 +311,47 @@ def test_ssh_setup_warns_on_timeout(tmp_path, monkeypatch, capsys):
     assert "timed out" in out
 
 
+def test_ssh_setup_warns_on_oserror(tmp_path, monkeypatch, capsys):
+    """`subprocess.run` can still raise OSError *after* a successful precheck.
+
+    The `shutil.which("ssh") is None` guard only proves a name resolved on
+    PATH at that instant. The exec itself can fail afterwards: the resolved
+    file is not executable (PermissionError), a wrapper shim is a dangling
+    symlink or was removed in between (FileNotFoundError), the binary is a
+    corrupt/foreign-arch image (OSError EXEC_FORMAT_ERROR), or the process
+    table is exhausted. All are OSError.
+
+    `test_ssh_setup_warns_when_ssh_client_missing` cannot cover this: it
+    returns None from `shutil.which`, so it exits at the precheck and never
+    reaches `subprocess.run`. This test forces the opposite — the precheck
+    passes and the exec is what fails — so it is the only coverage for the
+    `except OSError` branch.
+    """
+    config = _drive_ssh_backend(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/ssh")
+
+    ran = []
+
+    def _permission_denied(*_a, **_k):
+        ran.append(True)
+        raise PermissionError("Permission denied")
+
+    monkeypatch.setattr("subprocess.run", _permission_denied)
+
+    setup_mod.setup_terminal_backend(config)
+
+    # The precheck really was cleared and the exec really was attempted —
+    # otherwise this would be the missing-client test wearing a new name.
+    assert ran, "subprocess.run was never reached; the precheck short-circuited"
+
+    out = capsys.readouterr().out
+    assert "Could not run the SSH client" in out
+    # The OS reason is surfaced, not swallowed into a generic message.
+    assert "Permission denied" in out
+    assert "SSH client not found" not in out
+    assert "SSH connection successful" not in out
+
+
 def test_ssh_setup_reports_success(tmp_path, monkeypatch, capsys):
     """Positive control: a returncode==0 result still reports success, so the
     warning-path tests cannot pass vacuously."""


### PR DESCRIPTION
## What does this PR do?

The **Test SSH connection?** step in the `hermes setup` terminal-backend wizard (`setup_terminal_backend` in `hermes_cli/setup.py`) runs `subprocess.run(["ssh", ...], timeout=10)` with **no guard**. Two real conditions crash the wizard mid-run with an uncaught traceback:

1. **No ssh client on PATH** → `FileNotFoundError` when spawning `ssh`.
2. **Hung / unreachable host** → `subprocess.TimeoutExpired` after `timeout=10` (the `BatchMode=yes` / `ConnectTimeout=5` flags can't help once the process is spawned but the connection stalls).

This adds a `shutil.which("ssh")` precheck — mirroring the existing docker (`shutil.which("docker")`, ~L1239) and apptainer/singularity (~L1255) prechecks already in this file — and wraps the `subprocess.run` call in `try/except` for `TimeoutExpired` and `OSError`. `OSError` is the base class of `FileNotFoundError`, so it also covers PATH/permission spawn failures. In every failure case the wizard prints a clear warning and continues instead of aborting setup.

## Related Issue

Supersedes #7477 (no separate issue filed).

#7477 (`fix(cli): prevent crash when ssh binary is missing during setup test`) has been abandoned since April and is `CONFLICTING` / `DIRTY`. It also only caught `FileNotFoundError` via a bare `try/except` — it **misses the `TimeoutExpired` path entirely** and doesn't use the file's `shutil.which(...)` precheck convention. This PR is the superset: both crash paths, plus the in-file idiom.

## Sibling-site coverage

Concern: interactive setup-wizard `subprocess.run` to an external binary that crashes when the binary is absent or hangs.

Sweep: `grep -n 'subprocess\.\(run\|Popen\|check_output\|call\)' hermes_cli/setup.py` → sites at L814/816/818 (espeak installs) and L1431 (this ssh test).

- **Covered:** L1431 (the ssh connection test) — the only unguarded site.
- **Excluded (reasoned):** L814/816/818 (espeak `brew`/`choco`/`apt` installs) are already wrapped by `except (subprocess.CalledProcessError, FileNotFoundError)` at L820, and carry no `timeout=`, so `TimeoutExpired` cannot arise there. Touching them would be a no-op.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/setup.py`: add `shutil.which("ssh")` precheck; wrap the SSH-test `subprocess.run` in `try/except (subprocess.TimeoutExpired, OSError)`; warn-and-continue on each failure path.
- `tests/hermes_cli/test_setup.py`: three tests driving the SSH backend branch — missing client (asserts warning + `subprocess.run` never called), timeout (asserts warning, no traceback — the path #7477 misses), and a success positive-control.

## How to Test

1. On a machine without an ssh client on PATH (or with `ssh` shadowed), run `hermes setup`, choose the **SSH** terminal backend, and answer **yes** to "Test SSH connection?" — before this change the wizard dies with `FileNotFoundError`; after, it prints "SSH client not found on PATH …" and continues.
2. Point it at an unreachable host (e.g. a firewalled IP) to exercise the timeout path — the wizard now prints "SSH connection test timed out …" instead of crashing.
3. Automated: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_setup.py -k ssh_setup -v`. Regression-verified: both warning-path tests **fail** against `origin/main` (the uncaught exception propagates) and **pass** with the fix; the success control passes in both states.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the focused suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Python 3.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — the missing-client path is most common on Windows/minimal images; `shutil.which` + `OSError` handling is platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A