### PR TITLE
feat(update): add --stop-services to stop and relaunch this install's dashboard/serve processes

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6198,6 +6198,21 @@ def cmd_gui(args: argparse.Namespace):
     sys.exit(launch_result.returncode)
 
 
+# Cmdline substrings identifying this project's long-lived service processes:
+# the dashboard, and the headless backend (`hermes serve`) — the same
+# long-lived server under a different command name (the desktop app spawns
+# it). Shared by the stale-process scan below and the update flow's
+# ``--stop-services`` stop/relaunch path.
+_HERMES_SERVICE_CMDLINE_PATTERNS = [
+    "hermes dashboard",
+    "hermes_cli.main dashboard",
+    "hermes_cli/main.py dashboard",
+    "hermes serve",
+    "hermes_cli.main serve",
+    "hermes_cli/main.py serve",
+]
+
+
 def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
@@ -6226,17 +6241,7 @@ def _find_stale_dashboard_pids(
 
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
-    patterns = [
-        "hermes dashboard",
-        "hermes_cli.main dashboard",
-        "hermes_cli/main.py dashboard",
-        # The headless backend (`hermes serve`) is the same long-lived server
-        # under a different command name — the desktop app spawns it. Reap it
-        # on update for the same frontend/backend-mismatch reason.
-        "hermes serve",
-        "hermes_cli.main serve",
-        "hermes_cli/main.py serve",
-    ]
+    patterns = _HERMES_SERVICE_CMDLINE_PATTERNS
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -6668,61 +6673,38 @@ def _restart_managed_dashboard_service(
     return True
 
 
-def _kill_stale_dashboard_processes(
-    reason: str = "the running backend no longer matches the updated frontend",
-    *,
-    restart_managed: bool = False,
-) -> None:
-    """Kill running ``hermes dashboard`` processes.
+def _desktop_child_pids() -> set[int]:
+    """PIDs of desktop-managed backend children from ``HERMES_DESKTOP_CHILD_PID``.
 
-    Called at the end of ``hermes update`` (default ``reason``) and also
-    from ``hermes dashboard --stop`` (which overrides ``reason``).  The
-    dashboard has no service manager, so after a code update the running
-    process is guaranteed to be serving stale Python against a
-    freshly-updated JS bundle.  Leaving it alive produces silent
-    frontend/backend mismatches (new auth headers the old backend doesn't
-    recognise → every API call 401s).
+    The Hermes Desktop Electron app spawns ``hermes serve`` backends and sets
+    ``HERMES_DESKTOP_CHILD_PID`` (comma-separated; a lone int still parses for
+    back-compat) so update paths never kill processes the app supervises and
+    would immediately respawn.  (#37532)
+    """
+    raw_pid = os.environ.get("HERMES_DESKTOP_CHILD_PID")
+    parsed: set[int] = set()
+    if not raw_pid:
+        return parsed
+    for part in raw_pid.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            parsed.add(int(part))
+        except (ValueError, TypeError):
+            pass
+    return parsed
+
+
+def _terminate_service_pids(
+    pids: list[int],
+) -> tuple[list[int], list[tuple[int, str]]]:
+    """Terminate dashboard/serve service PIDs; returns ``(killed, failed)``.
 
     POSIX: SIGTERM, wait up to ~3s for graceful exit, SIGKILL any survivors.
     Windows: ``taskkill /PID <pid> /F`` since there's no clean SIGTERM
     equivalent for background console apps.
-
-    Manually-started dashboards are not auto-restarted because we don't know
-    the original launch args (--host, --port, --insecure, --tui, --no-open).
-    When ``restart_managed`` is true (the ``hermes update`` path), a detected
-    ``hermes-dashboard.service`` is restarted through systemd instead of
-    raw-killing its main PID.
     """
-    if restart_managed and _restart_managed_dashboard_service(reason):
-        return
-
-    # When the Hermes Desktop Electron app spawns this dashboard as a
-    # backend child, it sets HERMES_DESKTOP_CHILD_PID so that the update
-    # path can skip killing the desktop-managed process.  (#37532)
-    exclude: set[int] | None = None
-    raw_pid = os.environ.get("HERMES_DESKTOP_CHILD_PID")
-    if raw_pid:
-        # The desktop may manage several backends (one per active profile) and
-        # passes them comma-separated; a lone int still parses for back-compat.
-        parsed: set[int] = set()
-        for part in raw_pid.split(","):
-            part = part.strip()
-            if not part:
-                continue
-            try:
-                parsed.add(int(part))
-            except (ValueError, TypeError):
-                pass
-        if parsed:
-            exclude = parsed
-
-    pids = _find_stale_dashboard_pids(exclude_pids=exclude)
-    if not pids:
-        return
-
-    print()
-    print(f"⟲ Stopping {len(pids)} dashboard process(es) ({reason})")
-
     killed: list[int] = []
     failed: list[tuple[int, str]] = []
 
@@ -6783,6 +6765,53 @@ def _kill_stale_dashboard_processes(
                 killed.append(pid)
             except (PermissionError, OSError) as e:
                 failed.append((pid, str(e)))
+
+    return killed, failed
+
+
+def _kill_stale_dashboard_processes(
+    reason: str = "the running backend no longer matches the updated frontend",
+    *,
+    restart_managed: bool = False,
+) -> None:
+    """Kill running ``hermes dashboard`` processes.
+
+    Called at the end of ``hermes update`` (default ``reason``) and also
+    from ``hermes dashboard --stop`` (which overrides ``reason``).  The
+    dashboard has no service manager, so after a code update the running
+    process is guaranteed to be serving stale Python against a
+    freshly-updated JS bundle.  Leaving it alive produces silent
+    frontend/backend mismatches (new auth headers the old backend doesn't
+    recognise → every API call 401s).
+
+    POSIX: SIGTERM, wait up to ~3s for graceful exit, SIGKILL any survivors.
+    Windows: ``taskkill /PID <pid> /F`` since there's no clean SIGTERM
+    equivalent for background console apps.
+
+    Manually-started dashboards are not auto-restarted because we don't know
+    the original launch args (--host, --port, --insecure, --tui, --no-open) —
+    unless the update ran with ``--stop-services``, which records each
+    process's command line before stopping it and relaunches it afterwards.
+    When ``restart_managed`` is true (the ``hermes update`` path), a detected
+    ``hermes-dashboard.service`` is restarted through systemd instead of
+    raw-killing its main PID.
+    """
+    if restart_managed and _restart_managed_dashboard_service(reason):
+        return
+
+    # When the Hermes Desktop Electron app spawns this dashboard as a
+    # backend child, it sets HERMES_DESKTOP_CHILD_PID so that the update
+    # path can skip killing the desktop-managed process.  (#37532)
+    exclude = _desktop_child_pids() or None
+
+    pids = _find_stale_dashboard_pids(exclude_pids=exclude)
+    if not pids:
+        return
+
+    print()
+    print(f"⟲ Stopping {len(pids)} dashboard process(es) ({reason})")
+
+    killed, failed = _terminate_service_pids(pids)
 
     for pid in killed:
         print(f"    ✓ stopped PID {pid}")
@@ -10627,6 +10656,257 @@ def _resume_windows_gateways_after_update(token: dict | None) -> None:
         )
 
 
+def _dashboard_service_main_pid() -> int | None:
+    """Best-effort MainPID of a systemd-managed dashboard unit (POSIX only).
+
+    Used by ``--stop-services`` to leave a systemd-owned dashboard to
+    ``_restart_managed_dashboard_service``: raw-killing its main PID reads as
+    a clean stop to systemd, so ``Restart=on-failure`` would not revive it.
+    Returns ``None`` on Windows, without systemd, or when no unit is active.
+    """
+    if sys.platform == "win32":
+        return None
+    for scope in (("--user",), ()):
+        try:
+            result = subprocess.run(
+                [
+                    "systemctl",
+                    *scope,
+                    "show",
+                    "-p",
+                    "MainPID",
+                    "--value",
+                    _DASHBOARD_SYSTEMD_UNIT,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            continue
+        if result.returncode != 0:
+            continue
+        try:
+            pid = int((result.stdout or "").strip() or "0")
+        except ValueError:
+            continue
+        if pid > 0:
+            return pid
+    return None
+
+
+def _stop_hermes_services_for_update(args) -> dict | None:
+    """Stop this install's dashboard/serve processes before the venv sync.
+
+    Opt-in via ``hermes update --stop-services``. The dashboard and the
+    headless ``hermes serve`` backend run from this install's venv: on
+    Windows they keep native ``.pyd`` files locked (dead-ending the update at
+    the venv-process guard below), and on every platform they keep serving
+    pre-update code during the sync. Gateways already have a pause/resume
+    path around the sync; these services had none — they were only killed
+    after the update with a manual-restart hint, because their launch args
+    were unknown (#40449).
+
+    Records each stopped process's PID, command line, and working directory
+    so ``_restart_hermes_services_after_update`` can relaunch it. Never
+    touches desktop-app-managed backends (``HERMES_DESKTOP_CHILD_PID``), a
+    systemd-managed dashboard unit, or processes from other Hermes installs;
+    the venv-process guard's re-scan stays authoritative for whatever
+    remains, including anything this helper failed to stop. Returns a resume
+    token, or ``None`` when the flag is off or nothing was stopped. Never
+    raises.
+    """
+    if not getattr(args, "stop_services", False):
+        return None
+    try:
+        import psutil
+    except Exception:
+        print(
+            "⚠ --stop-services: psutil is unavailable, cannot identify Hermes "
+            "service processes — continuing without stopping services"
+        )
+        return None
+
+    venv_dir = PROJECT_ROOT / "venv"
+    try:
+        venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
+    except OSError:
+        venv_prefix = str(venv_dir).lower().rstrip(os.sep) + os.sep
+    try:
+        root_prefix = str(PROJECT_ROOT.resolve()).lower().rstrip(os.sep) + os.sep
+    except OSError:
+        root_prefix = str(PROJECT_ROOT).lower().rstrip(os.sep) + os.sep
+
+    skip: set[int] = _desktop_child_pids()
+    managed_pid = _dashboard_service_main_pid()
+    if managed_pid:
+        skip.add(managed_pid)
+    skip.add(os.getpid())
+    try:
+        for anc in psutil.Process().parents():
+            skip.add(int(anc.pid))
+    except Exception:
+        pass
+
+    services: list[dict] = []
+    try:
+        proc_iter = psutil.process_iter(["pid", "exe", "name", "cmdline", "cwd"])
+    except Exception:
+        return None
+    for proc in proc_iter:
+        try:
+            info = proc.info
+        except Exception:
+            continue
+        pid = info.get("pid")
+        if pid is None or int(pid) in skip:
+            continue
+        argv = list(info.get("cmdline") or [])
+        cmdline_raw = " ".join(argv)
+        if not any(p in cmdline_raw for p in _HERMES_SERVICE_CMDLINE_PATTERNS):
+            continue
+        # Same this-install ownership predicate as the venv-process guard:
+        # another install's dashboard is not ours to stop.
+        exe = info.get("exe")
+        try:
+            exe_norm = str(Path(exe).resolve()).lower() if exe else ""
+        except (OSError, ValueError):
+            exe_norm = str(exe).lower()
+        cmdline_low = cmdline_raw.lower()
+        cwd_raw = str(info.get("cwd") or "")
+        cwd_low = cwd_raw.lower().rstrip(os.sep) + os.sep
+        is_ours = bool(exe_norm) and exe_norm.startswith(venv_prefix)
+        if not is_ours and venv_prefix in cmdline_low:
+            is_ours = True
+        if not is_ours and "hermes_cli.main" in cmdline_low:
+            if root_prefix in cmdline_low or cwd_low.startswith(root_prefix):
+                is_ours = True
+        if not is_ours:
+            continue
+        label = "hermes dashboard" if "dashboard" in cmdline_low else "hermes serve"
+        services.append(
+            {
+                "pid": int(pid),
+                "argv": argv or None,
+                "cwd": cwd_raw or None,
+                "label": label,
+            }
+        )
+
+    if not services:
+        return None
+
+    print("→ Stopping Hermes service process(es) before updating (--stop-services)...")
+    for svc in services:
+        print(f"  → {svc['label']} (PID {svc['pid']})")
+
+    killed, failed = _terminate_service_pids([svc["pid"] for svc in services])
+    for pid, err_msg in failed:
+        print(f"  ✗ could not stop PID {pid}: {err_msg}")
+
+    # Wait for the stopped processes to actually exit: the venv-process guard
+    # re-scans live processes right after this, and our own dying PIDs must
+    # not trigger a spurious refusal.
+    import time as _time
+
+    from gateway.status import _pid_exists
+
+    pending = [int(pid) for pid in killed]
+    deadline = _time.monotonic() + 5.0
+    while pending:
+        if _time.monotonic() >= deadline:
+            break
+        pending = [pid for pid in pending if _pid_exists(pid)]
+        if pending:
+            _time.sleep(0.1)
+    unkillable = set(pending) | {pid for pid, _ in failed}
+    if unkillable:
+        # Leave them visible to the venv guard: a process we cannot stop
+        # still holds .pyd files, and refusing is the safe outcome.
+        print(
+            f"  ⚠ {len(unkillable)} process(es) still running; the venv guard "
+            "decides whether the update can proceed"
+        )
+
+    stopped = [svc for svc in services if svc["pid"] not in unkillable]
+    if not stopped:
+        return None
+    return {"resume_needed": True, "services": stopped}
+
+
+def _spawn_detached_service(argv: list[str], cwd: str | None) -> bool:
+    """Detached, windowless spawn of a recorded service command line."""
+    workdir = cwd if cwd and os.path.isdir(cwd) else str(PROJECT_ROOT)
+    kwargs: dict = {
+        "cwd": workdir,
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "close_fds": True,
+    }
+    if _is_windows():
+        from hermes_cli._subprocess_compat import (
+            windows_detach_flags,
+            windows_detach_flags_without_breakaway,
+        )
+
+        try:
+            subprocess.Popen(argv, creationflags=windows_detach_flags(), **kwargs)
+        except OSError:
+            # Job objects may deny CREATE_BREAKAWAY_FROM_JOB; retry without.
+            subprocess.Popen(
+                argv,
+                creationflags=windows_detach_flags_without_breakaway(),
+                **kwargs,
+            )
+    else:
+        subprocess.Popen(argv, start_new_session=True, **kwargs)
+    return True
+
+
+def _restart_hermes_services_after_update(token: dict | None) -> None:
+    """Relaunch services stopped by ``_stop_hermes_services_for_update``.
+
+    Called on every update outcome — success, venv-guard refusal, ZIP
+    fallback, zero-commit early return — and registered via ``atexit`` as a
+    safety net for error paths, mirroring
+    ``_resume_windows_gateways_after_update``. Idempotent: the first call
+    clears the token. Never raises (it runs at interpreter exit).
+    """
+    if not token or not token.get("resume_needed"):
+        return
+    token["resume_needed"] = False
+    services = token.get("services") or []
+    if not services:
+        return
+    print("→ Restarting Hermes service process(es) in the background...")
+    for svc in services:
+        argv = svc.get("argv")
+        label = svc.get("label") or "hermes service"
+        hint = "hermes dashboard" if "dashboard" in label else "hermes serve"
+        if not argv:
+            print(
+                f"  ⚠ PID {svc.get('pid')} had no recoverable command line — "
+                f"restart manually: {hint}"
+            )
+            continue
+        cmd_text = " ".join(str(a) for a in argv)
+        if not any(p in cmd_text for p in _HERMES_SERVICE_CMDLINE_PATTERNS):
+            # PID-reuse race at capture time: never replay a command line we
+            # would not have classified as a Hermes service.
+            print(f"  ⚠ not restarting unrecognized command line: {cmd_text[:80]}")
+            continue
+        try:
+            ok = _spawn_detached_service([str(a) for a in argv], svc.get("cwd"))
+        except Exception as exc:
+            logger.debug("Could not restart %s after update: %s", label, exc)
+            ok = False
+        if ok:
+            print(f"  ✓ Restarted {label} (was PID {svc.get('pid')})")
+        else:
+            print(f"  ✗ could not restart {label} — restart manually: {hint}")
+
+
 def _discard_lockfile_churn(git_cmd, repo_root):
     """Restore tracked ``package-lock.json`` files that npm dirtied locally.
 
@@ -10791,6 +11071,19 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _windows_gateway_resume,
         )
 
+    # Opt-in (--stop-services): stop this install's dashboard/serve processes
+    # and record how to relaunch them. Registered with atexit AFTER the
+    # gateway resume above so the LIFO exit order restarts services first —
+    # the reverse of the stop order.
+    _services_resume = _stop_hermes_services_for_update(args)
+    if _services_resume:
+        import atexit as _atexit
+
+        _atexit.register(
+            _restart_hermes_services_after_update,
+            _services_resume,
+        )
+
     # With gateways paused, anything still running from the venv interpreter
     # (most commonly the Desktop app's `hermes serve` backend) will keep .pyd
     # files locked and corrupt the dependency sync below. Refuse rather than
@@ -10805,6 +11098,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         _venv_holders = _detect_venv_python_processes()
         if _venv_holders:
             print(_format_venv_python_holders_message(_venv_holders))
+            _restart_hermes_services_after_update(_services_resume)
             _resume_windows_gateways_after_update(_windows_gateway_resume)
             sys.exit(2)
 
@@ -10868,6 +11162,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         try:
             _update_via_zip(args)
         finally:
+            _restart_hermes_services_after_update(_services_resume)
             _resume_windows_gateways_after_update(_windows_gateway_resume)
         return
 
@@ -11055,6 +11350,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
                 print("✓ Already up to date!")
+            _restart_hermes_services_after_update(_services_resume)
             _resume_windows_gateways_after_update(_windows_gateway_resume)
             return
 
@@ -12402,6 +12698,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("    Node.js dependency refresh did not complete.")
         else:
             _kill_stale_dashboard_processes(restart_managed=True)
+
+        # Relaunch services stopped by --stop-services only AFTER the stale
+        # sweep above — co-locating this with the gateway resume earlier
+        # would hand the freshly respawned processes straight back to that
+        # sweep as "stale".
+        _restart_hermes_services_after_update(_services_resume)
 
         print()
         print("Tip: You can now select a provider and model:")

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -73,4 +73,10 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
     )
+    update_parser.add_argument(
+        "--stop-services",
+        action="store_true",
+        default=False,
+        help="Stop hermes dashboard / hermes serve processes running from this install before the dependency sync, then relaunch them with their original command line and working directory once the update finishes — including when it fails or is aborted (not if the updater itself is force-killed). Desktop-app-managed backends are never touched (close the app instead), and processes from other installs still trigger the venv guard (see --force-venv).",
+    )
     update_parser.set_defaults(func=cmd_update)

--- a/tests/hermes_cli/test_update_stop_services.py
+++ b/tests/hermes_cli/test_update_stop_services.py
@@ -1,0 +1,613 @@
+"""Tests for ``hermes update --stop-services`` (refs #40449).
+
+Covers the opt-in stop/relaunch path for this install's dashboard/serve
+processes around the dependency sync:
+
+1. ``_stop_hermes_services_for_update`` — detection (service cmdline
+   patterns ∩ this-install ownership), exclusions (self/ancestors, desktop
+   children, systemd-managed dashboard), stop + exit-wait, resume token.
+2. ``_restart_hermes_services_after_update`` — argv/cwd replay, idempotent
+   token, per-service failure isolation, PID-reuse guard.
+3. ``_cmd_update_impl`` wiring — stop runs before the venv-holder guard's
+   re-scan, the guard refusal restarts stopped services before exit 2,
+   the ZIP finally restarts on failure, atexit registration, ``--check``
+   and no-flag runs never touch the new path, and the success tail relaunch
+   comes only after the stale-dashboard sweep.
+
+Windows-specific paths are exercised via ``_is_windows`` patching so the
+suite runs on any host (same approach as test_update_venv_health).
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import main as cli_main
+from hermes_cli.subcommands.update import build_update_parser
+
+
+# ---------------------------------------------------------------------------
+# Parser wiring
+# ---------------------------------------------------------------------------
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_update_parser(subparsers, cmd_update=lambda a: None)
+    return parser
+
+
+def test_parser_accepts_stop_services_flag():
+    parser = _build_parser()
+    assert parser.parse_args(["update", "--stop-services"]).stop_services is True
+    assert parser.parse_args(["update"]).stop_services is False
+
+
+def test_parser_help_renders_stop_services():
+    parser = _build_parser()
+    update_parser = next(
+        action
+        for action in parser._subparsers._group_actions
+        if isinstance(action, argparse._SubParsersAction)
+    ).choices["update"]
+    help_text = update_parser.format_help()
+    assert "--stop-services" in help_text
+    assert "relaunch" in help_text
+    assert "force-killed" in help_text
+
+
+# ---------------------------------------------------------------------------
+# _stop_hermes_services_for_update
+# ---------------------------------------------------------------------------
+
+
+def _proc(pid, exe, name, cmdline=None, cwd=""):
+    proc = MagicMock()
+    proc.info = {
+        "pid": pid,
+        "exe": exe,
+        "name": name,
+        "cmdline": cmdline or [],
+        "cwd": cwd,
+    }
+    return proc
+
+
+def _fake_psutil(procs):
+    me = MagicMock()
+    me.parents.return_value = []
+    return types.SimpleNamespace(
+        process_iter=lambda attrs: iter(procs),
+        Process=lambda *a, **k: me,
+    )
+
+
+def _stop_args(**overrides):
+    defaults = dict(stop_services=True)
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_stop_flag_off_returns_none_without_scanning():
+    scan = MagicMock()
+    with patch.object(cli_main, "_desktop_child_pids", scan):
+        assert cli_main._stop_hermes_services_for_update(SimpleNamespace()) is None
+        assert (
+            cli_main._stop_hermes_services_for_update(
+                SimpleNamespace(stop_services=False)
+            )
+            is None
+        )
+    scan.assert_not_called()
+
+
+def test_stop_no_psutil_warns_and_returns_none(capsys):
+    with patch.dict(sys.modules, {"psutil": None}):
+        token = cli_main._stop_hermes_services_for_update(_stop_args())
+    assert token is None
+    assert "psutil is unavailable" in capsys.readouterr().out
+
+
+def test_stop_detects_owned_services_and_builds_token(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("HERMES_DESKTOP_CHILD_PID", raising=False)
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    base_py = "C:\\Python311\\python.exe"
+    dashboard_argv = [
+        venv_py,
+        "-m",
+        "hermes_cli.main",
+        "dashboard",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "9119",
+    ]
+    fake = _fake_psutil(
+        [
+            # this install's dashboard → stopped, argv+cwd recorded
+            _proc(301, venv_py, "pythonw.exe", dashboard_argv, cwd=str(tmp_path)),
+            # another install's serve (foreign cwd, exe outside venv) → left alone
+            _proc(
+                302,
+                base_py,
+                "python.exe",
+                [base_py, "-m", "hermes_cli.main", "serve"],
+                cwd="C:\\other-install",
+            ),
+            # a gateway from this venv → not a dashboard/serve pattern → left alone
+            _proc(
+                303,
+                venv_py,
+                "pythonw.exe",
+                [venv_py, "-m", "hermes_cli.main", "gateway", "run"],
+            ),
+        ]
+    )
+    terminate = MagicMock(return_value=([301], []))
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake}
+    ), patch.object(cli_main, "_terminate_service_pids", terminate), patch.object(
+        cli_main, "_dashboard_service_main_pid", return_value=None
+    ), patch("gateway.status._pid_exists", return_value=False):
+        token = cli_main._stop_hermes_services_for_update(_stop_args())
+
+    terminate.assert_called_once_with([301])
+    assert token == {
+        "resume_needed": True,
+        "services": [
+            {
+                "pid": 301,
+                "argv": dashboard_argv,
+                "cwd": str(tmp_path),
+                "label": "hermes dashboard",
+            }
+        ],
+    }
+    out = capsys.readouterr().out
+    assert "--stop-services" in out
+    assert "hermes dashboard (PID 301)" in out
+
+
+def test_stop_excludes_desktop_children_and_managed_unit(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_DESKTOP_CHILD_PID", "401, 402")
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    serve_argv = [venv_py, "-m", "hermes_cli.main", "serve"]
+    fake = _fake_psutil(
+        [
+            _proc(401, venv_py, "python.exe", serve_argv),  # desktop child
+            _proc(402, venv_py, "python.exe", serve_argv),  # desktop child
+            _proc(403, venv_py, "python.exe", serve_argv),  # systemd MainPID
+            _proc(404, venv_py, "python.exe", serve_argv),  # genuinely ours
+        ]
+    )
+    terminate = MagicMock(return_value=([404], []))
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake}
+    ), patch.object(cli_main, "_terminate_service_pids", terminate), patch.object(
+        cli_main, "_dashboard_service_main_pid", return_value=403
+    ), patch("gateway.status._pid_exists", return_value=False):
+        token = cli_main._stop_hermes_services_for_update(_stop_args())
+
+    terminate.assert_called_once_with([404])
+    assert [svc["pid"] for svc in token["services"]] == [404]
+    assert token["services"][0]["label"] == "hermes serve"
+
+
+def test_stop_nothing_matched_returns_none(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("HERMES_DESKTOP_CHILD_PID", raising=False)
+    base_py = str(tmp_path / "elsewhere" / "python.exe")
+    fake = _fake_psutil(
+        [_proc(501, base_py, "python.exe", [base_py, "somescript.py"])]
+    )
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake}
+    ), patch.object(cli_main, "_dashboard_service_main_pid", return_value=None):
+        token = cli_main._stop_hermes_services_for_update(_stop_args())
+    assert token is None
+    assert "Stopping Hermes service" not in capsys.readouterr().out
+
+
+def test_stop_survivor_recorded_not_in_token(tmp_path, capsys, monkeypatch):
+    """A PID that will not die stays visible to the venv guard and is never
+    scheduled for relaunch."""
+    monkeypatch.delenv("HERMES_DESKTOP_CHILD_PID", raising=False)
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    dash = [venv_py, "-m", "hermes_cli.main", "dashboard"]
+    serve = [venv_py, "-m", "hermes_cli.main", "serve"]
+    fake = _fake_psutil(
+        [
+            _proc(601, venv_py, "python.exe", dash),
+            _proc(602, venv_py, "python.exe", serve),
+        ]
+    )
+    terminate = MagicMock(return_value=([601, 602], []))
+    # 601 exits, 602 survives past the 5s deadline.
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake}
+    ), patch.object(cli_main, "_terminate_service_pids", terminate), patch.object(
+        cli_main, "_dashboard_service_main_pid", return_value=None
+    ), patch(
+        "gateway.status._pid_exists", side_effect=lambda pid: pid == 602
+    ), patch(
+        "time.monotonic", side_effect=[0.0, 0.1, 10.0]
+    ), patch("time.sleep"):
+        token = cli_main._stop_hermes_services_for_update(_stop_args())
+
+    assert [svc["pid"] for svc in token["services"]] == [601]
+    out = capsys.readouterr().out
+    assert "still running" in out
+    assert "venv guard" in out
+
+
+def test_stop_all_survivors_returns_none(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_DESKTOP_CHILD_PID", raising=False)
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    fake = _fake_psutil(
+        [_proc(701, venv_py, "python.exe", [venv_py, "-m", "hermes_cli.main", "serve"])]
+    )
+    terminate = MagicMock(return_value=([], [(701, "access denied")]))
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake}
+    ), patch.object(cli_main, "_terminate_service_pids", terminate), patch.object(
+        cli_main, "_dashboard_service_main_pid", return_value=None
+    ):
+        token = cli_main._stop_hermes_services_for_update(_stop_args())
+    assert token is None
+
+
+# ---------------------------------------------------------------------------
+# _restart_hermes_services_after_update / _spawn_detached_service
+# ---------------------------------------------------------------------------
+
+
+def _token(*services):
+    return {"resume_needed": True, "services": list(services)}
+
+
+def _svc(pid, argv, cwd=None, label="hermes dashboard"):
+    return {"pid": pid, "argv": argv, "cwd": cwd, "label": label}
+
+
+def test_restart_respawns_recorded_argv_and_cwd(capsys):
+    spawn = MagicMock(return_value=True)
+    dash = ["python.exe", "-m", "hermes_cli.main", "dashboard", "--port", "9119"]
+    serve = ["python.exe", "-m", "hermes_cli.main", "serve"]
+    token = _token(
+        _svc(301, dash, cwd="C:\\install"),
+        _svc(302, serve, label="hermes serve"),
+    )
+    with patch.object(cli_main, "_spawn_detached_service", spawn):
+        cli_main._restart_hermes_services_after_update(token)
+
+    assert spawn.call_args_list == [
+        ((dash, "C:\\install"),),
+        ((serve, None),),
+    ]
+    out = capsys.readouterr().out
+    assert "Restarted hermes dashboard (was PID 301)" in out
+    assert "Restarted hermes serve (was PID 302)" in out
+
+
+def test_restart_is_idempotent(capsys):
+    spawn = MagicMock(return_value=True)
+    token = _token(_svc(301, ["python", "-m", "hermes_cli.main", "dashboard"]))
+    with patch.object(cli_main, "_spawn_detached_service", spawn):
+        cli_main._restart_hermes_services_after_update(token)
+        cli_main._restart_hermes_services_after_update(token)
+    assert spawn.call_count == 1
+    assert token["resume_needed"] is False
+
+
+def test_restart_none_and_cleared_tokens_are_noops(capsys):
+    spawn = MagicMock()
+    with patch.object(cli_main, "_spawn_detached_service", spawn):
+        cli_main._restart_hermes_services_after_update(None)
+        cli_main._restart_hermes_services_after_update({"resume_needed": False})
+        cli_main._restart_hermes_services_after_update(_token())
+    spawn.assert_not_called()
+    assert capsys.readouterr().out == ""
+
+
+def test_restart_spawn_failure_is_isolated_per_service(capsys):
+    spawn = MagicMock(side_effect=[OSError("boom"), True])
+    token = _token(
+        _svc(301, ["python", "-m", "hermes_cli.main", "dashboard"]),
+        _svc(302, ["python", "-m", "hermes_cli.main", "serve"], label="hermes serve"),
+    )
+    with patch.object(cli_main, "_spawn_detached_service", spawn):
+        cli_main._restart_hermes_services_after_update(token)
+    assert spawn.call_count == 2
+    out = capsys.readouterr().out
+    assert "could not restart hermes dashboard" in out
+    assert "restart manually: hermes dashboard" in out
+    assert "Restarted hermes serve (was PID 302)" in out
+
+
+def test_restart_missing_argv_prints_manual_hint(capsys):
+    spawn = MagicMock()
+    token = _token(_svc(301, None))
+    with patch.object(cli_main, "_spawn_detached_service", spawn):
+        cli_main._restart_hermes_services_after_update(token)
+    spawn.assert_not_called()
+    assert "restart manually: hermes dashboard" in capsys.readouterr().out
+
+
+def test_restart_refuses_unrecognized_command_line(capsys):
+    """PID-reuse race guard: never replay an argv that is not a Hermes
+    service command line."""
+    spawn = MagicMock()
+    token = _token(_svc(301, ["notepad.exe", "C:\\secrets.txt"]))
+    with patch.object(cli_main, "_spawn_detached_service", spawn):
+        cli_main._restart_hermes_services_after_update(token)
+    spawn.assert_not_called()
+    assert "unrecognized command line" in capsys.readouterr().out
+
+
+def test_spawn_detached_service_posix_kwargs(tmp_path):
+    argv = ["python", "-m", "hermes_cli.main", "dashboard"]
+    with patch.object(cli_main, "_is_windows", return_value=False), patch.object(
+        cli_main.subprocess, "Popen"
+    ) as popen:
+        assert cli_main._spawn_detached_service(argv, str(tmp_path)) is True
+    assert popen.call_args.args[0] == argv
+    assert popen.call_args.kwargs["cwd"] == str(tmp_path)
+    assert popen.call_args.kwargs["start_new_session"] is True
+
+
+def test_spawn_detached_service_missing_cwd_falls_back_to_project_root(tmp_path):
+    argv = ["python", "-m", "hermes_cli.main", "serve"]
+    with patch.object(cli_main, "_is_windows", return_value=False), patch.object(
+        cli_main, "PROJECT_ROOT", tmp_path
+    ), patch.object(cli_main.subprocess, "Popen") as popen:
+        cli_main._spawn_detached_service(argv, str(tmp_path / "gone"))
+    assert popen.call_args.kwargs["cwd"] == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _cmd_update_impl wiring
+# ---------------------------------------------------------------------------
+
+
+def _update_args(**overrides):
+    defaults = dict(
+        gateway=False,
+        check=False,
+        no_backup=True,
+        backup=False,
+        yes=True,
+        branch=None,
+        force=False,
+        force_venv=False,
+        stop_services=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class _PastGuard(Exception):
+    pass
+
+
+class _RootSentinel:
+    def __truediv__(self, _other):
+        raise _PastGuard
+
+
+def _drive_update_to_guard(args, *, stop_token=None, holders=True, calls=None):
+    """Drive _cmd_update_impl to the venv-holder guard with the stop/restart
+    helpers mocked; returns (outcome, mocks)."""
+    calls = calls if calls is not None else []
+
+    def _record(name, ret):
+        def _inner(*a, **k):
+            calls.append(name)
+            return ret
+
+        return _inner
+
+    stop = MagicMock(side_effect=_record("stop", stop_token))
+    restart = MagicMock(side_effect=_record("restart", None))
+    detect = MagicMock(
+        side_effect=_record(
+            "detect",
+            [(101, "python.exe", "python.exe -m hermes_cli.main serve")]
+            if holders
+            else [],
+        )
+    )
+    resume = MagicMock(side_effect=_record("resume", None))
+
+    with patch.object(cli_main, "_is_windows", return_value=True), patch.object(
+        cli_main, "_venv_scripts_dir", return_value=None
+    ), patch.object(cli_main, "_run_pre_update_backup"), patch.object(
+        cli_main, "_pause_windows_gateways_for_update", return_value=None
+    ), patch.object(
+        cli_main, "_resume_windows_gateways_after_update", resume
+    ), patch.object(
+        cli_main, "_stop_hermes_services_for_update", stop
+    ), patch.object(
+        cli_main, "_restart_hermes_services_after_update", restart
+    ), patch.object(
+        cli_main, "_detect_venv_python_processes", detect
+    ), patch.object(
+        cli_main, "PROJECT_ROOT", _RootSentinel()
+    ):
+        try:
+            cli_main._cmd_update_impl(args, gateway_mode=False)
+        except _PastGuard:
+            outcome = "past_guard"
+        except SystemExit as exc:
+            outcome = f"exit_{exc.code}"
+        else:
+            outcome = "returned"
+    return outcome, SimpleNamespace(
+        stop=stop, restart=restart, detect=detect, resume=resume, calls=calls
+    )
+
+
+def test_guard_refusal_restarts_stopped_services_before_exit_2():
+    token = {"resume_needed": True, "services": [{"pid": 1}]}
+    outcome, m = _drive_update_to_guard(
+        _update_args(stop_services=True), stop_token=token
+    )
+    assert outcome == "exit_2"
+    m.restart.assert_called_once_with(token)
+    m.resume.assert_called()
+    # stop runs before the guard's authoritative re-scan; the restart of our
+    # services precedes the gateway resume (reverse of the stop order).
+    assert m.calls.index("stop") < m.calls.index("detect")
+    assert m.calls.index("restart") < m.calls.index("resume")
+
+
+def test_stop_helper_called_even_without_flag_but_is_gated_internally():
+    """The call site is unconditional; the flag gate lives in the helper, so
+    a bare SimpleNamespace without the attr must sail through (getattr
+    contract)."""
+    outcome, m = _drive_update_to_guard(
+        SimpleNamespace(
+            gateway=False,
+            check=False,
+            no_backup=True,
+            backup=False,
+            yes=True,
+            branch=None,
+            force=False,
+            force_venv=False,
+        ),
+        stop_token=None,
+    )
+    assert outcome == "exit_2"
+    m.stop.assert_called_once()
+    m.restart.assert_called_once_with(None)
+
+
+def test_no_flag_run_produces_no_stop_services_output(capsys):
+    """Real helpers, no flag: the guard-refusal output is byte-identical to
+    the pre-flag behavior."""
+    args = _update_args()  # stop_services=False
+    with patch.object(cli_main, "_is_windows", return_value=True), patch.object(
+        cli_main, "_venv_scripts_dir", return_value=None
+    ), patch.object(cli_main, "_run_pre_update_backup"), patch.object(
+        cli_main, "_pause_windows_gateways_for_update", return_value=None
+    ), patch.object(
+        cli_main,
+        "_detect_venv_python_processes",
+        return_value=[(101, "python.exe", "python.exe -m hermes_cli.main serve")],
+    ), patch.object(cli_main, "PROJECT_ROOT", _RootSentinel()):
+        with pytest.raises(SystemExit) as exc_info:
+            cli_main._cmd_update_impl(args, gateway_mode=False)
+    assert exc_info.value.code == 2
+    out = capsys.readouterr().out
+    assert "Stopping Hermes service" not in out
+    assert "Restarting Hermes service" not in out
+    assert "--force-venv" in out
+
+
+def test_force_venv_with_stop_services_stops_then_skips_guard():
+    token = {"resume_needed": True, "services": [{"pid": 1}]}
+    outcome, m = _drive_update_to_guard(
+        _update_args(stop_services=True, force_venv=True), stop_token=token
+    )
+    assert outcome == "past_guard"
+    m.stop.assert_called_once()
+    m.detect.assert_not_called()
+
+
+def test_check_never_reaches_stop_services(monkeypatch):
+    stop = MagicMock()
+    check = MagicMock()
+    monkeypatch.setattr(cli_main, "_stop_hermes_services_for_update", stop)
+    monkeypatch.setattr(cli_main, "_cmd_update_check", check)
+    monkeypatch.setattr(cli_main, "_resolve_update_branch", lambda a: "main")
+    import hermes_cli.config as cli_config
+
+    monkeypatch.setattr(cli_config, "is_managed", lambda: False)
+    monkeypatch.setattr(cli_config, "detect_install_method", lambda root: "git")
+    cli_main.cmd_update(_update_args(check=True, stop_services=True))
+    check.assert_called_once()
+    stop.assert_not_called()
+
+
+def test_atexit_registered_with_restart_and_token():
+    token = {"resume_needed": True, "services": [{"pid": 1}]}
+    registered = []
+    with patch("atexit.register", side_effect=lambda fn, *a: registered.append((fn, a))):
+        outcome, m = _drive_update_to_guard(
+            _update_args(stop_services=True), stop_token=token
+        )
+    assert outcome == "exit_2"
+    assert (m.restart, (token,)) in [(fn, a) for fn, a in registered]
+
+
+def test_zip_path_restarts_services_in_finally(tmp_path, monkeypatch):
+    """A ZIP-path failure must still trigger the services restart (and the
+    gateway resume) via the finally block."""
+    args = _update_args(stop_services=True)
+    token = {"resume_needed": True, "services": [{"pid": 1}]}
+    restart = MagicMock()
+    resume = MagicMock()
+    monkeypatch.setattr(sys, "platform", "win32")
+    with patch.object(cli_main, "_is_windows", return_value=True), patch.object(
+        cli_main, "_venv_scripts_dir", return_value=None
+    ), patch.object(cli_main, "_run_pre_update_backup"), patch.object(
+        cli_main, "_pause_windows_gateways_for_update", return_value=None
+    ), patch.object(
+        cli_main, "_resume_windows_gateways_after_update", resume
+    ), patch.object(
+        cli_main, "_stop_hermes_services_for_update", return_value=token
+    ), patch.object(
+        cli_main, "_restart_hermes_services_after_update", restart
+    ), patch.object(
+        cli_main, "_detect_venv_python_processes", return_value=[]
+    ), patch.object(
+        cli_main, "PROJECT_ROOT", tmp_path  # no .git dir → ZIP path
+    ), patch.object(cli_main, "_discard_lockfile_churn"), patch.object(
+        cli_main, "_get_origin_url", return_value=""
+    ), patch.object(cli_main, "_is_fork", return_value=False), patch.object(
+        cli_main, "_update_via_zip", side_effect=RuntimeError("zip failed")
+    ):
+        with pytest.raises(RuntimeError, match="zip failed"):
+            cli_main._cmd_update_impl(args, gateway_mode=False)
+    restart.assert_called_once_with(token)
+    resume.assert_called_once()
+
+
+def test_success_tail_restart_comes_after_stale_dashboard_sweep():
+    """Ordering contract: the success-tail relaunch of --stop-services
+    services must come AFTER _kill_stale_dashboard_processes(restart_managed=
+    True), or the sweep would re-kill the freshly respawned services."""
+    src = inspect.getsource(cli_main._cmd_update_impl)
+    sweep = src.rindex("_kill_stale_dashboard_processes(restart_managed=True)")
+    relaunch = src.rindex("_restart_hermes_services_after_update(_services_resume)")
+    assert sweep < relaunch, (
+        "success-tail _restart_hermes_services_after_update must run after "
+        "the stale-dashboard sweep"
+    )
+    # ...and after the Windows gateway resume for the same run.
+    resume = src.rindex("_resume_windows_gateways_after_update(_windows_gateway_resume)")
+    assert resume < relaunch
+
+
+# ---------------------------------------------------------------------------
+# Extraction seams stay behavior-compatible
+# ---------------------------------------------------------------------------
+
+
+def test_desktop_child_pids_parsing(monkeypatch):
+    monkeypatch.setenv("HERMES_DESKTOP_CHILD_PID", " 12, x, 34,,56 ")
+    assert cli_main._desktop_child_pids() == {12, 34, 56}
+    monkeypatch.delenv("HERMES_DESKTOP_CHILD_PID")
+    assert cli_main._desktop_child_pids() == set()
+
+
+def test_dashboard_service_main_pid_windows_is_none():
+    with patch.object(cli_main.sys, "platform", "win32"):
+        assert cli_main._dashboard_service_main_pid() is None

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -104,6 +104,8 @@ Close the listed processes and re-run. If you're sure the concurrent process won
 
 A second, separate guard refuses to touch the venv while any process is running from its Python interpreter (the Desktop app's backend, a gateway, a Python REPL). Those processes keep native extension files (`.pyd`) locked, and a dependency sync that dies partway on an access-denied error strands the install between versions. This guard is **not** bypassed by `--force`; if you're certain the detected holders are false positives, use the explicit `hermes update --force-venv`.
 
+When the guard lists your **own** dashboard or headless backend (`hermes dashboard` / `hermes serve` — common when you auto-start the dashboard at login), pass `hermes update --stop-services` instead of stopping them by hand. It gracefully stops this install's dashboard/serve processes before the dependency sync, records each one's command line and working directory, and relaunches them (detached, in the background) once the update finishes — including when the update fails or aborts, so your services are never left silently stopped. It never touches Desktop-app-managed backends (close the app instead) or processes from other installs, and anything it could not stop is still caught by the guard above.
+
 Expected output looks like:
 
 ```

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1555,7 +1555,7 @@ hermes completion fish > ~/.config/fish/completions/hermes.fish
 ## `hermes update`
 
 ```bash
-hermes update [--gateway] [--check] [--no-backup] [--backup] [--yes]
+hermes update [--gateway] [--check] [--no-backup] [--backup] [--yes] [--stop-services]
 ```
 
 Pulls the latest `hermes-agent` code and reinstalls dependencies in the managed venv, then re-runs the post-install hooks (MCP servers, skills sync, completion install). Safe to run on a live install. Use `--check` to see whether your checkout is behind `origin/main` without installing.
@@ -1569,6 +1569,7 @@ Pulls the latest `hermes-agent` code and reinstalls dependencies in the managed 
 | `--no-backup` | Skip all pre-update backups for this run (both the quick state snapshot and the full zip), regardless of `updates.pre_update_backup`. |
 | `--backup` | Force a **full** pre-update backup for this run: the quick state snapshot plus a complete zip of `HERMES_HOME` (config, auth, sessions, skills, pairing data). The default mode is `quick` — a lightweight state snapshot only. Set the permanent mode via `updates.pre_update_backup: quick | full | off` in `config.yaml`. |
 | `--yes`, `-y` | Assume yes for interactive prompts such as config migration and stash restore. API-key entry is skipped; run `hermes config migrate` separately for those. |
+| `--stop-services` | Stop `hermes dashboard` / `hermes serve` processes launched from this install before dependencies are reinstalled, and relaunch them afterwards with their original command line and working directory — even if the update fails or is aborted. Relaunched services run detached in the background. Desktop-app-managed backends and other installs' processes are never touched; anything left holding the venv still triggers the venv guard. |
 
 Additional behavior:
 


### PR DESCRIPTION
## What does this PR do?

On Windows, `hermes update` already pauses gateways before the dependency sync, but a running dashboard or headless `hermes serve` backend still dead-ends the update at the venv-process guard (exit 2). The user has to hunt the process down, kill it, update, and restart it by hand — every update. Post-update, stale dashboards are killed but never relaunched because "we don't know the original launch args" (#40449).

This adds an opt-in `hermes update --stop-services` that closes exactly that gap: before the dependency sync it stops `hermes dashboard` / `hermes serve` processes belonging to **this install** (service cmdline patterns intersected with the venv guard's ownership predicate), records each one's PID, argv, and cwd, and relaunches them detached once the update finishes — on every outcome (success, guard refusal, ZIP fallback, zero-commit return), with an `atexit` safety net for error paths, mirroring the existing gateway pause/resume design.

Safety properties:

- **The guard stays authoritative.** Its re-scan runs unchanged after the stop; foreign holders — desktop backends, other installs, anything the stop could not kill — still refuse with exit 2, and the services we did stop are relaunched before exiting.
- **Never touches processes hermes doesn't own:** desktop-app-managed backends (`HERMES_DESKTOP_CHILD_PID`), systemd-managed dashboard units (left to `_restart_managed_dashboard_service`), other installs' processes.
- **Byte-for-byte identical without the flag** (default off, no config key).
- Success-tail relaunch is ordered **after** the stale-dashboard sweep so the sweep cannot re-kill the fresh processes (regression-tested).

Known residual (documented in the help text): if the updater itself is force-killed (SIGKILL/power loss), `atexit` cannot run and services stay down — the same property the gateway pause has. On a failed Node refresh the relaunched service may serve a stale JS bundle, the same exposure a manual restart had.

Scope note / related PRs: #64386 (`--force-kill`) and #67229 (auto-terminate strays on `--yes`) terminate holders but do not record-and-restore them; #61515 reaps gateway children; #40616 restarts systemd dashboard units post-update. This PR is the complementary record-and-restore contract for manually-launched dashboard/serve processes and does not change any of their code paths.

## Related Issue

Refs #40449 (the manual-dashboard half; the systemd-messaging half is #40616's territory)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/subcommands/update.py` — add `--stop-services` flag
- `hermes_cli/main.py` — new `_stop_hermes_services_for_update`, `_restart_hermes_services_after_update`, `_spawn_detached_service`, `_dashboard_service_main_pid`; behavior-preserving extractions `_HERMES_SERVICE_CMDLINE_PATTERNS`, `_desktop_child_pids`, `_terminate_service_pids`; five call-site insertions in `_cmd_update_impl`
- `tests/hermes_cli/test_update_stop_services.py` — 27 tests (parser, detection/ownership/exclusions, stop exit-wait + survivors, relaunch idempotency + PID-reuse guard, guard-refusal/ZIP/atexit wiring, no-flag byte-identical output, success-tail ordering)
- `website/docs/reference/cli-commands.md`, `website/docs/getting-started/updating.md` — document the flag

## How to Test

1. Start a dashboard from the install venv, e.g. `pythonw.exe -m hermes_cli.main dashboard --host 0.0.0.0` (or via a Scheduled Task)
2. Run `hermes update --stop-services --backup --yes`
3. The update stops the dashboard, completes, and relaunches it with the same argv; without the flag the venv guard refuses as before
4. Unit: `pytest tests/hermes_cli/test_update_stop_services.py -q` → 27 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see scope note: #64386, #67229, #61515, #40616)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests — new file 27/27; update/dashboard regression subset 209 passed, 16 failures identical on pristine HEAD (Windows-native baseline, #48986)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (26200), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `updating.md`, `cli-commands.md`, docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — feature works on POSIX too (stop uses the existing SIGTERM→SIGKILL path, relaunch uses `start_new_session`); Windows specifics behind `_is_windows()`/`sys.platform` exactly like the surrounding code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ hermes update --stop-services --backup --yes
⚕ Updating Hermes Agent...
→ Stopping Windows gateway process(es) before updating Hermes...
  ✓ Paused gateway profile(s): default
→ Stopping Hermes service process(es) before updating (--stop-services)...
  → hermes dashboard (PID 47772)
→ Fetching updates...
...
✓ Update complete!
  ✓ Restarting Windows gateway profile(s): default
→ Restarting Hermes service process(es) in the background...
  ✓ Restarted hermes dashboard (was PID 47772)
```

```
$ pytest tests/hermes_cli/test_update_stop_services.py -q
27 passed in 1.12s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
