### PR TITLE
fix(windows): utf-8 subprocess decode across the desktop backend — salvage #61978 + widen to sibling sites

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -160,6 +160,11 @@ def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str
             ["git", *args],
             capture_output=True,
             text=True,
+            # git output is UTF-8; on Windows text=True defaults to the ANSI
+            # code page and bytes like 0x90 (3rd byte of 🐛 in a commit
+            # subject) crash the stdlib reader thread (#52649).
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             cwd=str(cwd),
         )
@@ -179,7 +184,8 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     try:
         result = subprocess.run(
             ["git", "ls-remote", _UPSTREAM_REPO_URL, "refs/heads/main"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=10,
         )
     except Exception:
         return None
@@ -241,7 +247,8 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     try:
         result = subprocess.run(
             ["git", "rev-list", "--count", "HEAD..origin/main"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=5,
             cwd=str(repo_dir),
         )
         if result.returncode == 0:
@@ -343,6 +350,8 @@ def _git_short_hash(repo_dir: Path, rev: str) -> Optional[str]:
             ["git", "rev-parse", "--short=8", rev],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
             cwd=str(repo_dir),
         )
@@ -399,6 +408,8 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
             ["git", "rev-list", "--count", "origin/main..HEAD"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
             cwd=str(repo_dir),
         )
@@ -435,6 +446,8 @@ def get_latest_release_tag(repo_dir: Optional[Path] = None) -> Optional[tuple]:
             ["git", "describe", "--tags", "--abbrev=0"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=3,
             cwd=str(repo_dir),
         )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4158,6 +4158,12 @@ def _recent_upstream_commits(n: int = 20) -> List[Dict[str, Any]]:
             ],
             capture_output=True,
             text=True,
+            # git log emits UTF-8 (commit subjects can carry emoji/CJK). On
+            # Windows text=True defaults to the ANSI code page — a byte like
+            # 0x90 (3rd byte of 🐛) is undefined in cp1252 and crashed the
+            # stdlib _readerthread, killing the desktop backend (#52649).
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
         )
         if out.returncode != 0:
@@ -5780,6 +5786,10 @@ def _run_setup_command(
         env=_memory_provider_setup_env(),
         capture_output=True,
         text=True,
+        # Lossy UTF-8 decode — setup tools emit UTF-8; never let a
+        # locale-mismatched byte raise in the reader thread (#52649).
+        encoding="utf-8",
+        errors="replace",
         timeout=timeout,
         check=False,
     )
@@ -8711,6 +8721,10 @@ def _ensure_whatsapp_bridge_dependencies(bridge_dir: Path) -> None:
             cwd=str(bridge_dir),
             capture_output=True,
             text=True,
+            # npm output is UTF-8; guard the Windows ANSI-code-page default
+            # against undefined bytes crashing the reader thread (#52649).
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             env=with_hermes_node_path(),
             creationflags=windows_hide_flags(),
@@ -16199,6 +16213,8 @@ def _probe_docker_backend() -> tuple:
             ["docker", "info", "--format", "{{.ServerVersion}}"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=2,
         )
         if proc.returncode == 0:

--- a/tests/tui_gateway/test_subprocess_encoding.py
+++ b/tests/tui_gateway/test_subprocess_encoding.py
@@ -1,0 +1,132 @@
+"""Regression tests for UTF-8 encoding hardening in tui_gateway/server.py (#53137).
+
+On Windows with a non-UTF-8 system locale (e.g. GBK on Chinese Windows),
+text-mode subprocess reads defaulted to the locale encoding. When a child
+process emitted bytes invalid in that locale, an unhandled UnicodeDecodeError
+crashed the reader thread / gateway thread.
+
+#53137 added encoding="utf-8", errors="replace" to every text-mode subprocess
+call in tui_gateway/server.py. These tests assert that the kwargs survive so
+the crash class cannot silently regress.
+
+# Test pattern adapted from @devorun's PR #52700 (salvage convention).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tui_gateway.server as server
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+def _make_completed_process() -> MagicMock:
+    """A CompletedProcess-like mock with str stdout/stderr (text=True contract)."""
+    cp = MagicMock()
+    cp.stdout = ""
+    cp.stderr = ""
+    cp.returncode = 0
+    return cp
+
+
+# ── _SlashWorker.Popen path ──────────────────────────────────────────────
+
+def test_slash_worker_popen_uses_utf8_replace():
+    """The slash-worker subprocess.Popen must pass encoding="utf-8" and
+    errors="replace" so invalid bytes in child stdout/stderr don't raise
+    UnicodeDecodeError inside the drain threads (#53137).
+    """
+    with patch.dict("sys.modules", {
+        "hermes_constants": MagicMock(
+            get_hermes_home=MagicMock(return_value="/tmp/hermes_test")
+        ),
+    }):
+        with patch("subprocess.Popen") as mock_popen:
+            mock_popen.return_value.stdout = MagicMock()
+            mock_popen.return_value.stderr = MagicMock()
+
+            from tui_gateway.server import _SlashWorker
+
+            _SlashWorker(
+                session_key="test_key",
+                model="test-model",
+            )
+
+            assert mock_popen.called, "Popen was not invoked"
+            kwargs = mock_popen.call_args[1]
+            assert kwargs.get("encoding") == "utf-8", (
+                f"slash-worker Popen must set encoding='utf-8' (got {kwargs.get('encoding')!r})"
+            )
+            assert kwargs.get("errors") == "replace", (
+                f"slash-worker Popen must set errors='replace' (got {kwargs.get('errors')!r})"
+            )
+
+
+# ── cli.exec handler ─────────────────────────────────────────────────────
+
+def test_cli_exec_uses_utf8_replace():
+    """The cli.exec RPC handler runs `python -m hermes_cli.main` via
+    subprocess.run; it must pass encoding="utf-8" and errors="replace"
+    (#53137)."""
+    handler = server._methods["cli.exec"]
+    with patch("subprocess.run", return_value=_make_completed_process()) as mock_run:
+        # Non-interactive argv that passes _cli_exec_blocked.
+        resp = handler(1, {"argv": ["--version"]})
+        assert mock_run.called, "subprocess.run was not invoked"
+        kwargs = mock_run.call_args[1]
+        assert kwargs.get("encoding") == "utf-8", (
+            f"cli.exec subprocess.run must set encoding='utf-8' (got {kwargs.get('encoding')!r})"
+        )
+        assert kwargs.get("errors") == "replace", (
+            f"cli.exec subprocess.run must set errors='replace' (got {kwargs.get('errors')!r})"
+        )
+
+
+# ── shell.exec handler ───────────────────────────────────────────────────
+
+def test_shell_exec_uses_utf8_replace():
+    """The shell.exec RPC handler runs an arbitrary shell command via
+    subprocess.run; it must pass encoding="utf-8" and errors="replace"
+    (#53137)."""
+    handler = server._methods["shell.exec"]
+    with patch("subprocess.run", return_value=_make_completed_process()) as mock_run:
+        # A harmless, non-dangerous command that passes the approval gate.
+        with patch("tools.approval.detect_hardline_command", return_value=(False, "")), \
+             patch("tools.approval.detect_dangerous_command", return_value=(False, None, "")):
+            resp = handler(1, {"command": "echo hello"})
+        assert mock_run.called, "subprocess.run was not invoked"
+        kwargs = mock_run.call_args[1]
+        assert kwargs.get("encoding") == "utf-8", (
+            f"shell.exec subprocess.run must set encoding='utf-8' (got {kwargs.get('encoding')!r})"
+        )
+        assert kwargs.get("errors") == "replace", (
+            f"shell.exec subprocess.run must set errors='replace' (got {kwargs.get('errors')!r})"
+        )
+
+
+# ── quick-command exec path (via command.dispatch) ───────────────────────
+
+def test_quick_command_exec_uses_utf8_replace():
+    """A quick_command of type 'exec' is dispatched via command.dispatch;
+    the underlying subprocess.run must pass encoding="utf-8" and
+    errors="replace" (#53137)."""
+    handler = server._methods["command.dispatch"]
+    fake_cp = _make_completed_process()
+    with patch("subprocess.run", return_value=fake_cp) as mock_run, \
+         patch("tui_gateway.server._load_cfg", return_value={
+             "quick_commands": {"runcmd": {"type": "exec", "command": "echo hi"}}
+         }), \
+         patch("tools.environments.local._sanitize_subprocess_env", return_value={"PATH": "/usr/bin"}):
+        resp = handler(1, {"name": "runcmd", "arg": "", "session_id": ""})
+        assert mock_run.called, "subprocess.run was not invoked for quick-command exec"
+        kwargs = mock_run.call_args[1]
+        assert kwargs.get("encoding") == "utf-8", (
+            f"quick-command exec subprocess.run must set encoding='utf-8' (got {kwargs.get('encoding')!r})"
+        )
+        assert kwargs.get("errors") == "replace", (
+            f"quick-command exec subprocess.run must set errors='replace' (got {kwargs.get('errors')!r})"
+        )

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -113,6 +113,8 @@ def _build_sha() -> str:
             ["git", "rev-parse", "HEAD"],
             cwd=str(_repo_root()),
             text=True,
+            encoding="utf-8",
+            errors="replace",
             stderr=subprocess.DEVNULL,
             timeout=2,
         ).strip()
@@ -686,7 +688,7 @@ class ComputeHost:
 
 def _rss_mb(pid: int) -> float:
     try:
-        out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(pid)], text=True, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=2).strip()
+        out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(pid)], text=True, encoding="utf-8", errors="replace", stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=2).strip()
         return int(out.splitlines()[-1].strip()) / 1024.0 if out else 0.0
     except Exception:
         return 0.0

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -72,6 +72,8 @@ def _build_sha() -> str:
             ["git", "rev-parse", "HEAD"],
             cwd=str(_repo_root()),
             text=True,
+            encoding="utf-8",
+            errors="replace",
             stderr=subprocess.DEVNULL,
             timeout=2,
         ).strip()
@@ -112,6 +114,8 @@ def _pid_command(pid: int) -> str:
         return subprocess.check_output(
             ["ps", "-p", str(pid), "-o", "command="],
             text=True,
+            encoding="utf-8",
+            errors="replace",
             stderr=subprocess.DEVNULL,
             timeout=2,
         ).strip()
@@ -327,6 +331,11 @@ class HostSupervisor:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            # Lossy UTF-8 decode — the compute host emits UTF-8; a
+            # locale-mismatched byte must not raise inside the drain
+            # threads and kill the supervisor (#52649).
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
             start_new_session=True,
         )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -14188,9 +14188,7 @@ def _(rid, params: dict) -> dict:
         from hermes_cli._subprocess_compat import windows_hide_flags
 
         r = subprocess.run(
-            [
-                sys.executable, "-m", "hermes_cli.main", *argv
-            ],
+            [sys.executable, "-m", "hermes_cli.main", *argv],
             capture_output=True,
             text=True,
             # Force UTF-8 + lossy decode so non-UTF-8 child output can't crash

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -351,6 +351,12 @@ class _SlashWorker:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            # Force UTF-8 with lossy decoding so child output containing bytes
+            # that are invalid in the system locale (e.g. GBK on Chinese
+            # Windows) can't raise UnicodeDecodeError inside the drain threads
+            # and crash the gateway. See #53137.
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
             cwd=os.getcwd(),
             env=env,
@@ -11705,6 +11711,9 @@ def _(rid, params: dict) -> dict:
         try:
             res = subprocess.run(
                 argv, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL,
+                # Force UTF-8 + lossy decode so non-UTF-8 child output can't
+                # crash the gateway thread on locale-mismatched Windows (#53137).
+                encoding="utf-8", errors="replace",
                 creationflags=windows_hide_flags(),
             )
         except subprocess.TimeoutExpired:
@@ -14179,9 +14188,15 @@ def _(rid, params: dict) -> dict:
         from hermes_cli._subprocess_compat import windows_hide_flags
 
         r = subprocess.run(
-            [sys.executable, "-m", "hermes_cli.main", *argv],
+            [
+                sys.executable, "-m", "hermes_cli.main", *argv
+            ],
             capture_output=True,
             text=True,
+            # Force UTF-8 + lossy decode so non-UTF-8 child output can't crash
+            # the gateway thread on locale-mismatched Windows. See #53137.
+            encoding="utf-8",
+            errors="replace",
             timeout=min(int(params.get("timeout", 240)), 600),
             cwd=os.getcwd(),
             # cli.exec runs `python -m hermes_cli.main` (can drive the agent) →
@@ -14255,6 +14270,9 @@ def _(rid, params: dict) -> dict:
                 shell=True,
                 capture_output=True,
                 text=True,
+                # Force UTF-8 + lossy decode so non-UTF-8 child output can't
+                # crash the gateway thread on locale-mismatched Windows (#53137).
+                encoding="utf-8", errors="replace",
                 timeout=30,
                 stdin=subprocess.DEVNULL,
                 env=sanitized_env,
@@ -17348,6 +17366,9 @@ def _(rid, params: dict) -> dict:
 
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
+            # Force UTF-8 + lossy decode so non-UTF-8 child output can't crash
+            # the gateway thread on locale-mismatched Windows (#53137).
+            encoding="utf-8", errors="replace",
             stdin=subprocess.DEVNULL,
             creationflags=windows_hide_flags(),
         )


### PR DESCRIPTION
## Summary
Windows desktop backend no longer crashes with `UnicodeDecodeError: 'charmap' codec can't decode byte 0x90` in `subprocess._readerthread` — every text-mode subprocess capture in the desktop-backend process now decodes as UTF-8 with lossy fallback.

Root cause: on Windows, `subprocess` with `text=True` and no explicit `encoding=` decodes child output with the ANSI code page (cp1252/GBK/…). cp1252 defines 251 of 256 bytes, so the bug stayed latent for months — until commit `84db32484f` put a 🐛 emoji (UTF-8 `f0 9f 90 9b`) in a commit subject on `main`. Byte `0x90` is one of only five bytes undefined in cp1252, and the desktop update panel's `git log HEAD..origin/main` (`_recent_upstream_commits`) started pulling it through the stdlib reader thread on every Windows install behind that commit, crashing the backend (#52649, #53137, #63686, #61595, #58385).

Salvages PR #61978 by @Sahil-SS9 (server.py hardening + regression tests, cherry-picked with authorship preserved) and widens the fix to the sibling sites the crash actually came through.

## Changes
- `tui_gateway/server.py` (salvaged from #61978): `encoding="utf-8", errors="replace"` on the slash-worker Popen, pdftoppm, `cli.exec`, quick-command exec, and `shell.exec` — plus regression tests pinning the kwargs
- `hermes_cli/web_server.py`: git-log update panel (the site that fired), memory-provider setup runner, WhatsApp bridge npm install, docker probe
- `hermes_cli/banner.py`: all 5 git sites (startup update check runs in this process)
- `tui_gateway/host_supervisor.py`: build-SHA probe, ps probe, compute-host Popen drain threads
- `tui_gateway/compute_host.py`: build-SHA probe, ps rss probe

`errors="replace"` is the load-bearing half: even if a child ever emits genuinely non-UTF-8 bytes, decoding degrades to U+FFFD instead of raising in a daemon thread.

## Validation
| Check | Result |
|---|---|
| Legacy path repro: cp1252 decode of the real trigger line | raises `'charmap' ... byte 0x90` as reported |
| E2E: real git repo with 🐛 commit through `_recent_upstream_commits` + `banner._git_stdout` | decodes correctly, kwargs verified |
| Invalid byte `0x90` through the new path | degrades to `U+FFFD`, no exception |
| `tests/tui_gateway/` + banner tests | 457 passed, 0 failed |

Closes #61978 (salvaged with credit). Fixes #52649, #53137 (and duplicates #63686, #61595, #58385).

## Infographic

![utf8-subprocess-decode-guard](https://v3b.fal.media/files/b/0aa38ec3/aVjx3R1ttH8ztcxBnQsTh_Zk2RgU2k.png)
