### PR TITLE
fix(cli): parse custom provider model names containing colons

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2112,6 +2112,27 @@ _KNOWN_PROVIDER_NAMES: set[str] = (
 )
 
 
+def _configured_custom_provider_slug(provider_name: str) -> Optional[str]:
+    """Return the canonical slug for a configured custom provider name."""
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+        from hermes_cli.providers import custom_provider_slug
+
+        target = provider_name.strip().lower()
+        for entry in get_compatible_custom_providers():
+            if not isinstance(entry, dict):
+                continue
+            provider_key = str(entry.get("provider_key", "") or "").strip()
+            display_name = str(entry.get("name", "") or "").strip()
+            candidates = {value.lower() for value in (provider_key, display_name) if value}
+            if target in candidates:
+                return custom_provider_slug(provider_key or display_name)
+    except Exception:
+        pass
+
+    return None
+
+
 def list_available_providers() -> list[dict[str, str]]:
     """Return info about all providers the user could use with ``provider:model``.
 
@@ -2189,6 +2210,10 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
                 if custom_name and actual_model:
                     return (f"custom:{custom_name}", actual_model)
             return (normalize_provider(provider_part), model_part)
+        if provider_part and model_part:
+            configured_provider = _configured_custom_provider_slug(provider_part)
+            if configured_provider:
+                return (configured_provider, model_part)
     return (current_provider, stripped)
 
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -55,6 +55,63 @@ class TestParseModelInput:
         assert provider == "openrouter"
         assert model == "anthropic/claude-sonnet-4.5"
 
+    def test_configured_provider_key_preserves_colons_in_model_name(self):
+        config = {
+            "providers": {
+                "ollama-remote": {
+                    "base_url": "http://ollama.example:11434/v1",
+                    "name": "Remote Ollama",
+                }
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config):
+            provider, model = parse_model_input(
+                "ollama-remote:ornith:9b",
+                "openrouter",
+            )
+
+        assert provider == "custom:ollama-remote"
+        assert model == "ornith:9b"
+
+    def test_configured_provider_display_name_uses_provider_key(self):
+        config = {
+            "providers": {
+                "ollama-remote": {
+                    "base_url": "http://ollama.example:11434/v1",
+                    "name": "Remote Ollama",
+                }
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config):
+            provider, model = parse_model_input(
+                "Remote Ollama:ornith:9b",
+                "openrouter",
+            )
+
+        assert provider == "custom:ollama-remote"
+        assert model == "ornith:9b"
+
+    def test_legacy_custom_provider_name_preserves_colons_in_model_name(self):
+        config = {
+            "custom_providers": [
+                {
+                    "name": "Ollama Remote",
+                    "base_url": "http://ollama.example:11434/v1",
+                }
+            ]
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config):
+            provider, model = parse_model_input(
+                "Ollama Remote:ornith:9b",
+                "openrouter",
+            )
+
+        assert provider == "custom:ollama-remote"
+        assert model == "ornith:9b"
+
 
 # -- curated_models_for_provider ---------------------------------------------
 
@@ -518,5 +575,4 @@ class TestProbeApiModelsUserAgent:
         assert ua and ua.startswith("hermes-cli/")
         # No Authorization was set, but UA must still be present.
         assert req.get_header("Authorization") is None
-
 


### PR DESCRIPTION
## What does this PR do?

Fixes configured custom-provider selector IDs in the shared model parser used by ACP and `/model`.

The parser only recognized built-in provider prefixes and the explicit `custom:<provider>:<model>` form. A configured provider key or display name was therefore left in the model string, especially when the model ID also contained a colon.

## Related Issue

Fixes #70650

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Resolve configured provider keys and display names to the canonical `custom:<provider-key>` identity.
- Preserve everything after the first selector separator, including model IDs such as `ornith:9b`.
- Keep built-in providers and explicit `custom:` syntax ahead of configured-provider matching.
- Cover modern `providers` configuration and legacy `custom_providers` names.

## How to Test

1. Configure a provider with the key `ollama-remote`.
2. Select `/model ollama-remote:ornith:9b`.
3. Confirm the provider is `custom:ollama-remote` and the model is `ornith:9b`.

Validation on Windows 11:

- `scripts/run_tests.sh tests/acp/test_named_provider_catalogs.py tests/hermes_cli/test_model_validation.py -q` — 38 passed.
- `ruff check hermes_cli/models.py tests/hermes_cli/test_model_validation.py` — passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs.
- [x] This PR contains only changes related to this fix.
- [ ] Full `pytest tests/ -q` suite — not run; the focused ACP and parser suites are listed above.
- [x] I've added regression tests.
- [x] I've tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation update is N/A; no public workflow changed.
- [x] `cli-config.yaml.example` update is N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A.
- [x] Cross-platform impact considered; the parser change is platform-independent.
- [x] Tool descriptions/schemas update is N/A.
