### PR TITLE
fix(agent): keep tool results when a server reuses one tool_call_id

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3332,9 +3332,21 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # tool result. This is the final pre-API chokepoint, so dedup defensively
     # here even though repair_message_sequence also consumes matched ids.
     #   (a) collapse duplicate tool_calls WITHIN an assistant message
-    #   (b) drop later tool result messages reusing an already-seen id
+    #   (b) drop tool results that answer no OUTSTANDING tool call
+    #
+    # (b) tracks outstanding calls rather than every id ever seen, because
+    # ``tool_call_id`` is NOT globally unique in practice: llama.cpp emits a
+    # single constant id for every tool call it ever returns (verified: three
+    # separate completions from one server all carry the same id). A
+    # seen-once-drop-forever rule reads the SECOND legitimate tool result of
+    # such a session as a duplicate and deletes it, so from the second tool
+    # call onward the model never sees any result — it announces its next
+    # action and the turn dies with the work unfinished. Outstanding-call
+    # semantics keep both protections intact: a re-emitted result still
+    # answers no pending call and is still dropped, while a genuine new call
+    # that reuses the id re-arms that id first.
     seen_assistant_call_ids: set = set()
-    seen_result_call_ids: set = set()
+    outstanding_call_ids: set = set()
     deduped: List[Dict[str, Any]] = []
     removed_dupes = 0
     for msg in messages:
@@ -3348,17 +3360,22 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     continue
                 if cid:
                     seen_assistant_call_ids.add(cid)
+                    outstanding_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
                 msg = {**msg, "tool_calls": kept_tcs}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()
-            if cid and cid in seen_result_call_ids:
+            if cid and cid not in outstanding_call_ids:
                 removed_dupes += 1
                 continue
             if cid:
-                seen_result_call_ids.add(cid)
+                # Answered: this id is no longer outstanding, so a second
+                # result replaying it is still caught above.
+                outstanding_call_ids.discard(cid)
+                # A reused id must be re-armable by the next assistant call.
+                seen_assistant_call_ids.discard(cid)
             deduped.append(msg)
         else:
             deduped.append(msg)

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -331,6 +331,75 @@ def test_sanitize_preserves_distinct_tool_call_ids():
     assert sorted(m["tool_call_id"] for m in out if m.get("role") == "tool") == ["call_A", "call_B"]
 
 
+# ── tool_call_id reuse by local servers (#70724) ────────────────────────────
+# llama.cpp emits ONE constant tool_call_id for every tool call it returns, so
+# ``tool_call_id`` is not globally unique in practice. The #58327 dedup pass
+# must key off outstanding calls, not "seen at any point", or every result
+# after the first is deleted and the agent stops mid-task.
+
+
+CONSTANT_ID = "ZsSt4SkIFMRz0HtqT7MTlimNvzlKM896"
+
+
+def _call(cid, name="terminal"):
+    return {"role": "assistant", "content": None,
+            "tool_calls": [{"id": cid, "type": "function",
+                            "function": {"name": name, "arguments": "{}"}}]}
+
+
+def _result(cid, content):
+    return {"role": "tool", "tool_call_id": cid, "name": "terminal",
+            "content": content}
+
+
+def test_sanitize_keeps_results_when_server_reuses_one_tool_call_id():
+    """Every answered call survives even when all of them share one id.
+
+    Contract: a tool result is dropped for being unanswerable, never for
+    reusing an id that an earlier call already retired.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [{"role": "user", "content": "do three steps"}]
+    for i in range(3):
+        messages.append(_call(CONSTANT_ID))
+        messages.append(_result(CONSTANT_ID, f"step {i} output"))
+
+    out = sanitize_api_messages(list(messages))
+    results = [m for m in out if m.get("role") == "tool"]
+    assert [m["content"] for m in results] == [
+        "step 0 output", "step 1 output", "step 2 output",
+    ]
+    calls = [m for m in out if m.get("role") == "assistant" and m.get("tool_calls")]
+    assert len(calls) == 3
+
+
+def test_sanitize_still_drops_replayed_result_for_retired_call():
+    """The #58327 protection holds: a second result for an already-answered
+    call answers nothing outstanding and is still dropped."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        _call(CONSTANT_ID),
+        _result(CONSTANT_ID, "real"),
+        _result(CONSTANT_ID, "replayed by a retry/resume glitch"),
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert [m["content"] for m in out if m.get("role") == "tool"] == ["real"]
+
+
+def test_sanitize_drops_result_with_no_preceding_call():
+    """A tool result that never had a call is an orphan regardless of id."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    out = sanitize_api_messages([
+        {"role": "user", "content": "hi"},
+        _result("id_never_requested", "orphan"),
+    ])
+    assert [m for m in out if m.get("role") == "tool"] == []
+
+
 def test_sanitize_drops_empty_tool_calls_array():
     """sanitize_api_messages strips ``tool_calls: []`` from assistant messages.
 


### PR DESCRIPTION
## What does this PR do?

`sanitize_api_messages` deletes every tool result whose `tool_call_id` it has
already seen. That treats a repeated id as garbage from a retry/crash/resume
glitch, which assumes `tool_call_id` is globally unique.

It isn't. **llama.cpp emits one constant id for every tool call it returns** —
three separate completions from the same server all carry
`ZsSt4SkIFMRz0HtqT7MTlimNvzlKM896`. Under a seen-once-drop-forever rule the
*second* legitimate tool result of such a session looks like a duplicate and is
deleted, so from the second tool call onward the model never sees any tool
output. It announces its next action and the turn ends with the task unfinished.

The fix keys the dedup off **outstanding** calls instead of every id ever seen.
Both protections added by #58327 are preserved:

- a replayed result still answers no pending call, so it is still dropped;
- duplicate `tool_calls` sharing an id **within one assistant message** are
  still collapsed;
- a genuine new call that reuses the id re-arms that id first.

`repair_message_sequence` needs no change — it already resets its id set on every
assistant message, so only the final pre-API pass mis-fires (verified: 3/3
results survive there, 1/3 here).

#58327 fixes a real problem (DeepSeek rejects duplicate `tool_call_id` with HTTP
400), so this preserves that behavior rather than reverting it.

### Relation to other open PRs on this dedup pass

Not a duplicate of #67933 or #64345 — those fix the *downstream* shape (dedup
empties an assistant message's `tool_calls` array, which strict providers then
reject). This one fixes the *upstream* cause on the tool-result side: results
that should never have been dropped. They are complementary and can land
independently; this change reduces how often that empty-array shape is produced,
but the intra-message collapse can still produce it, so their guard is still
worth having.

## Related Issue

Fixes #70724

This came out of the investigation in #66429 (empty assistant messages) and its
PR #66509 — same pre-API sanitizer area, and where the trail started. They are
**different bugs** and this does not close #66429: there the payload is rejected
with HTTP 400 for an empty assistant message; here the payload is perfectly
valid and simply missing the tool output the model needs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_runtime_helpers.py` — in `sanitize_api_messages`, replace the
  `seen_result_call_ids` set with `outstanding_call_ids`: an assistant tool call
  arms its id, a tool result consumes it, and a result is dropped only when it
  answers nothing outstanding. Answering an id also clears it from
  `seen_assistant_call_ids` so a later call may legitimately reuse it.
- `tests/run_agent/test_message_sequence_repair.py` — three regression tests
  (below).

## How to Test

Deterministic, no model required:

```python
from agent.agent_runtime_helpers import sanitize_api_messages

CID = "ZsSt4SkIFMRz0HtqT7MTlimNvzlKM896"   # constant id, as llama.cpp emits
msgs = [{"role": "user", "content": "do three steps"}]
for i in range(3):
    msgs.append({"role": "assistant", "content": None,
                 "tool_calls": [{"id": CID, "type": "function",
                                 "function": {"name": "terminal", "arguments": "{}"}}]})
    msgs.append({"role": "tool", "tool_call_id": CID, "content": f"step {i} output"})

print([m["content"] for m in sanitize_api_messages(msgs) if m.get("role") == "tool"])
```

```
before: ['step 0 output']
after:  ['step 0 output', 'step 1 output', 'step 2 output']
```

End-to-end, against a live llama.cpp server. Task: create `a.txt` (ALPHA),
create `b.txt` (BETA), read both, write `c.txt` containing `ALPHA-BETA`. A run
passes only if `c.txt` exists — i.e. the whole tool chain survived. 8 runs per
arm, same model and server:

| build | runs completing the task | wall time per run |
|---|---|---|
| v0.19.0 (`3ef6bbd20`) | **1/6** | 5 runs hit a 150s ceiling without finishing |
| v0.19.0 + this fix | **8/8** | 17–26s |
| v0.18.0 (`662426ec3`, before #58327) | 20/20 | 14–71s |

Bisected to `dba585c17` over the 2258 commits between those releases; the
adjacent pair confirms it:

| commit | runs completing the task |
|---|---|
| `60906be3f` (parent) | **8/8** |
| `dba585c17` | **4/8** |

Regression tests added:

- `test_sanitize_keeps_results_when_server_reuses_one_tool_call_id` — the bug.
  Verified to **fail without this fix** (`['step 0 output'] != [3 outputs]`).
- `test_sanitize_still_drops_replayed_result_for_retired_call` — guards the
  #58327 protection.
- `test_sanitize_drops_result_with_no_preceding_call` — guards orphan handling.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — `scripts/run_tests.sh tests/agent/ tests/run_agent/`: **9023 passed, 0 failed**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu / Linux 7.0, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, the
      rationale lives in the code comment next to the changed logic
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, pure in-memory list logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Constant id straight from the server (three consecutive completions):

```
call 1 -> id='ZsSt4SkIFMRz0HtqT7MTlimNvzlKM896'
call 2 -> id='ZsSt4SkIFMRz0HtqT7MTlimNvzlKM896'
call 3 -> id='ZsSt4SkIFMRz0HtqT7MTlimNvzlKM896'
```

Message list in and out of `sanitize_api_messages` before the fix:

```
in:  system, user, assistant, tool, assistant, tool, assistant, tool
out: system, user, assistant, tool, assistant, assistant
     tool results surviving: 1 of 3
```

A failing run on v0.19.0 — the agent announces step 2 and the turn ends, with
`c.txt` never created:

```
"a.txt created. Now I'll create b.txt:"
```
