### PR TITLE
feat(kanban): dispatcher-authoritative worker-session provenance link

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1435,7 +1435,19 @@ def init_agent(
     
     # Session logging setup - auto-save conversation trajectories for debugging
     agent.session_start = datetime.now()
-    if session_id:
+    kanban_task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    kanban_session_id = (os.environ.get("HERMES_KANBAN_SESSION_ID") or "").strip()
+    if kanban_task_id:
+        if not kanban_session_id:
+            raise ValueError(
+                "dispatcher-pinned Kanban worker is missing HERMES_KANBAN_SESSION_ID"
+            )
+        if session_id and session_id != kanban_session_id:
+            raise ValueError(
+                "dispatcher-pinned Kanban worker session_id does not match the allocation"
+            )
+        agent.session_id = kanban_session_id
+    elif session_id:
         # Use provided session ID (e.g., from CLI)
         agent.session_id = session_id
     else:

--- a/cli.py
+++ b/cli.py
@@ -4229,9 +4229,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Deferred title: stored in memory until the session is created in the DB
         self._pending_title: Optional[str] = None
-        
+
+        kanban_task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+        kanban_session_id = (os.environ.get("HERMES_KANBAN_SESSION_ID") or "").strip()
+
         # Session ID: reuse existing one when resuming, otherwise generate fresh
-        if resume:
+        if kanban_task_id:
+            if not kanban_session_id:
+                raise ValueError(
+                    "dispatcher-pinned Kanban worker is missing HERMES_KANBAN_SESSION_ID"
+                )
+            if resume and resume != kanban_session_id:
+                raise ValueError(
+                    "dispatcher-pinned Kanban worker session_id does not match --resume"
+                )
+            self.session_id = kanban_session_id
+            self._resumed = False
+        elif resume:
             self.session_id = resume
             self._resumed = True
         else:

--- a/docs/kanban/worker-session-provenance-schema.md
+++ b/docs/kanban/worker-session-provenance-schema.md
@@ -1,0 +1,336 @@
+# Authoritative worker-session provenance schema
+
+Status: contract blueprint; no implementation
+
+Ground truth: `origin/main` at `a61183b56fdb45b9d2a0f2f6b8482e665ccf702f` (fetched 2026-07-24)
+
+Parent architecture: Kanban task `t_71bc4ffd`
+
+## Scope and invariants
+
+This contract gives later transcript maintenance a positive, persisted answer to one question: which exact Kanban board/task/run and profile state database own a Hermes session?
+
+The answer is authoritative only when all of the following are true:
+
+1. The board row is `attached`.
+2. The active board's live `board_instance_id` equals the row's `board_instance_id`.
+3. The active state database's live `state_db_instance_id` equals the row's `state_db_instance_id`.
+4. A state-DB row exists for the same `session_id`, the referenced `sessions` row exists, and all seven columns match byte-for-byte.
+5. The state-DB row is also `attached`.
+6. The board task/run join still agrees that `run_id` belongs to `task_id`.
+
+Anything else is unlinked or partial provenance and is ineligible for destructive maintenance. In particular, there is no legacy backfill from `sessions.cwd`, `sessions.source`, `parent_session_id`, timestamps, PIDs, prompts, comments, completion metadata, or filesystem paths.
+
+Instance identifiers are 128-bit random lowercase hex strings generated with `secrets.token_hex(16)`. They are opaque identities, not secrets and not hashes of mutable names or paths.
+
+## Current schema facts being preserved
+
+At the pinned `origin/main` revision:
+
+- `tasks.session_id` is documented as the originating chat/agent session (`hermes_cli/kanban_db.py:1205-1210`). It is not a worker transcript pointer.
+- `task_runs.profile` already records the selected worker profile (`hermes_cli/kanban_db.py:1256-1260`).
+- `sessions.profile_name` exists, but `sessions` has no board/task/run provenance (`hermes_state.py:1056-1104`).
+- The primary writable `SessionDB` connection enables `PRAGMA foreign_keys=ON` before schema initialization (`hermes_state.py:1654-1671`).
+- Both Kanban connection paths enable `PRAGMA foreign_keys=ON` (`hermes_cli/kanban_db.py:2100-2115`, `2126-2159`).
+
+## Board identity
+
+Each board database owns one immutable `board_instance_id` in a singleton `board_meta` row. A singleton table is preferred over a generic pragma or untyped key/value row because it gives the worker relation a real foreign-key target and makes a second identity structurally impossible.
+
+```sql
+CREATE TABLE IF NOT EXISTS board_meta (
+    singleton         INTEGER NOT NULL PRIMARY KEY CHECK (singleton = 1),
+    board_instance_id TEXT NOT NULL UNIQUE
+        CHECK (
+            length(board_instance_id) = 32
+            AND board_instance_id NOT GLOB '*[^0-9a-f]*'
+        )
+) WITHOUT ROWID;
+```
+
+A backup restored as the same logical board preserves this ID. A copied DB
+with the identity intact is still the same logical board. Creating a distinct
+board from that copy requires an exclusive clone/rekey operation that first
+revokes and removes the copied worker-link rows, then replaces the singleton
+ID; merely changing the board slug or path does not create a new identity.
+
+### First-upgrade algorithm
+
+The board identity migration runs on every uncached initialization path after connection pragmas are set. Its correctness does not depend on the best-effort cross-process init flock.
+
+1. Generate a candidate ID in application code.
+2. Start `BEGIN IMMEDIATE` through an init-only transaction helper with the
+   same busy/retry policy as Kanban writes. Do not route schema initialization
+   through the public `write_txn` delegated-child mutation guard.
+3. Create `board_meta` and the worker-link schema with `IF NOT EXISTS`.
+4. Execute:
+
+   ```sql
+   INSERT INTO board_meta (singleton, board_instance_id)
+   VALUES (1, :candidate)
+   ON CONFLICT(singleton) DO NOTHING;
+   ```
+
+5. In the same transaction, read:
+
+   ```sql
+   SELECT board_instance_id
+   FROM board_meta
+   WHERE singleton = 1;
+   ```
+
+6. Validate the exact lowercase-hex format. Missing or malformed data aborts initialization; it is never silently replaced.
+7. Commit and return the selected value.
+
+`BEGIN IMMEDIATE` serializes concurrent first-open writers. If two processes generated different candidates, one insert wins and both read the same committed value. A crash after table creation but before insert leaves an empty singleton table; the next open safely inserts. Re-running the migration is a no-op.
+
+Authorization-sensitive callers must read the ID from the live connection inside their current transaction. A module-level cached ID may be used for display only, never to register or attach a session.
+
+## State-database identity
+
+Each Hermes state-database incarnation owns one immutable
+`state_db_instance_id`. An explicit rename/copy rekey closes that incarnation
+and starts a new one; ordinary opens never mutate the ID. It is not
+`profile_name` and is not an absolute `HERMES_HOME` path. The state DB also
+records the profile name under which the identity was issued as a rename/copy
+guard; the name is an attribute, not the identity.
+
+```sql
+CREATE TABLE IF NOT EXISTS state_db_meta (
+    singleton              INTEGER NOT NULL PRIMARY KEY CHECK (singleton = 1),
+    state_db_instance_id   TEXT NOT NULL UNIQUE
+        CHECK (
+            length(state_db_instance_id) = 32
+            AND state_db_instance_id NOT GLOB '*[^0-9a-f]*'
+        ),
+    profile_name_at_issue  TEXT NOT NULL CHECK (profile_name_at_issue <> '')
+) WITHOUT ROWID;
+```
+
+This belongs in `hermes_state.py`'s declarative schema. The state schema version advances from 23 to 24 because this adds durable authorization state, even though the always-run reconciliation remains the correctness backstop.
+
+After `_init_schema()` has created the table, writable `SessionDB` initialization runs an unconditional `BEGIN IMMEDIATE` ensure step equivalent to the board algorithm: insert `(1, candidate, active_profile_name)` on singleton conflict do nothing, then select and validate the live row before commit. It never updates an existing valid ID.
+
+A read-only `SessionDB` must not seed identity. If `state_db_meta` or its singleton row is absent, read-only resolution returns `legacy_unlinked`; registration requires a writable initialized `SessionDB`.
+
+### Registration verification
+
+Every API that registers a reciprocal row accepts an expected identity, never authority by assertion. Inside the same state-DB write transaction that creates the session and reciprocal row, it must:
+
+1. Read `state_db_instance_id` and `profile_name_at_issue` from the live active state DB.
+2. Resolve the active profile name from the profile-scoped runtime, not from caller-provided data.
+3. Require `expected_state_db_instance_id == live_state_db_instance_id`.
+4. Require `expected_profile_name == active_profile_name == profile_name_at_issue`.
+5. Reject before writing on any mismatch.
+
+The board registration/attach API applies the same rule to `board_instance_id`: it reads the live singleton inside its transaction and compares it with the expected tuple. Neither API may accept a cached identity from startup as sufficient proof.
+
+## Board-side `worker_session_links`
+
+The relation has exactly the requested seven columns. There is deliberately no surrogate key.
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS uq_task_runs_id_task_id
+    ON task_runs(id, task_id);
+
+CREATE TABLE IF NOT EXISTS worker_session_links (
+    board_instance_id    TEXT NOT NULL,
+    task_id               TEXT NOT NULL,
+    run_id                INTEGER NOT NULL,
+    profile_name          TEXT NOT NULL CHECK (profile_name <> ''),
+    state_db_instance_id  TEXT NOT NULL,
+    session_id            TEXT NOT NULL,
+    state                 TEXT NOT NULL
+        CHECK (state IN ('allocated', 'attached', 'retired', 'orphaned')),
+
+    PRIMARY KEY (state_db_instance_id, session_id),
+
+    FOREIGN KEY (board_instance_id)
+        REFERENCES board_meta(board_instance_id)
+        ON UPDATE RESTRICT ON DELETE RESTRICT,
+    FOREIGN KEY (run_id, task_id)
+        REFERENCES task_runs(id, task_id)
+        ON DELETE CASCADE
+) WITHOUT ROWID;
+
+CREATE INDEX IF NOT EXISTS idx_worker_session_links_run
+    ON worker_session_links(board_instance_id, task_id, run_id);
+```
+
+The composite primary key enforces the required uniqueness within this board
+and makes both key columns non-null under SQLite's `WITHOUT ROWID` semantics.
+Because Hermes can host several independent board databases, the reciprocal
+state table's `session_id` primary key is the final cross-board/fleet boundary:
+a second board may reserve an `allocated` row, but it cannot create a second
+local reciprocal attachment for the same physical session. Consequently two
+boards can never both reach authoritative exact reciprocal `attached` state.
+
+`run_id` is intentionally not unique. Multiple rows with the same board/task/run and different session IDs are required for compression and other explicit continuations.
+
+The composite task-run foreign key prevents a row from pairing an existing run with the wrong task. Deleting a task/run cascades its board-side authority rows; this is authorization revocation, not evidence that the corresponding state sessions may be deleted. Any surviving state-side rows become reciprocal mismatches and therefore remain ineligible.
+
+## Reciprocal state-DB `worker_session_links`
+
+The state database uses the same relation name and exactly the same seven columns. `session_id` is the local primary key because one physical state DB can contain a session ID only once.
+
+```sql
+CREATE TABLE IF NOT EXISTS worker_session_links (
+    board_instance_id    TEXT NOT NULL,
+    task_id               TEXT NOT NULL,
+    run_id                INTEGER NOT NULL,
+    profile_name          TEXT NOT NULL CHECK (profile_name <> ''),
+    state_db_instance_id  TEXT NOT NULL,
+    session_id            TEXT NOT NULL PRIMARY KEY
+        REFERENCES sessions(id) ON DELETE CASCADE,
+    state                 TEXT NOT NULL
+        CHECK (state IN ('allocated', 'attached', 'retired', 'orphaned')),
+
+    FOREIGN KEY (state_db_instance_id)
+        REFERENCES state_db_meta(state_db_instance_id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
+) WITHOUT ROWID;
+```
+
+No state-side foreign key can target board tables because they live in another SQLite database. Exact reciprocal comparison is therefore an application-level invariant evaluated from live, locking connections to both databases.
+
+## State meanings and transitions
+
+- `allocated`: the board has reserved this session ID for the current run, but the exact local session/reciprocal commit has not yet been acknowledged by the board. Never eligible.
+- `attached`: the session and local reciprocal row committed, and the board compare-and-swap acknowledged the same tuple while the run claim was current. This is the only authoritative state.
+- `retired`: authority was explicitly revoked, for example because a retry superseded a transient session or maintenance deliberately retired the link. Never eligible.
+- `orphaned`: allocation/attachment was abandoned or an explicit repair quarantined a partial/mismatched pair. Never eligible.
+
+Allowed board transitions are monotonic:
+
+```text
+allocated -> attached
+allocated -> orphaned
+attached  -> retired
+attached  -> orphaned
+```
+
+Terminal states do not transition back. Repair that wants a valid attachment creates a new allocation; it does not infer or resurrect authority from cwd, parentage, or timestamps.
+
+Normal run closure must not retire every attached row: doing so would erase all provenance before retention-based maintenance could use it. Run closure instead marks any still-`allocated` rows `orphaned`; already-`attached` rows remain attached. A specific superseded retry session may be retired explicitly. The terminal `task_runs` row remains the source for run outcome and `ended_at`.
+
+## Two-phase cross-DB attach
+
+SQLite cannot atomically commit across the board and an independently opened profile state DB. The protocol is intentionally asymmetric and fail-closed:
+
+1. **Board allocation transaction**
+   - Re-read the live board ID.
+   - Verify task status, `current_run_id`, claim lock/expiry, and selected profile.
+   - Re-read the selected profile's live state DB ID.
+   - Generate a fresh session ID.
+   - Insert the board row as `allocated`.
+
+2. **State registration transaction**
+   - Re-read and verify the live state DB identity/profile binding.
+   - Insert the `sessions` row and reciprocal row in one transaction.
+   - The local reciprocal row is inserted as `attached`: locally, the session now exists and has committed provenance. If either insert fails, both roll back.
+
+3. **Board attach transaction**
+   - Re-read the live board ID and current task/run/claim/profile state.
+   - Compare-and-swap the exact row from `allocated` to `attached`.
+   - A zero-row update is a hard failure, never a fallback to an ordinary session.
+
+A crash after step 1 leaves board `allocated` with no local row. A crash after step 2 leaves board `allocated` and local `attached`. Both shapes are ineligible because exact reciprocal `attached` rows do not exist. Automatic startup repair is forbidden.
+
+Every continuation repeats all three steps with a fresh session ID. `parent_session_id` may describe transcript topology but never supplies provenance.
+
+## Read-only resolver contract
+
+The public resolver returns an authoritative link only after independently reading the live singleton IDs and exact rows from both locking read-only SQLite connections. It must not use `immutable=1` for live DBs.
+
+The resolver compares all seven columns, verifies the state-side `sessions` row exists, and verifies the board task/run join. Suggested non-authoritative classifications are:
+
+- `legacy_unlinked`
+- `board_allocated`
+- `board_terminal_state`
+- `state_row_missing`
+- `session_row_missing`
+- `tuple_mismatch`
+- `board_identity_mismatch`
+- `state_identity_mismatch`
+- `task_run_mismatch`
+- `attached`
+
+Only `attached` is eligible for later policy checks. Session age, `ended_at`, task/run terminality, maintenance locks, snapshots, and deletion are outside this schema contract and remain additional mandatory gates.
+
+## Profile rename, copy, and restore
+
+A profile rename or independent profile-home copy must not inherit the source state DB identity.
+
+- Current managed `profile create --clone-all` already excludes `state.db`, `state.db-wal`, and `state.db-shm`, so its fresh target naturally receives a new ID (`hermes_cli/profiles.py:104-126`).
+- Current `rename_profile` moves the directory without touching `state.db` (`hermes_cli/profiles.py:2150-2202`). The implementation must add an explicit identity-rekey step after quiescing the old profile and before the renamed profile may dispatch workers.
+- Any import/copy intended to create an independent profile must run the same rekey step before worker registration. A restore explicitly declared to restore the same logical profile/database may preserve the ID.
+
+Rekey runs under the profile-exclusive maintenance lock in one state-DB transaction:
+
+1. Require no active worker registration/attach transaction.
+2. Mark existing local worker links `orphaned`.
+3. Update the singleton to a new random ID and new `profile_name_at_issue`; `ON UPDATE CASCADE` carries the new ID into the now-orphaned local rows.
+4. Do not rewrite board rows. Their old identity no longer matches, so they fail closed.
+
+A byte-for-byte raw copy is information-theoretically indistinguishable from restoration of the same logical DB using DB-local contents alone. Such a copy is unsupported as an independent profile until the explicit rekey operation runs. Registration must reject a profile-name binding mismatch and an expected/live state ID mismatch; it must never silently rekey on worker startup.
+
+## Foreign-key pragma and cascade proof
+
+SQLite foreign keys are per connection and default off. The DDL alone is insufficient.
+
+Every writable board/state connection must execute `PRAGMA foreign_keys=ON` before any transaction and verify `PRAGMA foreign_keys` returns `1`. Setting it inside an already-open transaction is ineffective. Migration verification must run `PRAGMA foreign_key_check` and fail on any row.
+
+Current primary connections satisfy this:
+
+- Kanban `connect()` enables foreign keys on both fast and initialization paths.
+- Writable `SessionDB` enables foreign keys before `_init_schema()`.
+- Read-only `SessionDB` returns before setting the pragma, but it cannot delete and does not need cascades.
+
+A live probe against the current `SessionDB` connection created a session plus a temporary `session_id REFERENCES sessions(id) ON DELETE CASCADE` row, then deleted via `SessionDB.delete_session()`. The observed result was:
+
+```text
+foreign_keys=1, link rows before=1, delete returned true, link rows after=0
+```
+
+If a future raw SQLite writer omits the pragma, deleting a session can leave a stale reciprocal row. The resolver must still join to `sessions`, so the stale row is ineligible rather than authoritative; however, the orphan is a schema-integrity failure and must be surfaced by `foreign_key_check`, not ignored.
+
+## Explicit non-repurposing
+
+`tasks.session_id` remains the originating chat/agent session that created the card. It is never written with a worker transcript ID and is never consulted for worker-session ownership.
+
+`worker_session_id` in task-run completion metadata remains diagnostic only. It may help an operator investigate a run, but contradictory or missing metadata has no effect on authoritative resolution.
+
+## Migration and rollout checklist
+
+1. Fetch and pin current `origin/main`; do not implement against an installed stale checkout.
+2. Add board singleton/relation DDL and the transactional always-run identity ensure.
+3. Add state singleton/relation DDL, bump `SCHEMA_VERSION` to 24, and add the transactional always-run identity ensure.
+4. Do not backfill worker links for existing sessions or runs.
+5. Add live-read APIs for both IDs; do not expose an authorization cache.
+6. Add transactional state registration and board allocation/attach CAS APIs.
+7. Add the explicit rekey API and wire managed rename/copy/independent-restore paths before enabling worker registration there.
+8. Restart long-lived gateways/dispatchers after rollout. Old processes cannot create authoritative rows; sessions they create remain safely unlinked.
+9. Run schema checks on fresh and upgraded DBs, including `PRAGMA foreign_key_check`.
+10. Only after this contract is merged may maintenance locking and transcript GC consume it.
+
+## Required failure-mode tests
+
+- Eight or more concurrent first opens converge on one board ID and one state DB ID.
+- Interrupted migration with table present/row absent recovers idempotently.
+- Invalid or duplicate singleton data fails initialization without regeneration.
+- Two session IDs under one run succeed.
+- A second run claiming the same `(state_db_instance_id, session_id)` fails without modifying the first row.
+- A local session delete cascades the reciprocal state row with foreign keys enabled.
+- The missing-pragma fixture demonstrates the stale row and resolver ineligibility, then `foreign_key_check` detects it.
+- Board `allocated` without local row is ineligible.
+- Board `allocated` plus local `attached` is ineligible.
+- Exact reciprocal `attached` tuples resolve; a one-column mismatch does not.
+- A same-cwd human CLI session with no rows is unlinked.
+- Profile rename/copy rekeys before registration; replaying the old expected identity is rejected.
+- Compression creates a second independently attached row for the same run.
+- `tasks.session_id` and completion `worker_session_id` are ignored even when they contradict the reciprocal relation.
+
+A local DDL probe of the schema in this note observed one identity across eight
+concurrent board opens and, separately, eight concurrent state-DB opens. It
+also allowed two sessions for one run, rejected a duplicate state/session key,
+and cascaded the state reciprocal row on session deletion.

--- a/docs/kanban/worker-session-provenance-verification.md
+++ b/docs/kanban/worker-session-provenance-verification.md
@@ -1,0 +1,137 @@
+# Verification report — `t_911989ea`
+
+**Gate:** Verify deployed facts and rebase ground truth against fetched remote.
+**Head checked:** `a61183b56fdb45b9d2a0f2f6b8482e665ccf702f` (local `HEAD` and `origin/main` identical; `git rev-list --left-right --count HEAD...origin/main` = `0 0`).
+**Design doc under verification:** `docs/kanban/worker-session-provenance-schema.md` (untracked, authored by `t_89462c86`).
+
+## Verdict
+
+**No drift.** Every deployed fact called out in the design doc holds against
+`origin/main` at the pinned head, and the proposed `board_instance_id` /
+`state_db_instance_id` / reciprocal `worker_session_links` schema does NOT
+collide with any existing code, table, or migration. The implementation task
+(`t_1090554f`) may proceed against this ground truth.
+
+## Deployed facts the design doc relies on (all current)
+
+| Fact | Where it lives on `origin/main` | Status |
+|---|---|---|
+| Kanban pins `HERMES_KANBAN_TASK` | `hermes_cli/kanban_db.py:8754` (`env["HERMES_KANBAN_TASK"] = task.id`) | current |
+| Kanban pins `HERMES_KANBAN_RUN_ID` | `hermes_cli/kanban_db.py:8772-8773` | current |
+| Kanban pins `HERMES_KANBAN_CLAIM_LOCK` | `hermes_cli/kanban_db.py:8774-8775` | current |
+| Kanban pins `HERMES_KANBAN_BOARD` | `hermes_cli/kanban_db.py:8806-8807` | current |
+| Kanban pins `HERMES_KANBAN_DB` | `hermes_cli/kanban_db.py:8801` | current |
+| Kanban pins `HERMES_KANBAN_WORKSPACE` / `WORKSPACES_ROOT` | `hermes_cli/kanban_db.py:8755`, `8802` | current |
+| Kanban pins `HERMES_PROFILE` (worker profile) | `hermes_cli/kanban_db.py:8812` | current |
+| `tasks.session_id` is the originating chat session | `hermes_cli/kanban_db.py:1205-1210` (column doc: "Originating chat/agent session id when the task was created from inside an agent loop that propagated `HERMES_SESSION_ID`.") | current; meaning preserved, not repurposed |
+| `task_runs.profile` exists | `hermes_cli/kanban_db.py:1256-1260` (`task_runs` DDL: `profile TEXT`) | current |
+| `sessions.profile_name` exists, no task/run provenance on `sessions` | `hermes_state.py:1101` (`profile_name TEXT`); no `task_id` / `run_id` / `board_*` / `state_db_*` columns in the `sessions` table (lines 1056-1105) | current |
+| `worker_session_id` completion metadata stamped from `HERMES_SESSION_ID` | `tools/kanban_tools.py:160-165` (`stamped["worker_session_id"] = session_id`); tests in `tests/tools/test_kanban_tools.py:343-364` prove the env value overrides caller-supplied metadata | current; remains diagnostic only — no schema or authority tied to it |
+| Kanban `connect()` enables `PRAGMA foreign_keys=ON` (fast + init paths) | `hermes_cli/kanban_db.py:2109`, `2143` | current |
+| Writable `SessionDB` enables `PRAGMA foreign_keys=ON` before `_init_schema()` | `hermes_state.py:1669-1671` | current |
+| `HERMES_KANBAN_*` keys also documented centrally in `KANBAN_ENV_KEYS` | `agent/delegation_context.py:22-30` | current |
+| `HERMES_PROFILE` documented as the comment-authoring profile pin | `hermes_cli/kanban_db.py:8808-8812` | current |
+
+Nothing on the list has drifted since the design was written. The design
+doc's "ground truth: `origin/main` at `a61183b56...`" header is faithful to
+the live checkout.
+
+## Proposed-schema collision check
+
+Repo-wide ripgrep for `board_instance_id`, `state_db_instance_id`, and
+`worker_session_links` returns exactly one hit — the untracked design doc
+itself (`docs/kanban/worker-session-provenance-schema.md`). No table,
+column, index, or test on `origin/main` references any of the three
+identifiers. Implementation has not started.
+
+| Proposed object | Collision? | Notes |
+|---|---|---|
+| `board_meta` singleton table (board) | none | name unused on `origin/main` |
+| `state_db_meta` singleton table (state) | none | name unused on `origin/main`; sits next to existing `state_meta` (FTS storage version marker) without overlap |
+| Board `worker_session_links` (7 cols) | none | relation name unused; the new `uq_task_runs_id_task_id` UNIQUE INDEX is also unused |
+| State `worker_session_links` (7 cols, FK to `sessions(id)` ON DELETE CASCADE) | none | relation name unused |
+| `state_db_instance_id` column on state reciprocal | none | column name unused |
+| Bump `SCHEMA_VERSION` 23 → 24 in `hermes_state.py` | safe | `SCHEMA_VERSION = 23` at `hermes_state.py:213`; migration gating at `hermes_state.py:2999-3256` advances schema_version after data migrations; v24 is the next free slot |
+| `BEGIN IMMEDIATE` + retry policy mirror | safe | pattern already in use at `hermes_state.py:1665` (explicit `isolation_level=None`) and in kanban `write_txn`; the design doc explicitly forbids routing schema init through `write_txn`'s delegated-child mutation guard |
+
+The proposed DDL is additive and idempotent (`IF NOT EXISTS` everywhere, no
+column renames, no existing table touched). The two existing
+`PRAGMA foreign_keys=ON` activation points are exactly the ones the design
+doc claims they are.
+
+## `claim_task` / `_default_spawn` / `_set_worker_pid` / run-closing impact
+
+- `claim_task` (`hermes_cli/kanban_db.py:3989`): writes `task_runs` with
+  `status='running'`, `claim_lock`, `claim_expires`. Adding the
+  board-identity CAS in the design doc happens before `task_runs` insert
+  and the existing invariant recovery at lines 4034-4049 is preserved.
+- `_default_spawn` (`hermes_cli/kanban_db.py:8705`): builds the child env
+  from `task.assignee` + claim state. The pinned-env list (lines 8754-8812)
+  is exactly what the design doc needs; no new env var is required at
+  spawn time — `board_instance_id` and `state_db_instance_id` are read
+  from the live singletons inside each phase's transaction, not carried
+  in env.
+- `_set_worker_pid` (`hermes_cli/kanban_db.py:7736`): pure write to
+  `tasks.worker_pid` + `task_runs.worker_pid` + `spawned` event. The
+  design doc's worker attachment phase 3 happens strictly before
+  `_set_worker_pid` (phase 3 is what makes the session `attached`; the
+  pid record follows). No conflict.
+- Run-closing: `complete_task` (`hermes_cli/kanban_db.py:4599`) and
+  `claim_task`'s reclaim path (lines 4034-4049) write to `task_runs`
+  outcome / `ended_at` only. The design doc explicitly says run closure
+  marks still-`allocated` board rows `orphaned` and leaves `attached`
+  rows `attached`. That is an additive write against
+  `worker_session_links.state` and does not touch the run row.
+
+The two-phase attach (board `allocated` → state session+reciprocal
+`attached` → board CAS `attached`) slots in cleanly between the claim
+CAS (which already does idempotent `ON CONFLICT` semantics) and
+`_set_worker_pid`. No existing call site has to change shape; the
+contract is purely additive.
+
+## Migration conflict check on `origin/main`
+
+`SCHEMA_VERSION = 23` is the current value. There is no `v24` migration
+landed on `origin/main` and no work-in-progress file under
+`hermes_state.py` declares `state_db_meta` or `worker_session_links`.
+The 900-commit gap called out in the design doc was a 2026-07-24
+observation; the current checkout is in sync with the fetched remote,
+so any drift that may have existed at design time is now resolved and
+the design doc's "fetch and pin current `origin/main`; do not implement
+against an installed stale checkout" instruction in its rollout
+checklist is satisfied.
+
+## `tasks.session_id` non-repurposing
+
+The column at `hermes_cli/kanban_db.py:1210` is documented as
+"Originating chat/agent session id when the task was created from
+inside an agent loop that propagated `HERMES_SESSION_ID`." No write
+path on `origin/main` ever populates it with a worker transcript id,
+and no read path uses it to claim worker-session ownership. The design
+doc's "do not repurpose" invariant is consistent with the current code.
+
+## Recommendation
+
+Implementation (`t_1090554f`) may proceed against this ground truth.
+There is nothing to route back to the schema design task. Before merge,
+the implementer should still:
+
+1. Re-pin `origin/main` and re-run the verification once more
+   immediately before opening the PR (this report's freshness is bound
+   to head `a61183b56...`).
+2. Honor the design doc's mandatory failure-mode test list
+   (concurrent first-open convergence, two-DB crash matrix,
+   same-cwd-human-CLI non-linkage, profile rename/copy rekey, exact
+   reciprocal mismatch, etc.).
+3. Treat the untracked design doc as part of the contract — if the
+   PR disagrees with it, route the disagreement back to the schema
+   design task rather than silently diverging.
+
+## Files cited
+
+- `docs/kanban/worker-session-provenance-schema.md` (untracked; design contract)
+- `hermes_cli/kanban_db.py` (`claim_task` 3989, `complete_task` 4599, `_set_worker_pid` 7736, `_default_spawn` 8705, env pin 8754-8812, `connect()` 2080-2163)
+- `hermes_state.py` (`SCHEMA_VERSION` 213, `sessions` DDL 1056-1105, writable-init FK pragma 1669-1671, migration gate 2999-3256)
+- `tools/kanban_tools.py` (worker-session-id stamp 160-165)
+- `agent/delegation_context.py` (`KANBAN_ENV_KEYS` 22-30)
+- `tests/tools/test_kanban_tools.py` (worker-session-id behaviour 343-391)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -909,6 +909,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_gc.add_argument("--log-retention-days", type=int, default=30,
                       help="Delete worker log files older than N days (default: 30)")
 
+    p_repair_session_link = sub.add_parser(
+        "repair-session-link",
+        help="Explicitly finish a live allocated worker-session link",
+    )
+    p_repair_session_link.add_argument("task_id", nargs="?", default=None)
+    p_repair_session_link.add_argument("--session-id", default=None)
+    p_repair_session_link.add_argument("--run-id", type=int, default=None)
+    p_repair_session_link.add_argument("--claim-lock", default=None)
+    p_repair_session_link.add_argument("--json", action="store_true")
+
     # --- repair ---
     p_repair = sub.add_parser(
         "repair",
@@ -1062,6 +1072,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "specify":  _cmd_specify,
             "decompose":  _cmd_decompose,
             "gc":       _cmd_gc,
+            "repair-session-link": _cmd_repair_session_link,
         }
         handler = handlers.get(action)
         if not handler:
@@ -1120,6 +1131,7 @@ _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "specify",
     "decompose",
     "gc",
+    "repair-session-link",
 })
 
 _DELEGATED_CHILD_DENIED_BOARD_ACTIONS: frozenset[str] = frozenset({
@@ -3034,6 +3046,74 @@ def _cmd_gc(args: argparse.Namespace) -> int:
     )
     print(f"GC complete: {removed_ws} workspace(s), "
           f"{removed_events} event row(s), {removed_logs} log file(s) removed")
+    return 0
+
+
+def _cmd_repair_session_link(args: argparse.Namespace) -> int:
+    task_id = str(args.task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    session_id = str(args.session_id or os.environ.get("HERMES_KANBAN_SESSION_ID") or "").strip()
+    claim_lock = str(args.claim_lock or os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or "").strip()
+    run_id = args.run_id
+    if run_id is None:
+        raw_run_id = str(os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+        if raw_run_id:
+            try:
+                run_id = int(raw_run_id)
+            except ValueError:
+                run_id = None
+    if not task_id or not session_id or not claim_lock or run_id is None:
+        print(
+            "kanban repair-session-link requires task_id, session_id, run_id, and claim_lock "
+            "(args or pinned HERMES_KANBAN_* env).",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        from hermes_state import SessionDB
+
+        profile_name = str(get_active_profile_name() or "default").strip() or "default"
+        with kb.connect_closing() as conn:
+            link = kb.read_allocated_worker_session_link(
+                conn,
+                task_id=task_id,
+                run_id=int(run_id),
+                session_id=session_id,
+                claim_lock=claim_lock,
+                profile_name=profile_name,
+            )
+        session_db = SessionDB()
+        try:
+            if not session_db.has_exact_worker_session_link(link):
+                raise RuntimeError(
+                    "local reciprocal worker_session_links row is missing or not exactly attached"
+                )
+        finally:
+            session_db.close()
+        with kb.connect_closing() as conn:
+            with kb.write_txn(conn):
+                kb.attach_worker_session_link(
+                    conn,
+                    task_id=task_id,
+                    run_id=int(run_id),
+                    session_id=session_id,
+                    claim_lock=claim_lock,
+                    profile_name=profile_name,
+                )
+    except Exception as exc:
+        print(f"kanban repair-session-link: {exc}", file=sys.stderr)
+        return 1
+
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "task_id": task_id,
+            "run_id": int(run_id),
+            "session_id": session_id,
+            "state": "attached",
+        }, indent=2))
+    else:
+        print(f"Attached reciprocal worker session link for {task_id} run {int(run_id)}.")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1275,6 +1275,38 @@ CREATE TABLE IF NOT EXISTS task_runs (
     error               TEXT
 );
 
+CREATE TABLE IF NOT EXISTS board_meta (
+    singleton         INTEGER NOT NULL PRIMARY KEY CHECK (singleton = 1),
+    board_instance_id TEXT NOT NULL UNIQUE
+        CHECK (
+            length(board_instance_id) = 32
+            AND board_instance_id NOT GLOB '*[^0-9a-f]*'
+        )
+) WITHOUT ROWID;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_task_runs_id_task_id
+    ON task_runs(id, task_id);
+
+CREATE TABLE IF NOT EXISTS worker_session_links (
+    board_instance_id   TEXT NOT NULL,
+    task_id             TEXT NOT NULL,
+    run_id              INTEGER NOT NULL,
+    profile_name        TEXT NOT NULL CHECK (profile_name <> ''),
+    state_db_instance_id TEXT NOT NULL,
+    session_id          TEXT NOT NULL,
+    state               TEXT NOT NULL
+        CHECK (state IN ('allocated', 'attached', 'retired', 'orphaned')),
+
+    PRIMARY KEY (state_db_instance_id, session_id),
+
+    FOREIGN KEY (board_instance_id)
+        REFERENCES board_meta(board_instance_id)
+        ON UPDATE RESTRICT ON DELETE RESTRICT,
+    FOREIGN KEY (run_id, task_id)
+        REFERENCES task_runs(id, task_id)
+        ON DELETE CASCADE
+) WITHOUT ROWID;
+
 -- Files attached to a task (PDFs, images, source documents). The blob
 -- lives on disk under ``attachments_root(board)/<task_id>/<stored_name>``;
 -- this row carries metadata + the absolute ``stored_path`` so the
@@ -1316,6 +1348,8 @@ CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, c
 CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
+CREATE INDEX IF NOT EXISTS idx_worker_session_links_run
+    ON worker_session_links(board_instance_id, task_id, run_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
 """
@@ -1662,6 +1696,288 @@ class KanbanDbCorruptError(RuntimeError):
         super().__init__(
             f"Refusing to open corrupt kanban DB at {db_path}: {reason}. "
             f"Original preserved; backup at {backup_str}."
+        )
+
+
+class KanbanWorkerSessionLinkError(RuntimeError):
+    """Raised when Kanban worker-session provenance cannot be established."""
+
+
+def _is_valid_instance_identity(value: Any) -> bool:
+    text = str(value or "").strip()
+    return len(text) == 32 and not any(ch not in "0123456789abcdef" for ch in text)
+
+
+def _new_worker_session_id() -> str:
+    return f"{time.strftime('%Y%m%d_%H%M%S', time.localtime())}_{secrets.token_hex(3)}"
+
+
+@contextlib.contextmanager
+def _init_write_txn(conn: sqlite3.Connection):
+    """BEGIN IMMEDIATE helper for schema/identity initialization paths."""
+    _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE")
+    try:
+        yield conn
+    except Exception:
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.OperationalError:
+            pass
+        raise
+    else:
+        _execute_boundary_with_retry(conn, "COMMIT")
+
+
+def _live_board_instance_id(conn: sqlite3.Connection) -> str:
+    row = conn.execute(
+        "SELECT board_instance_id FROM board_meta WHERE singleton = 1"
+    ).fetchone()
+    board_instance_id = row["board_instance_id"] if row is not None else None
+    if not _is_valid_instance_identity(board_instance_id):
+        raise KanbanWorkerSessionLinkError(
+            "kanban board identity is missing or malformed"
+        )
+    return str(board_instance_id)
+
+
+def _ensure_board_instance_id(conn: sqlite3.Connection) -> str:
+    candidate = secrets.token_hex(16)
+    with _init_write_txn(conn):
+        conn.execute(
+            """
+            INSERT INTO board_meta (singleton, board_instance_id)
+            VALUES (1, ?)
+            ON CONFLICT(singleton) DO NOTHING
+            """,
+            (candidate,),
+        )
+        board_instance_id = _live_board_instance_id(conn)
+    return board_instance_id
+
+
+def _profile_state_db_instance_id(profile_name: str) -> str:
+    if not profile_name:
+        raise KanbanWorkerSessionLinkError("worker profile is required")
+    from hermes_cli.profiles import resolve_profile_env
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from hermes_state import SessionDB
+
+    hermes_home = resolve_profile_env(profile_name)
+    token = set_hermes_home_override(hermes_home)
+    try:
+        db = SessionDB(db_path=Path(hermes_home) / "state.db")
+        try:
+            state_db_instance_id = db.get_state_db_instance_id()
+        finally:
+            db.close()
+    finally:
+        reset_hermes_home_override(token)
+    if not _is_valid_instance_identity(state_db_instance_id):
+        raise KanbanWorkerSessionLinkError(
+            f"state DB identity unavailable for profile {profile_name!r}"
+        )
+    return str(state_db_instance_id)
+
+
+def _orphan_allocated_worker_links(
+    conn: sqlite3.Connection,
+    task_id: str,
+    run_id: Optional[int],
+) -> None:
+    if run_id is None:
+        return
+    conn.execute(
+        """
+        UPDATE worker_session_links
+           SET state = 'orphaned'
+         WHERE task_id = ?
+           AND run_id = ?
+           AND state = 'allocated'
+        """,
+        (task_id, int(run_id)),
+    )
+
+
+def _allocate_worker_session_link(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    run_id: int,
+    profile_name: str,
+) -> str:
+    board_instance_id = _live_board_instance_id(conn)
+    state_db_instance_id = _profile_state_db_instance_id(profile_name)
+    session_id = _new_worker_session_id()
+    conn.execute(
+        """
+        INSERT INTO worker_session_links (
+            board_instance_id, task_id, run_id, profile_name,
+            state_db_instance_id, session_id, state
+        ) VALUES (?, ?, ?, ?, ?, ?, 'allocated')
+        """,
+        (
+            board_instance_id,
+            task_id,
+            int(run_id),
+            profile_name,
+            state_db_instance_id,
+            session_id,
+        ),
+    )
+    return session_id
+
+
+def _worker_session_link_row(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    run_id: int,
+    session_id: str,
+) -> Optional[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT board_instance_id, task_id, run_id, profile_name,
+               state_db_instance_id, session_id, state
+          FROM worker_session_links
+         WHERE task_id = ? AND run_id = ? AND session_id = ?
+        """,
+        (task_id, int(run_id), session_id),
+    ).fetchone()
+
+
+def get_allocated_worker_session_id(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    run_id: int,
+) -> str:
+    rows = conn.execute(
+        """
+        SELECT session_id
+          FROM worker_session_links
+         WHERE task_id = ? AND run_id = ? AND state = 'allocated'
+        """,
+        (task_id, int(run_id)),
+    ).fetchall()
+    if len(rows) != 1:
+        raise KanbanWorkerSessionLinkError(
+            f"expected exactly one allocated worker session for {task_id}/{run_id}"
+        )
+    return str(rows[0]["session_id"])
+
+
+def read_allocated_worker_session_link(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    run_id: int,
+    session_id: str,
+    claim_lock: str,
+    profile_name: str,
+) -> dict[str, Any]:
+    row = _worker_session_link_row(
+        conn, task_id=task_id, run_id=run_id, session_id=session_id
+    )
+    if row is None or row["state"] != "allocated":
+        raise KanbanWorkerSessionLinkError(
+            "kanban worker session allocation is missing or no longer allocated"
+        )
+
+    task_row = conn.execute(
+        """
+        SELECT status, current_run_id, claim_lock, claim_expires, assignee
+          FROM tasks
+         WHERE id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    if task_row is None or task_row["status"] != "running":
+        raise KanbanWorkerSessionLinkError("kanban task is no longer runnable")
+    if int(task_row["current_run_id"] or 0) != int(run_id):
+        raise KanbanWorkerSessionLinkError("kanban run id no longer matches the task")
+
+    now = int(time.time())
+    run_row = conn.execute(
+        """
+        SELECT claim_lock, claim_expires, status, ended_at
+          FROM task_runs
+         WHERE id = ? AND task_id = ?
+        """,
+        (int(run_id), task_id),
+    ).fetchone()
+    if (
+        task_row["claim_lock"] != claim_lock
+        or not task_row["claim_expires"]
+        or int(task_row["claim_expires"]) < now
+        or run_row is None
+        or run_row["claim_lock"] != claim_lock
+        or not run_row["claim_expires"]
+        or int(run_row["claim_expires"]) < now
+        or run_row["status"] != "running"
+        or run_row["ended_at"] is not None
+    ):
+        raise KanbanWorkerSessionLinkError(
+            "kanban claim lock is not the exact live unexpired claim"
+        )
+    if str(task_row["assignee"] or "") != str(profile_name or ""):
+        raise KanbanWorkerSessionLinkError("kanban worker profile no longer matches")
+
+    live_board_instance_id = _live_board_instance_id(conn)
+    if live_board_instance_id != str(row["board_instance_id"] or ""):
+        raise KanbanWorkerSessionLinkError("kanban board identity no longer matches")
+
+    return {
+        "board_instance_id": str(row["board_instance_id"]),
+        "task_id": str(row["task_id"]),
+        "run_id": int(row["run_id"]),
+        "profile_name": str(row["profile_name"]),
+        "state_db_instance_id": str(row["state_db_instance_id"]),
+        "session_id": str(row["session_id"]),
+        "state": str(row["state"]),
+    }
+
+
+def attach_worker_session_link(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    run_id: int,
+    session_id: str,
+    claim_lock: str,
+    profile_name: str,
+) -> None:
+    link = read_allocated_worker_session_link(
+        conn,
+        task_id=task_id,
+        run_id=run_id,
+        session_id=session_id,
+        claim_lock=claim_lock,
+        profile_name=profile_name,
+    )
+    cur = conn.execute(
+        """
+        UPDATE worker_session_links
+           SET state = 'attached'
+         WHERE board_instance_id = ?
+           AND task_id = ?
+           AND run_id = ?
+           AND profile_name = ?
+           AND state_db_instance_id = ?
+           AND session_id = ?
+           AND state = 'allocated'
+        """,
+        (
+            link["board_instance_id"],
+            link["task_id"],
+            link["run_id"],
+            link["profile_name"],
+            link["state_db_instance_id"],
+            link["session_id"],
+        ),
+    )
+    if cur.rowcount != 1:
+        raise KanbanWorkerSessionLinkError(
+            "kanban worker session attach compare-and-swap failed"
         )
 
 
@@ -2156,6 +2472,7 @@ def connect(
                     # stale PRAGMA snapshots during gateway startup.
                     conn.executescript(SCHEMA_SQL)
                     _migrate_add_optional_columns(conn)
+                    _ensure_board_instance_id(conn)
                     _INITIALIZED_PATHS.add(resolved)
         except Exception:
             conn.close()
@@ -3789,6 +4106,7 @@ def _end_run(
             run_id,
         ),
     )
+    _orphan_allocated_worker_links(conn, task_id, run_id)
     conn.execute(
         "UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,),
     )
@@ -4036,6 +4354,9 @@ def claim_task(
             (task_id,),
         ).fetchone()
         if stale and stale["current_run_id"]:
+            _orphan_allocated_worker_links(
+                conn, task_id, int(stale["current_run_id"])
+            )
             conn.execute(
                 """
                 UPDATE task_runs
@@ -4092,6 +4413,13 @@ def claim_task(
             "UPDATE tasks SET current_run_id = ? WHERE id = ?",
             (run_id, task_id),
         )
+        if trow and trow["assignee"]:
+            _allocate_worker_session_link(
+                conn,
+                task_id=task_id,
+                run_id=int(run_id),
+                profile_name=str(trow["assignee"]),
+            )
         _append_event(
             conn, task_id, "claimed",
             {"lock": lock, "expires": expires, "run_id": run_id},
@@ -4174,6 +4502,13 @@ def claim_review_task(
             "UPDATE tasks SET current_run_id = ? WHERE id = ?",
             (run_id, task_id),
         )
+        if trow and trow["assignee"]:
+            _allocate_worker_session_link(
+                conn,
+                task_id=task_id,
+                run_id=int(run_id),
+                profile_name=str(trow["assignee"]),
+            )
         _append_event(
             conn, task_id, "claimed",
             {"lock": lock, "expires": expires, "run_id": run_id,
@@ -5723,6 +6058,10 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         )
         if cur.rowcount != 1:
             return False
+        if stale and stale["current_run_id"]:
+            _orphan_allocated_worker_links(
+                conn, task_id, int(stale["current_run_id"])
+            )
         _append_event(
             conn, task_id, "unblocked",
             {"status": new_status} if new_status != "ready" else None,
@@ -8773,6 +9112,13 @@ def _default_spawn(
         env["HERMES_KANBAN_RUN_ID"] = str(task.current_run_id)
     if task.claim_lock:
         env["HERMES_KANBAN_CLAIM_LOCK"] = task.claim_lock
+    if task.current_run_id is not None:
+        with connect_closing(board=board) as conn:
+            env["HERMES_KANBAN_SESSION_ID"] = get_allocated_worker_session_id(
+                conn,
+                task_id=task.id,
+                run_id=int(task.current_run_id),
+            )
     # Goal-loop mode: the worker reads these and wraps its run in the
     # Ralph-style /goal judge loop (see cli.py quiet-mode path). Only set
     # when enabled so non-goal tasks keep a clean env.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -20,6 +20,7 @@ import logging
 import os
 import random
 import re
+import secrets
 import sqlite3
 import sys
 import threading
@@ -210,7 +211,12 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 23
+SCHEMA_VERSION = 24
+
+
+def _is_valid_instance_identity(value: Any) -> bool:
+    text = str(value or "").strip()
+    return len(text) == 32 and not any(ch not in "0123456789abcdef" for ch in text)
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
 # state_meta key ``fts_storage_version``. The main schema version advances
@@ -1152,6 +1158,32 @@ CREATE TABLE IF NOT EXISTS session_model_usage (
     PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
 );
 
+CREATE TABLE IF NOT EXISTS state_db_meta (
+    singleton             INTEGER NOT NULL PRIMARY KEY CHECK (singleton = 1),
+    state_db_instance_id  TEXT NOT NULL UNIQUE
+        CHECK (
+            length(state_db_instance_id) = 32
+            AND state_db_instance_id NOT GLOB '*[^0-9a-f]*'
+        ),
+    profile_name_at_issue TEXT NOT NULL CHECK (profile_name_at_issue <> '')
+) WITHOUT ROWID;
+
+CREATE TABLE IF NOT EXISTS worker_session_links (
+    board_instance_id    TEXT NOT NULL,
+    task_id              TEXT NOT NULL,
+    run_id               INTEGER NOT NULL,
+    profile_name         TEXT NOT NULL CHECK (profile_name <> ''),
+    state_db_instance_id TEXT NOT NULL,
+    session_id           TEXT NOT NULL PRIMARY KEY
+        REFERENCES sessions(id) ON DELETE CASCADE,
+    state                TEXT NOT NULL
+        CHECK (state IN ('allocated', 'attached', 'retired', 'orphaned')),
+
+    FOREIGN KEY (state_db_instance_id)
+        REFERENCES state_db_meta(state_db_instance_id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
+) WITHOUT ROWID;
+
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
     value TEXT
@@ -1669,6 +1701,7 @@ class SessionDB:
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)
                 self._init_schema()
+                self._ensure_state_db_instance_id()
 
             try:
                 _connect_and_init()
@@ -2248,6 +2281,66 @@ class SessionDB:
                     logger.debug("WAL checkpoint (TRUNCATE) at close failed: %s", exc)
                 self._conn.close()
                 self._conn = None
+
+    def get_state_db_instance_id(self) -> Optional[str]:
+        """Return the live state DB identity, or None when absent on read-only DBs."""
+        with self._lock:
+            if self._conn is None:
+                return None
+            try:
+                table = self._conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type = 'table' AND name = 'state_db_meta' LIMIT 1"
+                ).fetchone()
+                if table is None:
+                    return None
+                row = self._conn.execute(
+                    "SELECT state_db_instance_id FROM state_db_meta WHERE singleton = 1"
+                ).fetchone()
+            except sqlite3.DatabaseError:
+                raise
+            except Exception:
+                return None
+        if row is None:
+            return None
+        value = row["state_db_instance_id"] if isinstance(row, sqlite3.Row) else row[0]
+        if not _is_valid_instance_identity(value):
+            raise RuntimeError("state DB identity is missing or malformed")
+        return str(value)
+
+    def _ensure_state_db_instance_id(self) -> str:
+        candidate = secrets.token_hex(16)
+
+        def _do(conn):
+            from hermes_cli.profiles import get_active_profile_name
+
+            active_profile_name = str(get_active_profile_name() or "default").strip() or "default"
+            conn.execute(
+                """
+                INSERT INTO state_db_meta (singleton, state_db_instance_id, profile_name_at_issue)
+                VALUES (1, ?, ?)
+                ON CONFLICT(singleton) DO NOTHING
+                """,
+                (candidate, active_profile_name),
+            )
+            row = conn.execute(
+                """
+                SELECT state_db_instance_id, profile_name_at_issue
+                  FROM state_db_meta
+                 WHERE singleton = 1
+                """
+            ).fetchone()
+            if row is None:
+                raise RuntimeError("state DB identity row is missing")
+            state_db_instance_id = row["state_db_instance_id"]
+            profile_name_at_issue = row["profile_name_at_issue"]
+            if not _is_valid_instance_identity(state_db_instance_id):
+                raise RuntimeError("state DB identity is missing or malformed")
+            if not str(profile_name_at_issue or "").strip():
+                raise RuntimeError("state DB profile binding is missing")
+            return str(state_db_instance_id)
+
+        return str(self._execute_write(_do))
 
     # ── Chunked FTS rebuild engine (v23 opt-in optimize) ──
     #
@@ -3350,8 +3443,9 @@ class SessionDB:
     # Session lifecycle
     # =========================================================================
 
-    def _insert_session_row(
+    def _insert_session_row_txn(
         self,
+        conn: sqlite3.Connection,
         session_id: str,
         source: str,
         model: str = None,
@@ -3400,107 +3494,226 @@ class SessionDB:
         crash before the gateway re-records the peer can't strand the child
         without a recoverable routing mapping (#59527).
         """
-        def _do(conn):
-            conn.execute(
-                """INSERT INTO sessions (
-                   id, source, user_id, session_key, chat_id, chat_type, thread_id,
-                   model, model_config, system_prompt, parent_session_id, cwd,
-                   profile_name, git_repo_root, started_at
-                )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                   ON CONFLICT(id) DO UPDATE SET
-                       model = COALESCE(sessions.model, excluded.model),
-                       model_config = COALESCE(sessions.model_config, excluded.model_config),
-                       system_prompt = COALESCE(sessions.system_prompt, excluded.system_prompt),
-                       session_key = COALESCE(sessions.session_key, excluded.session_key),
-                       chat_id = COALESCE(sessions.chat_id, excluded.chat_id),
-                       chat_type = COALESCE(sessions.chat_type, excluded.chat_type),
-                       thread_id = COALESCE(sessions.thread_id, excluded.thread_id),
-                       parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id),
-                       cwd = COALESCE(sessions.cwd, excluded.cwd),
-                       profile_name = COALESCE(sessions.profile_name, excluded.profile_name),
-                       git_repo_root = COALESCE(sessions.git_repo_root, excluded.git_repo_root)""",
-                (
-                    session_id,
-                    source,
-                    user_id,
-                    session_key,
-                    chat_id,
-                    chat_type,
-                    thread_id,
-                    model,
-                    json.dumps(model_config) if model_config else None,
-                    system_prompt,
-                    parent_session_id,
-                    cwd,
-                    profile_name,
-                    git_repo_root,
-                    time.time(),
-                ),
+        conn.execute(
+            """INSERT INTO sessions (
+               id, source, user_id, session_key, chat_id, chat_type, thread_id,
+               model, model_config, system_prompt, parent_session_id, cwd,
+               profile_name, git_repo_root, started_at
             )
-            if parent_session_id:
-                conn.execute(
-                    """UPDATE sessions
-                       SET cwd = COALESCE(sessions.cwd,
-                                 (SELECT p.cwd FROM sessions p
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                   model = COALESCE(sessions.model, excluded.model),
+                   model_config = COALESCE(sessions.model_config, excluded.model_config),
+                   system_prompt = COALESCE(sessions.system_prompt, excluded.system_prompt),
+                   session_key = COALESCE(sessions.session_key, excluded.session_key),
+                   chat_id = COALESCE(sessions.chat_id, excluded.chat_id),
+                   chat_type = COALESCE(sessions.chat_type, excluded.chat_type),
+                   thread_id = COALESCE(sessions.thread_id, excluded.thread_id),
+                   parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id),
+                   cwd = COALESCE(sessions.cwd, excluded.cwd),
+                   profile_name = COALESCE(sessions.profile_name, excluded.profile_name),
+                   git_repo_root = COALESCE(sessions.git_repo_root, excluded.git_repo_root)""",
+            (
+                session_id,
+                source,
+                user_id,
+                session_key,
+                chat_id,
+                chat_type,
+                thread_id,
+                model,
+                json.dumps(model_config) if model_config else None,
+                system_prompt,
+                parent_session_id,
+                cwd,
+                profile_name,
+                git_repo_root,
+                time.time(),
+            ),
+        )
+        if parent_session_id:
+            conn.execute(
+                """UPDATE sessions
+                   SET cwd = COALESCE(sessions.cwd,
+                             (SELECT p.cwd FROM sessions p
+                               WHERE p.id = sessions.parent_session_id)),
+                       git_repo_root = COALESCE(sessions.git_repo_root,
+                                       (SELECT p.git_repo_root FROM sessions p
+                                         WHERE p.id = sessions.parent_session_id)),
+                       git_branch = COALESCE(sessions.git_branch,
+                                    (SELECT p.git_branch FROM sessions p
+                                      WHERE p.id = sessions.parent_session_id))
+                 WHERE id = ? AND parent_session_id IS NOT NULL""",
+                (session_id,),
+            )
+            conn.execute(
+                """UPDATE sessions
+                   SET user_id = COALESCE(sessions.user_id,
+                                 (SELECT p.user_id FROM sessions p
                                    WHERE p.id = sessions.parent_session_id)),
-                           git_repo_root = COALESCE(sessions.git_repo_root,
-                                           (SELECT p.git_repo_root FROM sessions p
-                                             WHERE p.id = sessions.parent_session_id)),
-                           git_branch = COALESCE(sessions.git_branch,
-                                        (SELECT p.git_branch FROM sessions p
-                                          WHERE p.id = sessions.parent_session_id))
-                     WHERE id = ? AND parent_session_id IS NOT NULL""",
-                    (session_id,),
-                )
-                # Belt-and-suspenders for gateway routing metadata (#59527):
-                # the gateway re-records the peer on the child after rotation
-                # (d5b4879d4), but a hard crash between child creation and that
-                # write leaves the child row without origin columns, so
-                # ``find_latest_gateway_session_for_peer`` can't recover the
-                # mapping on restart. Inherit them from the parent at creation
-                # time — but ONLY for compression forks (parent already ended
-                # with end_reason='compression'). Delegate/subagent children
-                # are spawned while the parent is still live and must NOT
-                # inherit routing keys, or peer recovery could repoint gateway
-                # traffic into a subagent's session.
-                conn.execute(
-                    """UPDATE sessions
-                       SET user_id = COALESCE(sessions.user_id,
-                                     (SELECT p.user_id FROM sessions p
+                       session_key = COALESCE(sessions.session_key,
+                                     (SELECT p.session_key FROM sessions p
                                        WHERE p.id = sessions.parent_session_id)),
-                           session_key = COALESCE(sessions.session_key,
-                                         (SELECT p.session_key FROM sessions p
-                                           WHERE p.id = sessions.parent_session_id)),
-                           chat_id = COALESCE(sessions.chat_id,
-                                     (SELECT p.chat_id FROM sessions p
-                                       WHERE p.id = sessions.parent_session_id)),
-                           chat_type = COALESCE(sessions.chat_type,
-                                       (SELECT p.chat_type FROM sessions p
-                                         WHERE p.id = sessions.parent_session_id)),
-                           thread_id = COALESCE(sessions.thread_id,
-                                       (SELECT p.thread_id FROM sessions p
-                                         WHERE p.id = sessions.parent_session_id)),
-                           display_name = COALESCE(sessions.display_name,
-                                          (SELECT p.display_name FROM sessions p
-                                            WHERE p.id = sessions.parent_session_id)),
-                           origin_json = COALESCE(sessions.origin_json,
-                                         (SELECT p.origin_json FROM sessions p
-                                           WHERE p.id = sessions.parent_session_id))
-                     WHERE id = ? AND parent_session_id IS NOT NULL
-                       AND EXISTS (
-                           SELECT 1 FROM sessions p
-                           WHERE p.id = sessions.parent_session_id
-                             AND p.end_reason = 'compression'
-                       )""",
-                    (session_id,),
-                )
+                       chat_id = COALESCE(sessions.chat_id,
+                                 (SELECT p.chat_id FROM sessions p
+                                   WHERE p.id = sessions.parent_session_id)),
+                       chat_type = COALESCE(sessions.chat_type,
+                                   (SELECT p.chat_type FROM sessions p
+                                     WHERE p.id = sessions.parent_session_id)),
+                       thread_id = COALESCE(sessions.thread_id,
+                                   (SELECT p.thread_id FROM sessions p
+                                     WHERE p.id = sessions.parent_session_id)),
+                       display_name = COALESCE(sessions.display_name,
+                                      (SELECT p.display_name FROM sessions p
+                                        WHERE p.id = sessions.parent_session_id)),
+                       origin_json = COALESCE(sessions.origin_json,
+                                     (SELECT p.origin_json FROM sessions p
+                                       WHERE p.id = sessions.parent_session_id))
+                 WHERE id = ? AND parent_session_id IS NOT NULL
+                   AND EXISTS (
+                       SELECT 1 FROM sessions p
+                       WHERE p.id = sessions.parent_session_id
+                         AND p.end_reason = 'compression'
+                   )""",
+                (session_id,),
+            )
+
+    def _insert_session_row(
+        self,
+        session_id: str,
+        source: str,
+        **kwargs,
+    ) -> None:
+        def _do(conn):
+            self._insert_session_row_txn(conn, session_id, source, **kwargs)
+
         self._execute_write(_do)
 
-    def create_session(self, session_id: str, source: str, **kwargs) -> str:
+    def create_session(
+        self,
+        session_id: str,
+        source: str,
+        *,
+        worker_session_link: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> str:
         """Create a new session record. Returns the session_id."""
-        self._insert_session_row(session_id, source, **kwargs)
+        if worker_session_link is None:
+            self._insert_session_row(session_id, source, **kwargs)
+            return session_id
+
+        link = dict(worker_session_link)
+        create_kwargs = dict(kwargs)
+
+        def _do(conn):
+            from hermes_cli.profiles import get_active_profile_name
+
+            row = conn.execute(
+                """
+                SELECT state_db_instance_id, profile_name_at_issue
+                  FROM state_db_meta
+                 WHERE singleton = 1
+                """
+            ).fetchone()
+            if row is None:
+                raise RuntimeError("state DB identity row is missing")
+            live_state_db_instance_id = str(row["state_db_instance_id"] or "")
+            profile_name_at_issue = str(row["profile_name_at_issue"] or "")
+            active_profile_name = str(get_active_profile_name() or "default").strip() or "default"
+            expected_profile_name = str(link.get("profile_name") or "").strip()
+            expected_state_db_instance_id = str(link.get("state_db_instance_id") or "").strip()
+            if live_state_db_instance_id != expected_state_db_instance_id:
+                raise RuntimeError("state DB identity does not match Kanban allocation")
+            if (
+                not expected_profile_name
+                or expected_profile_name != active_profile_name
+                or expected_profile_name != profile_name_at_issue
+            ):
+                raise RuntimeError("active profile does not match Kanban allocation")
+
+            create_kwargs["profile_name"] = expected_profile_name
+            self._insert_session_row_txn(
+                conn,
+                session_id,
+                source,
+                **create_kwargs,
+            )
+
+            existing = conn.execute(
+                """
+                SELECT board_instance_id, task_id, run_id, profile_name,
+                       state_db_instance_id, session_id, state
+                  FROM worker_session_links
+                 WHERE session_id = ?
+                """,
+                (session_id,),
+            ).fetchone()
+            expected_tuple = (
+                str(link["board_instance_id"]),
+                str(link["task_id"]),
+                int(link["run_id"]),
+                expected_profile_name,
+                expected_state_db_instance_id,
+                session_id,
+                "attached",
+            )
+            if existing is None:
+                conn.execute(
+                    """
+                    INSERT INTO worker_session_links (
+                        board_instance_id, task_id, run_id, profile_name,
+                        state_db_instance_id, session_id, state
+                    ) VALUES (?, ?, ?, ?, ?, ?, 'attached')
+                    """,
+                    expected_tuple[:-1],
+                )
+            else:
+                existing_tuple = (
+                    str(existing["board_instance_id"]),
+                    str(existing["task_id"]),
+                    int(existing["run_id"]),
+                    str(existing["profile_name"]),
+                    str(existing["state_db_instance_id"]),
+                    str(existing["session_id"]),
+                    str(existing["state"]),
+                )
+                if existing_tuple != expected_tuple:
+                    raise RuntimeError(
+                        "existing worker session link does not match Kanban allocation"
+                    )
+
+        self._execute_write(_do)
         return session_id
+
+    def has_exact_worker_session_link(self, link: Dict[str, Any]) -> bool:
+        """Return whether the local attached reciprocal row exactly matches *link*."""
+        session_id = str(link.get("session_id") or "").strip()
+        if not session_id:
+            return False
+        with self._lock:
+            if self._conn is None:
+                return False
+            row = self._conn.execute(
+                """
+                SELECT w.board_instance_id, w.task_id, w.run_id, w.profile_name,
+                       w.state_db_instance_id, w.session_id, w.state
+                  FROM worker_session_links w
+                  JOIN sessions s ON s.id = w.session_id
+                 WHERE w.session_id = ?
+                """,
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return False
+        return (
+            str(row["board_instance_id"]) == str(link.get("board_instance_id"))
+            and str(row["task_id"]) == str(link.get("task_id"))
+            and int(row["run_id"]) == int(link.get("run_id"))
+            and str(row["profile_name"]) == str(link.get("profile_name"))
+            and str(row["state_db_instance_id"]) == str(link.get("state_db_instance_id"))
+            and str(row["session_id"]) == session_id
+            and str(row["state"]) == "attached"
+        )
 
     def record_gateway_session_peer(
         self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -605,14 +605,66 @@ class AIAgent:
         if self._session_db_created or not self._session_db:
             return
         source = _session_source_for_agent(self.platform)
+        kanban_task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
         try:
             try:
                 from hermes_cli.profiles import get_active_profile_name
-                _profile_for_session = get_active_profile_name()
+                _active_profile_name = get_active_profile_name()
+                _profile_for_session = _active_profile_name
                 if _profile_for_session == "default":
                     _profile_for_session = None
             except Exception:
+                _active_profile_name = "default"
                 _profile_for_session = None
+            if kanban_task_id:
+                from hermes_cli import kanban_db as _kb
+
+                expected_session_id = (os.environ.get("HERMES_KANBAN_SESSION_ID") or "").strip()
+                if not expected_session_id:
+                    raise RuntimeError("Kanban worker is missing HERMES_KANBAN_SESSION_ID")
+                if str(getattr(self, "session_id", "") or "") != expected_session_id:
+                    raise RuntimeError("Kanban worker session_id is not the pinned dispatcher allocation")
+                run_id_raw = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+                claim_lock = (os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or "").strip()
+                if not run_id_raw or not claim_lock:
+                    raise RuntimeError("Kanban worker is missing run/claim provenance")
+                try:
+                    run_id = int(run_id_raw)
+                except ValueError as exc:
+                    raise RuntimeError("Kanban worker run id is invalid") from exc
+                active_profile_name = str(_active_profile_name or "default").strip() or "default"
+                with _kb.connect_closing() as conn:
+                    link = _kb.read_allocated_worker_session_link(
+                        conn,
+                        task_id=kanban_task_id,
+                        run_id=run_id,
+                        session_id=expected_session_id,
+                        claim_lock=claim_lock,
+                        profile_name=active_profile_name,
+                    )
+                self._session_db.create_session(
+                    session_id=self.session_id,
+                    source=source,
+                    model=self.model,
+                    model_config=self._session_init_model_config,
+                    system_prompt=self._cached_system_prompt,
+                    user_id=None,
+                    parent_session_id=self._parent_session_id,
+                    cwd=_launch_cwd_for_session(source),
+                    worker_session_link=link,
+                )
+                with _kb.connect_closing() as conn:
+                    with _kb.write_txn(conn):
+                        _kb.attach_worker_session_link(
+                            conn,
+                            task_id=kanban_task_id,
+                            run_id=run_id,
+                            session_id=expected_session_id,
+                            claim_lock=claim_lock,
+                            profile_name=active_profile_name,
+                        )
+                self._session_db_created = True
+                return
             self._session_db.create_session(
                 session_id=self.session_id,
                 source=source,
@@ -626,6 +678,8 @@ class AIAgent:
             )
             self._session_db_created = True
         except Exception as e:
+            if kanban_task_id:
+                raise
             # Transient failure (e.g. SQLite lock). Keep _session_db alive —
             # _session_db_created stays False so next run_conversation() retries.
             logger.warning(


### PR DESCRIPTION
## Summary

Implements the worker-session provenance contract (kanban task `t_ab1e9168`) so transcript GC can positively identify which exact board/task/run and profile state database own a Hermes session.

**Design docs:** `docs/kanban/worker-session-provenance-schema.md` and `docs/kanban/worker-session-provenance-verification.md` (from sibling spec tasks).

## Changes

### Board side (`hermes_cli/kanban_db.py`)
- Singleton `board_meta` table with immutable `board_instance_id` (128-bit random hex, `secrets.token_hex(16)`)
- `worker_session_links` relation (7 columns, FK to `board_meta` + `task_runs`, `WITHOUT ROWID`)
- Session ID allocation inside the `claim_task`/`claim_review_task` write transaction — the **dispatcher is the sole allocator**
- Orphan still-`allocated` rows on every run-close path (`_end_run`, stale reclaim, unblock)
- Live validation API (`read_allocated_worker_session_link`) checks: task runnable, `current_run_id`, claim lock exact + unexpired, profile match, `board_instance_id` match
- Board attach CAS (`allocated` → `attached`) with hard-fail on zero rows
- `HERMES_KANBAN_SESSION_ID` pinned in `_default_spawn`

### State side (`hermes_state.py`)
- `SCHEMA_VERSION` 23 → 24
- Singleton `state_db_meta` (`state_db_instance_id` + `profile_name_at_issue`)
- Reciprocal `worker_session_links` (`session_id` PK, FK cascade on delete)
- `create_session(worker_session_link=...)` verifies live `state_db_instance_id` + active profile inside the write transaction before inserting session + reciprocal row
- `has_exact_worker_session_link()` for reciprocal verification

### Worker enforcement (`cli.py`, `agent/agent_init.py`, `run_agent.py`)
- CLI and `agent_init` require `HERMES_KANBAN_SESSION_ID` for Kanban workers; never generate a fallback
- `_ensure_db_session` performs the three-phase attach: live board validation → state registration → board CAS
- All mismatches are **fatal** for Kanban workers; ordinary sessions retain existing retry/degrade semantics

### CLI repair (`hermes_cli/kanban.py`)
- `hermes kanban repair-session-link` finishes a crash-after-step-2 allocation; never auto-invoked

## Contract invariants preserved
- No authority from `tasks.session_id`, `cwd`, `parent_session_id`, timestamps, PIDs, prompts, comments, completion metadata, or filesystem paths
- Monotonic state transitions: `allocated → attached`, `allocated → orphaned`, `attached → retired`, `attached → orphaned`
- Run closure orphans only `allocated` rows; `attached` provenance remains intact
- Read-only `SessionDB` does not seed identity

## Test plan
Tests are owned by separate task `t_8212166b`. This PR contains production code only.