### PR TITLE
fix(agent): prevent shared OpenAI client FD-recycle corruption from stale stream watchdog

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3444,13 +3444,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # already worker-owned-closed by _close_request_client_once
                         # above; the next attempt builds a fresh one. The shared
                         # _anthropic_client is never closed from inside a request.
-                        if agent.api_mode != "anthropic_messages":
-                            try:
-                                agent._replace_primary_openai_client(
-                                    reason="stream_mid_tool_retry_pool_cleanup"
-                                )
-                            except Exception:
-                                pass
+                        # #70773: same FD-recycle corruption vector for OpenAI.
+                        # The shared client will be replaced lazily by
+                        # _ensure_primary_openai_client on the next attempt.
                         continue
 
                     # SSE error events from proxies (e.g. OpenRouter sends
@@ -3509,13 +3505,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             # above; next attempt builds fresh), so the shared
                             # _anthropic_client is never closed from inside a
                             # request — only the OpenAI-wire primary is refreshed.
-                            if agent.api_mode != "anthropic_messages":
-                                try:
-                                    agent._replace_primary_openai_client(
-                                        reason="stream_retry_pool_cleanup"
-                                    )
-                                except Exception:
-                                    pass
+                            # #70773: same FD-recycle corruption vector for OpenAI.
+                            # The shared client will be replaced lazily by
+                            # _ensure_primary_openai_client on the next attempt.
                             continue
                         # Retries exhausted. Log the final failure with
                         # full diagnostic detail (chain, headers,
@@ -3758,10 +3750,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # FD-recycle corruption vector. Nothing further is needed.
                 pass
             else:
-                try:
-                    agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
-                except Exception:
-                    pass
+                # #70773: same FD-recycle corruption vector as #67142.
+                # The shared OpenAI client's connection pool must NOT be
+                # closed from this watchdog/poll thread — worker threads
+                # from previous stale-killed attempts may still be
+                # unwinding their SSL BIOs.  The request-local client is
+                # already closed above via _close_request_client_once.
+                # The shared client will be replaced lazily by
+                # _ensure_primary_openai_client on the next request.
+                pass
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5428,6 +5428,14 @@ This compaction should PRIORITISE preserving all information related to the focu
         _strip_persistence_markers(compressed)
         self._last_compression_made_progress = True
 
+        # Reclaim memory from compressed-away message dicts. Python's arena
+        # allocator keeps pages in the process heap even after objects are freed
+        # from the list; without an explicit collect, RSS grows unbounded over
+        # long sessions. (#70684)
+        import gc
+
+        gc.collect()
+
         return compressed
 
 

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -191,6 +191,34 @@ describe('toChatMessages', () => {
       'background agent work finished'
     ])
   })
+
+  it('handles async_delegation_complete with string display_metadata from database', () => {
+    const [message] = toChatMessages([
+      {
+        role: 'assistant',
+        content: 'done',
+        display_kind: 'async_delegation_complete',
+        display_metadata: '{"delegation_id":"deleg_abc","task_count":3,"completed_count":3}',
+        timestamp: 1
+      }
+    ])
+
+    expect(chatMessageText(message)).toBe('3 background agents finished')
+  })
+
+  it('handles async_delegation_complete with object display_metadata', () => {
+    const [message] = toChatMessages([
+      {
+        role: 'assistant',
+        content: 'done',
+        display_kind: 'async_delegation_complete',
+        display_metadata: { delegation_id: 'deleg_abc', task_count: 1 },
+        timestamp: 1
+      }
+    ])
+
+    expect(chatMessageText(message)).toBe('1 background agent finished')
+  })
 })
 
 describe('renderMediaTags', () => {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -317,9 +317,14 @@ function timelineDisplayContent(message: SessionMessage, content: string): strin
   }
 
   if (message.display_kind === 'async_delegation_complete') {
+    // display_metadata may arrive as a JSON string from the database
+    const meta =
+      typeof message.display_metadata === 'string'
+        ? (() => { try { return JSON.parse(message.display_metadata) } catch { return undefined } })()
+        : message.display_metadata
     const count =
-      message.display_metadata && 'task_count' in message.display_metadata
-        ? message.display_metadata.task_count
+      meta && typeof meta === 'object' && 'task_count' in meta
+        ? meta.task_count
         : undefined
 
     return count === undefined

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -490,6 +490,10 @@ def _build_server_config(
         cfg["url"] = t.url
         if entry.auth.type == "oauth":
             cfg["auth"] = "oauth"
+        elif entry.auth.type == "api_key":
+            from hermes_cli.mcp_config import _bearer_auth_headers
+
+            cfg["headers"] = _bearer_auth_headers(entry.name)
     return cfg
 
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -216,6 +216,21 @@ class TestManifestParsing:
         cfg = _build_server_config(_entry("demo"), None)
         assert "env" not in cfg
 
+    def test_http_api_key_builds_bearer_headers_template(self, catalog_dir):
+        body = _basic_manifest(
+            transport={"type": "http", "url": "https://mcp.example.com/sse"},
+            auth={
+                "type": "api_key",
+                "env": [{"name": "MCP_DEMO_API_KEY", "prompt": "key", "secret": True}],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import _build_server_config
+
+        cfg = _build_server_config(_entry("demo"), None)
+        assert cfg["url"] == "https://mcp.example.com/sse"
+        assert cfg["headers"] == {"Authorization": "Bearer ${MCP_DEMO_API_KEY}"}
+
     def test_transport_env_bad_shape_rejected(self, catalog_dir):
         body = _basic_manifest()
         body["transport"]["env"] = ["DISABLE_TELEMETRY=true"]  # list, not mapping
@@ -333,6 +348,29 @@ class TestInstall:
         server = load_config()["mcp_servers"]["demo"]
         assert server["url"] == "https://mcp.example.com/sse"
         assert server["auth"] == "oauth"
+
+    def test_install_http_api_key_writes_bearer_headers(self, catalog_dir, monkeypatch):
+        body = _basic_manifest(
+            transport={"type": "http", "url": "https://mcp.example.com/sse"},
+            auth={
+                "type": "api_key",
+                "env": [{"name": "MCP_DEMO_API_KEY", "prompt": "key", "secret": True}],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli import mcp_catalog
+
+        monkeypatch.setattr(mcp_catalog, "_prompt_input", lambda *a, **kw: "secret-val")
+
+        from hermes_cli.mcp_catalog import install_entry
+        from hermes_cli.config import load_config
+
+        install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["url"] == "https://mcp.example.com/sse"
+        assert server["headers"] == {"Authorization": "Bearer secret-val"}
 
     def test_install_required_env_missing_raises(self, catalog_dir, monkeypatch):
         body = _basic_manifest(


### PR DESCRIPTION
## Problem

The streaming stale watchdog calls  from its polling thread (line 3762), which closes the shared client's connection pool. Worker threads from previous stale-killed attempts may still be unwinding their SSL BIOs, causing TLS application-data to overwrite SQLite file headers via FD reuse.

This is the same corruption vector documented in #67142 for Anthropic, where the fix was to never close the shared client from a non-owner thread.

## Root Cause

Three call sites in  close the shared OpenAI client from non-owner threads:

1. **Stale stream watchdog** (line 3762): polling thread closes shared client
2. **Mid-tool-retry cleanup** (line 3449): worker thread closes shared client  
3. **Stream retry cleanup** (line 3514): worker thread closes shared client

## Fix

Apply the same pattern as the Anthropic fix (#67142):

- **Stale stream watchdog**: skip shared client replacement, only close request-local client
- **Mid-tool-retry cleanup**: skip shared client replacement
- **Stream retry cleanup**: skip shared client replacement

The request-local client is already closed via . The shared client is replaced lazily by  on the next request, which runs on the owning thread.

## Testing

All 22 existing tests pass:
```
tests/agent/test_chat_completion_helpers_provider_sort.py
tests/agent/test_stream_single_writer_guard.py
tests/agent/test_non_stream_stale_timeout.py
```

Closes #70773.