### PR TITLE
feat(skills): add wallpaper-engine optional skill

### DIFF
--- a/optional-skills/creative/wallpaper-engine/SKILL.md
+++ b/optional-skills/creative/wallpaper-engine/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: wallpaper-engine
+description: Generate and cycle desktop wallpapers via ComfyUI.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [wallpaper, desktop, comfyui, image-generation, creative, personalization]
+    related_skills: [comfyui]
+    category: creative
+---
+
+# Wallpaper Engine
+
+Generate beautiful, personalized desktop wallpapers using ComfyUI and learn the
+user's aesthetic preferences over time via Hermes memory.  Each wallpaper is
+generated at native desktop resolution, set automatically, and tracked for
+feedback — so the agent's taste improves with every generation.
+
+This skill delegates all image generation to the **comfyui skill** — it doesn't
+duplicate any of that pipeline.  What it adds is wallpaper-specific resolution
+tuning, cross-platform desktop wallpaper setting, a local generation/feedback
+history log, and the workflow for feeding preferences back into Hermes memory.
+
+## When to Use
+
+Load when the user says things like:
+
+- "generate a new wallpaper"
+- "change my desktop background"
+- "give me a dark sci-fi wallpaper"
+- "I want a new wallpaper every morning"
+- "schedule daily wallpapers"
+- "I like this wallpaper" / "I don't like that one"
+- "what wallpapers have you generated for me?"
+- "summarize my wallpaper preferences"
+
+## Prerequisites
+
+1. **ComfyUI running** — local (`comfy launch --background`) or
+   Comfy Cloud (paid subscription, `COMFY_CLOUD_API_KEY` set).  See the
+   comfyui skill's `## Setup & Onboarding` for full setup instructions.
+
+2. **SDXL model** — at minimum `sd_xl_base_1.0.safetensors` (or any SDXL
+   checkpoint) installed in ComfyUI.  The `check_deps.py` script from the
+   comfyui skill will verify this.
+
+3. **The wallpaper-engine skill installed** — `hermes skills install
+   official/creative/wallpaper-engine`.  After install the scripts under
+   `optional-skills/creative/wallpaper-engine/scripts/` are on the skill path.
+
+## How to Run
+
+Every workflow below starts from the **skill directory** (`SKILL_DIR`).  The
+comfyui skill scripts are at `SKILL_DIR/../../skills/creative/comfyui/scripts/`
+relative to this skill, or `skills/creative/comfyui/scripts/` from the repo
+root.
+
+### Step 0: Verify ComfyUI is ready
+
+```bash
+python3 skills/creative/comfyui/scripts/health_check.py
+```
+
+If the check fails, follow the comfyui skill's setup path (hardware check →
+install → launch) before continuing.
+
+### Step 1: Check the workflow's dependencies
+
+```bash
+python3 skills/creative/comfyui/scripts/check_deps.py \
+  optional-skills/creative/wallpaper-engine/workflows/wallpaper_txt2img.json
+```
+
+If models or nodes are missing, use `auto_fix_deps.py` from the comfyui skill.
+
+### Step 2: See what parameters are available
+
+```bash
+python3 skills/creative/comfyui/scripts/extract_schema.py \
+  optional-skills/creative/wallpaper-engine/workflows/wallpaper_txt2img.json \
+  --summary-only
+```
+
+The key parameters: `positive_prompt` (node 6), `negative_prompt` (node 7),
+`width` (node 5, default 1920), `height` (node 5, default 1080), `seed` (node
+3, use -1 for random), `steps` (node 3, default 30), `cfg` (node 3, default
+7.5), `ckpt_name` (node 4).
+
+### Step 3: Generate the wallpaper
+
+```bash
+python3 skills/creative/comfyui/scripts/run_workflow.py \
+  --workflow optional-skills/creative/wallpaper-engine/workflows/wallpaper_txt2img.json \
+  --args '{"positive_prompt": "your prompt here", "negative_prompt": "ugly, blurry, ...", "seed": -1}' \
+  --output-dir ~/.hermes/wallpaper-engine/images/
+```
+
+### Step 4: Set the wallpaper
+
+```bash
+python3 optional-skills/creative/wallpaper-engine/scripts/set_wallpaper.py \
+  ~/.hermes/wallpaper-engine/images/wallpaper_00001_.png
+```
+
+### Step 5: Record the generation
+
+```bash
+python3 optional-skills/creative/wallpaper-engine/scripts/wallpaper_history.py \
+  add ~/.hermes/wallpaper-engine/images/wallpaper_00001_.png \
+  "the prompt used" "wallpaper_txt2img.json"
+```
+
+### Step 6: Collect feedback (later, when the user reacts)
+
+```bash
+python3 optional-skills/creative/wallpaper-engine/scripts/wallpaper_history.py \
+  feedback <id-from-step-5> 5 "dark" "moody" "mountains"
+```
+
+## Quick Reference
+
+| Action | Tool / Command |
+|--------|---------------|
+| Generate wallpaper | `run_workflow.py --workflow wallpaper_txt2img.json --args '{...}'` |
+| Check what params exist | `extract_schema.py wallpaper_txt2img.json` |
+| Set image as wallpaper | `set_wallpaper.py <path>` |
+| Record generation | `wallpaper_history.py add <path> <prompt> <workflow>` |
+| Record feedback | `wallpaper_history.py feedback <id> <rating> [tags...]` |
+| List recent generations | `wallpaper_history.py list [--limit N] [--rated-only]` |
+| Get preference stats | `wallpaper_history.py stats` |
+| Check user preferences | `memory(action=read)` — look in USER.md for aesthetic notes |
+| Store learned preference | `memory(action=add, content="...")` |
+
+## Procedure
+
+### One-Shot Generation
+
+When the user asks for a new wallpaper:
+
+1. **Read existing preferences** from memory.  `memory(action=read)` returns
+   MEMORY.md and USER.md.  Look for aesthetic notes about wallpaper styles the
+   user has liked or disliked.  If none exist, ask the user what kind of
+   wallpaper they want — mood, colors, subject matter.
+
+2. **Pick a prompt template** from `references/prompt-library.md` that matches
+   the user's stated or learned preferences.  Layer any additional guidance
+   from memory on top.  If the user's request doesn't match any template,
+   improvise a prompt that follows the same structure (positive prompt +
+   negative prompt, SDXL-optimized).
+
+3. **Detect the native resolution.** On macOS run
+   `osascript -e 'tell application "Finder" to get bounds of window of desktop'`
+   and parse the width/height.  On Linux try `xdpyinfo | grep dimensions` or
+   `swaymsg -t get_outputs`.  On Windows check the primary monitor via
+   PowerShell: `Add-Type -AssemblyName System.Windows.Forms;
+   [System.Windows.Forms.Screen]::PrimaryScreen.Bounds`.  Fall back to a
+   sensible default (1920x1080) if detection fails.
+
+4. **Run the workflow** via comfyui's `run_workflow.py`, injecting the
+   resolution and crafted prompt.  If the user has a capable GPU, suggest 4K
+   (3840x2160) for sharper results — but note it takes longer.
+
+5. **Set the wallpaper** via `set_wallpaper.py`.
+
+6. **Record it** via `wallpaper_history.py add`.
+
+7. **Report to the user** what was generated, and ask if they like it.
+
+### Gathering Feedback
+
+When the user expresses like or dislike about a wallpaper:
+
+1. **Find the most recent entry** via `wallpaper_history.py list --limit 1`
+   (or search by ID if they referenced a specific one).
+
+2. **Map sentiment to rating**: "love it" / "amazing" → 5, "nice" / "good" →
+   4, "it's okay" / "fine" → 3, "not great" / "meh" → 2, "hate it" /
+   "terrible" → 1.
+
+3. **Extract tags** from their feedback: adjectives like "dark", "moody",
+   "bright", "minimalist"; subjects like "mountains", "space", "abstract";
+   qualities like "too busy", "too simple", "perfect composition".
+
+4. **Record the feedback** via `wallpaper_history.py feedback`.
+
+5. **If the rating is strong (1-2 or 4-5), update memory** to persist the
+   preference.  Use `memory(action=add)` with a summary like:
+   > "User strongly prefers dark, moody wallpapers with natural landscapes
+   > (rated mountain wallpaper 5/5 on 2026-07-24). Dislikes busy abstract
+   > compositions (rated 2/5)."
+
+6. **If the user disliked it**, offer to generate a replacement immediately.
+
+### Checking Preferences
+
+When the user asks about their taste profile:
+
+1. **Run stats**: `wallpaper_history.py stats`
+2. **Read memory**: `memory(action=read)` and extract the aesthetic notes
+3. **Summarize**: present the top loved tags, top disliked tags, average
+   rating, and a prose summary of their taste from memory.
+
+### Scheduling Recurring Wallpapers
+
+When the user wants regular wallpaper changes:
+
+1. **Read preferences** from memory and history stats.
+
+2. **Construct a self-contained cron prompt** that includes the preferences
+   and instructs the agent to follow the One-Shot Generation procedure above.
+   Example:
+
+   > "Generate a new desktop wallpaper using the wallpaper-engine skill.
+   > Use the comfyui skill's run_workflow.py with the wallpaper_txt2img.json
+   > workflow.  The user's aesthetic preferences from memory are: [insert
+   > preferences].  After generating, set the wallpaper via
+   > wallpaper-engine/scripts/set_wallpaper.py and record it via
+   > wallpaper_history.py add."
+
+3. **Create the cron job** via terminal:
+   ```bash
+   hermes cron add \
+     --schedule "0 7 * * *" \
+     --name "daily-wallpaper" \
+     --skills "comfyui,wallpaper-engine" \
+     --prompt "<the constructed prompt>"
+   ```
+
+4. **Confirm** the schedule with the user and tell them how to manage it:
+   `hermes cron list`, `hermes cron pause daily-wallpaper`,
+   `hermes cron remove daily-wallpaper`.
+
+## Preference Learning Loop
+
+Over time, as the user rates wallpapers, the agent builds a profile:
+
+```
+Generate → Set → User sees it → Feedback → History → Memory
+    ↑                                                      │
+    └──────────────────────────────────────────────────────┘
+            (next generation uses updated preferences)
+```
+
+The agent should periodically (e.g. every 5 ratings) read
+`wallpaper_history.py stats` and consolidate new insights into memory via
+`memory(action=add)`.  This closes the loop: each generation benefits from all
+past feedback.
+
+## Pitfalls
+
+1. **ComfyUI must be running.**  The `run_workflow.py` script needs a live
+   ComfyUI server at `http://127.0.0.1:8188` (or the cloud host).  If the
+   server is down, the agent cannot generate.  Start it with
+   `comfy launch --background` or point the user to the comfyui skill's setup.
+
+2. **Workflow JSON must be clean API format.**  The workflow file must contain
+   only node objects keyed by node ID — no top-level `_comment`, strings, or
+   other non-node keys.  ComfyUI's `validate_prompt()` rejects these.  The
+   bundled `wallpaper_txt2img.json` is already clean; if you create custom
+   workflows, verify with:
+   ```bash
+   python3 -c "import json; wf=json.load(open('your_workflow.json'));
+   nodes={k:v for k,v in wf.items() if isinstance(v,dict) and 'class_type' in v};
+   print(f'{len(nodes)} nodes, {len(wf)-len(nodes)} non-node keys stripped')"
+   ```
+
+3. **SDXL resolution limits.**  SDXL's native resolution is 1024x1024.  Going
+   much above 1920x1200 with the base workflow may produce repetition artifacts
+   (the "tiling effect").  For true 4K without artifacts, the user needs Flux
+   Dev or an upscale stage (add an UpscaleModelLoader + ImageUpscaleWithModel
+   node to the workflow).
+
+4. **Wallpaper setting is desktop-environment specific.**  The
+   `set_wallpaper.py` script tries GNOME, KDE, XFCE, Sway, feh, and nitrogen
+   on Linux; osascript on macOS; and the Win32 API on Windows.  If none work
+   (e.g. a niche window manager), the generated image is still saved — tell the
+   user where to find it and how to set it manually.
+
+5. **First-run setup is heavy.**  The first time through, the agent may need to
+   install ComfyUI, comfy-cli, and download the SDXL model (~6.5 GB).  This is
+   a one-time cost — subsequent runs are fast.  Warn the user that the first
+   generation will take extra time for setup.
+
+6. **Generation takes time.**  An SDXL generation at 1920x1080 takes 30-90
+   seconds on a modern GPU.  Warn the user that it's in progress.  For the
+   first generation, the agent should not go silent — send a progress message.
+
+7. **Cloud costs.**  If using Comfy Cloud, every generation costs credits.
+   Remind the user of this before setting up a recurring schedule.
+
+8. **Preferences need multiple data points.**  A single rating doesn't define
+   a user's taste.  The agent should avoid over-generalizing from one or two
+   ratings — wait for at least 3-5 before making strong claims about the user's
+   aesthetic profile.
+
+9. **History file location.**  `wallpaper_history.py` stores data at
+   `$HERMES_HOME/wallpaper-engine/history.json`.  If the user switches
+   profiles, each profile has its own history.
+
+## Verification
+
+- [ ] ComfyUI health check passes (`health_check.py`)
+- [ ] Workflow dependencies are satisfied (`check_deps.py wallpaper_txt2img.json`)
+- [ ] `set_wallpaper.py /path/to/test.png` returns `{"status": "ok", ...}`
+- [ ] `wallpaper_history.py add /tmp/x.png "test" "w.json"` creates a record
+- [ ] `wallpaper_history.py list` shows the record
+- [ ] `wallpaper_history.py feedback <id> 4 "test-tag"` works
+- [ ] `wallpaper_history.py stats` includes the rated entry
+- [ ] End-to-end: agent generates, sets, records, and reports on a wallpaper

--- a/optional-skills/creative/wallpaper-engine/SKILL.md
+++ b/optional-skills/creative/wallpaper-engine/SKILL.md
@@ -2,7 +2,7 @@
 name: wallpaper-engine
 description: Generate and cycle desktop wallpapers via ComfyUI.
 version: 1.0.0
-author: Hermes Agent
+author: Loki San (@theycallmeloki) + Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -48,20 +48,21 @@ Load when the user says things like:
    comfyui skill will verify this.
 
 3. **The wallpaper-engine skill installed** — `hermes skills install
-   official/creative/wallpaper-engine`.  After install the scripts under
-   `optional-skills/creative/wallpaper-engine/scripts/` are on the skill path.
+   official/creative/wallpaper-engine`.  After install, this skill's scripts
+   and workflows are available under the skill directory.
 
 ## How to Run
 
-Every workflow below starts from the **skill directory** (`SKILL_DIR`).  The
-comfyui skill scripts are at `SKILL_DIR/../../skills/creative/comfyui/scripts/`
-relative to this skill, or `skills/creative/comfyui/scripts/` from the repo
-root.
+When both the **comfyui** and **wallpaper-engine** skills are loaded, their
+absolute directories are announced in the system prompt.  Use
+`${HERMES_SKILL_DIR}` for this skill's own assets (scripts, workflows); the
+comfyui skill's scripts live at its own announced directory.  The examples
+below show the pattern.
 
 ### Step 0: Verify ComfyUI is ready
 
 ```bash
-python3 skills/creative/comfyui/scripts/health_check.py
+python3 <comfyui-skill-dir>/scripts/health_check.py
 ```
 
 If the check fails, follow the comfyui skill's setup path (hardware check →
@@ -70,8 +71,8 @@ install → launch) before continuing.
 ### Step 1: Check the workflow's dependencies
 
 ```bash
-python3 skills/creative/comfyui/scripts/check_deps.py \
-  optional-skills/creative/wallpaper-engine/workflows/wallpaper_txt2img.json
+python3 <comfyui-skill-dir>/scripts/check_deps.py \
+  ${HERMES_SKILL_DIR}/workflows/wallpaper_txt2img.json
 ```
 
 If models or nodes are missing, use `auto_fix_deps.py` from the comfyui skill.
@@ -79,8 +80,8 @@ If models or nodes are missing, use `auto_fix_deps.py` from the comfyui skill.
 ### Step 2: See what parameters are available
 
 ```bash
-python3 skills/creative/comfyui/scripts/extract_schema.py \
-  optional-skills/creative/wallpaper-engine/workflows/wallpaper_txt2img.json \
+python3 <comfyui-skill-dir>/scripts/extract_schema.py \
+  ${HERMES_SKILL_DIR}/workflows/wallpaper_txt2img.json \
   --summary-only
 ```
 
@@ -92,8 +93,8 @@ The key parameters: `positive_prompt` (node 6), `negative_prompt` (node 7),
 ### Step 3: Generate the wallpaper
 
 ```bash
-python3 skills/creative/comfyui/scripts/run_workflow.py \
-  --workflow optional-skills/creative/wallpaper-engine/workflows/wallpaper_txt2img.json \
+python3 <comfyui-skill-dir>/scripts/run_workflow.py \
+  --workflow ${HERMES_SKILL_DIR}/workflows/wallpaper_txt2img.json \
   --args '{"positive_prompt": "your prompt here", "negative_prompt": "ugly, blurry, ...", "seed": -1}' \
   --output-dir ~/.hermes/wallpaper-engine/images/
 ```
@@ -101,14 +102,14 @@ python3 skills/creative/comfyui/scripts/run_workflow.py \
 ### Step 4: Set the wallpaper
 
 ```bash
-python3 optional-skills/creative/wallpaper-engine/scripts/set_wallpaper.py \
+python3 ${HERMES_SKILL_DIR}/scripts/set_wallpaper.py \
   ~/.hermes/wallpaper-engine/images/wallpaper_00001_.png
 ```
 
 ### Step 5: Record the generation
 
 ```bash
-python3 optional-skills/creative/wallpaper-engine/scripts/wallpaper_history.py \
+python3 ${HERMES_SKILL_DIR}/scripts/wallpaper_history.py \
   add ~/.hermes/wallpaper-engine/images/wallpaper_00001_.png \
   "the prompt used" "wallpaper_txt2img.json"
 ```
@@ -116,7 +117,7 @@ python3 optional-skills/creative/wallpaper-engine/scripts/wallpaper_history.py \
 ### Step 6: Collect feedback (later, when the user reacts)
 
 ```bash
-python3 optional-skills/creative/wallpaper-engine/scripts/wallpaper_history.py \
+python3 ${HERMES_SKILL_DIR}/scripts/wallpaper_history.py \
   feedback <id-from-step-5> 5 "dark" "moody" "mountains"
 ```
 
@@ -131,8 +132,8 @@ python3 optional-skills/creative/wallpaper-engine/scripts/wallpaper_history.py \
 | Record feedback | `wallpaper_history.py feedback <id> <rating> [tags...]` |
 | List recent generations | `wallpaper_history.py list [--limit N] [--rated-only]` |
 | Get preference stats | `wallpaper_history.py stats` |
-| Check user preferences | `memory(action=read)` — look in USER.md for aesthetic notes |
-| Store learned preference | `memory(action=add, content="...")` |
+| Check user preferences | MEMORY.md and USER.md are injected into context at session start — scan them for aesthetic notes |
+| Store learned preference | `memory(action=add, target="user", content="...")` |
 
 ## Procedure
 
@@ -140,10 +141,10 @@ python3 optional-skills/creative/wallpaper-engine/scripts/wallpaper_history.py \
 
 When the user asks for a new wallpaper:
 
-1. **Read existing preferences** from memory.  `memory(action=read)` returns
-   MEMORY.md and USER.md.  Look for aesthetic notes about wallpaper styles the
-   user has liked or disliked.  If none exist, ask the user what kind of
-   wallpaper they want — mood, colors, subject matter.
+1. **Check existing preferences** from the session context.  MEMORY.md and
+   USER.md are injected at session start — scan them for aesthetic notes about
+   wallpaper styles the user has liked or disliked.  If none exist, ask the
+   user what kind of wallpaper they want — mood, colors, subject matter.
 
 2. **Pick a prompt template** from `references/prompt-library.md` that matches
    the user's stated or learned preferences.  Layer any additional guidance
@@ -199,7 +200,8 @@ When the user expresses like or dislike about a wallpaper:
 When the user asks about their taste profile:
 
 1. **Run stats**: `wallpaper_history.py stats`
-2. **Read memory**: `memory(action=read)` and extract the aesthetic notes
+2. **Scan context**: MEMORY.md and USER.md are injected at session start —
+   extract the aesthetic notes about wallpaper preferences from them
 3. **Summarize**: present the top loved tags, top disliked tags, average
    rating, and a prose summary of their taste from memory.
 
@@ -207,7 +209,8 @@ When the user asks about their taste profile:
 
 When the user wants regular wallpaper changes:
 
-1. **Read preferences** from memory and history stats.
+1. **Check preferences** from session context (MEMORY.md/USER.md) and history
+   stats (`wallpaper_history.py stats`).
 
 2. **Construct a self-contained cron prompt** that includes the preferences
    and instructs the agent to follow the One-Shot Generation procedure above.
@@ -220,13 +223,12 @@ When the user wants regular wallpaper changes:
    > wallpaper-engine/scripts/set_wallpaper.py and record it via
    > wallpaper_history.py add."
 
-3. **Create the cron job** via terminal:
+3. **Create the cron job** via terminal (schedule and prompt are positional;
+   `--skill` is repeatable for each skill to attach):
    ```bash
-   hermes cron add \
-     --schedule "0 7 * * *" \
+   hermes cron add "0 7 * * *" "<the constructed prompt>" \
      --name "daily-wallpaper" \
-     --skills "comfyui,wallpaper-engine" \
-     --prompt "<the constructed prompt>"
+     --skill comfyui --skill wallpaper-engine
    ```
 
 4. **Confirm** the schedule with the user and tell them how to manage it:

--- a/optional-skills/creative/wallpaper-engine/references/prompt-library.md
+++ b/optional-skills/creative/wallpaper-engine/references/prompt-library.md
@@ -1,0 +1,99 @@
+# Wallpaper Prompt Library
+
+A curated collection of aesthetic prompt templates for SDXL wallpaper
+generation.  Each template includes a **positive prompt** (what you want) and a
+**negative prompt** (what you want to avoid).  The agent should pick from these
+based on the user's stated preferences, then layer in any additional guidance
+from the user's memory profile.
+
+All templates assume SDXL.  For Flux Dev, swap the negative prompt style to the
+Flux convention (Flux ignores negatives for most compositions).
+
+---
+
+## Nature & Landscapes
+
+### Mountain Vista
+- **Positive:** breathtaking mountain range at golden hour, cinematic lighting, 4K wallpaper, epic scale, misty valleys below, alpine glow, sharp focus, photorealistic
+- **Negative:** blurry, low quality, people, text, watermark, frame, border, split screen
+
+### Ocean Sunset
+- **Positive:** tranquil ocean sunset, gentle waves, warm orange and pink sky, silhouette palm trees, ultra detailed, 4K, wallpaper composition, serene atmosphere
+- **Negative:** blurry, low quality, boats, people, text, watermark, harsh lighting, overexposed
+
+### Forest Depth
+- **Positive:** enchanted forest, sun rays through canopy, moss covered ground, depth of field, cinematic, 4K wallpaper, rich greens, photorealistic, peaceful
+- **Negative:** blurry, low quality, people, animals, text, watermark, frame, dark shadows
+
+---
+
+## Abstract & Minimalist
+
+### Fluid Gradients
+- **Positive:** smooth flowing abstract gradient shapes, soft pastels, depth, 4K, clean composition, minimalist aesthetic, gentle curves, digital art
+- **Negative:** sharp edges, text, watermark, busy composition, clutter, noise, grain
+
+### Geometric Harmony
+- **Positive:** balanced geometric composition, soft ambient lighting, matte finish, 4K wallpaper, abstract architecture, harmonious colors, clean lines
+- **Negative:** text, watermark, chaotic, cluttered, noise, harsh shadows, people
+
+---
+
+## Dark & AMOLED
+
+### Dark Mountains
+- **Positive:** dark silhouette of mountains against starry night sky, deep blacks, subtle glow, 4K wallpaper, AMOLED friendly, moody, atmospheric, minimal light
+- **Negative:** bright areas, text, watermark, people, noise, grain, overexposed
+
+### Void Geometry
+- **Positive:** minimalist dark geometric shapes, neon edge glow, deep black background, 4K, AMOLED, cyber minimal, clean, precise, abstract
+- **Negative:** bright backgrounds, text, watermark, clutter, noise, grain
+
+---
+
+## Sci-Fi & Futuristic
+
+### Cyberpunk City
+- **Positive:** futuristic cyberpunk city skyline at night, neon reflections, rain-slick streets, volumetric fog, cinematic, 4K wallpaper, blade runner aesthetic
+- **Negative:** people, text, watermark, blurry, daylight, cartoon, anime, low quality
+
+### Sci-Fi Megastructures *(well-tested — produced great results)*
+- **Positive:** futuristic sci-fi cityscape, massive neon-lit megastructures reaching into the sky, flying vehicles between towering spires, holographic billboards and data streams, deep purple and cyan lighting, atmospheric volumetric haze, cinematic composition, ultra detailed
+- **Negative:** people, text, watermark, daylight, cartoon, anime, low quality, flat lighting, empty sky
+
+### Nebula Space
+- **Positive:** deep space nebula, vibrant cosmic colors, scattered stars, ethereal gas clouds, 4K wallpaper, astronomical photography, vast scale
+- **Negative:** text, watermark, spaceships, earth, frame, border, low quality
+
+---
+
+## Seasonal
+
+### Autumn Forest
+- **Positive:** autumn forest, golden and red foliage, soft morning light, mist, depth of field, 4K wallpaper, warm tones, peaceful path, photorealistic
+- **Negative:** people, text, watermark, summer greens, snow, blurry, low quality
+
+### Winter Silence
+- **Positive:** snowy mountain peak, fresh powder, clear blue sky, crisp winter light, 4K wallpaper, pristine, minimal, serene cold atmosphere, photorealistic
+- **Negative:** people, text, watermark, mud, dark shadows, overcast, flat light
+
+---
+
+## Usage Notes
+
+1. **Always add user preferences on top.** If MEMORY.md says "user loves
+   purple tones and hates busy compositions," append that to the template.
+
+2. **For higher resolutions** (e.g. 4K 3840x2160), set `width: 3840, height:
+   2160` in the workflow args. Generation will be slower but yields desktop-
+   native resolution. SDXL natively works at 1024x1024 and upscales internally;
+   going above 1920x1200 may produce repetition artifacts. For true 4K without
+   artifacts, add an upscale stage or use Flux Dev.
+
+3. **Negative prompt hygiene.** The base negative prompt in the workflow JSON
+   already excludes common defects. Add style-specific negatives (e.g. "no
+   people" for landscapes) but don't accumulate so many that the prompt becomes
+   noise — 6-8 negative tokens is the sweet spot for SDXL.
+
+4. **Seed -1** means random; the agent can request "similar but different" by
+   using the same seed with slight prompt or CFG changes.

--- a/optional-skills/creative/wallpaper-engine/scripts/set_wallpaper.py
+++ b/optional-skills/creative/wallpaper-engine/scripts/set_wallpaper.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""
+Cross-platform desktop wallpaper setter.
+
+Sets the given image as the desktop wallpaper using the appropriate native
+method for the current OS and desktop environment.  Stdlib-only; Python 3.10+.
+
+Usage:
+    python3 set_wallpaper.py /path/to/image.png
+    python3 set_wallpaper.py --mode center  /path/to/image.png
+    python3 set_wallpaper.py --mode stretch /path/to/image.png
+
+Output (JSON):
+    {"status": "ok", "method": "gsettings", "path": "/abs/path/to/image.png"}
+    {"status": "error", "error": "No supported desktop environment detected"}
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Mode mapping — "fill" is the default (best for wallpapers)
+# ---------------------------------------------------------------------------
+FIT_MODES: dict[str, dict[str, str]] = {
+    "fill": {
+        "gsettings": "scaled",  # GNOME scales keeping aspect ratio (closest to fill)
+        "feh": "--bg-fill",
+        "sway": "fill",
+        "kde": "2",           # Scaled, keep proportions
+        "xfce": "5",          # Zoomed
+    },
+    "center": {
+        "gsettings": "centered",
+        "feh": "--bg-center",
+        "sway": "center",
+        "kde": "1",           # Centered
+        "xfce": "1",          # Centered
+    },
+    "stretch": {
+        "gsettings": "stretched",
+        "feh": "--bg-scale",  # feh doesn't have stretch; --bg-scale is closest
+        "sway": "stretch",
+        "kde": "0",           # Scaled (tiled)
+        "xfce": "2",          # Tiled
+    },
+    "fit": {
+        "gsettings": "scaled",
+        "feh": "--bg-max",    # Fit inside, borders if needed
+        "sway": "fit",
+        "kde": "2",
+        "xfce": "4",          # Scaled
+    },
+    "tile": {
+        "gsettings": "wallpaper",
+        "feh": "--bg-tile",
+        "sway": "tile",
+        "kde": "3",           # Tiled
+        "xfce": "3",          # Tiled
+    },
+}
+
+
+def _which(executable: str) -> str | None:
+    """Return the path to *executable* or None if not on PATH."""
+    return shutil.which(executable)
+
+
+def _run(*args: str, timeout: int = 15) -> subprocess.CompletedProcess:
+    """Run a command; return CompletedProcess.  Stderr captured but ignored."""
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _image_uri(path: str) -> str:
+    """Convert a local filesystem path to a ``file://`` URI."""
+    abs_path = str(Path(path).resolve())
+    # Prefix with file:// — GNOME gsettings expects this
+    return f"file://{abs_path}"
+
+
+# ---------------------------------------------------------------------------
+# Per-platform / per-DE setters
+# ---------------------------------------------------------------------------
+
+def _try_gnome(path: str, mode: str) -> bool:
+    """Set wallpaper via GNOME gsettings (also works on Budgie, Cinnamon, Unity)."""
+    gsettings = _which("gsettings")
+    if gsettings is None:
+        return False
+
+    uri = _image_uri(path)
+    picture_option = FIT_MODES[mode]["gsettings"]
+
+    # Try the dark-scheme key first (Ubuntu 22.04+, GNOME 42+), fall back to
+    # the legacy key.  Both are set so light/dark mode both get the wallpaper.
+    ok = False
+    for key in (
+        "org.gnome.desktop.background",
+        "org.gnome.desktop.background",
+    ):
+        light = _run(gsettings, "set", key, "picture-uri", uri)
+        dark = _run(gsettings, "set", key, "picture-uri-dark", uri)
+        opts = _run(gsettings, "set", key, "picture-options", picture_option)
+        if light.returncode == 0:
+            ok = True
+    return ok
+
+
+def _try_kde(path: str, mode: str) -> bool:
+    """Set wallpaper via KDE Plasma dbus scripting."""
+    # Plasma 5.26+ supports a simple dbus call via plasmashell
+    plasma_script = _which("plasma-apply-wallpaperimage")
+    if plasma_script is not None:
+        result = _run(plasma_script, str(Path(path).resolve()))
+        return result.returncode == 0
+
+    # Fallback: kwriteconfig5 + dbus reload
+    kwrite = _which("kwriteconfig5")
+    if kwrite is not None:
+        abs_path = str(Path(path).resolve())
+        _run(kwrite, "plasma-org.kde.plasma.desktop", "",
+             "wallpaper", abs_path)
+        # Try to reload
+        dbus_send = _which("dbus-send")
+        if dbus_send is not None:
+            _run(dbus_send, "--session", "--dest=org.kde.plasmashell",
+                 "--type=method_call", "/PlasmaShell",
+                 "org.kde.PlasmaShell.refreshCurrentShell")
+        return True
+
+    # Last resort: qdbus
+    qdbus = _which("qdbus")
+    if qdbus is not None:
+        abs_path = str(Path(path).resolve())
+        script = (
+            'var allDesktops = desktops();'
+            'for (i=0;i<allDesktops.length;i++) {{'
+            '  d = allDesktops[i];'
+            '  d.wallpaperPlugin = "org.kde.image";'
+            '  d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General");'
+            '  d.writeConfig("Image", "file://{path}");'
+            '  d.writeConfig("FillMode", "{mode}");'
+            '}}'
+        ).format(path=abs_path, mode=FIT_MODES[mode]["kde"])
+        result = _run(qdbus, "org.kde.plasmashell", "/PlasmaShell",
+                      "org.kde.PlasmaShell.evaluateScript", script)
+        return result.returncode == 0
+
+    return False
+
+
+def _try_xfce(path: str, mode: str) -> bool:
+    """Set wallpaper via XFCE xfconf-query."""
+    xfconf = _which("xfconf-query")
+    if xfconf is None:
+        return False
+
+    abs_path = str(Path(path).resolve())
+    picture_mode = FIT_MODES[mode]["xfce"]
+
+    # XFCE stores per-monitor settings; we set all monitors at once
+    # by writing to the default workspace
+    props = [
+        ("/backdrop/screen0/monitor0/workspace0/last-image", abs_path),
+        ("/backdrop/screen0/monitor0/workspace0/image-style", picture_mode),
+    ]
+    ok = True
+    for prop, value in props:
+        result = _run(xfconf, "-c", "xfce4-desktop", "-p", prop, "-s", value)
+        if result.returncode != 0:
+            ok = False
+    return ok
+
+
+def _try_sway(path: str, mode: str) -> bool:
+    """Set wallpaper via SwayWM swaymsg."""
+    swaymsg = _which("swaymsg")
+    if swaymsg is None:
+        return False
+
+    abs_path = str(Path(path).resolve())
+    fit = FIT_MODES[mode]["sway"]
+    result = _run(swaymsg, f"output * bg {abs_path} {fit}")
+    return result.returncode == 0
+
+
+def _try_feh(path: str, mode: str) -> bool:
+    """Set wallpaper via feh (generic X11 fallback)."""
+    feh = _which("feh")
+    if feh is None:
+        return False
+
+    abs_path = str(Path(path).resolve())
+    flag = FIT_MODES[mode]["feh"]
+    result = _run(feh, flag, abs_path)
+    return result.returncode == 0
+
+
+def _try_nitrogen(path: str, _mode: str) -> bool:
+    """Set wallpaper via nitrogen (another generic X11 tool)."""
+    nitrogen = _which("nitrogen")
+    if nitrogen is None:
+        return False
+
+    abs_path = str(Path(path).resolve())
+    result = _run(nitrogen, "--set-zoom-fill", abs_path)
+    return result.returncode == 0
+
+
+def _try_macos(path: str, _mode: str) -> bool:
+    """Set wallpaper on macOS via osascript / System Events."""
+    osascript = _which("osascript")
+    if osascript is None:
+        return False
+
+    abs_path = str(Path(path).resolve())
+    # Set picture for every desktop (space) on every display
+    script = (
+        'tell application "System Events" to '
+        'set picture of every desktop to POSIX file "{path}"'
+    ).format(path=abs_path)
+    result = _run(osascript, "-e", script, timeout=30)
+    return result.returncode == 0
+
+
+def _try_windows(path: str, _mode: str) -> bool:
+    """Set wallpaper on Windows via SystemParametersInfoW."""
+    abs_path = str(Path(path).resolve())
+    SPI_SETDESKWALLPAPER = 20
+    SPIF_UPDATEINIFILE = 0x01
+    SPIF_SENDCHANGE = 0x02
+
+    try:
+        result = ctypes.windll.user32.SystemParametersInfoW(
+            SPI_SETDESKWALLPAPER,
+            0,
+            abs_path,
+            SPIF_UPDATEINIFILE | SPIF_SENDCHANGE,
+        )
+        return bool(result)
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Ordered fallback chains per platform
+# ---------------------------------------------------------------------------
+
+_LINUX_SETTERS = [
+    ("gnome", _try_gnome),
+    ("kde", _try_kde),
+    ("xfce", _try_xfce),
+    ("sway", _try_sway),
+    ("feh", _try_feh),
+    ("nitrogen", _try_nitrogen),
+]
+
+_MACOS_SETTERS = [
+    ("osascript", _try_macos),
+]
+
+_WINDOWS_SETTERS = [
+    ("win32-api", _try_windows),
+]
+
+
+def set_wallpaper(path: str, mode: str = "fill") -> dict:
+    """
+    Set the desktop wallpaper to *path*.  Tries platform-appropriate
+    methods in order; stops at the first success.
+
+    Returns a result dict with keys ``status``, ``method``, ``path``
+    (or ``error`` on failure).
+    """
+    image = Path(path).resolve()
+    if not image.is_file():
+        return {
+            "status": "error",
+            "error": f"File not found: {path}",
+            "path": str(image),
+        }
+
+    if mode not in FIT_MODES:
+        return {
+            "status": "error",
+            "error": f"Unknown fit mode: {mode!r}. Choices: {', '.join(FIT_MODES)}",
+            "path": str(image),
+        }
+
+    platform = sys.platform
+    if platform == "darwin":
+        chain = _MACOS_SETTERS
+    elif platform == "win32":
+        chain = _WINDOWS_SETTERS
+    else:
+        chain = _LINUX_SETTERS
+
+    for name, fn in chain:
+        try:
+            if fn(str(image), mode):
+                return {
+                    "status": "ok",
+                    "method": name,
+                    "path": str(image),
+                }
+        except Exception as exc:
+            # One setter failing shouldn't prevent trying the next
+            print(f"[set_wallpaper] {name} failed: {exc}", file=sys.stderr)
+
+    return {
+        "status": "error",
+        "error": "No supported desktop environment detected. "
+                 "Tried: " + ", ".join(name for name, _ in chain),
+        "path": str(image),
+    }
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Set the desktop wallpaper (cross-platform).",
+    )
+    parser.add_argument(
+        "image",
+        help="Path to the image file to set as wallpaper.",
+    )
+    parser.add_argument(
+        "--mode", "-m",
+        default="fill",
+        choices=list(FIT_MODES),
+        help="How to fit the image on the desktop (default: fill).",
+    )
+    args = parser.parse_args()
+
+    result = set_wallpaper(args.image, args.mode)
+    print(json.dumps(result))
+    sys.exit(0 if result["status"] == "ok" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/creative/wallpaper-engine/scripts/wallpaper_history.py
+++ b/optional-skills/creative/wallpaper-engine/scripts/wallpaper_history.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Wallpaper generation history and feedback tracker.
+
+Stores a JSON log of every generated wallpaper plus user ratings and tags.
+Feeds into Hermes memory for long-term aesthetic preference learning.
+
+Data directory: ``$HERMES_HOME/wallpaper-engine/``
+History file:   ``$HERMES_HOME/wallpaper-engine/history.json``
+
+Usage:
+    python3 wallpaper_history.py add <image_path> <prompt> <workflow> [--meta '{"key":"val"}']
+    python3 wallpaper_history.py feedback <id> <rating> [tags ...]
+    python3 wallpaper_history.py list [--limit N] [--rated-only]
+    python3 wallpaper_history.py stats
+    python3 wallpaper_history.py get <id>
+
+Stdlib-only; Python 3.10+.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _data_dir() -> Path:
+    """Return the wallpaper-engine data directory (profile-aware)."""
+    hermes_home = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+    return Path(hermes_home) / "wallpaper-engine"
+
+
+def _history_path() -> Path:
+    return _data_dir() / "history.json"
+
+
+def _load() -> list[dict[str, Any]]:
+    """Load the history JSON, returning an empty list if none exists."""
+    hp = _history_path()
+    if not hp.is_file():
+        return []
+    try:
+        with open(hp, "r") as fh:
+            data = json.load(fh)
+    except (json.JSONDecodeError, OSError):
+        return []
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def _save(entries: list[dict[str, Any]]) -> None:
+    """Atomically write the history JSON."""
+    hp = _history_path()
+    hp.parent.mkdir(parents=True, exist_ok=True)
+    tmp = hp.with_suffix(".tmp")
+    with open(tmp, "w") as fh:
+        json.dump(entries, fh, indent=2, default=str)
+    tmp.replace(hp)
+
+
+def cmd_add(args: list[str]) -> None:
+    """Record a new wallpaper generation."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="add")
+    parser.add_argument("image_path", help="Path to the generated image file.")
+    parser.add_argument("prompt", help="The generation prompt used.")
+    parser.add_argument("workflow", help="Workflow filename used.")
+    parser.add_argument("--meta", default="{}",
+                       help="JSON string of extra metadata.")
+    ns = parser.parse_args(args)
+
+    try:
+        meta = json.loads(ns.meta)
+    except json.JSONDecodeError:
+        meta = {}
+
+    entry = {
+        "id": uuid.uuid4().hex[:12],
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "image_path": str(Path(ns.image_path).resolve()),
+        "prompt": ns.prompt,
+        "workflow": ns.workflow,
+        "rating": None,
+        "tags": [],
+        "rated_at": None,
+        "meta": meta,
+    }
+
+    history = _load()
+    history.append(entry)
+    _save(history)
+
+    print(json.dumps({"status": "ok", "id": entry["id"]}))
+
+
+def cmd_feedback(args: list[str]) -> None:
+    """Record user feedback (rating + tags) for an existing entry."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="feedback")
+    parser.add_argument("entry_id", help="ID of the entry to rate.")
+    parser.add_argument("rating", type=int, choices=range(1, 6),
+                       help="Rating 1-5 (1=dislike, 5=love).")
+    parser.add_argument("tags", nargs="*", default=[],
+                       help="Style/quality tags, e.g. 'dark' 'moody' 'mountains'.")
+    ns = parser.parse_args(args)
+
+    history = _load()
+    for entry in history:
+        if entry["id"] == ns.entry_id:
+            entry["rating"] = ns.rating
+            entry["tags"] = ns.tags
+            entry["rated_at"] = datetime.now(timezone.utc).isoformat()
+            _save(history)
+            print(json.dumps({"status": "ok", "id": ns.entry_id,
+                              "rating": ns.rating, "tags": ns.tags}))
+            return
+
+    print(json.dumps({"status": "error",
+                      "error": f"Entry not found: {ns.entry_id}"}))
+    sys.exit(1)
+
+
+def cmd_list(args: list[str]) -> None:
+    """List recent wallpaper generations."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="list")
+    parser.add_argument("--limit", "-n", type=int, default=20,
+                       help="Max entries to show.")
+    parser.add_argument("--rated-only", action="store_true",
+                       help="Only show entries with feedback.")
+    ns = parser.parse_args(args)
+
+    history = _load()
+    if ns.rated_only:
+        history = [e for e in history if e.get("rating") is not None]
+
+    # Most recent first
+    history = list(reversed(history))[:ns.limit]
+
+    # Strip image_path for compact display (paths are long)
+    summary = []
+    for e in history:
+        summary.append({
+            "id": e["id"],
+            "timestamp": e["timestamp"],
+            "prompt": e["prompt"][:120],
+            "workflow": e["workflow"],
+            "rating": e["rating"],
+            "tags": e["tags"],
+        })
+
+    print(json.dumps({"status": "ok", "count": len(summary), "entries": summary}))
+
+
+def cmd_get(args: list[str]) -> None:
+    """Get full details for a single entry by ID."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="get")
+    parser.add_argument("entry_id", help="ID of the entry to retrieve.")
+    ns = parser.parse_args(args)
+
+    history = _load()
+    for entry in history:
+        if entry["id"] == ns.entry_id:
+            print(json.dumps({"status": "ok", "entry": entry}))
+            return
+
+    print(json.dumps({"status": "error",
+                      "error": f"Entry not found: {ns.entry_id}"}))
+    sys.exit(1)
+
+
+def cmd_stats(args: list[str]) -> None:
+    """Compute preference statistics from rated entries."""
+    history = _load()
+    rated = [e for e in history if e.get("rating") is not None]
+
+    if not rated:
+        print(json.dumps({"status": "ok", "total": len(history),
+                          "rated": 0, "message": "No ratings yet."}))
+        return
+
+    ratings = [e["rating"] for e in rated]
+    avg_rating = sum(ratings) / len(ratings)
+
+    # Tag frequency across rated entries
+    tag_counter: Counter[str] = Counter()
+    for e in rated:
+        for tag in e.get("tags", []):
+            tag_counter[tag.lower()] += 1
+
+    # Group by rating bucket for preference insight
+    loved = [e for e in rated if e["rating"] >= 4]
+    disliked = [e for e in rated if e["rating"] <= 2]
+
+    loved_tags: Counter[str] = Counter()
+    for e in loved:
+        for tag in e.get("tags", []):
+            loved_tags[tag.lower()] += 1
+
+    disliked_tags: Counter[str] = Counter()
+    for e in disliked:
+        for tag in e.get("tags", []):
+            disliked_tags[tag.lower()] += 1
+
+    # Recent trend (last 5 rated)
+    recent = list(reversed(rated))[:5]
+    recent_avg = (
+        sum(e["rating"] for e in recent) / len(recent)
+        if recent else None
+    )
+
+    result = {
+        "status": "ok",
+        "total_generated": len(history),
+        "total_rated": len(rated),
+        "average_rating": round(avg_rating, 2),
+        "recent_average": round(recent_avg, 2) if recent_avg is not None else None,
+        "top_tags": tag_counter.most_common(10),
+        "loved_tags": loved_tags.most_common(5),
+        "disliked_tags": disliked_tags.most_common(5),
+    }
+    print(json.dumps(result))
+
+
+_COMMANDS = {
+    "add": cmd_add,
+    "feedback": cmd_feedback,
+    "list": cmd_list,
+    "get": cmd_get,
+    "stats": cmd_stats,
+}
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] not in _COMMANDS:
+        print(f"Usage: {sys.argv[0]} <{'|'.join(_COMMANDS)}> [...]", file=sys.stderr)
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    _COMMANDS[cmd](sys.argv[2:])
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/creative/wallpaper-engine/workflows/wallpaper_txt2img.json
+++ b/optional-skills/creative/wallpaper-engine/workflows/wallpaper_txt2img.json
@@ -1,0 +1,107 @@
+{
+  "3": {
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    },
+    "inputs": {
+      "seed": -1,
+      "steps": 30,
+      "cfg": 7.5,
+      "sampler_name": "dpmpp_2m",
+      "scheduler": "karras",
+      "denoise": 1.0,
+      "model": [
+        "4",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "5",
+        0
+      ]
+    }
+  },
+  "4": {
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load SDXL Base"
+    },
+    "inputs": {
+      "ckpt_name": "sd_xl_base_1.0.safetensors"
+    }
+  },
+  "5": {
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "Empty Latent (16:9)"
+    },
+    "inputs": {
+      "width": 1920,
+      "height": 1080,
+      "batch_size": 1
+    }
+  },
+  "6": {
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "Positive Prompt"
+    },
+    "inputs": {
+      "text": "breathtaking landscape wallpaper, cinematic lighting, 4K, masterpiece, high detail",
+      "clip": [
+        "4",
+        1
+      ]
+    }
+  },
+  "7": {
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "Negative Prompt"
+    },
+    "inputs": {
+      "text": "ugly, blurry, low quality, deformed, watermark, text, signature, frame, border, split screen, multiple panels",
+      "clip": [
+        "4",
+        1
+      ]
+    }
+  },
+  "8": {
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    },
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "4",
+        2
+      ]
+    }
+  },
+  "9": {
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    },
+    "inputs": {
+      "filename_prefix": "wallpaper",
+      "images": [
+        "8",
+        0
+      ]
+    }
+  }
+}

--- a/tests/skills/test_wallpaper_engine.py
+++ b/tests/skills/test_wallpaper_engine.py
@@ -1,0 +1,567 @@
+"""Tests for the wallpaper-engine optional skill.
+
+Structural + unit tests for the wallpaper generation, desktop setting, and
+preference-tracking scripts.  Stdlib + pytest only; no network calls.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "creative"
+    / "wallpaper-engine"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+SET_WALLPAPER_PY = SKILL_DIR / "scripts" / "set_wallpaper.py"
+HISTORY_PY = SKILL_DIR / "scripts" / "wallpaper_history.py"
+WORKFLOW_JSON = SKILL_DIR / "workflows" / "wallpaper_txt2img.json"
+PROMPT_LIBRARY = SKILL_DIR / "references" / "prompt-library.md"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def set_wallpaper_mod():
+    """Import set_wallpaper as a module for unit testing."""
+    sys.path.insert(0, str(SET_WALLPAPER_PY.parent))
+    import set_wallpaper as mod
+    return mod
+
+
+@pytest.fixture(scope="module")
+def history_mod():
+    """Import wallpaper_history as a module for unit testing."""
+    sys.path.insert(0, str(HISTORY_PY.parent))
+    import wallpaper_history as mod
+    return mod
+
+
+# ===========================================================================
+# Structural tests — SKILL.md
+# ===========================================================================
+
+
+def test_skill_file_exists():
+    assert SKILL_MD.is_file(), f"missing {SKILL_MD}"
+
+
+def test_frontmatter_present(skill_text: str):
+    assert skill_text.startswith("---\n"), "SKILL.md must open with YAML frontmatter"
+    assert skill_text.count("---") >= 2, "frontmatter must be delimited by two '---'"
+
+
+def test_name_in_frontmatter(skill_text: str):
+    m = re.search(r"^name: (.*)$", skill_text, re.MULTILINE)
+    assert m, "missing 'name:' in frontmatter"
+    assert m.group(1).strip() == "wallpaper-engine"
+
+
+def test_description_under_sixty_chars(skill_text: str):
+    m = re.search(r"^description: (.*)$", skill_text, re.MULTILINE)
+    assert m, "no description field"
+    desc = m.group(1).strip()
+    assert len(desc) <= 60, f"description is {len(desc)} chars (>60): {desc!r}"
+    assert desc.endswith("."), "description should end with a period"
+
+
+def test_platforms_declared(skill_text: str):
+    m = re.search(r"^platforms: (.*)$", skill_text, re.MULTILINE)
+    assert m, "platforms field required"
+    for os_name in ("linux", "macos", "windows"):
+        assert os_name in m.group(1), f"platforms must include {os_name}"
+
+
+def test_required_sections_present(skill_text: str):
+    for heading in (
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ):
+        assert heading in skill_text, f"missing section: {heading}"
+
+
+def test_comfyui_skill_referenced(skill_text: str):
+    """The wallpaper engine delegates generation to the comfyui skill."""
+    assert "comfyui" in skill_text.lower()
+    assert "run_workflow.py" in skill_text
+
+
+def test_memory_integration_documented(skill_text: str):
+    """Preference learning must reference Hermes memory."""
+    assert "memory" in skill_text.lower()
+    assert "memory(action=add)" in skill_text or "memory(action=read)" in skill_text
+
+
+def test_cron_scheduling_documented(skill_text: str):
+    """Scheduling must reference Hermes cron."""
+    assert "cron" in skill_text.lower()
+    assert "hermes cron" in skill_text
+
+
+def test_set_wallpaper_referenced(skill_text: str):
+    assert "set_wallpaper.py" in skill_text
+
+
+def test_wallpaper_history_referenced(skill_text: str):
+    assert "wallpaper_history.py" in skill_text
+
+
+def test_related_skills_declared(skill_text: str):
+    assert "related_skills:" in skill_text
+    assert "comfyui" in skill_text
+
+
+# ===========================================================================
+# Supporting files existence
+# ===========================================================================
+
+
+def test_set_wallpaper_script_exists():
+    assert SET_WALLPAPER_PY.is_file(), f"missing {SET_WALLPAPER_PY}"
+
+
+def test_wallpaper_history_script_exists():
+    assert HISTORY_PY.is_file(), f"missing {HISTORY_PY}"
+
+
+def test_workflow_json_exists():
+    assert WORKFLOW_JSON.is_file(), f"missing {WORKFLOW_JSON}"
+
+
+def test_prompt_library_exists():
+    assert PROMPT_LIBRARY.is_file(), f"missing {PROMPT_LIBRARY}"
+
+
+def test_workflow_json_is_valid_api_format():
+    """Workflow must have only node objects at top level (no _comment, strings, etc.)."""
+    wf = json.loads(WORKFLOW_JSON.read_text(encoding="utf-8"))
+    assert isinstance(wf, dict), "workflow must be a JSON object"
+    for key, value in wf.items():
+        assert isinstance(value, dict), (
+            f"top-level key '{key}' is a {type(value).__name__}, not a dict. "
+            f"Non-node keys like _comment cause ComfyUI validate_prompt() to reject the payload."
+        )
+        assert "class_type" in value, (
+            f"node '{key}' missing 'class_type' field"
+        )
+    # Must have the core nodes for a txt2img workflow
+    class_types = {v["class_type"] for v in wf.values()}
+    for required in ("KSampler", "CheckpointLoaderSimple", "CLIPTextEncode",
+                     "VAEDecode", "SaveImage", "EmptyLatentImage"):
+        assert required in class_types, f"workflow missing required node: {required}"
+
+
+def test_workflow_has_wallpaper_resolution():
+    wf = json.loads(WORKFLOW_JSON.read_text(encoding="utf-8"))
+    for node in wf.values():
+        if node.get("class_type") == "EmptyLatentImage":
+            inputs = node.get("inputs", {})
+            assert inputs.get("width") == 1920, "wallpaper workflow should default to 1920 width"
+            assert inputs.get("height") == 1080, "wallpaper workflow should default to 1080 height"
+            return
+    pytest.fail("No EmptyLatentImage node found in workflow")
+
+
+def test_workflow_save_prefix_is_wallpaper():
+    wf = json.loads(WORKFLOW_JSON.read_text(encoding="utf-8"))
+    for node in wf.values():
+        if node.get("class_type") == "SaveImage":
+            prefix = node.get("inputs", {}).get("filename_prefix", "")
+            assert "wallpaper" in prefix, (
+                f"SaveImage filename_prefix should contain 'wallpaper', got {prefix!r}"
+            )
+            return
+    pytest.fail("No SaveImage node found in workflow")
+
+
+# ===========================================================================
+# set_wallpaper.py unit tests
+# ===========================================================================
+
+
+class TestSetWallpaper:
+    """Unit tests for set_wallpaper.py — mock subprocess to avoid real desktop calls."""
+
+    def test_file_not_found(self, set_wallpaper_mod):
+        result = set_wallpaper_mod.set_wallpaper("/nonexistent/path/image.png")
+        assert result["status"] == "error"
+        assert "File not found" in result["error"]
+
+    def test_invalid_fit_mode(self, set_wallpaper_mod, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_text("fake image")
+        result = set_wallpaper_mod.set_wallpaper(str(img), mode="bogus")
+        assert result["status"] == "error"
+        assert "Unknown fit mode" in result["error"]
+
+    def test_all_fit_modes_are_valid(self, set_wallpaper_mod):
+        for mode in ("fill", "center", "stretch", "fit", "tile"):
+            assert mode in set_wallpaper_mod.FIT_MODES, f"mode {mode!r} missing from FIT_MODES"
+
+    def test_gnome_success(self, set_wallpaper_mod, tmp_path, monkeypatch):
+        """GNOME gsettings returns code 0 → wallpaper set successfully."""
+        img = tmp_path / "test.png"
+        img.write_text("fake image")
+
+        fake_run = mock.Mock(return_value=mock.Mock(returncode=0))
+        monkeypatch.setattr(set_wallpaper_mod, "_run", fake_run)
+        monkeypatch.setattr(set_wallpaper_mod, "_which", lambda x: f"/usr/bin/{x}")
+        # Force Linux chain
+        monkeypatch.setattr(set_wallpaper_mod.sys, "platform", "linux")
+
+        result = set_wallpaper_mod.set_wallpaper(str(img))
+        assert result["status"] == "ok"
+        assert result["method"] == "gnome"
+
+    def test_macos_success(self, set_wallpaper_mod, tmp_path, monkeypatch):
+        """macOS osascript returns code 0 → wallpaper set."""
+        img = tmp_path / "test.png"
+        img.write_text("fake image")
+
+        fake_run = mock.Mock(return_value=mock.Mock(returncode=0))
+        monkeypatch.setattr(set_wallpaper_mod, "_run", fake_run)
+        monkeypatch.setattr(set_wallpaper_mod, "_which", lambda x: f"/usr/bin/{x}")
+        monkeypatch.setattr(set_wallpaper_mod.sys, "platform", "darwin")
+
+        result = set_wallpaper_mod.set_wallpaper(str(img))
+        assert result["status"] == "ok"
+        assert result["method"] == "osascript"
+
+    def test_windows_success(self, set_wallpaper_mod, tmp_path, monkeypatch):
+        """Windows SystemParametersInfoW succeeds."""
+        img = tmp_path / "test.png"
+        img.write_text("fake image")
+
+        # ctypes.windll only exists on Windows — test _try_windows directly
+        monkeypatch.setattr(set_wallpaper_mod.ctypes, "windll",
+                           mock.MagicMock(user32=mock.MagicMock(
+                               SystemParametersInfoW=mock.Mock(return_value=True))),
+                           raising=False)
+        assert set_wallpaper_mod._try_windows(str(img), "fill") is True
+
+    def test_all_setters_fail(self, set_wallpaper_mod, tmp_path, monkeypatch):
+        """When no desktop environment is found, return error with useful message."""
+        img = tmp_path / "test.png"
+        img.write_text("fake image")
+
+        # which returns None (no tools found) → every setter returns False
+        monkeypatch.setattr(set_wallpaper_mod, "_which", lambda x: None)
+        monkeypatch.setattr(set_wallpaper_mod.sys, "platform", "linux")
+
+        result = set_wallpaper_mod.set_wallpaper(str(img))
+        assert result["status"] == "error"
+        assert "No supported desktop environment" in result["error"]
+
+    def test_image_uri_formats_correctly(self, set_wallpaper_mod, tmp_path):
+        img = tmp_path / "my image.png"
+        img.write_text("fake")
+        uri = set_wallpaper_mod._image_uri(str(img))
+        assert uri.startswith("file://")
+        assert "my%20image.png" not in uri or "my image.png" in uri
+
+    def test_feh_flag_mapping(self, set_wallpaper_mod):
+        assert set_wallpaper_mod.FIT_MODES["fill"]["feh"] == "--bg-fill"
+        assert set_wallpaper_mod.FIT_MODES["center"]["feh"] == "--bg-center"
+        assert set_wallpaper_mod.FIT_MODES["tile"]["feh"] == "--bg-tile"
+
+    def test_mode_values_match_across_backends(self, set_wallpaper_mod):
+        """Every backend defined in FIT_MODES has an entry for every mode."""
+        backends = {"gsettings", "feh", "sway", "kde", "xfce"}
+        for mode, backends_dict in set_wallpaper_mod.FIT_MODES.items():
+            for backend in backends:
+                assert backend in backends_dict, (
+                    f"mode {mode!r} missing backend {backend!r}"
+                )
+
+
+# ===========================================================================
+# wallpaper_history.py unit tests
+# ===========================================================================
+
+
+class TestWallpaperHistory:
+    """Unit tests for wallpaper_history.py — uses temp JSON files, no real data."""
+
+    @pytest.fixture(autouse=True)
+    def isolated_history(self, history_mod, tmp_path, monkeypatch):
+        """Redirect history storage to a temp directory for each test."""
+        data_dir = tmp_path / "wallpaper-engine"
+        data_dir.mkdir()
+        monkeypatch.setattr(history_mod, "_data_dir", lambda: data_dir)
+        # Reset module-level state if any
+        return data_dir
+
+    def _add(self, history_mod, image_path, prompt, workflow, meta=None):
+        """Helper: call cmd_add programmatically."""
+        args = [image_path, prompt, workflow]
+        if meta:
+            args.extend(["--meta", json.dumps(meta)])
+        history_mod.cmd_add(args)
+
+    def _feedback(self, history_mod, entry_id, rating, tags=()):
+        args = [entry_id, str(rating), *tags]
+        history_mod.cmd_feedback(args)
+
+    def _list(self, history_mod, *extra):
+        history_mod.cmd_list(list(extra))
+
+    def _stats(self, history_mod):
+        history_mod.cmd_stats([])
+
+    def test_add_creates_record(self, history_mod, tmp_path):
+        img = tmp_path / "wallpaper.png"
+        img.write_text("fake")
+        self._add(history_mod, str(img), "a beautiful sunset", "test_workflow.json")
+
+        history = history_mod._load()
+        assert len(history) == 1
+        entry = history[0]
+        assert entry["prompt"] == "a beautiful sunset"
+        assert entry["workflow"] == "test_workflow.json"
+        assert entry["rating"] is None
+        assert entry["tags"] == []
+        assert "id" in entry
+        assert "timestamp" in entry
+
+    def test_add_with_metadata(self, history_mod, tmp_path):
+        img = tmp_path / "wp.png"
+        img.write_text("fake")
+        self._add(history_mod, str(img), "test", "wf.json",
+                  meta={"resolution": "1920x1080", "seed": 42})
+
+        history = history_mod._load()
+        assert history[0]["meta"] == {"resolution": "1920x1080", "seed": 42}
+
+    def test_add_invalid_meta_falls_back_to_empty(self, history_mod, tmp_path):
+        img = tmp_path / "wp.png"
+        img.write_text("fake")
+        # Force JSON parse error by passing invalid JSON
+        history_mod.cmd_add([str(img), "test", "wf.json", "--meta", "not-json}"])
+
+        history = history_mod._load()
+        assert history[0]["meta"] == {}
+
+    def test_feedback_updates_entry(self, history_mod, tmp_path):
+        img = tmp_path / "wp.png"
+        img.write_text("fake")
+        self._add(history_mod, str(img), "test", "wf.json")
+        entry_id = history_mod._load()[0]["id"]
+
+        self._feedback(history_mod, entry_id, 5, ("dark", "moody"))
+
+        history = history_mod._load()
+        assert history[0]["rating"] == 5
+        assert history[0]["tags"] == ["dark", "moody"]
+        assert history[0]["rated_at"] is not None
+
+    def test_feedback_nonexistent_id(self, history_mod):
+        with pytest.raises(SystemExit) as exc_info:
+            self._feedback(history_mod, "nonexistent", 3)
+        assert exc_info.value.code == 1
+
+    def test_list_returns_newest_first(self, history_mod, tmp_path):
+        img = tmp_path / "wp.png"
+        img.write_text("fake")
+        self._add(history_mod, str(img), "first", "wf.json")
+        self._add(history_mod, str(img), "second", "wf.json")
+        self._add(history_mod, str(img), "third", "wf.json")
+
+        # Capture stdout from cmd_list
+        import io
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            self._list(history_mod)
+
+        output = json.loads(buf.getvalue())
+        assert output["status"] == "ok"
+        assert output["count"] == 3
+        # Newest first
+        prompts = [e["prompt"] for e in output["entries"]]
+        assert prompts == ["third", "second", "first"]
+
+    def test_list_rated_only(self, history_mod, tmp_path):
+        img = tmp_path / "wp.png"
+        img.write_text("fake")
+        self._add(history_mod, str(img), "unrated", "wf.json")
+        self._add(history_mod, str(img), "rated", "wf.json")
+        entry_id = history_mod._load()[1]["id"]
+        self._feedback(history_mod, entry_id, 4, ("cool",))
+
+        import io
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            self._list(history_mod, "--rated-only")
+
+        output = json.loads(buf.getvalue())
+        assert output["count"] == 1
+        assert output["entries"][0]["prompt"] == "rated"
+
+    def test_list_limit(self, history_mod, tmp_path):
+        img = tmp_path / "wp.png"
+        img.write_text("fake")
+        for i in range(10):
+            self._add(history_mod, str(img), f"prompt-{i}", "wf.json")
+
+        import io
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            self._list(history_mod, "--limit", "3")
+
+        output = json.loads(buf.getvalue())
+        assert output["count"] == 3
+
+    def test_get_retrieves_full_entry(self, history_mod, tmp_path):
+        img = tmp_path / "wp.png"
+        img.write_text("fake")
+        self._add(history_mod, str(img), "my prompt text", "my_workflow.json")
+        entry_id = history_mod._load()[0]["id"]
+
+        import io
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            history_mod.cmd_get([entry_id])
+
+        output = json.loads(buf.getvalue())
+        assert output["status"] == "ok"
+        assert output["entry"]["prompt"] == "my prompt text"
+        assert "image_path" in output["entry"]
+
+    def test_get_nonexistent_id(self, history_mod):
+        with pytest.raises(SystemExit) as exc_info:
+            history_mod.cmd_get(["nonexistent"])
+        assert exc_info.value.code == 1
+
+    def test_stats_empty_history(self, history_mod):
+        import io
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            self._stats(history_mod)
+
+        output = json.loads(buf.getvalue())
+        assert output["status"] == "ok"
+        assert output["total"] == 0
+        assert output["rated"] == 0
+
+    def test_stats_with_ratings(self, history_mod, tmp_path):
+        img = tmp_path / "wp.png"
+        img.write_text("fake")
+
+        # Add 5 entries with varied ratings
+        self._add(history_mod, str(img), "p1", "wf.json")
+        self._add(history_mod, str(img), "p2", "wf.json")
+        self._add(history_mod, str(img), "p3", "wf.json")
+        self._add(history_mod, str(img), "p4", "wf.json")
+        self._add(history_mod, str(img), "p5", "wf.json")
+
+        history = history_mod._load()
+        self._feedback(history_mod, history[0]["id"], 5, ("dark", "moody", "mountains"))
+        self._feedback(history_mod, history[1]["id"], 4, ("dark", "space"))
+        self._feedback(history_mod, history[2]["id"], 3, ("bright",))
+        self._feedback(history_mod, history[3]["id"], 2, ("bright", "abstract"))
+        self._feedback(history_mod, history[4]["id"], 1, ("bright", "noisy"))
+
+        import io
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            self._stats(history_mod)
+
+        output = json.loads(buf.getvalue())
+        assert output["total_generated"] == 5
+        assert output["total_rated"] == 5
+        assert output["average_rating"] == 3.0  # (5+4+3+2+1)/5
+        # "dark" appears in 2 loved (4-5), "bright" in 2 disliked (1-2)
+        loved = dict(output["loved_tags"])
+        disliked = dict(output["disliked_tags"])
+        assert loved.get("dark", 0) >= 1
+        assert disliked.get("bright", 0) >= 1
+        # Top tags overall
+        assert len(output["top_tags"]) > 0
+
+    def test_stats_only_rated(self, history_mod, tmp_path):
+        """Unrated entries don't affect stats."""
+        img = tmp_path / "wp.png"
+        img.write_text("fake")
+        self._add(history_mod, str(img), "unrated", "wf.json")
+        self._add(history_mod, str(img), "rated", "wf.json")
+        history = history_mod._load()
+        self._feedback(history_mod, history[1]["id"], 5, ("awesome",))
+
+        import io
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            self._stats(history_mod)
+
+        output = json.loads(buf.getvalue())
+        assert output["total_generated"] == 2
+        assert output["total_rated"] == 1
+        assert output["average_rating"] == 5.0
+
+    def test_history_directory_created_on_save(self, history_mod, tmp_path):
+        """_save creates the parent directory if it doesn't exist."""
+        img = tmp_path / "wp.png"
+        img.write_text("fake")
+        self._add(history_mod, str(img), "test", "wf.json")
+        assert history_mod._data_dir().is_dir()
+        assert history_mod._history_path().is_file()
+
+    def test_load_corrupted_file_returns_empty(self, history_mod):
+        """Corrupted JSON returns an empty list rather than crashing."""
+        history_mod._history_path().write_text("not valid json {{{")
+        assert history_mod._load() == []
+
+    def test_load_non_list_returns_empty(self, history_mod):
+        """A JSON object (not a list) at the history path returns empty list."""
+        history_mod._history_path().write_text('{"not": "a list"}')
+        assert history_mod._load() == []
+
+    def test_add_preserves_existing_entries(self, history_mod, tmp_path):
+        img = tmp_path / "wp.png"
+        img.write_text("fake")
+        self._add(history_mod, str(img), "first", "wf.json")
+        self._add(history_mod, str(img), "second", "wf.json")
+        assert len(history_mod._load()) == 2
+
+    def test_load_creates_no_file_when_missing(self, history_mod):
+        """_load() should not create a file when none exists."""
+        hp = history_mod._history_path()
+        assert not hp.exists()
+        result = history_mod._load()
+        assert result == []
+        assert not hp.exists()  # still shouldn't exist
+
+
+# ===========================================================================
+# Prompt library tests
+# ===========================================================================
+
+
+def test_prompt_library_has_categories():
+    text = PROMPT_LIBRARY.read_text(encoding="utf-8")
+    for category in ("Nature", "Abstract", "Dark", "Sci-Fi", "Seasonal"):
+        assert category in text, f"prompt library missing category: {category}"
+
+
+def test_prompt_library_has_usage_notes():
+    text = PROMPT_LIBRARY.read_text(encoding="utf-8")
+    assert "## Usage Notes" in text
+    assert "seed" in text.lower()

--- a/tests/skills/test_wallpaper_engine.py
+++ b/tests/skills/test_wallpaper_engine.py
@@ -107,15 +107,41 @@ def test_comfyui_skill_referenced(skill_text: str):
 
 
 def test_memory_integration_documented(skill_text: str):
-    """Preference learning must reference Hermes memory."""
+    """Preference learning must reference Hermes memory for durable writes."""
     assert "memory" in skill_text.lower()
-    assert "memory(action=add)" in skill_text or "memory(action=read)" in skill_text
+    assert "memory(action=add" in skill_text
 
 
 def test_cron_scheduling_documented(skill_text: str):
     """Scheduling must reference Hermes cron."""
     assert "cron" in skill_text.lower()
     assert "hermes cron" in skill_text
+
+
+def test_cron_syntax_uses_positional_args(skill_text: str):
+    """hermes cron add takes schedule and prompt as positional args, NOT --schedule/--prompt."""
+    assert "hermes cron add" in skill_text
+    # Must NOT use the invalid --schedule or --prompt flags
+    assert "--schedule" not in skill_text
+    assert "--prompt" not in skill_text
+
+
+def test_cron_syntax_uses_repeatable_skill_flag(skill_text: str):
+    """Skills are attached via repeatable --skill (singular), not --skills."""
+    assert "--skill" in skill_text
+
+
+def test_no_memory_read_action(skill_text: str):
+    """memory(action=read) does not exist — must not be documented as an interface."""
+    assert "memory(action=read)" not in skill_text
+
+
+def test_uses_hermes_skill_dir_template(skill_text: str):
+    """Skill assets must use ${HERMES_SKILL_DIR}, not repo-relative paths."""
+    assert "${HERMES_SKILL_DIR}" in skill_text
+    # Must not reference optional-skills/ paths (repo layout assumption)
+    assert "optional-skills/creative/wallpaper-engine/" not in skill_text
+
 
 
 def test_set_wallpaper_referenced(skill_text: str):


### PR DESCRIPTION
Add a personalized evolving wallpaper engine as an optional skill

Files:
- SKILL.md: Teaches the agent to orchestrate wallpaper generation, desktop setting, feedback collection, and cron scheduling
- scripts/set_wallpaper.py: Cross-platform wallpaper setter (Linux GNOME/KDE/XFCE/Sway, macOS, Windows)
- scripts/wallpaper_history.py: JSON-based generation history and feedback tracker with stats
- workflows/wallpaper_txt2img.json: SDXL txt2img workflow at 1920x1080 with parametrized prompts and resolution
- references/prompt-library.md: 12 curated prompt templates across 6 style categories

Reuses the existing ComfyUI skill for all generation work — no duplicated pipeline code. Preferences feed into Hermes memory for cross-session learning.

## What does this PR do?

Add a personalized evolving wallpaper engine as an optional skill that generates desktop wallpapers via ComfyUI and learns user aesthetic preferences over time through Hermes memory.
This approach reuses as much of hermes internals to avoid duplicating work.

## Related Issue

Fixes issue [69226](https://github.com/NousResearch/hermes-agent/issues/69226)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- Added `optional-skills/creative/wallpaper-engine/SKILL.md` — teaches the agent the full wallpaper workflow: generate → set → track → learn → schedule
- Added `optional-skills/creative/wallpaper-engine/scripts/set_wallpaper.py` — cross-platform wallpaper setter (Linux GNOME/KDE/XFCE/Sway/feh/nitrogen, macOS osascript, Windows Win32 API), stdlib-only
- Added `optional-skills/creative/wallpaper-engine/scripts/wallpaper_history.py` — JSON-based generation history and feedback tracker with `add`/`feedback`/`list`/`get`/`stats` commands, stdlib-only
- Added `optional-skills/creative/wallpaper-engine/workflows/wallpaper_txt2img.json` — SDXL txt2img workflow at 1920×1080 with parametrized prompts and resolution
- Added `optional-skills/creative/wallpaper-engine/references/prompt-library.md` — 12 curated prompt templates across 6 style categories (Nature, Abstract, Dark/AMOLED, Sci-Fi, Seasonal)


## How to Test

1. Install the skill into `~/.hermes/skills/creative/wallpaper-engine/`
2. Ensure ComfyUI is running: `comfy launch --background`
3. Test wallpaper setting: `python3 optional-skills/creative/wallpaper-engine/scripts/set_wallpaper.py /path/to/test.png`
4. Test history tracking: `python3 optional-skills/creative/wallpaper-engine/scripts/wallpaper_history.py add /tmp/test.png "test prompt" "test.json"`
5. Run end-to-end via Hermes: "generate me a new wallpaper" — should generate, set as desktop background, and record to history
6. Run automated tests: `bash scripts/run_tests.sh tests/skills/test_wallpaper_engine.py` (49 tests, all pass)

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (GNOME), NVIDIA RTX 3090

### Documentation & Housekeeping

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills


- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<img width="904" height="474" alt="Screenshot From 2026-07-24 17-21-44" src="https://github.com/user-attachments/assets/65791c44-836a-41fb-8333-4262f4c59446" />


