### PR TITLE
fix(telegram): streamed overflow finals lost under flood control are silently marked delivered

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1907,11 +1907,13 @@ class SendResult:
     raw_response: Any = None
     # Adapter-specific metadata.  Cross-layer contracts that affect delivery
     # semantics must be documented at the producer and consumer sites.  Current
-    # known contract: Telegram edit overflow partials set
+    # known contracts: Telegram edit overflow partials set
     # raw_response["partial_overflow"] with delivered_chunks, total_chunks,
     # last_message_id, delivered_prefix, and continuation_message_ids so the
     # stream consumer can send the missing tail instead of marking a clipped
-    # response complete.
+    # response complete. Telegram saturated streaming previews set
+    # raw_response["delivered_text"] to the truncated text actually visible on
+    # screen, rather than the oversized accumulated input.
     retryable: bool = False  # True for transient connection errors — base will retry automatically
     # Server-requested retry delay in seconds (e.g. Telegram FloodWait retry_after).
     # When present, _send_with_retry() honors this instead of its default backoff.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1914,7 +1914,25 @@ class GatewayStreamConsumer:
                             self._last_sent_text = ""
                             self._notify_new_message()
                         else:
-                            self._last_sent_text = text
+                            # Some adapters intentionally show less than the
+                            # accumulated input during streaming. Telegram, for
+                            # example, truncates oversized previews to one
+                            # message until finalize=True can split the full
+                            # answer. Track what actually landed; otherwise a
+                            # failed final split can make the cursor-cleanup
+                            # guard below mistake a clipped `(1/N)` preview for
+                            # the complete response and suppress recovery.
+                            raw_response = getattr(result, "raw_response", None)
+                            delivered_text = (
+                                raw_response.get("delivered_text")
+                                if isinstance(raw_response, dict)
+                                else None
+                            )
+                            self._last_sent_text = (
+                                delivered_text
+                                if isinstance(delivered_text, str)
+                                else text
+                            )
                         # Successful edit — reset flood strike counter
                         self._flood_strikes = 0
                         return True

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4451,7 +4451,11 @@ class TelegramAdapter(BasePlatformAdapter):
             # stream trips flood control (200s+ penalties) and hangs the final
             # delivery. Skip silently until finalize.
             if self._last_overflow_preview.get(_preview_key) == content:
-                return SendResult(success=True, message_id=message_id)
+                return SendResult(
+                    success=True,
+                    message_id=message_id,
+                    raw_response={"delivered_text": content},
+                )
         elif not finalize:
             # Content shrank back under the cap (segment break / new message
             # id) — clear stale saturation state so dedup can't mask a real
@@ -4467,7 +4471,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = content
-                return SendResult(success=True, message_id=message_id)
+                return SendResult(
+                    success=True,
+                    message_id=message_id,
+                    raw_response=(
+                        {"delivered_text": content}
+                        if _saturated_preview
+                        else None
+                    ),
+                )
 
             formatted = self.format_message(content)
             try:
@@ -4499,7 +4511,15 @@ class TelegramAdapter(BasePlatformAdapter):
             err_str = str(e).lower()
             # "Message is not modified" — content identical, treat as success
             if "not modified" in err_str:
-                return SendResult(success=True, message_id=message_id)
+                return SendResult(
+                    success=True,
+                    message_id=message_id,
+                    raw_response=(
+                        {"delivered_text": content}
+                        if _saturated_preview
+                        else None
+                    ),
+                )
             # Reactive split-and-deliver: parse_mode formatting can inflate
             # the payload past the limit even when the raw text was under
             # (e.g. MarkdownV2 escapes).  Same fix as the pre-flight path.
@@ -4516,14 +4536,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 truncated = self._truncate_stream_overflow_preview(content)
                 if self._last_overflow_preview.get(_preview_key) == truncated:
                     # Saturated-preview dedup (see pre-flight path above).
-                    return SendResult(success=True, message_id=message_id)
+                    return SendResult(
+                        success=True,
+                        message_id=message_id,
+                        raw_response={"delivered_text": truncated},
+                    )
                 await self._bot.edit_message_text(
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     text=truncated,
                 )
                 self._last_overflow_preview[_preview_key] = truncated
-                return SendResult(success=True, message_id=message_id)
+                return SendResult(
+                    success=True,
+                    message_id=message_id,
+                    raw_response={"delivered_text": truncated},
+                )
             # Flood control / RetryAfter — short waits are retried inline,
             # long waits return a failure immediately so streaming can fall back
             # to a normal final send instead of leaving a truncated partial.
@@ -4547,7 +4575,15 @@ class TelegramAdapter(BasePlatformAdapter):
                         message_id=int(message_id),
                         text=content,
                     )
-                    return SendResult(success=True, message_id=message_id)
+                    return SendResult(
+                        success=True,
+                        message_id=message_id,
+                        raw_response=(
+                            {"delivered_text": content}
+                            if _saturated_preview
+                            else None
+                        ),
+                    )
                 except Exception as retry_err:
                     safe_retry_error = _redact_telegram_error_text(retry_err)
                     logger.error(

--- a/tests/gateway/test_stream_consumer_fresh_final.py
+++ b/tests/gateway/test_stream_consumer_fresh_final.py
@@ -601,6 +601,48 @@ class TestFinalCleanupEditFloodControl:
         assert consumer.final_response_sent is False
         assert consumer.final_content_delivered is False
 
+    @pytest.mark.asyncio
+    async def test_failed_final_split_does_not_mark_truncated_preview_delivered(self):
+        """Telegram reports the one-message preview text it actually showed.
+
+        Without this cross-layer metadata, the consumer records the full
+        oversized input as visible. A flood-controlled final split then looks
+        like a cosmetic cursor-strip failure and incorrectly marks the clipped
+        `(1/N)` preview as complete, suppressing the gateway recovery send.
+        """
+        adapter = _make_adapter()
+        adapter.FALLBACK_ON_FINAL_EDIT_FLOOD = True
+        truncated_preview = "first chunk only\n\n(1/2)"
+        adapter.edit_message = AsyncMock(side_effect=[
+            SimpleNamespace(
+                success=True,
+                message_id="initial_preview",
+                raw_response={"delivered_text": truncated_preview},
+            ),
+            SimpleNamespace(
+                success=False,
+                error="flood_control:12",
+                raw_response=None,
+            ),
+        ])
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat",
+            config=StreamConsumerConfig(cursor=" ▉"),
+        )
+
+        await consumer._send_or_edit("preview")
+        full_text = "first chunk only" + (" plus unsent tail" * 400)
+        await consumer._send_or_edit(f"{full_text} ▉")
+        assert consumer._last_sent_text == truncated_preview
+
+        ok = await consumer._send_or_edit(full_text, finalize=True)
+
+        assert ok is False
+        assert consumer.final_response_sent is False
+        assert consumer.final_content_delivered is False
+        assert consumer._fallback_final_send is True
+
 
 class TestStreamConsumerConfigFreshFinalField:
     """The dataclass field must exist and default to 0 (disabled)."""

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -1001,6 +1001,7 @@ class TestEditMessageStreamingSafety:
         # The edit must contain truncated content (≤ MAX_MESSAGE_LENGTH).
         edited_text = adapter._bot.edit_message_text.call_args.kwargs["text"]
         assert len(edited_text) <= adapter.MAX_MESSAGE_LENGTH
+        assert result.raw_response["delivered_text"] == edited_text
 
     @pytest.mark.asyncio
     async def test_saturated_preview_dedups_repeat_oversized_edits(self):
@@ -1029,6 +1030,9 @@ class TestEditMessageStreamingSafety:
             r = await adapter.edit_message("123", "456", "x" * grow, finalize=False)
             assert r.success is True
             assert r.message_id == "456"
+            assert r.raw_response["delivered_text"] == (
+                adapter._last_overflow_preview[("123", "456")]
+            )
         assert adapter._bot.edit_message_text.await_count == 1, (
             "identical saturated previews must not be re-sent"
         )
@@ -1105,6 +1109,7 @@ class TestEditMessageStreamingSafety:
         assert adapter._bot.edit_message_text.await_count == 2
         retry_text = adapter._bot.edit_message_text.await_args_list[1].kwargs["text"]
         assert len(retry_text) <= adapter.MAX_MESSAGE_LENGTH
+        assert result.raw_response["delivered_text"] == retry_text
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

When a streamed Telegram final response overflows the 4096-char limit and the final split then hits flood control (429), the gateway falsely concludes the message was fully delivered. The user sees only the truncated `(1/2)` preview; the `(2/2)` chunk is silently lost, no retry fires, and the delivery-obligation ledger (#67181) never engages.

## Root cause

1. On a non-final oversized edit, the Telegram adapter truncates the streaming preview to `truncate_message(...)[0]` — only the visible first chunk — but returns `success=True` without reporting the truncated text.
2. `GatewayStreamConsumer` therefore records the full oversized input in `_last_sent_text`, even though Telegram only displayed chunk 1.
3. When the final overflow split fails under flood control, the cursor-cleanup heuristic sees `_visible_prefix() == final_text`, falsely sets `_final_content_delivered=True`, and suppresses both fallback delivery and the ledger obligation.

Observed in production (0.19.0, `3ef6bbd20`): a 4,681-char response delivered `(1/2)` only; `gateway.run` logged `content_delivered=True` while `delivery_obligations` held no row for the session, so the loss was silent and unrecoverable.

## Fix

The Telegram adapter now reports `raw_response["delivered_text"]` for truncated/deduplicated streaming previews, and the stream consumer records what actually landed rather than what was submitted. A flood-controlled final split therefore enters full fallback delivery instead of declaring a clipped preview complete.

Changed: `gateway/platforms/base.py`, `gateway/stream_consumer.py`, `plugins/platforms/telegram/adapter.py`, plus focused regressions in `tests/gateway/test_stream_consumer_fresh_final.py` and `tests/gateway/test_telegram_format.py`.

## Verification

- Unpatched 0.19.0 manual regression reproduces the bug (clipped preview falsely marked fully delivered).
- Patched build: clipped preview tracked, fallback delivered the complete response, stale-partial cleanup exercised.
- Live Telegram test: a 5,569-char streamed response delivered completely as two messages with `final_response_sent=True` and `final_content_delivered=True`.
- Focused pytest regressions added for both the consumer bookkeeping and the adapter's delivered-text reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
