### PR TITLE
fix(desktop): pass skin customCSS through to desktop theme context

### DIFF
--- a/apps/desktop/src/themes/backend-sync.test.ts
+++ b/apps/desktop/src/themes/backend-sync.test.ts
@@ -1,11 +1,19 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { $backendThemes, $pendingSkinApply, __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
+import {
+  $backendCustomCSS,
+  $backendThemes,
+  $pendingSkinApply,
+  __resetBackendSkinSync,
+  ingestBackendSkin,
+} from './backend-sync'
 
 const skin = (name: string) => ({
   name,
   colors: { background: '#101020', ui_accent: '#ff33aa', banner_text: '#eeeeee' }
 })
+
+const skinWithCSS = (name: string, customCSS: string) => ({ ...skin(name), customCSS })
 
 describe('ingestBackendSkin', () => {
   beforeEach(() => __resetBackendSkinSync())
@@ -98,6 +106,50 @@ describe('ingestBackendSkin', () => {
 
     expect($backendThemes.get().mono).toBeUndefined()
     expect($pendingSkinApply.get()).toBe('mono')
+  })
+
+  it('carries customCSS for a built-in-named user skin without shadowing the palette', () => {
+    ingestBackendSkin(skinWithCSS('mono', '.chat-input { font-size: 16px; }'), { apply: true })
+
+    expect($backendThemes.get().mono).toBeUndefined() // palette policy preserved
+    expect($pendingSkinApply.get()).toBe('mono')
+    expect($backendCustomCSS.get().mono).toBe('.chat-input { font-size: 16px; }')
+  })
+
+  it('keys default-named skin CSS under the resolved desktop default', () => {
+    ingestBackendSkin(skinWithCSS('default', 'body { background: red; }'), { apply: true })
+
+    expect($backendThemes.get().default).toBeUndefined()
+    // setTheme normalizes `default` → DEFAULT_SKIN_NAME ('nous'), so the CSS
+    // must be findable under that name when the theme is derived.
+    expect($backendCustomCSS.get().nous).toBe('body { background: red; }')
+  })
+
+  it('clears customCSS when a built-in-named skin drops the field', () => {
+    ingestBackendSkin(skinWithCSS('mono', 'a { color: red; }'), { apply: true })
+    expect($backendCustomCSS.get().mono).toBe('a { color: red; }')
+
+    // Same skin, CSS removed from the YAML — the entry must go so stale rules
+    // don't linger after the next apply.
+    ingestBackendSkin(skin('mono'), { apply: true })
+
+    expect($backendCustomCSS.get().mono).toBeUndefined()
+  })
+
+  it('does not populate the CSS store for non-built-in skins (converter carries it)', () => {
+    ingestBackendSkin(skinWithCSS('neon', 'a { color: red; }'), { apply: true })
+
+    expect($backendCustomCSS.get()).toEqual({})
+    expect($backendThemes.get().neon?.customCSS).toBe('a { color: red; }')
+  })
+
+  it('reset clears the custom CSS store', () => {
+    ingestBackendSkin(skinWithCSS('mono', 'a {}'), { apply: false })
+    expect($backendCustomCSS.get().mono).toBe('a {}')
+
+    __resetBackendSkinSync()
+
+    expect($backendCustomCSS.get()).toEqual({})
   })
 
   it('ignores empty payloads', () => {

--- a/apps/desktop/src/themes/backend-sync.ts
+++ b/apps/desktop/src/themes/backend-sync.ts
@@ -19,12 +19,19 @@
 import type { HermesSkin } from '@hermes/shared/skin'
 import { atom } from 'nanostores'
 
-import { BUILTIN_THEMES } from './presets'
+import { BUILTIN_THEMES, DEFAULT_SKIN_NAME } from './presets'
 import { skinToDesktopTheme } from './skin'
 import type { DesktopTheme } from './types'
 
 /** Skins pushed by the backend, keyed by name. Merged by `listAllThemes`. */
 export const $backendThemes = atom<Record<string, DesktopTheme>>({})
+
+/** Custom CSS carried by a user skin whose name is `default` or a desktop
+ *  built-in. The palette policy keeps built-in palettes (a user `mono.yaml`
+ *  must not shadow the desktop's hand-tuned mono), but the user's CSS is still
+ *  the skin file's truth — keyed by the name the desktop resolves the skin
+ *  under (`default` → `nous`). Merged into the active theme in context.tsx. */
+export const $backendCustomCSS = atom<Record<string, string>>({})
 
 /** One-shot skin name the ThemeProvider should switch to (it clears this). */
 export const $pendingSkinApply = atom<string | null>(null)
@@ -42,6 +49,7 @@ export function __resetBackendSkinSync(): void {
   lastSynced = null
   $backendThemes.set({})
   $pendingSkinApply.set(null)
+  $backendCustomCSS.set({})
 }
 
 /**
@@ -74,6 +82,25 @@ export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }
 
     if (JSON.stringify(current[name]) !== JSON.stringify(theme)) {
       $backendThemes.set({ ...current, [name]: theme })
+    }
+  } else {
+    // Built-in/default-named user skins never shadow the desktop palette, but
+    // their customCSS still belongs to the user's skin file (user skins take
+    // precedence over built-ins with the same name). Carry it separately so
+    // applyTheme can inject it on top of the built-in palette; dropping the
+    // field from the YAML clears the entry so stale rules don't linger.
+    const css = skin?.customCSS?.trim() ?? ''
+    const cssKey = name === 'default' ? DEFAULT_SKIN_NAME : name
+    const current = $backendCustomCSS.get()
+
+    if (css) {
+      if (current[cssKey] !== css) {
+        $backendCustomCSS.set({ ...current, [cssKey]: css })
+      }
+    } else if (current[cssKey]) {
+      const next = { ...current }
+      delete next[cssKey]
+      $backendCustomCSS.set(next)
     }
   }
 

--- a/apps/desktop/src/themes/context.test.tsx
+++ b/apps/desktop/src/themes/context.test.tsx
@@ -1,7 +1,7 @@
 import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
+import { $backendThemes, __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
 import { ThemeProvider } from './context'
 
 // The live-authoring loop: Hermes writes/edits one skin file and every surface
@@ -12,6 +12,9 @@ const bloomberg = (foreground: string) => ({
 })
 
 const cssVar = (name: string) => window.document.documentElement.style.getPropertyValue(name)
+
+const customStyleEl = () =>
+  window.document.getElementById('hermes-desktop-custom-css') as HTMLStyleElement | null
 
 describe('ThemeProvider ← backend skin sync', () => {
   beforeEach(() => {
@@ -66,5 +69,95 @@ describe('ThemeProvider ← backend skin sync', () => {
       ingestBackendSkin({ name: 'forest', colors: { background: '#001100', ui_text: '#66ff66' } }, { apply: false })
     )
     expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
+  })
+
+  it('injects customCSS from an applied backend skin', () => {
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    act(() =>
+      ingestBackendSkin({ ...bloomberg('#ff9f0a'), customCSS: '.chat-input { font-size: 16px; }' }, { apply: true })
+    )
+
+    expect(customStyleEl()?.textContent).toBe('.chat-input { font-size: 16px; }')
+  })
+
+  it('replaces customCSS in the SAME <style> tag when the active skin changes', () => {
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    act(() => ingestBackendSkin({ ...bloomberg('#ff9f0a'), customCSS: 'a { color: red; }' }, { apply: true }))
+    const first = customStyleEl()
+    expect(first?.textContent).toBe('a { color: red; }')
+
+    act(() =>
+      ingestBackendSkin(
+        { name: 'forest', colors: { background: '#001100', ui_text: '#66ff66' }, customCSS: 'b { color: blue; }' },
+        { apply: true }
+      )
+    )
+
+    const second = customStyleEl()
+    expect(second).not.toBeNull()
+    expect(second?.id).toBe(first?.id) // one tag reused — no accumulation
+    expect(second?.textContent).toBe('b { color: blue; }')
+  })
+
+  it('removes the style tag when switching to a CSS-less skin', () => {
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    act(() => ingestBackendSkin({ ...bloomberg('#ff9f0a'), customCSS: 'a { color: red; }' }, { apply: true }))
+    expect(customStyleEl()).not.toBeNull()
+
+    act(() => ingestBackendSkin(bloomberg('#00ff00'), { apply: true }))
+
+    expect(customStyleEl()).toBeNull()
+  })
+
+  it('applies customCSS for a built-in-named user skin without shadowing the built-in palette', () => {
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    act(() =>
+      ingestBackendSkin(
+        { name: 'mono', colors: { background: '#ff00ff', ui_text: '#00ff00' }, customCSS: '.status-bar { background: black; }' },
+        { apply: true }
+      )
+    )
+
+    // The user's CSS lands…
+    expect(customStyleEl()?.textContent).toBe('.status-bar { background: black; }')
+    // …but the palette policy still holds: the backend theme is never
+    // registered under a built-in name, so the painted background is the
+    // desktop's built-in mono, not the user YAML's #ff00ff.
+    expect($backendThemes.get().mono).toBeUndefined()
+    expect(cssVar('--theme-background-seed')).not.toBe('#ff00ff')
+  })
+
+  it('applies customCSS from a default-named user skin under the desktop default', () => {
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    act(() =>
+      ingestBackendSkin({ name: 'default', colors: { background: '#123456' }, customCSS: '.chat-input { font-size: 18px; }' }, { apply: true })
+    )
+
+    expect(customStyleEl()?.textContent).toBe('.chat-input { font-size: 18px; }')
   })
 })

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -256,6 +256,28 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
     document.head.appendChild(link)
     INJECTED_FONT_URLS.add(typo.fontUrl)
   }
+
+  // Inject / clear customCSS from the skin (mirrors web/src/themes/context.tsx).
+  // A theme carries the optional customCSS field; we inject/remove a single
+  // <style> tag to keep the DOM clean and avoid stale rules on switch.
+  const cssId = 'hermes-desktop-custom-css'
+  let cssEl = document.getElementById(cssId) as HTMLStyleElement | null
+  const customCSS = theme.customCSS?.trim()
+
+  if (!customCSS) {
+    if (cssEl) {
+      cssEl.remove()
+    }
+  } else {
+    if (!cssEl) {
+      cssEl = document.createElement('style')
+      cssEl.id = cssId
+      cssEl.dataset.hermesSkinCSS = 'true'
+      document.head.appendChild(cssEl)
+    }
+
+    cssEl.textContent = customCSS
+  }
 }
 
 // Pin Electron's nativeTheme to the app's mode so the NATIVE window chrome

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -17,7 +17,7 @@ import { matchesQuery, useMediaQuery } from '@/hooks/use-media-query'
 import { persistString, persistStringRecord, storedString, storedStringRecord } from '@/lib/storage'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 
-import { $backendThemes, $pendingSkinApply } from './backend-sync'
+import { $backendCustomCSS, $backendThemes, $pendingSkinApply } from './backend-sync'
 import { hexToRgb, mix, readableOn } from './color'
 import { BUILTIN_THEME_LIST, DEFAULT_SKIN_NAME, DEFAULT_TYPOGRAPHY, nousTheme } from './presets'
 import type { DesktopTheme, DesktopThemeColors } from './types'
@@ -133,7 +133,12 @@ function deriveTheme(skinName: string, mode: 'light' | 'dark'): DesktopTheme {
     name: `${skinName}-${mode}`,
     label: `${seed.label} ${mode === 'light' ? 'Light' : 'Dark'}`,
     description: `${seed.label} ${mode} palette`,
-    colors: getBaseColors(skinName, mode)
+    colors: getBaseColors(skinName, mode),
+    // A backend skin named `default`/`mono`/… keeps the desktop's own palette
+    // (never shadowed — see ingestBackendSkin), but its customCSS is carried
+    // separately in $backendCustomCSS. The seed's own customCSS (non-built-in
+    // backend skins) wins when both exist.
+    customCSS: seed.customCSS ?? $backendCustomCSS.get()[skinName]
   }
 }
 
@@ -343,6 +348,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // grid, and `/skin` without a reload.
   const userThemes = useStore($userThemes)
   const backendThemes = useStore($backendThemes)
+  const backendCustomCSS = useStore($backendCustomCSS)
   const registryVersion = useStore($registryVersion)
 
   const availableThemes = useMemo(
@@ -380,9 +386,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     () => deriveTheme(themeName, resolvedMode),
     // deriveTheme resolves its seed through the merged registry, so the theme
     // stores are its reactivity too — an in-place palette edit of the ACTIVE
-    // skin (live theme authoring) must repaint, not just a name switch.
+    // skin (live theme authoring) must repaint, not just a name switch. The
+    // backend CSS store matters the same way for built-in-named user skins.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [themeName, resolvedMode, userThemes, backendThemes, registryVersion]
+    [themeName, resolvedMode, userThemes, backendThemes, backendCustomCSS, registryVersion]
   )
 
   // What actually gets painted (matches the `.dark` class applyTheme toggles).

--- a/apps/desktop/src/themes/skin.ts
+++ b/apps/desktop/src/themes/skin.ts
@@ -112,6 +112,9 @@ export function skinToDesktopTheme(skin: HermesSkin): DesktopTheme | null {
     // Single palette in both slots: a skin is one-mode, so the light/dark toggle
     // shouldn't invert it. renderedModeFor still paints `.dark` from luminance.
     colors: palette,
-    darkColors: palette
+    darkColors: palette,
+    // Pass through raw CSS so the desktop can inject it as a scoped <style>
+    // tag — users put CSS in their skin YAML instead of hacking app.asar.
+    customCSS: skin.customCSS?.trim() || undefined,
   }
 }

--- a/apps/desktop/src/themes/types.ts
+++ b/apps/desktop/src/themes/types.ts
@@ -98,4 +98,8 @@ export interface DesktopTheme {
   terminal?: DesktopTerminalPalette
   /** Dark-variant terminal ANSI palette. Falls back to `terminal`. */
   darkTerminal?: DesktopTerminalPalette
+  /** Raw CSS injected as a scoped <style> tag on theme apply.
+   *  Persists across updates because it lives in ~/.hermes/skins/,
+   *  not inside app.asar. */
+  customCSS?: string
 }

--- a/apps/shared/src/skin.ts
+++ b/apps/shared/src/skin.ts
@@ -107,4 +107,8 @@ export interface HermesSkin {
   banner_hero?: string
   tool_prefix?: string
   help_header?: string
+  /** Raw CSS injected as a scoped <style> tag on theme apply.
+   *  Persists across updates because it lives in ~/.hermes/skins/,
+   *  not inside app.asar.  Clipped to 32 KiB by the Python normaliser. */
+  customCSS?: string
 }

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -175,6 +175,7 @@ class SkinConfig:
     tool_emojis: Dict[str, str] = field(default_factory=dict)  # per-tool emoji overrides
     banner_logo: str = ""    # Rich-markup ASCII art logo (replaces HERMES_AGENT_LOGO)
     banner_hero: str = ""    # Rich-markup hero art (replaces HERMES_CADUCEUS)
+    custom_css: str = ""     # Raw CSS injected as a <style> tag on the desktop GUI (32 KiB cap)
 
     def get_color(self, key: str, fallback: str = "") -> str:
         """Get a color value with fallback."""
@@ -855,6 +856,7 @@ def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
         tool_emojis=emoji_overrides,
         banner_logo=data.get("banner_logo", ""),
         banner_hero=data.get("banner_hero", ""),
+        custom_css=str(data.get("customCSS", "")).strip()[:32768],
     )
 
 

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -261,6 +261,54 @@ class TestUserSkins:
         assert pirate["source"] == "user"
 
 
+class TestCustomCSS:
+    """customCSS passthrough: parsed from user YAML, whitespace-stripped,
+    capped at 32 KiB, empty when the field is absent."""
+
+    def _load(self, tmp_path, monkeypatch, **skin_data):
+        from hermes_cli.skin_engine import load_skin
+
+        skins_dir = tmp_path / "skins"
+        skins_dir.mkdir()
+        import yaml
+
+        data = {"name": "styled", "colors": {"background": "#101010"}}
+        data.update(skin_data)
+        (skins_dir / "styled.yaml").write_text(yaml.dump(data), encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.skin_engine._skins_dir", lambda: skins_dir)
+        return load_skin("styled")
+
+    def test_user_skin_custom_css_passthrough(self, tmp_path, monkeypatch):
+        skin = self._load(tmp_path, monkeypatch, customCSS=".chat-input { font-size: 16px; }")
+
+        assert skin.custom_css == ".chat-input { font-size: 16px; }"
+
+    def test_user_skin_custom_css_whitespace_stripped(self, tmp_path, monkeypatch):
+        skin = self._load(tmp_path, monkeypatch, customCSS="\n  .status-bar { background: black; }  \n")
+
+        assert skin.custom_css == ".status-bar { background: black; }"
+
+    def test_user_skin_custom_css_empty_when_missing(self, tmp_path, monkeypatch):
+        skin = self._load(tmp_path, monkeypatch)
+
+        assert skin.custom_css == ""
+
+    def test_user_skin_custom_css_capped_at_32_ki_b(self, tmp_path, monkeypatch):
+        skin = self._load(tmp_path, monkeypatch, customCSS="x" * 40000)
+
+        assert len(skin.custom_css) == 32768
+
+    def test_builtin_skin_has_no_custom_css(self, tmp_path, monkeypatch):
+        from hermes_cli.skin_engine import load_skin
+
+        skins_dir = tmp_path / "skins"
+        skins_dir.mkdir()
+        monkeypatch.setattr("hermes_cli.skin_engine._skins_dir", lambda: skins_dir)
+
+        assert load_skin("default").custom_css == ""
+        assert load_skin("mono").custom_css == ""
+
+
 class TestDisplayIntegration:
     def test_get_skin_tool_prefix_default(self):
         from agent.display import get_skin_tool_prefix

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -2121,7 +2121,7 @@ def test_skin_live_switch_end_to_end(server, tmp_path, monkeypatch):
 
     (tmp_path / "skins").mkdir()
     (tmp_path / "skins" / "midnight.yaml").write_text(
-        "name: midnight\ndescription: t\ncolors:\n  banner_title: '#00ffcc'\n  background: '#001010'\n"
+        "name: midnight\ndescription: t\ncolors:\n  banner_title: '#00ffcc'\n  background: '#001010'\ncustomCSS: |\n  .chat-input { font-size: 16px; }\n"
     )
     monkeypatch.setattr(skin_engine, "get_hermes_home", lambda: tmp_path)
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
@@ -2144,6 +2144,9 @@ def test_skin_live_switch_end_to_end(server, tmp_path, monkeypatch):
     assert [ev for ev, _ in emitted] == ["skin.changed"]
     assert emitted[0][1]["name"] == "midnight"
     assert emitted[0][1]["colors"]["banner_title"] == "#00ffcc"
+    # customCSS rides the same payload end-to-end: parsed from the YAML,
+    # stripped, and emitted by resolve_skin().
+    assert emitted[0][1]["customCSS"] == ".chat-input { font-size: 16px; }"
 
 
 def test_broadcast_skin_if_changed_on_any_signature_move(server, monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2477,6 +2477,7 @@ def resolve_skin() -> dict:
             "banner_hero": skin.banner_hero,
             "tool_prefix": skin.tool_prefix,
             "help_header": (skin.branding or {}).get("help_header", ""),
+            "customCSS": skin.custom_css,
         }
     except Exception:
         return {}

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -107,6 +107,7 @@ Text strings used throughout the CLI interface.
 | `tool_emojis` | dict | Per-tool emoji overrides for spinners and progress (`{tool_name: emoji}`) | `{}` |
 | `banner_logo` | string | Rich-markup ASCII art logo (replaces the default HERMES_AGENT banner) | `""` |
 | `banner_hero` | string | Rich-markup hero art (replaces the default caduceus art) | `""` |
+| `customCSS` | string | Raw CSS injected into the desktop app and web dashboard while the skin is active (GUI surfaces only; ignored by the CLI/TUI). Capped at 32 KiB. | `""` |
 
 ## Custom skins
 
@@ -211,6 +212,24 @@ branding:
 
 tool_prefix: "▏"
 ```
+
+### Raw `customCSS`
+
+For selector-level styling that colors can't express — font sizes, spacing, pseudo-elements, animations — drop raw CSS into `customCSS`. The desktop app and web dashboard inject it as a `<style>` tag while the skin is active and remove it when you switch to a skin without it.
+
+```yaml
+name: myskin
+
+colors:
+  background: "#1a1030"
+  ui_accent: "#ff5fd2"
+
+customCSS: |
+  .chat-input { font-size: 16px; }
+  .status-bar { background: rgba(0, 0, 0, 0.5); }
+```
+
+The field is capped at 32 KiB and applies to GUI surfaces only — the CLI and TUI ignore it. Because it lives in your skin YAML under `~/.hermes/skins/`, it survives app updates (no more hacking `app.asar`).
 
 ## Hermes Mod — Visual Skin Editor
 


### PR DESCRIPTION
## Summary

The web dashboard supports `customCSS` in theme YAML (added in PR #14776, April 2026), but the desktop app's skin pipeline silently dropped the field. Users who wanted custom desktop styling had to hack `app.asar` — which gets overwritten on every update.

This adds `customCSS` passthrough through the full desktop skin pipeline so users can put CSS in `~/.hermes/skins/<name>.yaml`, which survives updates.

## Changes

| File | Change |
|---|---|
| `apps/shared/src/skin.ts` | Add `customCSS?: string` to `HermesSkin` |
| `apps/desktop/src/themes/types.ts` | Add `customCSS?: string` to `DesktopTheme` |
| `apps/desktop/src/themes/skin.ts` | Pass `skin.customCSS` through `skinToDesktopTheme()` |
| `apps/desktop/src/themes/context.tsx` | Inject/remove `<style>` tag in `applyTheme()` |
| `hermes_cli/skin_engine.py` | Add `custom_css` to `SkinConfig` dataclass; read `customCSS` from YAML with 32 KiB cap |
| `tui_gateway/server.py` | Emit `"customCSS"` in `resolve_skin()` JSON-RPC payload |

## How it works

```yaml
# ~/.hermes/skins/myskin.yaml
name: myskin
description: My custom skin
colors:
  background: "#1a1030"
  ui_accent: "#ff5fd2"
  # ... other colors ...

customCSS: |
  .chat-input { font-size: 16px; }
  .status-bar { background: rgba(0,0,0,0.5); }
```

The `customCSS` is injected as a `<style id="hermes-desktop-custom-css">` tag on theme apply, and removed when switching to a CSS-less theme. It's capped at 32 KiB (same as the web dashboard).

## Validation

- Python: 5 integration tests pass (passthrough, empty, whitespace, 32 KiB cap, resolve_skin shape)
- Existing skin-engine tests: all 15 pass
- Cross-vendor review (Flash + GPT-OSS): SHOULD-FIX, with the 32 KiB cap added per feedback

Closes #53013
Refs #53012
