### PR TITLE
fix(fallback): allow xai-oauth → xai failover on shared host/model

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1513,6 +1513,45 @@ def _fallback_entry_key(fb: dict) -> tuple[str, str, str]:
     )
 
 
+def _fallback_entry_is_same_backend_by_base_url(
+    *,
+    current_provider: str,
+    fb_provider: str,
+    current_base_url: str,
+    fb_base_url: str,
+    current_model: str,
+    fb_model: str,
+) -> bool:
+    """True when base_url+model identity means the fallback is the same backend.
+
+    Issue #22548: two ``custom_providers`` aliases that point at the same shim
+    URL with the same model must be skipped, or failover loops on the dead
+    backend.  First-class providers that share a host while using different
+    auth (``xai-oauth`` vs ``xai``, ``openai-codex`` vs ``openai-api``) are
+    distinct credential surfaces — skipping them strands configured failover
+    when primary and fallback reuse the same model slug on that host.
+    """
+    if not (
+        fb_base_url
+        and current_base_url
+        and fb_base_url == current_base_url
+        and fb_model == current_model
+    ):
+        return False
+    if fb_provider == current_provider:
+        return True
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        # Both sides are registered first-class providers → different auth
+        # identities even when the inference host matches. Allow failover.
+        if current_provider in PROVIDER_REGISTRY and fb_provider in PROVIDER_REGISTRY:
+            return False
+    except Exception:
+        pass
+    return True
+
+
 def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str]:
     """Return a skip reason for fallback entries known to be unusable locally."""
     fb_provider = (fb.get("provider") or "").strip().lower()
@@ -1601,7 +1640,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     # Skip entries that resolve to the current (provider, model) — falling
     # back to the same backend that just failed loops the failure. Compare
     # base_url too so two distinct custom_providers entries pointing at the
-    # same shim/proxy URL also dedup. See issue #22548.
+    # same shim/proxy URL also dedup. See issue #22548. Do NOT treat
+    # first-class providers that share a host (xai-oauth vs xai) as the same
+    # backend — they use different credentials.
     current_provider = (getattr(agent, "provider", "") or "").strip().lower()
     current_model = (getattr(agent, "model", "") or "").strip()
     current_base_url = str(getattr(agent, "base_url", "") or "").rstrip("/").lower()
@@ -1612,11 +1653,13 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_provider, fb_model,
         )
         return agent._try_activate_fallback(reason)
-    if (
-        fb_base_url_for_dedup
-        and current_base_url
-        and fb_base_url_for_dedup == current_base_url
-        and fb_model == current_model
+    if _fallback_entry_is_same_backend_by_base_url(
+        current_provider=current_provider,
+        fb_provider=fb_provider,
+        current_base_url=current_base_url,
+        fb_base_url=fb_base_url_for_dedup,
+        current_model=current_model,
+        fb_model=fb_model,
     ):
         logger.warning(
             "Fallback skip: chain entry base_url %s matches current backend",

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -334,3 +334,40 @@ class TestFallbackChainDedup:
 
         assert ok is False
         mock_resolve.assert_not_called()
+
+    def test_allows_xai_api_fallback_from_xai_oauth_same_host_model(self):
+        """xai-oauth and xai share api.x.ai but use different credentials.
+
+        A spending-limit 403 on OAuth must still be able to fall over to the
+        API-key provider even when both entries use the same model slug and
+        base URL.  Blind base_url+model dedup incorrectly skipped that path.
+        """
+        fbs = [
+            {
+                "provider": "xai",
+                "model": "grok-4.5",
+                "base_url": "https://api.x.ai/v1",
+            },
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent.provider = "xai-oauth"
+        agent.model = "grok-4.5"
+        agent.base_url = "https://api.x.ai/v1"
+
+        called = []
+
+        def _resolve(provider, model=None, raw_codex=False, **kwargs):
+            called.append((provider, model))
+            return _mock_client(base_url="https://api.x.ai/v1"), model
+
+        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_resolve):
+            with patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ):
+                ok = agent._try_activate_fallback()
+
+        assert ok is True
+        assert called == [("xai", "grok-4.5")]
+        assert agent.provider == "xai"
+        assert agent.model == "grok-4.5"


### PR DESCRIPTION
## Summary
- Stop treating first-class providers that share an inference host (xai-oauth vs xai) as the same backend during fallback base_url+model dedup.
- That dedup was meant for custom shim aliases (#22548) but was stranding configured API-key failover when OAuth hit a spending-limit 403 on the same model slug.
- Refs: #70203

## Test plan
- [x] `scripts/run_tests.sh tests/run_agent/test_provider_fallback.py`
- [ ] Manual: primary `xai-oauth` + `grok-4.5`, fallback `xai` + `grok-4.5` with `https://api.x.ai/v1`, trigger spending-limit 403 → should switch to xai instead of stopping on billing message