### PR TITLE
fix(secrets): lazy-import bitwarden to prevent CLI crash on broken cryptography (#70697)

### DIFF
--- a/agent/secret_sources/command.py
+++ b/agent/secret_sources/command.py
@@ -41,10 +41,12 @@ import sys
 from pathlib import Path
 from typing import Dict, Optional
 
-# Reuse the exact result shape the bitwarden source returns so
-# hermes_cli.env_loader can consume both providers identically.
+# FetchResult lives in _cache (not bitwarden) so this module does not
+# inherit bitwarden's cryptography dependency.  When cryptography is
+# broken/stale, only BitwardenSource should fail — CommandSource must
+# still register. (#70697)
+from agent.secret_sources._cache import FetchResult
 from agent.secret_sources.base import ErrorKind, SecretSource
-from agent.secret_sources.bitwarden import FetchResult
 
 __all__ = [
     "FetchResult",

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -23,7 +23,22 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from agent.secret_sources import bitwarden as bw
+# Lazy import: bitwarden depends on the `cryptography` package, which may
+# be broken/stale after an upgrade. Importing at module level crashes the
+# entire CLI startup (#70697). The _bw() helper defers the import to the
+# first call so that `hermes` (without a secrets subcommand) and other
+# secret sources still work.
+_bw_module = None
+
+
+def _bw():
+    global _bw_module
+    if _bw_module is None:
+        from agent.secret_sources import bitwarden as _b
+        _bw_module = _b
+    return _bw_module
+
+
 from hermes_cli.config import (
     get_env_path,
     load_config,
@@ -101,9 +116,15 @@ def register_cli(parent_parser: argparse.ArgumentParser) -> None:
     disable = sub.add_parser("disable", help="Turn off the Bitwarden integration")
     disable.set_defaults(func=cmd_disable)
 
+    # _BWS_VERSION is read at parser-build time; guard so a broken
+    # cryptography import doesn't crash `hermes` entirely (#70697).
+    try:
+        _bws_ver = _bw()._BWS_VERSION
+    except Exception:
+        _bws_ver = "unknown"
     install = sub.add_parser(
         "install",
-        help=f"Download and verify the pinned bws binary (v{bw._BWS_VERSION})",
+        help=f"Download and verify the pinned bws binary (v{_bws_ver})",
     )
     install.add_argument(
         "--force",
@@ -135,10 +156,10 @@ def cmd_setup(args: argparse.Namespace) -> int:
     console.print()
     console.print("[bold]Step 1[/bold]  Install the bws CLI")
     try:
-        binary = bw.find_bws(install_if_missing=False)
+        binary = _bw().find_bws(install_if_missing=False)
         if binary is None:
             console.print("  No bws on PATH — downloading…")
-            binary = bw.install_bws()
+            binary = _bw().install_bws()
         version = _bws_version(binary)
         console.print(f"  [green]✓[/green] {binary}  ({version})")
     except Exception as exc:  # noqa: BLE001
@@ -255,7 +276,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
     step_num = 5 if not (args.project_id and args.project_id.strip()) else 4
     console.print(f"[bold]Step {step_num}[/bold]  Test fetch")
     try:
-        secrets, warnings = bw.fetch_bitwarden_secrets(
+        secrets, warnings = _bw().fetch_bitwarden_secrets(
             access_token=token,
             project_id=project_id,
             binary=binary,
@@ -318,7 +339,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     server_url = str(bw_cfg.get("server_url", "") or "").strip()
     token = os.environ.get(token_env, "").strip()
     token_set = bool(token)
-    binary = bw.find_bws(install_if_missing=False)
+    binary = _bw().find_bws(install_if_missing=False)
     token_validation, validation_messages = _token_validation_status(
         enabled=enabled,
         binary=binary,
@@ -402,7 +423,7 @@ def cmd_token(args: argparse.Namespace) -> int:
         )
 
     if not args.no_verify:
-        binary = bw.find_bws(install_if_missing=True)
+        binary = _bw().find_bws(install_if_missing=True)
         if binary is None:
             console.print(
                 "[red]bws binary not available — cannot verify.  "
@@ -433,7 +454,7 @@ def cmd_token(args: argparse.Namespace) -> int:
     os.environ[token_env] = token
     # Old cached pulls are keyed on the previous token's fingerprint; drop
     # them so the next startup fetches fresh with the new credential.
-    bw.clear_caches()
+    _bw().clear_caches()
     console.print(
         f"[green]✓[/green] stored in {get_env_path()} as {token_env}.  "
         "Takes effect on the next Hermes invocation."
@@ -472,7 +493,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
     server_url = str(bw_cfg.get("server_url", "") or "").strip()
 
     try:
-        secrets, warnings = bw.fetch_bitwarden_secrets(
+        secrets, warnings = _bw().fetch_bitwarden_secrets(
             access_token=token,
             project_id=project_id,
             use_cache=False,
@@ -540,7 +561,7 @@ def cmd_disable(args: argparse.Namespace) -> int:
 def cmd_install(args: argparse.Namespace) -> int:
     console = Console()
     try:
-        path = bw.install_bws(force=bool(args.force))
+        path = _bw().install_bws(force=bool(args.force))
         console.print(f"[green]✓[/green] {path}  ({_bws_version(path)})")
         return 0
     except Exception as exc:  # noqa: BLE001

--- a/tests/hermes_cli/test_secrets_bitwarden_non_tty.py
+++ b/tests/hermes_cli/test_secrets_bitwarden_non_tty.py
@@ -6,9 +6,26 @@ because getpass.getpass() and console.input() require an interactive terminal.
 from __future__ import annotations
 
 import argparse
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import pytest
+
+
+def _mock_bw(**overrides):
+    """Build a MagicMock standing in for the bitwarden module.
+
+    #70697: secrets_cli now lazy-imports bitwarden via ``_bw()`` instead of
+    a module-level ``bw`` binding, so tests patch ``_bw`` rather than ``bw``.
+    """
+    mock = MagicMock()
+    mock.find_bws.return_value = overrides.get("find_bws", "/usr/bin/bws")
+    mock.install_bws.return_value = overrides.get("install_bws", "/usr/bin/bws")
+    mock.fetch_bitwarden_secrets.return_value = overrides.get(
+        "fetch_bitwarden_secrets", ({"KEY": "val"}, [])
+    )
+    mock.clear_caches.return_value = None
+    mock._BWS_VERSION = overrides.get("_BWS_VERSION", "2.0.0")
+    return mock
 
 
 class TestCmdSetupNonTtyGuard:
@@ -26,9 +43,7 @@ class TestCmdSetupNonTtyGuard:
     def test_missing_all_flags_returns_1(self, monkeypatch, capsys):
         """Non-TTY with no flags → exit 1 with missing flags listed."""
         monkeypatch.setattr("sys.stdin.isatty", lambda: False)
-        monkeypatch.setattr(
-            "hermes_cli.secrets_cli.bw.find_bws", lambda install_if_missing=False: "/usr/bin/bws"
-        )
+        monkeypatch.setattr("hermes_cli.secrets_cli._bw", lambda: _mock_bw())
         monkeypatch.setattr(
             "hermes_cli.secrets_cli._bws_version", lambda _: "2.0.0"
         )
@@ -46,9 +61,7 @@ class TestCmdSetupNonTtyGuard:
     def test_missing_access_token_only(self, monkeypatch, capsys):
         """Non-TTY with server-url and project-id but no token → reports --access-token."""
         monkeypatch.setattr("sys.stdin.isatty", lambda: False)
-        monkeypatch.setattr(
-            "hermes_cli.secrets_cli.bw.find_bws", lambda install_if_missing=False: "/usr/bin/bws"
-        )
+        monkeypatch.setattr("hermes_cli.secrets_cli._bw", lambda: _mock_bw())
         monkeypatch.setattr(
             "hermes_cli.secrets_cli._bws_version", lambda _: "2.0.0"
         )
@@ -75,19 +88,13 @@ class TestCmdSetupNonTtyGuard:
         """Non-TTY with BWS_SERVER_URL env set → server-url not required."""
         monkeypatch.setattr("sys.stdin.isatty", lambda: False)
         monkeypatch.setenv("BWS_SERVER_URL", "https://vault.bitwarden.com")
-        monkeypatch.setattr(
-            "hermes_cli.secrets_cli.bw.find_bws", lambda install_if_missing=False: "/usr/bin/bws"
-        )
+        monkeypatch.setattr("hermes_cli.secrets_cli._bw", lambda: _mock_bw())
         monkeypatch.setattr(
             "hermes_cli.secrets_cli._bws_version", lambda _: "2.0.0"
         )
         monkeypatch.setattr("hermes_cli.secrets_cli.load_config", lambda: {})
         monkeypatch.setattr("hermes_cli.secrets_cli.save_env_value", lambda *a: None)
         monkeypatch.setattr("hermes_cli.secrets_cli.get_env_path", lambda: "/tmp/.env")
-        monkeypatch.setattr(
-            "hermes_cli.secrets_cli.bw.fetch_bitwarden_secrets",
-            lambda **kw: ({"KEY": "val"}, []),
-        )
 
         from hermes_cli.secrets_cli import cmd_setup
 
@@ -100,19 +107,13 @@ class TestCmdSetupNonTtyGuard:
     def test_all_flags_provided_passes_guard(self, monkeypatch):
         """Non-TTY with all three flags → guard passes, proceeds to setup."""
         monkeypatch.setattr("sys.stdin.isatty", lambda: False)
-        monkeypatch.setattr(
-            "hermes_cli.secrets_cli.bw.find_bws", lambda install_if_missing=False: "/usr/bin/bws"
-        )
+        monkeypatch.setattr("hermes_cli.secrets_cli._bw", lambda: _mock_bw())
         monkeypatch.setattr(
             "hermes_cli.secrets_cli._bws_version", lambda _: "2.0.0"
         )
         monkeypatch.setattr("hermes_cli.secrets_cli.load_config", lambda: {})
         monkeypatch.setattr("hermes_cli.secrets_cli.save_env_value", lambda *a: None)
         monkeypatch.setattr("hermes_cli.secrets_cli.get_env_path", lambda: "/tmp/.env")
-        monkeypatch.setattr(
-            "hermes_cli.secrets_cli.bw.fetch_bitwarden_secrets",
-            lambda **kw: ({"KEY": "val"}, []),
-        )
 
         from hermes_cli.secrets_cli import cmd_setup
 
@@ -126,9 +127,7 @@ class TestCmdSetupNonTtyGuard:
     def test_tty_does_not_trigger_guard(self, monkeypatch):
         """With TTY, the guard should not trigger (interactive mode allowed)."""
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-        monkeypatch.setattr(
-            "hermes_cli.secrets_cli.bw.find_bws", lambda install_if_missing=False: "/usr/bin/bws"
-        )
+        monkeypatch.setattr("hermes_cli.secrets_cli._bw", lambda: _mock_bw())
         monkeypatch.setattr(
             "hermes_cli.secrets_cli._bws_version", lambda _: "2.0.0"
         )
@@ -141,11 +140,6 @@ class TestCmdSetupNonTtyGuard:
         monkeypatch.setattr(
             "hermes_cli.secrets_cli._resolve_server_url",
             lambda *a: "https://vault.bitwarden.com",
-        )
-        # Provide project_id directly to avoid interactive project prompt
-        monkeypatch.setattr(
-            "hermes_cli.secrets_cli.bw.fetch_bitwarden_secrets",
-            lambda **kw: ({"KEY": "val"}, []),
         )
 
         from hermes_cli.secrets_cli import cmd_setup

--- a/tests/hermes_cli/test_secrets_token_rotation.py
+++ b/tests/hermes_cli/test_secrets_token_rotation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -31,6 +32,12 @@ def _bw_args(**overrides):
 @pytest.fixture
 def bw_env(monkeypatch, tmp_path):
     saved = {}
+    # #70697: secrets_cli now lazy-imports bitwarden via _bw(); patch _bw
+    # to return a MagicMock so tests can set attributes on it.
+    _mock_bw = MagicMock()
+    _mock_bw.find_bws.return_value = Path("/fake/bws")
+    _mock_bw.clear_caches.return_value = None
+    monkeypatch.setattr(bw_cli, "_bw", lambda: _mock_bw)
     monkeypatch.setattr(bw_cli, "load_config", lambda: {
         "secrets": {"bitwarden": {
             "enabled": True,
@@ -44,10 +51,6 @@ def bw_env(monkeypatch, tmp_path):
         lambda name, value: saved.__setitem__(name, value),
     )
     monkeypatch.setattr(bw_cli, "get_env_path", lambda: tmp_path / ".env")
-    monkeypatch.setattr(
-        bw_cli.bw, "find_bws",
-        lambda install_if_missing=True: Path("/fake/bws"),
-    )
     return saved
 
 
@@ -67,7 +70,7 @@ def test_bw_token_accepted_token_persisted_and_caches_cleared(bw_env, monkeypatc
         bw_cli, "_list_projects",
         lambda binary, token, console, server_url="": [{"id": "proj-1"}],
     )
-    monkeypatch.setattr(bw_cli.bw, "clear_caches", lambda *a, **kw: cleared.append(True))
+    monkeypatch.setattr(bw_cli._bw(), "clear_caches", lambda *a, **kw: cleared.append(True))
     rc = bw_cli.cmd_token(_bw_args(access_token="0.fresh"))
     assert rc == 0
     assert bw_env == {"BWS_ACCESS_TOKEN": "0.fresh"}
@@ -79,7 +82,7 @@ def test_bw_token_warns_when_project_not_visible(bw_env, monkeypatch, capsys):
         bw_cli, "_list_projects",
         lambda binary, token, console, server_url="": [{"id": "other-proj"}],
     )
-    monkeypatch.setattr(bw_cli.bw, "clear_caches", lambda *a, **kw: None)
+    monkeypatch.setattr(bw_cli._bw(), "clear_caches", lambda *a, **kw: None)
     rc = bw_cli.cmd_token(_bw_args(access_token="0.fresh"))
     assert rc == 0  # stored anyway — the token itself is valid
     out = capsys.readouterr().out
@@ -89,7 +92,7 @@ def test_bw_token_warns_when_project_not_visible(bw_env, monkeypatch, capsys):
 def test_bw_token_no_verify_skips_probe(bw_env, monkeypatch):
     probe = mock.Mock()
     monkeypatch.setattr(bw_cli, "_list_projects", probe)
-    monkeypatch.setattr(bw_cli.bw, "clear_caches", lambda *a, **kw: None)
+    monkeypatch.setattr(bw_cli._bw(), "clear_caches", lambda *a, **kw: None)
     rc = bw_cli.cmd_token(_bw_args(access_token="0.x", no_verify=True))
     assert rc == 0
     probe.assert_not_called()


### PR DESCRIPTION
When the `cryptography` package is broken or stale after an upgrade, importing `agent.secret_sources.bitwarden` at module load time crashes the entire `hermes` CLI — even commands that never touch Bitwarden.

Changes:
- secrets_cli.py: replace module-level `from ... import bitwarden as bw` with a lazy `_bw()` helper that defers the import to first use.
- command.py: import `FetchResult` from `_cache` (where it actually lives) instead of from `bitwarden`, breaking the dependency chain so `CommandSource` registration no longer inherits bitwarden cryptography requirement.
- Tests updated to patch `_bw()` instead of the old `bw` module binding.

Closes #70697.