### PR TITLE
fix(catalog): wire api_key auth headers for http MCP servers

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -490,6 +490,10 @@ def _build_server_config(
         cfg["url"] = t.url
         if entry.auth.type == "oauth":
             cfg["auth"] = "oauth"
+        elif entry.auth.type == "api_key":
+            from hermes_cli.mcp_config import _bearer_auth_headers
+
+            cfg["headers"] = _bearer_auth_headers(entry.name)
     return cfg
 
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -216,6 +216,21 @@ class TestManifestParsing:
         cfg = _build_server_config(_entry("demo"), None)
         assert "env" not in cfg
 
+    def test_http_api_key_builds_bearer_headers_template(self, catalog_dir):
+        body = _basic_manifest(
+            transport={"type": "http", "url": "https://mcp.example.com/sse"},
+            auth={
+                "type": "api_key",
+                "env": [{"name": "MCP_DEMO_API_KEY", "prompt": "key", "secret": True}],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import _build_server_config
+
+        cfg = _build_server_config(_entry("demo"), None)
+        assert cfg["url"] == "https://mcp.example.com/sse"
+        assert cfg["headers"] == {"Authorization": "Bearer ${MCP_DEMO_API_KEY}"}
+
     def test_transport_env_bad_shape_rejected(self, catalog_dir):
         body = _basic_manifest()
         body["transport"]["env"] = ["DISABLE_TELEMETRY=true"]  # list, not mapping
@@ -333,6 +348,29 @@ class TestInstall:
         server = load_config()["mcp_servers"]["demo"]
         assert server["url"] == "https://mcp.example.com/sse"
         assert server["auth"] == "oauth"
+
+    def test_install_http_api_key_writes_bearer_headers(self, catalog_dir, monkeypatch):
+        body = _basic_manifest(
+            transport={"type": "http", "url": "https://mcp.example.com/sse"},
+            auth={
+                "type": "api_key",
+                "env": [{"name": "MCP_DEMO_API_KEY", "prompt": "key", "secret": True}],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli import mcp_catalog
+
+        monkeypatch.setattr(mcp_catalog, "_prompt_input", lambda *a, **kw: "secret-val")
+
+        from hermes_cli.mcp_catalog import install_entry
+        from hermes_cli.config import load_config
+
+        install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["url"] == "https://mcp.example.com/sse"
+        assert server["headers"] == {"Authorization": "Bearer secret-val"}
 
     def test_install_required_env_missing_raises(self, catalog_dir, monkeypatch):
         body = _basic_manifest(


### PR DESCRIPTION
## Problem

When an optional-mcps manifest declares `transport.type: http` with `auth.type: api_key`, `install_entry()` correctly prompts for the key and saves it to `.env`, but `_build_server_config()` only handled the `oauth` case. The `api_key` case produced a bare `url` entry with no `headers`, so every request to the server was unauthenticated (→ 401).

## Root Cause

In `hermes_cli/mcp_catalog.py`, `_build_server_config()` (line 489-492):
```python
elif t.type == http:
    cfg[url] = t.url
    if entry.auth.type == oauth:
        cfg[auth] = oauth
    # ← api_key case: nothing written, headers missing
```

## Fix

Import and call `_bearer_auth_headers(entry.name)` from `mcp_config.py` to produce the same `Authorization: Bearer ${MCP_<NAME>_API_KEY}` template used by the manual `hermes mcp add --url` path.

```python
elif t.type == http:
    cfg[url] = t.url
    if entry.auth.type == oauth:
        cfg[auth] = oauth
    elif entry.auth.type == api_key:
        from hermes_cli.mcp_config import _bearer_auth_headers
        cfg[headers] = _bearer_auth_headers(entry.name)
```

## Tests

- `test_http_api_key_builds_bearer_headers_template`: unit test for `_build_server_config()` verifying the template is correct
- `test_install_http_api_key_writes_bearer_headers`: integration test verifying end-to-end install writes headers to config

All 41 tests in `tests/hermes_cli/test_mcp_catalog.py` pass.

Closes #70632