### PR TITLE
fix(desktop): correlate image generation updates by prompt

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -572,6 +572,77 @@ describe('upsertToolPart', () => {
     expect(summaries).toEqual(['Did 5 searches', 'Did 5 searches'])
   })
 
+  it('reconciles image generation updates with the same prompt when event IDs differ', () => {
+    const started = upsertToolPart(
+      [],
+      {
+        args: { prompt: 'Draw a cat astronaut' },
+        name: 'image_generate',
+        tool_id: 'image-start'
+      },
+      'running'
+    )
+
+    const progressed = upsertToolPart(
+      started,
+      {
+        args: { prompt: 'Draw a cat astronaut' },
+        name: 'image_generate',
+        tool_id: 'image-progress'
+      },
+      'running'
+    )
+
+    const imageParts = progressed.filter(
+      (part): part is Extract<ChatMessagePart, { type: 'tool-call' }> =>
+        part.type === 'tool-call' && part.toolName === 'image_generate'
+    )
+
+    expect(imageParts).toHaveLength(1)
+    expect(imageParts[0]?.toolCallId).toBe('image-progress')
+  })
+
+  it('reconciles a name-only generating event with the identified tool start', () => {
+    const generating = upsertToolPart([], { name: 'image_generate' }, 'running')
+
+    const started = upsertToolPart(
+      generating,
+      {
+        args: { prompt: 'Draw a cat astronaut' },
+        name: 'image_generate',
+        tool_id: 'image-start'
+      },
+      'running'
+    )
+
+    const imageParts = started.filter(
+      (part): part is Extract<ChatMessagePart, { type: 'tool-call' }> =>
+        part.type === 'tool-call' && part.toolName === 'image_generate'
+    )
+
+    expect(imageParts).toHaveLength(1)
+    expect(imageParts[0]?.toolCallId).toBe('image-start')
+    expect(imageParts[0]?.args).toMatchObject({ prompt: 'Draw a cat astronaut' })
+  })
+
+  it('keeps parallel image generations with different prompts distinct', () => {
+    const startedCat = upsertToolPart(
+      [],
+      { args: { prompt: 'Draw a cat astronaut' }, name: 'image_generate', tool_id: 'image-cat' },
+      'running'
+    )
+
+    const startedDog = upsertToolPart(
+      startedCat,
+      { args: { prompt: 'Draw a dog astronaut' }, name: 'image_generate', tool_id: 'image-dog' },
+      'running'
+    )
+
+    const imageParts = startedDog.filter(part => part.type === 'tool-call' && part.toolName === 'image_generate')
+
+    expect(imageParts).toHaveLength(2)
+  })
+
   it('pairs a terminal completion with its context-only start when event IDs differ', () => {
     const started = upsertToolPart(
       [],

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -440,7 +440,7 @@ function toolPayloadMatchValues(payload: GatewayEventPayload | undefined): strin
   // `clarify.request` (a fresh request id) must correlate with the `tool.start`
   // row (the model's tool_call_id) so the two ids don't produce a duplicate
   // clarify card — same correlation ClarifyToolPending uses for request↔args.
-  const query = firstStringField(payloadArgs, ['search_term', 'query', 'question', 'command', 'code', 'path'])
+  const query = firstStringField(payloadArgs, ['search_term', 'query', 'question', 'command', 'code', 'path', 'prompt'])
   const context = typeof payload?.context === 'string' ? payload.context.trim() : ''
   const preview = typeof payload?.preview === 'string' ? payload.preview.trim() : ''
 
@@ -453,7 +453,7 @@ function toolPartMatchValues(part: ChatMessagePart): string[] {
   }
 
   const args = part.args as Record<string, unknown>
-  const query = firstStringField(args, ['search_term', 'query', 'question', 'command', 'code', 'path'])
+  const query = firstStringField(args, ['search_term', 'query', 'question', 'command', 'code', 'path', 'prompt'])
   const context = typeof args.context === 'string' ? args.context.trim() : ''
   const preview = typeof args.preview === 'string' ? args.preview.trim() : ''
 
@@ -516,7 +516,12 @@ function findToolPartIndex(
     const [singlePendingIndex] = pendingIndices
 
     if (phase === 'running' && matchValues.length && !overlaps(singlePendingIndex)) {
-      return stableId ? singlePendingIndex : -1
+      const pendingMatchValues = toolPartMatchValues(parts[singlePendingIndex])
+
+      // A name-only `tool.generating` row has no identifying values yet; let the
+      // subsequent stable-id start enrich it. Conflicting non-empty values are
+      // separate parallel calls and must not overwrite each other.
+      return stableId && pendingMatchValues.length === 0 ? singlePendingIndex : -1
     }
 
     return singlePendingIndex


### PR DESCRIPTION
## What does this PR do?

`image_generate` uses `prompt` as its identifying argument, but the Desktop live-event matcher did not include it when correlating tool updates.

When the gateway sent updates for one generation with different event IDs, Desktop could create a second pending tool part and render a duplicate image row.

This adds `prompt` to the correlation values. It also keeps name-only `tool.generating` events attached to the later `tool.start`, while preserving separate rows for parallel generations with different prompts.

## Related issue

Related to #70689. I am not marking it as fixed until the original packaged Windows scenario is confirmed.

PR #70891 handles the framework double-mount path. This PR prevents the live-event reducer from creating duplicate tool-call parts when event IDs change.

## Type of change

- [x] Bug fix

## Testing

- `npx vitest run --project ui src/lib/chat-messages.test.ts` — 44 passed
- `npm run check` — passed
- macOS arm64 app and DMG build — passed

## Checklist

- [x] Read the contributing guide
- [x] Used a Conventional Commit message
- [x] Checked for existing PRs
- [x] Kept the PR limited to this fix
- [x] Added regression tests
- [x] Considered cross-platform behavior

Docs, config examples, and tool schemas are unchanged.
