### PR TITLE
fix(sanitizer): drop tool_calls key when all calls deduped, not set empty array

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2892,7 +2892,20 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {**msg, "tool_calls": kept_tcs}
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                else:
+                    # ALL calls were duplicates (e.g. a host-fed/merged history
+                    # carries two assistant turns with the same tool_call ids —
+                    # observed from the WebUI sidecar+state.db merge). Writing
+                    # ``tool_calls: []`` here reproduces the exact 400 this
+                    # function's normalization pass exists to prevent — but that
+                    # pass runs BEFORE this dedup and cannot see arrays emptied
+                    # here. Drop the key entirely instead (DeepSeek: HTTP 400
+                    # "Invalid 'messages[N].tool_calls': empty array").
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
+                    if not str(msg.get("content") or "").strip():
+                        msg = {**msg, "content": "(duplicate tool call removed)"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()


### PR DESCRIPTION
## Problem

When `sanitize_api_messages` deduplicates `tool_call_ids`, if all calls in a message are duplicates, the current code sets `tool_calls: []` on the message dict. Strict providers (DeepSeek v4) reject this with HTTP 400:

```
Invalid 'messages[N].tool_calls': empty array.
Expected an array with minimum length 1, but got an empty array instead.
```

The existing pre-API chokepoint (lines 2738-2770) that drops empty/invalid `tool_calls` arrays **runs before** the dedup pass and cannot see arrays emptied here.

## Root Cause

```python
# Current code (line 2896):
if len(kept_tcs) != len(msg.get("tool_calls") or []):
    msg = {**msg, "tool_calls": kept_tcs}  # ❌ kept_tcs=[], produces tool_calls:[]
```

## Fix

When `kept_tcs` is empty (all calls were duplicates), drop the `tool_calls` key entirely instead of preserving an empty array. If dropping the key would leave the message body empty (edge case: host-fed/merged histories from WebUI sidecar), supply a placeholder content string.

```python
if len(kept_tcs) != len(msg.get("tool_calls") or []):
    if kept_tcs:
        msg = {**msg, "tool_calls": kept_tcs}
    else:
        msg = {k: v for k, v in msg.items() if k != "tool_calls"}
        if not str(msg.get("content") or "").strip():
            msg = {**msg, "content": "(duplicate tool call removed)"}
```

## Testing

- Reproduced: DeepSeek v4 HTTP 400 when WebUI sidecar + state.db merge produces duplicate tool_call_ids that all get deduped
- Verified: same payload passes after fix (key dropped, no empty array)