### PR TITLE
fix(gateway): bind every adapter to its runner

### DIFF
--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -4,10 +4,11 @@ Platform Adapter Registry
 Allows platform adapters (built-in and plugin) to self-register so the gateway
 can discover and instantiate them without hardcoded if/elif chains.
 
-Built-in adapters continue to use the existing if/elif in _create_adapter()
+Built-in adapters continue to use the existing if/elif in _instantiate_adapter()
 for now.  Plugin adapters register here via PluginContext.register_platform()
 and are looked up first -- if nothing is found the gateway falls through to
-the legacy code path.
+the legacy code path.  GatewayRunner._create_adapter() wraps both paths and
+binds every successful adapter to its runner.
 
 Usage (plugin side):
 

--- a/gateway/platforms/ADDING_A_PLATFORM.md
+++ b/gateway/platforms/ADDING_A_PLATFORM.md
@@ -174,7 +174,7 @@ Update `get_connected_platforms()` if your platform doesn't use token/api_key
 
 ## 3. Adapter Factory (`gateway/run.py`)
 
-Add to `_create_adapter()`:
+Add to `_instantiate_adapter()`:
 
 ```python
 elif platform == Platform.YOUR_PLATFORM:
@@ -184,6 +184,11 @@ elif platform == Platform.YOUR_PLATFORM:
         return None
     return YourAdapter(config)
 ```
+
+`_create_adapter()` wraps this factory and binds every successful adapter to
+its `GatewayRunner`. Do not construct platform adapters in lifecycle call sites;
+startup and reconnect must keep using the wrapper so profile routing is wired
+before `connect()`.
 
 ---
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10193,11 +10193,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return hashlib.sha256(("hermes-mux:" + token).encode("utf-8")).hexdigest()[:16]
 
     def _create_adapter(
-        self, 
-        platform: Platform, 
-        config: Any
+        self,
+        platform: Platform,
+        config: Any,
     ) -> Optional[BasePlatformAdapter]:
-        """Create the appropriate adapter for a platform.
+        """Create an adapter and bind it to this gateway runner.
+
+        Every lifecycle path — primary/secondary startup and reconnect — goes
+        through this method. Keep runner binding here so adapters can resolve
+        inbound profile routes before handlers or ``connect()`` run.
+        """
+        adapter = self._instantiate_adapter(platform, config)
+        if adapter is not None:
+            adapter.gateway_runner = self
+        return adapter
+
+    def _instantiate_adapter(
+        self,
+        platform: Platform,
+        config: Any,
+    ) -> Optional[BasePlatformAdapter]:
+        """Instantiate the appropriate adapter for a platform.
 
         Checks the platform_registry first (plugin adapters), then falls
         through to the built-in if/elif chain for core platforms.
@@ -10218,14 +10234,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if platform_registry.is_registered(platform.value):
                 adapter = platform_registry.create_adapter(platform.value, config)
                 if adapter is not None:
-                    # Inject a back-reference to the gateway runner so every
-                    # adapter can (a) deliver cross-platform admin alerts and
-                    # (b) resolve inbound profile routing through
-                    # ``runner._profile_name_for_source``. Unconditional:
-                    # ``BasePlatformAdapter`` declares ``gateway_runner``, so
-                    # this reaches ALL platforms (not just the ones that
-                    # pre-declared it), making profile routing platform-generic.
-                    adapter.gateway_runner = self
                     return adapter
                 # Registered but failed to instantiate — don't silently fall
                 # through to built-ins (there are none for plugin platforms).
@@ -10277,18 +10285,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not check_api_server_requirements():
                 logger.warning("API Server: aiohttp not installed")
                 return None
-            adapter = APIServerAdapter(config)
-            adapter.gateway_runner = self
-            return adapter
+            return APIServerAdapter(config)
 
         elif platform == Platform.WEBHOOK:
             from gateway.platforms.webhook import WebhookAdapter, check_webhook_requirements
             if not check_webhook_requirements():
                 logger.warning("Webhook: aiohttp not installed")
                 return None
-            adapter = WebhookAdapter(config)
-            adapter.gateway_runner = self  # For cross-platform delivery
-            return adapter
+            return WebhookAdapter(config)
 
         elif platform == Platform.MSGRAPH_WEBHOOK:
             from gateway.platforms.msgraph_webhook import (

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -221,7 +221,11 @@ def _install_secondary_reconnect_context(monkeypatch, runner, adapter, scoped_ho
             },
         ),
     )
-    monkeypatch.setattr(runner, "_create_adapter", lambda platform, config: adapter)
+    monkeypatch.setattr(
+        runner,
+        "_instantiate_adapter",
+        lambda platform, config: adapter,
+    )
 
 
 class TestSecondaryProfileFatalRecovery:
@@ -256,6 +260,7 @@ class TestSecondaryProfileFatalRecovery:
         assert len(tasks) == 1
         await tasks[0]
         assert runner._profile_adapters["reviewer"][Platform.DISCORD] is replacement
+        assert replacement.gateway_runner is runner
         assert scoped_homes
         assert all(path == Path("/profiles/reviewer") for path in scoped_homes)
 

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -198,7 +198,11 @@ class TestPlatformReconnectWatcher:
         succeed_adapter = StubAdapter(succeed=True)
         real_sleep = asyncio.sleep
 
-        with patch.object(runner, "_create_adapter", return_value=succeed_adapter):
+        with patch.object(
+            runner,
+            "_instantiate_adapter",
+            return_value=succeed_adapter,
+        ):
             with patch("gateway.run.build_channel_directory", create=True):
                 # Run one iteration of the watcher then stop
                 async def run_one_iteration():
@@ -220,6 +224,7 @@ class TestPlatformReconnectWatcher:
 
         assert Platform.TELEGRAM not in runner._failed_platforms
         assert Platform.TELEGRAM in runner.adapters
+        assert succeed_adapter.gateway_runner is runner
 
     @pytest.mark.asyncio
     async def test_reconnect_passes_is_reconnect_true(self):

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -9,7 +9,7 @@ import pytest
 from gateway.session import SessionSource, build_session_key
 from gateway.run import GatewayRunner
 from gateway.profile_routing import ProfileRoute
-from gateway.config import GatewayConfig, Platform
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
 
 
@@ -334,6 +334,36 @@ class TestGatewayRunnerInjection:
         assert hasattr(_ToyAdapter, "gateway_runner")
         assert _ToyAdapter.gateway_runner is None
 
+    def test_factory_binds_created_adapter_to_runner(self, monkeypatch):
+        runner = object.__new__(GatewayRunner)
+        adapter = MagicMock(spec=BasePlatformAdapter)
+        monkeypatch.setattr(
+            runner,
+            "_instantiate_adapter",
+            lambda platform, config: adapter,
+        )
+
+        created = runner._create_adapter(
+            Platform.SIGNAL,
+            PlatformConfig(enabled=True),
+        )
+
+        assert created is adapter
+        assert adapter.gateway_runner is runner
+
+    def test_factory_preserves_unavailable_adapter(self, monkeypatch):
+        runner = object.__new__(GatewayRunner)
+        monkeypatch.setattr(
+            runner,
+            "_instantiate_adapter",
+            lambda platform, config: None,
+        )
+
+        assert runner._create_adapter(
+            Platform.SIGNAL,
+            PlatformConfig(enabled=True),
+        ) is None
+
 
 # A concrete adapter we can instantiate without the full platform stack.
 # ``build_source`` only reads ``self.platform`` and ``self.gateway_runner``, so a
@@ -402,6 +432,74 @@ class TestAdapterToSessionKeyIntegration:
         assert source.profile == "ops"
         assert source._transport_adapter_ref() is adapter
 
+        key = build_session_key(source, profile=source.profile)
+        assert key.startswith("agent:ops:"), key
+        assert key != build_session_key(source, profile=None)
+
+    @pytest.mark.asyncio
+    async def test_real_signal_factory_routes_inbound_group_event(self, monkeypatch):
+        """A factory-built Signal adapter must route a real inbound event."""
+        group_id = "test-signal-route"
+        route_chat_id = f"group:{group_id}"
+        monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", group_id)
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            multiplex_profiles=True,
+            profile_routes=[
+                ProfileRoute(
+                    name="signal",
+                    platform="signal",
+                    profile="ops",
+                    chat_id=route_chat_id,
+                ),
+            ],
+        )
+        signal_config = PlatformConfig(
+            enabled=True,
+            extra={
+                "http_url": "http://127.0.0.1:18080",
+                "account": "+15555550123",
+            },
+        )
+
+        cold_adapter = runner._create_adapter(Platform.SIGNAL, signal_config)
+        replacement_adapter = runner._create_adapter(
+            Platform.SIGNAL,
+            signal_config,
+        )
+
+        assert cold_adapter is not None
+        assert replacement_adapter is not None
+        assert replacement_adapter is not cold_adapter
+        assert cold_adapter.gateway_runner is runner
+        assert replacement_adapter.gateway_runner is runner
+
+        captured = {}
+
+        async def capture_event(event):
+            captured["event"] = event
+
+        replacement_adapter.handle_message = capture_event
+        await replacement_adapter._handle_envelope(
+            {
+                "envelope": {
+                    "sourceNumber": "+15555550124",
+                    "sourceName": "Test Operator",
+                    "timestamp": 1700000000000,
+                    "dataMessage": {
+                        "message": "diagnose the cluster",
+                        "groupInfo": {
+                            "groupId": group_id,
+                            "groupName": "US East 7",
+                        },
+                    },
+                },
+            },
+        )
+
+        source = captured["event"].source
+        assert source.chat_id == route_chat_id
+        assert source.profile == "ops"
         key = build_session_key(source, profile=source.profile)
         assert key.startswith("agent:ops:"), key
         assert key != build_session_key(source, profile=None)

--- a/website/docs/developer-guide/adding-platform-adapters.md
+++ b/website/docs/developer-guide/adding-platform-adapters.md
@@ -541,9 +541,9 @@ Three touchpoints:
 
 ### 4. Gateway Runner (`gateway/run.py`)
 
-Five touchpoints:
+Six touchpoints:
 
-1. **`_create_adapter()`** — Add an `elif platform == Platform.NEWPLAT:` branch
+1. **`_instantiate_adapter()`** — Add an `elif platform == Platform.NEWPLAT:` branch. The `_create_adapter()` wrapper binds every successful adapter to its gateway runner.
 2. **`_is_user_authorized()` allowed_users map** — `Platform.NEWPLAT: "NEWPLAT_ALLOWED_USERS"`
 3. **`_is_user_authorized()` allow_all map** — `Platform.NEWPLAT: "NEWPLAT_ALLOW_ALL_USERS"`
 4. **Early env check `_any_allowlist` tuple** — Add `"NEWPLAT_ALLOWED_USERS"`

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/adding-platform-adapters.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/adding-platform-adapters.md
@@ -537,9 +537,9 @@ await self.handle_message(event)
 
 ### 4. Gateway Runner（`gateway/run.py`）
 
-五个接触点：
+六个接触点：
 
-1. **`_create_adapter()`** — 添加 `elif platform == Platform.NEWPLAT:` 分支
+1. **`_instantiate_adapter()`** — 添加 `elif platform == Platform.NEWPLAT:` 分支。`_create_adapter()` 包装器会将每个成功创建的适配器绑定到其网关运行器。
 2. **`_is_user_authorized()` allowed_users 映射** — `Platform.NEWPLAT: "NEWPLAT_ALLOWED_USERS"`
 3. **`_is_user_authorized()` allow_all 映射** — `Platform.NEWPLAT: "NEWPLAT_ALLOW_ALL_USERS"`
 4. **早期环境检查 `_any_allowlist` 元组** — 添加 `"NEWPLAT_ALLOWED_USERS"`


### PR DESCRIPTION
## What does this PR do?

`GatewayRunner` currently injects its back-reference only for registry plugins, API Server, and Webhook adapters. Directly constructed built-ins—including Signal—therefore keep `gateway_runner = None`, so inbound `profile_routes` cannot resolve and messages fall back to the default profile.

This moves runner binding to the shared `_create_adapter()` boundary and renames the branchy constructor to `_instantiate_adapter()`. Primary and secondary startup/reconnect paths already use `_create_adapter()`, so one invariant covers all adapter implementations and lifecycle paths.

This builds on the root-cause report and initial Signal-specific fix proposed by @agents-blueoi in #68332. The factory-boundary version here also covers reconnect-created adapters and sibling built-ins, with regression coverage.

## Related Issue

Related: #68332, #64835

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Bind every successful plugin or built-in adapter to its `GatewayRunner` in `gateway/run.py`.
- Preserve unavailable-adapter (`None`) behavior and remove branch-local injection.
- Exercise a real no-network Signal group envelope through factory creation, profile routing, and profile-scoped session-key construction.
- Exercise the shared wrapper during primary and secondary reconnect replacement.
- Update contributor docs in both website languages and the platform registry/module guide.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_signal.py tests/gateway/test_profile_resolution.py tests/gateway/test_platform_reconnect.py tests/gateway/test_multiplex_adapter_registry.py -q`.
2. Confirm 234 tests pass, including the real Signal envelope and both reconnect paths.
3. Run `scripts/run_tests.sh tests/gateway -q`. On macOS 27.0, 10,946 tests pass; three unrelated platform-specific failures reproduce on unmodified `origin/main` (`test_media_files_routed_by_type`, `test_spawns_subprocess_and_writes_output`, and `test_notify_supports_systemd_abstract_socket`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the focused suite passes; the broad gateway run has three macOS baseline failures documented above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; contributor factory docs were updated instead
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A; this is an internal routing invariant with automated regression coverage.
