### PR TITLE
fix(slack): fail closed without trusted bot identity

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -852,6 +852,18 @@ def _is_slack_voice_clip(file_obj: Dict[str, Any]) -> bool:
     return name.startswith("audio_message")
 
 
+def _trusted_bot_user_id(auth_response) -> str:
+    """Return Slack's bot user ID only for a verified bot-token response."""
+    try:
+        bot_id = auth_response.get("bot_id", "") or ""
+        user_id = auth_response.get("user_id", "") or ""
+    except Exception:
+        data = getattr(auth_response, "data", None) or {}
+        bot_id = data.get("bot_id", "") or ""
+        user_id = data.get("user_id", "") or ""
+    return str(user_id) if bot_id and user_id else ""
+
+
 class SlackAdapter(BasePlatformAdapter):
     """
     Slack bot adapter using Socket Mode.
@@ -1695,19 +1707,11 @@ class SlackAdapter(BasePlatformAdapter):
         (``xoxp-…`` / a legacy/personal OAuth token) it is the *installing
         human's* member ID and there is **no** ``bot_id``.
 
-        When that happens, ``self._bot_user_id`` becomes a human's member ID,
-        and every "is this the bot?" check downstream misfires: that one
-        person's ``<@…>`` mentions wake the bot (``is_mentioned`` in
-        ``_handle_slack_message``) and get stripped as if they were the bot's
-        own mention — so the agent is genuinely told it was @mentioned and
-        replies to messages merely *addressed to that human*. There is no
-        runtime API error to catch; the only detectable moment is here at
-        connect time, by noticing ``bot_id`` is absent from ``auth.test``.
-
-        Warning-only: a user token can still send/receive, and we don't want
-        to hard-fail a working-but-misconfigured install on connect. We log
-        exactly what is wrong and how to fix it, once per workspace per
-        process.
+        Without a trusted bot identity, native ``<@bot>`` text matching is
+        unavailable. Shared-channel admission therefore remains fail-closed
+        and accepts only Slack ``app_mention`` events or configured mention
+        patterns. A user token can still send and receive, so connect remains
+        warning-only and logs the remediation once per workspace per process.
         """
         try:
             warned = getattr(self, "_user_token_warned", None)
@@ -1738,12 +1742,12 @@ class SlackAdapter(BasePlatformAdapter):
                     "authenticated as a USER (member %s), not a bot — the "
                     "auth.test response has no 'bot_id'. This is almost "
                     "certainly a user token (xoxp-...) instead of a Bot User "
-                    "OAuth Token (xoxb-...). The bot's identity is now bound "
-                    "to that member's ID, so mentions OF THAT PERSON will be "
-                    "misrouted as mentions of the bot (the bot replies to "
-                    "messages merely addressed to them). Use the 'Bot User "
-                    "OAuth Token' (xoxb-...) from your Slack app's 'OAuth & "
-                    "Permissions' page in SLACK_BOT_TOKEN.",
+                    "OAuth Token (xoxb-...). Native bot mention detection is "
+                    "disabled for this workspace, so mention-gated channels "
+                    "will accept only app_mention events or configured "
+                    "mention_patterns. Use the 'Bot User OAuth Token' "
+                    "(xoxb-...) from your Slack app's 'OAuth & Permissions' "
+                    "page in SLACK_BOT_TOKEN.",
                     team_key or "this workspace",
                     user_id,
                 )
@@ -1910,7 +1914,7 @@ class SlackAdapter(BasePlatformAdapter):
                 _apply_slack_proxy(client, proxy_url)
                 auth_response = await client.auth_test()
                 team_id = auth_response.get("team_id", "")
-                bot_user_id = auth_response.get("user_id", "")
+                bot_user_id = _trusted_bot_user_id(auth_response)
                 bot_name = auth_response.get("user", "unknown")
                 team_name = auth_response.get("team", "unknown")
 
@@ -5602,7 +5606,8 @@ class SlackAdapter(BasePlatformAdapter):
         # Detect mentions authored only inside Block Kit blocks too (#52387)
         routing_text = _slack_mention_detection_text(event) or original_text or ""
         is_mentioned = bool(
-            (bot_uid and f"<@{bot_uid}>" in routing_text)
+            event.get("type") == "app_mention"
+            or (bot_uid and f"<@{bot_uid}>" in routing_text)
             or self._slack_message_matches_mention_patterns(routing_text)
         )
         event_thread_ts = event.get("thread_ts")
@@ -5637,7 +5642,7 @@ class SlackAdapter(BasePlatformAdapter):
                 if allow_bots == "mentions" and not is_mentioned:
                     return
 
-        if not is_one_to_one_dm and bot_uid:
+        if not is_one_to_one_dm:
             # Check allowed channels — if set, only respond in these channels (whitelist)
             allowed_channels = self._slack_allowed_channels()
             if allowed_channels and channel_id not in allowed_channels:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -863,6 +863,18 @@ def _is_slack_voice_clip(file_obj: Dict[str, Any]) -> bool:
     return name.startswith("audio_message")
 
 
+def _trusted_bot_user_id(auth_response) -> str:
+    """Return Slack's bot user ID only for a verified bot-token response."""
+    try:
+        bot_id = auth_response.get("bot_id", "") or ""
+        user_id = auth_response.get("user_id", "") or ""
+    except Exception:
+        data = getattr(auth_response, "data", None) or {}
+        bot_id = data.get("bot_id", "") or ""
+        user_id = data.get("user_id", "") or ""
+    return str(user_id) if bot_id and user_id else ""
+
+
 class SlackAdapter(BasePlatformAdapter):
     """
     Slack bot adapter using Socket Mode.
@@ -1706,19 +1718,11 @@ class SlackAdapter(BasePlatformAdapter):
         (``xoxp-…`` / a legacy/personal OAuth token) it is the *installing
         human's* member ID and there is **no** ``bot_id``.
 
-        When that happens, ``self._bot_user_id`` becomes a human's member ID,
-        and every "is this the bot?" check downstream misfires: that one
-        person's ``<@…>`` mentions wake the bot (``is_mentioned`` in
-        ``_handle_slack_message``) and get stripped as if they were the bot's
-        own mention — so the agent is genuinely told it was @mentioned and
-        replies to messages merely *addressed to that human*. There is no
-        runtime API error to catch; the only detectable moment is here at
-        connect time, by noticing ``bot_id`` is absent from ``auth.test``.
-
-        Warning-only: a user token can still send/receive, and we don't want
-        to hard-fail a working-but-misconfigured install on connect. We log
-        exactly what is wrong and how to fix it, once per workspace per
-        process.
+        Without a trusted bot identity, native ``<@bot>`` text matching is
+        unavailable. Shared-channel admission therefore remains fail-closed
+        and accepts only Slack ``app_mention`` events or configured mention
+        patterns. A user token can still send and receive, so connect remains
+        warning-only and logs the remediation once per workspace per process.
         """
         try:
             warned = getattr(self, "_user_token_warned", None)
@@ -1749,12 +1753,12 @@ class SlackAdapter(BasePlatformAdapter):
                     "authenticated as a USER (member %s), not a bot — the "
                     "auth.test response has no 'bot_id'. This is almost "
                     "certainly a user token (xoxp-...) instead of a Bot User "
-                    "OAuth Token (xoxb-...). The bot's identity is now bound "
-                    "to that member's ID, so mentions OF THAT PERSON will be "
-                    "misrouted as mentions of the bot (the bot replies to "
-                    "messages merely addressed to them). Use the 'Bot User "
-                    "OAuth Token' (xoxb-...) from your Slack app's 'OAuth & "
-                    "Permissions' page in SLACK_BOT_TOKEN.",
+                    "OAuth Token (xoxb-...). Native bot mention detection is "
+                    "disabled for this workspace, so mention-gated channels "
+                    "will accept only app_mention events or configured "
+                    "mention_patterns. Use the 'Bot User OAuth Token' "
+                    "(xoxb-...) from your Slack app's 'OAuth & Permissions' "
+                    "page in SLACK_BOT_TOKEN.",
                     team_key or "this workspace",
                     user_id,
                 )
@@ -1921,8 +1925,9 @@ class SlackAdapter(BasePlatformAdapter):
                 _apply_slack_proxy(client, proxy_url)
                 auth_response = await client.auth_test()
                 team_id = auth_response.get("team_id", "")
-                bot_user_id = auth_response.get("user_id", "")
-                bot_name = auth_response.get("user", "unknown")
+                bot_user_id = _trusted_bot_user_id(auth_response)
+                auth_name = auth_response.get("user", "unknown")
+                bot_name = auth_name if bot_user_id else ""
                 team_name = auth_response.get("team", "unknown")
 
                 self._team_clients[team_id] = client
@@ -1939,7 +1944,7 @@ class SlackAdapter(BasePlatformAdapter):
 
                 logger.info(
                     "[Slack] Authenticated as @%s in workspace %s (team: %s)",
-                    bot_name,
+                    auth_name,
                     team_name,
                     team_id,
                 )
@@ -5306,16 +5311,12 @@ class SlackAdapter(BasePlatformAdapter):
                 normalized_event["_slack_changed_event_ts"] = changed_event_ts
             event = normalized_event
 
-        # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777)
-        # Scope the dedup id by workspace: Slack event ts values are only
-        # unique within one workspace, so two teams' events with the same ts
-        # must not suppress each other.
+        # Build the workspace-scoped dedup ID now, but claim it only after
+        # admission. Slack may emit a generic message before its app_mention
+        # twin; a rejected generic event must not suppress the trusted twin.
         event_ts = event.get("_slack_changed_event_ts") or event.get("ts", "")
         dedup_team_id = self._event_team_id(event, payload)
-        if event_ts and self._dedup.is_duplicate(
-            self._workspace_event_id(dedup_team_id, event_ts)
-        ):
-            return
+        dedup_id = self._workspace_event_id(dedup_team_id, event_ts)
 
         channel_id = event.get("channel", "")
         if self._is_ignored_channel(channel_id):
@@ -5626,7 +5627,8 @@ class SlackAdapter(BasePlatformAdapter):
         # Detect mentions authored only inside Block Kit blocks too (#52387)
         routing_text = _slack_mention_detection_text(event) or original_text or ""
         is_mentioned = bool(
-            (bot_uid and f"<@{bot_uid}>" in routing_text)
+            event.get("type") == "app_mention"
+            or (bot_uid and f"<@{bot_uid}>" in routing_text)
             or self._slack_message_matches_mention_patterns(routing_text)
         )
         event_thread_ts = event.get("thread_ts")
@@ -5661,7 +5663,7 @@ class SlackAdapter(BasePlatformAdapter):
                 if allow_bots == "mentions" and not is_mentioned:
                     return
 
-        if not is_one_to_one_dm and bot_uid:
+        if not is_one_to_one_dm:
             # Check allowed channels — if set, only respond in these channels (whitelist)
             allowed_channels = self._slack_allowed_channels()
             if allowed_channels and channel_id not in allowed_channels:
@@ -5923,6 +5925,9 @@ class SlackAdapter(BasePlatformAdapter):
                     watermark_ts=ts,
                     team_id=team_id,
                 )
+
+        if event_ts and self._dedup.is_duplicate(dedup_id):
+            return
 
         # Determine message type
         msg_type = MessageType.TEXT

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -500,6 +500,7 @@ class TestAppMentionHandler:
         mock_app.client = AsyncMock()
         mock_app.client.auth_test = AsyncMock(
             return_value={
+                "bot_id": "B_BOT",
                 "user_id": "U_BOT",
                 "user": "testbot",
             }
@@ -509,6 +510,7 @@ class TestAppMentionHandler:
         mock_web_client = AsyncMock()
         mock_web_client.auth_test = AsyncMock(
             return_value={
+                "bot_id": "B_BOT",
                 "user_id": "U_BOT",
                 "user": "testbot",
                 "team_id": "T_FAKE",
@@ -916,6 +918,7 @@ class TestSlackSocketWatchdog:
         mock_web_client = AsyncMock()
         mock_web_client.auth_test = AsyncMock(
             return_value={
+                "bot_id": "B_BOT",
                 "user_id": "U_BOT",
                 "user": "testbot",
                 "team_id": "T_FAKE",

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -204,6 +204,56 @@ def _redirect_cache(tmp_path, monkeypatch):
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "text", "mention_patterns", "expected_calls"),
+    [
+        ("message", "ordinary channel message", [], 0),
+        ("app_mention", "trusted native mention", [], 1),
+        ("message", "hermes check this", ["^hermes"], 1),
+    ],
+)
+async def test_missing_trusted_identity_uses_real_channel_gate(
+    adapter, event_type, text, mention_patterns, expected_calls
+):
+    adapter._bot_user_id = None
+    adapter._team_bot_user_ids = {}
+    adapter.config.extra.update({"require_mention": True, "mention_patterns": mention_patterns})
+    await adapter._handle_slack_message(
+        {
+            "type": event_type,
+            "text": text,
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T1",
+            "ts": "1234567890.000001",
+            "client_msg_id": "cmid-trusted-identity-gate",
+        }
+    )
+    assert adapter.handle_message.await_count == expected_calls
+
+
+@pytest.mark.asyncio
+async def test_native_mention_supersedes_same_timestamp_generic_event(adapter):
+    adapter._bot_user_id = None
+    adapter._team_bot_user_ids = {}
+    adapter.config.extra["require_mention"] = True
+    event = {
+        "text": "trusted native mention",
+        "user": "U_USER",
+        "channel": "C123",
+        "channel_type": "channel",
+        "team": "T1",
+        "ts": "1234567890.000002",
+        "client_msg_id": "cmid-native-mention-order",
+    }
+    await adapter._handle_slack_message({"type": "message", **event})
+    await adapter._handle_slack_message({"type": "app_mention", **event})
+    await adapter._handle_slack_message({"type": "app_mention", **event})
+    adapter.handle_message.assert_awaited_once()
+
+
 class TestBotEventDiagnostics:
     """#30091 — surface upstream filters that drop bot events."""
 
@@ -332,6 +382,7 @@ class TestAppMentionHandler:
         mock_app.client = AsyncMock()
         mock_app.client.auth_test = AsyncMock(
             return_value={
+                "bot_id": "B_BOT",
                 "user_id": "U_BOT",
                 "user": "testbot",
             }
@@ -341,6 +392,7 @@ class TestAppMentionHandler:
         mock_web_client = AsyncMock()
         mock_web_client.auth_test = AsyncMock(
             return_value={
+                "bot_id": "B_BOT",
                 "user_id": "U_BOT",
                 "user": "testbot",
                 "team_id": "T_FAKE",
@@ -541,6 +593,10 @@ class TestSlackConnectCleanup:
             result = await adapter.connect()
 
         assert result is True
+        assert adapter._bot_user_id == ""
+        assert adapter._team_bot_user_ids == {"T_FAKE": ""}
+        assert adapter._bot_display_name == ""
+        assert adapter._team_bot_names == {"T_FAKE": ""}
         first_handler.close_async.assert_awaited_once_with()
         assert adapter._handler is second_handler
 
@@ -659,6 +715,7 @@ class TestSlackSocketWatchdog:
         mock_web_client = AsyncMock()
         mock_web_client.auth_test = AsyncMock(
             return_value={
+                "bot_id": "B_BOT",
                 "user_id": "U_BOT",
                 "user": "testbot",
                 "team_id": "T_FAKE",

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -247,7 +247,8 @@ def test_free_response_channels_int_list():
 
 def _would_process(adapter, *, is_dm=False, channel_id=CHANNEL_ID,
                    text="hello", mentioned=False, thread_reply=False,
-                   active_session=False, channel_type=None):
+                   active_session=False, channel_type=None,
+                   native_app_mention=False):
     """Simulate the mention gating logic from _handle_slack_message.
 
     Returns True if the message would be processed, False if it would be
@@ -267,11 +268,12 @@ def _would_process(adapter, *, is_dm=False, channel_id=CHANNEL_ID,
     if mentioned:
         text = f"<@{bot_uid}> {text}"
     is_mentioned = bool(
-        (bot_uid and f"<@{bot_uid}>" in text)
+        native_app_mention
+        or (bot_uid and f"<@{bot_uid}>" in text)
         or adapter._slack_message_matches_mention_patterns(text)
     )
 
-    if not is_one_to_one_dm and bot_uid:
+    if not is_one_to_one_dm:
         # allowed_channels check (whitelist — must pass before other gating)
         allowed = adapter._slack_allowed_channels()
         if allowed and channel_id not in allowed:
@@ -432,29 +434,50 @@ def test_thread_reply_without_active_session_ignored():
     ) is False
 
 
-def test_bot_uid_none_processes_channel_message():
-    """When bot_uid is None (before auth_test), channel messages pass through.
+def test_bot_uid_none_keeps_channel_mention_gate_closed():
+    """When bot_uid is unknown, mention-gated channel messages stay closed.
 
-    This preserves the old behavior: the gating block is skipped entirely
-    when bot_uid is falsy, so messages are not silently dropped during
-    startup or for new workspaces.
+    Identity resolution must not bypass channel admission during startup or
+    for a token that does not represent a bot.
     """
     adapter = _make_adapter(require_mention=True)
     adapter._bot_user_id = None
     adapter._team_bot_user_ids = {}
 
-    # With bot_uid=None, the `if not is_dm and bot_uid:` condition is False,
-    # so the gating block is skipped — message passes through.
+    # A missing identity no longer bypasses the shared-channel gate.
     bot_uid = adapter._team_bot_user_ids.get("T1", adapter._bot_user_id)
     assert bot_uid is None
 
-    # Simulate: gating block not entered when bot_uid is falsy
+    # Shared-channel gating is entered even when bot_uid is falsy.
     is_dm = False
-    if not is_dm and bot_uid:
+    if not is_dm:
         result = False  # would enter gating
     else:
         result = True  # gating skipped, message processed
-    assert result is True
+    assert result is False
+
+
+def test_bot_uid_none_accepts_native_app_mention():
+    adapter = _make_adapter(require_mention=True)
+    adapter._bot_user_id = None
+    adapter._team_bot_user_ids = {}
+
+    assert _would_process(
+        adapter,
+        text="trusted Slack mention",
+        native_app_mention=True,
+    ) is True
+
+
+def test_bot_uid_none_accepts_configured_mention_pattern():
+    adapter = _make_adapter(
+        require_mention=True,
+        mention_patterns=["^hermes"],
+    )
+    adapter._bot_user_id = None
+    adapter._team_bot_user_ids = {}
+
+    assert _would_process(adapter, text="hermes check this") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -166,7 +166,7 @@ def _would_process(adapter, *, is_dm=False, channel_id=CHANNEL_ID,
         or adapter._slack_message_matches_mention_patterns(text)
     )
 
-    if not is_one_to_one_dm and bot_uid:
+    if not is_one_to_one_dm:
         # allowed_channels check (whitelist — must pass before other gating)
         allowed = adapter._slack_allowed_channels()
         if allowed and channel_id not in allowed:
@@ -292,31 +292,6 @@ def test_thread_reply_without_active_session_ignored():
         adapter, text="followup",
         thread_reply=True, active_session=False,
     ) is False
-
-
-def test_bot_uid_none_processes_channel_message():
-    """When bot_uid is None (before auth_test), channel messages pass through.
-
-    This preserves the old behavior: the gating block is skipped entirely
-    when bot_uid is falsy, so messages are not silently dropped during
-    startup or for new workspaces.
-    """
-    adapter = _make_adapter(require_mention=True)
-    adapter._bot_user_id = None
-    adapter._team_bot_user_ids = {}
-
-    # With bot_uid=None, the `if not is_dm and bot_uid:` condition is False,
-    # so the gating block is skipped — message passes through.
-    bot_uid = adapter._team_bot_user_ids.get("T1", adapter._bot_user_id)
-    assert bot_uid is None
-
-    # Simulate: gating block not entered when bot_uid is falsy
-    is_dm = False
-    if not is_dm and bot_uid:
-        result = False  # would enter gating
-    else:
-        result = True  # gating skipped, message processed
-    assert result is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_user_token_warning.py
+++ b/tests/gateway/test_slack_user_token_warning.py
@@ -2,14 +2,11 @@
 Tests for the connect-time user-token (vs bot-token) nudge.
 
 ``auth.test`` returns the ``user_id`` of whatever principal owns the configured
-token. A real bot token (``xoxb-…``) resolves to the app's bot user and the
-response carries a ``bot_id``; a user/legacy token (``xoxp-…``) resolves to the
-installing *human's* member ID with **no** ``bot_id``. In the latter case the
-adapter binds its identity to a human's member ID, so that person's ``<@…>``
-mentions are misrouted as mentions of the bot. ``_warn_if_not_bot_token``
-detects the missing ``bot_id`` at connect time — the only point where this is
-observable, since a user token still sends/receives without any runtime error —
-and logs an actionable, warning-only nudge.
+token. A real bot token resolves to the app's bot user and the response carries
+a ``bot_id``; a user/legacy token resolves to the installing human's member ID
+with no ``bot_id``. The adapter must not trust that human ID as the bot identity.
+``_warn_if_not_bot_token`` detects the missing ``bot_id`` at connect time and
+logs an actionable warning while shared-channel mention gating stays closed.
 """
 
 import logging
@@ -51,7 +48,10 @@ _ensure_slack_mock()
 import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
 _slack_mod.SLACK_AVAILABLE = True
 
-from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+from plugins.platforms.slack.adapter import (  # noqa: E402
+    SlackAdapter,
+    _trusted_bot_user_id,
+)
 
 
 class _DictAuthResponse(dict):
@@ -80,6 +80,21 @@ def test_warns_when_bot_id_absent(caplog):
     matched = [r for r in caplog.records
                if "authenticated as a USER" in r.message and "U_HUMAN" in r.message]
     assert matched
+
+
+def test_user_token_identity_is_not_bound_as_bot():
+    resp = _DictAuthResponse(team_id="T1", user_id="U_HUMAN", user="trevor")
+    assert _trusted_bot_user_id(resp) == ""
+
+
+def test_bot_token_identity_is_trusted():
+    resp = _DictAuthResponse(
+        team_id="T1",
+        user_id="U_BOT",
+        bot_id="B123",
+        user="hermes",
+    )
+    assert _trusted_bot_user_id(resp) == "U_BOT"
 
 
 def test_no_warning_when_bot_id_present(caplog):


### PR DESCRIPTION
## Summary

- trust `auth.test.user_id` as Slack's bot identity only when the response also contains `bot_id`
- keep shared-channel allowlist and mention admission active when native bot identity is unavailable
- accept trusted `app_mention` events and configured mention patterns while leaving one-to-one DMs unchanged

This prevents a user token's human identity from becoming the bot mention target and prevents missing identity resolution from bypassing `require_mention`.

Fixes #70748

## Tests

- `python -m pytest tests/gateway/test_slack.py tests/gateway/test_slack_mention.py tests/gateway/test_slack_user_token_warning.py -q` (`514 passed`)
- `python -m ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py tests/gateway/test_slack_mention.py tests/gateway/test_slack_user_token_warning.py`
- `git diff --check`
