### PR TITLE
fix(desktop): clarify insecure-context microphone failures

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -74,6 +74,12 @@ HERMES_HOME=/tmp/throwaway npm run dev
 npm run dev:fake-boot   # exercise the startup overlay with deterministic delays
 ```
 
+Microphone capture runs in the renderer and follows Chromium's secure-context
+rules. A remote `HERMES_DESKTOP_DEV_SERVER` URL must use HTTPS or be reached
+through localhost (for example, with an SSH port forward); plain HTTP on a LAN
+or Tailscale address does not expose `getUserMedia`. The packaged native app is
+not affected.
+
 ### Building installers
 
 ```bash

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { type MicRecorderErrorCopy, microphoneCapabilityError } from './use-mic-recorder'
+
+const copy: MicRecorderErrorCopy = {
+  microphoneAccessDenied: 'access denied',
+  microphoneConstraintsUnsupported: 'constraints unsupported',
+  microphoneInUse: 'in use',
+  microphonePermissionDenied: 'permission denied',
+  microphoneSecureContextRequired: 'secure context required',
+  microphoneStartFailed: 'start failed',
+  microphoneUnsupported: 'unsupported',
+  noMicrophone: 'no microphone'
+}
+
+describe('microphoneCapabilityError', () => {
+  it('reports an insecure context before the generic capability error', () => {
+    expect(microphoneCapabilityError(copy, false, undefined, undefined)?.message).toBe('secure context required')
+  })
+
+  it('keeps the unsupported error for a secure runtime without recording APIs', () => {
+    expect(microphoneCapabilityError(copy, true, undefined, undefined)?.message).toBe('unsupported')
+  })
+
+  it('returns no error when the recording APIs are available', () => {
+    const mediaDevices = { getUserMedia: async () => ({}) as MediaStream } as MediaDevices
+    const mediaRecorder = class {} as unknown as typeof MediaRecorder
+
+    expect(microphoneCapabilityError(copy, true, mediaDevices, mediaRecorder)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -22,6 +22,7 @@ export interface MicRecorderErrorCopy {
   microphoneConstraintsUnsupported: string
   microphoneInUse: string
   microphonePermissionDenied: string
+  microphoneSecureContextRequired: string
   microphoneStartFailed: string
   microphoneUnsupported: string
   noMicrophone: string
@@ -57,6 +58,23 @@ function micError(error: unknown, copy: MicRecorderErrorCopy): Error {
   }
 
   return new Error(copy.microphoneStartFailed)
+}
+
+export function microphoneCapabilityError(
+  copy: MicRecorderErrorCopy,
+  secureContext: boolean | undefined,
+  mediaDevices: MediaDevices | undefined,
+  mediaRecorder: typeof MediaRecorder | undefined
+): Error | null {
+  if (secureContext === false) {
+    return new Error(copy.microphoneSecureContextRequired)
+  }
+
+  if (!mediaDevices?.getUserMedia || typeof mediaRecorder === 'undefined') {
+    return new Error(copy.microphoneUnsupported)
+  }
+
+  return null
 }
 
 export function useMicRecorder(copy: MicRecorderErrorCopy): {
@@ -171,8 +189,15 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       return
     }
 
-    if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
-      throw new Error(copy.microphoneUnsupported)
+    const capabilityError = microphoneCapabilityError(
+      copy,
+      window.isSecureContext,
+      navigator.mediaDevices,
+      typeof MediaRecorder === 'undefined' ? undefined : MediaRecorder
+    )
+
+    if (capabilityError) {
+      throw capabilityError
     }
 
     const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -131,6 +131,7 @@ export const ar = defineLocale({
       microphoneFailed: 'فشل الميكروفون',
       microphoneInUse: 'الميكروفون مستخدم من تطبيق آخر.',
       microphonePermissionDenied: 'تم رفض إذن الميكروفون.',
+      microphoneSecureContextRequired: 'يتطلب تسجيل الميكروفون HTTPS أو localhost أو تطبيق سطح المكتب الأصلي.',
       microphoneStartFailed: 'تعذر بدء تسجيل الميكروفون.',
       microphoneUnsupported: 'هذا المتصفح لا يدعم تسجيل الميكروفون.',
       noMicrophone: 'لم يتم العثور على ميكروفون.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -148,6 +148,7 @@ export const en: Translations = {
       microphoneFailed: 'Microphone failed',
       microphoneInUse: 'Microphone is already in use by another app.',
       microphonePermissionDenied: 'Microphone permission was denied.',
+      microphoneSecureContextRequired: 'Microphone recording requires HTTPS, localhost, or the native desktop app.',
       microphoneStartFailed: 'Could not start microphone recording.',
       microphoneUnsupported: 'This runtime does not support microphone recording.',
       noMicrophone: 'No microphone was found.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -149,6 +149,8 @@ export const ja = defineLocale({
       microphoneFailed: 'マイクが失敗しました',
       microphoneInUse: 'マイクは他のアプリで使用中です。',
       microphonePermissionDenied: 'マイクのアクセス許可が拒否されました。',
+      microphoneSecureContextRequired:
+        'マイク録音には HTTPS、localhost、またはネイティブデスクトップアプリが必要です。',
       microphoneStartFailed: 'マイクの録音を開始できませんでした。',
       microphoneUnsupported: 'このランタイムはマイク録音をサポートしていません。',
       noMicrophone: 'マイクが見つかりませんでした。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -189,6 +189,7 @@ export interface Translations {
       microphoneFailed: string
       microphoneInUse: string
       microphonePermissionDenied: string
+      microphoneSecureContextRequired: string
       microphoneStartFailed: string
       microphoneUnsupported: string
       noMicrophone: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -144,6 +144,7 @@ export const zhHant = defineLocale({
       microphoneFailed: '麥克風發生錯誤',
       microphoneInUse: '麥克風正被其他應用程式使用中。',
       microphonePermissionDenied: '麥克風權限被拒絕。',
+      microphoneSecureContextRequired: '麥克風錄音需要 HTTPS、localhost 或原生桌面應用程式。',
       microphoneStartFailed: '無法開始麥克風錄音。',
       microphoneUnsupported: '目前執行環境不支援麥克風錄音。',
       noMicrophone: '找不到麥克風。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -144,6 +144,7 @@ export const zh: Translations = {
       microphoneFailed: '麦克风出错',
       microphoneInUse: '麦克风正被其他应用占用。',
       microphonePermissionDenied: '麦克风权限被拒绝。',
+      microphoneSecureContextRequired: '麦克风录音需要 HTTPS、localhost 或原生桌面应用。',
       microphoneStartFailed: '无法开始麦克风录音。',
       microphoneUnsupported: '当前运行环境不支持麦克风录音。',
       noMicrophone: '未找到麦克风。',


### PR DESCRIPTION
## What does this PR do?

When the renderer is loaded from plain HTTP on a non-localhost address, Chromium does not expose microphone capture APIs. The recorder currently reports that as a generic unsupported-runtime error, which sends remote Desktop users in the wrong direction.

This change checks `window.isSecureContext` before the capability fallback, adds a specific localized error for insecure origins, and documents the HTTPS/localhost requirement for remote `HERMES_DESKTOP_DEV_SERVER` workflows.

## Related Issue

Fixes #70778

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- Distinguish an insecure origin from a runtime that genuinely lacks recording APIs.
- Keep the existing unsupported-runtime message for secure contexts without `getUserMedia` or `MediaRecorder`.
- Add English, Japanese, Simplified Chinese, and Traditional Chinese copy.
- Document HTTPS or localhost/SSH forwarding for remote renderer URLs.
- Add focused regression tests for insecure, unsupported, and supported capability states.

## How to Test

1. Load the Desktop renderer from plain HTTP on a non-localhost address and press the mic button.
2. Confirm the error points to HTTPS, localhost, or the native app.
3. Load from a secure context and confirm unsupported runtimes still use the existing generic message.

Validation run on Windows 11:

- Focused Vitest suite — 3 passed
- Desktop TypeScript typecheck — passed
- Desktop ESLint — 0 errors (17 existing warnings)
- Desktop production build and dist assertion — passed

A full UI run reached 2045 passed and 1 skipped. Seven failures appeared in unrelated Billing, Messaging, and Skills tests. Messaging and Skills passed when rerun; the remaining two Billing failures were reproduced unchanged on a clean latest `upstream/main` worktree (27 passed, 2 failed), so they are not introduced by this PR.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs
- [x] This PR contains only changes related to this fix
- [x] Python `pytest` is N/A for this Desktop-only change; relevant checks are listed above
- [x] I've added regression tests
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] I've updated the Desktop README
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] Cross-platform impact considered; behavior follows Chromium secure-context rules on every OS
- [x] Tool descriptions/schemas update is N/A