### PR TITLE
Sidebar date dividers, growing pinned section, and opt-in stale-session auto-archive

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -43,6 +43,22 @@ export function SidebarRowNest({ className, ...props }: React.ComponentProps<'di
   return <SidebarRowStack className={cn('pb-1 pl-4', className)} {...props} />
 }
 
+/**
+ * Chronological date-bucket separator ("Yesterday" / "Last week" / "June") for
+ * the session list. One flat row — a small caption plus a hairline rule — so it
+ * groups sessions by recency without adding a level of indentation.
+ */
+export function SidebarDateDivider({ className, label, ...props }: React.ComponentProps<'div'> & { label: string }) {
+  return (
+    <div className={cn('flex select-none items-center gap-2 px-2 pb-0.5 pt-2', className)} {...props}>
+      <span className="shrink-0 text-[0.64rem] font-semibold uppercase tracking-[0.12em] text-(--ui-text-quaternary)">
+        {label}
+      </span>
+      <span aria-hidden="true" className="h-px flex-1 bg-(--ui-stroke-tertiary)" />
+    </div>
+  )
+}
+
 /** Outer grid — sole owner of row height. */
 export function SidebarRowShell({
   actions,

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1275,6 +1275,7 @@ export function ChatSidebar({
                   // virtualized long list, which must keep its own scroller.
                   !recentsVirtualizes && COMPACT_FLAT
                 )}
+                dateGrouped={inProject || !agentOrderManual}
                 dndSensors={dndSensors}
                 emptyState={
                   showSessionSkeletons ? (

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1239,7 +1239,7 @@ export function ChatSidebar({
             {!trimmedQuery && (
               <SidebarSessionsSection
                 activeSessionId={activeSidebarSessionId}
-                contentClassName={cn('flex max-h-44 flex-col gap-px rounded-lg pb-2 pt-1', GROUP_BODY)}
+                contentClassName={cn('flex max-h-[50vh] flex-col gap-px rounded-lg pb-2 pt-1', GROUP_BODY)}
                 dndSensors={dndSensors}
                 emptyState={<SidebarPinnedEmptyState />}
                 label={s.pinned}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -7,11 +7,14 @@ import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
+import { useI18n } from '@/i18n'
 import { flattenSessionsWithBranches } from '@/lib/session-branch-tree'
+import { groupEntriesByRecency, type SidebarListRow, toSessionRows } from '@/lib/session-date-groups'
+import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
 
-import { SidebarCount } from './chrome'
+import { SidebarCount, SidebarDateDivider } from './chrome'
 import {
   EnteredProjectContent,
   ProjectOverviewRow,
@@ -139,6 +142,11 @@ interface SidebarSessionsSectionProps {
   // lists (Pinned / search results) in the All-profiles view, where no group
   // header communicates ownership (#66003).
   showProfileTags?: boolean
+  // Insert "Yesterday" / "Last week" date dividers into the chronological
+  // session list (flat recents + entered-project lanes). Off for hand-ordered
+  // lists, pinned, messaging groups, and the project overview, where the order
+  // isn't strictly by recency so a date bucket would be misleading.
+  dateGrouped?: boolean
 }
 
 export function SidebarSessionsSection({
@@ -179,8 +187,11 @@ export function SidebarSessionsSection({
   onReorderProjects,
   projectBackRow,
   dndSensors,
-  showProfileTags = false
+  showProfileTags = false,
+  dateGrouped = false
 }: SidebarSessionsSectionProps) {
+  const { t } = useI18n()
+  const dividerLabels = t.sidebar.dateDivider
   const sectionOpen = collapsible ? open : true
   const hasGroupedSessions = Boolean(groups?.some(group => group.sessions.length > 0))
   // A defined project list is itself content (even an empty project should
@@ -219,9 +230,29 @@ export function SidebarSessionsSection({
     )
   }
 
+  // A single flat/virtual/lane list row — either a date divider or a session.
+  const renderListRow = (row: SidebarListRow, draggable: boolean) =>
+    row.kind === 'divider' ? (
+      <SidebarDateDivider key={row.key} label={sessionBucketLabel(row.bucket, dividerLabels)} />
+    ) : (
+      renderRow(row.entry.session, draggable, row.entry.branchStem)
+    )
+
   // Sessions inside repos/worktrees are date-ordered and static.
   const renderRows = (items: SessionInfo[]) =>
     flattenSessionsWithBranches(items).map(({ branchStem, session }) => renderRow(session, false, branchStem))
+
+  // Same as `renderRows`, but with date dividers folded in — used for
+  // entered-project lanes so a lane spanning multiple days reads
+  // chronologically, matching the flat recents list.
+  const renderRowsDated = (items: SessionInfo[]) => {
+    const entries = flattenSessionsWithBranches(items)
+
+    return (dateGrouped ? groupEntriesByRecency(entries) : toSessionRows(entries)).map(row => renderListRow(row, false))
+  }
+
+  // Flat recents as list rows: grouped by recency when enabled, plain otherwise.
+  const flatRows: SidebarListRow[] = dateGrouped ? groupEntriesByRecency(displayEntries) : toSessionRows(displayEntries)
 
   const flatVirtualized =
     !showEmptyState &&
@@ -254,7 +285,7 @@ export function SidebarSessionsSection({
             onNewSession={onNewSessionInWorkspace}
             project={projectContent}
             removedSessionIds={removedSessionIds}
-            renderRows={renderRows}
+            renderRows={renderRowsDated}
             repoWorktrees={projectRepoWorktrees}
           />
         ) : (
@@ -310,13 +341,13 @@ export function SidebarSessionsSection({
       <VirtualSessionList
         activeSessionId={activeSessionId}
         className={contentClassName}
-        entries={displayEntries}
         onArchiveSession={onArchiveSession}
         onBranchSession={onBranchSession}
         onDeleteSession={onDeleteSession}
         onResumeSession={onResumeSession}
         onTogglePin={onTogglePin}
         pinned={pinned}
+        rows={flatRows}
         showProfileTags={showProfileTags}
         sortable={sessionsDraggable}
         workingSessionIdSet={workingSessionIdSet}
@@ -334,11 +365,11 @@ export function SidebarSessionsSection({
   } else if (sessionsDraggable && onReorderSessions) {
     inner = (
       <ReorderableList ids={sessions.map(s => s.id)} onReorder={onReorderSessions} sensors={dndSensors}>
-        {displayEntries.map(({ branchStem, session }) => renderRow(session, true, branchStem))}
+        {flatRows.map(row => renderListRow(row, true))}
       </ReorderableList>
     )
   } else {
-    inner = displayEntries.map(({ branchStem, session }) => renderRow(session, false, branchStem))
+    inner = flatRows.map(row => renderListRow(row, false))
   }
 
   // The virtualizer owns its own scroller, so suppress the wrapper's overflow

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -4,10 +4,13 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import { type FC, useCallback, useRef } from 'react'
 
 import type { SessionInfo } from '@/hermes'
-import { type SidebarSessionEntry } from '@/lib/session-branch-tree'
+import { useI18n } from '@/i18n'
+import { type SidebarListRow } from '@/lib/session-date-groups'
+import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
 
+import { SidebarDateDivider } from './chrome'
 import { SidebarSessionRow } from './session-row'
 
 interface SessionRowCommonProps {
@@ -27,7 +30,7 @@ interface SessionRowCommonProps {
 interface VirtualSessionListProps {
   activeSessionId: null | string
   className?: string
-  entries: SidebarSessionEntry[]
+  rows: SidebarListRow[]
   onArchiveSession: (sessionId: string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
   onDeleteSession: (sessionId: string) => void
@@ -45,7 +48,7 @@ const OVERSCAN_ROWS = 12
 export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   activeSessionId,
   className,
-  entries,
+  rows: listRows,
   onArchiveSession,
   onBranchSession,
   onDeleteSession,
@@ -56,12 +59,18 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   sortable,
   workingSessionIdSet
 }) => {
+  const { t } = useI18n()
+  const dividerLabels = t.sidebar.dateDivider
   const scrollerRef = useRef<HTMLDivElement | null>(null)
 
   const virtualizer = useVirtualizer({
-    count: entries.length,
+    count: listRows.length,
     estimateSize: () => ROW_ESTIMATE_PX,
-    getItemKey: index => entries[index]?.session.id ?? index,
+    getItemKey: index => {
+      const row = listRows[index]
+
+      return row ? (row.kind === 'divider' ? row.key : row.entry.session.id) : index
+    },
     getScrollElement: () => scrollerRef.current,
     // jsdom-friendly default; the real rect takes over on first observe.
     initialRect: { height: 600, width: 240 },
@@ -74,13 +83,25 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   const paddingBottom = Math.max(0, totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0))
 
   const rows = virtualItems.map(virtualItem => {
-    const entry = entries[virtualItem.index]
+    const row = listRows[virtualItem.index]
 
-    if (!entry) {
+    if (!row) {
       return null
     }
 
-    const { branchStem, session } = entry
+    // Dividers are non-sortable, self-measured rows interleaved with sessions.
+    if (row.kind === 'divider') {
+      return (
+        <SidebarDateDivider
+          data-index={virtualItem.index}
+          key={row.key}
+          label={sessionBucketLabel(row.bucket, dividerLabels)}
+          ref={virtualizer.measureElement}
+        />
+      )
+    }
+
+    const { branchStem, session } = row.entry
     const reorderable = sortable && !branchStem
 
     const commonProps: SessionRowCommonProps = {

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -54,6 +54,7 @@ import {
 import { $filePreviewTarget, $previewTarget, closeRightRail } from '@/store/preview'
 import { $reviewOpen, closeReview, REVIEW_PANE_ID } from '@/store/review'
 import { $currentCwd, $selectedStoredSessionId, $sessions, sessionMatchesStoredId } from '@/store/session'
+import { watchSessionPins } from '@/store/session-pin-sync'
 
 import type { SessionDragPayload } from '../chat/composer/inline-refs'
 import { watchRouteTiles } from '../chat/route-tile'
@@ -396,6 +397,10 @@ watchContributedPanes()
 // main.
 watchSessionTiles()
 watchRouteTiles()
+
+// Mirror sidebar pins into the backend keep-flag so the auto-archive sweep
+// never hides a pinned chat (and pre-existing pins migrate transparently).
+watchSessionPins()
 
 // The main tab reads as its SESSION (the loaded title, "New session" on a
 // fresh draft) — a stack of main + tiles is then just a row of session names.

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -1,8 +1,15 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Tip } from '@/components/ui/tooltip'
-import { deleteSession, listAllProfileSessions, setSessionArchived } from '@/hermes'
+import {
+  deleteSession,
+  getHermesConfigRecord,
+  listAllProfileSessions,
+  saveHermesConfig,
+  setSessionArchived
+} from '@/hermes'
 import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
@@ -10,10 +17,12 @@ import { Archive, ArchiveOff, FolderOpen, Loader2, Trash2 } from '@/lib/icons'
 import { notify, notifyError } from '@/store/notifications'
 import { untombstoneSessions } from '@/store/projects'
 import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSessions } from '@/store/session'
-import type { SessionInfo } from '@/types/hermes'
+import type { HermesConfigRecord, SessionInfo } from '@/types/hermes'
 
-import { EmptyState, ListRow, SectionHeading, SettingsContent, SettingsSkeleton } from './primitives'
+import { EmptyState, ListRow, SectionHeading, SettingsContent, SettingsSkeleton, ToggleRow } from './primitives'
 import { useDeepLinkHighlight } from './use-deep-link-highlight'
+
+const DEFAULT_AUTO_ARCHIVE_DAYS = 3
 
 const ARCHIVED_FETCH_LIMIT = 200
 
@@ -114,6 +123,8 @@ export function SessionsSettings() {
     <SettingsContent>
       <DefaultProjectDirSetting />
 
+      <AutoArchiveSetting />
+
       <SectionHeading
         icon={Archive}
         meta={sessions.length ? String(sessions.length) : undefined}
@@ -171,6 +182,112 @@ export function SessionsSettings() {
         </div>
       )}
     </SettingsContent>
+  )
+}
+
+// Opt-in retention: soft-hide chats untouched for N days. The policy itself
+// (last-activity sweep, pin exemption) lives in the backend
+// (sessions.auto_archive in config.yaml + SessionDB.maybe_auto_archive); this
+// just toggles the config keys, so CLI / gateway / Desktop all honour one
+// setting. Pins are exempt on the backend, so pinned chats survive regardless.
+function AutoArchiveSetting() {
+  const { t } = useI18n()
+  const s = t.settings.sessions
+  const [config, setConfig] = useState<HermesConfigRecord | null>(null)
+  const [enabled, setEnabled] = useState(false)
+  const [days, setDays] = useState(DEFAULT_AUTO_ARCHIVE_DAYS)
+
+  useEffect(() => {
+    // Config REST is only reachable through the Electron bridge; skip in
+    // non-Electron contexts (tests/storybook) rather than throwing.
+    if (!window.hermesDesktop) {
+      return
+    }
+
+    let alive = true
+
+    void getHermesConfigRecord()
+      .then(record => {
+        if (!alive) {
+          return
+        }
+
+        const sessions = (record.sessions ?? {}) as Record<string, unknown>
+        const parsedDays = Number(sessions.auto_archive_days)
+        setConfig(record)
+        setEnabled(Boolean(sessions.auto_archive))
+        setDays(Number.isFinite(parsedDays) && parsedDays > 0 ? Math.round(parsedDays) : DEFAULT_AUTO_ARCHIVE_DAYS)
+      })
+      .catch(() => {
+        // Leave the control unmounted if config can't be read.
+      })
+
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  const persist = useCallback(
+    async (autoArchive: boolean, archiveDays: number) => {
+      if (!config) {
+        return
+      }
+
+      const sessions = {
+        ...((config.sessions ?? {}) as Record<string, unknown>),
+        auto_archive: autoArchive,
+        auto_archive_days: archiveDays
+      }
+
+      const updated = { ...config, sessions }
+      setConfig(updated)
+
+      try {
+        await saveHermesConfig(updated)
+      } catch (err) {
+        notifyError(err, s.autoArchiveFailed)
+      }
+    },
+    [config, s.autoArchiveFailed]
+  )
+
+  if (!config) {
+    return null
+  }
+
+  return (
+    <div className="mb-6">
+      <ToggleRow
+        checked={enabled}
+        description={s.autoArchiveDesc}
+        label={s.autoArchiveTitle}
+        onChange={on => {
+          setEnabled(on)
+          void persist(on, days)
+        }}
+      />
+      {enabled && (
+        <ListRow
+          action={
+            <div className="flex items-center gap-2">
+              <Input
+                aria-label={s.autoArchiveDaysLabel}
+                className="w-20"
+                min={1}
+                onBlur={() => void persist(true, days)}
+                onChange={e => setDays(Math.max(1, Math.round(Number(e.target.value) || 1)))}
+                type="number"
+                value={days}
+              />
+              <span className="text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                {s.autoArchiveDaysUnit}
+              </span>
+            </div>
+          }
+          title={s.autoArchiveDaysLabel}
+        />
+      )}
+    </div>
   )
 }
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -546,6 +546,19 @@ export function setSessionArchived(id: string, archived: boolean, profile?: stri
   })
 }
 
+// Mirror a sidebar pin to the backend "keep" flag so the sessions.auto_archive
+// sweep (which runs backend-side, blind to Desktop localStorage) never hides a
+// pinned chat. Best-effort: the sidebar stays localStorage-driven for its own
+// display; this only feeds the backend policy.
+export function setSessionPinnedRemote(id: string, pinned: boolean, profile?: string | null): Promise<{ ok: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/sessions/${encodeURIComponent(id)}`,
+    method: 'PATCH',
+    body: { pinned }
+  })
+}
+
 export function searchSessions(query: string): Promise<SessionSearchResponse> {
   return window.hermesDesktop.api<SessionSearchResponse>({
     path: `/api/sessions/search?q=${encodeURIComponent(query)}`

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -843,6 +843,12 @@ export const en: Translations = {
       messages: count => `${count} ${count === 1 ? 'message' : 'messages'}`,
       restored: 'Restored',
       deleteConfirm: title => `Permanently delete "${title}"? This cannot be undone.`,
+      autoArchiveTitle: 'Auto-archive stale chats',
+      autoArchiveDesc:
+        "Automatically archive chats you haven't touched in a while. Pinned chats are never archived, and nothing is deleted — archived chats just move here.",
+      autoArchiveDaysLabel: 'Archive after',
+      autoArchiveDaysUnit: 'days of inactivity',
+      autoArchiveFailed: 'Could not update auto-archive',
       defaultDirTitle: 'Default project directory',
       defaultDirDesc:
         'New sessions start in this folder unless you pick another. Leave it unset to use your home directory.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1773,6 +1773,13 @@ export const en: Translations = {
       ageDay: 'd',
       ageHour: 'h',
       ageMin: 'm'
+    },
+    dateDivider: {
+      today: 'Earlier today',
+      yesterday: 'Yesterday',
+      thisWeek: 'Earlier this week',
+      lastWeek: 'Last week',
+      thisMonth: 'Earlier this month'
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -890,6 +890,12 @@ export const ja = defineLocale({
       messages: count => `${count} 件のメッセージ`,
       restored: '復元しました',
       deleteConfirm: title => `"${title}" を完全に削除しますか？この操作は元に戻せません。`,
+      autoArchiveTitle: '古いチャットを自動アーカイブ',
+      autoArchiveDesc:
+        'しばらく操作していないチャットを自動的にアーカイブします。ピン留めしたチャットはアーカイブされず、削除もされません。アーカイブされたチャットはここに移動します。',
+      autoArchiveDaysLabel: 'アーカイブまでの日数',
+      autoArchiveDaysUnit: '日間操作なし',
+      autoArchiveFailed: '自動アーカイブを更新できませんでした',
       defaultDirTitle: 'デフォルトのプロジェクトディレクトリ',
       defaultDirDesc:
         '別のフォルダーを選択しない限り、新しいセッションはこのフォルダーで開始します。未設定の場合はホームディレクトリが使用されます。',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1706,6 +1706,13 @@ export const ja = defineLocale({
       ageDay: '日',
       ageHour: '時間',
       ageMin: '分'
+    },
+    dateDivider: {
+      today: '今日の早い時間',
+      yesterday: '昨日',
+      thisWeek: '今週',
+      lastWeek: '先週',
+      thisMonth: '今月'
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -723,6 +723,11 @@ export interface Translations {
       messages: (count: number) => string
       restored: string
       deleteConfirm: (title: string) => string
+      autoArchiveTitle: string
+      autoArchiveDesc: string
+      autoArchiveDaysLabel: string
+      autoArchiveDaysUnit: string
+      autoArchiveFailed: string
       defaultDirTitle: string
       defaultDirDesc: string
       defaultDirUpdated: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1486,6 +1486,13 @@ export interface Translations {
       ageHour: string
       ageMin: string
     }
+    dateDivider: {
+      today: string
+      yesterday: string
+      thisWeek: string
+      lastWeek: string
+      thisMonth: string
+    }
   }
 
   composer: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -863,6 +863,12 @@ export const zhHant = defineLocale({
       messages: count => `${count} 則訊息`,
       restored: '已還原',
       deleteConfirm: title => `永久刪除「${title}」？此操作無法復原。`,
+      autoArchiveTitle: '自動封存閒置對話',
+      autoArchiveDesc:
+        '自動封存你一段時間未使用的對話。已釘選的對話永遠不會被封存，也不會刪除任何內容——封存的對話會移到這裡。',
+      autoArchiveDaysLabel: '封存前',
+      autoArchiveDaysUnit: '天無活動',
+      autoArchiveFailed: '無法更新自動封存設定',
       defaultDirTitle: '預設專案目錄',
       defaultDirDesc: '新工作階段預設從此資料夾開始，除非您選擇其他目錄。留空則使用您的家目錄。',
       defaultDirUpdated: '預設專案目錄已更新',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1652,6 +1652,13 @@ export const zhHant = defineLocale({
       ageDay: '天',
       ageHour: '時',
       ageMin: '分'
+    },
+    dateDivider: {
+      today: '今天稍早',
+      yesterday: '昨天',
+      thisWeek: '本週',
+      lastWeek: '上週',
+      thisMonth: '本月'
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1042,6 +1042,12 @@ export const zh: Translations = {
       messages: count => `${count} 条消息`,
       restored: '已恢复',
       deleteConfirm: title => `永久删除“${title}”？此操作无法撤销。`,
+      autoArchiveTitle: '自动归档闲置会话',
+      autoArchiveDesc:
+        '自动归档你一段时间未使用的会话。已置顶的会话永远不会被归档，也不会删除任何内容——归档的会话会移动到这里。',
+      autoArchiveDaysLabel: '归档前',
+      autoArchiveDaysUnit: '天无活动',
+      autoArchiveFailed: '无法更新自动归档设置',
       defaultDirTitle: '默认项目目录',
       defaultDirDesc: '新会话默认从此文件夹开始，除非你选择其他目录。留空则使用你的 home 目录。',
       defaultDirUpdated: '默认项目目录已更新',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1962,6 +1962,13 @@ export const zh: Translations = {
       ageDay: '天',
       ageHour: '时',
       ageMin: '分'
+    },
+    dateDivider: {
+      today: '今天早些时候',
+      yesterday: '昨天',
+      thisWeek: '本周',
+      lastWeek: '上周',
+      thisMonth: '本月'
     }
   },
 

--- a/apps/desktop/src/lib/session-date-groups.test.ts
+++ b/apps/desktop/src/lib/session-date-groups.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import type { SidebarSessionEntry } from './session-branch-tree'
+import { groupEntriesByRecency, toSessionRows } from './session-date-groups'
+
+const session = (id: string, overrides: Partial<SessionInfo> = {}): SessionInfo =>
+  ({
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 0,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: 'cli',
+    started_at: 0,
+    title: id,
+    tool_call_count: 0,
+    ...overrides
+  }) as SessionInfo
+
+const entry = (s: SessionInfo, branchStem?: string): SidebarSessionEntry =>
+  branchStem ? { branchStem, session: s } : { session: s }
+
+// Fixed "now": Thursday 18 Jun 2026, local noon (15 Jun 2026 is a Monday).
+// All tests pin a Monday week start so calendar boundaries are deterministic.
+const NOW = new Date(2026, 5, 18, 12, 0, 0).getTime()
+const MONDAY = 1
+
+const at = (year: number, month: number, day: number, hour = 10, minute = 0): number =>
+  Math.floor(new Date(year, month, day, hour, minute, 0).getTime() / 1000)
+
+const group = (entries: SidebarSessionEntry[], nowMs = NOW) => groupEntriesByRecency(entries, nowMs, MONDAY)
+
+const dividerKeys = (rows: ReturnType<typeof groupEntriesByRecency>): string[] =>
+  rows.flatMap(row => (row.kind === 'divider' ? [row.key] : []))
+
+describe('groupEntriesByRecency', () => {
+  it('cuts the head after the most recent handful, then divides by coarse ranges', () => {
+    // The morning run (30m/30m/4h/30m gaps, then a 14h silence) is the
+    // unlabelled head; each older group gets one divider, coarsening with age.
+    const rows = group([
+      entry(session('a', { last_active: at(2026, 5, 18, 11) })),
+      entry(session('b', { last_active: at(2026, 5, 18, 10, 30) })),
+      entry(session('c', { last_active: at(2026, 5, 18, 10) })),
+      entry(session('d', { last_active: at(2026, 5, 18, 6) })),
+      entry(session('e', { last_active: at(2026, 5, 18, 5, 30) })),
+      entry(session('f', { last_active: at(2026, 5, 17, 15) })), // yesterday
+      entry(session('g', { last_active: at(2026, 5, 16, 15) })), // Tue this week
+      entry(session('h', { last_active: at(2026, 5, 14) })), // Sun last week
+      entry(session('i', { last_active: at(2026, 5, 3) })), // earlier in June
+      entry(session('j', { last_active: at(2026, 4, 28) })), // May
+      entry(session('k', { last_active: at(2025, 11, 3) })) // December 2025
+    ])
+
+    expect(rows.slice(0, 5).every(row => row.kind === 'session')).toBe(true)
+    expect(rows[5]).toMatchObject({ key: 'yesterday', kind: 'divider' })
+    expect(dividerKeys(rows)).toEqual(['yesterday', 'this-week', 'last-week', 'this-month', 'm-2026-4', 'my-2025-11'])
+  })
+
+  it('labels the rest of the current day "earlier today" past a real break', () => {
+    // Five rapid-fire sessions, a ~4h pause, then more of the same day.
+    const rows = group([
+      entry(session('a', { last_active: at(2026, 5, 18, 11) })),
+      entry(session('b', { last_active: at(2026, 5, 18, 10, 58) })),
+      entry(session('c', { last_active: at(2026, 5, 18, 10, 56) })),
+      entry(session('d', { last_active: at(2026, 5, 18, 10, 54) })),
+      entry(session('e', { last_active: at(2026, 5, 18, 10, 52) })),
+      entry(session('f', { last_active: at(2026, 5, 18, 7) })),
+      entry(session('g', { last_active: at(2026, 5, 18, 6, 58) }))
+    ])
+
+    expect(rows.findIndex(row => row.kind === 'divider')).toBe(5)
+    expect(dividerKeys(rows)).toEqual(['today'])
+  })
+
+  it('never slices a rapid-fire burst mid-run', () => {
+    // Eleven sessions two minutes apart: no gap qualifies as a break, so the
+    // whole burst stays in the head and the divider lands after it.
+    const burst = Array.from({ length: 11 }, (_, i) =>
+      entry(session(`s${i}`, { last_active: at(2026, 5, 18, 11) - i * 120 }))
+    )
+
+    const rows = group([...burst, entry(session('old', { last_active: at(2026, 5, 17, 15) }))])
+
+    expect(rows.findIndex(row => row.kind === 'divider')).toBe(11)
+    expect(dividerKeys(rows)).toEqual(['yesterday'])
+  })
+
+  it('chains the head run across midnight', () => {
+    // Viewed at 00:58: tonight plus last evening is one run; yesterday's
+    // afternoon (a different nominal day) opens the labelled groups.
+    const smallHours = new Date(2026, 5, 19, 0, 58).getTime()
+
+    const rows = group(
+      [
+        entry(session('a', { last_active: at(2026, 5, 19, 0, 30) })),
+        entry(session('b', { last_active: at(2026, 5, 18, 23, 50) })),
+        entry(session('c', { last_active: at(2026, 5, 18, 23, 20) })),
+        entry(session('d', { last_active: at(2026, 5, 17, 20) }))
+      ],
+      smallHours
+    )
+
+    expect(rows.findIndex(row => row.kind === 'divider')).toBe(3)
+    expect(dividerKeys(rows)).toEqual(['yesterday'])
+  })
+
+  it('dissolves a stale head into its own calendar group (fuzzy merge)', () => {
+    // Newest session is 6 days old and the rows below it share its "last week"
+    // bucket: cutting there would strand near-identical neighbours around a
+    // divider, so no head is kept and the whole bucket leads unlabelled.
+    const rows = group([
+      entry(session('a', { last_active: at(2026, 5, 12) })),
+      entry(session('b', { last_active: at(2026, 5, 11, 15) })),
+      entry(session('c', { last_active: at(2026, 5, 11, 10) })),
+      entry(session('d', { last_active: at(2026, 5, 3) })),
+      entry(session('e', { last_active: at(2026, 4, 20) }))
+    ])
+
+    expect(rows.slice(0, 3).every(row => row.kind === 'session')).toBe(true)
+    expect(dividerKeys(rows)).toEqual(['this-month', 'm-2026-4'])
+  })
+
+  it('keeps an isolated newest session as the head when its bucket differs', () => {
+    const rows = group([
+      entry(session('a', { last_active: at(2026, 5, 18, 9) })),
+      entry(session('b', { last_active: at(2026, 5, 17, 15) })),
+      entry(session('c', { last_active: at(2026, 5, 3) }))
+    ])
+
+    expect(rows.findIndex(row => row.kind === 'divider')).toBe(1)
+    expect(dividerKeys(rows)).toEqual(['yesterday', 'this-month'])
+  })
+
+  it('emits no dividers when everything is one unbroken run', () => {
+    const rows = group([
+      entry(session('a', { last_active: at(2026, 5, 18, 11) })),
+      entry(session('b', { last_active: at(2026, 5, 18, 10, 50) })),
+      entry(session('c', { last_active: at(2026, 5, 18, 10, 40) }))
+    ])
+
+    expect(rows.every(row => row.kind === 'session')).toBe(true)
+  })
+
+  it('collapses a big gap straight to the next month/year (empty ranges omitted)', () => {
+    const rows = group([
+      entry(session('t', { last_active: at(2026, 5, 18, 11) })),
+      entry(session('t2', { last_active: at(2026, 5, 18, 10, 30) })),
+      entry(session('j1', { last_active: at(2026, 0, 5) })),
+      entry(session('j2', { last_active: at(2026, 0, 3) })),
+      entry(session('old', { last_active: at(2024, 2, 9) }))
+    ])
+
+    expect(dividerKeys(rows)).toEqual(['m-2026-0', 'my-2024-2'])
+  })
+
+  it('never labels the first rendered group, even when it is not recent', () => {
+    // Newest session is weeks old and alone in its month: it opens the list
+    // unlabelled; only the transitions below it are marked.
+    const rows = group([
+      entry(session('a', { last_active: at(2026, 4, 20) })),
+      entry(session('b', { last_active: at(2026, 2, 3) })),
+      entry(session('c', { last_active: at(2025, 11, 3) }))
+    ])
+
+    expect(rows[0]).toMatchObject({ kind: 'session' })
+    expect(dividerKeys(rows)).toEqual(['m-2026-2', 'my-2025-11'])
+  })
+
+  it('keeps branch children in their parent cluster without opening a new bucket', () => {
+    const parent = session('parent', { last_active: at(2026, 5, 18, 11) })
+    const child = session('child', { last_active: at(2024, 0, 1), parent_session_id: 'parent' })
+
+    const rows = group([entry(parent), entry(child, '└─ ')])
+
+    expect(rows).toEqual([
+      { entry: entry(parent), kind: 'session' },
+      { entry: entry(child, '└─ '), kind: 'session' }
+    ])
+  })
+
+  it('never emits a divider twice under a non-monotonic order', () => {
+    const rows = group([
+      entry(session('a', { last_active: at(2026, 5, 16) })), // head run
+      entry(session('b', { last_active: at(2026, 4, 5) })), // May — divider
+      entry(session('c', { last_active: at(2026, 5, 16) })) // head again — no repeat
+    ])
+
+    expect(dividerKeys(rows)).toEqual(['m-2026-4'])
+  })
+
+  it('falls back to started_at when last_active is missing', () => {
+    const rows = group([
+      entry(session('head', { last_active: at(2026, 5, 18, 11) })),
+      entry(session('s', { last_active: 0, started_at: at(2026, 5, 10) }))
+    ])
+
+    expect(dividerKeys(rows)).toEqual(['last-week'])
+  })
+})
+
+describe('toSessionRows', () => {
+  it('wraps entries as session rows with no dividers', () => {
+    const entries = [entry(session('a')), entry(session('b'), '└─ ')]
+
+    expect(toSessionRows(entries)).toEqual([
+      { entry: entries[0], kind: 'session' },
+      { entry: entries[1], kind: 'session' }
+    ])
+  })
+})

--- a/apps/desktop/src/lib/session-date-groups.ts
+++ b/apps/desktop/src/lib/session-date-groups.ts
@@ -1,0 +1,151 @@
+import { type SidebarSessionEntry } from '@/lib/session-branch-tree'
+import { calendarBucket, HOUR, localeWeekStartDay, MINUTE, SECOND, type SessionBucket } from '@/lib/time'
+
+// A flat list row is either a chronological date-bucket divider or a session
+// entry. Interleaving these lets the flat list (and the virtualizer) render
+// date separators inline without a second layer of nesting.
+export type SidebarListRow =
+  | { bucket: SessionBucket; key: string; kind: 'divider' }
+  | { entry: SidebarSessionEntry; kind: 'session' }
+
+// The row's own age label reads from `last_active || started_at`; bucket off the
+// same value so a divider lines up with what the row actually shows.
+const recencyMs = (entry: SidebarSessionEntry): number =>
+  (entry.session.last_active || entry.session.started_at || 0) * SECOND
+
+// Aim the head at "the most recent handful". A break shorter than
+// MIN_RUN_BREAK_MS never counts as one — that would slice a rapid-fire burst —
+// and a silence longer than MAX_RUN_GAP_MS always ends the run: without that
+// bound a sparse list (a project lane) would chain weeks of stale sessions
+// into one giant "recent" head.
+const TARGET_HEAD_SESSIONS = 5
+const MIN_RUN_BREAK_MS = 30 * MINUTE
+const MAX_RUN_GAP_MS = 8 * HOUR
+
+// The unlabelled head is the newest run of sessions, cut at a *real* break in
+// activity. Candidate cut points are every gap of at least MIN_RUN_BREAK_MS
+// inside the contiguous run (gaps ≤ MAX_RUN_GAP_MS), plus the run's own end;
+// among them we pick the one whose head size lands closest (log-scale) to
+// TARGET_HEAD_SESSIONS. So the first divider shows up after roughly the most
+// recent five sessions — but only ever at a genuine pause, never mid-burst: a
+// truly unbroken run stays whole, and an isolated newest session stands alone.
+// Runs chain naturally across midnight.
+//
+// Fuzzy-merge rule: when the cut falls at the run's end and the sessions just
+// below it share the head's calendar bucket, the head adds nothing — it's just
+// the top of that group. Dissolve it (the first-group rule keeps the top
+// unlabelled anyway) so a divider never strands near-identical neighbours,
+// e.g. a lone 6-day-old session above a "Last week" label.
+//
+// Returns the oldest timestamp (ms) still inside the head; -Infinity means the
+// whole list is one run, +Infinity means no head (calendar groups own it all).
+function headRunCutoffMs(entries: readonly SidebarSessionEntry[], nowMs: number, weekStartsOn: number): number {
+  const times = entries
+    .filter(entry => !entry.branchStem)
+    .map(recencyMs)
+    .sort((a, b) => b - a)
+
+  let bestIdx = -1
+  let bestScore = Number.POSITIVE_INFINITY
+  let runEnded = false
+
+  for (let i = 1; i < times.length; i++) {
+    const gap = times[i - 1] - times[i]
+    const endsRun = gap > MAX_RUN_GAP_MS
+
+    if (gap >= MIN_RUN_BREAK_MS || endsRun) {
+      // `i` sessions would sit above a cut at this gap.
+      const score = Math.abs(Math.log(i / TARGET_HEAD_SESSIONS))
+
+      if (score < bestScore) {
+        bestScore = score
+        bestIdx = i
+        runEnded = endsRun
+      }
+    }
+
+    if (endsRun) {
+      break
+    }
+  }
+
+  if (bestIdx === -1) {
+    return Number.NEGATIVE_INFINITY
+  }
+
+  if (runEnded) {
+    const headBucket = calendarBucket(times[0] / SECOND, nowMs, weekStartsOn)
+    const belowBucket = calendarBucket(times[bestIdx] / SECOND, nowMs, weekStartsOn)
+
+    if (headBucket.key === belowBucket.key) {
+      return Number.POSITIVE_INFINITY
+    }
+  }
+
+  return times[bestIdx - 1]
+}
+
+// Insert a date divider before each labelled group. The unlabelled head is the
+// newest run of sessions (see headRunCutoffMs); below it, groups are coarse
+// calendar ranges — earlier today → yesterday → earlier this week → last week
+// → earlier this month → month → month + year — one divider per range, never
+// one per day. Whatever group happens to render first is also never labelled.
+// Branch children inherit their parent cluster's group and never trigger a
+// divider, so a parent→branches block never splits.
+export function groupEntriesByRecency(
+  entries: readonly SidebarSessionEntry[],
+  nowMs = Date.now(),
+  weekStartsOn = localeWeekStartDay()
+): SidebarListRow[] {
+  const rows: SidebarListRow[] = []
+  const emitted = new Set<string>()
+  const cutoff = headRunCutoffMs(entries, nowMs, weekStartsOn)
+  let lastKey: null | string = null
+
+  for (const entry of entries) {
+    // Nested branch rows travel with their parent cluster; they never open a new
+    // bucket or move the divider cursor.
+    if (entry.branchStem) {
+      rows.push({ entry, kind: 'session' })
+
+      continue
+    }
+
+    const ms = recencyMs(entry)
+
+    // Head-run sessions are never labelled.
+    if (ms >= cutoff) {
+      rows.push({ entry, kind: 'session' })
+      lastKey = '__recent__'
+
+      continue
+    }
+
+    const bucket = calendarBucket(ms / SECOND, nowMs, weekStartsOn)
+
+    if (bucket.key !== lastKey) {
+      lastKey = bucket.key
+      const alreadyEmitted = emitted.has(bucket.key)
+
+      // Mark it emitted even when skipped so a non-monotonic order (possible
+      // inside a project lane) can't later re-label it or collide React keys.
+      emitted.add(bucket.key)
+
+      // A divider only ever separates two groups — never label the very first
+      // rendered row, whatever group it belongs to.
+      if (rows.length > 0 && !alreadyEmitted) {
+        rows.push({ bucket, key: bucket.key, kind: 'divider' })
+      }
+    }
+
+    rows.push({ entry, kind: 'session' })
+  }
+
+  return rows
+}
+
+// Wrap entries as plain session rows (no dividers) so the ungrouped path shares
+// the same `SidebarListRow[]` shape as the grouped one.
+export function toSessionRows(entries: readonly SidebarSessionEntry[]): SidebarListRow[] {
+  return entries.map(entry => ({ entry, kind: 'session' }))
+}

--- a/apps/desktop/src/lib/time.test.ts
+++ b/apps/desktop/src/lib/time.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { DAY, formatAgo, HOUR, MINUTE, SECOND } from './time'
+import { calendarBucket, DAY, formatAgo, HOUR, MINUTE, nominalDayStart, SECOND, sessionBucketLabel } from './time'
 
 const labels = {
   ageNow: 'now',
@@ -28,5 +28,97 @@ describe('formatAgo', () => {
 
   it('clamps future timestamps to "now"', () => {
     expect(ago(-HOUR)).toBe('now')
+  })
+})
+
+// Thursday 18 Jun 2026, local noon (15 Jun 2026 is a Monday).
+const THU_NOON = new Date(2026, 5, 18, 12, 0, 0).getTime()
+
+const secondsAt = (year: number, month: number, day: number, hour = 10) =>
+  Math.floor(new Date(year, month, day, hour, 0, 0).getTime() / 1000)
+
+describe('nominalDayStart', () => {
+  it('rolls the day boundary at 4 AM, not midnight', () => {
+    // 1 AM Saturday still belongs to Friday's run.
+    expect(nominalDayStart(new Date(2026, 5, 20, 1, 30).getTime())).toBe(new Date(2026, 5, 19).getTime())
+    expect(nominalDayStart(new Date(2026, 5, 20, 4, 30).getTime())).toBe(new Date(2026, 5, 20).getTime())
+  })
+})
+
+describe('calendarBucket', () => {
+  // Monday week start: the current week began Mon 15 Jun, last week is Jun 8-14.
+  const MONDAY = 1
+
+  const kindAt = (year: number, month: number, day: number, hour = 10) =>
+    calendarBucket(secondsAt(year, month, day, hour), THU_NOON, MONDAY).kind
+
+  it('buckets the current day (and, defensively, the future) as today', () => {
+    // The head run normally absorbs these; "Earlier today" covers the rest.
+    expect(kindAt(2026, 5, 18, 5)).toBe('today')
+    expect(kindAt(2026, 5, 18, 23)).toBe('today')
+    expect(kindAt(2026, 5, 19)).toBe('today')
+  })
+
+  it('assigns the small hours to the previous evening', () => {
+    // 1 AM today (before the 4 AM rollover) is part of yesterday's run.
+    expect(kindAt(2026, 5, 18, 1)).toBe('yesterday')
+
+    // And viewed at 00:58, last evening's sessions are still the current day.
+    const smallHours = new Date(2026, 5, 19, 0, 58).getTime()
+
+    expect(calendarBucket(secondsAt(2026, 5, 18, 23), smallHours, MONDAY).kind).toBe('today')
+    expect(calendarBucket(secondsAt(2026, 5, 18, 10), smallHours, MONDAY).kind).toBe('today')
+    expect(calendarBucket(secondsAt(2026, 5, 17, 15), smallHours, MONDAY).kind).toBe('yesterday')
+  })
+
+  it('uses coarse, non-overlapping ranges that coarsen with age', () => {
+    expect(kindAt(2026, 5, 17)).toBe('yesterday')
+    expect(kindAt(2026, 5, 16)).toBe('thisWeek') // Tue this week
+    expect(kindAt(2026, 5, 15)).toBe('thisWeek') // Mon this week
+    expect(kindAt(2026, 5, 14)).toBe('lastWeek') // Sun last week
+    expect(kindAt(2026, 5, 8)).toBe('lastWeek') // Mon last week
+    expect(kindAt(2026, 5, 7)).toBe('thisMonth') // earlier in June
+    expect(kindAt(2026, 5, 1)).toBe('thisMonth')
+    expect(kindAt(2026, 4, 28)).toBe('month') // May, same year
+    expect(kindAt(2025, 11, 3)).toBe('monthYear') // December, prior year
+  })
+
+  it('respects a Sunday week start', () => {
+    // With the week starting Sun 14 Jun, that Sunday is this week, not last.
+    expect(calendarBucket(secondsAt(2026, 5, 14), THU_NOON, 0).kind).toBe('thisWeek')
+    expect(calendarBucket(secondsAt(2026, 5, 13), THU_NOON, 0).kind).toBe('lastWeek')
+  })
+
+  it('keys same-month sessions together and disambiguates across years', () => {
+    expect(calendarBucket(secondsAt(2026, 2, 3), THU_NOON, MONDAY).key).toBe('m-2026-2')
+    expect(calendarBucket(secondsAt(2026, 2, 20), THU_NOON, MONDAY).key).toBe('m-2026-2')
+    expect(calendarBucket(secondsAt(2025, 2, 3), THU_NOON, MONDAY).key).toBe('my-2025-2')
+  })
+})
+
+describe('sessionBucketLabel', () => {
+  const labels = {
+    lastWeek: 'Last week',
+    thisMonth: 'Earlier this month',
+    thisWeek: 'Earlier this week',
+    today: 'Earlier today',
+    yesterday: 'Yesterday'
+  }
+
+  const labelAt = (year: number, month: number, day: number) =>
+    sessionBucketLabel(calendarBucket(secondsAt(year, month, day), THU_NOON, 1), labels)
+
+  it('uses fixed labels for the relative buckets', () => {
+    expect(labelAt(2026, 5, 18)).toBe('Earlier today')
+    expect(labelAt(2026, 5, 17)).toBe('Yesterday')
+    expect(labelAt(2026, 5, 16)).toBe('Earlier this week')
+    expect(labelAt(2026, 5, 10)).toBe('Last week')
+    expect(labelAt(2026, 5, 2)).toBe('Earlier this month')
+  })
+
+  it('formats month (same year) and month + year (prior year) via Intl', () => {
+    // en-US default in the test env: month name, plus year for the prior year.
+    expect(labelAt(2026, 2, 3)).toBe('March')
+    expect(labelAt(2025, 11, 3)).toBe('December 2025')
   })
 })

--- a/apps/desktop/src/lib/time.ts
+++ b/apps/desktop/src/lib/time.ts
@@ -25,6 +25,12 @@ export const fmtDateTime = new Intl.DateTimeFormat(undefined, { dateStyle: 'medi
 // Date only, "5 Jun 2026" (starmap tooltip).
 export const fmtDate = new Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
 
+// Month name alone / with year — session-list date-bucket dividers ("September",
+// "September 2025").
+export const fmtMonth = new Intl.DateTimeFormat(undefined, { month: 'long' })
+export const fmtMonthYear = new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' })
+
+
 // ── Relative time ──────────────────────────────────────────────────────────
 const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto', style: 'short' })
 
@@ -48,6 +54,142 @@ export function relativeTime(targetMs: number, nowMs = Date.now()): string {
   }
 
   return rtf.format(sign * Math.round(abs / DAY), 'day')
+}
+
+// A dated divider bucket below the sidebar's unlabelled "recent" head cluster
+// (see session-date-groups.ts for the clustering). Buckets are coarse,
+// non-overlapping calendar ranges — one divider per *cluster* of activity,
+// never one per day, and never a rolling window like "previous 7 days" that
+// semantically overlaps the groups above it. `kind` drives the label; `at` is
+// the session's nominal day start (ms) for month formatting.
+export type SessionBucketKind = 'lastWeek' | 'month' | 'monthYear' | 'thisMonth' | 'thisWeek' | 'today' | 'yesterday'
+
+export interface SessionBucket {
+  at: number
+  key: string
+  kind: SessionBucketKind
+}
+
+// Fixed divider labels, resolved from i18n (month labels come from Intl).
+export interface SessionBucketLabels {
+  lastWeek: string
+  thisMonth: string
+  thisWeek: string
+  today: string
+  yesterday: string
+}
+
+export const startOfLocalDay = (ms: number): number => {
+  const d = new Date(ms)
+
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+}
+
+// The human day doesn't end at midnight — it ends when you sleep. Sessions
+// from the small hours belong to the previous evening's run, so the day
+// boundary sits at 4 AM local (same trick activity/sleep trackers use).
+// A 12:30 AM session groups with 11:50 PM instead of splitting off.
+export const DAY_ROLLOVER_HOUR = 4
+
+// Start of the *nominal* local day a timestamp belongs to, honoring the 4 AM
+// rollover: Saturday 1 AM → start of Friday.
+export const nominalDayStart = (ms: number): number => startOfLocalDay(ms - DAY_ROLLOVER_HOUR * HOUR)
+
+// Locale-aware first day of week in JS getDay() convention (0=Sun … 6=Sat).
+// Intl.Locale weekInfo reports 1=Mon … 7=Sun; unsupported → Monday.
+export function localeWeekStartDay(): number {
+  try {
+    const locale = new Intl.Locale(new Intl.DateTimeFormat().resolvedOptions().locale)
+    const withWeekInfo = locale as { getWeekInfo?: () => { firstDay?: number }; weekInfo?: { firstDay?: number } }
+    const firstDay = (withWeekInfo.getWeekInfo?.() ?? withWeekInfo.weekInfo)?.firstDay
+
+    return typeof firstDay === 'number' ? firstDay % 7 : 1
+  } catch {
+    return 1
+  }
+}
+
+// Start of the local calendar week containing `ms` (DST-safe Date field math).
+export function startOfLocalWeek(ms: number, weekStartsOn: number): number {
+  const d = new Date(startOfLocalDay(ms))
+  const back = (d.getDay() - weekStartsOn + 7) % 7
+
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() - back).getTime()
+}
+
+// Coarse calendar bucket for a Unix-seconds timestamp. Granularity coarsens
+// with age: earlier today → yesterday → earlier this week → last week →
+// earlier this month → month → month + year. Empty ranges simply never emit a
+// bucket, so a sparse tail jumps straight to its month or month-year. The
+// newest run of sessions never reaches here (it is the unlabelled head — see
+// session-date-groups.ts), which is what makes "Earlier today" truthful.
+export function calendarBucket(
+  seconds: number,
+  nowMs = Date.now(),
+  weekStartsOn = localeWeekStartDay()
+): SessionBucket {
+  const nominal = nominalDayStart(seconds * SECOND)
+  const todayNominal = nominalDayStart(nowMs)
+  const dayDiff = Math.round((todayNominal - nominal) / DAY)
+
+  if (dayDiff <= 0) {
+    return { at: nominal, key: 'today', kind: 'today' }
+  }
+
+  if (dayDiff === 1) {
+    return { at: nominal, key: 'yesterday', kind: 'yesterday' }
+  }
+
+  const weekStart = startOfLocalWeek(todayNominal, weekStartsOn)
+
+  if (nominal >= weekStart) {
+    return { at: nominal, key: 'this-week', kind: 'thisWeek' }
+  }
+
+  const ws = new Date(weekStart)
+
+  if (nominal >= new Date(ws.getFullYear(), ws.getMonth(), ws.getDate() - 7).getTime()) {
+    return { at: nominal, key: 'last-week', kind: 'lastWeek' }
+  }
+
+  const d = new Date(nominal)
+  const now = new Date(todayNominal)
+  const sameYear = d.getFullYear() === now.getFullYear()
+
+  if (sameYear && d.getMonth() === now.getMonth()) {
+    return { at: nominal, key: 'this-month', kind: 'thisMonth' }
+  }
+
+  const ym = `${d.getFullYear()}-${d.getMonth()}`
+
+  return sameYear ? { at: nominal, key: `m-${ym}`, kind: 'month' } : { at: nominal, key: `my-${ym}`, kind: 'monthYear' }
+}
+
+// Localized divider label for a bucket: fixed relative strings from i18n,
+// Intl-formatted month / month-year for the rest.
+export function sessionBucketLabel(bucket: SessionBucket, labels: SessionBucketLabels): string {
+  switch (bucket.kind) {
+    case 'today':
+      return labels.today
+
+    case 'yesterday':
+      return labels.yesterday
+
+    case 'thisWeek':
+      return labels.thisWeek
+
+    case 'lastWeek':
+      return labels.lastWeek
+
+    case 'thisMonth':
+      return labels.thisMonth
+
+    case 'month':
+      return fmtMonth.format(bucket.at)
+
+    case 'monthYear':
+      return fmtMonthYear.format(bucket.at)
+  }
 }
 
 export type ElapsedUnit = 'day' | 'hour' | 'minute' | 'second'

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+const patch = vi.fn<(id: string, pinned: boolean, profile?: null | string) => Promise<{ ok: boolean }>>(() =>
+  Promise.resolve({ ok: true })
+)
+
+vi.mock('@/hermes', () => ({
+  setSessionPinnedRemote: (id: string, pinned: boolean, profile?: null | string) => patch(id, pinned, profile)
+}))
+
+import { $pinnedSessionIds } from '@/store/layout'
+import { $sessions } from '@/store/session'
+
+import { watchSessionPins } from './session-pin-sync'
+
+const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
+  ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
+
+const flush = () => Promise.resolve()
+
+beforeAll(() => {
+  ;(globalThis as { window?: unknown }).window ??= {}
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {}
+  // Attach the listeners once — module state is process-global.
+  watchSessionPins()
+})
+
+beforeEach(() => {
+  $sessions.set([])
+  $pinnedSessionIds.set([])
+  patch.mockClear()
+})
+
+afterEach(() => {
+  $sessions.set([])
+  $pinnedSessionIds.set([])
+})
+
+describe('watchSessionPins', () => {
+  it('mirrors a new pin as pinned=true with the row profile', async () => {
+    $sessions.set([row('a', { profile: 'work' })])
+    $pinnedSessionIds.set(['a'])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('a', true, 'work')
+  })
+
+  it('mirrors an unpin as pinned=false', async () => {
+    $sessions.set([row('b')])
+    $pinnedSessionIds.set(['b'])
+    await flush()
+    patch.mockClear()
+
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('b', false, undefined)
+  })
+
+  it('defers a pin whose row is not loaded, then flushes once it appears', async () => {
+    $pinnedSessionIds.set(['c'])
+    await flush()
+    // No row yet -> nothing sent.
+    expect(patch).not.toHaveBeenCalled()
+
+    $sessions.set([row('c', { profile: 'p2' })])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('c', true, 'p2')
+  })
+
+  it('matches a pin id against the lineage root', async () => {
+    // pin id is the lineage root; the live row carries it as _lineage_root_id.
+    $sessions.set([row('tip', { _lineage_root_id: 'root' })])
+    $pinnedSessionIds.set(['root'])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('root', true, undefined)
+  })
+
+  it('does not re-PATCH an already-mirrored pin on unrelated session updates', async () => {
+    $sessions.set([row('d')])
+    $pinnedSessionIds.set(['d'])
+    await flush()
+    patch.mockClear()
+
+    // A session-list refresh that doesn't change the pinned set.
+    $sessions.set([row('d'), row('e')])
+    await flush()
+
+    expect(patch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -1,0 +1,75 @@
+/**
+ * Mirror the sidebar's localStorage pins into the backend "keep" flag.
+ *
+ * Pins live in `$pinnedSessionIds` (localStorage) and drive the sidebar UI.
+ * The `sessions.auto_archive` sweep, however, runs backend-side and is blind to
+ * localStorage — so without this bridge it could hide a pinned chat. This
+ * watcher PATCHes `pinned` on the session REST endpoint whenever the pinned set
+ * changes, and re-asserts the whole current set at boot, which transparently
+ * migrates pre-existing pins (no flag, no user action — the sweep just starts
+ * honouring them). It never touches the sidebar's own display; localStorage
+ * stays the source of truth there.
+ */
+
+import { setSessionPinnedRemote } from '@/hermes'
+import { $pinnedSessionIds } from '@/store/layout'
+import { $sessions, sessionMatchesStoredId } from '@/store/session'
+
+// pin ids we've successfully PATCHed pinned=true this session.
+const mirrored = new Set<string>()
+// pin ids awaiting their row so we can resolve the owning profile before PATCH.
+const pending = new Set<string>()
+
+function profileFor(pinId: string): null | string | undefined {
+  return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
+}
+
+function reconcile(): void {
+  // Config/session REST is only reachable through the Electron bridge.
+  if (!window.hermesDesktop) {
+    return
+  }
+
+  const current = new Set($pinnedSessionIds.get())
+
+  // Unpinned: anything we were tracking that's no longer in the set.
+  for (const id of [...mirrored, ...pending]) {
+    if (!current.has(id)) {
+      mirrored.delete(id)
+      pending.delete(id)
+      void setSessionPinnedRemote(id, false, profileFor(id)).catch(() => {})
+    }
+  }
+
+  // Newly pinned: hold until we can resolve the row (for its profile).
+  for (const id of current) {
+    if (!mirrored.has(id)) {
+      pending.add(id)
+    }
+  }
+
+  // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
+  // retry on the next $sessions change.
+  for (const id of [...pending]) {
+    const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
+
+    if (!row) {
+      continue
+    }
+
+    pending.delete(id)
+    mirrored.add(id)
+    void setSessionPinnedRemote(id, true, row.profile).catch(() => {
+      // Let a later reconcile retry the mirror.
+      mirrored.delete(id)
+      pending.add(id)
+    })
+  }
+}
+
+// Sync once, then re-sync on pin-set and session-list changes. Call once per app.
+export function watchSessionPins(): void {
+  reconcile()
+  $pinnedSessionIds.listen(reconcile)
+  $sessions.listen(reconcile)
+}

--- a/cli.py
+++ b/cli.py
@@ -1972,6 +1972,16 @@ def _run_state_db_auto_maintenance(session_db) -> None:
             logger.debug("Orphan compression finalize skipped: %s", _finalize_exc)
 
         cfg = (_load_full_config().get("sessions") or {})
+
+        # Auto-archive (soft-hide stale sessions) is independent of the
+        # destructive auto_prune sweep — run it first, before prune's early
+        # return, so enabling one doesn't require the other.
+        if cfg.get("auto_archive", False):
+            session_db.maybe_auto_archive(
+                idle_days=float(cfg.get("auto_archive_days", 3)),
+                min_interval_hours=int(cfg.get("min_interval_hours", 24)),
+            )
+
         if not cfg.get("auto_prune", False):
             return
         session_db.maybe_auto_prune_and_vacuum(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3598,6 +3598,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 from hermes_cli.config import load_config as _load_full_config
                 _sess_cfg = (_load_full_config().get("sessions") or {})
+                # Non-destructive stale-session archive, independent of prune.
+                if _sess_cfg.get("auto_archive", False):
+                    self._session_db._db.maybe_auto_archive(
+                        idle_days=float(_sess_cfg.get("auto_archive_days", 3)),
+                        min_interval_hours=int(_sess_cfg.get("min_interval_hours", 24)),
+                    )
                 if _sess_cfg.get("auto_prune", False):
                     # Construction-time, before the loop serves traffic; sync DB is fine.
                     self._session_db._db.maybe_auto_prune_and_vacuum(
@@ -23360,6 +23366,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     CHANNEL_DIR_EVERY = 5    # ticks — every 5 minutes
     PASTE_SWEEP_EVERY = 60   # ticks — once per hour
     CURATOR_EVERY = 60       # ticks — poll hourly (inner gate handles the real cadence)
+    AUTO_ARCHIVE_EVERY = 60  # ticks — poll hourly (state_meta gate owns the real cadence)
 
     logger.info("Gateway housekeeping started (interval=%ds)", interval)
     tick_count = 0
@@ -23423,6 +23430,28 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
                 )
             except Exception as e:
                 logger.debug("Curator tick error: %s", e)
+
+        # Stale-session auto-archive — a live timer, so gateways that stay up
+        # for weeks keep sweeping on schedule (the startup hook fires once).
+        # maybe_auto_archive() is gated by sessions.min_interval_hours in
+        # state_meta; this is just the poll rate. Opens its own SessionDB —
+        # SQLite connections are thread-bound and this runs off-loop.
+        if tick_count % AUTO_ARCHIVE_EVERY == 0:
+            try:
+                from hermes_cli.config import load_config as _load_full_config
+                from hermes_state import SessionDB
+                _sess_cfg = (_load_full_config().get("sessions") or {})
+                if _sess_cfg.get("auto_archive", False):
+                    _adb = SessionDB()
+                    try:
+                        _adb.maybe_auto_archive(
+                            idle_days=float(_sess_cfg.get("auto_archive_days", 3)),
+                            min_interval_hours=int(_sess_cfg.get("min_interval_hours", 24)),
+                        )
+                    finally:
+                        _adb.close()
+            except Exception as e:
+                logger.debug("Auto-archive tick error: %s", e)
 
         stop_event.wait(timeout=interval)
     logger.info("Gateway housekeeping stopped")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3226,6 +3226,15 @@ DEFAULT_CONFIG = {
         # How many days of ended-session history to keep.  Matches the
         # default of ``hermes sessions prune``.
         "retention_days": 90,
+        # When true, auto-archive (soft-hide, never delete) sessions that
+        # haven't been touched in ``auto_archive_days`` days, once per
+        # (roughly) min_interval_hours.  "Touched" is last activity, not
+        # creation, so an old-but-recently-used session is spared.  Pinned
+        # sessions are always exempt.  Off by default — opt in explicitly.
+        "auto_archive": False,
+        # Idle threshold (days of no activity) before auto-archive hides a
+        # session.  Only applies when auto_archive is true.
+        "auto_archive_days": 3,
         # VACUUM after a prune that actually deleted rows.  SQLite does not
         # reclaim disk space on DELETE — freed pages are just reused on
         # subsequent INSERTs — so without VACUUM the file stays bloated

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -223,11 +223,16 @@ async def _lifespan(app: "FastAPI"):
     # /api/status).  The loop exits immediately when httpx is unavailable.
     selftest_task = asyncio.create_task(_dashboard_selftest_loop())
 
+    # Live auto-archive timer — keeps a backend that stays up for days
+    # sweeping stale sessions on schedule, independent of list requests.
+    auto_archive_task = asyncio.create_task(_auto_archive_ticker_loop())
+
     try:
         yield
     finally:
         pty_reaper_task.cancel()
         selftest_task.cancel()
+        auto_archive_task.cancel()
         await PTY_REGISTRY.close_all()
         if cron_stop is not None:
             cron_stop.set()
@@ -4776,6 +4781,10 @@ def get_sessions(
     try:
         db = _open_session_db_for_profile(profile)
         try:
+            # Opportunistic, config-gated, double-throttled stale-session
+            # sweep — the only auto_archive hook that fires for Desktop's
+            # `hermes serve` backend. No-op when disabled or run recently.
+            _maybe_auto_archive_for_profile(db, profile)
             min_message_count = max(0, min_messages)
             archived_only = archived == "only"
             include_archived = archived == "include"
@@ -11446,6 +11455,71 @@ def _open_session_db_for_profile(profile: Optional[str]):
     return SessionDB(db_path=Path(home) / "state.db")
 
 
+# In-process throttle for the opportunistic auto-archive trigger, keyed by
+# profile. Bounds the config.yaml read to at most once per this window per
+# profile; the actual sweep is throttled far more coarsely by state_meta
+# (sessions.min_interval_hours) inside maybe_auto_archive.
+_AUTO_ARCHIVE_CHECK_INTERVAL_S = 300.0
+_last_auto_archive_check: Dict[str, float] = {}
+
+
+def _maybe_auto_archive_for_profile(db, profile: Optional[str]) -> None:
+    """Run the config-gated stale-session auto-archive for ``profile``.
+
+    The Desktop backend is spawned as ``hermes serve`` — it runs neither the
+    interactive CLI nor the messaging gateway, so neither of those startup
+    hooks fire for Desktop users. Triggering the (double-throttled, config-off
+    by default) sweep from the session-list path is what makes
+    ``sessions.auto_archive`` take effect there. Never raises.
+    """
+    try:
+        key = profile or ""
+        now = time.monotonic()
+        last = _last_auto_archive_check.get(key)
+        if last is not None and now - last < _AUTO_ARCHIVE_CHECK_INTERVAL_S:
+            return
+        _last_auto_archive_check[key] = now
+
+        from hermes_cli.config import load_config as _load_full_config
+        cfg = (_load_full_config().get("sessions") or {})
+        if not cfg.get("auto_archive", False):
+            return
+        db.maybe_auto_archive(
+            idle_days=float(cfg.get("auto_archive_days", 3)),
+            min_interval_hours=int(cfg.get("min_interval_hours", 24)),
+        )
+    except Exception as exc:
+        _log.debug("opportunistic auto-archive skipped: %s", exc)
+
+
+async def _auto_archive_ticker_loop(
+    interval_s: float = 3600.0, initial_delay_s: float = 90.0
+) -> None:
+    """Live timer for the stale-session auto-archive (primary profile).
+
+    A long-running Desktop/serve backend must keep sweeping on schedule even
+    when no ``/api/sessions`` request arrives to fire the opportunistic
+    trigger — e.g. the app sits open for days on an idle chat. The real
+    cadence is still owned by state_meta (``sessions.min_interval_hours``)
+    inside ``maybe_auto_archive``; this loop is only the poll rate.
+    """
+
+    def _sweep() -> None:
+        db = _open_session_db_for_profile(None)
+        try:
+            _maybe_auto_archive_for_profile(db, None)
+        finally:
+            db.close()
+
+    await asyncio.sleep(initial_delay_s)
+    while True:
+        try:
+            await asyncio.to_thread(_sweep)
+        except Exception as exc:
+            _log.debug("auto-archive tick skipped: %s", exc)
+        await asyncio.sleep(interval_s)
+
+
 @app.get("/api/sessions/{session_id}")
 async def get_session_detail(session_id: str, profile: Optional[str] = None):
     db = _open_session_db_for_profile(profile)
@@ -11550,6 +11624,9 @@ async def delete_session_endpoint(session_id: str, profile: Optional[str] = None
 class SessionRename(BaseModel):
     title: Optional[str] = None
     archived: Optional[bool] = None
+    # Durable "keep" flag mirrored from the Desktop sidebar's pins; pinned
+    # sessions are exempt from the sessions.auto_archive stale sweep.
+    pinned: Optional[bool] = None
     # Mutate a session belonging to another profile (opens its state.db). Omit
     # for the current/default profile.
     profile: Optional[str] = None
@@ -11557,21 +11634,22 @@ class SessionRename(BaseModel):
 
 @app.patch("/api/sessions/{session_id}")
 async def rename_session_endpoint(session_id: str, body: SessionRename):
-    """Update a session: rename (or clear its title) and/or archive it.
+    """Update a session: rename, archive, and/or pin it.
 
     ``title`` renames (empty/null clears the title); ``archived`` soft-hides or
-    restores the session. Either field may be omitted. ``profile`` targets
-    another profile's session.
+    restores the session; ``pinned`` sets the durable keep flag (exempts the
+    session from the auto-archive sweep). Any field may be omitted. ``profile``
+    targets another profile's session.
     """
     db = _open_session_db_for_profile(body.profile)
     try:
         sid = db.resolve_session_id(session_id)
         if not sid:
             raise HTTPException(status_code=404, detail="Session not found")
-        if body.title is None and body.archived is None:
+        if body.title is None and body.archived is None and body.pinned is None:
             raise HTTPException(
                 status_code=400,
-                detail="Nothing to update; provide 'title' and/or 'archived'.",
+                detail="Nothing to update; provide 'title', 'archived', and/or 'pinned'.",
             )
         if body.title is not None:
             try:
@@ -11581,9 +11659,13 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
                 raise HTTPException(status_code=400, detail=str(e))
         if body.archived is not None:
             db.set_session_archived(sid, body.archived)
+        if body.pinned is not None:
+            db.set_session_pinned(sid, body.pinned)
         result = {"ok": True, "title": db.get_session_title(sid) or ""}
         if body.archived is not None:
             result["archived"] = bool(body.archived)
+        if body.pinned is not None:
+            result["pinned"] = bool(body.pinned)
         return result
     finally:
         db.close()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1101,6 +1101,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     profile_name TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,
     archived INTEGER NOT NULL DEFAULT 0,
+    pinned INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -5074,6 +5075,58 @@ class SessionDB:
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
+    def set_session_pinned(self, session_id: str, pinned: bool) -> bool:
+        """Pin or unpin a session (and its whole compression lineage).
+
+        ``pinned`` is a durable "keep" flag: pinned sessions are exempt from
+        the ``sessions.auto_archive`` stale sweep (see
+        :meth:`archive_stale_sessions`). Desktop is the current writer — its
+        sidebar pins mirror here so a backend/other-surface sweep honours
+        them. Like :meth:`set_session_archived` the whole compression chain is
+        flipped as a unit, so pinning the surfaced tip protects the root (and
+        vice-versa) no matter which id the caller holds. Returns True when at
+        least one row changed.
+        """
+        def _do(conn):
+            cursor = conn.execute(
+                """
+                WITH RECURSIVE
+                  ancestors(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT parent.id
+                    FROM ancestors a
+                    JOIN sessions child ON child.id = a.id
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  descendants(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT child.id
+                    FROM descendants d
+                    JOIN sessions parent ON parent.id = d.id
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  lineage(id) AS (
+                    SELECT id FROM ancestors
+                    UNION
+                    SELECT id FROM descendants
+                  )
+                UPDATE sessions
+                SET pinned = ?
+                WHERE id IN (SELECT id FROM lineage)
+                """,
+                (session_id, session_id, 1 if pinned else 0),
+            )
+            rowcount = cursor.rowcount
+            if rowcount is None or rowcount < 0:
+                rowcount = conn.execute("SELECT changes()").fetchone()[0]
+            return rowcount
+        rowcount = self._execute_write(_do)
+        return rowcount > 0
+
     def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""
         with self._lock:
@@ -9032,6 +9085,55 @@ class SessionDB:
             self.set_session_archived(row["id"], True)
         return len(rows)
 
+    def archive_stale_sessions(
+        self, idle_days: float, *, exclude_pinned: bool = True
+    ) -> int:
+        """Archive every session untouched for at least ``idle_days`` days.
+
+        "Touched" is the latest message timestamp (falling back to
+        ``started_at``) — i.e. real recency, not creation time — so a session
+        created long ago but active yesterday is spared, while an old
+        abandoned one (even a still-open one) is swept. This differs from
+        :meth:`archive_sessions`, which ages on ``started_at`` and only ended
+        sessions.
+
+        Guards:
+          * ``pinned = 0`` when ``exclude_pinned`` (the Desktop "keep" flag).
+          * ``archived = 0`` so repeat runs are idempotent no-ops.
+          * only lineage *tips* / standalone rows are candidates
+            (``end_reason <> 'compression'``); a stale tip archives its whole
+            chain via :meth:`set_session_archived`, so we never resurrect an
+            active conversation by matching an old compressed-away root whose
+            live continuation is recent.
+
+        Returns the number of sessions archived. Never raises for an empty or
+        non-positive ``idle_days`` — it simply archives nothing.
+        """
+        if idle_days is None or idle_days < 0:
+            return 0
+        cutoff = time.time() - float(idle_days) * 86400.0
+        pin_clause = "AND s.pinned = 0" if exclude_pinned else ""
+        with self._lock:
+            rows = self._conn.execute(
+                f"""
+                SELECT s.id FROM sessions s
+                WHERE s.archived = 0
+                  AND COALESCE(s.end_reason, '') <> 'compression'
+                  {pin_clause}
+                  AND COALESCE(
+                        (SELECT MAX(m.timestamp) FROM messages m
+                         WHERE m.session_id = s.id),
+                        s.started_at
+                      ) < ?
+                ORDER BY s.started_at ASC
+                """,
+                (cutoff,),
+            ).fetchall()
+        ids = [(r["id"] if isinstance(r, sqlite3.Row) else r[0]) for r in rows]
+        for sid in ids:
+            self.set_session_archived(sid, True)
+        return len(ids)
+
     def prune_sessions(
         self,
         older_than_days: Optional[float] = 90,
@@ -9845,6 +9947,59 @@ class SessionDB:
         except Exception as exc:
             # Maintenance must never block startup. Log and return error marker.
             logger.warning("state.db auto-maintenance failed: %s", exc)
+            result["error"] = str(exc)
+
+        return result
+
+    def maybe_auto_archive(
+        self,
+        idle_days: float = 3,
+        min_interval_hours: int = 24,
+        exclude_pinned: bool = True,
+    ) -> Dict[str, Any]:
+        """Idempotent auto-archive: soft-hide sessions idle for ``idle_days``.
+
+        Sibling of :meth:`maybe_auto_prune_and_vacuum` but non-destructive —
+        it archives (hides) rather than deletes, and ages on last activity
+        (see :meth:`archive_stale_sessions`) rather than creation. Records the
+        last run in ``state_meta['last_auto_archive']`` so calls within
+        ``min_interval_hours`` no-op; safe to call opportunistically (startup
+        hooks, or when the Desktop backend lists sessions).
+
+        Never raises. Returns a dict with:
+          - ``"skipped"`` (bool) — within min_interval_hours of last run
+          - ``"archived"`` (int) — sessions archived this run
+          - ``"error"`` (str, optional) — present only on failure
+        """
+        result: Dict[str, Any] = {"skipped": False, "archived": 0}
+        try:
+            last_raw = self.get_meta("last_auto_archive")
+            now = time.time()
+            if last_raw:
+                try:
+                    if now - float(last_raw) < min_interval_hours * 3600:
+                        result["skipped"] = True
+                        return result
+                except (TypeError, ValueError):
+                    pass  # corrupt meta; treat as no prior run
+
+            archived = self.archive_stale_sessions(
+                idle_days, exclude_pinned=exclude_pinned
+            )
+            result["archived"] = archived
+
+            # Record even a zero-archive run so we don't re-sweep every call
+            # within the interval window.
+            self.set_meta("last_auto_archive", str(now))
+
+            if archived > 0:
+                logger.info(
+                    "state.db auto-archive: archived %d session(s) idle >= %s days",
+                    archived,
+                    idle_days,
+                )
+        except Exception as exc:
+            logger.warning("state.db auto-archive failed: %s", exc)
             result["error"] = str(exc)
 
         return result

--- a/tests/gateway/test_async_session_db.py
+++ b/tests/gateway/test_async_session_db.py
@@ -125,8 +125,10 @@ _GATEWAY_FILES = ("gateway/run.py", "gateway/slash_commands.py")
 #   - self._session_db._db.<x>: the sync escape, allowed ONLY where the call is
 #     provably off the event loop — construction (__init__, before the loop
 #     serves) and the run_sync closure (executed in a thread-pool executor).
-#     Three such sites today; a fourth must be justified and this count bumped.
-_ALLOWED_SYNC_DB_ESCAPES = 3
+#     Four such sites today (maybe_auto_archive joined maybe_auto_prune_and_vacuum
+#     in the construction-time maintenance block); a fifth must be justified and
+#     this count bumped.
+_ALLOWED_SYNC_DB_ESCAPES = 4
 
 # Sync helpers that touch SessionDB but are NEVER invoked bare on the loop:
 # every loop-side call wraps them in ``asyncio.to_thread(...)`` and the only

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1945,17 +1945,11 @@ class TestWebServerEndpoints:
         ws._last_auto_archive_check.clear()
 
         # The helper imports load_config lazily from hermes_cli.config; patch there.
-        import hermes_cli.config as _config_mod
-
-        def _cfg():
-            return {"sessions": {"auto_archive": True, "auto_archive_days": 3, "min_interval_hours": 0}}
-
-        prev = _config_mod.load_config
-        _config_mod.load_config = _cfg  # type: ignore[assignment]
+        cfg = {"sessions": {"auto_archive": True, "auto_archive_days": 3, "min_interval_hours": 0}}
         try:
-            listed = self.client.get("/api/sessions").json()["sessions"]
+            with patch("hermes_cli.config.load_config", return_value=cfg):
+                listed = self.client.get("/api/sessions").json()["sessions"]
         finally:
-            _config_mod.load_config = prev  # type: ignore[assignment]
             ws._last_auto_archive_check.clear()
 
         assert all(s["id"] != "stale-serve" for s in listed)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1878,6 +1878,88 @@ class TestWebServerEndpoints:
         resp = self.client.patch("/api/sessions/no-fields", json={})
         assert resp.status_code == 400
 
+    def test_patch_session_pins_and_exempts_from_auto_archive(self):
+        """PATCH pinned=true sets the keep flag; a pinned stale session is
+        spared by the auto-archive sweep while an unpinned one is hidden."""
+        import time as _time
+
+        from hermes_state import SessionDB
+
+        old = _time.time() - 30 * 86400
+        db = SessionDB()
+        try:
+            for sid in ("keep-me", "drop-me"):
+                db.create_session(session_id=sid, source="cli")
+                db.append_message(session_id=sid, role="user", content="hi")
+                db._conn.execute(
+                    "UPDATE sessions SET started_at = ? WHERE id = ?", (old, sid)
+                )
+                db._conn.execute(
+                    "UPDATE messages SET timestamp = ? WHERE session_id = ?", (old, sid)
+                )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.patch("/api/sessions/keep-me", json={"pinned": True})
+        assert resp.status_code == 200
+        assert resp.json()["pinned"] is True
+
+        db = SessionDB()
+        try:
+            archived = db.archive_stale_sessions(3)
+        finally:
+            db.close()
+
+        assert archived == 1
+        listed = self.client.get("/api/sessions").json()["sessions"]
+        ids = {s["id"] for s in listed}
+        assert "keep-me" in ids  # pinned -> spared
+        assert "drop-me" not in ids  # unpinned + stale -> archived
+
+    def test_list_triggers_config_gated_auto_archive(self):
+        """With sessions.auto_archive on, listing sessions opportunistically
+        sweeps stale ones (the Desktop `hermes serve` code path)."""
+        import time as _time
+
+        import hermes_cli.web_server as ws
+        from hermes_state import SessionDB
+
+        old = _time.time() - 30 * 86400
+        db = SessionDB()
+        try:
+            db.create_session(session_id="stale-serve", source="cli")
+            db.append_message(session_id="stale-serve", role="user", content="hi")
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?", (old, "stale-serve")
+            )
+            db._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+                (old, "stale-serve"),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        # Reset the in-process throttle so the trigger actually evaluates config.
+        ws._last_auto_archive_check.clear()
+
+        # The helper imports load_config lazily from hermes_cli.config; patch there.
+        import hermes_cli.config as _config_mod
+
+        def _cfg():
+            return {"sessions": {"auto_archive": True, "auto_archive_days": 3, "min_interval_hours": 0}}
+
+        prev = _config_mod.load_config
+        _config_mod.load_config = _cfg  # type: ignore[assignment]
+        try:
+            listed = self.client.get("/api/sessions").json()["sessions"]
+        finally:
+            _config_mod.load_config = prev  # type: ignore[assignment]
+            ws._last_auto_archive_check.clear()
+
+        assert all(s["id"] != "stale-serve" for s in listed)
+
     def test_profiles_sessions_tags_default_profile(self):
         """The cross-profile aggregator returns the default profile's rows
         tagged profile="default" (single-profile parity with /api/sessions)."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -6488,6 +6488,133 @@ class TestSessionArchive:
         assert db.session_count(include_archived=True) == 2
 
 
+class TestSessionPinAndStaleArchive:
+    """Pin as a durable keep flag + last-activity-based stale auto-archive."""
+
+    def _pinned(self, db, sid):
+        row = db._conn.execute(
+            "SELECT pinned FROM sessions WHERE id = ?", (sid,)
+        ).fetchone()
+        return row["pinned"] if row is not None else None
+
+    def _make_idle(self, db, sid, *, days_idle, source="cli"):
+        """A session whose latest activity was ``days_idle`` days ago."""
+        db.create_session(session_id=sid, source=source)
+        db.append_message(session_id=sid, role="user", content=f"msg {sid}")
+        old = time.time() - days_idle * 86400
+        db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = ?", (old, sid))
+        db._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE session_id = ?", (old, sid)
+        )
+        db._conn.commit()
+
+    # ── pin flag ──────────────────────────────────────────────────────────
+    def test_set_session_pinned_roundtrip(self, db):
+        db.create_session(session_id="s1", source="cli")
+        assert db.set_session_pinned("s1", True) is True
+        assert self._pinned(db, "s1") == 1
+        assert db.set_session_pinned("s1", False) is True
+        assert self._pinned(db, "s1") == 0
+
+    def test_set_session_pinned_missing_row(self, db):
+        assert db.set_session_pinned("nope", True) is False
+
+    def test_pin_propagates_across_compression_lineage(self, db):
+        db.create_session(session_id="root", source="cli")
+        db.end_session("root", end_reason="compression")
+        db.create_session(session_id="tip", source="cli", parent_session_id="root")
+
+        # Pinning the surfaced tip pins the compressed-away root too.
+        assert db.set_session_pinned("tip", True) is True
+        assert self._pinned(db, "root") == 1
+        assert self._pinned(db, "tip") == 1
+
+    # ── stale archive ─────────────────────────────────────────────────────
+    def test_archives_only_sessions_idle_past_threshold(self, db):
+        self._make_idle(db, "stale", days_idle=5)
+        self._make_idle(db, "fresh", days_idle=1)
+
+        assert db.archive_stale_sessions(3) == 1
+        assert db.get_session("stale")["archived"] == 1
+        assert db.get_session("fresh")["archived"] == 0
+
+    def test_recency_uses_last_activity_not_creation(self, db):
+        # Created long ago, but a message landed today -> not stale.
+        db.create_session(session_id="old_but_active", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (time.time() - 60 * 86400, "old_but_active"),
+        )
+        db._conn.commit()
+        db.append_message(
+            session_id="old_but_active", role="user", content="fresh activity"
+        )
+
+        assert db.archive_stale_sessions(3) == 0
+        assert db.get_session("old_but_active")["archived"] == 0
+
+    def test_pinned_sessions_are_spared(self, db):
+        self._make_idle(db, "keep", days_idle=10)
+        db.set_session_pinned("keep", True)
+
+        assert db.archive_stale_sessions(3) == 0
+        assert db.get_session("keep")["archived"] == 0
+        # Opting out of the pin guard sweeps it.
+        assert db.archive_stale_sessions(3, exclude_pinned=False) == 1
+        assert db.get_session("keep")["archived"] == 1
+
+    def test_already_archived_is_idempotent(self, db):
+        self._make_idle(db, "stale", days_idle=5)
+        assert db.archive_stale_sessions(3) == 1
+        assert db.archive_stale_sessions(3) == 0
+
+    def test_stale_tip_archives_whole_compression_chain(self, db):
+        # A compressed-away root is never a candidate on its own (its live
+        # continuation may be fresh); the tip drives the decision and archives
+        # the chain as a unit.
+        db.create_session(session_id="root", source="cli")
+        db.end_session("root", end_reason="compression")
+        db.create_session(session_id="tip", source="cli", parent_session_id="root")
+        old = time.time() - 9 * 86400
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id IN ('root', 'tip')", (old,)
+        )
+        db._conn.commit()
+
+        assert db.archive_stale_sessions(3) == 1  # one candidate (the tip)
+        assert db.get_session("root")["archived"] == 1
+        assert db.get_session("tip")["archived"] == 1
+
+    def test_non_positive_threshold_archives_nothing(self, db):
+        self._make_idle(db, "stale", days_idle=100)
+        assert db.archive_stale_sessions(-1) == 0
+        assert db.get_session("stale")["archived"] == 0
+
+    # ── throttled wrapper ─────────────────────────────────────────────────
+    def test_maybe_auto_archive_runs_then_throttles(self, db):
+        self._make_idle(db, "stale", days_idle=5)
+        first = db.maybe_auto_archive(idle_days=3, min_interval_hours=24)
+        assert first["skipped"] is False
+        assert first["archived"] == 1
+        assert db.get_meta("last_auto_archive") is not None
+
+        # A newly-stale session within the interval is left untouched.
+        self._make_idle(db, "stale2", days_idle=5)
+        second = db.maybe_auto_archive(idle_days=3, min_interval_hours=24)
+        assert second["skipped"] is True
+        assert second["archived"] == 0
+        assert db.get_session("stale2")["archived"] == 0
+
+    def test_maybe_auto_archive_reruns_after_interval(self, db):
+        self._make_idle(db, "stale", days_idle=5)
+        db.maybe_auto_archive(idle_days=3, min_interval_hours=24)
+        db.set_meta("last_auto_archive", str(time.time() - 48 * 3600))
+
+        self._make_idle(db, "stale2", days_idle=5)
+        result = db.maybe_auto_archive(idle_days=3, min_interval_hours=24)
+        assert result["skipped"] is False
+        assert result["archived"] == 1
+
 
 class TestSessionIdSearch:
     """Session id search backs Desktop's Search Sessions UX."""


### PR DESCRIPTION
## Summary

- **Date dividers in the sessions sidebar.** The flat recents list and entered-project lanes group by recency: an unlabelled head of the newest run of sessions (cut at a real break in activity, mathematically sized toward the most recent handful), then one divider per coarse calendar range — Earlier today / Yesterday / Earlier this week / Last week / Earlier this month / month / month + year. Empty ranges are skipped, the first rendered group is never labelled, branch clusters never split, virtualized lists render dividers inline, and hand-ordered lists / pinned / project previews stay divider-free. The head cut only ever lands on a genuine pause (≥ 30 min gap inside a run chained by ≤ 8 h gaps), and a head that would merely top its own calendar group dissolves into it, so near-identical neighbours are never stranded across a divider. Verified by simulating the grouping against a real 840-session state.db, both the flat list and a sparse project lane.
- **Pinned section grows to fit.** The pinned list was hard-capped at `max-h-44` with an invisible scrollbar; it now grows up to half the viewport.
- **Opt-in auto-archive for stale sessions.** New `sessions.auto_archive` / `sessions.auto_archive_days` config (off by default): soft-hide — never delete — sessions with no activity for N days, aging on last activity rather than creation. Sweeps are state_meta-throttled and fire from CLI startup, gateway startup + hourly housekeeping, and the serve/dashboard backend (opportunistic on session list + an hourly lifespan ticker). A new `pinned` column (declaratively migrated) exempts sessions; `PATCH /api/sessions/{id}` accepts `pinned` and flips the whole compression lineage as a unit. Desktop adds the settings toggle and transparently mirrors its localStorage sidebar pins to the backend flag so the sweep can never hide a pinned chat.

## Test plan

- [x] Unit tests for the grouping math: head-run sizing, burst protection, midnight chaining, fuzzy dissolve, dedupe under non-monotonic order, `started_at` fallback (`session-date-groups.test.ts`, `time.test.ts`)
- [x] Pin-mirroring tests (`session-pin-sync.test.ts`); desktop suite for touched areas (899 tests), typecheck, eslint
- [x] Backend tests: `set_session_pinned` lineage propagation, `archive_stale_sessions` guards (pinned exemption, idempotence, compression tips), `maybe_auto_archive` throttling, PATCH `pinned`, config-gated sweep on GET /api/sessions (`scripts/run_tests.sh tests/test_hermes_state.py tests/hermes_cli/test_web_server.py`)
- [ ] Manual: flat list and entered-project lane render sensible dividers against a large real session history