### PR TITLE
fix(gateway): do not resurrect disconnected platforms via channel aliases

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -52,13 +52,19 @@ def _apply_channel_aliases(platforms: Dict[str, Any]) -> None:
 
     Renames matching entries in place; injects a placeholder entry for an
     aliased id that hasn't been discovered yet (so a freshly-created group is
-    addressable by name before its first message). Mutates *platforms*.
+    addressable by name before its first message).
+
+    Only overlays platforms already present in *platforms*. Creating keys via
+    ``setdefault`` would resurrect disconnected/decommissioned platforms into
+    list/resolve results and defeat the connected-only session-discovery guard.
+    Connected platforms still get an (possibly empty) list before this runs, so
+    pre-naming undiscovered chats keeps working. Mutates *platforms*.
     """
     aliases = _load_channel_aliases()
     for plat_name, id_map in aliases.items():
         if not isinstance(id_map, dict):
             continue
-        entries = platforms.setdefault(plat_name, [])
+        entries = platforms.get(plat_name)
         if not isinstance(entries, list):
             continue
         for chat_id, friendly in id_map.items():

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -342,6 +342,8 @@ class TestChannelAliases:
     def test_alias_persists_through_rebuild(self, tmp_path, monkeypatch):
         """build_channel_directory must bake aliases into the written file so
         they survive the periodic regeneration, not just live reads."""
+        from gateway.config import Platform
+
         cache_file = tmp_path / "channel_directory.json"
         monkeypatch.setattr("gateway.channel_directory._build_from_sessions",
                             lambda plat: [{"id": "120363@g.us", "name": "120363",
@@ -349,9 +351,64 @@ class TestChannelAliases:
                             if plat == "whatsapp" else [])
         with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
              self._setup_aliases(tmp_path, {"whatsapp": {"120363@g.us": "general"}}):
-            asyncio.run(build_channel_directory({}))
+            # WhatsApp must be connected so session discovery creates the
+            # platform key; aliases then rename within that key.
+            asyncio.run(build_channel_directory({Platform.WHATSAPP: object()}))
             on_disk = json.loads(cache_file.read_text())
         names = [e["name"] for e in on_disk["platforms"]["whatsapp"]
                  if e["id"] == "120363@g.us"]
         assert names == ["general"]
+
+    def test_aliases_do_not_resurrect_disconnected_platforms(self, tmp_path):
+        """Alias overlay must not invent platform keys for adapters that are
+        not connected (would defeat the connected-only session-discovery guard)."""
+        from gateway.config import Platform
+
+        cache_file = tmp_path / "channel_directory.json"
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+             patch(
+                 "gateway.channel_directory._build_from_sessions",
+                 return_value=[{"id": "tg1", "name": "Alice", "type": "dm",
+                                "thread_id": None}],
+             ), \
+             self._setup_aliases(tmp_path, {
+                 "whatsapp": {"family@g.us": "family"},
+                 "signal": {"+15551234567": "Mom"},
+             }):
+            directory = asyncio.run(
+                build_channel_directory({Platform.TELEGRAM: object()})
+            )
+            plats = directory["platforms"]
+            assert "telegram" in plats
+            assert "whatsapp" not in plats
+            assert "signal" not in plats
+            assert resolve_channel_name("whatsapp", "family") is None
+            on_disk = json.loads(cache_file.read_text())
+            assert "whatsapp" not in on_disk["platforms"]
+            assert "signal" not in on_disk["platforms"]
+
+    def test_apply_aliases_skips_missing_platform_keys(self):
+        """Aliases for platforms absent from the directory must be no-ops."""
+        platforms = {"telegram": [{"id": "1", "name": "Alice", "type": "dm"}]}
+        with patch(
+            "gateway.channel_directory._load_channel_aliases",
+            return_value={"whatsapp": {"family@g.us": "family"}},
+        ):
+            _apply_channel_aliases(platforms)
+        assert "whatsapp" not in platforms
+        assert platforms["telegram"][0]["name"] == "Alice"
+
+    def test_apply_aliases_handles_malformed_map(self):
+        """Non-dict alias maps and non-string aliases must not raise."""
+        platforms = {"whatsapp": [{"id": "1@g.us", "name": "1", "type": "group"}]}
+        with patch("gateway.channel_directory._load_channel_aliases",
+                   return_value={
+                       "whatsapp": "not-a-dict",
+                       "telegram": None,
+                       "signal": {"+15551234567": 123},
+                   }):
+            _apply_channel_aliases(platforms)  # should not raise
+        assert platforms["whatsapp"][0]["name"] == "1"
+        assert "signal" not in platforms
+        assert "telegram" not in platforms
 

--- a/tests/gateway/test_channel_directory_connected_only.py
+++ b/tests/gateway/test_channel_directory_connected_only.py
@@ -33,3 +33,40 @@ def test_does_not_resurrect_disconnected_platforms_from_session_history(tmp_path
     assert set(calls) <= {"telegram"}
 
 
+def test_connected_platform_still_uses_session_discovery(tmp_path):
+    cache_file = tmp_path / "channel_directory.json"
+
+    with patch(
+        "gateway.channel_directory._build_from_sessions",
+        return_value={"channels": []},
+    ) as mock_sessions, patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+        directory = asyncio.run(build_channel_directory({Platform.TELEGRAM: object()}))
+
+    assert "telegram" in directory["platforms"]
+    mock_sessions.assert_any_call("telegram")
+
+
+def test_aliases_do_not_resurrect_disconnected_platforms(tmp_path):
+    """channel_aliases.json must not invent keys for platforms without adapters."""
+    import json
+
+    cache_file = tmp_path / "channel_directory.json"
+    alias_file = tmp_path / "channel_aliases.json"
+    alias_file.write_text(json.dumps({
+        "whatsapp": {"family@g.us": "family"},
+        "signal": {"+15551234567": "Mom"},
+    }))
+
+    with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+         patch("gateway.channel_directory.CHANNEL_ALIASES_PATH", alias_file), \
+         patch(
+             "gateway.channel_directory._build_from_sessions",
+             return_value=[{"id": "tg1", "name": "Alice", "type": "dm",
+                            "thread_id": None}],
+         ):
+        directory = asyncio.run(build_channel_directory({Platform.TELEGRAM: object()}))
+
+    plats = directory["platforms"]
+    assert "telegram" in plats
+    for stale in ("whatsapp", "signal", "matrix"):
+        assert stale not in plats, f"{stale} resurrected via channel aliases"


### PR DESCRIPTION
## What does this PR do?

Stop `channel_aliases.json` from inventing platform keys for adapters that are not connected in this gateway process. That overlay was defeating the connected-only session-discovery guard and exposing stale `send_message` list/resolve targets.

### Bug Cause

`_apply_channel_aliases` used `platforms.setdefault(plat_name, [])` for every alias platform. After build (and again on `load_directory`), aliases for WhatsApp/Signal/etc. created empty platform lists and injected placeholder entries even when only Telegram (or another subset) was connected. Those keys were written to `channel_directory.json` and surfaced by `resolve_channel_name` / `format_directory_for_display`.

### Reproduction Steps

1. Configure `channel_aliases.json` with WhatsApp and Signal friendly names while only Telegram is connected.
2. Run `build_channel_directory` with only a Telegram adapter (or wait for the 5-minute refresh).
3. Call `resolve_channel_name("whatsapp", "<alias>")` or `send_message(action="list")`.

Expected: only connected platforms appear; WhatsApp resolve returns None.
Before fix: WhatsApp/Signal keys appear on disk and in list/resolve results.

### Fix

Change `_apply_channel_aliases` to `platforms.get(plat_name)` and skip missing keys. Connected platforms still receive an (possibly empty) list from session discovery before aliases run, so pre-naming undiscovered chats on a live platform still works. Tests cover rebuild-with-connected-adapter, missing-key no-op, and connected-only alias regression.

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/channel_directory.py` - overlay aliases only onto platforms already present in the directory
- `tests/gateway/test_channel_directory.py` - fix rebuild test to use a connected WhatsApp adapter; add missing-key and no-resurrect coverage
- `tests/gateway/test_channel_directory_connected_only.py` - assert aliases cannot resurrect disconnected platforms

## How to Test

1. Manual: with Telegram-only adapters and WhatsApp/Signal aliases, rebuild the directory and confirm only `telegram` is persisted; WhatsApp resolve returns None.
2. Automated (already run locally, 50 passed):

```bash
scripts/run_tests.sh \
  tests/gateway/test_channel_directory.py \
  tests/gateway/test_channel_directory_connected_only.py \
  -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - N/A (pure Python directory overlay)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
