### PR TITLE
 fix(agent): add lock to _tool_defs_cache to prevent concurrent dict mutation

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -268,6 +268,7 @@ _LEGACY_TOOLSET_MAP = {
 # inner check_fn TTL cache in registry.py handles environment drift (Docker
 # daemon start/stop, env var changes, etc.) on a 30 s horizon.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
+_tool_defs_cache_lock = threading.Lock()
 
 # Hard cap on memoized get_tool_definitions() results. A long-lived Gateway
 # process sees many distinct toolset/config fingerprints over its lifetime
@@ -282,7 +283,8 @@ def _clear_tool_defs_cache() -> None:
     """Drop memoized get_tool_definitions() results. Called when dynamic
     schema dependencies change (e.g. discord capability cache reset,
     execute_code sandbox reconfigured)."""
-    _tool_defs_cache.clear()
+    with _tool_defs_cache_lock:
+        _tool_defs_cache.clear()
 
 
 def get_tool_definitions(
@@ -334,15 +336,16 @@ def get_tool_definitions(
             bool(skip_tool_search_assembly),
             _is_delegated_child_context(),
         )
-        cached = _tool_defs_cache.get(cache_key)
-        if cached is not None:
-            # Update _last_resolved_tool_names so downstream callers see
-            # consistent state even on a cache hit.
-            global _last_resolved_tool_names
-            _last_resolved_tool_names = [t["function"]["name"] for t in cached]
-            # Return a shallow copy of the list but share the dict references —
-            # schemas are treated as read-only by all known callers.
-            return list(cached)
+        with _tool_defs_cache_lock:
+            cached = _tool_defs_cache.get(cache_key)
+            if cached is not None:
+                # Update _last_resolved_tool_names so downstream callers see
+                # consistent state even on a cache hit.
+                global _last_resolved_tool_names
+                _last_resolved_tool_names = [t["function"]["name"] for t in cached]
+                # Return a shallow copy of the list but share the dict references --
+                # schemas are treated as read-only by all known callers.
+                return list(cached)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
                                        skip_tool_search_assembly=skip_tool_search_assembly)
@@ -357,9 +360,10 @@ def get_tool_definitions(
         # Bound the cache with LRU eviction so a long-lived Gateway process
         # doesn't accumulate entries unboundedly across the many distinct
         # toolset/config fingerprints it sees over its lifetime (#19251).
-        if len(_tool_defs_cache) >= _TOOL_DEFS_CACHE_MAX:
-            _tool_defs_cache.pop(next(iter(_tool_defs_cache)))  # evict oldest
-        _tool_defs_cache[cache_key] = result
+        with _tool_defs_cache_lock:
+            if len(_tool_defs_cache) >= _TOOL_DEFS_CACHE_MAX:
+                _tool_defs_cache.pop(next(iter(_tool_defs_cache)))  # evict oldest
+            _tool_defs_cache[cache_key] = result
         return list(result)
     return result
 


### PR DESCRIPTION
## What

`_tool_defs_cache` in `model_tools.py` is a plain `dict` used as a memoization cache for `get_tool_definitions()`. The gateway's 10-thread pool calls `get_tool_definitions()` concurrently from different sessions. Three race conditions exist:

1. **LRU eviction TOCTOU** (line 360-361): Two threads check `len() >= 8` simultaneously, both call `pop()` -- second may raise `KeyError` or evict the wrong entry.
2. **Cache clear vs. read** (line 285 vs 337): `_clear_tool_defs_cache()` calls `.clear()` while another thread iterates -- `RuntimeError: dictionary changed size during iteration`.
3. **Stale re-insert**: Clear races with concurrent insert, stale entry immediately re-inserted.

## Fix

Added `_tool_defs_cache_lock = threading.Lock()`. All cache reads, writes, eviction, and clear operations now acquire the lock.

- `_clear_tool_defs_cache()`: Wrapped `.clear()` in `with _tool_defs_cache_lock:`.
- Cache hit path: Wrapped `.get()` in `with _tool_defs_cache_lock:`.
- Cache miss path: Wrapped LRU eviction + insert in `with _tool_defs_cache_lock:`.

## Why

Denial of service (tool schema generation crash via `RuntimeError`) and stale schema serving after config changes in the gateway.

## How to Test

```bash
python -c "
import model_tools, threading
assert hasattr(model_tools, '_tool_defs_cache_lock')
assert isinstance(model_tools._tool_defs_cache_lock, type(threading.Lock()))
print('PASS: cache lock exists')
"
scripts/run_tests.sh tests/tools/test_tool_search.py -q
```
