### PR TITLE
fix(desktop): resume fails on string display_metadata from delegation events

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -191,6 +191,57 @@ describe('toChatMessages', () => {
       'background agent work finished'
     ])
   })
+
+  it('loads async_delegation_complete when display_metadata is a JSON string', () => {
+    // Remote / corrupted session rows can leave display_metadata as TEXT that
+    // only got one json.loads — using `in` on that string throws and fails resume.
+    const meta = {
+      delegation_id: 'deleg_0d84d484',
+      task_count: 1,
+      completed_count: 1,
+      failed_count: 0,
+      duration_seconds: 193.55
+    }
+
+    expect(() =>
+      toChatMessages([
+        {
+          role: 'user',
+          content: 'opaque delegation context payload',
+          display_kind: 'async_delegation_complete',
+          display_metadata: JSON.stringify(meta) as unknown as typeof meta,
+          timestamp: 1
+        }
+      ])
+    ).not.toThrow()
+
+    const [message] = toChatMessages([
+      {
+        role: 'user',
+        content: 'opaque delegation context payload',
+        display_kind: 'async_delegation_complete',
+        display_metadata: JSON.stringify(meta) as unknown as typeof meta,
+        timestamp: 1
+      }
+    ])
+
+    expect(message.role).toBe('system')
+    expect(chatMessageText(message)).toBe('1 background agent finished')
+  })
+
+  it('loads async_delegation_complete when display_metadata is a parsed object', () => {
+    const [message] = toChatMessages([
+      {
+        role: 'user',
+        content: 'opaque delegation context payload',
+        display_kind: 'async_delegation_complete',
+        display_metadata: { delegation_id: 'deleg_1', task_count: 3 },
+        timestamp: 1
+      }
+    ])
+
+    expect(chatMessageText(message)).toBe('3 background agents finished')
+  })
 })
 
 describe('renderMediaTags', () => {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -311,16 +311,36 @@ function transcriptContent(displayKind: SessionMessage['display_kind'], content:
   return displayKind === 'hidden' ? null : content
 }
 
+function taskCountFromDisplayMetadata(meta: SessionMessage['display_metadata'] | string | unknown): number | undefined {
+  let value: unknown = meta
+
+  // Session DB / remote backends can surface display_metadata as a JSON string
+  // (e.g. historically double-encoded TEXT). Never use `in` here — it throws on
+  // primitives and bricks session.resume for any transcript with a delegation event.
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value)
+    } catch {
+      return undefined
+    }
+  }
+
+  if (!value || typeof value !== 'object') {
+    return undefined
+  }
+
+  const count = (value as { task_count?: unknown }).task_count
+
+  return typeof count === 'number' ? count : undefined
+}
+
 function timelineDisplayContent(message: SessionMessage, content: string): string {
   if (message.display_kind === 'model_switch') {
     return 'model changed'
   }
 
   if (message.display_kind === 'async_delegation_complete') {
-    const count =
-      message.display_metadata && 'task_count' in message.display_metadata
-        ? message.display_metadata.task_count
-        : undefined
+    const count = taskCountFromDisplayMetadata(message.display_metadata)
 
     return count === undefined
       ? 'background agent work finished'

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5709,6 +5709,60 @@ class SessionDB:
                 return content
         return content
 
+    @staticmethod
+    def _encode_display_metadata(display_metadata: Any) -> Optional[str]:
+        """Serialize display_metadata for the TEXT column without double-encoding.
+
+        Import / replace paths sometimes hand us an already-serialized JSON
+        string (same hazard as tool_calls). ``json.dumps`` on that string would
+        store a quoted JSON string; one ``json.loads`` on read then yields a
+        Python ``str``, which crashes desktop resume (``'task_count' in meta``).
+        """
+        if display_metadata is None:
+            return None
+        if isinstance(display_metadata, str):
+            raw = display_metadata.strip()
+            if not raw:
+                return None
+            try:
+                parsed = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Ignoring non-JSON display_metadata string on write")
+                return None
+            if not isinstance(parsed, dict):
+                logger.warning("Ignoring non-object display_metadata on write")
+                return None
+            return json.dumps(parsed)
+        if isinstance(display_metadata, dict):
+            return json.dumps(display_metadata)
+        logger.warning(
+            "Ignoring unexpected display_metadata type on write: %s",
+            type(display_metadata).__name__,
+        )
+        return None
+
+    @staticmethod
+    def _decode_display_metadata(raw: Any) -> Optional[Dict[str, Any]]:
+        """Parse display_metadata TEXT, tolerating historical double-encoding."""
+        if raw is None:
+            return None
+        try:
+            meta = json.loads(raw) if isinstance(raw, str) else raw
+        except (TypeError, json.JSONDecodeError):
+            logger.warning("Ignoring invalid display metadata on message row")
+            return None
+        # One json.loads on a double-encoded row yields a JSON string — unwrap.
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta)
+            except (TypeError, json.JSONDecodeError):
+                logger.warning("Ignoring invalid display metadata on message row")
+                return None
+        if isinstance(meta, dict):
+            return meta
+        logger.warning("Ignoring non-object display metadata on message row")
+        return None
+
     def append_message(
         self,
         session_id: str,
@@ -5754,7 +5808,7 @@ class SessionDB:
         """
         # Display metadata is presentation-only and never changes the model
         # context role/content replayed to providers.
-        display_metadata_json = json.dumps(display_metadata) if display_metadata else None
+        display_metadata_json = self._encode_display_metadata(display_metadata)
         # Serialize structured fields to JSON before entering the write txn
         reasoning_details_json = (
             json.dumps(reasoning_details)
@@ -5871,7 +5925,7 @@ class SessionDB:
                 "UPDATE messages SET display_kind = ?, display_metadata = ? WHERE id = ?",
                 (
                     _scrub_surrogates(display_kind),
-                    json.dumps(display_metadata) if display_metadata else None,
+                    self._encode_display_metadata(display_metadata),
                     row[0],
                 ),
             )
@@ -5965,7 +6019,7 @@ class SessionDB:
                     1,
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
                     _scrub_surrogates(msg.get("display_kind")) if isinstance(msg.get("display_kind"), str) else None,
-                    json.dumps(msg["display_metadata"]) if msg.get("display_metadata") else None,
+                    self._encode_display_metadata(msg.get("display_metadata")),
                 ),
             )
             inserted += 1
@@ -6558,10 +6612,9 @@ class SessionDB:
             if row["display_kind"]:
                 msg["display_kind"] = row["display_kind"]
             if row["display_metadata"]:
-                try:
-                    msg["display_metadata"] = json.loads(row["display_metadata"])
-                except (TypeError, json.JSONDecodeError):
-                    logger.warning("Ignoring invalid display metadata on message row")
+                decoded_meta = self._decode_display_metadata(row["display_metadata"])
+                if decoded_meta is not None:
+                    msg["display_metadata"] = decoded_meta
             if row["timestamp"]:
                 msg["timestamp"] = row["timestamp"]
             if row["tool_call_id"]:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -7235,3 +7235,50 @@ class TestDisplayMetadataPersistence:
         assert len(switched) == 1
         assert switched[0]["display_metadata"] == meta
 
+    def test_replace_messages_does_not_double_encode_string_metadata(self, db):
+        """Import/replace can hand display_metadata as an already-JSON string."""
+        db.create_session("s1", source="cli")
+        meta = {
+            "delegation_id": "deleg_0d84d484",
+            "task_count": 1,
+            "completed_count": 1,
+            "failed_count": 0,
+            "duration_seconds": 193.55,
+        }
+        db.replace_messages(
+            "s1",
+            [
+                {
+                    "role": "user",
+                    "content": "event",
+                    "display_kind": "async_delegation_complete",
+                    "display_metadata": json.dumps(meta),
+                }
+            ],
+        )
+        reloaded = db.get_messages_as_conversation("s1")
+        assert reloaded[0]["display_metadata"] == meta
+
+    def test_decode_tolerates_historically_double_encoded_metadata(self, db):
+        """Rows written before the encode guard must still resume as dicts."""
+        db.create_session("s1", source="cli")
+        meta = {"delegation_id": "deleg_old", "task_count": 2}
+        double_encoded = json.dumps(json.dumps(meta))
+        with sqlite3.connect(db.db_path) as conn:
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp, "
+                "display_kind, display_metadata, observed, active) "
+                "VALUES (?, ?, ?, ?, ?, ?, 0, 1)",
+                (
+                    "s1",
+                    "user",
+                    "event",
+                    time.time(),
+                    "async_delegation_complete",
+                    double_encoded,
+                ),
+            )
+            conn.commit()
+        reloaded = db.get_messages_as_conversation("s1")
+        assert reloaded[0]["display_metadata"] == meta
+


### PR DESCRIPTION
## Summary
- Desktop `session.resume` crashed with `Cannot use 'in' operator to search for 'task_count'` when a transcript contained an `async_delegation_complete` row whose `display_metadata` was still a JSON string (common after replace/import double-encoding).
- Harden desktop timeline rendering to parse/typeof-check metadata (same posture as the TUI) so resume no longer bricks the session.
- Teach `SessionDB` encode/decode helpers to avoid writing double-encoded `display_metadata` and to unwrap historically corrupted rows on read.

## Test plan
- [x] `npx vitest run src/lib/chat-messages.test.ts` (apps/desktop)
- [x] `scripts/run_tests.sh tests/test_hermes_state.py -k DisplayMetadata`
- [ ] Open a desktop session that previously used background `delegate_task`, force-quit / reconnect, confirm resume loads without "Resume failed"
- [ ] Confirm a fresh delegation-complete event still shows `"N background agent(s) finished"`