### PR TITLE
fix(acp): allow safe macOS temp edits

### DIFF
--- a/tests/acp/test_approval_isolation.py
+++ b/tests/acp/test_approval_isolation.py
@@ -15,7 +15,7 @@ Both fixed together by:
 
 import threading
 
-
+import pytest
 
 class TestThreadLocalApprovalCallback:
     """GHSA-qg5c-hvr5-hjgr: set_approval_callback must be per-thread so
@@ -201,6 +201,30 @@ class TestAcpExecAskGate:
     (HERMES_EXEC_ASK takes the gateway-queue path which requires a
     notify_cb registered in _gateway_notify_cbs — not applicable to ACP,
     which uses a direct callback shape.)"""
+
+    @pytest.fixture(autouse=True)
+    def _hermetic_approval_caches(self, monkeypatch):
+        """Isolate against approval-bypass caches that populate at import time.
+
+        ``tools.approval`` eagerly loads the developer's real permanent
+        ``command_allowlist`` (e.g. the ``recursive delete`` pattern) into the
+        module-global ``_permanent_approved`` set the first time it is imported
+        — which happens during collection, before the per-test HERMES_HOME
+        isolation fixture can point at an empty profile. A leaked ``recursive
+        delete`` entry makes ``rm -rf`` auto-approve via ``is_approved`` and
+        never reach the interactive callback, silently defeating these tests.
+
+        Swap the three bypass containers for empty ones via monkeypatch (auto
+        restored after each test). Production code reads these names out of the
+        module globals, so it transparently sees the empty sets for the test's
+        duration — no production behavior is altered.
+        """
+        import tools.approval as approval
+
+        monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False)
+        monkeypatch.setattr(approval, "_permanent_approved", set())
+        monkeypatch.setattr(approval, "_session_approved", {})
+        monkeypatch.setattr(approval, "_session_yolo", set())
 
     def test_interactive_env_var_routes_to_callback(self, monkeypatch):
         """When HERMES_INTERACTIVE is set and an approval callback is

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -296,6 +296,44 @@ class TestCheckSensitivePathMacOSBypass:
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
+    def test_current_temp_subtree_allowed(self, tmp_path):
+        from tools.file_tools import _check_sensitive_path
+
+        assert _check_sensitive_path(str(tmp_path / "ordinary.txt")) is None
+
+    def test_symlink_escape_from_temp_stays_blocked(self, tmp_path):
+        from tools.file_tools import _check_sensitive_path
+
+        escape = tmp_path / "escape"
+        escape.symlink_to("/private/var/db/evil.conf")
+        assert _check_sensitive_path(str(escape)) is not None
+
+    def test_non_temp_private_var_still_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+
+        assert _check_sensitive_path("/private/var/db/dslocal/nodes") is not None
+
+    def test_broad_tmpdir_cannot_create_private_var_carveout(self, monkeypatch):
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(file_tools.tempfile, "gettempdir", lambda: "/private/var/tmp")
+        monkeypatch.setattr(file_tools, "_canonical_tempdir", None)
+        monkeypatch.setattr(file_tools, "_canonical_tempdir_loaded", False)
+        assert file_tools._get_canonical_tempdir() is None
+
+    def test_hermes_config_inside_temp_stays_blocked(self, tmp_path, monkeypatch):
+        import tools.file_tools as file_tools
+
+        config_path = tmp_path / "config.yaml"
+        monkeypatch.setattr(
+            file_tools, "_hermes_config_resolved", str(config_path.resolve())
+        )
+        monkeypatch.setattr(file_tools, "_hermes_config_resolved_loaded", True)
+
+        error = file_tools._check_sensitive_path(str(config_path))
+        assert error is not None
+        assert "Hermes config file" in error
+
 
 class TestAtomicWrite:
     """write_file / patch land via a temp-file + atomic rename.

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,6 +7,7 @@ import logging
 import os
 import posixpath
 import sys
+import tempfile
 import threading
 from pathlib import Path, PurePosixPath
 
@@ -575,6 +576,63 @@ _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 _hermes_config_resolved: str | None = None
 _hermes_config_resolved_loaded = False
 
+_canonical_tempdir: str | None = None
+_canonical_tempdir_loaded = False
+
+
+def _get_canonical_tempdir() -> str | None:
+    """Return the process's canonical (symlink-resolved) temp directory.
+
+    On macOS ``tempfile.gettempdir()`` lives under ``/var/folders/...`` which
+    resolves to ``/private/var/folders/...`` — a subtree of the broadly
+    protected ``/private/var/`` prefix. Writes to the current process's own
+    temp tree are legitimate (pytest ``tmp_path``, atomic-write scratch files),
+    so we carve out exactly this real subtree while keeping the rest of
+    ``/private/var`` blocked. Cached because ``realpath`` hits the filesystem.
+    """
+    global _canonical_tempdir, _canonical_tempdir_loaded
+    if _canonical_tempdir_loaded:
+        return _canonical_tempdir
+    _canonical_tempdir_loaded = True
+    try:
+        candidate = os.path.realpath(tempfile.gettempdir())
+    except (OSError, ValueError):
+        _canonical_tempdir = None
+        return _canonical_tempdir
+
+    # The carve-out exists only for macOS's per-user runtime temp shape:
+    # /private/var/folders/<bucket>/<user-hash>/T.  TMPDIR is configurable;
+    # never let a broad value such as /private/var or /private/var/tmp weaken
+    # the protected-prefix guard below.
+    parts = Path(candidate).parts
+    if (
+        sys.platform == "darwin"
+        and len(parts) == 7
+        and parts[:4] == ("/", "private", "var", "folders")
+        and parts[-1] == "T"
+    ):
+        _canonical_tempdir = candidate
+    else:
+        _canonical_tempdir = None
+    return _canonical_tempdir
+
+
+def _is_within_dir(path: str, directory: str) -> bool:
+    """Path-boundary-safe containment: is ``path`` inside ``directory``?
+
+    Uses ``os.path.commonpath`` so a sibling like ``/private/var/foldersX``
+    is NOT treated as inside ``/private/var/folders`` (a plain ``startswith``
+    would wrongly match). Both arguments must be absolute, symlink-resolved
+    paths for the result to be a real-filesystem containment check.
+    """
+    if not path or not directory:
+        return False
+    try:
+        return os.path.commonpath([path, directory]) == directory
+    except ValueError:
+        # Raised for mixed absolute/relative or different drives.
+        return False
+
 
 def _get_hermes_config_resolved() -> str | None:
     """Return the resolved absolute path of the Hermes config file (cached)."""
@@ -604,9 +662,23 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
-    for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
-            return _err
+    # Allow writes inside THIS process's canonical temp subtree, even though it
+    # lives under a protected prefix (macOS temp is /private/var/folders/...).
+    # ``resolved`` has already followed symlinks (Path.resolve), so a symlink
+    # planted in temp that points at a protected path resolves OUTSIDE the temp
+    # tree and stays blocked by the prefix checks below.
+    canonical_tmp = _get_canonical_tempdir()
+    is_runtime_temp = False
+    if canonical_tmp:
+        try:
+            real_target = os.path.realpath(resolved)
+        except (OSError, ValueError):
+            real_target = resolved
+        is_runtime_temp = _is_within_dir(real_target, canonical_tmp)
+    if not is_runtime_temp:
+        for prefix in _SENSITIVE_PATH_PREFIXES:
+            if resolved.startswith(prefix) or normalized.startswith(prefix):
+                return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
     # Prevent agents from modifying the Hermes config file directly.


### PR DESCRIPTION
## Summary
- allow file-tool writes inside the canonical macOS per-user runtime temp directory (`/private/var/folders/<bucket>/<user-hash>/T`)
- preserve `/private/var` protection everywhere else, including symlink escapes, broad/custom `TMPDIR` values, exact sensitive paths and the Hermes config file
- make ACP approval-routing tests hermetic against developer-local import-time approval caches

## Problem
The ACP edit-approval suite creates targets with pytest `tmp_path`. On macOS those paths resolve beneath `/private/var/folders/...`, while the file-tool security guard previously rejected all `/private/var` paths. Three edit-approval tests therefore failed before reaching the approval flow. Two approval-routing tests were also susceptible to developer-local cached approval bypass state.

## Verification
- `uv run --extra acp --extra dev python -m pytest -q tests/acp` → **310 passed**
- `uv run --extra dev python -m pytest -q tests/tools/test_file_write_safety.py` → **51 passed**
- `git diff --check`

## Security notes
- the carve-out only activates for the exact canonical Darwin per-user temp shape
- a broad/custom `TMPDIR` such as `/private/var/tmp` cannot create an exception
- symlinks resolving outside the runtime temp subtree remain blocked
- Hermes config protection is evaluated even when the config path itself is beneath the temp root
