### PR TITLE
 fix(agent): make _last_resolved_tool_names thread-local to prevent cross-session tool bleed

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -227,7 +227,17 @@ TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
 
 # Resolved tool names from the last get_tool_definitions() call.
 # Used by code_execution_tool to know which tools are available in this session.
-_last_resolved_tool_names: List[str] = []
+# Thread-local to prevent cross-session tool bleed in the gateway's
+# ThreadPoolExecutor: each session's thread gets its own copy.
+_last_resolved_tool_names_local = threading.local()
+
+
+def _get_last_resolved_tool_names() -> List[str]:
+    return getattr(_last_resolved_tool_names_local, "names", [])
+
+
+def _set_last_resolved_tool_names(names: List[str]) -> None:
+    _last_resolved_tool_names_local.names = names
 
 
 # =============================================================================
@@ -338,8 +348,7 @@ def get_tool_definitions(
         if cached is not None:
             # Update _last_resolved_tool_names so downstream callers see
             # consistent state even on a cache hit.
-            global _last_resolved_tool_names
-            _last_resolved_tool_names = [t["function"]["name"] for t in cached]
+            _set_last_resolved_tool_names([t["function"]["name"] for t in cached])
             # Return a shallow copy of the list but share the dict references —
             # schemas are treated as read-only by all known callers.
             return list(cached)
@@ -533,8 +542,7 @@ def _compute_tool_definitions(
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
 
-    global _last_resolved_tool_names
-    _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
+    _set_last_resolved_tool_names([t["function"]["name"] for t in filtered_tools])
 
     # Sanitize schemas for broad backend compatibility. llama.cpp's
     # json-schema-to-grammar converter (used by its OAI server to build
@@ -1304,7 +1312,7 @@ def handle_function_call(
             if function_name == "execute_code":
                 # Prefer the caller-provided list so subagents can't overwrite
                 # the parent's tool set via the process-global.
-                sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
+                sandbox_enabled = enabled_tools if enabled_tools is not None else _get_last_resolved_tool_names()
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
                     return registry.dispatch(
                         function_name, next_args,

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -562,7 +562,7 @@ class TestToolNamePreservation(unittest.TestCase):
 
         parent = _make_mock_parent(depth=0)
         original_tools = ["terminal", "read_file", "web_search", "execute_code", "delegate_task"]
-        model_tools._last_resolved_tool_names = list(original_tools)
+        model_tools._set_last_resolved_tool_names(list(original_tools))
 
         with patch("run_agent.AIAgent") as MockAgent:
             mock_child = MagicMock()
@@ -573,7 +573,7 @@ class TestToolNamePreservation(unittest.TestCase):
 
             delegate_task(goal="Test tool preservation", parent_agent=parent)
 
-        self.assertEqual(model_tools._last_resolved_tool_names, original_tools)
+        self.assertEqual(model_tools._get_last_resolved_tool_names(), original_tools)
 
     def test_global_tool_names_restored_after_child_failure(self):
         """Even when the child agent raises, the global must be restored."""
@@ -581,7 +581,7 @@ class TestToolNamePreservation(unittest.TestCase):
 
         parent = _make_mock_parent(depth=0)
         original_tools = ["terminal", "read_file", "web_search"]
-        model_tools._last_resolved_tool_names = list(original_tools)
+        model_tools._set_last_resolved_tool_names(list(original_tools))
 
         with patch("run_agent.AIAgent") as MockAgent:
             mock_child = MagicMock()
@@ -591,7 +591,7 @@ class TestToolNamePreservation(unittest.TestCase):
             result = json.loads(delegate_task(goal="Crash test", parent_agent=parent))
             self.assertEqual(result["results"][0]["status"], "error")
 
-        self.assertEqual(model_tools._last_resolved_tool_names, original_tools)
+        self.assertEqual(model_tools._get_last_resolved_tool_names(), original_tools)
 
     def test_build_child_agent_does_not_raise_name_error(self):
         """Regression: _build_child_agent must not reference _saved_tool_names.
@@ -723,7 +723,7 @@ class TestToolNamePreservation(unittest.TestCase):
 
         parent = _make_mock_parent(depth=0)
         expected_tools = ["read_file", "web_search", "execute_code"]
-        model_tools._last_resolved_tool_names = list(expected_tools)
+        model_tools._set_last_resolved_tool_names(list(expected_tools))
 
         captured = {}
 

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -504,7 +504,7 @@ class TestRegression_ToolsetScoping:
         model_tools.get_tool_definitions(
             enabled_toolsets=["mcp-pollute"], quiet_mode=True,
         )
-        before = set(model_tools._last_resolved_tool_names)
+        before = set(model_tools._get_last_resolved_tool_names())
         assert "terminal" not in before
 
         # A scoped tool_search call must not widen the process-global
@@ -515,7 +515,7 @@ class TestRegression_ToolsetScoping:
             function_args={"query": "pollute"},
             enabled_toolsets=["mcp-pollute"],
         )
-        after = set(model_tools._last_resolved_tool_names)
+        after = set(model_tools._get_last_resolved_tool_names())
         assert "terminal" not in after, (
             "bridge dispatch polluted _last_resolved_tool_names with "
             "out-of-scope tools"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1812,7 +1812,7 @@ def _run_single_child(
     import model_tools
 
     _saved_tool_names = getattr(
-        child, "_delegate_saved_tool_names", list(model_tools._last_resolved_tool_names)
+        child, "_delegate_saved_tool_names", list(model_tools._get_last_resolved_tool_names())
     )
 
     child_pool = getattr(child, "_credential_pool", None)
@@ -2380,7 +2380,7 @@ def _run_single_child(
 
         saved_tool_names = getattr(child, "_delegate_saved_tool_names", None)
         if isinstance(saved_tool_names, list):
-            model_tools._last_resolved_tool_names = list(saved_tool_names)
+            model_tools._set_last_resolved_tool_names(list(saved_tool_names))
 
         # Remove child from active tracking
 
@@ -2581,7 +2581,7 @@ def delegate_task(
     # which overwrites model_tools._last_resolved_tool_names with child's toolset.
     import model_tools as _model_tools
 
-    _parent_tool_names = list(_model_tools._last_resolved_tool_names)
+    _parent_tool_names = list(_model_tools._get_last_resolved_tool_names())
 
     # Capture the ORIGINATING session's wake target BEFORE any child agent is
     # constructed: _build_child_agent() -> AIAgent() -> agent_init calls
@@ -2641,7 +2641,7 @@ def delegate_task(
             children.append((i, t, child))
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
-        _model_tools._last_resolved_tool_names = _parent_tool_names
+        _model_tools._set_last_resolved_tool_names(_parent_tool_names)
 
     def _execute_and_aggregate() -> dict:
         """Run all built children (1 or N), join on them, aggregate results,


### PR DESCRIPTION
## What

`_last_resolved_tool_names` in `model_tools.py` is a process-global `List[str]` that is overwritten on every call to `get_tool_definitions()` (line 341 on cache hit, line 536 on fresh compute). When `handle_function_call` is called for `execute_code` with `enabled_tools=None` (line 1307), the sandbox falls back to this global.

The gateway runs 10 concurrent agent sessions via `ThreadPoolExecutor`. Session A calls `get_tool_definitions()` (overwriting the global with session A's toolset), and session B simultaneously calls `handle_function_call("execute_code", ...)` with `enabled_tools=None`. Session B's sandbox picks up session A's tool list -- granting a restricted session access to tools it should not have (e.g. `terminal`, `web_search`, `delegate_task`).

## Fix

Replaced the process-global `List[str]` with `threading.local()` storage. Each session's thread gets its own copy via `_get_last_resolved_tool_names()` / `_set_last_resolved_tool_names()` helpers.

- `model_tools.py`: Declaration changed to `threading.local()`, getter/setter functions added. Cache-hit path (line 341) and fresh-compute path (line 536) now call `_set_last_resolved_tool_names()`. `execute_code` fallback (line 1307) calls `_get_last_resolved_tool_names()`.
- `tools/delegate_tool.py`: All 4 references updated to use getter/setter.
- `tests/tools/test_delegate.py`: Test assertions updated.
- `tests/tools/test_tool_search.py`: Test assertions updated.

PR #34451 attempted this fix but was closed without merge.

## Why

Cross-session privilege escalation: a restricted user session can inherit tools from another user's session context in the default gateway configuration.

## How to Test

```bash
python -c "
import model_tools, threading
model_tools._set_last_resolved_tool_names(['tool_a'])
results = {}
def worker(name):
    model_tools._set_last_resolved_tool_names([f'{name}_tool'])
    import time; time.sleep(0.01)
    results[name] = model_tools._get_last_resolved_tool_names()
threads = [threading.Thread(target=worker, args=(f's{i}',)) for i in range(5)]
for t in threads: t.start()
for t in threads: t.join()
for name, val in results.items():
    assert val == [f'{name}_tool']
print('PASS: no cross-session bleed')
"
scripts/run_tests.sh tests/tools/test_delegate.py -q
scripts/run_tests.sh tests/tools/test_tool_search.py -q
```
