### PR TITLE
feat(holographic): add Chinese regex patterns for auto_extract fact harvesting

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -402,13 +402,22 @@ class HolographicMemoryProvider(MemoryProvider):
             return pre or None
 
         _PREF_PATTERNS = [
+            # English
             re.compile(r'\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)', re.IGNORECASE),
             re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+\w+\s+is\s+(.+)', re.IGNORECASE),
             re.compile(r'\bI\s+(?:always|never|usually)\s+(.+)', re.IGNORECASE),
+            # Chinese
+            re.compile(r'我(?:喜欢|偏好|要用|用|需要|想要|希望)\s*(.+)', re.UNICODE),
+            re.compile(r'我的(?:首选|偏好|默认|常用|常用|固定)\s*[是:：]?\s*(.+)', re.UNICODE),
+            re.compile(r'我(?:总是|永远|一般|通常|一直|从来都?不)\s*(.+)', re.UNICODE),
         ]
         _DECISION_PATTERNS = [
+            # English
             re.compile(r'\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+)', re.IGNORECASE),
             re.compile(r'\bthe\s+project\s+(?:uses|needs|requires)\s+(.+)', re.IGNORECASE),
+            # Chinese
+            re.compile(r'(?:我们|咱们)\s*(?:决定|同意|选(?:择|定)了?|商量好了?)\s*(?:[去]?要)?\s*(.+)', re.UNICODE),
+            re.compile(r'(?:这个项目|该项目)\s*(?:用|需要|依赖|要求)\s*(.+)', re.UNICODE),
         ]
 
         extracted = 0


### PR DESCRIPTION
## What does this PR do?

Adds Chinese-language regex patterns to the `HolographicMemoryProvider._auto_extract_facts` method so that auto-extraction of durable facts works for Chinese-language conversations.

Previously, `_PREF_PATTERNS` and `_DECISION_PATTERNS` only matched English phrasing (e.g. "I prefer…", "we decided…"), so Chinese-only conversations produced zero auto-extracted facts when `auto_extract: true` was enabled — the feature was effectively dead for non-English users.

This is an enhancement to an existing in-tree memory provider (holographic), not a new provider.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/memory/holographic/__init__.py`:
  - Added 3 Chinese preference patterns to `_PREF_PATTERNS`:
    - 我(喜欢|偏好|要用|用|需要|想要|希望)… → user_pref
    - 我的(首选|偏好|默认|常用|固定)… → user_pref
    - 我(总是|永远|一般|通常|一直|从来都?不)… → user_pref
  - Added 2 Chinese decision patterns to `_DECISION_PATTERNS`:
    - (我们|咱们)(决定|同意|选择/定了|商量好了)… → project
    - (这个项目|该项目)(用|需要|依赖|要求)… → project
  - Original English patterns preserved unchanged.
  - No config, schema, or behavior changes for existing users.

## How to Test

1. Set `memory.provider: holographic` and `plugins.hermes-memory-store.auto_extract: true`
2. In a session, send Chinese messages like "我偏好使用简洁的回复" or "我们决定选这个方案"
3. After session ends, check `memory_store.db`:

   ```bash
   sqlite3 ~/.hermes/profiles/<profile>/memory_store.db "SELECT content, category FROM facts ORDER BY created_at DESC LIMIT 5;"
   ```

   The Chinese statements should appear as newly persisted facts (category = user_pref or project).

4. Existing English auto-extraction still works (run the existing English-path tests).

## Checklist

### Code

- [x] I searched for existing PRs to make sure this isn#t a duplicate
- [x] My commit messages follow Conventional Commits (`feat(holographic):`)
- [x] My PR contains **only** changes related to this feature
- [ ] I#ve run `pytest tests/plugins/memory/test_holographic_auto_extract.py` and all tests pass
- [ ] I#ve added tests for my changes — *(existing test suite only covers English patterns; Chinese tests would be a follow-up)*
- [x] I#ve tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — no new config keys, no documentation docs, no new tools
- [x] N/A — no cross-platform impact (pure regex addition)
- [x] N/A — tool schemas unchanged
