### PR TITLE
feat(image-gen): add Azure OpenAI and Foundry backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,10 +130,11 @@ config/mcporter.json
 hermes_cli/tui_dist/*
 hermes_cli/scripts/
 docs/superpowers/*
-# Working directory for the Hermes Agent's session state (~/.hermes/ at runtime;
+# Working directories for Hermes Agent session state (~/.hermes/ at runtime;
 # also created in-repo when an agent operates in this checkout). Plans, audit
-# logs, and per-session caches are never artifacts of the codebase.
+# logs, credentials, generated media, and per-session caches are never code.
 .hermes/
+.hermes-dev/
 
 # Desktop/bootstrap install marker written into the managed checkout root by the
 # bootstrap installer. It is Hermes-managed runtime state, never a code change —

--- a/agent/image_gen_registry.py
+++ b/agent/image_gen_registry.py
@@ -115,15 +115,17 @@ def get_active_provider() -> Optional[ImageGenProvider]:
 
     # 1. Explicit config wins — return regardless of is_available() so the
     #    user gets a precise downstream error message rather than a silent
-    #    backend switch.
+    #    backend switch. A missing registration also fails closed: selecting
+    #    one provider must never authorize a different paid provider.
     if configured:
         provider = snapshot.get(configured)
         if provider is not None:
             return provider
         logger.debug(
-            "image_gen.provider='%s' configured but not registered; falling back",
+            "image_gen.provider='%s' configured but not registered; failing closed",
             configured,
         )
+        return None
 
     # 2. Fallback: single registered provider — but only if it's actually
     #    available (no credentials = don't surface it as "active").

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4164,6 +4164,14 @@ OPTIONAL_ENV_VARS = {
         "category": "tool",
         "advanced": True,
     },
+    "AZURE_OPENAI_IMAGE_KEY": {
+        "description": "Azure OpenAI API key for image generation",
+        "prompt": "Azure OpenAI image API key",
+        "url": "https://ai.azure.com/",
+        "tools": ["image_generate"],
+        "password": True,
+        "category": "tool",
+    },
     "FAL_KEY": {
         "description": "FAL API key for image and video generation",
         "prompt": "FAL API key",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional, Set
 
 
 from hermes_cli.config import (
+    _set_nested,
     cfg_get,
     load_config, save_config, get_env_value, save_env_value,
 )
@@ -2322,12 +2323,144 @@ def _plugin_image_gen_providers() -> list[dict]:
             "badge": schema.get("badge", ""),
             "tag": schema.get("tag", ""),
             "env_vars": schema.get("env_vars", []),
+            "config_fields": schema.get("config_fields", []),
             "image_gen_plugin_name": provider.name,
         }
+        if callable(schema.get("readiness_check")):
+            row["readiness_check"] = schema["readiness_check"]
         if schema.get("post_setup"):
             row["post_setup"] = schema["post_setup"]
         rows.append(row)
     return rows
+
+
+def _normalize_provider_config_field(
+    field: dict,
+    value: object,
+) -> tuple[str, Optional[str]]:
+    """Apply a provider-owned normalizer to one non-secret setup value.
+
+    A ``config_fields`` entry may expose ``normalize(value) -> str``. The
+    callback owns provider-specific validation and canonicalization; raising
+    ``ValueError`` returns its concise correction to the shared setup UI.
+    """
+    normalized = value.strip() if isinstance(value, str) else ""
+    if not normalized:
+        return "", None
+
+    callback = field.get("normalize")
+    if not callable(callback):
+        return normalized, None
+
+    try:
+        result = callback(normalized)
+    except ValueError as exc:
+        correction = str(exc).strip()
+        return "", correction or "Enter a valid value for this provider."
+    except Exception:  # noqa: BLE001 - plugin callbacks must not break setup
+        logger.exception("Provider config field normalization failed")
+        return "", "This value could not be validated. Please try again."
+
+    if not isinstance(result, str) or not result.strip():
+        return "", "Enter a valid value for this provider."
+    return result.strip(), None
+
+
+def _required_provider_config_fields_present(provider: dict, config: dict) -> bool:
+    """Return whether all required non-secret fields are present and valid."""
+    fields = provider.get("config_fields", [])
+    if not isinstance(fields, list):
+        return True
+    for field in fields:
+        if not isinstance(field, dict) or not field.get("required"):
+            continue
+        key = field.get("key")
+        if not isinstance(key, str) or not key.strip():
+            continue
+        value = cfg_get(config, *key.strip().split("."), default=None)
+        normalized, correction = _normalize_provider_config_field(field, value)
+        if not normalized or correction:
+            return False
+    return True
+
+
+def _configure_provider_config_fields(
+    provider: dict,
+    config: dict,
+    *,
+    reconfigure: bool = False,
+) -> bool:
+    """Prompt for provider-declared non-secret ``config.yaml`` fields.
+
+    Image backends can expose dotted ``config_fields`` alongside secret
+    ``env_vars`` in their setup schema. A field may provide a provider-owned
+    ``normalize`` callback for validation and canonicalization. Invalid input
+    is never written: the shared UI shows the callback's correction and
+    re-prompts. Values never pass through credential storage or password UX.
+
+    Returns ``True`` when every required field has a valid non-blank value.
+    """
+    fields = provider.get("config_fields", [])
+    if not isinstance(fields, list):
+        return True
+
+    all_configured = True
+    for field in fields:
+        if not isinstance(field, dict):
+            continue
+        key = field.get("key")
+        if not isinstance(key, str) or not key.strip():
+            continue
+        key = key.strip()
+
+        existing = cfg_get(config, *key.split("."), default=None)
+        existing_text, existing_error = _normalize_provider_config_field(
+            field, existing
+        )
+        required = bool(field.get("required"))
+
+        if existing_text and not existing_error and not reconfigure:
+            if existing_text != existing:
+                _set_nested(config, key, existing_text)
+            _print_success(f"  {key}: already configured")
+            continue
+
+        default = (
+            existing_text
+            if not existing_error
+            else ""
+        ) or str(field.get("default") or "").strip()
+        prompt = str(field.get("prompt") or key)
+        if reconfigure:
+            prompt = f"{prompt} (Enter to keep current)"
+
+        while True:
+            # These values are explicitly non-secret. Ignore password-shaped
+            # metadata so provider config never enters credential storage/UX.
+            value = _prompt(f"    {prompt}", default or None, password=False)
+            entered = value.strip() if isinstance(value, str) else ""
+            if not entered:
+                if required and not existing_text:
+                    _print_warning(f"    Skipped required setting: {key}")
+                    all_configured = False
+                else:
+                    _print_info(
+                        "    Kept current" if existing_text else "    Skipped"
+                    )
+                break
+
+            normalized, correction = _normalize_provider_config_field(
+                field, entered
+            )
+            if correction:
+                _print_warning(f"    {correction}")
+                continue
+
+            _set_nested(config, key, normalized)
+            _print_success("    Saved")
+            break
+
+    return all_configured
 
 
 def _plugin_video_gen_providers() -> list[dict]:
@@ -2769,8 +2902,9 @@ def provider_readiness_status(
     - ``"needs_auth"``  — needs a sign-in: Nous Portal login/entitlement for
       managed Tool Gateway rows, or xAI Grok OAuth / XAI_API_KEY for
       ``post_setup: "xai_grok"`` rows.
-    - ``"needs_setup"`` — keyless row whose ``post_setup`` install hook has
-      verifiably not run yet (see ``_POST_SETUP_READY``).
+    - ``"needs_setup"`` — a required non-secret config field is empty, or a
+      keyless row's ``post_setup`` install hook has verifiably not run yet
+      (see ``_POST_SETUP_READY``).
 
     Keyless ≠ usable: this is the server-side truth the GUI "Ready" pill
     renders from (the old client-side heuristic showed Ready for every
@@ -2782,10 +2916,33 @@ def provider_readiness_status(
     (selecting a row runs its hook, so the active row has been set up).
     """
     env_vars = provider.get("env_vars", [])
-    if env_vars:
-        if all(get_env_value(e["key"]) for e in env_vars):
-            return "ready"
+    required_env_vars = [
+        entry
+        for entry in env_vars
+        if isinstance(entry, dict) and entry.get("required", True)
+    ]
+    if required_env_vars and not all(
+        get_env_value(entry["key"]) for entry in required_env_vars
+    ):
         return "needs_keys"
+
+    # Required config.yaml settings are setup state, not credentials. Check
+    # them only after credential presence so the UI can give the right action.
+    if not _required_provider_config_fields_present(provider, config):
+        return "needs_setup"
+
+    # Plugin setup metadata may provide an endpoint-aware readiness predicate
+    # when a credential is optional only for some configurations. Keeping that
+    # decision at the provider edge avoids making a key globally mandatory.
+    readiness_check = provider.get("readiness_check")
+    if callable(readiness_check):
+        try:
+            status = readiness_check(config, get_env_value)
+        except Exception:
+            return "needs_setup"
+        if status in {"ready", "needs_keys", "needs_auth", "needs_setup"}:
+            return status
+        return "needs_setup"
 
     managed_feature = provider.get("managed_nous_feature")
     if provider.get("requires_nous_auth") or managed_feature:
@@ -3556,8 +3713,9 @@ def _configure_provider(
     *,
     force_fresh: bool = True,
 ):
-    """Configure a single provider - prompt for API keys and set config."""
+    """Configure a single provider - prompt for secrets and non-secret settings."""
     env_vars = provider.get("env_vars", [])
+    config_fields = provider.get("config_fields", [])
     managed_feature = provider.get("managed_nous_feature")
 
     # Nous-managed Tool Gateway backends are always listed (see
@@ -3621,7 +3779,7 @@ def _configure_provider(
     # there is a single source of truth for these writes.
     _write_provider_config(provider, config, managed_feature=managed_feature)
 
-    if not env_vars:
+    if not env_vars and not config_fields:
         if provider.get("post_setup"):
             _run_post_setup(provider["post_setup"])
         _print_success(f"  {provider['name']} - no configuration needed!")
@@ -3702,7 +3860,14 @@ def _configure_provider(
                 _print_success("    Saved")
             else:
                 _print_warning("    Skipped")
-                all_configured = False
+                if var.get("required", True):
+                    all_configured = False
+
+    if config_fields:
+        all_configured = (
+            _configure_provider_config_fields(provider, config)
+            and all_configured
+        )
 
     # Run post-setup hooks if needed
     if provider.get("post_setup") and all_configured:
@@ -4040,8 +4205,9 @@ def _reconfigure_provider(
     *,
     force_fresh: bool = True,
 ):
-    """Reconfigure a provider - update API keys."""
+    """Reconfigure a provider's secrets and non-secret settings."""
     env_vars = provider.get("env_vars", [])
+    config_fields = provider.get("config_fields", [])
     managed_feature = provider.get("managed_nous_feature")
 
     # Same inline Nous Portal login + entitlement gate as _configure_provider:
@@ -4116,7 +4282,7 @@ def _reconfigure_provider(
                     section["use_gateway"] = False
                 break
 
-    if not env_vars:
+    if not env_vars and not config_fields:
         if provider.get("post_setup"):
             _run_post_setup(provider["post_setup"])
         _print_success(f"  {provider['name']} - no configuration needed!")
@@ -4156,6 +4322,13 @@ def _reconfigure_provider(
             _print_success("    Updated")
         else:
             _print_info("    Kept current")
+
+    if config_fields:
+        _configure_provider_config_fields(
+            provider,
+            config,
+            reconfigure=True,
+        )
 
     if provider.get("post_setup"):
         _run_post_setup(provider["post_setup"])

--- a/plugins/image_gen/azure-openai/__init__.py
+++ b/plugins/image_gen/azure-openai/__init__.py
@@ -1,0 +1,549 @@
+"""Azure OpenAI image generation backend.
+
+The provider is registered through the existing image-generation plugin edge.
+This module owns Azure's setup metadata and profile-aware configuration
+resolution; native SDK request handling is implemented separately.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Optional, Union
+from urllib.parse import urlsplit
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+)
+
+
+DEFAULT_AZURE_IMAGE_API_VERSION = "2024-10-21"
+DEFAULT_API_VERSION = DEFAULT_AZURE_IMAGE_API_VERSION
+
+_IMAGE_PROVIDER_SETUP_ACTION = (
+    "Run hermes tools, open Image Generation, then configure credentials "
+    "or select another provider."
+)
+_AZURE_ENDPOINT_CORRECTION = (
+    "Use https://<resource>.services.ai.azure.com/openai/v1 for Foundry, "
+    "or https://<resource>.openai.azure.com for direct Azure OpenAI."
+)
+
+_ENDPOINT_CONFIG_KEY = "image_gen.azure_openai.endpoint"
+_DEPLOYMENT_CONFIG_KEY = "image_gen.azure_openai.deployment_name"
+
+EndpointFamily = Literal["azure-openai", "foundry-v1"]
+
+
+@dataclass(frozen=True)
+class AzureImageSettings:
+    """Complete, normalized settings required by an Azure image client."""
+
+    endpoint: str
+    api_key: Optional[str]
+    deployment_name: str
+    api_version: Optional[str]
+    endpoint_family: EndpointFamily
+
+
+@dataclass(frozen=True)
+class AzureImageConfigurationError:
+    """A missing or invalid Azure setting without retaining credentials."""
+
+    field: str
+    error_type: str
+    message: str
+    canonical_key: Optional[str] = None
+    setup_action: Optional[str] = None
+
+    @property
+    def config_key(self) -> Optional[str]:
+        """Backward-friendly alias for callers building provider responses."""
+        return self.canonical_key
+
+    @property
+    def missing_field(self) -> str:
+        """Explicit alias used by readiness and error-mapping callers."""
+        return self.field
+
+
+def _trimmed(value: object) -> Optional[str]:
+    """Return a stripped non-empty string, otherwise ``None``."""
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _azure_config(config: Mapping[str, object]) -> Mapping[str, object]:
+    image_gen = config.get("image_gen")
+    if not isinstance(image_gen, Mapping):
+        return {}
+    azure = image_gen.get("azure_openai")
+    return azure if isinstance(azure, Mapping) else {}
+
+
+def normalize_azure_image_endpoint(
+    endpoint: str,
+) -> Optional[tuple[str, EndpointFamily]]:
+    """Normalize and classify supported Azure image endpoint families.
+
+    Foundry's OpenAI-compatible endpoint is already a complete ``base_url``;
+    direct Azure OpenAI resources instead use the SDK's ``azure_endpoint``.
+    Query strings, fragments, embedded credentials, non-default ports, and
+    unexpected paths are rejected so routing cannot silently switch families.
+    """
+    try:
+        parsed = urlsplit(endpoint.strip())
+        port = parsed.port
+    except (TypeError, ValueError):
+        return None
+    if (
+        parsed.scheme.lower() != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in (None, 443)
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+
+    hostname = parsed.hostname.lower().rstrip(".")
+    path = parsed.path.rstrip("/")
+
+    if hostname.endswith(".services.ai.azure.com") and path.lower() == "/openai/v1":
+        return f"https://{hostname}/openai/v1", "foundry-v1"
+    if hostname.endswith(".openai.azure.com") and not path:
+        return f"https://{hostname}", "azure-openai"
+    return None
+
+
+def normalize_azure_image_setup_endpoint(endpoint: str) -> str:
+    """Validate and canonicalize an endpoint entered through provider setup."""
+    normalized = normalize_azure_image_endpoint(endpoint)
+    if normalized is None:
+        raise ValueError(_AZURE_ENDPOINT_CORRECTION)
+    return normalized[0]
+
+
+def resolve_azure_image_settings(
+    config: Mapping[str, object],
+    environ: Mapping[str, str],
+) -> Union[AzureImageSettings, AzureImageConfigurationError]:
+    """Resolve endpoint-family-aware settings without mutating either input."""
+    azure = _azure_config(config)
+    api_key = _trimmed(environ.get("AZURE_OPENAI_IMAGE_KEY"))
+    endpoint = _trimmed(azure.get("endpoint")) or _trimmed(
+        environ.get("AZURE_OPENAI_ENDPOINT")
+    )
+    deployment_name = _trimmed(azure.get("deployment_name")) or _trimmed(
+        environ.get("AZURE_IMAGE_DEPLOYMENT_NAME")
+    )
+
+    if endpoint is None:
+        return AzureImageConfigurationError(
+            field="endpoint",
+            error_type="configuration_error",
+            message="Azure OpenAI image endpoint is not configured.",
+            canonical_key=_ENDPOINT_CONFIG_KEY,
+            setup_action=_IMAGE_PROVIDER_SETUP_ACTION,
+        )
+    if deployment_name is None:
+        return AzureImageConfigurationError(
+            field="deployment_name",
+            error_type="configuration_error",
+            message="Azure OpenAI image deployment is not configured.",
+            canonical_key=_DEPLOYMENT_CONFIG_KEY,
+            setup_action=_IMAGE_PROVIDER_SETUP_ACTION,
+        )
+
+    endpoint_info = normalize_azure_image_endpoint(endpoint)
+    if endpoint_info is None:
+        return AzureImageConfigurationError(
+            field="endpoint",
+            error_type="configuration_error",
+            message=(
+                "Azure OpenAI image endpoint is invalid. Use a Foundry OpenAI "
+                "v1 endpoint or a direct Azure OpenAI resource endpoint."
+            ),
+            canonical_key=_ENDPOINT_CONFIG_KEY,
+            setup_action=_IMAGE_PROVIDER_SETUP_ACTION,
+        )
+
+    normalized_endpoint, endpoint_family = endpoint_info
+    if api_key is None and endpoint_family == "azure-openai":
+        return AzureImageConfigurationError(
+            field="api_key",
+            error_type="auth_required",
+            message=(
+                "Authentication is required for the configured image provider "
+                "(Azure OpenAI)."
+            ),
+            setup_action=_IMAGE_PROVIDER_SETUP_ACTION,
+        )
+
+    api_version = None
+    if endpoint_family == "azure-openai":
+        api_version = (
+            _trimmed(azure.get("api_version")) or DEFAULT_AZURE_IMAGE_API_VERSION
+        )
+
+    return AzureImageSettings(
+        endpoint=normalized_endpoint,
+        api_key=api_key,
+        deployment_name=deployment_name,
+        api_version=api_version,
+        endpoint_family=endpoint_family,
+    )
+
+
+class AzureOpenAIImageGenProvider(ImageGenProvider):
+    """Azure OpenAI text-to-image provider registered as ``azure-openai``."""
+
+    @property
+    def name(self) -> str:
+        return "azure-openai"
+
+    @property
+    def display_name(self) -> str:
+        return "Azure OpenAI"
+
+    def is_available(self) -> bool:
+        """Return whether the SDK and structurally required settings exist."""
+        try:
+            import openai
+            from hermes_cli.config import load_config
+
+            settings = resolve_azure_image_settings(load_config(), os.environ)
+            if not isinstance(settings, AzureImageSettings):
+                return False
+            if settings.endpoint_family == "azure-openai":
+                return hasattr(openai, "AzureOpenAI")
+            if not hasattr(openai, "OpenAI"):
+                return False
+            if settings.api_key:
+                return True
+
+            from agent.azure_identity_adapter import has_azure_identity_installed
+
+            return has_azure_identity_installed()
+        except Exception:  # noqa: BLE001 - picker readiness must remain defensive
+            return False
+
+    def picker_readiness_status(
+        self,
+        config: Mapping[str, object],
+        get_secret: Any,
+    ) -> str:
+        """Return endpoint-aware auth readiness without minting a token."""
+        environ = dict(os.environ)
+        api_key = _trimmed(get_secret("AZURE_OPENAI_IMAGE_KEY"))
+        if api_key is None:
+            environ.pop("AZURE_OPENAI_IMAGE_KEY", None)
+        else:
+            environ["AZURE_OPENAI_IMAGE_KEY"] = api_key
+
+        settings = resolve_azure_image_settings(config, environ)
+        if isinstance(settings, AzureImageConfigurationError):
+            return "needs_keys" if settings.field == "api_key" else "needs_setup"
+        if settings.endpoint_family != "foundry-v1" or settings.api_key:
+            return "ready"
+
+        from agent.azure_identity_adapter import has_azure_identity_installed
+
+        return "ready" if has_azure_identity_installed() else "needs_auth"
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": self.display_name,
+            "badge": "paid",
+            "tag": "Azure OpenAI and Foundry image deployments — text-to-image",
+            "env_vars": [
+                {
+                    "key": "AZURE_OPENAI_IMAGE_KEY",
+                    "prompt": "Azure OpenAI image API key (optional with Foundry Entra ID)",
+                    "password": True,
+                    "required": False,
+                },
+            ],
+            "config_fields": [
+                {
+                    "key": _ENDPOINT_CONFIG_KEY,
+                    "prompt": "Azure endpoint (resource root or Foundry /openai/v1)",
+                    "required": True,
+                    "normalize": normalize_azure_image_setup_endpoint,
+                },
+                {
+                    "key": _DEPLOYMENT_CONFIG_KEY,
+                    "prompt": "Azure image deployment",
+                    "required": True,
+                },
+            ],
+            "readiness_check": self.picker_readiness_status,
+        }
+
+    def capabilities(self) -> Dict[str, Any]:
+        return {"modalities": ["text"], "max_reference_images": 0}
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        *,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Generate and materialize an Azure image response."""
+        import base64
+
+        from agent.image_gen_provider import (
+            normalize_reference_images,
+            resolve_aspect_ratio,
+            save_b64_image,
+            save_url_image,
+            success_response,
+        )
+
+        normalized_prompt = prompt.strip() if isinstance(prompt, str) else ""
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        has_source_image = bool(
+            (isinstance(image_url, str) and image_url.strip())
+            or normalize_reference_images(reference_image_urls)
+        )
+        if has_source_image:
+            return error_response(
+                error=(
+                    "Azure OpenAI image generation is text-to-image only; "
+                    "image_url and reference_image_urls are unsupported."
+                ),
+                error_type="modality_unsupported",
+                provider=self.name,
+                prompt=normalized_prompt,
+                aspect_ratio=aspect,
+            )
+
+        if not normalized_prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider=self.name,
+                aspect_ratio=aspect,
+            )
+
+        from hermes_cli.config import load_config
+
+        settings = resolve_azure_image_settings(load_config(), os.environ)
+        if isinstance(settings, AzureImageConfigurationError):
+            error = settings.message
+            if settings.setup_action:
+                error = f"{error} {settings.setup_action}"
+            payload = error_response(
+                error=error,
+                error_type=settings.error_type,
+                provider=self.name,
+                prompt=normalized_prompt,
+                aspect_ratio=aspect,
+            )
+            if settings.setup_action:
+                payload["setup_action"] = settings.setup_action
+            if settings.config_key:
+                payload["config_key"] = settings.config_key
+            return payload
+
+        def sanitized_exception_text(exc: BaseException) -> str:
+            """Remove the exact Azure key before an exception reaches any sink."""
+            try:
+                text = str(exc)
+            except Exception:  # noqa: BLE001 - hostile exceptions stay safe
+                text = type(exc).__name__
+            if settings.api_key:
+                text = text.replace(settings.api_key, "[REDACTED]")
+
+            from agent.redact import redact_sensitive_text
+
+            return redact_sensitive_text(text, force=True)
+
+        try:
+            import openai
+        except ImportError:
+            return error_response(
+                error="openai Python package not installed (pip install openai)",
+                error_type="missing_dependency",
+                provider=self.name,
+                model=settings.deployment_name,
+                prompt=normalized_prompt,
+                aspect_ratio=aspect,
+            )
+
+        sizes = {
+            "landscape": "1536x1024",
+            "square": "1024x1024",
+            "portrait": "1024x1536",
+        }
+        size = sizes.get(aspect, sizes[DEFAULT_ASPECT_RATIO])
+
+        # The deployment name is authoritative; generic model/quality kwargs
+        # are deliberately ignored. Foundry's endpoint is already a complete
+        # OpenAI-compatible base URL and must never receive Azure REST options.
+        if settings.endpoint_family == "foundry-v1" and settings.api_key is None:
+            from agent.azure_identity_adapter import has_azure_identity_installed
+
+            if not has_azure_identity_installed():
+                payload = error_response(
+                    error=(
+                        "Authentication is required for the configured image "
+                        "provider (Azure OpenAI). "
+                        f"{_IMAGE_PROVIDER_SETUP_ACTION}"
+                    ),
+                    error_type="auth_required",
+                    provider=self.name,
+                    model=settings.deployment_name,
+                    prompt=normalized_prompt,
+                    aspect_ratio=aspect,
+                )
+                payload["setup_action"] = _IMAGE_PROVIDER_SETUP_ACTION
+                return payload
+
+        try:
+            if settings.endpoint_family == "foundry-v1":
+                api_credential: Any = settings.api_key
+                if api_credential is None:
+                    from agent.azure_identity_adapter import (
+                        SCOPE_AI_AZURE_DEFAULT,
+                        build_token_provider,
+                    )
+
+                    api_credential = build_token_provider(
+                        scope=SCOPE_AI_AZURE_DEFAULT
+                    )
+                client = openai.OpenAI(
+                    base_url=settings.endpoint,
+                    api_key=api_credential,
+                )
+            else:
+                client = openai.AzureOpenAI(
+                    api_key=settings.api_key,
+                    azure_endpoint=settings.endpoint,
+                    api_version=settings.api_version,
+                )
+        except Exception as exc:  # noqa: BLE001 - SDK boundary
+            import logging
+
+            safe_error = sanitized_exception_text(exc)
+            logging.getLogger(__name__).error(
+                "Azure image client construction failed: %s", safe_error
+            )
+            return error_response(
+                error=f"Could not initialize Azure image client: {safe_error}",
+                error_type="api_error",
+                provider=self.name,
+                model=settings.deployment_name,
+                prompt=normalized_prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            response = client.images.generate(
+                model=settings.deployment_name,
+                prompt=normalized_prompt,
+                size=size,
+                n=1,
+            )
+        except Exception as exc:  # noqa: BLE001 - SDK boundary
+            import logging
+
+            safe_error = sanitized_exception_text(exc)
+            logging.getLogger(__name__).error(
+                "Azure OpenAI image generation failed: %s", safe_error
+            )
+            return error_response(
+                error=f"Azure OpenAI image generation failed: {safe_error}",
+                error_type="api_error",
+                provider=self.name,
+                model=settings.deployment_name,
+                prompt=normalized_prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            data = getattr(response, "data", None)
+            first = data[0] if data else None
+            b64 = getattr(first, "b64_json", None) if first is not None else None
+            url = getattr(first, "url", None) if first is not None else None
+            revised_prompt = (
+                getattr(first, "revised_prompt", None) if first is not None else None
+            )
+        except (IndexError, KeyError, TypeError):
+            b64 = url = revised_prompt = None
+
+        if isinstance(b64, str) and b64.strip():
+            b64 = b64.strip()
+            try:
+                # Validate separately so malformed service output is classified
+                # as an empty response, not as a local cache I/O failure.
+                base64.b64decode(b64, validate=True)
+            except (ValueError, TypeError):
+                return error_response(
+                    error="Azure OpenAI returned invalid base64 image data",
+                    error_type="empty_response",
+                    provider=self.name,
+                    model=settings.deployment_name,
+                    prompt=normalized_prompt,
+                    aspect_ratio=aspect,
+                )
+
+            try:
+                saved_path = save_b64_image(b64, prefix="azure_openai")
+            except Exception as exc:  # noqa: BLE001 - persistence boundary
+                safe_error = sanitized_exception_text(exc)
+                return error_response(
+                    error=f"Could not save Azure OpenAI image to cache: {safe_error}",
+                    error_type="io_error",
+                    provider=self.name,
+                    model=settings.deployment_name,
+                    prompt=normalized_prompt,
+                    aspect_ratio=aspect,
+                )
+            image_ref = str(saved_path)
+        elif isinstance(url, str) and url.strip():
+            url = url.strip()
+            try:
+                saved_path = save_url_image(url, prefix="azure_openai")
+            except Exception:  # noqa: BLE001 - original URL is the required fallback
+                image_ref = url
+            else:
+                image_ref = str(saved_path)
+        else:
+            return error_response(
+                error="Azure OpenAI response contained neither b64_json nor URL",
+                error_type="empty_response",
+                provider=self.name,
+                model=settings.deployment_name,
+                prompt=normalized_prompt,
+                aspect_ratio=aspect,
+            )
+
+        extra: Dict[str, Any] = {"size": size}
+        if isinstance(revised_prompt, str) and revised_prompt:
+            extra["revised_prompt"] = revised_prompt
+
+        return success_response(
+            image=image_ref,
+            model=settings.deployment_name,
+            prompt=normalized_prompt,
+            aspect_ratio=aspect,
+            provider=self.name,
+            modality="text",
+            extra=extra,
+        )
+
+
+def register(ctx) -> None:
+    """Register the Azure OpenAI image provider with the shared registry."""
+    ctx.register_image_gen_provider(AzureOpenAIImageGenProvider())

--- a/plugins/image_gen/azure-openai/__init__.py
+++ b/plugins/image_gen/azure-openai/__init__.py
@@ -23,9 +23,21 @@ from agent.image_gen_provider import (
 DEFAULT_AZURE_IMAGE_API_VERSION = "2024-10-21"
 DEFAULT_API_VERSION = DEFAULT_AZURE_IMAGE_API_VERSION
 
-_IMAGE_PROVIDER_SETUP_ACTION = (
-    "Run hermes tools, open Image Generation, then configure credentials "
+_AZURE_IMAGE_KEY_SETUP_ACTION = (
+    "Configure AZURE_OPENAI_IMAGE_KEY in Image Generation via hermes tools, "
     "or select another provider."
+)
+_AZURE_ENDPOINT_SETUP_ACTION = (
+    "Configure image_gen.azure_openai.endpoint in Image Generation via "
+    "hermes tools, or select another provider."
+)
+_AZURE_DEPLOYMENT_SETUP_ACTION = (
+    "Configure image_gen.azure_openai.deployment_name in Image Generation "
+    "via hermes tools, or select another provider."
+)
+_FOUNDRY_KEYLESS_SETUP_ACTION = (
+    "Configure AZURE_OPENAI_IMAGE_KEY, or install the optional azure-identity "
+    "package to use Foundry Entra ID authentication."
 )
 _AZURE_ENDPOINT_CORRECTION = (
     "Use https://<resource>.services.ai.azure.com/openai/v1 for Foundry, "
@@ -150,7 +162,7 @@ def resolve_azure_image_settings(
             error_type="configuration_error",
             message="Azure OpenAI image endpoint is not configured.",
             canonical_key=_ENDPOINT_CONFIG_KEY,
-            setup_action=_IMAGE_PROVIDER_SETUP_ACTION,
+            setup_action=_AZURE_ENDPOINT_SETUP_ACTION,
         )
     if deployment_name is None:
         return AzureImageConfigurationError(
@@ -158,7 +170,7 @@ def resolve_azure_image_settings(
             error_type="configuration_error",
             message="Azure OpenAI image deployment is not configured.",
             canonical_key=_DEPLOYMENT_CONFIG_KEY,
-            setup_action=_IMAGE_PROVIDER_SETUP_ACTION,
+            setup_action=_AZURE_DEPLOYMENT_SETUP_ACTION,
         )
 
     endpoint_info = normalize_azure_image_endpoint(endpoint)
@@ -171,7 +183,7 @@ def resolve_azure_image_settings(
                 "v1 endpoint or a direct Azure OpenAI resource endpoint."
             ),
             canonical_key=_ENDPOINT_CONFIG_KEY,
-            setup_action=_IMAGE_PROVIDER_SETUP_ACTION,
+            setup_action=_AZURE_ENDPOINT_SETUP_ACTION,
         )
 
     normalized_endpoint, endpoint_family = endpoint_info
@@ -183,7 +195,7 @@ def resolve_azure_image_settings(
                 "Authentication is required for the configured image provider "
                 "(Azure OpenAI)."
             ),
-            setup_action=_IMAGE_PROVIDER_SETUP_ACTION,
+            setup_action=_AZURE_IMAGE_KEY_SETUP_ACTION,
         )
 
     api_version = None
@@ -399,7 +411,7 @@ class AzureOpenAIImageGenProvider(ImageGenProvider):
                     error=(
                         "Authentication is required for the configured image "
                         "provider (Azure OpenAI). "
-                        f"{_IMAGE_PROVIDER_SETUP_ACTION}"
+                        f"{_FOUNDRY_KEYLESS_SETUP_ACTION}"
                     ),
                     error_type="auth_required",
                     provider=self.name,
@@ -407,7 +419,7 @@ class AzureOpenAIImageGenProvider(ImageGenProvider):
                     prompt=normalized_prompt,
                     aspect_ratio=aspect,
                 )
-                payload["setup_action"] = _IMAGE_PROVIDER_SETUP_ACTION
+                payload["setup_action"] = _FOUNDRY_KEYLESS_SETUP_ACTION
                 return payload
 
         try:

--- a/plugins/image_gen/azure-openai/plugin.yaml
+++ b/plugins/image_gen/azure-openai/plugin.yaml
@@ -1,0 +1,5 @@
+name: azure-openai
+version: 1.0.0
+description: "Azure OpenAI image generation backend for configured image deployments."
+author: Hermes Agent
+kind: backend

--- a/tests/agent/test_image_gen_registry.py
+++ b/tests/agent/test_image_gen_registry.py
@@ -93,18 +93,19 @@ class TestGetActiveProvider:
         active = image_gen_registry.get_active_provider()
         assert active is not None and active.name == "openai"
 
-    def test_missing_configured_provider_falls_back(self, tmp_path, monkeypatch):
+    def test_missing_configured_provider_does_not_select_another_paid_backend(
+        self, tmp_path, monkeypatch
+    ):
         import yaml
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "config.yaml").write_text(
-            yaml.safe_dump({"image_gen": {"provider": "replicate"}})
+            yaml.safe_dump({"image_gen": {"provider": "azure-openai"}})
         )
-        # Only FAL is registered — configured provider doesn't exist
         image_gen_registry.register_provider(_FakeProvider("fal"))
-        active = image_gen_registry.get_active_provider()
-        # Falls back to FAL preference (legacy default) rather than None
-        assert active is not None and active.name == "fal"
+        image_gen_registry.register_provider(_FakeProvider("openai"))
+
+        assert image_gen_registry.get_active_provider() is None
 
     def test_none_when_empty(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/hermes_cli/test_image_gen_picker.py
+++ b/tests/hermes_cli/test_image_gen_picker.py
@@ -6,6 +6,7 @@ Covers `_plugin_image_gen_providers`, `_visible_providers`, and
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -50,7 +51,8 @@ class _FakeProvider(ImageGenProvider):
 
 
 @pytest.fixture(autouse=True)
-def _reset_registry():
+def _reset_registry(monkeypatch, tmp_path):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
     image_gen_registry._reset_for_tests()
     yield
     image_gen_registry._reset_for_tests()
@@ -277,3 +279,219 @@ class TestConfigWriting:
 
         assert config["image_gen"]["provider"] == "fal"
         assert config["image_gen"]["use_gateway"] is False
+
+
+class TestAzureSetupMetadata:
+    def test_azure_image_key_is_secret_tool_metadata_only(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        metadata = OPTIONAL_ENV_VARS["AZURE_OPENAI_IMAGE_KEY"]
+        assert metadata["password"] is True
+        assert metadata["category"] == "tool"
+        assert "image_generate" in metadata["tools"]
+        assert "AZURE_OPENAI_ENDPOINT" not in OPTIONAL_ENV_VARS
+        assert "AZURE_IMAGE_DEPLOYMENT_NAME" not in OPTIONAL_ENV_VARS
+
+    def test_image_provider_rows_preserve_non_secret_config_fields(self):
+        from hermes_cli import tools_config
+
+        fields = [
+            {
+                "key": "image_gen.azure_openai.endpoint",
+                "prompt": "Azure endpoint",
+                "required": True,
+            },
+        ]
+        image_gen_registry.register_provider(
+            _FakeProvider(
+                "config-fields-provider",
+                schema={
+                    "name": "Azure OpenAI",
+                    "env_vars": [{"key": "AZURE_OPENAI_IMAGE_KEY"}],
+                    "config_fields": fields,
+                },
+            )
+        )
+
+        row = next(
+            row
+            for row in tools_config._plugin_image_gen_providers()
+            if row["image_gen_plugin_name"] == "config-fields-provider"
+        )
+
+        assert row["config_fields"] == fields
+        assert row["env_vars"] == [{"key": "AZURE_OPENAI_IMAGE_KEY"}]
+
+
+class TestNonSecretProviderConfigFields:
+    def test_initial_setup_discovers_azure_and_writes_nested_fields_to_active_profile(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_cli import plugins as plugins_module
+        from hermes_cli import tools_config
+        from hermes_cli.config import read_raw_config
+
+        profile_home = tmp_path / ".hermes" / "profiles" / "azure"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        # Exercise real bundled-manifest discovery rather than manually
+        # registering the provider. Bundled backend manifests must auto-load
+        # without a plugins.enabled opt-in before the picker is built.
+        manager = plugins_module.PluginManager()
+        monkeypatch.setattr(plugins_module, "_plugin_manager", manager)
+        rows = tools_config._plugin_image_gen_providers()
+
+        loaded = manager._plugins["image_gen/azure-openai"]
+        assert loaded.manifest.source == "bundled"
+        assert loaded.manifest.kind == "backend"
+        assert loaded.manifest.requires_env == []
+        assert loaded.enabled is True, f"error: {loaded.error}"
+
+        provider_row = next(
+            row
+            for row in rows
+            if row.get("image_gen_plugin_name") == "azure-openai"
+        )
+        assert provider_row["name"] == "Azure OpenAI"
+
+        prompts = []
+        values = iter([
+            "https://example-resource.services.ai.azure.com/openai/v1",
+            "test-image-deployment",
+        ])
+
+        def prompt(question, default=None, password=False):
+            prompts.append((question, default, password))
+            if password:
+                return ""
+            return next(values)
+
+        monkeypatch.setattr(tools_config, "_prompt", prompt)
+        monkeypatch.setattr(tools_config, "get_env_value", lambda key: None)
+        monkeypatch.setattr(
+            tools_config,
+            "save_env_value",
+            lambda *args, **kwargs: pytest.fail("config fields must not use credential storage"),
+        )
+
+        config = {}
+        tools_config._configure_provider(provider_row, config)
+        tools_config.save_config(config)
+
+        saved = read_raw_config()
+        azure = saved["image_gen"]["azure_openai"]
+        assert azure == {
+            "endpoint": "https://example-resource.services.ai.azure.com/openai/v1",
+            "deployment_name": "test-image-deployment",
+        }
+        assert saved["image_gen"]["provider"] == "azure-openai"
+        assert (profile_home / "config.yaml").exists()
+        assert len(prompts) == 3
+        assert prompts[0][2] is True
+        assert all(password is False for _, _, password in prompts[1:])
+
+    def test_reconfigure_updates_visible_fields_and_keeps_blank_existing_value(self, monkeypatch):
+        from hermes_cli import tools_config
+
+        image_gen_registry.register_provider(_FakeProvider("azure-openai"))
+        answers = iter([
+            "https://new-resource.openai.azure.com",
+            "",
+            "2025-04-01-preview",
+        ])
+        prompts = []
+
+        def prompt(question, default=None, password=False):
+            prompts.append((question, default, password))
+            return next(answers)
+
+        monkeypatch.setattr(tools_config, "_prompt", prompt)
+
+        config = {
+            "image_gen": {
+                "provider": "azure-openai",
+                "azure_openai": {
+                    "endpoint": "https://old-resource.openai.azure.com",
+                    "deployment_name": "existing-deployment",
+                },
+            },
+        }
+        provider_row = {
+            "name": "Azure OpenAI",
+            "env_vars": [],
+            "config_fields": [
+                {"key": "image_gen.azure_openai.endpoint", "required": True},
+                {"key": "image_gen.azure_openai.deployment_name", "required": True},
+                {"key": "image_gen.azure_openai.api_version", "required": False},
+            ],
+            "image_gen_plugin_name": "azure-openai",
+        }
+
+        tools_config._reconfigure_provider(provider_row, config)
+
+        azure = config["image_gen"]["azure_openai"]
+        assert azure["endpoint"] == "https://new-resource.openai.azure.com"
+        assert azure["deployment_name"] == "existing-deployment"
+        assert azure["api_version"] == "2025-04-01-preview"
+        assert all(password is False for _, _, password in prompts)
+
+
+def test_provider_readiness_is_endpoint_auth_aware(monkeypatch):
+    from agent import azure_identity_adapter
+    from hermes_cli import plugins as plugins_module
+    from hermes_cli import tools_config
+
+    manager = plugins_module.PluginManager()
+    monkeypatch.setattr(plugins_module, "_plugin_manager", manager)
+    provider = next(
+        row
+        for row in tools_config._plugin_image_gen_providers()
+        if row.get("image_gen_plugin_name") == "azure-openai"
+    )
+    credentials = {"AZURE_OPENAI_IMAGE_KEY": None}
+    monkeypatch.setattr(
+        tools_config, "get_env_value", lambda key: credentials.get(key)
+    )
+
+    foundry_config = {
+        "image_gen": {
+            "azure_openai": {
+                "endpoint": "https://example.services.ai.azure.com/openai/v1",
+                "deployment_name": "image-deployment",
+            },
+        },
+    }
+    direct_config = {
+        "image_gen": {
+            "azure_openai": {
+                "endpoint": "https://example.openai.azure.com",
+                "deployment_name": "image-deployment",
+            },
+        },
+    }
+
+    monkeypatch.setattr(
+        azure_identity_adapter, "has_azure_identity_installed", lambda: False
+    )
+    assert (
+        tools_config.provider_readiness_status(provider, foundry_config)
+        == "needs_auth"
+    )
+
+    monkeypatch.setattr(
+        azure_identity_adapter, "has_azure_identity_installed", lambda: True
+    )
+    assert tools_config.provider_readiness_status(provider, foundry_config) == "ready"
+    assert (
+        tools_config.provider_readiness_status(provider, direct_config)
+        == "needs_keys"
+    )
+
+    credentials["AZURE_OPENAI_IMAGE_KEY"] = "secret"
+    monkeypatch.setattr(
+        azure_identity_adapter, "has_azure_identity_installed", lambda: False
+    )
+    assert tools_config.provider_readiness_status(provider, foundry_config) == "ready"
+    assert tools_config.provider_readiness_status(provider, direct_config) == "ready"
+    assert tools_config.provider_readiness_status(provider, {}) == "needs_setup"

--- a/tests/plugins/image_gen/test_azure_openai_provider.py
+++ b/tests/plugins/image_gen/test_azure_openai_provider.py
@@ -1,0 +1,738 @@
+"""Focused tests for Azure OpenAI image settings resolution."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_PLUGIN_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "plugins"
+    / "image_gen"
+    / "azure-openai"
+    / "__init__.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "plugins.image_gen.azure_openai_test_plugin", _PLUGIN_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+azure_plugin = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = azure_plugin
+_SPEC.loader.exec_module(azure_plugin)
+
+
+def _config(endpoint="canonical-endpoint", deployment="canonical-deployment", **extra):
+    azure = {
+        "endpoint": endpoint,
+        "deployment_name": deployment,
+        **extra,
+    }
+    return {"image_gen": {"azure_openai": azure}}
+
+
+def test_resolver_trims_values_and_prefers_canonical_direct_azure_config():
+    config = _config(
+        endpoint="  https://canonical.openai.azure.com/  ",
+        deployment="  canonical-deployment  ",
+        api_version="  2025-04-01-preview  ",
+    )
+    environ = {
+        "AZURE_OPENAI_IMAGE_KEY": "  secret-key  ",
+        "AZURE_OPENAI_ENDPOINT": "https://compat.openai.azure.com",
+        "AZURE_IMAGE_DEPLOYMENT_NAME": "compat-deployment",
+    }
+
+    result = azure_plugin.resolve_azure_image_settings(config, environ)
+
+    assert result == azure_plugin.AzureImageSettings(
+        endpoint="https://canonical.openai.azure.com",
+        api_key="secret-key",
+        deployment_name="canonical-deployment",
+        api_version="2025-04-01-preview",
+        endpoint_family="azure-openai",
+    )
+
+
+def test_resolver_normalizes_foundry_v1_and_ignores_azure_rest_api_version():
+    result = azure_plugin.resolve_azure_image_settings(
+        _config(
+            endpoint=" https://example-resource.services.ai.azure.com/openai/v1/ ",
+            deployment=" test-image-deployment ",
+            api_version="2099-01-01-test",
+        ),
+        {"AZURE_OPENAI_IMAGE_KEY": "key"},
+    )
+
+    assert result == azure_plugin.AzureImageSettings(
+        endpoint="https://example-resource.services.ai.azure.com/openai/v1",
+        api_key="key",
+        deployment_name="test-image-deployment",
+        api_version=None,
+        endpoint_family="foundry-v1",
+    )
+
+
+def test_resolver_uses_trimmed_compatibility_fallbacks_for_blank_config():
+    result = azure_plugin.resolve_azure_image_settings(
+        _config(endpoint=" \t", deployment="\n"),
+        {
+            "AZURE_OPENAI_IMAGE_KEY": "key",
+            "AZURE_OPENAI_ENDPOINT": "  https://compat.openai.azure.com/ ",
+            "AZURE_IMAGE_DEPLOYMENT_NAME": " compat-deployment ",
+        },
+    )
+
+    assert isinstance(result, azure_plugin.AzureImageSettings)
+    assert result.endpoint == "https://compat.openai.azure.com"
+    assert result.deployment_name == "compat-deployment"
+    assert result.api_version == azure_plugin.DEFAULT_AZURE_IMAGE_API_VERSION
+    assert result.endpoint_family == "azure-openai"
+
+
+@pytest.mark.parametrize(
+    ("config", "environ", "field", "error_type", "canonical_key"),
+    [
+        (
+            _config(endpoint="https://resource.openai.azure.com"),
+            {"AZURE_OPENAI_IMAGE_KEY": "  "},
+            "api_key",
+            "auth_required",
+            None,
+        ),
+        (
+            _config(endpoint=" "),
+            {"AZURE_OPENAI_IMAGE_KEY": "secret", "AZURE_OPENAI_ENDPOINT": ""},
+            "endpoint",
+            "configuration_error",
+            "image_gen.azure_openai.endpoint",
+        ),
+        (
+            _config(deployment=None),
+            {
+                "AZURE_OPENAI_IMAGE_KEY": "secret",
+                "AZURE_IMAGE_DEPLOYMENT_NAME": "\t",
+            },
+            "deployment_name",
+            "configuration_error",
+            "image_gen.azure_openai.deployment_name",
+        ),
+        (
+            _config(endpoint="https://example.invalid/openai/v1"),
+            {"AZURE_OPENAI_IMAGE_KEY": "secret"},
+            "endpoint",
+            "configuration_error",
+            "image_gen.azure_openai.endpoint",
+        ),
+    ],
+)
+def test_resolver_returns_field_specific_safe_results(
+    config, environ, field, error_type, canonical_key
+):
+    secret = environ.get("AZURE_OPENAI_IMAGE_KEY")
+
+    result = azure_plugin.resolve_azure_image_settings(config, environ)
+
+    assert isinstance(result, azure_plugin.AzureImageConfigurationError)
+    assert result.field == field
+    assert result.error_type == error_type
+    assert result.canonical_key == canonical_key
+    if secret and secret.strip():
+        assert secret.strip() not in result.message
+        assert secret.strip() not in (result.setup_action or "")
+
+
+def test_foundry_settings_allow_explicit_keyless_entra_path():
+    result = azure_plugin.resolve_azure_image_settings(
+        _config(
+            endpoint="https://example-resource.services.ai.azure.com/openai/v1",
+            deployment="test-image-deployment",
+        ),
+        {},
+    )
+
+    assert isinstance(result, azure_plugin.AzureImageSettings)
+    assert result.endpoint_family == "foundry-v1"
+    assert result.api_key is None
+
+
+def test_resolver_treats_non_mapping_and_non_string_values_as_missing():
+    result = azure_plugin.resolve_azure_image_settings(
+        {"image_gen": {"azure_openai": "invalid"}},
+        {
+            "AZURE_OPENAI_IMAGE_KEY": "key",
+            "AZURE_OPENAI_ENDPOINT": "https://resource.openai.azure.com",
+            "AZURE_IMAGE_DEPLOYMENT_NAME": 42,
+        },
+    )
+
+    assert isinstance(result, azure_plugin.AzureImageConfigurationError)
+    assert result.field == "deployment_name"
+
+
+class TestAzureOpenAIProviderRegistration:
+    def test_identity_setup_schema_and_text_only_capabilities(self):
+        provider = azure_plugin.AzureOpenAIImageGenProvider()
+
+        assert provider.name == "azure-openai"
+        assert provider.display_name == "Azure OpenAI"
+
+        schema = provider.get_setup_schema()
+        assert schema["name"] == "Azure OpenAI"
+        assert schema["badge"] == "paid"
+        assert schema["env_vars"] == [
+            {
+                "key": "AZURE_OPENAI_IMAGE_KEY",
+                "prompt": "Azure OpenAI image API key (optional with Foundry Entra ID)",
+                "password": True,
+                "required": False,
+            }
+        ]
+        assert schema["config_fields"] == [
+            {
+                "key": "image_gen.azure_openai.endpoint",
+                "prompt": "Azure endpoint (resource root or Foundry /openai/v1)",
+                "required": True,
+                "normalize": azure_plugin.normalize_azure_image_setup_endpoint,
+            },
+            {
+                "key": "image_gen.azure_openai.deployment_name",
+                "prompt": "Azure image deployment",
+                "required": True,
+            },
+        ]
+        assert provider.capabilities() == {
+            "modalities": ["text"],
+            "max_reference_images": 0,
+        }
+
+    @pytest.mark.parametrize(
+        ("endpoint", "key", "expected"),
+        [
+            ("https://resource.openai.azure.com", "secret", True),
+            ("https://resource.services.ai.azure.com/openai/v1", "secret", True),
+            ("https://resource.openai.azure.com", "", False),
+        ],
+    )
+    def test_availability_matches_endpoint_client_and_auth(
+        self, monkeypatch, endpoint, key, expected
+    ):
+        import hermes_cli.config as config_module
+
+        class OpenAIModule:
+            AzureOpenAI = object
+            OpenAI = object
+
+        monkeypatch.setitem(sys.modules, "openai", OpenAIModule())
+        monkeypatch.setenv("AZURE_OPENAI_IMAGE_KEY", key)
+        monkeypatch.setattr(
+            config_module,
+            "load_config",
+            lambda: _config(endpoint=endpoint, deployment="image-deployment"),
+        )
+
+        assert azure_plugin.AzureOpenAIImageGenProvider().is_available() is expected
+
+    def test_register_adds_exactly_one_provider(self):
+        registered = []
+
+        class Context:
+            def register_image_gen_provider(self, provider):
+                registered.append(provider)
+
+        azure_plugin.register(Context())
+
+        assert len(registered) == 1
+        assert isinstance(registered[0], azure_plugin.AzureOpenAIImageGenProvider)
+        assert registered[0].name == "azure-openai"
+
+
+class TestAzureOpenAIRequestConstruction:
+    @staticmethod
+    def _install_fake_sdk(monkeypatch):
+        calls = {"constructors": [], "requests": []}
+
+        class Images:
+            def generate(self, **kwargs):
+                calls["requests"].append(kwargs)
+                return object()
+
+        class AzureOpenAI:
+            def __init__(self, **kwargs):
+                calls["constructors"].append(("AzureOpenAI", kwargs))
+                self.images = Images()
+
+        class OpenAI:
+            def __init__(self, **kwargs):
+                calls["constructors"].append(("OpenAI", kwargs))
+                self.images = Images()
+
+        class OpenAIModule:
+            pass
+
+        OpenAIModule.AzureOpenAI = AzureOpenAI
+        OpenAIModule.OpenAI = OpenAI
+        monkeypatch.setitem(sys.modules, "openai", OpenAIModule())
+        return calls
+
+    @staticmethod
+    def _configure(
+        monkeypatch,
+        *,
+        endpoint="https://resource.openai.azure.com",
+        key=" resolved-key ",
+        api_version="2024-10-21",
+    ):
+        import hermes_cli.config as config_module
+
+        if key is None:
+            monkeypatch.delenv("AZURE_OPENAI_IMAGE_KEY", raising=False)
+        else:
+            monkeypatch.setenv("AZURE_OPENAI_IMAGE_KEY", key)
+        monkeypatch.setattr(
+            config_module,
+            "load_config",
+            lambda: _config(
+                endpoint=f" {endpoint} ",
+                deployment=" azure-image-deployment ",
+                api_version=f" {api_version} ",
+            ),
+        )
+
+    def test_direct_azure_constructs_native_client_and_exact_request(
+        self, monkeypatch
+    ):
+        calls = self._install_fake_sdk(monkeypatch)
+        self._configure(monkeypatch, api_version="2025-04-01-preview")
+
+        azure_plugin.AzureOpenAIImageGenProvider().generate(
+            "  paint a moonlit harbor  ",
+            aspect_ratio="square",
+            model="generic-model-must-be-ignored",
+            quality="unverified-param-must-not-be-forwarded",
+        )
+
+        assert calls["constructors"] == [
+            (
+                "AzureOpenAI",
+                {
+                    "api_key": "resolved-key",
+                    "azure_endpoint": "https://resource.openai.azure.com",
+                    "api_version": "2025-04-01-preview",
+                },
+            )
+        ]
+        assert calls["requests"] == [
+            {
+                "model": "azure-image-deployment",
+                "prompt": "paint a moonlit harbor",
+                "size": "1024x1024",
+                "n": 1,
+            }
+        ]
+
+    def test_foundry_constructs_openai_client_without_azure_rest_arguments(
+        self, monkeypatch
+    ):
+        calls = self._install_fake_sdk(monkeypatch)
+        self._configure(
+            monkeypatch,
+            endpoint="https://example-resource.services.ai.azure.com/openai/v1/",
+            api_version="2099-01-01-test",
+        )
+
+        azure_plugin.AzureOpenAIImageGenProvider().generate(
+            "  paint a moonlit harbor  ", aspect_ratio="square"
+        )
+
+        assert calls["constructors"] == [
+            (
+                "OpenAI",
+                {
+                    "base_url": (
+                        "https://example-resource.services.ai.azure.com/openai/v1"
+                    ),
+                    "api_key": "resolved-key",
+                },
+            )
+        ]
+        assert calls["requests"] == [
+            {
+                "model": "azure-image-deployment",
+                "prompt": "paint a moonlit harbor",
+                "size": "1024x1024",
+                "n": 1,
+            }
+        ]
+
+    def test_foundry_keyless_uses_shared_bearer_token_provider(self, monkeypatch):
+        from agent import azure_identity_adapter
+
+        calls = self._install_fake_sdk(monkeypatch)
+        token_provider = lambda: "token"  # noqa: E731 - SDK contract fixture
+        scopes = []
+        monkeypatch.setattr(
+            azure_identity_adapter, "has_azure_identity_installed", lambda: True
+        )
+        monkeypatch.setattr(
+            azure_identity_adapter,
+            "build_token_provider",
+            lambda *, scope: scopes.append(scope) or token_provider,
+        )
+        self._configure(
+            monkeypatch,
+            endpoint="https://resource.services.ai.azure.com/openai/v1",
+            key=None,
+        )
+
+        azure_plugin.AzureOpenAIImageGenProvider().generate("draw a fox")
+
+        assert scopes == ["https://ai.azure.com/.default"]
+        assert calls["constructors"] == [
+            (
+                "OpenAI",
+                {
+                    "base_url": "https://resource.services.ai.azure.com/openai/v1",
+                    "api_key": token_provider,
+                },
+            )
+        ]
+
+    def test_foundry_keyless_without_identity_is_actionable(self, monkeypatch):
+        from agent import azure_identity_adapter
+
+        calls = self._install_fake_sdk(monkeypatch)
+        monkeypatch.setattr(
+            azure_identity_adapter, "has_azure_identity_installed", lambda: False
+        )
+        self._configure(
+            monkeypatch,
+            endpoint="https://resource.services.ai.azure.com/openai/v1",
+            key=None,
+        )
+
+        result = azure_plugin.AzureOpenAIImageGenProvider().generate("draw a fox")
+
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+        assert "AZURE_OPENAI_IMAGE_KEY" in result["setup_action"]
+        assert "azure-identity" in result["setup_action"]
+        assert calls == {"constructors": [], "requests": []}
+
+    @pytest.mark.parametrize(
+        ("aspect_ratio", "expected_size"),
+        [
+            ("landscape", "1536x1024"),
+            ("square", "1024x1024"),
+            ("portrait", "1024x1536"),
+            ("unsupported", "1536x1024"),
+        ],
+    )
+    def test_maps_supported_sizes_and_defaults_invalid_aspects(
+        self, monkeypatch, aspect_ratio, expected_size
+    ):
+        calls = self._install_fake_sdk(monkeypatch)
+        self._configure(monkeypatch)
+
+        azure_plugin.AzureOpenAIImageGenProvider().generate(
+            "prompt", aspect_ratio=aspect_ratio
+        )
+
+        assert calls["requests"][0]["size"] == expected_size
+
+    @pytest.mark.parametrize(
+        ("image_url", "reference_image_urls"),
+        [
+            ("https://example.test/source.png", None),
+            (None, ["https://example.test/reference.png"]),
+        ],
+    )
+    def test_rejects_source_images_before_client_construction(
+        self, monkeypatch, image_url, reference_image_urls
+    ):
+        calls = self._install_fake_sdk(monkeypatch)
+
+        result = azure_plugin.AzureOpenAIImageGenProvider().generate(
+            "  edit this image  ",
+            image_url=image_url,
+            reference_image_urls=reference_image_urls,
+        )
+
+        assert result["success"] is False
+        assert result["error_type"] == "modality_unsupported"
+        assert result["prompt"] == "edit this image"
+        assert calls == {"constructors": [], "requests": []}
+
+
+class TestAzureOpenAIResponseMaterialization:
+    @staticmethod
+    def _response(*, b64=None, url=None, revised_prompt=None, include_data=True):
+        if not include_data:
+            return type("Response", (), {"data": []})()
+        image = type(
+            "GeneratedImage",
+            (),
+            {"b64_json": b64, "url": url, "revised_prompt": revised_prompt},
+        )()
+        return type("Response", (), {"data": [image]})()
+
+    @staticmethod
+    def _install_fake_sdk(monkeypatch, response):
+        class Images:
+            def generate(self, **kwargs):
+                return response
+
+        class AzureOpenAI:
+            def __init__(self, **kwargs):
+                self.images = Images()
+
+        class OpenAIModule:
+            pass
+
+        OpenAIModule.AzureOpenAI = AzureOpenAI
+        monkeypatch.setitem(sys.modules, "openai", OpenAIModule())
+
+    @staticmethod
+    def _configure(monkeypatch):
+        import hermes_cli.config as config_module
+
+        monkeypatch.setenv("AZURE_OPENAI_IMAGE_KEY", "secret")
+        monkeypatch.setattr(
+            config_module,
+            "load_config",
+            lambda: _config(
+                endpoint="https://resource.openai.azure.com",
+                deployment="azure-image-deployment",
+            ),
+        )
+
+    def test_base64_output_is_saved_under_profile_cache_with_response_identity(
+        self, monkeypatch
+    ):
+        from hermes_constants import get_hermes_home
+
+        self._install_fake_sdk(
+            monkeypatch,
+            self._response(b64="aGVybWVz", revised_prompt="a refined prompt"),
+        )
+        self._configure(monkeypatch)
+
+        result = azure_plugin.AzureOpenAIImageGenProvider().generate(
+            "  draw a lighthouse  ", aspect_ratio="portrait"
+        )
+
+        image_path = Path(result["image"])
+        assert result == {
+            "success": True,
+            "image": str(image_path),
+            "model": "azure-image-deployment",
+            "prompt": "draw a lighthouse",
+            "aspect_ratio": "portrait",
+            "modality": "text",
+            "provider": "azure-openai",
+            "size": "1024x1536",
+            "revised_prompt": "a refined prompt",
+        }
+        assert image_path.parent == get_hermes_home() / "cache" / "images"
+        assert image_path.read_bytes() == b"hermes"
+
+    def test_url_output_uses_shared_persistence_helper(self, monkeypatch, tmp_path):
+        import agent.image_gen_provider as image_helpers
+
+        original_url = "https://example.test/generated.png"
+        cached_path = tmp_path / "cached.png"
+        calls = []
+
+        def save_url(url, **kwargs):
+            calls.append((url, kwargs))
+            return cached_path
+
+        monkeypatch.setattr(image_helpers, "save_url_image", save_url)
+        self._install_fake_sdk(monkeypatch, self._response(url=original_url))
+        self._configure(monkeypatch)
+
+        result = azure_plugin.AzureOpenAIImageGenProvider().generate("draw a fox")
+
+        assert result["success"] is True
+        assert result["image"] == str(cached_path)
+        assert calls == [(original_url, {"prefix": "azure_openai"})]
+
+    def test_url_cache_failure_preserves_original_url(self, monkeypatch):
+        import agent.image_gen_provider as image_helpers
+
+        original_url = "https://example.test/ephemeral.png"
+
+        def fail_cache(*args, **kwargs):
+            raise OSError("cache unavailable")
+
+        monkeypatch.setattr(image_helpers, "save_url_image", fail_cache)
+        self._install_fake_sdk(monkeypatch, self._response(url=original_url))
+        self._configure(monkeypatch)
+
+        result = azure_plugin.AzureOpenAIImageGenProvider().generate("draw a fox")
+
+        assert result["success"] is True
+        assert result["image"] == original_url
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            _response.__func__(include_data=False),
+            _response.__func__(b64="%%%not-base64%%%"),
+        ],
+    )
+    def test_absent_or_invalid_output_returns_empty_response(
+        self, monkeypatch, response
+    ):
+        self._install_fake_sdk(monkeypatch, response)
+        self._configure(monkeypatch)
+
+        result = azure_plugin.AzureOpenAIImageGenProvider().generate("draw a fox")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+        assert result["model"] == "azure-image-deployment"
+
+    def test_base64_cache_failure_returns_sanitized_io_error(self, monkeypatch):
+        import agent.image_gen_provider as image_helpers
+
+        key = "cache-failure-azure-key-7Yq2"
+
+        def fail_cache(*args, **kwargs):
+            raise OSError(f"disk full while handling credential {key}")
+
+        monkeypatch.setattr(image_helpers, "save_b64_image", fail_cache)
+        self._install_fake_sdk(monkeypatch, self._response(b64="aGVybWVz"))
+        self._configure(monkeypatch)
+        monkeypatch.setenv("AZURE_OPENAI_IMAGE_KEY", key)
+
+        result = azure_plugin.AzureOpenAIImageGenProvider().generate("draw a fox")
+
+        assert result["success"] is False
+        assert result["error_type"] == "io_error"
+        assert result["model"] == "azure-image-deployment"
+        assert "[REDACTED]" in result["error"]
+        assert key not in result["error"]
+
+
+class TestAzureOpenAIFailureHandling:
+    @staticmethod
+    def _configure(monkeypatch, *, key, endpoint, deployment):
+        import hermes_cli.config as config_module
+
+        monkeypatch.delenv("AZURE_OPENAI_IMAGE_KEY", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        monkeypatch.delenv("AZURE_IMAGE_DEPLOYMENT_NAME", raising=False)
+        if key is not None:
+            monkeypatch.setenv("AZURE_OPENAI_IMAGE_KEY", key)
+        monkeypatch.setattr(
+            config_module,
+            "load_config",
+            lambda: _config(endpoint=endpoint, deployment=deployment),
+        )
+
+    @pytest.mark.parametrize(
+        (
+            "key",
+            "endpoint",
+            "deployment",
+            "error_type",
+            "setup_target",
+            "config_key",
+        ),
+        [
+            (
+                None,
+                "https://resource.openai.azure.com",
+                "image-deployment",
+                "auth_required",
+                "AZURE_OPENAI_IMAGE_KEY",
+                None,
+            ),
+            (
+                "azure-secret",
+                None,
+                "image-deployment",
+                "configuration_error",
+                "image_gen.azure_openai.endpoint",
+                "image_gen.azure_openai.endpoint",
+            ),
+            (
+                "azure-secret",
+                "https://resource.openai.azure.com",
+                None,
+                "configuration_error",
+                "image_gen.azure_openai.deployment_name",
+                "image_gen.azure_openai.deployment_name",
+            ),
+        ],
+    )
+    def test_missing_settings_return_actionable_standard_errors(
+        self,
+        monkeypatch,
+        key,
+        endpoint,
+        deployment,
+        error_type,
+        setup_target,
+        config_key,
+    ):
+        self._configure(
+            monkeypatch,
+            key=key,
+            endpoint=endpoint,
+            deployment=deployment,
+        )
+
+        result = azure_plugin.AzureOpenAIImageGenProvider().generate("draw a fox")
+
+        assert result["success"] is False
+        assert result["error_type"] == error_type
+        assert setup_target in result["error"]
+        assert setup_target in result["setup_action"]
+        if config_key is None:
+            assert "config_key" not in result
+        else:
+            assert result["config_key"] == config_key
+
+    @pytest.mark.parametrize("failure_stage", ["construction", "generation"])
+    def test_sdk_failures_are_api_errors_with_key_redacted_from_response_and_logs(
+        self, monkeypatch, caplog, failure_stage
+    ):
+        key = "arbitrary-azure-image-key-9Zx7"
+        self._configure(
+            monkeypatch,
+            key=key,
+            endpoint="https://resource.openai.azure.com",
+            deployment="image-deployment",
+        )
+
+        class Images:
+            def generate(self, **kwargs):
+                raise RuntimeError(f"Azure service echoed credential {key}")
+
+        class AzureOpenAI:
+            def __init__(self, **kwargs):
+                if failure_stage == "construction":
+                    raise RuntimeError(f"Azure client rejected credential {key}")
+                self.images = Images()
+
+        class OpenAIModule:
+            pass
+
+        OpenAIModule.AzureOpenAI = AzureOpenAI
+        monkeypatch.setitem(sys.modules, "openai", OpenAIModule())
+
+        with caplog.at_level("ERROR", logger=azure_plugin.__name__):
+            result = azure_plugin.AzureOpenAIImageGenProvider().generate("draw a fox")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert result["model"] == "image-deployment"
+        assert "[REDACTED]" in result["error"]
+        assert key not in result["error"]
+        assert key not in caplog.text
+        assert "[REDACTED]" in caplog.text

--- a/tests/plugins/image_gen/test_krea_provider.py
+++ b/tests/plugins/image_gen/test_krea_provider.py
@@ -206,7 +206,7 @@ class TestGenerate:
             result = KreaImageGenProvider().generate(prompt="A cinematic lamp")
 
         assert result["success"] is True
-        assert result["image"] == "/tmp/krea_krea-2-medium_test.png"
+        assert Path(result["image"]) == Path("/tmp/krea_krea-2-medium_test.png")
         assert result["provider"] == "krea"
         assert result["model"] == "krea-2-medium"
         assert result["aspect_ratio"] == "landscape"

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -310,7 +310,9 @@ class TestGenerate:
             result = provider.generate("a cat")
 
         assert result["success"] is True
-        assert result["image"].startswith("/")
+        assert Path(result["image"]) == Path(
+            "/tmp/openai_gpt-image-2_20260524_000000_deadbeef.png"
+        )
         assert "example.com" not in result["image"]
         mock_save_url.assert_called_once()
 

--- a/tests/plugins/image_gen/test_openrouter_compat_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_compat_provider.py
@@ -268,7 +268,7 @@ class TestGenerate:
             result = _openrouter().generate(prompt="a pet")
 
         assert result["success"] is True
-        assert result["image"] == "/tmp/openrouter_gen.png"
+        assert Path(result["image"]) == Path("/tmp/openrouter_gen.png")
         assert result["provider"] == "openrouter"
         mock_save.assert_called_once()
 
@@ -282,7 +282,7 @@ class TestGenerate:
             result = _openrouter().generate(prompt="a pet")
 
         assert result["success"] is True
-        assert result["image"] == "/tmp/openrouter_gen_url.png"
+        assert Path(result["image"]) == Path("/tmp/openrouter_gen_url.png")
         mock_save_url.assert_called_once()
 
     def test_empty_response(self):
@@ -420,7 +420,7 @@ class TestGenerate:
 
         assert result["success"] is True
         assert result["model"] == _FALLBACK_MODEL
-        assert result["image"] == "/tmp/openrouter_gen_fallback.png"
+        assert Path(result["image"]) == Path("/tmp/openrouter_gen_fallback.png")
         assert mock_post.call_count == 2
         first_model = mock_post.call_args_list[0].kwargs["json"]["model"]
         second_model = mock_post.call_args_list[1].kwargs["json"]["model"]

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -183,8 +183,10 @@ class TestGenerate:
             result = provider.generate(prompt="A cat playing piano")
 
         assert result["success"] is True
-        assert result["image"].startswith("/"), (
-            f"URL response must be cached to an absolute path, got {result['image']!r}"
+        assert Path(result["image"]) == Path(
+            "/tmp/xai_grok-imagine-image_20260524_000000_deadbeef.jpg"
+        ), (
+            f"URL response must preserve the cached path, got {result['image']!r}"
         )
         assert "imgen.x.ai" not in result["image"], (
             "ephemeral xAI URL must not leak into result.image — caller will 404"

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -422,7 +422,19 @@ class TestExtractHttpStatus:
 class TestManagedGatewayErrorTranslation:
     """4xx from the Nous managed gateway should be translated to a user-actionable message."""
 
-    def test_4xx_translates_to_value_error_with_remediation(self, image_tool, monkeypatch):
+    @pytest.fixture
+    def managed_fal_home(self, tmp_path, monkeypatch):
+        """Give fal_client a Windows home without changing runner semantics."""
+        from pathlib import Path
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    def test_4xx_translates_to_value_error_with_remediation(
+        self, image_tool, monkeypatch, managed_fal_home
+    ):
         """403 from managed gateway → ValueError mentioning FAL_KEY + hermes tools."""
         from unittest.mock import MagicMock
 
@@ -450,7 +462,9 @@ class TestManagedGatewayErrorTranslation:
         # Original exception chained for debugging
         assert exc_info.value.__cause__ is bad_request
 
-    def test_5xx_is_not_translated(self, image_tool, monkeypatch):
+    def test_5xx_is_not_translated(
+        self, image_tool, monkeypatch, managed_fal_home
+    ):
         """500s are real outages, not model-availability issues — don't rewrite them."""
         from unittest.mock import MagicMock
 
@@ -484,7 +498,9 @@ class TestManagedGatewayErrorTranslation:
         with pytest.raises(_MockHttpxError):
             image_tool._submit_fal_request("fal-ai/flux-2-pro", {"prompt": "x"})
 
-    def test_non_http_exception_from_managed_bubbles_up(self, image_tool, monkeypatch):
+    def test_non_http_exception_from_managed_bubbles_up(
+        self, image_tool, monkeypatch, managed_fal_home
+    ):
         """Connection errors, timeouts, etc. from managed mode aren't 4xx —
         they should bubble up unchanged so callers can retry or diagnose."""
         from unittest.mock import MagicMock

--- a/tests/tools/test_image_generation_artifacts.py
+++ b/tests/tools/test_image_generation_artifacts.py
@@ -1,6 +1,8 @@
 import json
 from types import SimpleNamespace
 
+import pytest
+
 
 def test_postprocess_adds_agent_visible_image_for_active_ssh_env(monkeypatch, tmp_path):
     from tools import image_generation_tool
@@ -88,6 +90,64 @@ def test_postprocess_leaves_remote_image_urls_unchanged(monkeypatch):
     assert image_generation_tool._postprocess_image_generate_result(raw) == raw
 
 
+def test_postprocess_preserves_raw_text_and_non_success_json_strings():
+    from tools import image_generation_tool
+
+    unchanged_results = (
+        "provider returned unparseable raw text",
+        json.dumps({"success": False, "error": "generation failed"}),
+        json.dumps("provider returned serialized text"),
+    )
+
+    for raw in unchanged_results:
+        result = image_generation_tool._postprocess_image_generate_result(raw)
+
+        assert isinstance(result, str)
+        assert result == raw
+
+
+def test_postprocess_requires_normalized_string_input():
+    from tools import image_generation_tool
+
+    with pytest.raises(TypeError, match="requires a normalized string"):
+        image_generation_tool._postprocess_image_generate_result(
+            {"success": True, "image": "/tmp/image.png"}
+        )
+
+
+def test_postprocess_transformed_result_is_valid_json_and_preserves_fields(
+    monkeypatch, tmp_path
+):
+    from tools import image_generation_tool
+
+    hermes_home = tmp_path / ".hermes"
+    image_path = hermes_home / "cache" / "images" / "generated-雪.png"
+    image_path.parent.mkdir(parents=True)
+    image_path.write_bytes(b"png")
+    env = SimpleNamespace(_remote_home="/home/remote", _sync_manager=None)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(image_generation_tool, "_active_terminal_env", lambda task_id: env)
+
+    original = {
+        "success": True,
+        "image": str(image_path),
+        "provider": "azure-openai",
+        "metadata": {"prompt": "draw 雪"},
+    }
+    raw = image_generation_tool._postprocess_image_generate_result(
+        json.dumps(original, ensure_ascii=False)
+    )
+    result = json.loads(raw)
+
+    assert isinstance(raw, str)
+    assert result == {
+        **original,
+        "host_image": str(image_path),
+        "agent_visible_image": "/home/remote/.hermes/cache/images/generated-雪.png",
+    }
+
+
 def test_handle_image_generate_postprocesses_plugin_result(monkeypatch, tmp_path):
     from tools import image_generation_tool
 
@@ -122,3 +182,72 @@ def test_handle_image_generate_postprocesses_plugin_result(monkeypatch, tmp_path
 
     assert seen_task_ids == ["plugin-task"]
     assert result["agent_visible_image"] == "/home/remote/.hermes/cache/images/plugin.png"
+
+
+def test_normalize_image_tool_result_preserves_raw_unicode_string():
+    from tools import image_generation_tool
+
+    raw = '  {"message": "雪"}  '
+
+    assert image_generation_tool._normalize_image_tool_result(raw) == raw
+
+
+def test_normalize_image_tool_result_serializes_mapping_as_unicode_json():
+    from tools import image_generation_tool
+
+    result = image_generation_tool._normalize_image_tool_result(
+        {"success": True, "image": "https://example.com/雪.png"}
+    )
+
+    assert "雪" in result
+    assert json.loads(result) == {
+        "success": True,
+        "image": "https://example.com/雪.png",
+    }
+
+
+def test_normalize_image_tool_result_rejects_unsupported_and_unserializable_values():
+    from tools import image_generation_tool
+
+    for value in (["unexpected"], {"success": True, "bad": {1, 2}}):
+        raw = image_generation_tool._normalize_image_tool_result(value)
+        result = json.loads(raw)
+
+        assert isinstance(raw, str)
+        assert result["error_type"] == "tool_result_contract"
+        assert result["tool"] == "image_generate"
+        assert result["result_type"] == type(value).__name__
+
+
+def test_handle_image_generate_normalizes_all_provider_branches(monkeypatch):
+    from tools import image_generation_tool
+
+    mapping_result = {
+        "success": True,
+        "image": "https://example.com/雪.png",
+        "provider": "test",
+    }
+
+    for branch in ("plugin", "managed_krea", "fal"):
+        with monkeypatch.context() as scoped:
+            scoped.setattr(
+                image_generation_tool,
+                "_dispatch_to_plugin_provider",
+                lambda *args, **kwargs: mapping_result if branch == "plugin" else None,
+            )
+            scoped.setattr(
+                image_generation_tool,
+                "_maybe_route_managed_krea",
+                lambda *args, **kwargs: mapping_result if branch == "managed_krea" else None,
+            )
+            scoped.setattr(
+                image_generation_tool,
+                "image_generate_tool",
+                lambda *args, **kwargs: mapping_result,
+            )
+
+            raw = image_generation_tool._handle_image_generate({"prompt": "draw"})
+
+            assert isinstance(raw, str)
+            assert "雪" in raw
+            assert json.loads(raw) == mapping_result

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -30,6 +30,39 @@ class _FakeCodexProvider(ImageGenProvider):
         }
 
 
+class _MisconfiguredAzureProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "azure-openai"
+
+    def is_available(self) -> bool:
+        return False
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        return {
+            "success": False,
+            "image": None,
+            "error": "Azure OpenAI image API key is not configured.",
+            "error_type": "auth_required",
+            "provider": self.name,
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "setup_action": "Configure AZURE_OPENAI_IMAGE_KEY with `hermes tools`.",
+        }
+
+
+class _ForbiddenFallbackProvider(ImageGenProvider):
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        raise AssertionError(f"{self.name} fallback must not be called")
+
+
 class TestPluginDispatch:
     def test_dispatch_routes_to_codex_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool
@@ -97,6 +130,102 @@ class TestPluginDispatch:
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["aspect_ratio"] == "portrait"
+
+    def test_explicit_misconfigured_azure_surfaces_azure_error_without_fallback(
+        self, monkeypatch
+    ):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        azure = _MisconfiguredAzureProvider()
+        image_gen_registry.register_provider(azure)
+        image_gen_registry.register_provider(_ForbiddenFallbackProvider("openai"))
+        image_gen_registry.register_provider(_ForbiddenFallbackProvider("fal"))
+
+        monkeypatch.setattr(
+            image_generation_tool,
+            "_read_configured_image_provider",
+            lambda: "azure-openai",
+        )
+        monkeypatch.setattr(
+            image_generation_tool, "_read_configured_image_model", lambda: None
+        )
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda **kw: None)
+        monkeypatch.setattr(
+            image_generation_tool,
+            "image_generate_tool",
+            lambda **kw: (_ for _ in ()).throw(
+                AssertionError("legacy FAL fallback must not be called")
+            ),
+        )
+
+        payload = json.loads(
+            image_generation_tool._handle_image_generate(
+                {"prompt": "draw a fox", "aspect_ratio": "square"}
+            )
+        )
+
+        assert payload["success"] is False
+        assert payload["provider"] == "azure-openai"
+        assert payload["error_type"] == "auth_required"
+        assert "AZURE_OPENAI_IMAGE_KEY" in payload["setup_action"]
+
+    def test_explicit_misconfigured_provider_remains_exposed(self, monkeypatch):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        image_gen_registry.register_provider(_MisconfiguredAzureProvider())
+        monkeypatch.setattr(
+            image_generation_tool,
+            "_read_configured_image_provider",
+            lambda: "azure-openai",
+        )
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda **kw: None)
+        monkeypatch.setattr(image_generation_tool, "check_fal_api_key", lambda: False)
+
+        assert image_generation_tool.check_image_generation_requirements() is True
+
+    def test_explicit_provider_discovery_failure_does_not_fall_through(
+        self, monkeypatch
+    ):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setattr(
+            image_generation_tool,
+            "_read_configured_image_provider",
+            lambda: "azure-openai",
+        )
+        monkeypatch.setattr(
+            image_generation_tool, "_read_configured_image_model", lambda: None
+        )
+        monkeypatch.setattr(
+            plugins_module,
+            "_ensure_plugins_discovered",
+            lambda **kw: (_ for _ in ()).throw(RuntimeError("discovery failed")),
+        )
+        monkeypatch.setattr(
+            image_generation_tool,
+            "_maybe_route_managed_krea",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("managed Krea fallback must not be called")
+            ),
+        )
+        monkeypatch.setattr(
+            image_generation_tool,
+            "image_generate_tool",
+            lambda **kw: (_ for _ in ()).throw(
+                AssertionError("legacy FAL fallback must not be called")
+            ),
+        )
+
+        payload = json.loads(
+            image_generation_tool._handle_image_generate({"prompt": "draw a fox"})
+        )
+
+        assert payload["success"] is False
+        assert payload["error_type"] == "provider_unavailable"
+        assert "no fallback provider was attempted" in payload["error"]
 
     def test_unset_provider_keeps_legacy_fal_path(self, monkeypatch):
         """An unrelated API key must not opt the user into paid image generation."""

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -803,16 +803,42 @@ def _force_artifact_sync(env: Any) -> None:
         logger.warning("Could not force-sync generated image artifact: %s", exc)
 
 
+def _normalize_image_tool_result(value: object) -> str:
+    """Return an image tool result as raw text or a valid JSON string."""
+    if isinstance(value, str):
+        return value
+
+    from collections.abc import Mapping
+
+    if isinstance(value, Mapping):
+        try:
+            return json.dumps(dict(value), ensure_ascii=False)
+        except Exception:
+            pass
+
+    result_type = type(value).__name__
+    return json.dumps({
+        "error": f"Image tool returned unsupported result type: {result_type}",
+        "error_type": "tool_result_contract",
+        "tool": "image_generate",
+        "result_type": result_type,
+    }, ensure_ascii=False)
+
+
 def _postprocess_image_generate_result(raw: str, task_id: str | None = None) -> str:
     """Annotate successful local image results with backend-visible paths.
 
+    ``raw`` must already have passed through ``_normalize_image_tool_result``.
     ``image`` remains the host/gateway-deliverable path.  When the active
     terminal backend has a different filesystem, ``agent_visible_image`` gives
     the path the agent can use with terminal/file tools.
     """
+    if not isinstance(raw, str):
+        raise TypeError("image_generate post-processing requires a normalized string")
+
     try:
-        payload = json.loads(raw) if isinstance(raw, str) else raw
-    except Exception:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return raw
 
     if not isinstance(payload, dict) or not payload.get("success"):
@@ -1084,33 +1110,34 @@ def _build_no_backend_setup_message() -> str:
 
 
 def check_image_generation_requirements() -> bool:
-    """True if FAL or the explicitly configured image backend is available."""
+    """True when the selected image backend can handle a tool call.
+
+    An explicitly selected plugin remains exposed even when ``is_available()``
+    is false so its own actionable configuration error reaches the user.  It
+    must never borrow FAL availability and silently route to that paid backend.
+    """
+    configured = _read_configured_image_provider()
+    if configured and configured != "fal":
+        try:
+            from agent.image_gen_registry import get_provider
+            from hermes_cli.plugins import _ensure_plugins_discovered
+
+            _ensure_plugins_discovered()
+            return get_provider(configured) is not None
+        except Exception:
+            return False
+
     try:
         if check_fal_api_key():
             # Trigger the lazy fal_client import here as the SDK presence
             # check. Raises ImportError if the optional ``fal-client``
             # package isn't installed; the caller's except ImportError
-            # below catches that and continues to plugin probing.
+            # below treats the FAL path as unavailable.
             _load_fal_client()
             return True
     except ImportError:
         pass
-
-    configured = _read_configured_image_provider()
-    if not configured or configured == "fal":
-        return False
-
-    # Probe only the explicitly selected plugin. Merely possessing a cloud
-    # provider key must not opt a user into a paid image-generation backend.
-    try:
-        from agent.image_gen_registry import get_provider
-        from hermes_cli.plugins import _ensure_plugins_discovered
-
-        _ensure_plugins_discovered()
-        provider = get_provider(configured)
-        return bool(provider and provider.is_available())
-    except Exception:
-        return False
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -1296,8 +1323,16 @@ def _dispatch_to_plugin_provider(
         _ensure_plugins_discovered()
         provider = get_provider(configured)
     except Exception as exc:
-        logger.debug("image_gen plugin dispatch skipped: %s", exc)
-        return None
+        logger.debug("image_gen plugin dispatch failed closed: %s", exc)
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": (
+                f"Configured image provider '{configured}' could not be loaded; "
+                "no fallback provider was attempted."
+            ),
+            "error_type": "provider_unavailable",
+        })
 
     if provider is None:
         try:
@@ -1516,7 +1551,8 @@ def _handle_image_generate(args, **kw):
         reference_image_urls=reference_image_urls,
     )
     if dispatched is not None:
-        return _postprocess_image_generate_result(dispatched, task_id=task_id)
+        normalized = _normalize_image_tool_result(dispatched)
+        return _postprocess_image_generate_result(normalized, task_id=task_id)
 
     # Managed-mode Krea routing: when no explicit plugin provider is configured
     # but the selected model is a native ``krea-2-*`` id, a portal user routes to
@@ -1529,7 +1565,8 @@ def _handle_image_generate(args, **kw):
         reference_image_urls=reference_image_urls,
     )
     if krea_routed is not None:
-        return _postprocess_image_generate_result(krea_routed, task_id=task_id)
+        normalized = _normalize_image_tool_result(krea_routed)
+        return _postprocess_image_generate_result(normalized, task_id=task_id)
 
     raw = image_generate_tool(
         prompt=prompt,
@@ -1537,7 +1574,8 @@ def _handle_image_generate(args, **kw):
         image_url=image_url,
         reference_image_urls=reference_image_urls,
     )
-    return _postprocess_image_generate_result(raw, task_id=task_id)
+    normalized = _normalize_image_tool_result(raw)
+    return _postprocess_image_generate_result(normalized, task_id=task_id)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Adds native Azure OpenAI and Microsoft Foundry image-generation support through Hermes' existing `ImageGenProvider` plugin architecture.

### Provider support

- Direct Azure OpenAI resource endpoints:
  `https://<resource>.openai.azure.com`
- Microsoft Foundry OpenAI v1 endpoints:
  `https://<resource>.services.ai.azure.com/openai/v1`
- API-key authentication for both endpoint families
- Optional Microsoft Entra ID authentication for Foundry
- Text-to-image generation through the existing `image_generate` tool
- Landscape, square, and portrait output sizes
- Base64 and URL response persistence through existing profile-aware cache helpers

### Configuration

The provider is configured through `hermes tools` under Image Generation.

Secrets and non-secret settings are kept separate:

- `AZURE_OPENAI_IMAGE_KEY` is stored as a protected credential.
- Endpoint and deployment name are stored in `config.yaml`.
- Existing environment-based endpoint and deployment settings remain supported as compatibility fallbacks.
- Missing configuration produces actionable setup guidance without exposing credentials.

### Safety and compatibility

- Explicit Azure selection fails closed and never silently falls back to FAL, OpenAI, or another paid provider.
- Provider exceptions and logs redact the complete Azure image key.
- Image tool results are normalized before entering the conversation loop.
- Existing OpenAI, FAL, Krea, OpenRouter, and xAI provider behavior remains supported.
- No new core model tool was added.
- No additional runtime SDK was introduced; the existing OpenAI SDK is reused.

## Related Issue

No existing issue.

This is being opened as a draft so maintainers can confirm whether Azure image generation should remain a bundled backend or be distributed as a standalone plugin under the project's third-party integration policy.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvement

## Breaking Changes?

No. Existing provider selection, tool names, schemas, and configuration remain compatible.

Azure is only used when the user explicitly selects and configures the `azure-openai` image provider.

## Testing

The focused provider, picker, dispatch, and registry suite was run through the repository test wrapper:

```text
scripts/run_tests.sh \
  tests/plugins/image_gen/test_azure_openai_provider.py \
  tests/hermes_cli/test_image_gen_picker.py \
  tests/tools/test_image_generation_plugin_dispatch.py \
  tests/tools/test_registry.py -q
