### PR TITLE
fix(cron): isolate multiplex profile failures

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -298,60 +298,94 @@ class InProcessCronScheduler(CronScheduler):
         # Recovery + initial heartbeat for every profile.
         for entry in profile_homes:
             home = entry[1] if isinstance(entry, tuple) else entry
-            home_token = set_hermes_home_override(str(home))
             try:
-                with use_cron_store(home):
-                    recovered = self.recover_interrupted()
-                    if recovered:
-                        logger.warning(
-                            "Marked %d interrupted cron execution(s) for profile at %s",
-                            recovered,
-                            home,
-                        )
-                    record_ticker_heartbeat()
-            finally:
-                reset_hermes_home_override(home_token)
-
-        while not stop_event.is_set():
-            ok = False
-            try:
-                if can_dispatch is not None and not can_dispatch():
-                    logger.debug("Cron dispatch paused while gateway drains existing work")
-                else:
-                    for entry in profile_homes:
-                        home = entry[1] if isinstance(entry, tuple) else entry
-                        home_token = set_hermes_home_override(str(home))
-                        try:
-                            with use_cron_store(home):
-                                cron_tick(
-                                    verbose=False,
-                                    adapters=adapters,
-                                    loop=loop,
-                                    sync=False,
-                                    can_dispatch=can_dispatch,
-                                )
-                        finally:
-                            reset_hermes_home_override(home_token)
-                ok = True
-            except BaseException as e:
-                logger.error("Cron tick error: %s", e, exc_info=True)
-                _tick_error = f"{type(e).__name__}: {e}"
-            else:
-                _tick_error = None
-            # Record per-profile heartbeat after each tick cycle.
-            for entry in profile_homes:
-                home = entry[1] if isinstance(entry, tuple) else entry
                 home_token = set_hermes_home_override(str(home))
                 try:
                     with use_cron_store(home):
-                        record_ticker_heartbeat(success=ok)
-                        # Surface the failure reason (or clear it) per profile
-                        # so `hermes cron status` can show WHY ticks fail
-                        # (#68483).
-                        if ok:
-                            clear_ticker_error()
-                        elif _tick_error:
-                            record_ticker_error(_tick_error)
+                        recovered = self.recover_interrupted()
+                        if recovered:
+                            logger.warning(
+                                "Marked %d interrupted cron execution(s) for profile at %s",
+                                recovered,
+                                home,
+                            )
+                        record_ticker_heartbeat()
                 finally:
                     reset_hermes_home_override(home_token)
+            except BaseException as e:
+                logger.error(
+                    "Cron startup recovery error for profile at %s: %s",
+                    home,
+                    e,
+                    exc_info=True,
+                )
+
+        while not stop_event.is_set():
+            profile_results: list[tuple[bool, str | None]] = [
+                (False, None) for _ in profile_homes
+            ]
+            try:
+                if can_dispatch is not None and not can_dispatch():
+                    logger.debug("Cron dispatch paused while gateway drains existing work")
+                    profile_results = [(True, None) for _ in profile_homes]
+                else:
+                    for index, entry in enumerate(profile_homes):
+                        home = entry[1] if isinstance(entry, tuple) else entry
+                        try:
+                            home_token = set_hermes_home_override(str(home))
+                            try:
+                                with use_cron_store(home):
+                                    cron_tick(
+                                        verbose=False,
+                                        adapters=adapters,
+                                        loop=loop,
+                                        sync=False,
+                                        can_dispatch=can_dispatch,
+                                    )
+                            finally:
+                                reset_hermes_home_override(home_token)
+                        except BaseException as e:
+                            logger.error(
+                                "Cron tick error for profile at %s: %s",
+                                home,
+                                e,
+                                exc_info=True,
+                            )
+                            profile_results[index] = (
+                                False,
+                                f"{type(e).__name__}: {e}",
+                            )
+                        else:
+                            profile_results[index] = (True, None)
+            except BaseException as e:
+                logger.error("Cron tick cycle error: %s", e, exc_info=True)
+                cycle_error = f"{type(e).__name__}: {e}"
+                profile_results = [
+                    (False, cycle_error) for _ in profile_homes
+                ]
+
+            # Persist each profile's liveness and failure reason independently.
+            # A broken profile must not mark healthy siblings failed, retain
+            # their stale error markers, or stop their heartbeat writes.
+            for index, entry in enumerate(profile_homes):
+                home = entry[1] if isinstance(entry, tuple) else entry
+                success, tick_error = profile_results[index]
+                try:
+                    home_token = set_hermes_home_override(str(home))
+                    try:
+                        with use_cron_store(home):
+                            record_ticker_heartbeat(success=success)
+                            if success:
+                                clear_ticker_error()
+                            elif tick_error:
+                                record_ticker_error(tick_error)
+                    finally:
+                        reset_hermes_home_override(home_token)
+                except BaseException as e:
+                    logger.error(
+                        "Cron heartbeat error for profile at %s: %s",
+                        home,
+                        e,
+                        exc_info=True,
+                    )
             stop_event.wait(interval)

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -414,3 +414,151 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+def test_multiplex_heartbeat_scoped_per_profile(tmp_path, monkeypatch):
+    """record_ticker_heartbeat is scoped to each profile's store under
+    multiplex, so 'hermes cron status' can report liveness per profile."""
+    from cron.scheduler_provider import InProcessCronScheduler
+    from cron.jobs import record_ticker_heartbeat as _real_heartbeat
+
+    p_default = tmp_path / "default"
+    p_sec = tmp_path / "home-ops"
+    for d in (p_default, p_sec):
+        (d / "cron").mkdir(parents=True)
+    profile_homes = [("default", p_default), ("home-ops", p_sec)]
+
+    beat_log: list[str] = []
+
+    def _track_beat(*, success=False):
+        beat_log.append(str(success))
+        # Write the real heartbeat files so we can check them after.
+        _real_heartbeat(success=success)
+
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+
+    with patch("cron.scheduler.tick", return_value=0), \
+         patch("cron.jobs.record_ticker_heartbeat", side_effect=_track_beat):
+        t = threading.Thread(
+            target=prov.start,
+            args=(stop,),
+            kwargs={"interval": 0, "profile_homes": profile_homes},
+            daemon=True,
+        )
+        t.start()
+        deadline = time.monotonic() + 10
+        # Wait for at least 2 tick iterations over all profiles (2 profiles).
+        while len(beat_log) < len(profile_homes) * 2 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+    # Every profile should have a heartbeat file.
+    assert (p_default / "cron" / "ticker_heartbeat").exists(), \
+        "default profile heartbeat file missing"
+    assert (p_sec / "cron" / "ticker_heartbeat").exists(), \
+        "secondary profile heartbeat file missing"
+
+
+def test_multiplex_ticker_isolates_profile_failures(tmp_path):
+    """A failure must not starve or retain errors for healthy siblings."""
+    from cron.jobs import get_ticker_last_error, record_ticker_error, use_cron_store
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_constants import get_hermes_home
+
+    failing_home = tmp_path / "failing"
+    healthy_home = tmp_path / "healthy"
+    for home in (failing_home, healthy_home):
+        (home / "cron").mkdir(parents=True)
+        with use_cron_store(home):
+            record_ticker_error("RuntimeError: stale failure")
+
+    stop = threading.Event()
+    tick_homes: list[str] = []
+
+    def _tick(*args, **kwargs):
+        home = str(get_hermes_home())
+        tick_homes.append(home)
+        if home == str(failing_home):
+            raise RuntimeError("profile-local failure")
+        stop.set()
+        return 0
+
+    provider = InProcessCronScheduler()
+    with patch("cron.scheduler.tick", side_effect=_tick):
+        thread = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": [
+                    ("failing", failing_home),
+                    ("healthy", healthy_home),
+                ],
+            },
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=5)
+        stop.set()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert str(healthy_home) in tick_homes
+    assert not (failing_home / "cron" / "ticker_last_success").exists()
+    assert (healthy_home / "cron" / "ticker_last_success").exists()
+    with use_cron_store(failing_home):
+        assert get_ticker_last_error() == "RuntimeError: profile-local failure"
+    with use_cron_store(healthy_home):
+        assert get_ticker_last_error() is None
+
+
+def test_multiplex_recovery_isolates_profile_failures(tmp_path):
+    """A recovery error in one profile must not abort scheduler startup."""
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_constants import get_hermes_home
+
+    failing_home = tmp_path / "failing"
+    healthy_home = tmp_path / "healthy"
+    for home in (failing_home, healthy_home):
+        (home / "cron").mkdir(parents=True)
+
+    stop = threading.Event()
+    recovery_homes: list[str] = []
+
+    def _recover():
+        home = str(get_hermes_home())
+        recovery_homes.append(home)
+        if home == str(failing_home):
+            raise RuntimeError("profile-local recovery failure")
+        return 0
+
+    def _tick(*args, **kwargs):
+        stop.set()
+        return 0
+
+    provider = InProcessCronScheduler()
+    with (
+        patch.object(provider, "recover_interrupted", side_effect=_recover),
+        patch("cron.scheduler.tick", side_effect=_tick),
+        patch("cron.jobs.record_ticker_heartbeat", lambda **kwargs: None),
+    ):
+        thread = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": [
+                    ("failing", failing_home),
+                    ("healthy", healthy_home),
+                ],
+            },
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=5)
+        stop.set()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert recovery_homes == [str(failing_home), str(healthy_home)]


### PR DESCRIPTION
## Summary

Isolate each served profile during multiplex cron recovery, ticking, heartbeat recording, and ticker-error persistence.

The multiplex ticker added in #69377 iterates over every served profile, but the exception boundary previously wrapped the whole loop. If one profile raised, profiles later in the list were skipped for that cycle. Repeated failures could therefore starve otherwise healthy profiles indefinitely. The shared outcome also wrote the same heartbeat and `ticker_last_error` state to every profile.

## Changes

- catch startup recovery errors per profile so one broken store does not abort scheduler startup
- isolate the complete per-profile tick context and continue to later profiles after a failure
- track each profile's success and error independently
- record heartbeat plus the matching error write/clear inside that profile's cron-store scope
- isolate heartbeat/error persistence failures so they cannot suppress sibling updates
- add regressions for scoped heartbeats, tick failure isolation, startup recovery isolation, and per-store error markers

## Validation

- `scripts/run_tests.sh tests/cron/test_scheduler_provider.py tests/cron/test_cron_profile_isolation.py -q` — 24 passed
- `ruff check cron/scheduler_provider.py tests/cron/test_scheduler_provider.py tests/cron/test_cron_profile_isolation.py` — passed
- `python scripts/check-windows-footguns.py cron/scheduler_provider.py tests/cron/test_scheduler_provider.py tests/cron/test_cron_profile_isolation.py` — passed
- `git diff --check` — passed

Tested in an isolated Linux VM against current `main` (`f3cda0ceb`).