### PR TITLE
fix(webhook): validate parsed payload is a dict to prevent endpoint 500 crash

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -625,6 +625,12 @@ class WebhookAdapter(BasePlatformAdapter):
                     {"error": "Cannot parse body"}, status=400
                 )
 
+        if not isinstance(payload, dict):
+            return web.json_response(
+                {"error": "Payload must be a JSON object or form data"},
+                status=400,
+            )
+
         # Check event type filter
         event_type = (
             request.headers.get("X-GitHub-Event", "")

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -500,6 +500,28 @@ class TestValidateSignature:
         assert adapter._validate_signature(req, body, secret) is True
 
 
+class TestHandleWebhookPayloadValidation:
+    """Tests for WebhookAdapter._handle_webhook payload validation."""
+
+    @pytest.mark.asyncio
+    async def test_handle_webhook_rejects_non_dict_json_payload(self):
+        """A JSON array or non-dict JSON body must return 400 Bad Request."""
+        from gateway.platforms.webhook import _INSECURE_NO_AUTH
+        adapter = _make_adapter(routes={"r1": {"secret": _INSECURE_NO_AUTH, "prompt": "x"}})
+        f = asyncio.Future()
+        f.set_result(b"[1, 2, 3]")
+        req = _mock_request(
+            headers={},
+            match_info={"route_name": "r1"},
+            content_length=9,
+        )
+        req.read = lambda: f
+        resp = await adapter._handle_webhook(req)
+        assert resp.status == 400
+        assert "JSON object" in resp.text
+
+
+
 # ===================================================================
 # Prompt rendering
 # ===================================================================


### PR DESCRIPTION
### Summary

Fixes a P1 unhandled HTTP 500 endpoint crash in `gateway/platforms/webhook.py` (`_handle_webhook`) when receiving valid non-object JSON payloads.

### Cause
When an HTTP POST request is received on a configured webhook route, `_handle_webhook` parses the raw bytes with `json.loads(raw_body)`. If the request body is valid JSON but not a JSON object (e.g., a JSON array `[1, 2]`, number `123`, or string `"data"`), `json.loads` succeeds and assigns a `list`/`int`/`str` to `payload`.

Subsequent property access like `payload.get("event_type", "")` threw an unhandled `AttributeError: 'list' object has no attribute 'get'`, causing the Webhook adapter handler to fail with HTTP 500 internal server error instead of returning a proper HTTP 400 Bad Request response. (Other platform adapters such as `whatsapp_cloud.py` and `msgraph_webhook.py` explicitly validate `isinstance(payload, dict)`).

### Solution
- Added explicit `isinstance(payload, dict)` check after body parsing in `WebhookAdapter._handle_webhook`, returning a 400 Bad Request error if payload is non-dict.
- Added unit test `test_handle_webhook_rejects_non_dict_json_payload` in `tests/gateway/test_webhook_adapter.py`.