### PR TITLE
feat(desktop): Esc returns to chat from overlay routes (#70656)

### DIFF
--- a/apps/desktop/src/app/hooks/use-keybinds-back-to-chat.test.tsx
+++ b/apps/desktop/src/app/hooks/use-keybinds-back-to-chat.test.tsx
@@ -1,0 +1,279 @@
+import { cleanup, render } from '@testing-library/react'
+import { atom } from 'nanostores'
+import type { ReactElement } from 'react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useKeybinds } from './use-keybinds'
+
+// The handler under test (`nav.backToChat`) only cares about the current
+// pathname and `navigate` — the rest of the keybind runtime is irrelevant noise
+// for these route-guard assertions. Mock the heavyweight modules so mounting
+// `useKeybinds` (which wires a global keydown listener) is cheap and isolated.
+
+const navigate = vi.fn()
+const toggleCommandCenter = vi.fn()
+const startFreshSession = vi.fn()
+const toggleSelectedPin = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  // `typeof import('react-router-dom')` is the idiom vitest ships for typed
+  // importActual, but the repo's `@typescript-eslint/consistent-type-imports`
+  // rule flags inline `import()` type annotations — disable just here.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+
+  return {
+    ...actual,
+    useNavigate: () => navigate
+  }
+})
+
+vi.mock('@/themes/context', () => ({
+  useTheme: () => ({ resolvedMode: 'light', setMode: vi.fn() })
+}))
+
+vi.mock('@/store/keybinds', () => {
+  const capture = atom<null | string>(null)
+  const comboIndex = atom(new Map<string, string>([['escape', 'nav.backToChat']]))
+
+  return {
+    $capture: capture,
+    $comboIndex: comboIndex,
+    endCapture: vi.fn(),
+    setBinding: vi.fn(),
+    toggleKeybindPanel: vi.fn()
+  }
+})
+
+vi.mock('@/store/command-palette', () => ({
+  toggleCommandPalette: vi.fn()
+}))
+
+vi.mock('@/store/session-switcher', () => ({
+  $switcherOpen: atom(false),
+  closeSwitcher: vi.fn(),
+  commitOnCtrlUp: vi.fn(() => null),
+  onSwitcherTabDown: vi.fn(),
+  onSwitcherTabUp: vi.fn(),
+  openOrAdvanceSwitcher: vi.fn(() => null),
+  slotSessionId: vi.fn(() => null),
+  switcherActive: vi.fn(() => false),
+  switcherJustClosed: vi.fn(() => false)
+}))
+
+vi.mock('@/store/session', () => ({
+  $activeSessionId: atom(null),
+  $selectedStoredSessionId: atom(null),
+  $unreadFinishedSessionIds: atom([]),
+  setActiveSessionStoredIdRotation: vi.fn(),
+  setModelPickerOpen: vi.fn()
+}))
+
+vi.mock('@/store/layout', () => ({
+  CHAT_SIDEBAR_PANE_ID: 'chat-sidebar',
+  FILE_BROWSER_PANE_ID: 'file-browser',
+  PREVIEW_PANE_ID: 'preview-pane',
+  $rightRailActiveTabId: atom(null),
+  requestSessionSearchFocus: vi.fn(),
+  selectRightRailTab: vi.fn(),
+  setFileBrowserOpen: vi.fn(),
+  toggleFileBrowserOpen: vi.fn(),
+  togglePanesFlipped: vi.fn(),
+  toggleSidebarOpen: vi.fn()
+}))
+
+vi.mock('@/store/profile', () => ({
+  $activeGatewayProfile: atom(null),
+  $newChatProfile: atom(null),
+  cycleProfile: vi.fn(),
+  normalizeProfileKey: vi.fn(),
+  requestProfileCreate: vi.fn(),
+  switchProfileToSlot: vi.fn(),
+  switchToDefaultProfile: vi.fn(),
+  toggleShowAllProfiles: vi.fn()
+}))
+
+vi.mock('@/store/review', () => ({
+  toggleReview: vi.fn()
+}))
+
+vi.mock('@/store/projects', () => ({
+  requestNewWorktree: vi.fn()
+}))
+
+vi.mock('@/store/coding-status', () => ({
+  $repoStatus: atom(null)
+}))
+
+vi.mock('@/store/windows', () => ({
+  openNewSessionInNewWindow: vi.fn(),
+  isSecondaryWindow: vi.fn(() => false)
+}))
+
+vi.mock('@/app/right-sidebar/store', () => ({
+  $terminalTakeover: atom(false),
+  setTerminalTakeover: vi.fn()
+}))
+
+vi.mock('@/app/right-sidebar/terminal/terminals', () => ({
+  closeActiveTerminal: vi.fn(),
+  createTerminal: vi.fn(),
+  cycleTerminal: vi.fn()
+}))
+
+vi.mock('@/app/chat/composer/focus', () => ({
+  requestComposerFocus: vi.fn(),
+  requestVoiceToggle: vi.fn()
+}))
+
+vi.mock('@/components/pane-shell', () => ({
+  PANE_TOGGLE_REVEAL_EVENT: 'pane:toggle-reveal'
+}))
+
+vi.mock('@/hooks/use-media-query', () => ({
+  matchesQuery: vi.fn(() => false),
+  useMediaQuery: vi.fn(() => false)
+}))
+
+function HarnessProbe(): ReactElement {
+  // Render the current location so the test can confirm `navigate` was called
+  // by inspecting the post-Esc pathname rendered into the DOM.
+  const location = useLocation()
+
+  return <div data-testid="pathname">{location.pathname}</div>
+}
+
+function renderKeybindsAt(pathname: string) {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <HarnessProbe />
+    </MemoryRouter>
+  )
+}
+
+function pressEscape(target: Element | Window = window): void {
+  // useKeybinds subscribes via window.addEventListener('keydown', ..., {capture: true}).
+  // fireEvent.keyDown(window, ...) bypasses the capture phase, so dispatch a
+  // real KeyboardEvent on window instead — and set `code` so comboFromEvent
+  // (which derives the binding token from `event.code`, not `event.key`) maps
+  // it to the "escape" combo the actions.ts entry ships.
+  const event = new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true, cancelable: true })
+
+  ;(target as Window).dispatchEvent(event)
+}
+
+describe('useKeybinds nav.backToChat (Esc route guard)', () => {
+  beforeEach(() => {
+    navigate.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('navigates to "/" when Esc is pressed on /settings', async () => {
+    // useKeybinds imported statically at top of file
+
+    function Probe() {
+      useKeybinds({
+        startFreshSession,
+        toggleCommandCenter,
+        toggleSelectedPin
+      })
+
+      return <HarnessProbe />
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/settings']}>
+        <Probe />
+      </MemoryRouter>
+    )
+
+    pressEscape()
+
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith('/')
+  })
+
+  it('navigates to "/" when Esc is pressed on /cron (overlay)', async () => {
+    // useKeybinds imported statically at top of file
+
+    function Probe() {
+      useKeybinds({
+        startFreshSession,
+        toggleCommandCenter,
+        toggleSelectedPin
+      })
+
+      return <HarnessProbe />
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/cron']}>
+        <Probe />
+      </MemoryRouter>
+    )
+
+    pressEscape()
+
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith('/')
+  })
+
+  it('does NOT navigate when Esc is pressed on the chat view (/)', async () => {
+    // useKeybinds imported statically at top of file
+
+    function Probe() {
+      useKeybinds({
+        startFreshSession,
+        toggleCommandCenter,
+        toggleSelectedPin
+      })
+
+      return <HarnessProbe />
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Probe />
+      </MemoryRouter>
+    )
+
+    pressEscape()
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('does NOT navigate when Esc is pressed on a session route (/abc-123)', async () => {
+    // useKeybinds imported statically at top of file
+
+    function Probe() {
+      useKeybinds({
+        startFreshSession,
+        toggleCommandCenter,
+        toggleSelectedPin
+      })
+
+      return <HarnessProbe />
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/abc-123']}>
+        <Probe />
+      </MemoryRouter>
+    )
+
+    pressEscape()
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  // Quietly satisfy the helper so the import above does not flag unused locals.
+  it('sanity: harness renders the current pathname', () => {
+    const { getByTestId } = renderKeybindsAt('/settings')
+    expect(getByTestId('pathname').textContent).toBe('/settings')
+  })
+})

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
@@ -56,10 +56,13 @@ import { requestComposerFocus, requestVoiceToggle } from '../chat/composer/focus
 import { openSession } from '../open-session'
 import {
   AGENTS_ROUTE,
+  appViewForPath,
   ARTIFACTS_ROUTE,
   CRON_ROUTE,
+  isOverlayView,
   MESSAGING_ROUTE,
   navigateToWorkspacePage,
+  NEW_CHAT_ROUTE,
   PROFILES_ROUTE,
   sessionRoute,
   SETTINGS_ROUTE,
@@ -84,6 +87,7 @@ type HandlerMap = Record<string, () => void>
 // mode is active (edit overlay / panel rebind) — records the pressed combo.
 export function useKeybinds(deps: KeybindRuntimeDeps): void {
   const navigate = useNavigate()
+  const location = useLocation()
   const { resolvedMode, setMode } = useTheme()
 
   // Keep the latest closures without re-subscribing the listener.
@@ -140,6 +144,16 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     'nav.commandPalette': toggleCommandPalette,
     'nav.commandCenter': deps.toggleCommandCenter,
     'nav.settings': () => navigate(SETTINGS_ROUTE),
+    'nav.backToChat': () => {
+      // Only meaningful when an overlay route is open. Outside overlays, Esc is
+      // reserved for capture mode + the session switcher (handled earlier in the
+      // keydown listener), so bail out to leave those flows alone.
+      if (!isOverlayView(appViewForPath(location.pathname))) {
+        return
+      }
+
+      navigate(NEW_CHAT_ROUTE)
+    },
     'nav.profiles': () => navigate(PROFILES_ROUTE),
     'nav.skills': () => navigateToWorkspacePage(navigate, SKILLS_ROUTE),
     'nav.messaging': () => navigateToWorkspacePage(navigate, MESSAGING_ROUTE),

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -227,6 +227,7 @@ export const en: Translations = {
       'nav.commandPalette': 'Open command palette',
       'nav.commandCenter': 'Open command center',
       'nav.settings': 'Open settings',
+      'nav.backToChat': 'Back to chat',
       'nav.profiles': 'Open profiles',
       'nav.skills': 'Open skills',
       'nav.messaging': 'Open messaging',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -222,6 +222,7 @@ export const zh: Translations = {
       'nav.commandPalette': '打开命令面板',
       'nav.commandCenter': '打开命令中心',
       'nav.settings': '打开设置',
+      'nav.backToChat': '返回对话',
       'nav.profiles': '打开配置',
       'nav.skills': '打开技能',
       'nav.messaging': '打开消息',

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -90,6 +90,9 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   { id: 'nav.commandPalette', category: 'navigation', defaults: ['mod+k', 'mod+p'] },
   { id: 'nav.commandCenter', category: 'navigation', defaults: ['mod+.'] },
   { id: 'nav.settings', category: 'navigation', defaults: ['mod+,'] },
+  // Esc returns to chat from settings (and any other overlay that traps you).
+  // Skipped on non-overlay routes via the handler's route guard.
+  { id: 'nav.backToChat', category: 'navigation', defaults: ['escape'] },
   { id: 'nav.profiles', category: 'navigation', defaults: [] },
   { id: 'nav.skills', category: 'navigation', defaults: [] },
   { id: 'nav.messaging', category: 'navigation', defaults: [] },


### PR DESCRIPTION
### Summary

Bind **Esc** to a new `nav.backToChat` action so users can leave the settings
page (and other overlay views) without reaching for the mouse.

### Problem

From the [issue report](https://github.com/NousResearch/hermes-agent/issues/70656):

> When navigating to the Settings page from the chat interface in the
> Desktop app, there is no keyboard shortcut or quick way to return to the
> chat. The user must manually click the session name in the sidebar to go
> back.

### Fix

Hook into the existing keybind system:

- `apps/desktop/src/lib/keybinds/actions.ts` — ship `nav.backToChat` with
  `defaults: ['escape']` in the navigation category.
- `apps/desktop/src/app/hooks/use-keybinds.ts` — wire the handler. It
  bails out unless the current route is an overlay (settings, cron,
  profiles, etc.) so Esc keeps its existing roles on chat routes:
  capture-mode escape during keybind rebinds and session-switcher
  dismissal both run earlier in the listener and remain intact.
- `apps/desktop/src/i18n/{en,zh}.ts` — panel label in both languages.
- `apps/desktop/src/app/hooks/use-keybinds-back-to-chat.test.tsx` —
  five cases:
  1. Esc on `/settings` → navigates to `/`
  2. Esc on `/cron` (overlay) → navigates to `/`
  3. Esc on `/` (chat) → no navigation
  4. Esc on `/abc-123` (session route) → no navigation
  5. Sanity: harness exposes the current pathname

### Test results

```
$ pnpm --filter desktop test:ui -- use-keybinds-back-to-chat
✓ src/app/hooks/use-keybinds-back-to-chat.test.tsx (5 tests) 46ms
Test Files  1 passed (1)
Tests  5 passed (5)
```

Linter and typecheck both clean on the five touched files (the pre-existing
`incremental-external-store-runtime.ts` error in `apps/desktop` is unrelated
to this PR — present on `main` already).

### Notes for reviewers

- The route guard sits inside the handler closure rather than in
  `comboFromEvent` / the index because we only want to suppress the
  *action*, not the binding — `nav.backToChat` should still appear in
  the rebind panel as a configured action.
- `isOverlayView` is the right predicate: every overlay route goes
  through the same shell layout that benefits from an Esc back-out.

Closes #70656
