### PR TITLE
fix(delegation): harden async delegation notification formatting against malformed fields

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1276,6 +1276,25 @@ def test_format_returns_none_for_empty_event():
     assert "unknown" in result
 
 
+def test_format_async_delegation_handles_malformed_fields():
+    # Test non-string/non-list toolsets and non-dict/string-indexed batch results
+    evt_toolsets = {
+        "type": "async_delegation",
+        "toolsets": [None, "web"],
+    }
+    res1 = format_process_notification(evt_toolsets)
+    assert "Toolsets: web" in res1
+
+    evt_batch = {
+        "type": "async_delegation",
+        "is_batch": True,
+        "results": [None, {"task_index": "0", "status": "completed", "summary": "done"}],
+    }
+    res2 = format_process_notification(evt_batch)
+    assert "ASYNC DELEGATION BATCH COMPLETE" in res2
+    assert "done" in res2
+
+
 def test_drain_notifications_returns_pending_events():
     from tools.process_registry import process_registry
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2046,7 +2046,7 @@ def _format_async_delegation(evt: dict) -> str:
     deleg_id = evt.get("delegation_id", "unknown")
     goal = evt.get("goal", "") or ""
     context = evt.get("context")
-    toolsets = evt.get("toolsets")
+    raw_toolsets = evt.get("toolsets")
     role = evt.get("role") or "leaf"
     model = evt.get("model") or "?"
     status = evt.get("status") or "completed"
@@ -2057,13 +2057,20 @@ def _format_async_delegation(evt: dict) -> str:
     dispatched_at = evt.get("dispatched_at")
     completed_at = evt.get("completed_at") or _time.time()
 
+    if isinstance(raw_toolsets, str):
+        toolsets_str = raw_toolsets
+    elif isinstance(raw_toolsets, (list, tuple, set)):
+        toolsets_str = ", ".join(str(t) for t in raw_toolsets if t is not None)
+    else:
+        toolsets_str = ""
+
     # ----- Batch (fan-out) completion: consolidated multi-task block -----
     # A whole delegate_task fan-out dispatched as one background unit finishes
     # together and carries a per-task `results` list. Render every subagent's
     # summary in one block so the model gets the consolidated outcome at once.
     batch_results = evt.get("results")
     if evt.get("is_batch") or isinstance(batch_results, list):
-        results = batch_results or []
+        results = [r for r in (batch_results or []) if isinstance(r, dict)]
         goals = evt.get("goals") or []
         n = len(results) if results else len(goals)
         total_dur = evt.get("total_duration_seconds", duration)
@@ -2081,19 +2088,24 @@ def _format_async_delegation(evt: dict) -> str:
             lines.append(f"Dispatched: {ts}{age}")
         if context:
             lines.append(f"Context you provided: {context}")
-        if toolsets:
-            lines.append(f"Toolsets: {', '.join(toolsets)}")
+        if toolsets_str:
+            lines.append(f"Toolsets: {toolsets_str}")
         lines.append(f"Role: {role}   Model: {model}   Total duration: {total_dur}s")
         if error and not results:
             lines.append("--- ERROR ---")
             lines.append(f"The batch did not complete successfully: {error}")
             return "\n".join(lines)
-        for r in sorted(results, key=lambda x: x.get("task_index", 0)):
-            idx = r.get("task_index", 0)
+        def _get_task_idx(r: dict) -> int:
+            try:
+                return int(r.get("task_index", 0))
+            except (TypeError, ValueError):
+                return 0
+        for r in sorted(results, key=_get_task_idx):
+            idx = _get_task_idx(r)
             r_status = r.get("status", "?")
             r_summary = r.get("summary")
             r_error = r.get("error")
-            r_goal = goals[idx] if idx < len(goals) else r.get("goal", "")
+            r_goal = goals[idx] if isinstance(goals, list) and 0 <= idx < len(goals) else r.get("goal", "")
             icon = "✓" if r_status in ("completed", "success") else "✗"
             lines.append("")
             header = f"--- {icon} TASK {idx + 1}/{n}"
@@ -2143,8 +2155,8 @@ def _format_async_delegation(evt: dict) -> str:
     lines.append(f"Original goal: {goal}")
     if context:
         lines.append(f"Context you provided: {context}")
-    if toolsets:
-        lines.append(f"Toolsets: {', '.join(toolsets)}")
+    if toolsets_str:
+        lines.append(f"Toolsets: {toolsets_str}")
     lines.append(f"Role: {role}   Model: {model}")
     lines.append(f"Status: {status}   API calls: {api_calls}   Duration: {duration}s")
     lines.append("--- RESULT ---")


### PR DESCRIPTION
### Summary

Fixes a P1 runtime crash in `tools/process_registry.py` (`_format_async_delegation`) when formatting background subagent and batch delegation completion events.

### Cause
When background subagent tasks completed and returned notification events, `_format_async_delegation` assumed strict schema types:
1. `toolsets` formatting executed `', '.join(toolsets)` directly, which crashed with `TypeError` if `toolsets` was a raw string or contained `None` elements.
2. Batch/fan-out result rendering sorted `results` using `x.get("task_index", 0)` without validating that elements in `results` were `dict` instances or that `task_index` was an integer, triggering unhandled `AttributeError` or `TypeError` crashes in the background notification handler.

### Solution
- Coerce and filter `toolsets` safely regardless of string/list/set type.
- Filter non-dict elements from batch `results` and safely parse integer task indices.
- Added unit test `test_format_async_delegation_handles_malformed_fields` in `tests/tools/test_process_registry.py`.