### PR TITLE
fix(desktop): use generic session actions tooltip

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -25,6 +25,7 @@ vi.mock('@/i18n', () => ({
           finishedUnread: 'Finished',
           handoffOrigin: (platform: string) => `Started on ${platform}`,
           needsInput: 'Needs input',
+          sessionActions: 'Session actions',
           sessionRunning: 'Running',
           waitingForAnswer: 'Waiting for answer'
         }
@@ -127,7 +128,7 @@ const tipTrigger = (el: HTMLElement) => el.closest('[data-slot="tooltip-trigger"
 const noop = vi.fn()
 
 describe('SidebarSessionRow', () => {
-  it('wires the actions kebab tooltip text through to SessionActionsMenu', () => {
+  it('uses a generic tooltip for the session actions kebab', () => {
     render(
       <SidebarSessionRow
         isPinned={false}
@@ -141,9 +142,8 @@ describe('SidebarSessionRow', () => {
       />
     )
 
-    expect(screen.getByTestId('session-actions-menu').getAttribute('data-tooltip')).toBe(
-      'Actions for Hermes doctor health check results'
-    )
+    expect(screen.getByTestId('session-actions-menu').getAttribute('data-tooltip')).toBe('Session actions')
+    expect(screen.getByRole('button', { name: 'Session actions' })).toBeTruthy()
   })
 
   it('does not render a handoff avatar for a locally-started session', () => {

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -116,10 +116,10 @@ export function SidebarSessionRow({
               profile={session.profile}
               sessionId={session.id}
               title={title}
-              tooltip={r.actionsFor(title)}
+              tooltip={r.sessionActions}
             >
               <Button
-                aria-label={r.actionsFor(title)}
+                aria-label={r.sessionActions}
                 className="size-5 rounded-[4px] bg-transparent text-transparent transition-colors duration-100 hover:bg-(--ui-control-active-background) hover:text-foreground focus-visible:bg-(--ui-control-active-background) focus-visible:text-foreground focus-visible:ring-0 data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground group-hover:text-(--ui-text-tertiary) [&_svg]:size-3.5!"
                 size="icon"
                 variant="ghost"


### PR DESCRIPTION
## What does this PR do?

Replaces the session kebab tooltip `Actions for <chat title>` with the existing generic `sessionActions` copy (`Session actions`). The title is already visible on the same row, so repeating it in the hover tooltip adds noise without helping the user.

This deliberately preserves the visual tooltip introduced by #67500. The `Tip > DropdownMenuTrigger > button` composition is unchanged. The tooltip and `aria-label` both use the existing generic `sessionActions` copy, as required by the Desktop design contract.

## Related Issue

Fixes #70798

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/session-row.tsx`: use the generic localized session-actions label for both the tooltip and accessible name.
- `apps/desktop/src/app/chat/sidebar/session-row.test.tsx`: assert the generic tooltip and matching generic `aria-label`.

## How to Test

1. Run `cd apps/desktop && npm run test:ui -- src/app/chat/sidebar/session-row.test.tsx src/app/chat/sidebar/session-actions-menu.test.tsx`.
2. Confirm all 5 tests pass, including the #67500 regression test that verifies the dropdown still opens with the trigger wrapped in a `Tip`.
3. Run `cd apps/desktop && npx eslint src/app/chat/sidebar/session-row.tsx src/app/chat/sidebar/session-row.test.tsx`.
4. Run `cd apps/desktop && npm run typecheck`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits (`fix(desktop):`).
- [x] I searched for existing PRs and found no open PR addressing #70798.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this change only touches Desktop TSX and its Vitest coverage.
- [x] I've added regression coverage for the changed behavior.
- [x] I've tested on Linux 6.1 (Node.js 24.18.0): focused Vitest 5/5, touched-file ESLint, and Desktop typecheck pass.

### Documentation & Housekeeping

- [x] Documentation update — N/A: no documented behavior or configuration changes.
- [x] `cli-config.yaml.example` update — N/A: no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A: no architecture or workflow changes.
- [x] Cross-platform impact considered: renderer-only localized copy change; no platform-specific code path.
- [x] Tool descriptions/schemas update — N/A: no tool behavior changed.

## Regression Analysis for #67500

#67500 fixed missing visual tooltips and corrected the Radix `asChild` composition so menu trigger props and refs reach the real button. This PR does **not** remove the `Tip`, change that composition, or alter menu behavior. It changes only the label passed to the existing `Tip`. The dedicated #67500 test (`still opens the dropdown on click with the trigger wrapped in a Tip`) remains green.
