### PR TITLE
fix(agent): preserve Gemma 4 reasoning replay

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3058,6 +3058,12 @@ def intent_ack_continuation_enabled(agent) -> bool:
 
 
 
+def _preserves_gemma4_reasoning_replay(agent) -> bool:
+    """Return True when the active model uses Gemma 4 reasoning replay."""
+    model = str(getattr(agent, "model", "") or "").strip().lower()
+    return bool(re.search(r"(?:^|[/_.:-])gemma[-_.]?4(?:$|[/_.:-])", model))
+
+
 def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> None:
     """Copy provider-facing reasoning fields onto an API replay message."""
     if source_msg.get("role") != "assistant":
@@ -3085,7 +3091,9 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     # covers the already-built api_messages path. Refs #45655.
     existing = source_msg.get("reasoning_content")
     if isinstance(existing, str):
-        if not needs_thinking_pad:
+        if _preserves_gemma4_reasoning_replay(agent) and existing.strip():
+            api_msg["reasoning_content"] = existing
+        elif not needs_thinking_pad:
             api_msg.pop("reasoning_content", None)
         elif existing == "":
             api_msg["reasoning_content"] = " "
@@ -3174,6 +3182,7 @@ def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
     removed.
     """
     needs_pad = agent._needs_thinking_reasoning_pad()
+    preserves_gemma4_replay = _preserves_gemma4_reasoning_replay(agent)
     changed = 0
     for api_msg in api_messages:
         if api_msg.get("role") != "assistant":
@@ -3184,10 +3193,14 @@ def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
             copy_reasoning_content_for_api(agent, api_msg, api_msg)
             if api_msg.get("reasoning_content"):
                 changed += 1
-        else:
+        elif not preserves_gemma4_replay:
             # Strict provider — strip any stale reasoning_content pad left
             # over from a reasoning primary so the fallback request doesn't
             # 400/422 on it.
+            if "reasoning_content" in api_msg:
+                api_msg.pop("reasoning_content", None)
+                changed += 1
+        elif not str(api_msg.get("reasoning_content") or "").strip():
             if "reasoning_content" in api_msg:
                 api_msg.pop("reasoning_content", None)
                 changed += 1

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -662,12 +662,25 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 prev["content"] = joined
             elif not prev_content and new_content is not None:
                 prev["content"] = new_content
-            # Carry reasoning_content from the later turn only if the
-            # earlier turn lacks it (strict thinking providers require a
-            # reasoning_content on the merged tool-call turn; the first
-            # non-empty one suffices).
-            if not prev.get("reasoning_content") and msg.get("reasoning_content"):
+            # Keep replay provenance atomic with the reasoning value. When the
+            # later row contributes tool calls, its pair supersedes any
+            # thinking-prefill reasoning from the earlier row; associating the
+            # earlier scratchpad with the later calls would make it replayable
+            # under the wrong response boundary.
+            replay_origin_key = "_reasoning_replay_origin"
+            if new_calls:
+                prev.pop("reasoning_content", None)
+                prev.pop(replay_origin_key, None)
+                if "reasoning_content" in msg:
+                    prev["reasoning_content"] = msg["reasoning_content"]
+                    if replay_origin_key in msg:
+                        prev[replay_origin_key] = msg[replay_origin_key]
+            elif not prev.get("reasoning_content") and msg.get("reasoning_content"):
                 prev["reasoning_content"] = msg["reasoning_content"]
+                if replay_origin_key in msg:
+                    prev[replay_origin_key] = msg[replay_origin_key]
+            if "reasoning_content" not in prev:
+                prev.pop(replay_origin_key, None)
             repairs += 1
             continue
         collapsed.append(msg)
@@ -3737,7 +3750,42 @@ def intent_ack_continuation_enabled(agent) -> bool:
 
 
 
-def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> None:
+def _reasoning_replay_route(agent) -> tuple[Any, str]:
+    """Return concrete model plus a non-reversible route fingerprint."""
+    model = getattr(agent, "model", None)
+    provider = getattr(agent, "provider", None)
+    base_url = getattr(agent, "base_url", None)
+    if getattr(agent, "provider", None) == "moa":
+        client = getattr(agent, "client", None)
+        runtime = getattr(client, "last_aggregator_runtime", None)
+        slot = getattr(client, "last_aggregator_slot", None)
+        if isinstance(runtime, dict):
+            model = runtime.get("model") or model
+            provider = runtime.get("provider") or provider
+            if "base_url" in runtime:
+                base_url = runtime["base_url"]
+        elif isinstance(slot, dict):
+            try:
+                from agent.moa_loop import _slot_runtime
+
+                runtime = _slot_runtime(slot)
+            except Exception:
+                runtime = slot
+            model = runtime.get("model") or slot.get("model") or model
+            provider = runtime.get("provider") or slot.get("provider") or provider
+            base_url = runtime.get("base_url") or slot.get("base_url") or base_url
+    from agent.message_sanitization import reasoning_replay_route_fingerprint
+
+    return model, reasoning_replay_route_fingerprint(provider, base_url, model)
+
+
+def copy_reasoning_content_for_api(
+    agent,
+    source_msg: dict,
+    api_msg: dict,
+    *,
+    preserve_explicit_reasoning: bool = False,
+) -> None:
     """Copy provider-facing reasoning fields onto an API replay message.
 
     Forwarder — the strip-vs-repad POLICY is owned by
@@ -3746,8 +3794,14 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     """
     from agent.message_sanitization import apply_reasoning_content_policy
 
+    model, replay_origin = _reasoning_replay_route(agent)
     apply_reasoning_content_policy(
-        source_msg, api_msg, agent._needs_thinking_reasoning_pad()
+        source_msg,
+        api_msg,
+        agent._needs_thinking_reasoning_pad(),
+        model=model,
+        preserve_explicit_reasoning=preserve_explicit_reasoning,
+        replay_origin=replay_origin,
     )
 
 
@@ -3782,8 +3836,12 @@ def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
     """
     from agent.message_sanitization import reapply_reasoning_echo
 
+    model, replay_origin = _reasoning_replay_route(agent)
     return reapply_reasoning_echo(
-        api_messages, agent._needs_thinking_reasoning_pad()
+        api_messages,
+        agent._needs_thinking_reasoning_pad(),
+        model=model,
+        replay_origin=replay_origin,
     )
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3218,11 +3218,13 @@ def _record_route_info(
     route_info: Optional[Dict[str, str]],
     provider: Optional[str],
     model: Optional[str],
+    base_url: Optional[str] = None,
 ) -> None:
     """Expose the concrete route selected for one auxiliary call."""
     if route_info is not None:
         route_info["provider"] = provider or "auto"
         route_info["model"] = model or "default"
+        route_info["base_url"] = str(base_url or "")
 
 
 def _relay_auxiliary_metadata(
@@ -4591,6 +4593,7 @@ def _retry_same_provider_sync(
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
     extra_headers: Optional[Dict[str, str]] = None,
+    route_info: Optional[Dict[str, str]] = None,
 ) -> Any:
     if task == "vision":
         effective_provider, retry_client, retry_model = resolve_vision_provider_client(
@@ -4618,6 +4621,12 @@ def _retry_same_provider_sync(
         )
 
     retry_base = str(getattr(retry_client, "base_url", "") or "")
+    _record_route_info(
+        route_info,
+        _fallback_provider_from_label(effective_provider or resolved_provider),
+        retry_model or final_model,
+        retry_base or resolved_base_url,
+    )
     retry_kwargs = _build_call_kwargs(
         effective_provider or resolved_provider,
         retry_model or final_model,
@@ -4666,6 +4675,7 @@ async def _retry_same_provider_async(
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
     extra_headers: Optional[Dict[str, str]] = None,
+    route_info: Optional[Dict[str, str]] = None,
 ) -> Any:
     if task == "vision":
         effective_provider, retry_client, retry_model = resolve_vision_provider_client(
@@ -4693,6 +4703,12 @@ async def _retry_same_provider_async(
         )
 
     retry_base = str(getattr(retry_client, "base_url", "") or "")
+    _record_route_info(
+        route_info,
+        _fallback_provider_from_label(effective_provider or resolved_provider),
+        retry_model or final_model,
+        retry_base or resolved_base_url,
+    )
     retry_kwargs = _build_call_kwargs(
         effective_provider or resolved_provider,
         retry_model or final_model,
@@ -5003,6 +5019,7 @@ def _call_fallback_candidate_sync(
     effective_timeout: float,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
+    route_info: Optional[Dict[str, str]] = None,
 ) -> Optional[Any]:
     """Call one fallback candidate with stale-credential recovery.
 
@@ -5033,6 +5050,12 @@ def _call_fallback_candidate_sync(
         )
         effective_timeout = fb_timeout
     destination = _fallback_destination(task, fb_client, fb_model, fb_label)
+    _record_route_info(
+        route_info,
+        destination.provider,
+        destination.model,
+        destination.base_url,
+    )
     fallback_messages, fallback_tools = _replan_synchronous_cache_sections(
         messages,
         tools,
@@ -5074,6 +5097,12 @@ def _call_fallback_candidate_sync(
                     or str(getattr(retry_client, "base_url", "") or ""),
                     destination.api_mode,
                     retry_model or destination.model,
+                )
+                _record_route_info(
+                    route_info,
+                    retry_destination.provider,
+                    retry_destination.model,
+                    retry_destination.base_url,
                 )
                 retry_messages, retry_tools = _replan_synchronous_cache_sections(
                     messages,
@@ -5128,6 +5157,7 @@ async def _call_fallback_candidate_async(
     effective_timeout: float,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
+    route_info: Optional[Dict[str, str]] = None,
 ) -> Optional[Any]:
     """Async mirror of :func:`_call_fallback_candidate_sync`."""
     fb_timeout = _fallback_entry_timeout(task, fb_label)
@@ -5139,6 +5169,12 @@ async def _call_fallback_candidate_async(
         )
         effective_timeout = fb_timeout
     destination = _fallback_destination(task, fb_client, fb_model, fb_label)
+    _record_route_info(
+        route_info,
+        destination.provider,
+        destination.model,
+        destination.base_url,
+    )
     fallback_messages, fallback_tools = _replan_synchronous_cache_sections(
         messages,
         tools,
@@ -5181,6 +5217,12 @@ async def _call_fallback_candidate_async(
                     or str(getattr(retry_client, "base_url", "") or ""),
                     destination.api_mode,
                     retry_model or destination.model,
+                )
+                _record_route_info(
+                    route_info,
+                    retry_destination.provider,
+                    retry_destination.model,
+                    retry_destination.base_url,
                 )
                 retry_messages, retry_tools = _replan_synchronous_cache_sections(
                     messages,
@@ -8253,6 +8295,23 @@ def _build_call_kwargs(
     task: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
+    # Replay provenance must survive until the concrete auxiliary destination
+    # is selected. In particular, call_llm may replace a configured MoA
+    # aggregator with a different fallback route after a 402/429. Shape the
+    # scratchpad for this exact candidate and strip the internal marker here,
+    # at the last shared request-construction boundary.
+    from agent.message_sanitization import prepare_reasoning_replay_messages_for_route
+
+    route_provider = _fallback_provider_from_label(provider)
+    route_base_url = base_url or (
+        _current_custom_base_url() if route_provider == "custom" else ""
+    )
+    messages = prepare_reasoning_replay_messages_for_route(
+        messages,
+        provider=route_provider,
+        model=model,
+        base_url=route_base_url,
+    )
     kwargs: Dict[str, Any] = {
         "model": model,
         "messages": messages,
@@ -8367,9 +8426,7 @@ def _build_call_kwargs(
     # ``extra_body.reasoning``. Profiles are the source of truth for those wire
     # shapes. Providers without a reasoning-aware profile retain the generic
     # ``extra_body.reasoning`` fallback used by Codex-compatible adapters.
-    effective_base = base_url or (
-        _current_custom_base_url() if provider == "custom" else ""
-    )
+    effective_base = route_base_url
     profile_body: Dict[str, Any] = {}
     profile_reasoning_extra: Dict[str, Any] = {}
     profile_top_level: Dict[str, Any] = {}
@@ -9190,7 +9247,10 @@ def _call_llm_impl(
         resolved_api_mode,
     )
     _record_route_info(
-        route_info, _fallback_provider_from_label(request_provider), final_model
+        route_info,
+        _fallback_provider_from_label(request_provider),
+        final_model,
+        str(getattr(client, "base_url", resolved_base_url) or ""),
     )
 
     # Log what we're about to do — makes auxiliary operations visible
@@ -9209,6 +9269,7 @@ def _call_llm_impl(
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
         base_url=_base_info or resolved_base_url, task=task)
+    rejected_compat_options: set[str] = set()
     if extra_headers:
         kwargs["extra_headers"] = dict(extra_headers)
 
@@ -9216,6 +9277,48 @@ def _call_llm_impl(
     _client_base = str(getattr(client, "base_url", "") or "")
     if _is_anthropic_compat_endpoint(request_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
+
+    def _retarget_sync_attempt(route_client: Any, route_model: str) -> dict[str, Any]:
+        """Rebuild request projection and route ledger for a recovered route."""
+        route_provider = (
+            _effective_provider_for_client(route_client, request_provider)
+            or request_provider
+        )
+        route_base = str(getattr(route_client, "base_url", "") or "")
+        rebuilt = _build_call_kwargs(
+            route_provider,
+            route_model,
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            timeout=effective_timeout,
+            extra_body=effective_extra_body,
+            reasoning_config=reasoning_config,
+            base_url=route_base or resolved_base_url,
+            task=task,
+        )
+        if extra_headers:
+            rebuilt["extra_headers"] = dict(extra_headers)
+        # Preserve only omissions established by an actual compatibility 400.
+        # Ordinary absence is model-specific (notably max_tokens versus
+        # max_completion_tokens) and must not erase the rebuilt route's cap.
+        if "temperature" in rejected_compat_options:
+            rebuilt.pop("temperature", None)
+        if "token_limit" in rejected_compat_options:
+            rebuilt.pop("max_tokens", None)
+            rebuilt.pop("max_completion_tokens", None)
+        if _is_anthropic_compat_endpoint(route_provider, route_base):
+            rebuilt["messages"] = _convert_openai_images_to_anthropic(
+                rebuilt["messages"]
+            )
+        _record_route_info(
+            route_info,
+            _fallback_provider_from_label(route_provider),
+            route_model,
+            route_base or resolved_base_url,
+        )
+        return rebuilt
 
     # Streaming path: return the raw SDK Stream iterator directly. This is used by
     # the MoA aggregator so its tokens stream to the user. It deliberately skips
@@ -9338,6 +9441,7 @@ def _call_llm_impl(
             raise _last_transient
     except Exception as first_err:
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
+            rejected_compat_options.add("temperature")
             retry_kwargs = dict(kwargs)
             retry_kwargs.pop("temperature", None)
             logger.info(
@@ -9381,10 +9485,13 @@ def _call_llm_impl(
         )
         if max_tokens is not None and (
             "max_tokens" in err_str
+            or "max_completion_tokens" in err_str
             or "unsupported_parameter" in err_str
             or _is_unsupported_parameter_error(first_err, "max_tokens")
+            or _is_unsupported_parameter_error(first_err, "max_completion_tokens")
             or _is_zai_param_error
         ):
+            rejected_compat_options.add("token_limit")
             kwargs.pop("max_tokens", None)
             kwargs.pop("max_completion_tokens", None)
             try:
@@ -9421,7 +9528,7 @@ def _call_llm_impl(
                     "retrying with refreshed recommendation %r",
                     task or "call", kwargs.get("model"), healed_model,
                 )
-                kwargs["model"] = healed_model
+                kwargs = _retarget_sync_attempt(client, healed_model)
                 try:
                     return _validate_llm_response(
                         _relay_sync_completion(
@@ -9458,8 +9565,10 @@ def _call_llm_impl(
                     "Auxiliary %s: refreshed Nous runtime credentials after paid account check, retrying",
                     task or "call",
                 )
-                if refreshed_model and refreshed_model != kwargs.get("model"):
-                    kwargs["model"] = refreshed_model
+                kwargs = _retarget_sync_attempt(
+                    refreshed_client,
+                    refreshed_model or str(kwargs.get("model") or final_model or ""),
+                )
                 try:
                     return _validate_llm_response(
                         _relay_sync_completion(
@@ -9492,8 +9601,10 @@ def _call_llm_impl(
             if refreshed_client is not None:
                 logger.info("Auxiliary %s: refreshed Nous runtime credentials after 401, retrying",
                             task or "call")
-                if refreshed_model and refreshed_model != kwargs.get("model"):
-                    kwargs["model"] = refreshed_model
+                kwargs = _retarget_sync_attempt(
+                    refreshed_client,
+                    refreshed_model or str(kwargs.get("model") or final_model or ""),
+                )
                 return _validate_llm_response(
                     _relay_sync_completion(
                         refreshed_client,
@@ -9534,6 +9645,7 @@ def _call_llm_impl(
                     effective_extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
                     extra_headers=extra_headers,
+                    route_info=route_info,
                 )
 
         # ── Same-provider credential-pool recovery ─────────────────────
@@ -9583,6 +9695,7 @@ def _call_llm_impl(
                         effective_extra_body=effective_extra_body,
                         reasoning_config=reasoning_config,
                         extra_headers=extra_headers,
+                        route_info=route_info,
                     )
                 except Exception as retry2_err:
                     # The rotated key also hit a quota/auth wall.  Mark it
@@ -9712,7 +9825,10 @@ def _call_llm_impl(
 
             if fb_client is not None:
                 _record_route_info(
-                    route_info, _fallback_provider_from_label(fb_label), fb_model
+                    route_info,
+                    _fallback_provider_from_label(fb_label),
+                    fb_model,
+                    str(getattr(fb_client, "base_url", "") or ""),
                 )
                 fb_resp = _call_fallback_candidate_sync(
                     fb_client, fb_model, fb_label,
@@ -9720,7 +9836,8 @@ def _call_llm_impl(
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, effective_timeout=effective_timeout,
                     effective_extra_body=effective_extra_body,
-                    reasoning_config=reasoning_config)
+                    reasoning_config=reasoning_config,
+                    route_info=route_info)
                 if fb_resp is not None:
                     return fb_resp
                 # The candidate had a stale/unrefreshable credential and was
@@ -9730,7 +9847,10 @@ def _call_llm_impl(
                     resolved_provider, task, reason="stale fallback credential")
                 if fb_client is not None:
                     _record_route_info(
-                        route_info, _fallback_provider_from_label(fb_label), fb_model
+                        route_info,
+                        _fallback_provider_from_label(fb_label),
+                        fb_model,
+                        str(getattr(fb_client, "base_url", "") or ""),
                     )
                     fb_resp = _call_fallback_candidate_sync(
                         fb_client, fb_model, fb_label,
@@ -9738,7 +9858,8 @@ def _call_llm_impl(
                         temperature=temperature, max_tokens=max_tokens,
                         tools=tools, effective_timeout=effective_timeout,
                         effective_extra_body=effective_extra_body,
-                        reasoning_config=reasoning_config)
+                        reasoning_config=reasoning_config,
+                        route_info=route_info)
                     if fb_resp is not None:
                         return fb_resp
             # All fallback layers exhausted — emit a single user-visible
@@ -9976,7 +10097,10 @@ async def _async_call_llm_impl(
         resolved_api_mode,
     )
     _record_route_info(
-        route_info, _fallback_provider_from_label(request_provider), final_model
+        route_info,
+        _fallback_provider_from_label(request_provider),
+        final_model,
+        str(getattr(client, "base_url", resolved_base_url) or ""),
     )
 
     # Pass the client's actual base_url (not just resolved_base_url) so
@@ -9989,10 +10113,50 @@ async def _async_call_llm_impl(
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
         base_url=_client_base or resolved_base_url, task=task)
+    rejected_compat_options: set[str] = set()
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(request_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
+
+    def _retarget_async_attempt(route_client: Any, route_model: str) -> dict[str, Any]:
+        """Async-path mirror of recovered-route request projection."""
+        route_provider = (
+            _effective_provider_for_client(route_client, request_provider)
+            or request_provider
+        )
+        route_base = str(getattr(route_client, "base_url", "") or "")
+        rebuilt = _build_call_kwargs(
+            route_provider,
+            route_model,
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            timeout=effective_timeout,
+            extra_body=effective_extra_body,
+            reasoning_config=reasoning_config,
+            base_url=route_base or resolved_base_url,
+            task=task,
+        )
+        # Preserve only compatibility omissions proved by a provider error;
+        # allow a recovered model to select the other token-limit spelling.
+        if "temperature" in rejected_compat_options:
+            rebuilt.pop("temperature", None)
+        if "token_limit" in rejected_compat_options:
+            rebuilt.pop("max_tokens", None)
+            rebuilt.pop("max_completion_tokens", None)
+        if _is_anthropic_compat_endpoint(route_provider, route_base):
+            rebuilt["messages"] = _convert_openai_images_to_anthropic(
+                rebuilt["messages"]
+            )
+        _record_route_info(
+            route_info,
+            _fallback_provider_from_label(route_provider),
+            route_model,
+            route_base or resolved_base_url,
+        )
+        return rebuilt
 
     try:
         # Retry ONCE on the same provider for a transient transport blip
@@ -10054,6 +10218,7 @@ async def _async_call_llm_impl(
                 task)
     except Exception as first_err:
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
+            rejected_compat_options.add("temperature")
             retry_kwargs = dict(kwargs)
             retry_kwargs.pop("temperature", None)
             logger.info(
@@ -10093,10 +10258,13 @@ async def _async_call_llm_impl(
         )
         if max_tokens is not None and (
             "max_tokens" in err_str
+            or "max_completion_tokens" in err_str
             or "unsupported_parameter" in err_str
             or _is_unsupported_parameter_error(first_err, "max_tokens")
+            or _is_unsupported_parameter_error(first_err, "max_completion_tokens")
             or _is_zai_param_error
         ):
+            rejected_compat_options.add("token_limit")
             kwargs.pop("max_tokens", None)
             kwargs.pop("max_completion_tokens", None)
             try:
@@ -10132,7 +10300,7 @@ async def _async_call_llm_impl(
                     "retrying with refreshed recommendation %r",
                     task or "call", kwargs.get("model"), healed_model,
                 )
-                kwargs["model"] = healed_model
+                kwargs = _retarget_async_attempt(client, healed_model)
                 try:
                     return _validate_llm_response(
                         await _relay_async_completion(
@@ -10168,8 +10336,10 @@ async def _async_call_llm_impl(
                     "Auxiliary %s (async): refreshed Nous runtime credentials after paid account check, retrying",
                     task or "call",
                 )
-                if refreshed_model and refreshed_model != kwargs.get("model"):
-                    kwargs["model"] = refreshed_model
+                kwargs = _retarget_async_attempt(
+                    refreshed_client,
+                    refreshed_model or str(kwargs.get("model") or final_model or ""),
+                )
                 try:
                     return _validate_llm_response(
                         await _relay_async_completion(
@@ -10201,8 +10371,10 @@ async def _async_call_llm_impl(
             if refreshed_client is not None:
                 logger.info("Auxiliary %s (async): refreshed Nous runtime credentials after 401, retrying",
                             task or "call")
-                if refreshed_model and refreshed_model != kwargs.get("model"):
-                    kwargs["model"] = refreshed_model
+                kwargs = _retarget_async_attempt(
+                    refreshed_client,
+                    refreshed_model or str(kwargs.get("model") or final_model or ""),
+                )
                 return _validate_llm_response(
                     await _relay_async_completion(
                         refreshed_client,
@@ -10241,6 +10413,7 @@ async def _async_call_llm_impl(
                     effective_timeout=effective_timeout,
                     effective_extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
+                    route_info=route_info,
                 )
 
         # ── Same-provider credential-pool recovery (mirrors sync) ─────
@@ -10284,6 +10457,7 @@ async def _async_call_llm_impl(
                         effective_timeout=effective_timeout,
                         effective_extra_body=effective_extra_body,
                         reasoning_config=reasoning_config,
+                        route_info=route_info,
                     )
                 except Exception as retry2_err:
                     if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
@@ -10383,6 +10557,7 @@ async def _async_call_llm_impl(
                     route_info,
                     _fallback_provider_from_label(fb_label),
                     async_fb_model or fb_model,
+                    str(getattr(async_fb, "base_url", "") or ""),
                 )
                 fb_resp = await _call_fallback_candidate_async(
                     async_fb, async_fb_model or fb_model, fb_label,
@@ -10390,7 +10565,8 @@ async def _async_call_llm_impl(
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, effective_timeout=effective_timeout,
                     effective_extra_body=effective_extra_body,
-                    reasoning_config=reasoning_config)
+                    reasoning_config=reasoning_config,
+                    route_info=route_info)
                 if fb_resp is not None:
                     return fb_resp
                 # Stale/unrefreshable candidate credential — quarantined; walk
@@ -10405,6 +10581,7 @@ async def _async_call_llm_impl(
                         route_info,
                         _fallback_provider_from_label(fb_label),
                         async_fb_model or fb_model,
+                        str(getattr(async_fb, "base_url", "") or ""),
                     )
                     fb_resp = await _call_fallback_candidate_async(
                         async_fb, async_fb_model or fb_model, fb_label,
@@ -10412,7 +10589,8 @@ async def _async_call_llm_impl(
                         temperature=temperature, max_tokens=max_tokens,
                         tools=tools, effective_timeout=effective_timeout,
                         effective_extra_body=effective_extra_body,
-                        reasoning_config=reasoning_config)
+                        reasoning_config=reasoning_config,
+                        route_info=route_info)
                     if fb_resp is not None:
                         return fb_resp
             # All fallback layers exhausted — warn before re-raising. (#26882)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -36,6 +36,7 @@ from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
 from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
+    _preserves_gemma4_reasoning_replay,
     _sanitize_surrogates,
     _repair_tool_call_arguments,
 )
@@ -1742,6 +1743,26 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     if "reasoning_content" not in msg and reasoning_text:
         msg["reasoning_content"] = reasoning_text
 
+    # Capture the producing route at the response boundary. This underscore
+    # marker is internal-only and stripped before the wire/persistence, but it
+    # lets active-turn Gemma 4 continuations distinguish same-named models on
+    # different providers or endpoints after a fallback.
+    native_reasoning_content = bool(
+        raw_reasoning_content is not None
+        and getattr(assistant_message, "_reasoning_content_is_native", True)
+    )
+    if (
+        assistant_tool_calls
+        and native_reasoning_content
+        and isinstance(raw_reasoning_content, str)
+        and raw_reasoning_content.strip()
+    ):
+        from agent.agent_runtime_helpers import _reasoning_replay_route
+
+        replay_model, replay_origin = _reasoning_replay_route(agent)
+        if _preserves_gemma4_reasoning_replay(replay_model):
+            msg["_reasoning_replay_origin"] = replay_origin
+
     if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
         # Pass reasoning_details back unmodified so providers (OpenRouter,
         # Anthropic, OpenAI) can maintain reasoning continuity across turns.
@@ -2377,11 +2398,25 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     try:
         # Build API messages, stripping internal-only fields
         # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
+        from agent.conversation_compression import _is_real_user_message
+
+        current_turn_user_idx = max(
+            (i for i, msg in enumerate(messages) if _is_real_user_message(msg)),
+            default=-1,
+        )
         _needs_sanitize = agent._should_sanitize_tool_calls()
         api_messages = []
-        for msg in messages:
+        for idx, msg in enumerate(messages):
             api_msg = msg.copy()
-            agent._copy_reasoning_content_for_api(msg, api_msg)
+            agent._copy_reasoning_content_for_api(
+                msg,
+                api_msg,
+                preserve_explicit_reasoning=(
+                    current_turn_user_idx >= 0
+                    and idx > current_turn_user_idx
+                    and bool(msg.get("tool_calls"))
+                ),
+            )
             for internal_field in ("reasoning", "finish_reason"):
                 api_msg.pop(internal_field, None)
             # Strict OpenAI-compatible gateways (Fireworks-backed OpenCode Go,
@@ -2444,10 +2479,23 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
         # Strip all remaining underscore-prefixed scaffolding keys before the
         # wire. The summary path calls chat.completions.create() directly,
-        # bypassing the transport's universal underscore-key sweeper.
+        # bypassing the transport's universal underscore-key sweeper. MoA is
+        # the exception: its auxiliary client still has to select the concrete
+        # aggregator/fallback route, so replay provenance must survive until
+        # _build_call_kwargs compares and strips it for that exact candidate.
+        _summary_internal_allowlist = (
+            {"_reasoning_replay_origin"} if agent.provider == "moa" else set()
+        )
         for api_msg in api_messages:
             if isinstance(api_msg, dict):
-                for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
+                for internal_key in [
+                    k for k in api_msg
+                    if (
+                        isinstance(k, str)
+                        and k.startswith("_")
+                        and k not in _summary_internal_allowlist
+                    )
+                ]:
                     api_msg.pop(internal_key, None)
 
         summary_extra_body = {}
@@ -2728,7 +2776,7 @@ def cleanup_task_resources(agent, task_id: str) -> None:
 
 def _build_partial_stream_stub(
     role, full_content, full_reasoning, model_name, usage_obj, *,
-    dropped_tool_names=None,
+    dropped_tool_names=None, reasoning_content_is_native=False,
 ):
     """Build a partial-stream-stub response for mid-stream drop scenarios.
 
@@ -2743,6 +2791,7 @@ def _build_partial_stream_stub(
         content=full_content,
         tool_calls=None,
         reasoning_content=full_reasoning,
+        _reasoning_content_is_native=reasoning_content_is_native,
     )
     mock_choice = SimpleNamespace(
         index=0,
@@ -3362,6 +3411,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         model_name = None
         role = "assistant"
         reasoning_parts: list = []
+        # Gemma replay may trust the combined stream only when every reasoning
+        # segment came from the provider-native reasoning_content field.
+        reasoning_content_is_native = True
         usage_obj = None
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
@@ -3442,6 +3494,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             "role": role,
                             "content": "".join(content_parts) or None,
                             "reasoning_content": "".join(reasoning_parts) or None,
+                            "_reasoning_content_is_native": reasoning_content_is_native,
                             "tool_calls": tool_calls or None,
                         },
                         "finish_reason": finish_reason or "stop",
@@ -3544,8 +3597,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 model_name = chunk.model
 
             # Accumulate reasoning content
-            reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
+            native_reasoning_delta = getattr(delta, "reasoning_content", None)
+            reasoning_text = native_reasoning_delta or getattr(delta, "reasoning", None)
             if reasoning_text:
+                reasoning_content_is_native = (
+                    reasoning_content_is_native and bool(native_reasoning_delta)
+                )
                 # Summary-part models (gpt-5.x and other Responses relays) send
                 # one complete markdown block per delta with no separator, so
                 # the parts glue into a single unreadable run. Only the tail of
@@ -3809,6 +3866,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 "".join(reasoning_parts) or None,
                 model_name, usage_obj,
                 dropped_tool_names=_dropped_names or None,
+                reasoning_content_is_native=reasoning_content_is_native,
             )
 
         # Text-only stream drop: the upstream closed the connection (or the
@@ -3830,6 +3888,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 role, full_content,
                 "".join(reasoning_parts) or None,
                 model_name, usage_obj,
+                reasoning_content_is_native=reasoning_content_is_native,
             )
 
         effective_finish_reason = finish_reason or "stop"
@@ -3842,6 +3901,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             content=full_content,
             tool_calls=mock_tool_calls,
             reasoning_content=full_reasoning,
+            _reasoning_content_is_native=reasoning_content_is_native,
         )
         mock_choice = SimpleNamespace(
             index=0,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -72,6 +72,7 @@ from agent.context_engine import (
     sanitize_memory_context,
 )
 from agent.model_metadata import estimate_request_tokens_rough
+from agent.message_sanitization import _MOA_REFERENCE_GUIDANCE_METADATA_KEY
 from agent.session_activity import ActivityProvenance, normalize_activity_provenance
 
 logger = logging.getLogger(__name__)
@@ -1928,10 +1929,43 @@ def _message_text(message: Any) -> str:
 _SYNTHETIC_USER_FLAGS = (
     "_todo_snapshot_synthetic",
     "_empty_recovery_synthetic",
+    "_length_continuation_nudge",
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
     "_dropped_toolcall_nudge",
+    "_kanban_stop_synthetic",
 )
+
+
+def _without_moa_reference_guidance(message: dict) -> dict:
+    """Return the trailing user turn before MoA merged private guidance.
+
+    MoA must merge its reference block into an existing trailing user row to
+    preserve strict role alternation.  Runtime continuation nudges are
+    recognized by their original exact content after SessionDB projection, so
+    classify that original prefix rather than the private suffix appended for
+    the acting aggregator.
+    """
+    metadata = message.get(_MOA_REFERENCE_GUIDANCE_METADATA_KEY)
+    if not isinstance(metadata, dict):
+        return message
+    candidate = dict(message)
+    candidate.pop(_MOA_REFERENCE_GUIDANCE_METADATA_KEY, None)
+    shape = metadata.get("shape")
+    if shape == "standalone":
+        candidate["content"] = ""
+        return candidate
+    boundary = metadata.get("boundary")
+    if not isinstance(boundary, int) or isinstance(boundary, bool) or boundary < 0:
+        return message
+    content = message.get("content")
+    if shape == "string" and isinstance(content, str) and boundary <= len(content):
+        candidate["content"] = content[:boundary]
+        return candidate
+    if shape == "list" and isinstance(content, list) and boundary <= len(content):
+        candidate["content"] = list(content[:boundary])
+        return candidate
+    return message
 
 
 def _is_real_user_message(message: Any) -> bool:
@@ -1947,14 +1981,20 @@ def _is_real_user_message(message: Any) -> bool:
         return False
     if any(message.get(flag) for flag in _SYNTHETIC_USER_FLAGS):
         return False
-    text = _message_text(message).strip()
+    candidate = _without_moa_reference_guidance(message)
+    text = _message_text(candidate).strip()
     if not text:
-        return False
+        # Image/audio-only human turns have no extractable text but are still
+        # actionable current-turn anchors. The canonical predicate recognizes
+        # supported structured content while rejecting compaction scaffolding.
+        from agent.context_compressor import is_user_originated_turn
+
+        return is_user_originated_turn(candidate)
     if text.startswith(_SYNTHETIC_USER_PREFIXES):
         return False
     from agent.context_compressor import ContextCompressor
 
-    return not ContextCompressor._is_synthetic_compression_user_turn(message)
+    return not ContextCompressor._is_synthetic_compression_user_turn(candidate)
 
 
 def _strip_stale_todo_snapshot(content: Any) -> Any:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1876,6 +1876,13 @@ def run_conversation(
                 agent.session_id or "-",
             )
 
+        # Repair/compression can replace rows and stale the prologue index.
+        # Re-anchor before selecting this turn's replayable reasoning.
+        current_turn_user_idx = reanchor_current_turn_user_idx(
+            messages, user_message
+        )
+        agent._persist_user_message_idx = current_turn_user_idx
+
         api_messages = []
         for idx, msg in enumerate(messages):
 
@@ -1947,7 +1954,15 @@ def run_conversation(
 
             # For ALL assistant messages, pass reasoning back to the API
             # This ensures multi-turn reasoning context is preserved
-            agent._copy_reasoning_content_for_api(msg, api_msg)
+            agent._copy_reasoning_content_for_api(
+                msg,
+                api_msg,
+                preserve_explicit_reasoning=(
+                    current_turn_user_idx >= 0
+                    and idx > current_turn_user_idx
+                    and bool(msg.get("tool_calls"))
+                ),
+            )
 
             # Remove 'reasoning' field - it's for trajectory storage only
             # We've copied it to 'reasoning_content' for the API above

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -22,6 +22,11 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Request-local provenance set by the MoA facade when it appends private
+# reference guidance to a user-role row. It is stripped at the concrete
+# auxiliary wire boundary and must never be inferred from user-controlled text.
+_MOA_REFERENCE_GUIDANCE_METADATA_KEY = "_moa_reference_guidance_appended"
+
 # Lone surrogate code points are invalid in UTF-8 and crash json.dumps
 # inside the OpenAI SDK.  Used by every surrogate-sanitization helper
 # below as well as by run_agent and the CLI for paste-from-clipboard
@@ -709,16 +714,151 @@ def needs_reasoning_echo(provider: Any, model: Any, base_url: Any) -> bool:
     return reasoning_echo_family(provider, model, base_url) is not None
 
 
+def _preserves_gemma4_reasoning_replay(model: Any) -> bool:
+    """True for Gemma 4 model ids that replay explicit reasoning content."""
+    model_lower = str(model or "").strip().lower()
+    return bool(re.search(r"(?:^|[/_.:-])gemma[-_.]?4(?:$|[/_.:-])", model_lower))
+
+
+_REASONING_REPLAY_ORIGIN_KEY = "_reasoning_replay_origin"
+
+
+def reasoning_replay_route_fingerprint(
+    provider: Any, base_url: Any, model: Any
+) -> str:
+    """Return the non-reversible identity for one concrete model route."""
+    from urllib.parse import urlsplit, urlunsplit
+
+    parsed = urlsplit(str(base_url or "").strip())
+    userinfo, at, hostport = parsed.netloc.rpartition("@")
+    authority_prefix = f"{userinfo}@" if at else ""
+    if hostport.startswith("["):
+        closing_bracket = hostport.find("]")
+        if closing_bracket >= 0:
+            normalized_hostport = (
+                f"[{hostport[1:closing_bracket].lower()}]"
+                f"{hostport[closing_bracket + 1:]}"
+            )
+        else:
+            normalized_hostport = hostport.lower()
+    else:
+        hostname, colon, port = hostport.partition(":")
+        normalized_hostport = hostname.lower() + (f":{port}" if colon else "")
+    normalized_base_url = urlunsplit(
+        (
+            parsed.scheme.lower(),
+            authority_prefix + normalized_hostport,
+            parsed.path[:-1] if parsed.path.endswith("/") else parsed.path,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+    route = (
+        str(provider or "").strip().lower(),
+        normalized_base_url,
+        str(model or "").strip(),
+    )
+    return hashlib.sha256(
+        "\0".join(route).encode("utf-8", errors="surrogatepass")
+    ).hexdigest()
+
+
+def prepare_reasoning_replay_messages_for_route(
+    messages: list[dict], *, provider: Any, model: Any, base_url: Any
+) -> list[dict]:
+    """Shape marked Gemma reasoning for one selected auxiliary destination.
+
+    Auxiliary fallback selection happens after the caller builds its message
+    list. Keep provenance in that source list, then copy, compare, pad/strip,
+    and remove the internal marker only after a concrete route is known.
+    """
+    replay_origin = reasoning_replay_route_fingerprint(provider, base_url, model)
+    needs_thinking_pad = needs_reasoning_echo(provider, model, base_url)
+    prepared: list[dict] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            prepared.append(message)
+            continue
+        has_replay_origin = _REASONING_REPLAY_ORIGIN_KEY in message
+        has_guidance_marker = _MOA_REFERENCE_GUIDANCE_METADATA_KEY in message
+        if not has_replay_origin and not has_guidance_marker:
+            prepared.append(message)
+            continue
+        wire_message = dict(message)
+        wire_message.pop(_MOA_REFERENCE_GUIDANCE_METADATA_KEY, None)
+        source_origin = wire_message.pop(_REASONING_REPLAY_ORIGIN_KEY, None)
+        # Guidance provenance can live on user-role rows. Its only wire action
+        # is marker removal; reasoning_content is an assistant-only replay
+        # field and must never be synthesized on user/tool/system messages.
+        if not has_replay_origin or wire_message.get("role") != "assistant":
+            prepared.append(wire_message)
+            continue
+        existing = wire_message.get("reasoning_content")
+        keep_explicit = bool(
+            _preserves_gemma4_reasoning_replay(model)
+            and source_origin == replay_origin
+            and isinstance(existing, str)
+            and existing.strip()
+        )
+        if not keep_explicit:
+            if needs_thinking_pad:
+                wire_message["reasoning_content"] = " "
+            else:
+                wire_message.pop("reasoning_content", None)
+        prepared.append(wire_message)
+    return prepared
+
+
+def _has_matching_reasoning_replay_origin(api_msg: dict, replay_origin: Any) -> bool:
+    """Whether reasoning originated from this provider/endpoint/model route."""
+    return bool(
+        replay_origin
+        and api_msg.get(_REASONING_REPLAY_ORIGIN_KEY) == replay_origin
+    )
+
+
 def apply_reasoning_content_policy(
-    source_msg: dict, api_msg: dict, needs_thinking_pad: bool
+    source_msg: dict,
+    api_msg: dict,
+    needs_thinking_pad: bool,
+    model: Any = None,
+    preserve_explicit_reasoning: bool = False,
+    replay_origin: Any = None,
 ) -> None:
     """Copy provider-facing reasoning fields onto an API replay message.
 
     ``needs_thinking_pad`` is the require-side flag (see
     ``needs_reasoning_echo`` / the agent's cached
-    ``_needs_thinking_reasoning_pad``). Mutates ``api_msg`` in place.
+    ``_needs_thinking_reasoning_pad``). Gemma 4 keeps explicit non-whitespace
+    content only inside the active tool turn, without synthesizing a pad.
     """
     if source_msg.get("role") != "assistant":
+        return
+
+    # Ephemeral provenance lives only on the request copy. Chat transports and
+    # the direct-summary path strip underscore-prefixed keys before the wire.
+    source_origin = source_msg.get(_REASONING_REPLAY_ORIGIN_KEY)
+    api_msg.pop(_REASONING_REPLAY_ORIGIN_KEY, None)
+
+    # A marked scratchpad is valid only for the exact producing route and the
+    # active Gemma tool turn. Resolve that trust decision before the legacy
+    # explicit-content branches: require-side fallbacks must receive their
+    # schema pad, never another provider's private reasoning.
+    if source_origin:
+        existing = source_msg.get("reasoning_content")
+        if (
+            preserve_explicit_reasoning
+            and _preserves_gemma4_reasoning_replay(model)
+            and source_origin == replay_origin
+            and isinstance(existing, str)
+            and existing.strip()
+        ):
+            api_msg["reasoning_content"] = existing
+            api_msg[_REASONING_REPLAY_ORIGIN_KEY] = source_origin
+        elif needs_thinking_pad:
+            api_msg["reasoning_content"] = " "
+        else:
+            api_msg.pop("reasoning_content", None)
         return
 
     # 1. Explicit reasoning_content already set.
@@ -800,7 +940,12 @@ def apply_reasoning_content_policy(
     api_msg.pop("reasoning_content", None)
 
 
-def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:
+def reapply_reasoning_echo(
+    api_messages: list,
+    needs_thinking_pad: bool,
+    model: Any = None,
+    replay_origin: Any = None,
+) -> int:
     """Re-pad (or strip) assistant turns' reasoning_content for the active provider.
 
     ``api_messages`` is built once, before the retry loop, while the *primary*
@@ -829,16 +974,49 @@ def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:
     Returns the number of assistant turns whose reasoning_content was added or
     removed.
     """
+    from agent.conversation_compression import _is_real_user_message
+
+    last_user_idx = max(
+        (i for i, msg in enumerate(api_messages) if _is_real_user_message(msg)),
+        default=-1,
+    )
     changed = 0
-    for api_msg in api_messages:
+    for idx, api_msg in enumerate(api_messages):
         if api_msg.get("role") != "assistant":
             continue
         if needs_thinking_pad:
-            if api_msg.get("reasoning_content"):
+            existing = api_msg.get("reasoning_content")
+            has_replay_origin = _REASONING_REPLAY_ORIGIN_KEY in api_msg
+            if existing and (
+                not has_replay_origin
+                or _has_matching_reasoning_replay_origin(api_msg, replay_origin)
+            ):
                 continue
+            # Never pass a marked Gemma scratchpad across a fallback route;
+            # let the normal policy synthesize the target provider's pad.
+            before = existing
+            if has_replay_origin:
+                api_msg.pop("reasoning_content", None)
+                api_msg.pop(_REASONING_REPLAY_ORIGIN_KEY, None)
             apply_reasoning_content_policy(api_msg, api_msg, needs_thinking_pad)
-            if api_msg.get("reasoning_content"):
+            if api_msg.get("reasoning_content") != before:
                 changed += 1
+        elif (
+            _preserves_gemma4_reasoning_replay(model)
+            and idx > last_user_idx
+            and api_msg.get("tool_calls")
+        ):
+            existing = api_msg.get("reasoning_content")
+            if (
+                isinstance(existing, str)
+                and existing.strip()
+                and _has_matching_reasoning_replay_origin(api_msg, replay_origin)
+            ):
+                continue
+            if "reasoning_content" in api_msg:
+                api_msg.pop("reasoning_content", None)
+                changed += 1
+            api_msg.pop(_REASONING_REPLAY_ORIGIN_KEY, None)
         else:
             # Strict provider — strip any stale reasoning_content pad left
             # over from a reasoning primary so the fallback request doesn't
@@ -846,6 +1024,7 @@ def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:
             if "reasoning_content" in api_msg:
                 api_msg.pop("reasoning_content", None)
                 changed += 1
+            api_msg.pop(_REASONING_REPLAY_ORIGIN_KEY, None)
     return changed
 
 

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from agent.auxiliary_client import call_llm
 from agent.message_content import flatten_message_text
+from agent.message_sanitization import _MOA_REFERENCE_GUIDANCE_METADATA_KEY
 from agent.transports import get_transport
 
 logger = logging.getLogger(__name__)
@@ -105,28 +106,50 @@ def _redact_trace_messages(messages: Any) -> Any:
     """
     if not isinstance(messages, list):
         return messages
+    def _redact_reasoning_value(value: Any) -> Any:
+        if isinstance(value, str):
+            return _redact_reference_text(value)
+        if isinstance(value, list):
+            return [_redact_reasoning_value(item) for item in value]
+        if isinstance(value, dict):
+            return {
+                key: _redact_reasoning_value(nested)
+                for key, nested in value.items()
+            }
+        return value
+
+    reasoning_keys = {
+        "reasoning",
+        "reasoning_content",
+        "reasoning_details",
+        "codex_reasoning_items",
+        "codex_message_items",
+        "anthropic_content_blocks",
+        "_anthropic_content_blocks",
+    }
     out: list[Any] = []
     for m in messages:
         if not isinstance(m, dict):
             out.append(m)
             continue
+        redacted = {
+            key: _redact_reasoning_value(value) if key in reasoning_keys else value
+            for key, value in m.items()
+        }
         content = m.get("content")
         if isinstance(content, str):
-            out.append({**m, "content": _redact_reference_text(content)})
+            redacted["content"] = _redact_reference_text(content)
+            out.append(redacted)
         elif isinstance(content, list):
-            out.append(
-                {
-                    **m,
-                    "content": [
-                        {**p, "text": _redact_reference_text(p.get("text"))}
-                        if isinstance(p, dict) and isinstance(p.get("text"), str)
-                        else p
-                        for p in content
-                    ],
-                }
-            )
+            redacted["content"] = [
+                {**p, "text": _redact_reference_text(p.get("text"))}
+                if isinstance(p, dict) and isinstance(p.get("text"), str)
+                else p
+                for p in content
+            ]
+            out.append(redacted)
         else:
-            out.append(m)
+            out.append(redacted)
     return out
 
 
@@ -1467,11 +1490,23 @@ def _attach_reference_guidance(agg_messages: list[dict[str, Any]], guidance: str
         last_content = last.get("content")
         if isinstance(last_content, str):
             last["content"] = last_content + "\n\n" + guidance
+            last[_MOA_REFERENCE_GUIDANCE_METADATA_KEY] = {
+                "shape": "string",
+                "boundary": len(last_content),
+            }
             return
         if isinstance(last_content, list):
             last["content"] = [*last_content, {"type": "text", "text": "\n\n" + guidance}]
+            last[_MOA_REFERENCE_GUIDANCE_METADATA_KEY] = {
+                "shape": "list",
+                "boundary": len(last_content),
+            }
             return
-    agg_messages.append({"role": "user", "content": guidance})
+    agg_messages.append({
+        "role": "user",
+        "content": guidance,
+        _MOA_REFERENCE_GUIDANCE_METADATA_KEY: {"shape": "standalone"},
+    })
 
 
 def peel_reference_guidance(
@@ -1507,6 +1542,7 @@ def peel_reference_guidance(
         # Attach shape (a): merged into a trailing string user turn.
         peeled = dict(last)
         peeled["content"] = content[: -len(suffix)]
+        peeled.pop(_MOA_REFERENCE_GUIDANCE_METADATA_KEY, None)
         return [*messages[:-1], peeled]
     if isinstance(content, list) and content:
         last_part = content[-1]
@@ -1516,6 +1552,7 @@ def peel_reference_guidance(
                 # Attach shape (b): guidance rode as its own trailing part.
                 peeled = dict(last)
                 peeled["content"] = list(content[:-1])
+                peeled.pop(_MOA_REFERENCE_GUIDANCE_METADATA_KEY, None)
                 if not peeled["content"]:
                     # The guidance part was the only content — mirror the
                     # string shape (c) and drop the whole message rather
@@ -1527,6 +1564,7 @@ def peel_reference_guidance(
                 new_part["text"] = text[: -len(suffix)]
                 peeled = dict(last)
                 peeled["content"] = [*content[:-1], new_part]
+                peeled.pop(_MOA_REFERENCE_GUIDANCE_METADATA_KEY, None)
                 return [*messages[:-1], peeled]
     return messages
 
@@ -1587,6 +1625,9 @@ class MoAChatCompletions:
         # create(); read by session cost accounting to price the aggregator's
         # acting turn at its real model instead of the virtual preset name.
         self.last_aggregator_slot: Any = None
+        # Concrete provider/model/base_url that actually served the most recent
+        # aggregator response. This follows auxiliary-client fallback routing.
+        self.last_aggregator_runtime: Any = None
         # Full-turn trace parts stashed on a cache-MISS create(), awaiting the
         # caller to stitch in the live session_id + resolved aggregator output
         # and flush to the trace file (only when moa.save_traces is on).
@@ -1859,6 +1900,7 @@ class MoAChatCompletions:
             agg_runtime.pop("extra_body", None),
             extra_body,
         )
+        successful_route: dict[str, str] = {}
         _agg_response = call_llm(
             task="moa_aggregator",
             messages=agg_messages,
@@ -1869,9 +1911,12 @@ class MoAChatCompletions:
             # Prepared requests must retain the acting aggregator's reasoning
             # policy exactly as the direct create() path does (#64187).
             reasoning_config=_aggregator_reasoning_config(aggregator),
+            route_info=successful_route,
             **stream_kwargs,
             **agg_runtime,
         )
+        if successful_route:
+            self.last_aggregator_runtime = dict(successful_route)
         # Non-streaming path (quiet mode / eval / subagents): the aggregator
         # output is available inline, so capture it into the pending trace now.
         # Streaming path: the aggregator's raw token stream is returned to the
@@ -2332,6 +2377,11 @@ class MoAClient:
         aggregator's acting turn at its real model instead of the virtual
         preset name."""
         return getattr(self.chat.completions, "last_aggregator_slot", None)
+
+    @property
+    def last_aggregator_runtime(self) -> Any:
+        """Concrete route that successfully served the latest aggregator call."""
+        return getattr(self.chat.completions, "last_aggregator_runtime", None)
 
     def consume_and_save_trace(
         self, session_id: Any = None, aggregator_output_fallback: Any = None

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -819,6 +819,13 @@ class ChatCompletionsTransport(ProviderTransport):
         provider_data: Dict[str, Any] = {}
         if reasoning_content is not None:
             provider_data["reasoning_content"] = reasoning_content
+        reasoning_content_is_native = getattr(
+            msg, "_reasoning_content_is_native", None
+        )
+        if reasoning_content_is_native is not None:
+            provider_data["_reasoning_content_is_native"] = bool(
+                reasoning_content_is_native
+            )
         rd = getattr(msg, "reasoning_details", None)
         if rd:
             provider_data["reasoning_details"] = rd

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -117,6 +117,11 @@ class NormalizedResponse:
         return pd.get("reasoning_content")
 
     @property
+    def _reasoning_content_is_native(self) -> bool:
+        pd = self.provider_data or {}
+        return bool(pd.get("_reasoning_content_is_native", True))
+
+    @property
     def reasoning_details(self):
         pd = self.provider_data or {}
         return pd.get("reasoning_details")

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -273,7 +273,7 @@ def reanchor_current_turn_user_idx(messages: List[Any], user_message: Any) -> in
     scaffolding, not the active ask. Returns -1 when the list has no
     user-originated message at all.
     """
-    from agent.context_compressor import is_user_originated_turn
+    from agent.conversation_compression import _is_real_user_message
 
     fallback = -1
     for i in range(len(messages) - 1, -1, -1):
@@ -284,7 +284,7 @@ def reanchor_current_turn_user_idx(messages: List[Any], user_message: Any) -> in
             return i
         # Prefer a real human turn over a synthetic handoff / continuation
         # marker when the exact content was rewritten by merge-into-tail.
-        if fallback < 0 and is_user_originated_turn(msg):
+        if fallback < 0 and _is_real_user_message(msg):
             fallback = i
     return fallback
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -7490,10 +7490,21 @@ class AIAgent:
             "mimo", (self.provider or "").lower(), self.model, self.base_url
         )
 
-    def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
+    def _copy_reasoning_content_for_api(
+        self,
+        source_msg: dict,
+        api_msg: dict,
+        *,
+        preserve_explicit_reasoning: bool = False,
+    ) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.copy_reasoning_content_for_api``."""
         from agent.agent_runtime_helpers import copy_reasoning_content_for_api
-        return copy_reasoning_content_for_api(self, source_msg, api_msg)
+        return copy_reasoning_content_for_api(
+            self,
+            source_msg,
+            api_msg,
+            preserve_explicit_reasoning=preserve_explicit_reasoning,
+        )
 
     def _reapply_reasoning_echo_for_provider(self, api_messages: list) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.reapply_reasoning_echo_for_provider``."""

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -568,6 +568,31 @@ class TestReanchorCurrentTurnUserIdx:
         messages = ["junk", {"role": "user", "content": "hello"}, None]
         assert reanchor_current_turn_user_idx(messages, "hello") == 1
 
+    def test_image_only_exact_turn_remains_anchorable(self):
+        image_content = [
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,AAAA"},
+            }
+        ]
+        messages = [
+            {"role": "user", "content": "historical"},
+            {"role": "user", "content": image_content},
+        ]
+
+        assert reanchor_current_turn_user_idx(messages, image_content) == 1
+
+    def test_exact_background_process_turn_beats_prior_human_fallback(self):
+        background_turn = (
+            "[IMPORTANT: Background process 42 completed]\nReview its output."
+        )
+        messages = [
+            {"role": "user", "content": "historical human task"},
+            {"role": "user", "content": background_turn},
+        ]
+
+        assert reanchor_current_turn_user_idx(messages, background_turn) == 1
+
 
 class TestPrologueMoaAndInPlaceBackfill:
     def test_no_stamp_for_moa_turns(self):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1563,9 +1563,11 @@ class TestCallLlmPaymentFallback:
         primary_client.chat.completions.create.side_effect = rate_err
 
         fallback_client = MagicMock()
+        fallback_client.base_url = "https://fallback.example/v1"
         fallback_client.chat.completions.create.return_value = MagicMock(choices=[
             MagicMock(message=MagicMock(content="fallback response"))
         ])
+        route_info = {}
 
         with patch("agent.auxiliary_client._get_cached_client",
                     return_value=(primary_client, "xiaomi/mimo-v2-pro")), \
@@ -1576,9 +1578,305 @@ class TestCallLlmPaymentFallback:
             result = call_llm(
                 task="session_search",
                 messages=[{"role": "user", "content": "hello"}],
+                route_info=route_info,
             )
         # Fallback client should have been used
         assert fallback_client.chat.completions.create.called
+        assert route_info == {
+            "provider": "openrouter",
+            "model": "fallback-model",
+            "base_url": "https://fallback.example/v1",
+        }
+
+    def test_moa_fallback_reselects_marked_reasoning_for_actual_route(self, monkeypatch):
+        from agent.message_sanitization import reasoning_replay_route_fingerprint
+
+        primary_client = MagicMock()
+        primary_client.base_url = "https://primary.example/v1"
+        primary_client.chat.completions.create.side_effect = (
+            self._make_429_rate_limit_error()
+        )
+
+        fallback_model = "google/gemma-4-31b-it"
+        fallback_client = MagicMock()
+        fallback_client.base_url = "https://fallback.example/v1"
+        fallback_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="fallback response"))]
+        )
+        origin = reasoning_replay_route_fingerprint(
+            "openrouter", fallback_client.base_url, fallback_model
+        )
+        messages = [
+            {"role": "user", "content": "continue"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "call_1"}],
+                "reasoning_content": "private scratchpad",
+                "_reasoning_replay_origin": origin,
+            },
+        ]
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary_client, "configured-primary"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", "configured-primary", None, None, None),
+        ), patch(
+            "agent.auxiliary_client._try_payment_fallback",
+            return_value=(fallback_client, fallback_model, "openrouter"),
+        ):
+            call_llm(task="moa_aggregator", messages=messages)
+
+        primary_wire = primary_client.chat.completions.create.call_args.kwargs[
+            "messages"
+        ][1]
+        fallback_wire = fallback_client.chat.completions.create.call_args.kwargs[
+            "messages"
+        ][1]
+        assert "reasoning_content" not in primary_wire
+        assert fallback_wire["reasoning_content"] == "private scratchpad"
+        assert "_reasoning_replay_origin" not in primary_wire
+        assert "_reasoning_replay_origin" not in fallback_wire
+        assert messages[1]["_reasoning_replay_origin"] == origin
+
+    def test_moa_nous_model_heal_records_and_projects_actual_route(self):
+        from agent.message_sanitization import reasoning_replay_route_fingerprint
+
+        stale_model = "openai/stale-model"
+        healed_model = "google/gemma-4-31b-it"
+        base_url = "https://inference-api.nousresearch.com/v1"
+        stale_error = Exception("requested model does not exist in our configuration")
+        stale_error.status_code = 404
+        client = MagicMock()
+        client.base_url = base_url
+        client.chat.completions.create.side_effect = [
+            stale_error,
+            _DummyResponse("healed response"),
+        ]
+        origin = reasoning_replay_route_fingerprint("nous", base_url, healed_model)
+        messages = [
+            {"role": "user", "content": "continue"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "call_1"}],
+                "reasoning_content": "private scratchpad",
+                "_reasoning_replay_origin": origin,
+            },
+        ]
+        route_info = {}
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("nous", stale_model, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, stale_model),
+        ), patch(
+            "agent.auxiliary_client._refresh_nous_recommended_model",
+            return_value=healed_model,
+        ):
+            result = call_llm(
+                task="moa_aggregator",
+                messages=messages,
+                route_info=route_info,
+            )
+
+        assert result.choices[0].message.content == "healed response"
+        healed_wire = client.chat.completions.create.call_args_list[1].kwargs[
+            "messages"
+        ][1]
+        assert healed_wire["reasoning_content"] == "private scratchpad"
+        assert "_reasoning_replay_origin" not in healed_wire
+        assert route_info == {
+            "provider": "nous",
+            "model": healed_model,
+            "base_url": base_url,
+        }
+
+    @pytest.mark.asyncio
+    async def test_async_moa_nous_model_heal_records_actual_route(self):
+        stale_model = "openai/stale-model"
+        healed_model = "google/gemma-4-31b-it"
+        base_url = "https://inference-api.nousresearch.com/v1"
+        stale_error = Exception("requested model does not exist in our configuration")
+        stale_error.status_code = 404
+        client = MagicMock()
+        client.base_url = base_url
+        client.chat.completions.create = AsyncMock(
+            side_effect=[stale_error, _DummyResponse("healed response")]
+        )
+        route_info = {}
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("nous", stale_model, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, stale_model),
+        ), patch(
+            "agent.auxiliary_client._refresh_nous_recommended_model",
+            return_value=healed_model,
+        ):
+            result = await async_call_llm(
+                task="moa_aggregator",
+                messages=[{"role": "user", "content": "continue"}],
+                route_info=route_info,
+            )
+
+        assert result.choices[0].message.content == "healed response"
+        assert route_info == {
+            "provider": "nous",
+            "model": healed_model,
+            "base_url": base_url,
+        }
+
+    def test_nous_auth_recovery_preserves_rejected_temperature_omission(self):
+        unsupported = Exception("Unsupported parameter: temperature")
+        unsupported.status_code = 400
+        stale_client = MagicMock()
+        stale_client.base_url = "https://inference-api.nousresearch.com/v1"
+        stale_client.chat.completions.create.side_effect = [
+            unsupported,
+            _AuxAuth401("expired after compatibility retry"),
+        ]
+        fresh_client = MagicMock()
+        fresh_client.base_url = stale_client.base_url
+        fresh_client.chat.completions.create.return_value = _DummyResponse("fresh")
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("nous", "model-a", None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(stale_client, "model-a"),
+        ), patch(
+            "agent.auxiliary_client._refresh_nous_auxiliary_client",
+            return_value=(fresh_client, "model-b"),
+        ):
+            result = call_llm(
+                task="moa_aggregator",
+                messages=[{"role": "user", "content": "continue"}],
+                temperature=0.2,
+            )
+
+        assert result.choices[0].message.content == "fresh"
+        assert "temperature" not in fresh_client.chat.completions.create.call_args.kwargs
+        assert fresh_client.chat.completions.create.call_args.kwargs["model"] == "model-b"
+
+    @pytest.mark.asyncio
+    async def test_async_nous_auth_recovery_preserves_rejected_temperature_omission(
+        self,
+    ):
+        unsupported = Exception("Unsupported parameter: temperature")
+        unsupported.status_code = 400
+        stale_client = MagicMock()
+        stale_client.base_url = "https://inference-api.nousresearch.com/v1"
+        stale_client.chat.completions.create = AsyncMock(
+            side_effect=[unsupported, _AuxAuth401("expired after compatibility retry")]
+        )
+        fresh_client = MagicMock()
+        fresh_client.base_url = stale_client.base_url
+        fresh_client.chat.completions.create = AsyncMock(
+            return_value=_DummyResponse("fresh")
+        )
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("nous", "model-a", None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(stale_client, "model-a"),
+        ), patch(
+            "agent.auxiliary_client._refresh_nous_auxiliary_client",
+            return_value=(fresh_client, "model-b"),
+        ):
+            result = await async_call_llm(
+                task="moa_aggregator",
+                messages=[{"role": "user", "content": "continue"}],
+                temperature=0.2,
+            )
+
+        assert result.choices[0].message.content == "fresh"
+        assert "temperature" not in fresh_client.chat.completions.create.call_args.kwargs
+
+    def test_nous_paid_recovery_preserves_rejected_max_tokens_omission(self):
+        unsupported = Exception("Unsupported parameter: max_tokens")
+        unsupported.status_code = 400
+        payment = self._make_402_error()
+        stale_client = MagicMock()
+        stale_client.base_url = "https://inference-api.nousresearch.com/v1"
+        stale_client.chat.completions.create.side_effect = [unsupported, payment]
+        fresh_client = MagicMock()
+        fresh_client.base_url = stale_client.base_url
+        fresh_client.chat.completions.create.return_value = _DummyResponse("fresh")
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("nous", "model-a", None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(stale_client, "model-a"),
+        ), patch(
+            "agent.auxiliary_client._nous_portal_account_has_fresh_paid_access",
+            return_value=True,
+        ), patch(
+            "agent.auxiliary_client._refresh_nous_auxiliary_client",
+            return_value=(fresh_client, "model-b"),
+        ):
+            result = call_llm(
+                task="moa_aggregator",
+                messages=[{"role": "user", "content": "continue"}],
+                max_tokens=128,
+            )
+
+        assert result.choices[0].message.content == "fresh"
+        fresh_kwargs = fresh_client.chat.completions.create.call_args.kwargs
+        assert "max_tokens" not in fresh_kwargs
+        assert "max_completion_tokens" not in fresh_kwargs
+
+    def test_nous_model_heal_retargets_explicit_output_cap_spelling(self):
+        stale_model = "gpt-5.4"
+        healed_model = "google/gemma-4-31b-it"
+        stale_error = Exception("requested model does not exist in our configuration")
+        stale_error.status_code = 404
+        client = MagicMock()
+        client.base_url = "https://inference-api.nousresearch.com/v1"
+        client.chat.completions.create.side_effect = [
+            stale_error,
+            _DummyResponse("healed"),
+        ]
+
+        def _token_param(value, *, model=None):
+            key = "max_completion_tokens" if model == stale_model else "max_tokens"
+            return {key: value}
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("nous", stale_model, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, stale_model),
+        ), patch(
+            "agent.auxiliary_client._refresh_nous_recommended_model",
+            return_value=healed_model,
+        ), patch(
+            "agent.auxiliary_client.auxiliary_max_tokens_param",
+            side_effect=_token_param,
+        ):
+            result = call_llm(
+                task="moa_reference",
+                messages=[{"role": "user", "content": "advise"}],
+                max_tokens=321,
+            )
+
+        assert result.choices[0].message.content == "healed"
+        first_kwargs = client.chat.completions.create.call_args_list[0].kwargs
+        healed_kwargs = client.chat.completions.create.call_args_list[1].kwargs
+        assert first_kwargs["max_completion_tokens"] == 321
+        assert "max_tokens" not in first_kwargs
+        assert healed_kwargs["max_tokens"] == 321
+        assert "max_completion_tokens" not in healed_kwargs
 
     def test_401_auth_error_triggers_fallback_in_auto_mode(self, monkeypatch):
         """401 auth errors should trigger fallback in auto mode (#21165).
@@ -1645,10 +1943,11 @@ class TestStaleFallbackCandidateSkip:
         fresh_fb = MagicMock()
         fresh_fb.base_url = "https://api.anthropic.com"
         fresh_fb.chat.completions.create.return_value = _DummyResponse("fresh-fallback")
+        route_info = {}
 
         def _cached_client(provider, model=None, **kw):
             if provider == "anthropic":
-                return (fresh_fb, "claude-haiku-4-5-20251001")
+                return (fresh_fb, "claude-sonnet-4-6")
             return (primary_client, "gpt-5.5")
 
         with patch("agent.auxiliary_client._resolve_task_provider_model",
@@ -1665,12 +1964,18 @@ class TestStaleFallbackCandidateSkip:
             result = call_llm(
                 task="compression",
                 messages=[{"role": "user", "content": "summarize"}],
+                route_info=route_info,
             )
 
         assert result.choices[0].message.content == "fresh-fallback"
         mock_refresh.assert_called_once_with("anthropic")
         assert stale_fb.chat.completions.create.call_count == 1
         assert fresh_fb.chat.completions.create.call_count == 1
+        assert route_info == {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "base_url": "https://api.anthropic.com",
+        }
 
     def test_unrefreshable_stale_candidate_is_skipped_to_next(self, monkeypatch):
         """Refresh fails (expired setup token) → candidate quarantined, chain

--- a/tests/agent/test_message_sanitization_policy.py
+++ b/tests/agent/test_message_sanitization_policy.py
@@ -12,12 +12,15 @@ from types import SimpleNamespace
 import pytest
 
 from agent.message_sanitization import (
+    _MOA_REFERENCE_GUIDANCE_METADATA_KEY,
     apply_reasoning_content_policy,
     coalesce_tool_call_id,
     deterministic_call_id,
     matches_reasoning_echo_family,
     needs_reasoning_echo,
+    prepare_reasoning_replay_messages_for_route,
     reapply_reasoning_echo,
+    reasoning_replay_route_fingerprint,
     reasoning_echo_family,
     uniquify_tool_call_ids,
 )
@@ -233,12 +236,51 @@ class TestApplyReasoningContentPolicy:
             {"role": "assistant", "content": "x", "reasoning_content": " "}, api, False)
         assert "reasoning_content" not in api
 
+    @pytest.mark.parametrize(
+        ("same_tool_turn", "reasoning_content", "expected"),
+        [(True, "native thought", "native thought"), (False, "completed thought", None), (True, " ", None)],
+    )
+    def test_gemma4_only_preserves_explicit_current_tool_turn_reasoning(
+        self, same_tool_turn, reasoning_content, expected
+    ):
+        api = {"role": "assistant", "reasoning_content": reasoning_content}
+        origin = "route-primary"
+        api["_reasoning_replay_origin"] = origin
+        apply_reasoning_content_policy(dict(api), api, False, model="google/gemma-4-31b-it",
+                                       preserve_explicit_reasoning=same_tool_turn,
+                                       replay_origin=origin)
+        if expected is None:
+            assert "reasoning_content" not in api
+        else:
+            assert api["reasoning_content"] == expected
+
     def test_cross_provider_poisoned_history_pads_with_space(self):
         src = {"role": "assistant", "content": "x", "reasoning": "other-provider CoT",
                "tool_calls": [{"id": "c", "function": {"name": "t", "arguments": "{}"}}]}
         api = {"role": "assistant", "content": "x"}
         apply_reasoning_content_policy(src, api, True)
         assert api["reasoning_content"] == " "  # pad, never the foreign CoT
+
+    def test_require_side_fallback_pads_foreign_marked_scratchpad(self):
+        src = {
+            "role": "assistant",
+            "tool_calls": [{}],
+            "reasoning_content": "private Gemma scratchpad",
+            "_reasoning_replay_origin": "gemma-route",
+        }
+        api = dict(src)
+
+        apply_reasoning_content_policy(
+            src,
+            api,
+            True,
+            model="deepseek-reasoner",
+            preserve_explicit_reasoning=True,
+            replay_origin="deepseek-route",
+        )
+
+        assert api["reasoning_content"] == " "
+        assert "_reasoning_replay_origin" not in api
 
     def test_reasoning_promoted_only_on_require_side(self):
         src = {"role": "assistant", "content": "x", "reasoning": "healthy"}
@@ -286,6 +328,431 @@ class TestReapplyReasoningEcho:
         msgs = copy.deepcopy(self.MSGS)
         assert reapply_reasoning_echo(msgs, False) == 1
         assert all("reasoning_content" not in m for m in msgs)
+
+    def test_gemma4_reapply_keeps_only_current_tool_turn_reasoning(self):
+        current = {"role": "assistant", "tool_calls": [{}], "reasoning_content": "current"}
+        current["_reasoning_replay_origin"] = "route-primary"
+        apply_reasoning_content_policy(
+            current,
+            current,
+            False,
+            model="gemma4:31b",
+            preserve_explicit_reasoning=True,
+            replay_origin="route-primary",
+        )
+        msgs = [
+            {"role": "assistant", "tool_calls": [{}], "reasoning_content": "old"},
+            {"role": "user", "content": "current"},
+            current,
+            {"role": "assistant", "tool_calls": [{}], "reasoning_content": " "},
+        ]
+        assert reapply_reasoning_echo(
+            msgs,
+            False,
+            model="gemma4:31b",
+            replay_origin="route-primary",
+        ) == 2
+        assert "reasoning_content" not in msgs[0]
+        assert msgs[2]["reasoning_content"] == "current"
+        assert "reasoning_content" not in msgs[3]
+
+    @pytest.mark.parametrize(
+        "synthetic_flag",
+        ["_empty_recovery_synthetic", "_kanban_stop_synthetic"],
+    )
+    def test_synthetic_user_nudge_does_not_end_gemma_tool_turn(self, synthetic_flag):
+        current = {
+            "role": "assistant",
+            "tool_calls": [{}],
+            "reasoning_content": "current",
+            "_reasoning_replay_origin": "route-primary",
+        }
+        msgs = [
+            {"role": "user", "content": "current task"},
+            current,
+            {
+                "role": "user",
+                "content": "Continue processing after the empty response.",
+                synthetic_flag: True,
+            },
+        ]
+
+        assert reapply_reasoning_echo(
+            msgs,
+            False,
+            model="gemma4:31b",
+            replay_origin="route-primary",
+        ) == 0
+        assert current["reasoning_content"] == "current"
+        assert current["_reasoning_replay_origin"] == "route-primary"
+
+    def test_moa_reference_guidance_does_not_end_gemma_tool_turn(self):
+        current = {
+            "role": "assistant",
+            "tool_calls": [{}],
+            "reasoning_content": "current",
+            "_reasoning_replay_origin": "route-primary",
+        }
+        msgs = [
+            {"role": "user", "content": "current task"},
+            current,
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            {
+                "role": "user",
+                "content": "[Mixture of Agents reference context]\nAdvice body.",
+                _MOA_REFERENCE_GUIDANCE_METADATA_KEY: {"shape": "standalone"},
+            },
+        ]
+
+        assert reapply_reasoning_echo(
+            msgs,
+            False,
+            model="gemma4:31b",
+            replay_origin="route-primary",
+        ) == 0
+        assert current["reasoning_content"] == "current"
+        assert current["_reasoning_replay_origin"] == "route-primary"
+
+    @pytest.mark.parametrize(
+        "nudge_name",
+        [
+            "_LENGTH_CONTINUATION_OUTPUT_LIMIT",
+            "_CODEX_INCOMPLETE_NUDGE",
+            "_CODEX_ACK_CONTINUATION_NUDGE",
+            "_EMPTY_TOOL_RESPONSE_NUDGE",
+        ],
+    )
+    def test_moa_guidance_merged_into_synthetic_nudge_keeps_tool_turn_reasoning(
+        self, nudge_name
+    ):
+        import agent.conversation_loop as conversation_loop
+
+        current = {
+            "role": "assistant",
+            "tool_calls": [{}],
+            "reasoning_content": "current",
+            "_reasoning_replay_origin": "route-primary",
+        }
+        nudge = getattr(conversation_loop, nudge_name)
+        msgs = [
+            {"role": "user", "content": "current task"},
+            current,
+            {
+                "role": "user",
+                "content": (
+                    nudge
+                    + "\n\n[Mixture of Agents reference context]\nAdvice body."
+                ),
+                _MOA_REFERENCE_GUIDANCE_METADATA_KEY: {
+                    "shape": "string",
+                    "boundary": len(nudge),
+                },
+            },
+        ]
+
+        assert reapply_reasoning_echo(
+            msgs,
+            False,
+            model="gemma4:31b",
+            replay_origin="route-primary",
+        ) == 0
+        assert current["reasoning_content"] == "current"
+        assert current["_reasoning_replay_origin"] == "route-primary"
+
+    def test_length_continuation_flag_survives_changed_content(self):
+        current = {
+            "role": "assistant",
+            "tool_calls": [{}],
+            "reasoning_content": "current",
+            "_reasoning_replay_origin": "route-primary",
+        }
+        msgs = [
+            {"role": "user", "content": "current task"},
+            current,
+            {
+                "role": "user",
+                "content": "runtime-decorated continuation text",
+                "_length_continuation_nudge": True,
+            },
+        ]
+
+        assert reapply_reasoning_echo(
+            msgs,
+            False,
+            model="gemma4:31b",
+            replay_origin="route-primary",
+        ) == 0
+        assert current["reasoning_content"] == "current"
+
+    def test_moa_guidance_keeps_image_only_user_turn_as_real_boundary(self):
+        current = {
+            "role": "assistant",
+            "tool_calls": [{}],
+            "reasoning_content": "must be old after a real user turn",
+            "_reasoning_replay_origin": "route-primary",
+        }
+        msgs = [
+            current,
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+                    {
+                        "type": "text",
+                        "text": (
+                            "\n\n[Mixture of Agents reference context]\nAdvice body."
+                        ),
+                    },
+                ],
+                _MOA_REFERENCE_GUIDANCE_METADATA_KEY: {
+                    "shape": "list",
+                    "boundary": 1,
+                },
+            },
+        ]
+
+        assert reapply_reasoning_echo(
+            msgs,
+            False,
+            model="gemma4:31b",
+            replay_origin="route-primary",
+        ) == 1
+        assert "reasoning_content" not in current
+
+    def test_repeated_header_inside_guidance_does_not_create_user_boundary(self):
+        from agent.moa_loop import _attach_reference_guidance
+
+        current = {
+            "role": "assistant",
+            "tool_calls": [{}],
+            "reasoning_content": "current",
+            "_reasoning_replay_origin": "route-primary",
+        }
+        msgs = [
+            {"role": "user", "content": "current task"},
+            current,
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+        ]
+        _attach_reference_guidance(
+            msgs,
+            (
+                "[Mixture of Agents reference context]\nAdvice quotes this:\n"
+                "[Mixture of Agents reference context]\nNested example."
+            ),
+        )
+
+        assert reapply_reasoning_echo(
+            msgs,
+            False,
+            model="gemma4:31b",
+            replay_origin="route-primary",
+        ) == 0
+        assert current["reasoning_content"] == "current"
+
+    def test_user_authored_moa_header_remains_a_real_boundary(self):
+        current = {
+            "role": "assistant",
+            "tool_calls": [{}],
+            "reasoning_content": "belongs to the previous turn",
+            "_reasoning_replay_origin": "route-primary",
+        }
+        msgs = [
+            {"role": "user", "content": "previous task"},
+            current,
+            {
+                "role": "user",
+                "content": "[Mixture of Agents reference context]\nPlease explain this block.",
+            },
+        ]
+
+        assert reapply_reasoning_echo(
+            msgs,
+            False,
+            model="gemma4:31b",
+            replay_origin="route-primary",
+        ) == 1
+        assert "reasoning_content" not in current
+
+    def test_fallback_to_gemma4_strips_foreign_reasoning(self):
+        msgs = [
+            {"role": "user", "content": "current"},
+            {"role": "assistant", "tool_calls": [{}], "reasoning_content": "foreign"},
+        ]
+
+        assert reapply_reasoning_echo(
+            msgs,
+            False,
+            model="gemma4:31b",
+            replay_origin="route-fallback",
+        ) == 1
+        assert "reasoning_content" not in msgs[1]
+
+    def test_require_side_fallback_replaces_foreign_gemma_reasoning(self):
+        msgs = [
+            {"role": "user", "content": "current"},
+            {
+                "role": "assistant",
+                "tool_calls": [{}],
+                "reasoning": "normalized copy must not cross routes",
+                "reasoning_content": "gemma scratchpad",
+                "_reasoning_replay_origin": "route-gemma",
+            },
+        ]
+
+        assert reapply_reasoning_echo(
+            msgs,
+            True,
+            model="deepseek-v4",
+            replay_origin="route-deepseek",
+        ) == 1
+        assert msgs[1]["reasoning_content"] == " "
+        assert "_reasoning_replay_origin" not in msgs[1]
+
+    def test_same_model_different_endpoint_does_not_match_origin(self):
+        source = {
+            "role": "assistant",
+            "tool_calls": [{}],
+            "reasoning_content": "primary secret",
+            "_reasoning_replay_origin": "route-TenantA",
+        }
+        api = dict(source)
+
+        apply_reasoning_content_policy(
+            source,
+            api,
+            False,
+            model="Gemma4:Custom",
+            preserve_explicit_reasoning=True,
+            replay_origin="route-tenanta",
+        )
+
+        assert "reasoning_content" not in api
+        assert "_reasoning_replay_origin" not in api
+
+    def test_moa_uses_resolved_gemma4_aggregator_model(self):
+        from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider
+
+        agent = SimpleNamespace(
+            provider="moa", model="closed",
+            base_url="",
+            client=SimpleNamespace(last_aggregator_slot={
+                "provider": "custom",
+                "base_url": "https://gemma.test/v1",
+                "model": "google/gemma-4-31b-it",
+            }),
+            _needs_thinking_reasoning_pad=lambda: False,
+        )
+        source = {"role": "assistant", "tool_calls": [{}], "reasoning_content": "thought"}
+        from agent.agent_runtime_helpers import _reasoning_replay_route
+        _, source["_reasoning_replay_origin"] = _reasoning_replay_route(agent)
+        current = dict(source)
+        from agent.agent_runtime_helpers import copy_reasoning_content_for_api
+        copy_reasoning_content_for_api(
+            agent, source, current, preserve_explicit_reasoning=True
+        )
+        msgs = [{"role": "user", "content": "current"}, current]
+
+        assert reapply_reasoning_echo_for_provider(agent, msgs) == 0
+        assert msgs[1]["reasoning_content"] == "thought"
+
+    def test_moa_uses_actual_successful_fallback_route(self):
+        from agent.agent_runtime_helpers import _reasoning_replay_route
+
+        fallback_route = {
+            "provider": "openai",
+            "base_url": "https://fallback.test/v1",
+            "model": "fallback-model",
+        }
+        moa_agent = SimpleNamespace(
+            provider="moa",
+            model="closed",
+            base_url="",
+            client=SimpleNamespace(
+                last_aggregator_slot={
+                    "provider": "custom",
+                    "base_url": "https://gemma.test/v1",
+                    "model": "google/gemma-4-31b-it",
+                },
+                last_aggregator_runtime=fallback_route,
+            ),
+        )
+        direct_agent = SimpleNamespace(**fallback_route)
+
+        model, fingerprint = _reasoning_replay_route(moa_agent)
+        _, expected_fingerprint = _reasoning_replay_route(direct_agent)
+
+        assert model == "fallback-model"
+        assert fingerprint == expected_fingerprint
+
+    def test_auxiliary_wire_shapes_marked_reasoning_for_concrete_route(self):
+        gemma_route = {
+            "provider": "openrouter",
+            "base_url": "https://gemma.test/v1",
+            "model": "google/gemma-4-31b-it",
+        }
+        origin = reasoning_replay_route_fingerprint(**gemma_route)
+        source = [
+            {"role": "user", "content": "current"},
+            {
+                "role": "assistant",
+                "tool_calls": [{}],
+                "reasoning_content": "private scratchpad",
+                "_reasoning_replay_origin": origin,
+            },
+        ]
+
+        same_route = prepare_reasoning_replay_messages_for_route(
+            source, **gemma_route
+        )
+        strict_route = prepare_reasoning_replay_messages_for_route(
+            source,
+            provider="openai",
+            base_url="https://strict.test/v1",
+            model="strict-model",
+        )
+        require_side_route = prepare_reasoning_replay_messages_for_route(
+            source,
+            provider="deepseek",
+            base_url="https://api.deepseek.com/v1",
+            model="deepseek-reasoner",
+        )
+
+        assert same_route[1]["reasoning_content"] == "private scratchpad"
+        assert "reasoning_content" not in strict_route[1]
+        assert require_side_route[1]["reasoning_content"] == " "
+        assert all("_reasoning_replay_origin" not in rows[1] for rows in (
+            same_route, strict_route, require_side_route
+        ))
+        assert source[1]["_reasoning_replay_origin"] == origin
+
+    def test_auxiliary_wire_strips_moa_guidance_provenance(self):
+        source = [
+            {
+                "role": "user",
+                "content": "task\n\n[Mixture of Agents reference context]\nAdvice.",
+                _MOA_REFERENCE_GUIDANCE_METADATA_KEY: {
+                    "shape": "string",
+                    "boundary": len("task"),
+                },
+            },
+        ]
+
+        for route in (
+            {
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "model": "google/gemma-4-31b-it",
+            },
+            {
+                "provider": "deepseek",
+                "base_url": "https://api.deepseek.com/v1",
+                "model": "deepseek-reasoner",
+            },
+        ):
+            wire = prepare_reasoning_replay_messages_for_route(source, **route)
+            assert _MOA_REFERENCE_GUIDANCE_METADATA_KEY not in wire[0]
+            assert "reasoning_content" not in wire[0]
+        assert source[0][_MOA_REFERENCE_GUIDANCE_METADATA_KEY]["shape"] == "string"
 
     def test_idempotent(self):
         import copy

--- a/tests/agent/test_moa_aggregator_cost_slot.py
+++ b/tests/agent/test_moa_aggregator_cost_slot.py
@@ -98,3 +98,85 @@ def test_client_exposes_last_aggregator_slot(moa_config, monkeypatch):
     assert slot is not None
     assert slot["model"] == "anthropic/claude-opus-4.8"
     assert slot["provider"] == "openrouter"
+
+
+def test_create_captures_successful_aggregator_fallback_route(moa_config, monkeypatch):
+    from agent.moa_loop import MoAClient
+
+    def fake_call_llm(**kwargs):
+        if kwargs.get("task") == "moa_aggregator":
+            kwargs["route_info"].update(
+                provider="openai",
+                model="fallback-model",
+                base_url="https://fallback.test/v1",
+            )
+            return _response("acted")
+        return _response("advice")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    client = MoAClient("closed")
+    client.chat.completions.create(
+        model="closed",
+        messages=[{"role": "user", "content": "clean the db"}],
+    )
+
+    assert client.last_aggregator_runtime == {
+        "provider": "openai",
+        "model": "fallback-model",
+        "base_url": "https://fallback.test/v1",
+    }
+
+
+def test_prepare_preserves_previous_successful_aggregator_route(moa_config, monkeypatch):
+    """Advisor preparation must not erase the route that produced history."""
+    from agent.moa_loop import MoAClient
+
+    def fake_call_llm(**kwargs):
+        assert kwargs.get("task") == "moa_reference"
+        return _response("advice")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    client = MoAClient("closed")
+    previous_route = {
+        "provider": "openrouter",
+        "model": "google/gemma-4-31b-it",
+        "base_url": "https://fallback.test/v1",
+    }
+    client.chat.completions.last_aggregator_runtime = dict(previous_route)
+
+    prepared = client.chat.completions.prepare(
+        [{"role": "user", "content": "continue the tool turn"}]
+    )
+
+    assert prepared["aggregator"]
+    assert client.last_aggregator_runtime == previous_route
+
+
+def test_failed_aggregator_call_preserves_previous_successful_route(
+    moa_config, monkeypatch
+):
+    """A failed replacement attempt cannot invalidate history provenance."""
+    from agent.moa_loop import MoAClient
+
+    def fake_call_llm(**kwargs):
+        if kwargs.get("task") == "moa_reference":
+            return _response("advice")
+        raise RuntimeError("all aggregator routes failed")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    client = MoAClient("closed")
+    previous_route = {
+        "provider": "openrouter",
+        "model": "google/gemma-4-31b-it",
+        "base_url": "https://fallback.test/v1",
+    }
+    client.chat.completions.last_aggregator_runtime = dict(previous_route)
+
+    with pytest.raises(RuntimeError, match="all aggregator routes failed"):
+        client.chat.completions.create(
+            model="closed",
+            messages=[{"role": "user", "content": "continue"}],
+        )
+
+    assert client.last_aggregator_runtime == previous_route

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -748,6 +748,9 @@ def test_reference_guidance_appended_at_end_in_tool_loop():
     # The reference block is appended as a new trailing turn, not merged upstream.
     assert messages[-1]["role"] == "user"
     assert messages[-1]["content"] == "REFERENCE BLOCK"
+    assert messages[-1]["_moa_reference_guidance_appended"] == {
+        "shape": "standalone"
+    }
     assert len(messages) == 5
 
 
@@ -828,6 +831,48 @@ def test_prepared_aggregator_preserves_reasoning_config(monkeypatch):
     )
 
     assert captured["reasoning_config"] == expected_reasoning
+
+
+def test_prepared_aggregator_keeps_replay_origin_until_route_selection(monkeypatch):
+    from agent import moa_loop
+
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return _response("aggregator acted")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+    prepared = {
+        "messages": [
+            {"role": "user", "content": "question"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call_1"}],
+                "reasoning_content": "scratchpad",
+                "_reasoning_replay_origin": "internal-route-fingerprint",
+            },
+        ],
+        "aggregator": {"provider": "openrouter", "model": "aggregator"},
+        "aggregator_temperature": None,
+    }
+
+    facade = moa_loop.MoAChatCompletions("review")
+    facade._call_prepared_aggregator(prepared, {})
+
+    assert captured["messages"][1]["_reasoning_replay_origin"] == (
+        "internal-route-fingerprint"
+    )
+    assert captured["messages"][1]["reasoning_content"] == "scratchpad"
+    assert prepared["messages"][1]["_reasoning_replay_origin"] == (
+        "internal-route-fingerprint"
+    )
 
 
 

--- a/tests/run_agent/test_moa_privacy_filter.py
+++ b/tests/run_agent/test_moa_privacy_filter.py
@@ -13,7 +13,7 @@ adds conservative email + formatted-phone patterns and wires two modes:
 
 from types import SimpleNamespace
 
-from agent.moa_loop import _redact_reference_text
+from agent.moa_loop import _redact_reference_text, _redact_trace_messages
 
 
 def _response(content="done", *, tool_calls=None):
@@ -59,6 +59,38 @@ def test_non_string_input_passes_through():
     assert _redact_reference_text(None) is None
     assert _redact_reference_text(42) == 42
     assert _redact_reference_text("") == ""
+
+
+def test_trace_redaction_covers_nested_reasoning_carriers():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "visible ceo@example.com",
+            "reasoning": "call (555) 867-5309",
+            "reasoning_content": "email ceo@example.com",
+            "reasoning_details": [
+                {"type": "summary", "text": "contact ceo@example.com"}
+            ],
+            "codex_reasoning_items": [
+                {"type": "reasoning", "summary": ["phone (555) 867-5309"]}
+            ],
+            "codex_message_items": [
+                {"type": "message", "content": "email ceo@example.com"}
+            ],
+            "anthropic_content_blocks": [
+                {"type": "thinking", "thinking": "phone (555) 867-5309"}
+            ],
+        }
+    ]
+
+    redacted = _redact_trace_messages(messages)
+    serialized = str(redacted)
+
+    assert "ceo@example.com" not in serialized
+    assert "(555) 867-5309" not in serialized
+    assert "[redacted email]" in serialized
+    assert "[redacted phone]" in serialized
+    assert messages[0]["reasoning_content"] == "email ceo@example.com"
 
 
 # --- mode wiring ------------------------------------------------------------

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -8293,6 +8293,83 @@ class TestReasoningReplayForStrictProviders:
         replayed_assistant = next(msg for msg in sent_messages if msg.get("role") == "assistant")
         assert replayed_assistant["reasoning_content"] == "provider-native scratchpad"
 
+    def test_gemma4_preserves_explicit_reasoning_content_on_replay(self, agent):
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:8000/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "custom"
+        agent.model = "google/gemma-4-E4B-it"
+        prior_assistant = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": "{\"q\":\"test\"}"},
+                }
+            ],
+            "reasoning_content": "inspect the repository before continuing",
+        }
+        tool_result = {"role": "tool", "tool_call_id": "c1", "content": "ok"}
+        final_resp = _mock_response(content="done", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = final_resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "next step",
+                conversation_history=[prior_assistant, tool_result],
+            )
+
+        assert result["completed"] is True
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        replayed_assistant = next(msg for msg in sent_messages if msg.get("role") == "assistant")
+        assert (
+            replayed_assistant["reasoning_content"]
+            == "inspect the repository before continuing"
+        )
+
+    def test_gemma4_drops_synthetic_reasoning_pad_on_replay(self, agent):
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:8000/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "custom"
+        agent.model = "gemma4:27b"
+        prior_assistant = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": "{\"q\":\"test\"}"},
+                }
+            ],
+            "reasoning_content": " ",
+        }
+        tool_result = {"role": "tool", "tool_call_id": "c1", "content": "ok"}
+        final_resp = _mock_response(content="done", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = final_resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "next step",
+                conversation_history=[prior_assistant, tool_result],
+            )
+
+        assert result["completed"] is True
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        replayed_assistant = next(msg for msg in sent_messages if msg.get("role") == "assistant")
+        assert "reasoning_content" not in replayed_assistant
+
     def test_strict_provider_strips_reasoning_content_on_replay(self, agent):
         """On a strict provider (Mistral et al.) reasoning_content from a
         prior reasoning primary must be stripped on replay — otherwise the

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2536,6 +2536,80 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         assert "reasoning" not in kwargs.get("extra_body", {})
 
+    def test_summary_preserves_current_gemma_tool_turn_reasoning(self, agent):
+        agent.provider = "custom"
+        agent.base_url = "https://gemma.test/v1"
+        agent.model = "google/gemma-4-31b-it"
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+        messages = [
+            {"role": "user", "content": "do stuff"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "call_1", "function": {"name": "run", "arguments": "{}"}}],
+                "reasoning_content": "provider scratchpad",
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+        ]
+        from agent.agent_runtime_helpers import _reasoning_replay_route
+
+        _, messages[1]["_reasoning_replay_origin"] = _reasoning_replay_route(agent)
+
+        assert agent._handle_max_iterations(messages, 60) == "Summary"
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        tool_turn = next(msg for msg in sent_messages if msg.get("tool_calls"))
+        assert tool_turn["reasoning_content"] == "provider scratchpad"
+
+    def test_moa_summary_keeps_origin_until_concrete_route_selection(self, agent):
+        actual_route = {
+            "provider": "openrouter",
+            "base_url": "https://gemma.test/v1",
+            "model": "google/gemma-4-31b-it",
+        }
+        agent.provider = "moa"
+        agent.model = "review"
+        agent.base_url = "moa://local"
+        agent._base_url_lower = agent.base_url
+        summary_client = MagicMock()
+        summary_client.chat.completions.create.return_value = _mock_response(
+            content="Summary"
+        )
+        agent.client = SimpleNamespace(
+            last_aggregator_slot=dict(actual_route),
+            last_aggregator_runtime=dict(actual_route),
+        )
+        agent._cached_system_prompt = "You are helpful."
+        from agent.message_sanitization import reasoning_replay_route_fingerprint
+
+        origin = reasoning_replay_route_fingerprint(**actual_route)
+        messages = [
+            {"role": "user", "content": "do stuff"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "run", "arguments": "{}"},
+                    }
+                ],
+                "reasoning_content": "provider scratchpad",
+                "_reasoning_replay_origin": origin,
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+        ]
+
+        with patch.object(
+            agent, "_ensure_primary_openai_client", return_value=summary_client
+        ):
+            assert agent._handle_max_iterations(messages, 60) == "Summary"
+
+        sent_messages = summary_client.chat.completions.create.call_args.kwargs[
+            "messages"
+        ]
+        tool_turn = next(msg for msg in sent_messages if msg.get("tool_calls"))
+        assert tool_turn["reasoning_content"] == "provider scratchpad"
+        assert tool_turn["_reasoning_replay_origin"] == origin
+
     def test_summary_request_removes_orphan_tool_result(self, agent):
         """Regression: max-iterations summary request must NOT contain
         orphan tool results (tool_call_id with no matching assistant tool_call)."""
@@ -5536,9 +5610,21 @@ class TestAnthropicCredentialRefresh:
 # _streaming_api_call tests
 # ===================================================================
 
-def _make_chunk(content=None, tool_calls=None, finish_reason=None, model="test/model"):
+def _make_chunk(
+    content=None,
+    tool_calls=None,
+    finish_reason=None,
+    model="test/model",
+    reasoning_content=None,
+    reasoning=None,
+):
     """Build a SimpleNamespace mimicking an OpenAI streaming chunk."""
-    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    delta = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=reasoning_content,
+        reasoning=reasoning,
+    )
     choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
     return SimpleNamespace(model=model, choices=[choice])
 
@@ -5591,6 +5677,81 @@ class TestStreamingApiCall:
         assert tc[0].function.name == "web_search"
         assert tc[0].function.arguments == '{"q":"test"}'
         assert tc[0].id == "call_1"
+
+    def test_normalized_reasoning_stream_is_not_marked_provider_native(self, agent):
+        agent.provider = "custom"
+        agent.base_url = "https://gemma.test/v1"
+        agent.model = "google/gemma-4-31b-it"
+        chunks = [
+            _make_chunk(reasoning="normalized thought"),
+            _make_chunk(
+                tool_calls=[_make_tc_delta(0, "call_1", "web_search", "{}")],
+                finish_reason="tool_calls",
+            ),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        response = agent._interruptible_streaming_api_call({"messages": []})
+        response = agent._get_transport().normalize_response(response)
+        stored = agent._build_assistant_message(response, "tool_calls")
+
+        assert stored["reasoning_content"] == "normalized thought"
+        assert "_reasoning_replay_origin" not in stored
+
+    @pytest.mark.parametrize(
+        "reasoning_chunks",
+        [
+            [
+                _make_chunk(reasoning="normalized thought"),
+                _make_chunk(reasoning_content="native thought"),
+            ],
+            [
+                _make_chunk(reasoning_content="native thought"),
+                _make_chunk(reasoning="normalized thought"),
+            ],
+        ],
+    )
+    def test_mixed_reasoning_stream_is_not_marked_provider_native(
+        self, agent, reasoning_chunks
+    ):
+        agent.provider = "custom"
+        agent.base_url = "https://gemma.test/v1"
+        agent.model = "google/gemma-4-31b-it"
+        chunks = reasoning_chunks + [
+            _make_chunk(
+                tool_calls=[_make_tc_delta(0, "call_1", "web_search", "{}")],
+                finish_reason="tool_calls",
+            )
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        response = agent._interruptible_streaming_api_call({"messages": []})
+        response = agent._get_transport().normalize_response(response)
+        stored = agent._build_assistant_message(response, "tool_calls")
+
+        assert "native thought" in stored["reasoning_content"]
+        assert "normalized thought" in stored["reasoning_content"]
+        assert "_reasoning_replay_origin" not in stored
+
+    def test_native_reasoning_stream_is_marked_provider_native(self, agent):
+        agent.provider = "custom"
+        agent.base_url = "https://gemma.test/v1"
+        agent.model = "google/gemma-4-31b-it"
+        chunks = [
+            _make_chunk(reasoning_content="native thought"),
+            _make_chunk(
+                tool_calls=[_make_tc_delta(0, "call_1", "web_search", "{}")],
+                finish_reason="tool_calls",
+            ),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        response = agent._interruptible_streaming_api_call({"messages": []})
+        response = agent._get_transport().normalize_response(response)
+        stored = agent._build_assistant_message(response, "tool_calls")
+
+        assert stored["reasoning_content"] == "native thought"
+        assert "_reasoning_replay_origin" in stored
 
     def test_multiple_tool_calls(self, agent):
         chunks = [
@@ -6039,7 +6200,214 @@ class TestReasoningReplayForStrictProviders:
         replayed_assistant = next(msg for msg in sent_messages if msg.get("role") == "assistant")
         assert replayed_assistant["reasoning_content"] == "provider-native scratchpad"
 
+    def test_gemma4_replays_reasoning_only_inside_current_tool_turn(self, agent):
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:8000/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "custom"
+        agent.model = "google/gemma-4-31b-it"
+        old_tool = {"id": "old", "type": "function", "function": {"name": "web_search", "arguments": "{}"}}
+        history = [
+            {"role": "user", "content": "old task"},
+            {"role": "assistant", "content": "", "tool_calls": [old_tool], "reasoning_content": "completed thought"},
+            {"role": "tool", "tool_call_id": "old", "content": "old result"},
+            {"role": "assistant", "content": "old answer"},
+        ]
+        # This snapshot remains stale until the new turn is finalized. Replay
+        # must use the live transcript/user boundary instead.
+        agent._session_messages = [dict(msg) for msg in history]
+        current_tool = _mock_tool_call(call_id="current")
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="", finish_reason="tool_calls", tool_calls=[current_tool], reasoning_content="current thought"),
+            _mock_response(content="done", finish_reason="stop"),
+        ]
 
+        with (
+            patch("run_agent.handle_function_call", return_value="current result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.run_conversation("current task", conversation_history=history)
+
+        first_sent = agent.client.chat.completions.create.call_args_list[0].kwargs["messages"]
+        first_old = next(msg for msg in first_sent if msg.get("tool_calls"))
+        assert "reasoning_content" not in first_old
+
+        sent = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+        replayed = {m["tool_calls"][0]["id"]: m for m in sent if m.get("tool_calls")}
+        assert "reasoning_content" not in replayed["old"]
+        assert replayed["current"]["reasoning_content"] == "current thought"
+        assert "_reasoning_replay_origin" not in replayed["current"]
+
+    def test_gemma4_reanchors_after_request_repair_rewrites_messages(self, agent):
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:8000/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "custom"
+        agent.model = "google/gemma-4-31b-it"
+        history = [
+            {"role": "user", "content": "old task"},
+            {"role": "assistant", "content": "old answer"},
+        ]
+        current_tool = _mock_tool_call(call_id="current")
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[current_tool],
+                reasoning_content="current thought",
+            ),
+            _mock_response(content="done", finish_reason="stop"),
+        ]
+        repair_calls = 0
+
+        def rewrite_before_second_request(_agent, messages):
+            nonlocal repair_calls
+            repair_calls += 1
+            if repair_calls == 2:
+                del messages[:2]
+                return 2
+            return 0
+
+        with (
+            patch(
+                "agent.agent_runtime_helpers.repair_message_sequence_with_cursor",
+                side_effect=rewrite_before_second_request,
+            ),
+            patch("run_agent.handle_function_call", return_value="current result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.run_conversation("current task", conversation_history=history)
+        sent = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+        replayed = next(msg for msg in sent if msg.get("tool_calls"))
+        assert replayed["reasoning_content"] == "current thought"
+        assert "_reasoning_replay_origin" not in replayed
+
+    def test_gemma4_response_records_producing_route(self, agent):
+        self._setup_agent(agent)
+        agent.provider = "custom"
+        agent.base_url = "https://Example.test/TenantA/v1"
+        agent.model = "google/Gemma-4-Custom"
+        response = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(call_id="route")],
+            reasoning_content="native thought",
+        )
+
+        stored = agent._build_assistant_message(
+            response.choices[0].message, "tool_calls"
+        )
+
+        from agent.agent_runtime_helpers import _reasoning_replay_route
+        _, expected_origin = _reasoning_replay_route(agent)
+        assert stored["_reasoning_replay_origin"] == expected_origin
+        assert "Example.test" not in expected_origin
+
+    def test_replay_route_normalizes_only_endpoint_safe_url_components(self, agent):
+        from agent.agent_runtime_helpers import _reasoning_replay_route
+
+        self._setup_agent(agent)
+        agent.provider = "custom"
+        agent.model = "google/gemma-4-31b-it"
+        agent.base_url = "HTTPS://User:Pass@Example.TEST/v1/"
+        _, first = _reasoning_replay_route(agent)
+        agent.base_url = "https://User:Pass@example.test/v1"
+        _, second = _reasoning_replay_route(agent)
+
+        assert first == second
+
+    @pytest.mark.parametrize(
+        ("first_url", "second_url"),
+        [
+            ("https://gw.example/v1?tenant=a/", "https://gw.example/v1?tenant=a"),
+            ("https://gw.example/v1#tenant-a/", "https://gw.example/v1#tenant-a"),
+            ("https://User@gw.example/v1", "https://user@gw.example/v1"),
+            ("https://gw.example/v1", "https://gw.example/v1//"),
+        ],
+    )
+    def test_replay_route_does_not_alias_sensitive_url_components(
+        self, agent, first_url, second_url
+    ):
+        from agent.agent_runtime_helpers import _reasoning_replay_route
+
+        self._setup_agent(agent)
+        agent.provider = "custom"
+        agent.model = "google/gemma-4-31b-it"
+        agent.base_url = first_url
+        _, first = _reasoning_replay_route(agent)
+        agent.base_url = second_url
+        _, second = _reasoning_replay_route(agent)
+
+        assert first != second
+
+    @pytest.mark.parametrize(
+        "synthetic_flag",
+        [
+            "_kanban_stop_synthetic",
+            "_pre_verify_synthetic",
+            "_verification_stop_synthetic",
+        ],
+    )
+    def test_gemma4_reanchor_ignores_synthetic_user_nudges(
+        self, synthetic_flag
+    ):
+        from agent.turn_context import reanchor_current_turn_user_idx
+
+        messages = [
+            {"role": "user", "content": "rewritten current task"},
+            {"role": "assistant", "tool_calls": [{}]},
+            {
+                "role": "user",
+                "content": "internal continuation",
+                synthetic_flag: True,
+            },
+        ]
+
+        assert reanchor_current_turn_user_idx(messages, "original current task") == 0
+
+    def test_repair_keeps_tool_call_reasoning_and_origin_atomic(self, agent):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "thinking prefill",
+                "reasoning_content": "prefill reasoning",
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call_1", "function": {"name": "run", "arguments": "{}"}}],
+                "reasoning_content": "tool reasoning",
+                "_reasoning_replay_origin": "tool route",
+            },
+        ]
+
+        assert agent._repair_message_sequence(messages) == 1
+        assert messages[0]["reasoning_content"] == "tool reasoning"
+        assert messages[0]["_reasoning_replay_origin"] == "tool route"
+
+    def test_gemma4_normalized_reasoning_is_not_marked_replayable(self, agent):
+        self._setup_agent(agent)
+        agent.provider = "custom"
+        agent.base_url = "https://example.test/v1"
+        agent.model = "google/gemma-4-31b-it"
+        response = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(call_id="normalized")],
+        )
+        response.choices[0].message.reasoning = "normalized only"
+        response.choices[0].message.reasoning_content = None
+
+        stored = agent._build_assistant_message(
+            response.choices[0].message, "tool_calls"
+        )
+
+        assert stored["reasoning_content"] == "normalized only"
+        assert "_reasoning_replay_origin" not in stored
 
 # ---------------------------------------------------------------------------
 # Bugfix: _vprint force=True on error messages during TTS


### PR DESCRIPTION
## Summary

- preserve provider-native Gemma 4 `reasoning_content` only for the active tool-call turn and the exact concrete provider/base URL/model route that produced it
- carry replay provenance through streaming normalization, request repair, context compression, continuation/reanchor paths, and MoA prepared requests
- keep cross-provider fallback isolated: matching Gemma routes receive their scratchpad, reasoning-echo routes receive only their schema pad, and strict routes receive neither
- record the route that actually succeeds after auxiliary fallback, credential refresh, or stale-model healing, while preserving request compatibility repairs and configured output caps
- keep internal replay/guidance metadata off provider wires and redact private reasoning plus provider replay sidecars from privacy-filtered MoA traces

Fixes #70745.

## Why

Hermes captures provider-native reasoning, but Gemma 4 tool-turn continuations lost it during replay. Preserving the field by model name alone is unsafe when a request can be repaired, compacted, or routed through MoA and auxiliary fallbacks. This update binds replay to the active user boundary and a non-reversible fingerprint of the concrete route that produced the reasoning.

The behavior remains deliberately narrow. Historical turns, synthetic whitespace, normalized non-native reasoning, mismatched routes, and unrelated models do not gain Gemma scratchpad replay.

## Tests

```text
python -m pytest -q \
  tests/agent/test_message_sanitization_policy.py \
  tests/agent/test_moa_aggregator_cost_slot.py \
  tests/run_agent/test_moa_loop_mode.py \
  tests/run_agent/test_moa_privacy_filter.py \
  tests/agent/test_moa_aggregator_cache_control.py \
  tests/agent/test_cache_disabled_on_stubs.py \
  tests/agent/test_api_content_sidecar.py \
  tests/agent/test_reference_handoff_active_turn.py \
  tests/agent/test_failover_identity.py \
  tests/agent/test_auxiliary_client.py::TestCallLlmPaymentFallback \
  tests/agent/test_auxiliary_client.py::TestStaleFallbackCandidateSkip \
  tests/agent/test_auxiliary_client.py::TestAuxiliaryFallbackLayering \
  tests/agent/test_auxiliary_client.py::TestSynchronousFallbackCachePlans \
  tests/agent/test_auxiliary_client.py::TestAsynchronousFallbackCachePlans
201 passed

python -m pytest -q tests/run_agent/test_run_agent.py \
  -k "gemma4 or replay or reanchor or summary or moa or native_reasoning_stream or reasoning_content"
26 passed, 237 deselected

# Final post-rebase critical proof on current main
131 passed

python -m ruff check agent/message_sanitization.py \
  agent/conversation_compression.py agent/moa_loop.py agent/auxiliary_client.py
All checks passed!

python -m py_compile agent/message_sanitization.py \
  agent/conversation_compression.py agent/moa_loop.py agent/auxiliary_client.py

git diff --check origin/main...HEAD
```

The final structured branch review reported no accepted/actionable findings.
