### PR TITLE
fix(state): deserialize display_metadata in get_messages and get_messages_around

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6169,6 +6169,14 @@ class SessionDB:
                 except (json.JSONDecodeError, TypeError):
                     logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
                     msg["tool_calls"] = []
+            # Pop the raw column value so the key is only re-added on
+            # successful parse — matching _rows_to_conversation's contract.
+            raw_metadata = msg.pop("display_metadata", None)
+            if raw_metadata:
+                try:
+                    msg["display_metadata"] = json.loads(raw_metadata)
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning("Failed to deserialize display_metadata in get_messages")
             result.append(msg)
         return result
 
@@ -6238,6 +6246,14 @@ class SessionDB:
                         "Failed to deserialize tool_calls in get_messages_around, falling back to []"
                     )
                     msg["tool_calls"] = []
+            raw_metadata = msg.pop("display_metadata", None)
+            if raw_metadata:
+                try:
+                    msg["display_metadata"] = json.loads(raw_metadata)
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning(
+                        "Failed to deserialize display_metadata in get_messages_around"
+                    )
             result.append(msg)
 
         # before_rows includes the anchor itself; subtract 1 for the count of

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -7235,3 +7235,54 @@ class TestDisplayMetadataPersistence:
         assert len(switched) == 1
         assert switched[0]["display_metadata"] == meta
 
+    def test_get_messages_deserializes_display_metadata(self, db):
+        """get_messages() must return display_metadata as a parsed dict, not a raw JSON string."""
+        db.create_session("s1", source="cli")
+        meta = {"task_count": 2, "delegation_id": "del-1", "duration_seconds": 45.0}
+        db.append_message(
+            "s1", "user", "delegation done",
+            display_kind="async_delegation_complete",
+            display_metadata=meta,
+        )
+        messages = db.get_messages("s1")
+        assert len(messages) == 1
+        assert isinstance(messages[0]["display_metadata"], dict)
+        assert messages[0]["display_metadata"] == meta
+
+    def test_get_messages_around_deserializes_display_metadata(self, db):
+        """get_messages_around() must return display_metadata as a parsed dict, not a raw JSON string."""
+        db.create_session("s1", source="cli")
+        meta = {"task_count": 3, "delegation_id": "del-2", "completed_count": 3}
+        msg_id = db.append_message(
+            "s1", "user", "delegation done",
+            display_kind="async_delegation_complete",
+            display_metadata=meta,
+        )
+        result = db.get_messages_around("s1", around_message_id=msg_id, window=2)
+        # The anchored message should be in the window
+        anchored = [m for m in result["window"] if m.get("display_kind") == "async_delegation_complete"]
+        assert len(anchored) == 1
+        assert isinstance(anchored[0]["display_metadata"], dict)
+        assert anchored[0]["display_metadata"] == meta
+
+    def test_display_metadata_omitted_on_parse_failure(self, db):
+        """Corrupt display_metadata JSON must not crash — key should be absent."""
+        db.create_session("s1", source="cli")
+        # Write a valid row so we have a message, then corrupt display_metadata directly
+        db.append_message("s1", "user", "ok")
+        msg_id = db.append_message(
+            "s1", "user", "event",
+            display_kind="async_delegation_complete",
+            display_metadata={"task_count": 1},
+        )
+        # Inject corrupt JSON via raw SQL
+        db._conn.execute(
+            "UPDATE messages SET display_metadata = ? WHERE id = ?",
+            ("not valid json {{{", msg_id),
+        )
+        db._conn.commit()
+        # get_messages must not crash and must omit the key
+        messages = db.get_messages("s1")
+        event_msg = [m for m in messages if m.get("id") == msg_id][0]
+        assert "display_metadata" not in event_msg
+


### PR DESCRIPTION
## What

`get_messages()` and `get_messages_around()` in `hermes_state.py` use `SELECT *` but don't deserialize the `display_metadata` column (added in #69771) from JSON. The frontend receives a raw JSON string, and the `'task_count' in message.display_metadata` expression in `chat-messages.ts` throws `TypeError` because JavaScript's `in` operator requires an object, not a primitive.

## How to reproduce

1. Have a session with an `async_delegation_complete` display event (any session that used `delegate_task`)
2. Resume it in Desktop or load messages via `GET /api/sessions/{id}/messages`
3. "Resume failed" popup with `Cannot use 'in' operator to search for 'task_count' in {"delegation_id":...}`

## Fix

Add `json.loads()` for `display_metadata` in both `get_messages()` and `get_messages_around()`, matching the existing pattern for `tool_calls` and the pattern already in `_rows_to_conversation()`.

## Testing

- `tests/test_hermes_state.py`: 413 passed
- `tests/hermes_cli/test_web_server.py -k session`: 49 passed

Closes #70835