### PR TITLE
fix(kanban): make creation-time blocks sticky

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3141,6 +3141,25 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if initial_status == "blocked":
+                    # ``initial_status='blocked'`` is an explicit operator
+                    # hold, not a transient circuit-breaker state.  Record the
+                    # sticky marker in the same transaction as the task row so
+                    # no dispatcher tick can observe a blocked task without
+                    # the event that keeps ``recompute_ready`` from promoting
+                    # it.  An event-write failure rolls the whole creation
+                    # back rather than leaving an ambiguous blocked row.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": None,
+                            "kind": None,
+                            "recurrences": 0,
+                            "source": "initial_status",
+                        },
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -5417,6 +5436,54 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+
+    # Creation-time holds are already blocked before a worker can claim them.
+    # Let an operator bind a durable reason/kind to that same hold without
+    # manufacturing a worker run or treating the annotation as a
+    # block→unblock→re-block recurrence.  A dependency block is a routing
+    # request (to ``todo``), not an annotation, and an expected run id cannot
+    # match a never-claimed creation-time hold.
+    existing = conn.execute(
+        "SELECT status, block_recurrences FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if existing is not None and existing["status"] == "blocked":
+        if kind == "dependency" or expected_run_id is not None:
+            return False
+        recurrences = max(int(existing["block_recurrences"] or 0), 1)
+        with write_txn(conn):
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET block_kind = ?, block_recurrences = ?
+                 WHERE id = ? AND status = 'blocked' AND current_run_id IS NULL
+                """,
+                (kind, recurrences, task_id),
+            )
+            if cur.rowcount != 1:
+                return False
+            _append_event(
+                conn,
+                task_id,
+                "blocked",
+                {
+                    "reason": reason,
+                    "kind": kind,
+                    "recurrences": recurrences,
+                    "source": "existing_block_annotation",
+                },
+            )
+            blocked_task = get_task(conn, task_id)
+        _fire_kanban_lifecycle_hook(
+            "kanban_task_blocked",
+            task_id,
+            board=get_current_board(),
+            assignee=blocked_task.assignee if blocked_task else None,
+            run_id=None,
+            reason=reason,
+        )
+        return True
+
     routed_to = "blocked"
     recurrences = 0
     with write_txn(conn):

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -272,6 +272,133 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Creation-time blocked tasks must be atomically sticky
+# ---------------------------------------------------------------------------
+
+
+def test_initial_status_blocked_is_sticky_and_emits_block_event(
+    kanban_home: Path,
+) -> None:
+    """``initial_status='blocked'`` is an operator hold, not a transient
+    circuit-breaker state.  It must be sticky from the creation transaction
+    and must expose both the initial task state and the sticky-block marker in
+    event history."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="awaiting authorization",
+            assignee="default",
+            initial_status="blocked",
+        )
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        events = kb.list_events(conn, tid)
+        assert [event.kind for event in events] == ["created", "blocked"]
+        assert events[0].payload is not None
+        assert events[0].payload["status"] == "blocked"
+        assert events[1].payload == {
+            "reason": None,
+            "kind": None,
+            "recurrences": 0,
+            "source": "initial_status",
+        }
+
+        for _ in range(5):
+            assert kb.recompute_ready(conn) == 0
+            task = kb.get_task(conn, tid)
+            assert task is not None
+            assert task.status == "blocked"
+        assert kb.claim_task(conn, tid) is None
+
+
+def test_initial_block_event_failure_rolls_back_entire_creation(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The initial ``blocked`` marker is part of the same transaction as the
+    task row.  A marker-write failure must never leave a blocked row without
+    sticky history."""
+    original = kb._append_event
+
+    def fail_initial_block(conn, task_id, kind, payload=None, *, run_id=None):
+        if kind == "blocked":
+            raise RuntimeError("injected blocked-event failure")
+        return original(conn, task_id, kind, payload, run_id=run_id)
+
+    monkeypatch.setattr(kb, "_append_event", fail_initial_block)
+    with kb.connect() as conn:
+        with pytest.raises(RuntimeError, match="injected blocked-event failure"):
+            kb.create_task(conn, title="must roll back", initial_status="blocked")
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM task_events").fetchone()[0] == 0
+
+
+def test_existing_initial_block_can_be_annotated_without_synthetic_run(
+    kanban_home: Path,
+) -> None:
+    """An authorization workflow creates the task blocked, then binds the
+    canonical digest as its reason.  Annotating that same hold must succeed
+    without pretending a worker ran or incrementing the unblock-loop count."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="authorization", initial_status="blocked")
+
+        assert kb.block_task(
+            conn,
+            tid,
+            reason="standards-owner-authorization-hold:abc123",
+            kind="needs_input",
+        )
+        assert kb.block_task(
+            conn,
+            tid,
+            reason="standards-owner-authorization-hold:abc123",
+            kind="needs_input",
+        )
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.block_kind == "needs_input"
+        assert task.block_recurrences == 1
+        events = kb.list_events(conn, tid)
+        assert [event.kind for event in events] == ["created", "blocked", "blocked", "blocked"]
+        assert events[-1].payload == {
+            "reason": "standards-owner-authorization-hold:abc123",
+            "kind": "needs_input",
+            "recurrences": 1,
+            "source": "existing_block_annotation",
+        }
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (tid,)
+        ).fetchone()[0] == 0
+        assert kb.recompute_ready(conn) == 0
+
+
+def test_explicit_unblock_releases_initial_sticky_block(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        kb.complete_task(conn, parent, summary="done")
+        child = kb.create_task(
+            conn,
+            title="child",
+            parents=[parent],
+            initial_status="blocked",
+        )
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "blocked"
+
+        assert kb.unblock_task(conn, child)
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "ready"
+        assert kb.list_events(conn, child)[-1].kind == "unblocked"
+
+
+# ---------------------------------------------------------------------------
 # Schema-init recovery on legacy DBs is covered by
 # tests/hermes_cli/test_kanban_db.py::test_connect_migrates_legacy_db_before_optional_column_indexes
 # (landed via #28754 / #28781).  The original PR shipped a duplicate test


### PR DESCRIPTION
## 中文摘要

- `create_task(initial_status="blocked")`现在在同一 SQLite 事务写入`created`和初始`blocked`事件。
- `recompute_ready`不再把创建即阻断的任务提升为`ready`。
- `block_task`允许给尚未运行且已 blocked 的任务追加持久原因事件，不伪造 run，也不重复增加循环次数。
- 显式`unblock_task`仍是唯一解除路径。

## Summary

Make creation-time blocked tasks sticky by persisting the initial block event atomically. Allow an already-blocked, never-run task to receive a durable reason annotation without fabricating a run or inflating recurrence counters.

## Verification

- `tests/hermes_cli/test_kanban_blocked_sticky.py`: 10 passed
- affected matrix: 645 passed, 1 skipped, plus one pre-existing order-dependent WAL warning test failure; the same failure reproduces on `origin/main` and passes in isolation
- `ruff check`: passed
- full-suite attempt is not claimed green: local E2E logging teardown races produced pre-existing failures and timed out at 600s
