### PR TITLE
fix: preserve config-backed custom provider tokens in auth.json

### DIFF
--- a/agent/credential_persistence.py
+++ b/agent/credential_persistence.py
@@ -23,6 +23,25 @@ _PERSISTABLE_PROVIDER_SOURCES = frozenset({
     ("nous", "device_code"),
     ("openai-codex", "device_code"),
     ("xai-oauth", "device_code"),
+    # Config-backed custom providers: API keys resolved from config.yaml at
+    # startup.  Stripping these on persist forces re-resolution from .env on
+    # every gateway restart, but credential_pool reads from auth.json at
+    # runtime — so stripped tokens cause 401s for pool-routed providers.
+    ("custom:nvidia", "config:nvidia"),
+    ("custom:openrouter", "config:openrouter"),
+    ("custom:alibaba-dashscope", "config:alibaba-dashscope"),
+    ("custom:cline", "config:cline"),
+    ("custom:github-models", "config:github-models"),
+    ("custom:blackboxai", "config:blackboxai"),
+    ("custom:notita", "config:notita"),
+    ("custom:zyloo", "config:zyloo"),
+    ("custom:zenmuxai", "config:zenmuxai"),
+    ("custom:zenmux-kimi", "config:zenmux-kimi"),
+    ("custom:tokenrouter", "config:tokenrouter"),
+    ("custom:windows-qnn-npu", "config:windows-qnn-npu"),
+    ("custom:xiaomi-year", "config:xiaomi-year"),
+    ("custom:xiaomi-credit", "config:xiaomi-credit"),
+    ("custom:nous-research", "config:nous-research"),
 })
 
 _SAFE_SECRETISH_METADATA_KEYS = frozenset({


### PR DESCRIPTION
## Problem

The credential sanitizer in `credential_persistence.py` classifies all non-OAuth providers as "borrowed" and strips their `access_token` on every `to_dict()` / persist call. This means `auth.json` stores **empty tokens for every custom provider** (NIM, OpenRouter, DashScope, Cline, etc.).

For the main model provider (resolved directly from config.yaml + .env at runtime), this is invisible — it never reads from auth.json. But **pool-routed providers** (like NIM, used by delegation and cron jobs) read from the credential pool in auth.json and get 401 errors.

## Root Cause

`_PERSISTABLE_PROVIDER_SOURCES` only contains 5 OAuth flows:

```python
_PERSISTABLE_PROVIDER_SOURCES = frozenset({
    ("anthropic", "hermes_pkce"),
    ("minimax-oauth", "oauth"),
    ("nous", "device_code"),
    ("openai-codex", "device_code"),
    ("xai-oauth", "device_code"),
})
```

All config-backed custom providers (source `config:<Name>`) fail the persistability check, so their tokens are stripped on every serialization.

## Fix

Add all config-backed custom providers to `_PERSISTABLE_PROVIDER_SOURCES`. These are API keys resolved from `config.yaml` at startup — they don't rotate, don't expire, and need to survive the disk boundary for credential pool routing to work.

## Impact

- Fixes NIM (and other custom provider) cron jobs timing out with `waiting for non-streaming API response`
- Fixes the recurring "auth.json empty token" issue that requires manual token re-seeding
- No change to OAuth providers (Anthropic, Nous, etc.) — those still go through the existing refresh flow
- The allowlist only covers providers defined in config.yaml — new providers still fail closed by default