### PR TITLE
fix(slack): treat closed aiohttp ClientSession as Socket Mode unhealthy

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1314,6 +1314,25 @@ class SlackAdapter(BasePlatformAdapter):
                     await self._restart_socket_mode("socket task stopped")
                     continue
 
+                # slack_sdk's SocketModeClient keeps a single aiohttp
+                # ClientSession for its own entire lifetime and retries
+                # forever inside its own connect() loop. If that session
+                # ever gets closed from inside that loop (not just the
+                # WebSocket), is_connected() can keep reporting an
+                # ambiguous/stale value while every retry fails forever with
+                # RuntimeError("Session is closed") -- this is a separate,
+                # more specific signal than a generic transport blip, so it
+                # gets its own reason string for observability.
+                client = getattr(self._handler, "client", None)
+                session = (
+                    getattr(client, "aiohttp_client_session", None)
+                    if client is not None
+                    else None
+                )
+                if session is not None and getattr(session, "closed", False):
+                    await self._restart_socket_mode("aiohttp session closed")
+                    continue
+
                 connected = await self._socket_transport_connected()
                 if connected is False:
                     await self._restart_socket_mode("transport disconnected")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -10,6 +10,7 @@ We mock the slack modules at import time to avoid collection errors.
 
 import asyncio
 import contextlib
+import logging
 import importlib
 from importlib.machinery import PathFinder
 import os
@@ -883,6 +884,7 @@ class TestSlackSocketWatchdog:
                 self.client = MagicMock()
                 self.client.proxy = proxy
                 self.client.is_connected = lambda: True
+                self.client.aiohttp_client_session = MagicMock(closed=False)
                 self._start_event = asyncio.Event()
                 self.closed = False
                 self.start_calls = 0
@@ -1246,6 +1248,52 @@ class TestSlackSocketWatchdog:
                 assert len(instances) >= 2, "watchdog did not heal wedged (lying) transport"
                 assert instances[0].closed is True
                 assert adapter._handler is instances[-1]
+            finally:
+                await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_watchdog_reconnects_when_aiohttp_session_is_closed(self, caplog):
+        """slack_sdk's SocketModeClient keeps one aiohttp ClientSession for its
+        own entire lifetime and retries forever inside its own internal
+        connect() loop. If that session gets closed while the loop is still
+        running, every retry fails forever with RuntimeError("Session is
+        closed") -- but is_connected() only reflects WebSocket-level state,
+        so this dual-state (WebSocket looking fine, HTTP session dead) is
+        exactly what the old check missed. Verify the watchdog catches this
+        via aiohttp_client_session.closed even while is_connected() still
+        reports True, and that it logs a distinct reason from a plain
+        transport disconnect.
+        """
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        adapter._socket_watchdog_interval_s = 0.01
+        factory, instances = self._make_fake_handler_factory()
+
+        with contextlib.ExitStack() as stack:
+            for p in self._patch_stack(factory):
+                stack.enter_context(p)
+
+            try:
+                assert await adapter.connect() is True
+                assert len(instances) == 1
+
+                # is_connected() still reports healthy -- only the aiohttp
+                # session itself is dead, matching the production incident.
+                assert instances[0].client.is_connected() is True
+                instances[0].client.aiohttp_client_session.closed = True
+
+                with caplog.at_level(logging.WARNING):
+                    for _ in range(40):
+                        if len(instances) >= 2:
+                            break
+                        await asyncio.sleep(0.01)
+
+                assert len(instances) >= 2, "watchdog did not heal dead aiohttp session"
+                assert instances[0].closed is True
+                assert adapter._handler is instances[-1]
+                assert any(
+                    "aiohttp session closed" in record.message
+                    for record in caplog.records
+                ), "expected a distinct 'aiohttp session closed' reason in the logs"
             finally:
                 await adapter.disconnect()
 


### PR DESCRIPTION
## Title
fix(slack): treat closed aiohttp ClientSession as Socket Mode unhealthy

## Description

The Slack platform adapter's Socket Mode watchdog (`_socket_watchdog_loop` / `_socket_transport_connected` in `plugins/platforms/slack/adapter.py`) only rebuilds the handler when its transport-connected probe returns `False`. That probe only proxies `slack_sdk.socket_mode.aiohttp.SocketModeClient.is_connected`, which reflects WebSocket-level state but never inspects `client.aiohttp_client_session.closed`.

`SocketModeClient` keeps one `aiohttp.ClientSession` for its own entire lifetime and retries forever inside its own internal `connect()` loop (by the SDK's own documented design — a single session is meant to live for the app's lifetime, which is a reasonable choice; the gap is that the retry loop never handles that session itself entering a closed state, separate report filed against `slackapi/python-slack-sdk`). If that session gets closed while the loop is still running, every subsequent retry fails identically forever with `RuntimeError: Session is closed`, but WebSocket-level state can still look "connected enough" (e.g. some backlog events like `user_change` still arrive) that this watchdog never notices and never triggers a rebuild.

Observed in production: a node stuck retrying every ~10s for over 24 hours with zero self-healing. Hermes's own watchdog fired its rebuild twice early in the incident, then went silent for the remaining ~37 hours while the SDK's internal loop kept spinning uselessly. Only a full process restart cleared it, since that's the only thing that constructs a genuinely fresh `aiohttp.ClientSession`.

### Why fix this in Hermes too, not just wait on an SDK fix

Even with an upstream SDK fix, Hermes shouldn't treat `is_connected()` as the sole health signal for a component whose rebuild path is already correct — defense in depth: detect a dead HTTP session, then rebuild the handler via the existing (already correct) mechanism.

## Fix

Added an explicit check for the underlying session's `.closed` flag in the watchdog loop, with its own distinct restart reason for log observability:

```python
client = getattr(self._handler, "client", None)
session = (
    getattr(client, "aiohttp_client_session", None)
    if client is not None
    else None
)
if session is not None and getattr(session, "closed", False):
    await self._restart_socket_mode("aiohttp session closed")
    continue
```

Placed after the existing `socket task missing`/`socket task stopped` checks and before the generic `_socket_transport_connected()` check, so more specific signals are checked first. This plugs into the existing `_restart_socket_mode` rebuild path, which already correctly constructs a fresh handler/client/session — the gap was purely in detection.

`aiohttp_client_session` is accessed defensively via `getattr` (not a guaranteed public API on `SocketModeClient`) — if a future SDK version renames or removes it, this check simply no-ops and the existing `transport disconnected` probe still applies as a fallback.

## Testing

**Production incident (pre-patch):** one node logged `Failed to connect (error: Session is closed); Retrying...` continuously for ~39 hours. Hermes's watchdog logged `transport disconnected` twice (at the start of the incident), then went silent for the rest. A full process restart cleared the wedge (new `Socket Mode connected`, zero `Session is closed` since).

**Unit test added** (`tests/gateway/test_slack.py::TestSlackSocketWatchdog::test_watchdog_reconnects_when_aiohttp_session_is_closed`): mocks a handler where `is_connected()` still reports `True` but `aiohttp_client_session.closed` is `True`, and asserts the watchdog reconnects with the distinct `"aiohttp session closed"` log reason. Also fixed the shared `_make_fake_handler_factory` test fixture to explicitly default `aiohttp_client_session` to an open (non-closed) mock — a bare `MagicMock()`'s auto-vivified `.closed` attribute is truthy by default, which would have silently made every *existing* watchdog test exercise this new code path instead of the one each is actually named for.

Verified both directions before submitting:
- Confirmed the new test **fails** against the pre-patch code (`AssertionError: watchdog did not heal dead aiohttp session`)
- Confirmed it **passes** with the fix applied
- Full `tests/gateway/test_slack.py` suite: 248 passed, no regressions

**Patch verification post-deploy on the affected production node:** clean restart, zero `Session is closed` errors since, and a real human Slack message sent after the patch was deployed was logged as a genuine inbound event and answered normally in the same thread — confirmed via the gateway's own inbound-message log line, not just event-callback noise.

## Follow-up (not blocking this PR)

If a rebuilt handler's session were to immediately close again, `_restart_socket_mode` would fire every watchdog interval (~15s). The existing `_socket_reconnect_lock` serializes concurrent restarts but doesn't rate-limit repeated ones over time. Not observed in practice, but worth a cooldown if it ever is.

## Related

- Root cause in the SDK itself (why the session gets closed inside `connect()`'s loop in the first place): issue filed against `slackapi/python-slack-sdk` — link once filed
- Production signature that led to this: continuous `Failed to connect (error: Session is closed); Retrying...` with intermittent event delivery still occurring, and no Hermes-side reconnect after the first 1-2 watchdog cycles
