### PR TITLE
fix(agent): retry short-window rate limits before fallback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -76,6 +76,7 @@ from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
     jittered_backoff,
+    should_retry_short_window_rate_limit,
     zai_coding_overload_retry_ceiling,
 )
 from agent.trajectory import has_incomplete_scratchpad
@@ -3897,8 +3898,16 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+                _short_window_retry_pending = (
+                    classified.reason == FailoverReason.rate_limit
+                    and should_retry_short_window_rate_limit(
+                        api_error,
+                        retry_count=retry_count,
+                        max_retries=max_retries,
+                    )
+                )
                 _should_fallback = (
-                    is_rate_limited
+                    (is_rate_limited and not _short_window_retry_pending)
                     or (_is_transport_failure and retry_count >= 2)
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -6,6 +6,7 @@ rate-limited provider concurrently.
 """
 
 import random
+import re
 import threading
 import time
 from typing import Any
@@ -31,6 +32,10 @@ _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 # long-tier entry is reachable). Keeping it a single module constant prevents
 # the two from silently desyncing if the short-retry count is ever tuned.
 _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = 3
+
+# A short RPM/TPM throttle usually clears without changing models. Count
+# failures, including the initial request, before the fallback chain may run.
+_SHORT_WINDOW_RATE_LIMIT_ATTEMPTS = 3
 
 
 def jittered_backoff(
@@ -83,6 +88,56 @@ def _error_text(error: Any) -> str:
         getattr(error, "response", None),
     ]
     return " ".join(str(part) for part in parts if part is not None).lower()
+
+
+def is_short_window_rate_limit_error(error: Any) -> bool:
+    """Return True for explicit per-minute RPM/TPM HTTP 429 throttles.
+
+    Bare quota errors are intentionally excluded. They may represent daily,
+    monthly, subscription, or billing walls where waiting on the same model
+    only wastes the retry budget.
+    """
+    response = getattr(error, "response", None)
+    status = getattr(error, "status_code", None)
+    if status is None:
+        status = getattr(response, "status_code", None)
+    if status != 429:
+        return False
+
+    text = _error_text(error)
+    permanent_signals = (
+        "insufficient credit",
+        "insufficient balance",
+        "payment required",
+        "billing",
+        "subscription",
+        "per day",
+        "daily",
+        "per week",
+        "weekly",
+        "per month",
+        "monthly",
+    )
+    if any(signal in text for signal in permanent_signals):
+        return False
+
+    return bool(
+        re.search(r"\b(?:rpm|tpm)\b", text)
+        or re.search(r"\b(?:requests?|tokens?)\s*(?:/|per[- ]?)\s*minute\b", text)
+        or "per-minute" in text
+    )
+
+
+def should_retry_short_window_rate_limit(
+    error: Any,
+    *,
+    retry_count: int,
+    max_retries: int,
+    attempt_budget: int = _SHORT_WINDOW_RATE_LIMIT_ATTEMPTS,
+) -> bool:
+    """Whether a short-window 429 still has same-model retry budget."""
+    retry_ceiling = min(max(0, max_retries), max(0, attempt_budget))
+    return retry_count < retry_ceiling and is_short_window_rate_limit_error(error)
 
 
 def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, error: Any) -> bool:

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -5,7 +5,13 @@ import threading
 import agent.retry_utils as retry_utils
 from types import SimpleNamespace
 
-from agent.retry_utils import adaptive_rate_limit_backoff, is_zai_coding_overload_error, jittered_backoff
+from agent.retry_utils import (
+    adaptive_rate_limit_backoff,
+    is_short_window_rate_limit_error,
+    is_zai_coding_overload_error,
+    jittered_backoff,
+    should_retry_short_window_rate_limit,
+)
 
 
 def test_backoff_is_exponential():
@@ -117,6 +123,62 @@ def test_backoff_uses_locked_tick_for_seed(monkeypatch):
 
     assert len(recorded_seeds) == 2
     assert len(set(recorded_seeds)) == 2, f"Expected unique seeds, got {recorded_seeds}"
+
+
+def _rate_limit_error(message, *, status_code=429):
+    return SimpleNamespace(
+        status_code=status_code,
+        body={"error": {"message": message}},
+    )
+
+
+def test_short_window_rate_limit_classifier_accepts_explicit_minute_windows():
+    for message in (
+        "Rate limit reached for requests per minute",
+        "TPM limit exceeded",
+        "tokens/minute quota exceeded",
+        "Per-minute request limit reached",
+    ):
+        assert is_short_window_rate_limit_error(_rate_limit_error(message))
+
+
+def test_short_window_rate_limit_classifier_rejects_long_term_and_ambiguous_limits():
+    for message in (
+        "Quota exceeded",
+        "Daily token quota exceeded",
+        "Monthly usage limit reached",
+        "Subscription limit reached",
+        "Insufficient credits for requests per minute",
+    ):
+        assert not is_short_window_rate_limit_error(_rate_limit_error(message))
+    assert not is_short_window_rate_limit_error(
+        _rate_limit_error("requests per minute", status_code=400)
+    )
+
+
+def test_short_window_rate_limit_uses_bounded_same_model_budget():
+    error = _rate_limit_error("Rate limit reached: 100 requests per minute")
+
+    assert should_retry_short_window_rate_limit(
+        error, retry_count=1, max_retries=5
+    )
+    assert should_retry_short_window_rate_limit(
+        error, retry_count=2, max_retries=5
+    )
+    assert not should_retry_short_window_rate_limit(
+        error, retry_count=3, max_retries=5
+    )
+
+
+def test_short_window_rate_limit_respects_smaller_configured_retry_ceiling():
+    error = _rate_limit_error("TPM limit exceeded")
+
+    assert should_retry_short_window_rate_limit(
+        error, retry_count=1, max_retries=2
+    )
+    assert not should_retry_short_window_rate_limit(
+        error, retry_count=2, max_retries=2
+    )
 
 
 def _zai_overload_error():


### PR DESCRIPTION
## Summary

- recognize explicit RPM, TPM, and per-minute HTTP 429 throttles
- spend a bounded same-model retry budget before activating configured fallback models
- keep billing, subscription, daily/monthly limits, ambiguous quota errors, and upstream throttles on their existing escalation paths

Fixes #70738.

## Tests

- `python -m pytest tests/test_retry_utils.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_32646_fallback_429_after_timeout.py tests/run_agent/test_nous_429_fallback_reentry.py -q` (50 passed)
- `python -m pytest tests/agent/test_error_classifier.py -q` (199 passed)
- `python -m ruff check agent/retry_utils.py agent/conversation_loop.py tests/test_retry_utils.py`
- `git diff --check`