### PR TITLE
fix(gateway): retry restart completion delivery

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -3,6 +3,9 @@
 import math
 import os
 from collections.abc import Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
 
 from hermes_cli.config import DEFAULT_CONFIG
 
@@ -17,6 +20,16 @@ GATEWAY_FATAL_CONFIG_EXIT_CODE = 78
 # and launchd's XPC_SERVICE_NAME, this survives wrappers that replace the child
 # environment (e.g. ``sudo env -i``).
 EXTERNAL_GATEWAY_SUPERVISOR_ENV = "HERMES_GATEWAY_EXTERNAL_SUPERVISOR"
+
+
+@contextmanager
+def restart_notification_marker_lock(hermes_home: str | Path) -> Iterator[None]:
+    """Serialize restart-marker compare/write/unlink operations across processes."""
+    from hermes_cli.active_sessions import _FileLock
+
+    lock_path = Path(hermes_home) / ".restart_notify.lock"
+    with _FileLock(lock_path):
+        yield
 
 DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT = float(DEFAULT_CONFIG["agent"]["restart_drain_timeout"])
 DEFAULT_GATEWAY_SIGNAL_INTERRUPT_GRACE_TIMEOUT = float(DEFAULT_CONFIG["gateway"]["signal_interrupt_grace_timeout"])

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3248,6 +3248,7 @@ class GatewayRunner(
     _restart_via_service: bool = False
     _detached_restart_helper_started: bool = False
     _restart_command_source: Optional[SessionSource] = None
+    _restart_notification_request_id: Optional[str] = None
     _stop_task: Optional[asyncio.Task] = None
     _restart_task: Optional[asyncio.Task] = None
     _profile_failed_platforms: Optional[Dict[str, Dict[Platform, asyncio.Task]]] = None
@@ -3401,6 +3402,8 @@ class GatewayRunner(
         self._restart_requested = self._signal_initiated_shutdown = self._restart_task_started = False
         self._restart_detached = self._restart_via_service = self._detached_restart_helper_started = False
         self._restart_command_source: Optional[SessionSource] = None
+        self._restart_command_lock = asyncio.Lock()
+        self._restart_notification_request_id: Optional[str] = None
         # Construction clock: bounds the /restart redelivery guard's window (missing dedup marker = stale).
         self._startup_time: float = time.time()
         # True when booted from a chat /restart (.restart_notify.json existed). One-shot signal so the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -83,6 +83,11 @@ _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 # transport cannot block the session-stall watcher pass (notify-only path;
 # on timeout the latch stays clear and the next tick retries).
 _STALL_NOTIFY_SEND_TIMEOUT_SECONDS = 15.0
+# Platform reconnects can outlive initial startup. Keep durable lifecycle
+# delivery alive through one bounded recovery window without blocking startup.
+_RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS = 180.0
+_RESTART_NOTIFICATION_RETRY_BASE_DELAY_SECS = 1.0
+_RESTART_NOTIFICATION_RETRY_MAX_DELAY_SECS = 30.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
@@ -2382,6 +2387,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    SendResult,
     _prefix_within_utf16_limit,
     _reply_anchor_for_event,
     build_auto_tts_output_path,
@@ -10664,10 +10670,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
-        
+
         Returns True if at least one adapter connected successfully.
         """
         logger.info("Starting Hermes Gateway...")
+
+        # Claim the restart marker before adapters connect. A second /restart
+        # can replace it as soon as an adapter starts receiving events, so a
+        # later read would let this process send and delete the next process's
+        # completion obligation.
+        restart_marker_payload = None
+        if _restart_notification_pending():
+            try:
+                restart_marker_payload = (
+                    _hermes_home / ".restart_notify.json"
+                ).read_text(encoding="utf-8")
+            except FileNotFoundError:
+                pass
+            except (OSError, UnicodeError) as e:
+                logger.warning(
+                    "Restart notification marker could not be claimed: %s",
+                    e,
+                )
+
         # Enable faulthandler for stack dumps on freezes/crashes (#70344).
         # Falls back to a log file when sys.stderr is None (Windows VBS /
         # pythonw / detached service) — otherwise the gateway would die
@@ -11410,16 +11435,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await asyncio.sleep(1.0)
 
         # Notify the chat that initiated /restart that the gateway is back.
-        chat_restart_notification_pending = _restart_notification_pending()
+        chat_restart_notification_pending = restart_marker_payload is not None
         planned_restart_notification_pending = _planned_restart_notification_pending()
-        # Capture, before _send_restart_notification() unlinks the marker,
+        # Capture, before the background delivery can unlink the marker,
         # whether this process booted from a chat-originated /restart. Used as
         # a one-shot signal by the /restart redelivery guard so a missing
         # dedup marker only suppresses a /restart when we KNOW we just came out
         # of a restart cycle (see _is_stale_restart_redelivery).
         if chat_restart_notification_pending:
             self._booted_from_restart = True
-        await self._send_restart_notification()
+            # Delivery can be temporarily refused while an adapter finishes
+            # reconnecting (Telegram reports this as retryable
+            # ``send_path_degraded``). Run the bounded retry loop in the
+            # background so lifecycle delivery never blocks gateway startup.
+            if restart_marker_payload is not None:
+                self._spawn_supervised(
+                    lambda marker_payload=restart_marker_payload: (
+                        self._send_restart_notification(
+                            claimed_marker_payload=marker_payload,
+                        )
+                    ),
+                    "restart_notification",
+                    restart=False,
+                )
 
         # Broadcast a lightweight "gateway is back" message to configured home
         # channels only for non-chat planned restarts (terminal/SIGUSR1/service
@@ -21168,32 +21206,102 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return True
 
-    async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
-        """Notify the chat that initiated /restart that the gateway is back."""
+    async def _send_restart_notification(
+        self,
+        *,
+        claimed_marker_payload: Optional[str] = None,
+    ) -> Optional[tuple[str, str, Optional[str]]]:
+        """Notify the chat that initiated /restart that the gateway is back.
+
+        A retryable ``SendResult`` means the adapter knows no message was
+        delivered and a later attempt is safe. Keep the durable marker while
+        backing off so a shutdown during that wait leaves the obligation for
+        the next process. Permanent failures and bounded retry exhaustion
+        consume the marker to avoid stale notifications on unrelated boots.
+        A newer marker supersedes this task and is never consumed by it.
+        """
         notify_path = _hermes_home / ".restart_notify.json"
         if not notify_path.exists():
             return None
 
+        cleanup_marker = False
+        marker_payload = None
         try:
-            data = json.loads(notify_path.read_text(encoding="utf-8"))
+            try:
+                marker_payload = notify_path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                cleanup_marker = False
+                return None
+            except (OSError, UnicodeError) as e:
+                logger.warning(
+                    "Could not read restart notification marker before delivery; "
+                    "preserving it for a later process: %s",
+                    e,
+                )
+                return None
+            if (
+                claimed_marker_payload is not None
+                and marker_payload != claimed_marker_payload
+            ):
+                cleanup_marker = False
+                logger.info(
+                    "Preserving newer restart notification marker before "
+                    "earlier delivery attempt started"
+                )
+                return None
+            data = json.loads(marker_payload)
+            if not isinstance(data, dict):
+                logger.warning(
+                    "Restart notification marker is not a JSON object; "
+                    "preserving it for manual recovery"
+                )
+                return None
             platform_str = data.get("platform")
             chat_id = data.get("chat_id")
             chat_type = data.get("chat_type")
             thread_id = data.get("thread_id")
             message_id = data.get("message_id")
 
-            if not platform_str or not chat_id:
+            if (
+                not isinstance(platform_str, str)
+                or not platform_str
+                or platform_str.strip() != platform_str
+                or not isinstance(chat_id, str)
+                or not chat_id
+                or chat_id.strip() != chat_id
+            ):
+                logger.warning(
+                    "Restart notification marker has an invalid platform or chat_id; "
+                    "preserving it for manual recovery"
+                )
                 return None
-
-            platform = Platform(platform_str)
-            transport = resolve_delivery_transport(platform, self.config, self.adapters)
-            if transport is None:
-                logger.debug(
-                    "Restart notification skipped: no live transport for %s",
-                    platform_str,
+            optional_string_fields = (
+                "chat_type",
+                "thread_id",
+                "message_id",
+                "request_id",
+                "user_id",
+                "scope_id",
+            )
+            if any(
+                (value := data.get(field)) is not None
+                and (not isinstance(value, str) or not value.strip())
+                for field in optional_string_fields
+            ) or (
+                "delivered_via_upstream_relay" in data
+                and not isinstance(data["delivered_via_upstream_relay"], bool)
+            ):
+                logger.warning(
+                    "Restart notification marker has invalid routing metadata; "
+                    "preserving it for manual recovery"
                 )
                 return None
 
+            platform = Platform(platform_str)
+            # Parsing and route admission succeeded. From here onward, terminal
+            # outcomes consume this generation unless a safe retry/shutdown path
+            # explicitly preserves it.
+            cleanup_marker = True
             platform_cfg = self.config.platforms.get(platform)
             if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
                 logger.info(
@@ -21202,50 +21310,285 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return None
 
-            metadata = self._thread_metadata_for_target(
-                platform,
-                chat_id,
-                thread_id,
-                chat_type=chat_type,
-                reply_to_message_id=message_id,
-                adapter=transport.adapter,
-            )
-            if data.get("delivered_via_upstream_relay") is True:
-                metadata = dict(metadata or {})
-                if data.get("user_id"):
-                    metadata["user_id"] = str(data["user_id"])
-                if data.get("scope_id"):
-                    metadata["scope_id"] = str(data["scope_id"])
-            result = await transport.send(
-                platform,
-                str(chat_id),
-                "♻ Gateway restarted successfully. Your session continues.",
-                metadata=_non_conversational_metadata(metadata, platform=platform),
-            )
-            # adapter.send() catches provider errors (e.g. "Chat not found")
-            # and returns SendResult(success=False) rather than raising, so
-            # we must inspect the result before claiming success — otherwise
-            # the log line is misleading and hides real delivery failures.
-            if result is not None and getattr(result, "success", True) is False:
+            deadline = time.monotonic() + _RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS
+            delay = _RESTART_NOTIFICATION_RETRY_BASE_DELAY_SECS
+            attempt = 0
+            error = "retry budget expired before delivery"
+
+            while True:
+                shutdown_event = getattr(self, "_shutdown_event", None)
+                if (
+                    getattr(self, "_running", True) is False
+                    or (
+                        shutdown_event is not None
+                        and shutdown_event.is_set()
+                    )
+                ):
+                    cleanup_marker = False
+                    return None
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(
+                        "Restart notification to %s:%s was not delivered after "
+                        "%.0fs of retrying: %s",
+                        platform_str,
+                        chat_id,
+                        _RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS,
+                        error,
+                    )
+                    return None
+
+                try:
+                    current_marker_payload = notify_path.read_text(encoding="utf-8")
+                except FileNotFoundError:
+                    cleanup_marker = False
+                    logger.info(
+                        "Stopping restart notification worker because its marker "
+                        "was removed before the next delivery attempt"
+                    )
+                    return None
+                except (OSError, UnicodeError) as e:
+                    cleanup_marker = False
+                    logger.warning(
+                        "Could not revalidate restart notification marker before "
+                        "delivery; preserving it for a later process: %s",
+                        e,
+                    )
+                    return None
+                if current_marker_payload != marker_payload:
+                    cleanup_marker = False
+                    logger.info(
+                        "Stopping superseded restart notification worker before "
+                        "the next delivery attempt"
+                    )
+                    return None
+
+                transport = resolve_delivery_transport(platform, self.config, self.adapters)
+                if transport is None:
+                    error = f"no live transport for {platform_str}"
+                    retryable = True
+                    retry_after = None
+                else:
+                    metadata = self._thread_metadata_for_target(
+                        platform,
+                        chat_id,
+                        thread_id,
+                        chat_type=chat_type,
+                        reply_to_message_id=message_id,
+                        adapter=transport.adapter,
+                    )
+                    if data.get("delivered_via_upstream_relay") is True:
+                        metadata = dict(metadata or {})
+                        if data.get("user_id"):
+                            metadata["user_id"] = str(data["user_id"])
+                        if data.get("scope_id"):
+                            metadata["scope_id"] = str(data["scope_id"])
+                    send_timeout = deadline - time.monotonic()
+                    if send_timeout <= 0:
+                        logger.warning(
+                            "Restart notification to %s:%s was not delivered after "
+                            "%.0fs of retrying: %s",
+                            platform_str,
+                            chat_id,
+                            _RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS,
+                            error,
+                        )
+                        return None
+
+                    provider_dispatch_started = False
+
+                    async def _dispatch_before_deadline():
+                        nonlocal provider_dispatch_started
+                        # Scheduling the provider call yields to the event loop. A newer
+                        # /restart can replace the marker after the outer validation but
+                        # before this task starts, so revalidate ownership, shutdown state,
+                        # and the hard deadline at the last synchronous point before
+                        # transport.send.
+                        try:
+                            dispatch_marker_payload = notify_path.read_text(
+                                encoding="utf-8"
+                            )
+                        except (OSError, UnicodeError):
+                            return False, True, None
+                        if dispatch_marker_payload != marker_payload:
+                            return False, True, None
+                        if not self._running or self._shutdown_event.is_set():
+                            return False, True, None
+                        if deadline - time.monotonic() <= 0:
+                            return False, False, None
+                        # No await occurs between this assignment and entering the
+                        # provider coroutine. Cancellation before the child task runs
+                        # therefore remains a known-safe no-send outcome; cancellation
+                        # after this point is ambiguous and consumes the marker.
+                        provider_dispatch_started = True
+                        return True, False, await transport.send(
+                            platform,
+                            str(chat_id),
+                            "♻ Gateway restarted successfully. Your session continues.",
+                            metadata=_non_conversational_metadata(
+                                metadata,
+                                platform=platform,
+                            ),
+                        )
+
+                    send_task = asyncio.ensure_future(_dispatch_before_deadline())
+                    try:
+                        done, _pending = await asyncio.wait(
+                            {send_task}, timeout=send_timeout
+                        )
+                        if send_task not in done:
+                            send_task.cancel()
+                            send_task.add_done_callback(consume_detached_task_result)
+                            logger.warning(
+                                "Restart notification to %s:%s exceeded its %.1fs "
+                                "remaining delivery budget; outcome is ambiguous",
+                                platform_str,
+                                chat_id,
+                                send_timeout,
+                            )
+                            return None
+                        dispatched, preserve_marker, result = await send_task
+                    except asyncio.CancelledError:
+                        if not provider_dispatch_started:
+                            cleanup_marker = False
+                        elif send_task.done() and not send_task.cancelled():
+                            try:
+                                (
+                                    dispatched,
+                                    preserve_after_dispatch,
+                                    completed_result,
+                                ) = send_task.result()
+                            except Exception:
+                                # A completed provider exception is still ambiguous.
+                                pass
+                            else:
+                                if preserve_after_dispatch or (
+                                    dispatched
+                                    and isinstance(completed_result, SendResult)
+                                    and not completed_result.success
+                                    and completed_result.retryable
+                                ):
+                                    cleanup_marker = False
+                        send_task.cancel()
+                        send_task.add_done_callback(consume_detached_task_result)
+                        raise
+                    if preserve_marker:
+                        cleanup_marker = False
+                        logger.info(
+                            "Stopping restart notification worker because its marker "
+                            "changed, disappeared, or could not be revalidated before "
+                            "provider dispatch"
+                        )
+                        return None
+                    if not dispatched:
+                        logger.warning(
+                            "Restart notification to %s:%s reached its total "
+                            "delivery deadline before provider dispatch",
+                            platform_str,
+                            chat_id,
+                        )
+                        return None
+                    # The transport catches provider errors (e.g. "Chat not
+                    # found") and returns SendResult(success=False), so inspect
+                    # the result before claiming success.
+                    if result is None or getattr(result, "success", True) is not False:
+                        logger.info(
+                            "Sent restart notification to %s:%s",
+                            platform_str,
+                            chat_id,
+                        )
+                        return (
+                            str(platform_str),
+                            str(chat_id),
+                            str(thread_id) if thread_id else None,
+                        )
+                    error = getattr(result, "error", "send returned success=False")
+                    retryable = bool(getattr(result, "retryable", False))
+                    retry_after = getattr(result, "retry_after", None)
+
+                if not retryable:
+                    logger.warning(
+                        "Restart notification to %s:%s was not delivered: %s",
+                        platform_str,
+                        chat_id,
+                        error,
+                    )
+                    return None
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(
+                        "Restart notification to %s:%s was not delivered after "
+                        "%.0fs of retrying: %s",
+                        platform_str,
+                        chat_id,
+                        _RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS,
+                        error,
+                    )
+                    return None
+
+                try:
+                    requested_delay = max(0.0, float(retry_after or 0.0))
+                except (TypeError, ValueError):
+                    requested_delay = 0.0
+                if requested_delay > remaining:
+                    logger.warning(
+                        "Restart notification to %s:%s was not delivered; "
+                        "provider retry delay %.1fs exceeds the %.1fs remaining budget: %s",
+                        platform_str,
+                        chat_id,
+                        requested_delay,
+                        remaining,
+                        error,
+                    )
+                    return None
+
+                sleep_for = min(max(delay, requested_delay), remaining)
+                attempt += 1
                 logger.warning(
-                    "Restart notification to %s:%s was not delivered: %s",
+                    "Restart notification to %s:%s was deferred: %s; "
+                    "retrying in %.1fs (attempt %d)",
                     platform_str,
                     chat_id,
-                    getattr(result, "error", "send returned success=False"),
+                    error,
+                    sleep_for,
+                    attempt,
                 )
-                return None
-
-            logger.info(
-                "Sent restart notification to %s:%s",
-                platform_str,
-                chat_id,
-            )
-            return str(platform_str), str(chat_id), str(thread_id) if thread_id else None
+                # Cancellation during this safe pre-send backoff must leave the
+                # marker for the replacement process. Once the wait completes,
+                # the next send attempt owns normal ambiguous-send cleanup.
+                cleanup_marker = False
+                await asyncio.sleep(sleep_for)
+                cleanup_marker = True
+                delay = min(
+                    delay * 2,
+                    _RESTART_NOTIFICATION_RETRY_MAX_DELAY_SECS,
+                )
         except Exception as e:
             logger.warning("Restart notification failed: %s", e)
             return None
         finally:
-            notify_path.unlink(missing_ok=True)
+            if cleanup_marker:
+                # The only supported writer is the synchronous /restart handler on
+                # this gateway event loop. With no await between comparison and
+                # unlink, that producer cannot replace the marker in this section.
+                try:
+                    marker_is_current = (
+                        marker_payload is None
+                        or notify_path.read_text(encoding="utf-8") == marker_payload
+                    )
+                    if marker_is_current:
+                        notify_path.unlink(missing_ok=True)
+                    else:
+                        logger.info(
+                            "Preserving newer restart notification marker after "
+                            "earlier delivery attempt"
+                        )
+                except FileNotFoundError:
+                    pass
+                except (OSError, UnicodeError) as e:
+                    logger.warning("Restart notification marker cleanup failed: %s", e)
 
     async def _send_home_channel_startup_notifications(
         self,

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -16,13 +16,19 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, Dict, Optional, cast
 
+from agent.async_utils import consume_detached_task_result
 from gateway.config import Platform, _BUILTIN_PLATFORM_VALUES
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.delivery import resolve_delivery_transport
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.session import SessionEntry, SessionSource
 from gateway.run_shutdown import _log_suppressed, _notice_target_key, _send_error, _send_failed
 
 # Log-record parity with the origin module.
 logger = logging.getLogger("gateway.run")
+
+_RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS = 180.0
+_RESTART_NOTIFICATION_RETRY_BASE_DELAY_SECS = 1.0
+_RESTART_NOTIFICATION_RETRY_MAX_DELAY_SECS = 15.0
 
 _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
 # Routing fields copied verbatim from a process watcher onto its synthetic completion event.
@@ -596,55 +602,323 @@ class GatewayNotificationsMixin:
                     p.unlink(missing_ok=True)
         return True
 
-    async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
-        """Notify the chat that initiated /restart that the gateway is back."""
-        from gateway.delivery import resolve_delivery_transport
+    async def _send_restart_notification(
+        self, *, claimed_marker_payload: Optional[str] = None,
+    ) -> Optional[tuple[str, str, Optional[str]]]:
+        """Deliver one owned restart marker with a bounded transient-retry window.
+
+        Known-safe pre-send failures keep the durable marker for a reconnect or
+        later boot. Successful, permanent, and ambiguous provider outcomes
+        consume only the marker generation this worker claimed.
+        """
         from gateway.run import _hermes_home, _non_conversational_metadata
+
         notify_path = _hermes_home / ".restart_notify.json"
-        if not notify_path.exists():
-            return None
+        marker_payload = claimed_marker_payload
+        marker_request_id: Optional[str] = None
+        marker_owned = False
+        delivered_target: Optional[tuple[str, str, Optional[str]]] = None
+        clear_marker = False
+
+        def _read_marker_payload() -> Optional[str]:
+            try:
+                return notify_path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                return None
+
+        def _owns_marker() -> bool:
+            current_payload = _read_marker_payload()
+            if current_payload is None or current_payload != marker_payload:
+                return False
+            if marker_request_id is None:
+                return False
+            try:
+                current_data = json.loads(current_payload)
+            except Exception:
+                return False
+            current_request_id = current_data.get("request_id")
+            if current_request_id is None:
+                current_request_id = f"legacy:{current_payload}"
+            return current_request_id == marker_request_id
+
+        def _clear_owned_marker() -> None:
+            if getattr(self, "_restart_notification_request_id", None) != marker_request_id:
+                return
+            from gateway.restart import restart_notification_marker_lock
+
+            try:
+                with restart_notification_marker_lock(_hermes_home):
+                    if not _owns_marker():
+                        return
+                    notify_path.unlink(missing_ok=True)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to verify restart notification marker before cleanup: %s", exc
+                )
+                return
+            if delivered_target is not None:
+                (_hermes_home / ".restart_prompt_sent.json").unlink(missing_ok=True)
+
         try:
-            data = json.loads(notify_path.read_text(encoding="utf-8"))
+            if marker_payload is None:
+                try:
+                    marker_payload = _read_marker_payload()
+                except Exception as exc:
+                    logger.warning("Failed to read restart notification marker: %s", exc)
+                    return None
+            if marker_payload is None:
+                return None
+
+            try:
+                data = json.loads(marker_payload)
+            except Exception as exc:
+                logger.warning("Failed to parse restart notification marker: %s", exc)
+                return None
+            if not isinstance(data, dict):
+                logger.warning("Restart notification marker is not a JSON object")
+                return None
+
             platform_str = data.get("platform")
             chat_id = data.get("chat_id")
             thread_id = data.get("thread_id")
-            if not platform_str or not chat_id:
+            if not isinstance(platform_str, str) or not platform_str.strip():
+                logger.warning("Restart notification marker has invalid platform")
                 return None
-            platform = Platform(platform_str)
-            transport = resolve_delivery_transport(platform, self.config, self.adapters)
-            if transport is None:
-                logger.debug("Restart notification skipped: no live transport for %s", platform_str)
+            if not isinstance(chat_id, str) or not chat_id.strip():
+                logger.warning("Restart notification marker has invalid chat_id")
                 return None
+            if thread_id is not None and not isinstance(thread_id, str):
+                logger.warning("Restart notification marker has invalid thread_id")
+                return None
+
+            marker_request_id = data.get("request_id")
+            if marker_request_id is not None and (
+                not isinstance(marker_request_id, str) or not marker_request_id
+            ):
+                logger.warning("Restart notification marker has invalid request_id")
+                return None
+            if marker_request_id is None:
+                marker_request_id = f"legacy:{marker_payload}"
+
+            if getattr(self, "_restart_notification_request_id", None) is None:
+                self._restart_notification_request_id = marker_request_id
+            try:
+                marker_owned = _owns_marker()
+            except Exception as exc:
+                logger.warning("Failed to verify restart notification marker: %s", exc)
+                return None
+            if not marker_owned:
+                return None
+
+            try:
+                platform = Platform(platform_str)
+            except (TypeError, ValueError):
+                logger.warning("Restart notification marker has unknown platform: %s", platform_str)
+                return None
+
             platform_cfg = self.config.platforms.get(platform)
             if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
                 logger.info(
-                    "Restart notification suppressed: %s has gateway_restart_notification=false", platform_str
+                    "Restart notification suppressed: %s has gateway_restart_notification=false",
+                    platform_str,
                 )
+                clear_marker = True
                 return None
-            metadata = self._pending_marker_metadata(platform, chat_id, data, transport.adapter)
-            if data.get("delivered_via_upstream_relay") is True:
-                metadata = dict(metadata or {})
-                for field in ("user_id", "scope_id"):
-                    if data.get(field):
-                        metadata[field] = str(data[field])
-            result = await transport.send(
-                platform, str(chat_id), "♻ Gateway restarted successfully. Your session continues.",
-                metadata=_non_conversational_metadata(metadata, platform=platform),
-            )
-            # adapter.send() catches provider errors (e.g. "Chat not found") and returns
-            # SendResult(success=False) rather than raising, so inspect the result before claiming success.
-            if _send_failed(result):
+
+            deadline = time.monotonic() + _RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS
+            delay = _RESTART_NOTIFICATION_RETRY_BASE_DELAY_SECS
+            attempt = 0
+
+            while True:
+                if not self._running:
+                    return None
+                if self._restart_notification_request_id != marker_request_id:
+                    return None
+                try:
+                    if not _owns_marker():
+                        return None
+                except Exception as exc:
+                    logger.warning("Failed to verify restart notification marker: %s", exc)
+                    return None
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(
+                        "Restart notification retry budget exhausted after %.1fs",
+                        _RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS,
+                    )
+                    return None
+
+                transport = resolve_delivery_transport(platform, self.config, self.adapters)
+                if transport is None:
+                    result = SendResult(
+                        success=False,
+                        error=f"{platform_str} adapter not available",
+                        retryable=True,
+                    )
+                else:
+                    metadata = self._pending_marker_metadata(
+                        platform, chat_id, data, transport.adapter
+                    )
+                    if data.get("delivered_via_upstream_relay") is True:
+                        metadata = dict(metadata or {})
+                        for field in ("user_id", "scope_id"):
+                            if data.get(field):
+                                metadata[field] = str(data[field])
+                    send_started = False
+
+                    async def _dispatch_once() -> SendResult:
+                        nonlocal send_started
+                        if not self._running:
+                            return SendResult(
+                                success=False,
+                                error="gateway shutdown in progress",
+                                retryable=True,
+                            )
+                        if self._restart_notification_request_id != marker_request_id:
+                            return SendResult(
+                                success=False,
+                                error="restart notification marker superseded",
+                                retryable=True,
+                            )
+                        try:
+                            if not _owns_marker():
+                                return SendResult(
+                                    success=False,
+                                    error="restart notification marker superseded",
+                                    retryable=True,
+                                )
+                        except Exception as exc:
+                            return SendResult(
+                                success=False,
+                                error=f"restart notification marker check failed: {exc}",
+                                retryable=True,
+                            )
+                        if deadline - time.monotonic() <= 0:
+                            return SendResult(
+                                success=False,
+                                error="restart notification retry budget exhausted",
+                                retryable=True,
+                            )
+                        send_started = True
+                        return await transport.send(
+                            platform,
+                            str(chat_id),
+                            "♻ Gateway restarted successfully. Your session continues.",
+                            metadata=_non_conversational_metadata(metadata, platform=platform),
+                        )
+
+                    send_task = asyncio.ensure_future(_dispatch_once())
+                    try:
+                        done, _pending = await asyncio.wait({send_task}, timeout=remaining)
+                    except asyncio.CancelledError:
+                        if send_task.done():
+                            if send_task.cancelled():
+                                clear_marker = send_started
+                                raise
+                            try:
+                                completed_result = send_task.result()
+                            except Exception:
+                                clear_marker = True
+                            else:
+                                if not completed_result.success and completed_result.retryable:
+                                    raise
+                                clear_marker = True
+                        elif send_started:
+                            clear_marker = True
+                        send_task.cancel()
+                        send_task.add_done_callback(consume_detached_task_result)
+                        raise
+
+                    if send_task not in done:
+                        send_task.cancel()
+                        send_task.add_done_callback(consume_detached_task_result)
+                        logger.warning(
+                            "Restart notification send exceeded %.1fs; consuming marker to avoid duplicates",
+                            _RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS,
+                        )
+                        clear_marker = True
+                        return None
+                    try:
+                        result = send_task.result()
+                    except asyncio.CancelledError:
+                        clear_marker = send_started
+                        raise
+                    except Exception as exc:
+                        logger.warning(
+                            "Restart notification send raised; consuming marker to avoid duplicate: %s",
+                            exc,
+                        )
+                        clear_marker = True
+                        return None
+
+                if result.success:
+                    logger.info("Sent restart notification to %s:%s", platform_str, chat_id)
+                    delivered_target = (
+                        str(platform_str),
+                        str(chat_id),
+                        str(thread_id) if thread_id else None,
+                    )
+                    clear_marker = True
+                    return delivered_target
+
+                if not result.retryable:
+                    logger.warning(
+                        "Restart notification to %s:%s was not delivered: %s",
+                        platform_str,
+                        chat_id,
+                        result.error,
+                    )
+                    clear_marker = True
+                    return None
+
+                if not self._running:
+                    return None
+                if self._restart_notification_request_id != marker_request_id:
+                    return None
+                try:
+                    if not _owns_marker():
+                        return None
+                except Exception as exc:
+                    logger.warning("Failed to verify restart notification marker: %s", exc)
+                    return None
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(
+                        "Restart notification retry budget exhausted after %.1fs",
+                        _RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS,
+                    )
+                    return None
+
+                retry_delay = result.retry_after
+                if retry_delay is None:
+                    retry_delay = delay
+                    delay = min(delay * 2, _RESTART_NOTIFICATION_RETRY_MAX_DELAY_SECS)
+                retry_delay = max(0.0, min(float(retry_delay), remaining))
+                attempt += 1
                 logger.warning(
-                    "Restart notification to %s:%s was not delivered: %s", platform_str, chat_id, _send_error(result),
+                    "Restart notification attempt %d failed (%s); retrying in %.1fs",
+                    attempt,
+                    result.error,
+                    retry_delay,
                 )
-                return None
-            logger.info("Sent restart notification to %s:%s", platform_str, chat_id)
-            return str(platform_str), str(chat_id), str(thread_id) if thread_id else None
-        except Exception as e:
-            logger.warning("Restart notification failed: %s", e)
+                await asyncio.sleep(retry_delay)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("Restart notification failed: %s", exc)
             return None
         finally:
-            notify_path.unlink(missing_ok=True)
+            if clear_marker:
+                cleanup_lock = getattr(self, "_restart_command_lock", None)
+                if cleanup_lock is None:
+                    _clear_owned_marker()
+                else:
+                    # The restart handler holds this lock while publishing replacement
+                    # marker generations, so ownership check + unlink cannot delete one.
+                    async with cleanup_lock:
+                        _clear_owned_marker()
 
     def _home_channel_transports(self):
         """Yield ``(platform, platform_cfg, home, transport)`` for every home channel with a live transport."""

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -193,7 +193,12 @@ class GatewayStartupMixin:
                 logger.log(level, message, exc_info=(type(exc), exc, exc.__traceback__))
         return _report
 
-    async def _await_startup_boot_sends(self, *, planned_restart_notification_pending: bool) -> None:
+    async def _await_startup_boot_sends(
+        self,
+        *,
+        restart_marker_payload: Optional[str],
+        planned_restart_notification_pending: bool,
+    ) -> None:
         """Run boot-path sends without letting them pin the inbound restore gate (one Telegram
         flood-control sleep must not freeze inbound on every platform): same bounded wait as the
         resume gate, sends finish in the background on timeout. The ledger claim + ``resume_pending``
@@ -206,22 +211,31 @@ class GatewayStartupMixin:
         from gateway.run import _clear_planned_restart_notification, _startup_restore_drain_timeout_secs
         claimed = await self._claim_pending_obligations()
 
-        async def _boot_sends() -> None:
-            await self._send_restart_notification()
-            if planned_restart_notification_pending:
+        boot_tasks: set[asyncio.Task] = set()
+        if restart_marker_payload is not None:
+            boot_tasks.add(asyncio.create_task(self._send_restart_notification(
+                claimed_marker_payload=restart_marker_payload,
+            )))
+
+        if planned_restart_notification_pending:
+            async def _send_planned_restart_notification() -> None:
                 try:
                     await self._send_home_channel_startup_notifications(skip_targets=None)
                 finally:
                     _clear_planned_restart_notification()
-            await self._redeliver_claimed_obligations(claimed)
 
-        boot_task = asyncio.create_task(_boot_sends())
+            boot_tasks.add(asyncio.create_task(_send_planned_restart_notification()))
+
+        # Delivery-ledger replay is independent of lifecycle notifications: a
+        # rate-limited restart message must not hold generated responses behind it.
+        boot_tasks.add(asyncio.create_task(self._redeliver_claimed_obligations(claimed)))
+
         timeout = _startup_restore_drain_timeout_secs()
         if timeout <= 0:
-            await boot_task  # unbounded: a failing send surfaces here (unlike the gate path)
+            await asyncio.gather(*boot_tasks)
             return
         await self._wait_bounded_or_release(
-            {boot_task}, timeout,
+            boot_tasks, timeout,
             "Boot-path sends still running after %.0fs; releasing inbound gate so other platforms are not "
             "frozen. Restart notification / obligation redelivery continue in the background.",
             "background boot-path send failed after gate release: see traceback", track=True,
@@ -1156,22 +1170,21 @@ class GatewayStartupMixin:
         ):
             self._schedule_update_notification_watch()
 
-    async def _start_finish_wiring(self, connected_count: int) -> None:
+    async def _start_finish_wiring(
+        self, connected_count: int, *, restart_marker_payload: Optional[str]
+    ) -> None:
         """Post-connect wiring: services, boot notifications, startup restore, recovered watchers."""
-        from gateway.run import _planned_restart_notification_pending, _restart_notification_pending
+        from gateway.run import _planned_restart_notification_pending
         await self._start_post_connect_services(connected_count)
         # Let fresh adapters settle before lifecycle sends (helps Discord thread deliveries).
         if connected_count > 0:
             await asyncio.sleep(1.0)
-        # Before _send_restart_notification() unlinks the marker: did we boot from a chat /restart?
-        # One-shot signal for _is_stale_restart_redelivery.
-        if _restart_notification_pending():
-            self._booted_from_restart = True
         # Boot-path adapter.send() calls must not pin the inbound restore gate (a Telegram flood-
         # control sleep here once froze every platform).
         # Restart notification, home-channel startup notice, and obligation redelivery all call
         # adapter.send(). Bound them the same way _finish_startup_restore bounds resume turns. See #91969.
         await self._await_startup_boot_sends(
+            restart_marker_payload=restart_marker_payload,
             planned_restart_notification_pending=_planned_restart_notification_pending(),
         )
         # Auto-resume restart-interrupted sessions (ledger-answered ones were cleared above); a failed
@@ -1237,7 +1250,26 @@ class GatewayStartupMixin:
 
     async def start(self) -> bool:
         """Start the gateway and all configured platform adapters."""
+        from gateway.run import _hermes_home
+
         logger.info("Starting Hermes Gateway...")
+        # Claim the exact restart-marker generation before adapters connect. A
+        # platform can accept another /restart as soon as connect() begins; the
+        # boot worker must never read that replacement as its own work.
+        restart_notify_path = _hermes_home / ".restart_notify.json"
+        restart_marker_payload: Optional[str] = None
+        if restart_notify_path.exists():
+            self._booted_from_restart = True
+            try:
+                restart_marker_payload = restart_notify_path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                self._booted_from_restart = False
+            except (OSError, UnicodeError) as exc:
+                logger.warning(
+                    "Could not claim restart notification marker at startup; "
+                    "preserving it for a later process: %s",
+                    exc,
+                )
         self._start_install_faulthandler()
         self._start_log_startup_environment()
         if await self._abort_startup_if_shutdown_requested():
@@ -1286,7 +1318,9 @@ class GatewayStartupMixin:
         self._running = True
         self._install_plugin_message_injector()
         self._update_runtime_status("running")
-        await self._start_finish_wiring(connected_count)
+        await self._start_finish_wiring(
+            connected_count, restart_marker_payload=restart_marker_payload
+        )
         self._start_spawn_background_watchers()
         logger.info("Press Ctrl+C to stop")
         return True

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -15,9 +15,10 @@ import re
 import shlex
 import sys
 import time
+import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from agent.i18n import t
 from gateway.config import HomeChannel, Platform, PlatformConfig, persist_home_channel
@@ -32,6 +33,36 @@ from hermes_cli.config import atomic_config_write, cfg_get
 from utils import atomic_json_write, is_truthy_value
 
 logger = logging.getLogger("gateway.run")
+
+
+async def _atomic_json_write_completion_safe(
+    path: Path, payload: dict[str, Any]
+) -> asyncio.CancelledError | None:
+    """Finish an in-flight marker write and return deferred cancellation."""
+    def _write_locked() -> None:
+        from gateway.restart import restart_notification_marker_lock
+
+        with restart_notification_marker_lock(path.parent):
+            atomic_json_write(path, payload, indent=None)
+
+    write_task = asyncio.create_task(asyncio.to_thread(_write_locked))
+    cancellation: asyncio.CancelledError | None = None
+    while True:
+        try:
+            await asyncio.shield(write_task)
+            break
+        except asyncio.CancelledError as exc:
+            if write_task.cancelled():
+                raise
+            # Do not release the command lock while the worker thread can still
+            # overwrite a marker published by a newer restart request.
+            cancellation = exc
+        except Exception:
+            if cancellation is not None:
+                logger.debug("Cancelled marker write failed while draining", exc_info=True)
+                return cancellation
+            raise
+    return cancellation
 
 
 # /rollback result keys -> i18n line for files the safe restore left alone.
@@ -497,6 +528,17 @@ class GatewaySlashCommandsMixin(
         return f"✓ {name} resumed — retrying on next watcher tick."
 
     async def _handle_restart_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
+        """Serialize restart marker publication and the restart state transition."""
+        lock = getattr(self, "_restart_command_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._restart_command_lock = lock
+        async with lock:
+            return await self._handle_restart_command_serialized(event)
+
+    async def _handle_restart_command_serialized(
+        self, event: MessageEvent
+    ) -> Union[str, EphemeralReply]:
         """Handle /restart command - drain active work, then restart the gateway."""
         from gateway.run import _hermes_home
         # Idempotency check: if the previous gateway process recorded this same /restart (platform +
@@ -513,14 +555,11 @@ class GatewaySlashCommandsMixin(
             count = self._running_agent_count()
             return t("gateway.draining", count=count) if count else EphemeralReply(t("gateway.restart.in_progress"))
 
-        async def _write_marker(name: str, build, label: str) -> None:
-            try:
-                await asyncio.to_thread(atomic_json_write, _hermes_home / name, build(), indent=None)
-            except Exception as e:
-                logger.debug("Failed to write restart %s: %s", label, e)
+        request_id = uuid.uuid4().hex
 
         def _notify_payload() -> dict:
             data = _restart_notify_payload(event)
+            data["request_id"] = request_id
             mid = str(event.message_id) if event.message_id is not None else event.source.message_id
             try:
                 self._restart_command_source = dataclasses.replace(event.source, message_id=mid)
@@ -536,12 +575,36 @@ class GatewaySlashCommandsMixin(
                 data["update_id"] = event.platform_update_id
             return data
 
-        # Save the requester's routing info so the new gateway process can notify them once back.
-        await _write_marker(".restart_notify.json", _notify_payload, "notify file")
+        pending_cancellation: asyncio.CancelledError | None = None
+
+        # Publish the generation before dispatching the worker-thread write. An
+        # older delivery worker can then avoid unlinking this marker during the
+        # final read/unlink race.
+        self._restart_notification_request_id = request_id
+        try:
+            pending_cancellation = await _atomic_json_write_completion_safe(
+                _hermes_home / ".restart_notify.json", _notify_payload()
+            )
+        except asyncio.CancelledError as exc:
+            pending_cancellation = exc
+        except Exception as exc:
+            logger.debug("Failed to write restart notify file: %s", exc)
+
         # Record the triggering platform + update_id in a dedicated dedup marker. Unlike
         # .restart_notify.json (unlinked once the new gateway sends its notification) this persists
         # so a delayed Telegram redelivery is still detectable. Overwritten on every /restart.
-        await _write_marker(".restart_last_processed.json", _dedup_payload, "dedup marker")
+        try:
+            cancellation = await _atomic_json_write_completion_safe(
+                _hermes_home / ".restart_last_processed.json", _dedup_payload()
+            )
+            if pending_cancellation is None:
+                pending_cancellation = cancellation
+        except asyncio.CancelledError as exc:
+            if pending_cancellation is None:
+                pending_cancellation = exc
+        except Exception as exc:
+            logger.debug("Failed to write restart dedup marker: %s", exc)
+
         active_agents = self._running_agent_count()
         # Under a service manager (systemd/launchd) or Docker/Podman, exit 75 so the supervisor /
         # restart policy restarts us — detached setsid+bash fails there (systemd KillMode=mixed kills
@@ -549,6 +612,11 @@ class GatewaySlashCommandsMixin(
         from gateway.restart import is_container_restart_context, is_gateway_supervisor_process
         via_service = is_gateway_supervisor_process() or is_container_restart_context()
         self.request_restart(detached=not via_service, via_service=via_service)
+        # Marker publication and the restart transition are one obligation. Only
+        # propagate cancellation after restart was requested, so a completed
+        # worker write cannot leave a false success marker behind.
+        if pending_cancellation is not None:
+            raise pending_cancellation
         # Track sessions that were active at shutdown for stuck-loop detection (#7536). On each restart, the
         # counter increments for sessions that were running. If a session hits the threshold (3 consecutive
         # restarts while active), the next startup auto-suspends it — breaking the loop.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -25,6 +25,7 @@ import re
 import shlex
 import sys
 import time
+import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -1557,6 +1558,9 @@ class GatewaySlashCommandsMixin:
                 "platform": event.source.platform.value if event.source.platform else None,
                 "chat_id": event.source.chat_id,
                 "chat_type": event.source.chat_type,
+                # Distinguish a replacement marker even when the same source
+                # immediately requests another restart with identical routing.
+                "request_id": uuid.uuid4().hex,
             }
             if event.source.delivered_via_upstream_relay is True:
                 notify_data["delivered_via_upstream_relay"] = True

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -61,6 +61,8 @@ def make_restart_runner(
     )
     runner._running = True
     runner._shutdown_event = asyncio.Event()
+    runner._restart_command_lock = asyncio.Lock()
+    runner._restart_notification_request_id = None
     runner._exit_reason = None
     runner._exit_code = None
     runner._running_agents = {}

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -1,12 +1,16 @@
 """Tests for /restart notification — the gateway notifies the requester on comeback."""
 
+import asyncio
 import json
+import threading
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 import gateway.run as gateway_run
+import gateway.run_notifications as gateway_notifications
 from gateway.config import HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.session import build_session_key
@@ -24,12 +28,40 @@ def test_planned_restart_notification_pending_roundtrip(tmp_path, monkeypatch):
     marker = tmp_path / ".restart_pending.json"
 
     assert gateway_run._planned_restart_notification_pending() is False
-    marker.write_text("{}")
+    marker.write_text("{}", encoding="utf-8")
     assert gateway_run._planned_restart_notification_pending() is True
 
     gateway_run._clear_planned_restart_notification()
 
     assert gateway_run._planned_restart_notification_pending() is False
+
+
+def test_restart_marker_lock_serializes_old_cleanup_with_new_writer(tmp_path):
+    """An old worker cannot unlink a newer marker written by another process."""
+    from gateway.restart import restart_notification_marker_lock
+
+    marker = tmp_path / ".restart_notify.json"
+    marker.write_text(json.dumps({"request_id": "old"}), encoding="utf-8")
+    writer_started = threading.Event()
+    writer_done = threading.Event()
+
+    def _write_new_marker():
+        writer_started.set()
+        with restart_notification_marker_lock(tmp_path):
+            marker.write_text(json.dumps({"request_id": "new"}), encoding="utf-8")
+        writer_done.set()
+
+    with restart_notification_marker_lock(tmp_path):
+        assert json.loads(marker.read_text(encoding="utf-8"))["request_id"] == "old"
+        writer = threading.Thread(target=_write_new_marker, daemon=True)
+        writer.start()
+        assert writer_started.wait(timeout=1.0)
+        assert not writer_done.wait(timeout=0.05)
+        marker.unlink()
+
+    writer.join(timeout=1.0)
+    assert not writer.is_alive()
+    assert json.loads(marker.read_text(encoding="utf-8"))["request_id"] == "new"
 
 
 # ── _handle_restart_command writes .restart_notify.json ──────────────────
@@ -56,12 +88,175 @@ async def test_restart_command_writes_notify_file(tmp_path, monkeypatch):
 
     notify_path = tmp_path / ".restart_notify.json"
     assert notify_path.exists()
-    data = json.loads(notify_path.read_text())
+    data = json.loads(notify_path.read_text(encoding="utf-8"))
     assert data["platform"] == "telegram"
     assert data["chat_id"] == "42"
     assert data["chat_type"] == "dm"
     assert data["message_id"] == "m1"
+    assert len(data["request_id"]) == 32
     assert "thread_id" not in data  # no thread → omitted
+
+
+@pytest.mark.asyncio
+async def test_restart_command_gives_identical_route_a_unique_request_id(
+    tmp_path, monkeypatch
+):
+    """Consecutive markers from the same route must remain distinguishable."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="42"),
+    )
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    await runner._handle_restart_command(event)
+    first = json.loads((tmp_path / ".restart_notify.json").read_text(encoding="utf-8"))
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    await runner._handle_restart_command(event)
+    second = json.loads((tmp_path / ".restart_notify.json").read_text(encoding="utf-8"))
+
+    assert first["request_id"] != second["request_id"]
+    assert {k: v for k, v in first.items() if k != "request_id"} == {
+        k: v for k, v in second.items() if k != "request_id"
+    }
+
+
+@pytest.mark.asyncio
+async def test_restart_command_serializes_async_marker_writes(tmp_path, monkeypatch):
+    """Concurrent restart commands cannot reorder their worker-thread writes."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    import gateway.slash_commands as gateway_slash
+
+    notify_write_started = threading.Event()
+    allow_notify_write = threading.Event()
+    notify_payloads = []
+
+    def _blocking_atomic_json_write(path, payload, **_kwargs):
+        path = Path(path)
+        if path.name == ".restart_notify.json":
+            notify_payloads.append(dict(payload))
+            notify_write_started.set()
+            assert allow_notify_write.wait(timeout=2)
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr(
+        gateway_slash,
+        "atomic_json_write",
+        _blocking_atomic_json_write,
+    )
+
+    runner, _adapter = make_restart_runner()
+
+    def _request_restart(**_kwargs):
+        runner._restart_requested = True
+        return True
+
+    runner.request_restart = MagicMock(side_effect=_request_restart)
+    first_event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="first"),
+        message_id="m1",
+    )
+    second_event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="second"),
+        message_id="m2",
+    )
+
+    first_task = asyncio.create_task(runner._handle_restart_command(first_event))
+    assert await asyncio.to_thread(notify_write_started.wait, 2)
+    second_task = asyncio.create_task(runner._handle_restart_command(second_event))
+    await asyncio.sleep(0)
+
+    try:
+        assert not second_task.done()
+    finally:
+        allow_notify_write.set()
+
+    await asyncio.gather(first_task, second_task)
+
+    runner.request_restart.assert_called_once()
+    assert len(notify_payloads) == 1
+    assert notify_payloads[0]["chat_id"] == "first"
+    marker = json.loads(
+        (tmp_path / ".restart_notify.json").read_text(encoding="utf-8")
+    )
+    assert marker["chat_id"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_restart_command_cancellation_does_not_orphan_marker_writer(
+    tmp_path, monkeypatch
+):
+    """Cancellation publishes the marker and requests restart before unlocking."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    import gateway.slash_commands as gateway_slash
+
+    first_write_started = threading.Event()
+    second_write_started = threading.Event()
+    allow_first_write = threading.Event()
+
+    def _ordered_atomic_json_write(path, payload, **_kwargs):
+        path = Path(path)
+        if path.name == ".restart_notify.json":
+            if payload["chat_id"] == "first":
+                first_write_started.set()
+                assert allow_first_write.wait(timeout=2)
+            else:
+                second_write_started.set()
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr(gateway_slash, "atomic_json_write", _ordered_atomic_json_write)
+
+    runner, _adapter = make_restart_runner()
+
+    def _request_restart(**_kwargs):
+        runner._restart_requested = True
+        return True
+
+    runner.request_restart = MagicMock(side_effect=_request_restart)
+    first_event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="first"),
+        message_id="m1",
+    )
+    second_event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="second"),
+        message_id="m2",
+    )
+
+    first_task = asyncio.create_task(runner._handle_restart_command(first_event))
+    assert await asyncio.to_thread(first_write_started.wait, 2)
+    first_task.cancel()
+    await asyncio.sleep(0)
+    first_task.cancel()
+    second_task = asyncio.create_task(runner._handle_restart_command(second_event))
+    second_started_before_release = await asyncio.to_thread(
+        second_write_started.wait, 0.2
+    )
+
+    allow_first_write.set()
+    results = await asyncio.gather(first_task, second_task, return_exceptions=True)
+
+    assert not second_started_before_release
+    assert isinstance(results[0], asyncio.CancelledError)
+    runner.request_restart.assert_called_once()
+    marker = json.loads(
+        (tmp_path / ".restart_notify.json").read_text(encoding="utf-8")
+    )
+    assert marker["chat_id"] == "first"
+    assert runner._restart_requested is True
 
 
 @pytest.mark.asyncio
@@ -282,6 +477,913 @@ async def test_relay_restart_notification_uses_logical_platform_and_owner(tmp_pa
     metadata = relay.send_for_platform.await_args.kwargs["metadata"]
     assert metadata["user_id"] == "U123"
     assert metadata["scope_id"] == "T123"
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_retries_when_adapter_appears(
+    tmp_path, monkeypatch
+):
+    """A platform reconnect during startup must not lose the notification."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+    dedup_path = tmp_path / ".restart_last_processed.json"
+    dedup_payload = json.dumps(
+        {"platform": "telegram", "update_id": 100, "requested_at": time.time()}
+    )
+    dedup_path.write_text(dedup_payload, encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(return_value=SendResult(success=True, message_id="m-1"))
+    adapter.send = send
+    runner.adapters = {}
+
+    async def _restore_adapter(_delay):
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+    monkeypatch.setattr(gateway_notifications.asyncio, "sleep", _restore_adapter)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "42", None)
+    send.assert_awaited_once()
+    assert not notify_path.exists()
+    assert dedup_path.read_text(encoding="utf-8") == dedup_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_preserves_captured_marker_if_first_read_fails(
+    tmp_path, monkeypatch
+):
+    """A transient first-read failure preserves the captured unsent obligation."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps(
+            {
+                "platform": "telegram",
+                "chat_id": "42",
+                "request_id": "captured",
+            }
+        ),
+        encoding="utf-8",
+    )
+    claimed_payload = notify_path.read_text(encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock()
+    adapter.send = send
+    real_read_text = Path.read_text
+    failed = False
+
+    def _fail_first_marker_read(path, *args, **kwargs):
+        nonlocal failed
+        if path == notify_path and not failed:
+            failed = True
+            raise OSError("temporary marker read failure")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _fail_first_marker_read)
+
+    delivered_target = await runner._send_restart_notification(
+        claimed_marker_payload=claimed_payload
+    )
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert real_read_text(notify_path, encoding="utf-8") == claimed_payload
+
+
+@pytest.mark.parametrize(
+    "marker_payload",
+    [
+        "{not-json",
+        "[]",
+        json.dumps({"platform": "not-a-platform", "chat_id": "42"}),
+        json.dumps({"platform": "telegram"}),
+        json.dumps({"platform": "telegram", "chat_id": "   "}),
+        json.dumps({"platform": "telegram", "chat_id": {"not": "a route"}}),
+        json.dumps({"platform": "telegram", "chat_id": ["42"]}),
+        json.dumps({"platform": "telegram", "chat_id": 42}),
+        json.dumps({"platform": ["telegram"], "chat_id": "42"}),
+        json.dumps(
+            {
+                "platform": "telegram",
+                "chat_id": "42",
+                "thread_id": {"not": "a thread"},
+            }
+        ),
+    ],
+    ids=[
+        "invalid-json",
+        "non-object",
+        "unknown-platform",
+        "missing-route",
+        "blank-chat-id",
+        "object-chat-id",
+        "list-chat-id",
+        "integer-chat-id",
+        "list-platform",
+        "object-thread-id",
+    ],
+)
+@pytest.mark.asyncio
+async def test_send_restart_notification_preserves_malformed_marker(
+    tmp_path, monkeypatch, marker_payload
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(marker_payload, encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock()
+    adapter.send = send
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert notify_path.read_text(encoding="utf-8") == marker_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_preserves_unreadable_marker(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    marker_bytes = b"\xff\xfe"
+    notify_path.write_bytes(marker_bytes)
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock()
+    adapter.send = send
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert notify_path.read_bytes() == marker_bytes
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_retries_retryable_refusal(
+    tmp_path, monkeypatch
+):
+    """A safe pre-send refusal is retried instead of consuming the marker."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(
+        side_effect=[
+            SendResult(
+                success=False,
+                error="send_path_degraded",
+                retryable=True,
+            ),
+            SendResult(success=True, message_id="m-1"),
+        ]
+    )
+    adapter.send = send
+    sleep = AsyncMock()
+    monkeypatch.setattr(gateway_notifications.asyncio, "sleep", sleep)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "42", None)
+    assert send.await_count == 2
+    sleep.assert_awaited_once_with(1.0)
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_stops_when_marker_replaced_during_backoff(
+    tmp_path, monkeypatch
+):
+    """A newer restart marker supersedes an older worker before its retry."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps(
+            {
+                "platform": "telegram",
+                "chat_id": "42",
+                "request_id": "old",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(
+        side_effect=[
+            SendResult(
+                success=False,
+                error="send_path_degraded",
+                retryable=True,
+            ),
+            SendResult(success=True, message_id="must-not-send"),
+        ]
+    )
+    adapter.send = send
+
+    async def _replace_marker(_delay):
+        notify_path.write_text(
+            json.dumps(
+                {
+                    "platform": "telegram",
+                    "chat_id": "42",
+                    "request_id": "new",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(gateway_notifications.asyncio, "sleep", _replace_marker)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_awaited_once()
+    assert json.loads(notify_path.read_text(encoding="utf-8"))["request_id"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_stops_when_async_replacement_is_announced(
+    tmp_path, monkeypatch
+):
+    """A queued worker-thread write supersedes old bytes before its retry."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    old_payload = json.dumps(
+        {"platform": "telegram", "chat_id": "42", "request_id": "old"}
+    )
+    notify_path.write_text(old_payload, encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    calls = 0
+
+    async def _announce_replacement_before_write(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            runner._restart_notification_request_id = "new"
+            return SendResult(
+                success=False,
+                error="send_path_degraded",
+                retryable=True,
+            )
+        return SendResult(success=True, message_id="must-not-send")
+
+    send = AsyncMock(side_effect=_announce_replacement_before_write)
+    adapter.send = send
+    monkeypatch.setattr(gateway_notifications.asyncio, "sleep", AsyncMock())
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_awaited_once()
+    assert notify_path.read_text(encoding="utf-8") == old_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_revalidates_marker_in_dispatch_task(
+    tmp_path, monkeypatch
+):
+    """A replacement written after scheduling must supersede the stale send."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps(
+            {
+                "platform": "telegram",
+                "chat_id": "42",
+                "request_id": "old",
+            }
+        ),
+        encoding="utf-8",
+    )
+    replacement_payload = json.dumps(
+        {
+            "platform": "telegram",
+            "chat_id": "42",
+            "request_id": "new",
+        }
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(return_value=SendResult(success=True, message_id="must-not-send"))
+    adapter.send = send
+    real_ensure_future = gateway_notifications.asyncio.ensure_future
+
+    def _schedule_after_replacement(coro):
+        task = real_ensure_future(coro)
+        notify_path.write_text(replacement_payload, encoding="utf-8")
+        return task
+
+    monkeypatch.setattr(gateway_notifications.asyncio, "ensure_future", _schedule_after_replacement)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert notify_path.read_text(encoding="utf-8") == replacement_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_honors_retry_after(
+    tmp_path, monkeypatch
+):
+    """Provider-requested retry delays take precedence over local backoff."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(
+        side_effect=[
+            SendResult(
+                success=False,
+                error="rate limited",
+                retryable=True,
+                retry_after=5.0,
+            ),
+            SendResult(success=True, message_id="m-1"),
+        ]
+    )
+    adapter.send = send
+    sleep = AsyncMock()
+    monkeypatch.setattr(gateway_notifications.asyncio, "sleep", sleep)
+
+    await runner._send_restart_notification()
+
+    sleep.assert_awaited_once_with(5.0)
+    assert send.await_count == 2
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_retry_budget_is_bounded(
+    tmp_path, monkeypatch
+):
+    """Persistent retryable failures exhaust the budget but preserve redelivery."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_notifications,
+        "_RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS",
+        3.0,
+    )
+    monkeypatch.setattr(
+        gateway_notifications,
+        "_RESTART_NOTIFICATION_RETRY_MAX_DELAY_SECS",
+        2.0,
+    )
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            error="send_path_degraded",
+            retryable=True,
+        )
+    )
+    adapter.send = send
+    clock = {"now": 0.0}
+    sleeps = []
+
+    async def _advance_clock(delay):
+        sleeps.append(delay)
+        clock["now"] += delay
+
+    monkeypatch.setattr(
+        gateway_notifications,
+        "time",
+        MagicMock(monotonic=lambda: clock["now"]),
+    )
+    monkeypatch.setattr(gateway_notifications.asyncio, "sleep", _advance_clock)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    assert sleeps == [1.0, 2.0]
+    # The second sleep reaches the deadline. Do not launch one more send after
+    # the retry budget is already exhausted.
+    assert send.await_count == 2
+    assert notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_rechecks_deadline_inside_dispatch_task(
+    tmp_path, monkeypatch
+):
+    """Event-loop congestion cannot start the provider after total expiry."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_notifications,
+        "_RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS",
+        0.01,
+    )
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    entered = []
+
+    async def _record_send(*_args, **_kwargs):
+        entered.append(time.monotonic())
+        return SendResult(success=True, message_id="late-dispatch")
+
+    adapter.send = AsyncMock(side_effect=_record_send)
+    real_resolve = gateway_notifications.resolve_delivery_transport
+
+    def _congest_before_child_dispatch(platform, config, adapters):
+        transport = real_resolve(platform, config, adapters)
+        asyncio.get_running_loop().call_soon(time.sleep, 0.03)
+        return transport
+
+    monkeypatch.setattr(
+        gateway_notifications,
+        "resolve_delivery_transport",
+        _congest_before_child_dispatch,
+    )
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert entered == []
+    assert delivered_target is None
+    assert notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_rechecks_deadline_after_marker_read(
+    tmp_path, monkeypatch
+):
+    """A marker read that crosses expiry cannot begin a provider call."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_notifications,
+        "_RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS",
+        1.0,
+    )
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    fake_now = 0.0
+    monkeypatch.setattr(gateway_notifications.time, "monotonic", lambda: fake_now)
+    real_read_text = Path.read_text
+    marker_reads = 0
+
+    def _expire_during_dispatch_marker_read(path, *args, **kwargs):
+        nonlocal fake_now, marker_reads
+        value = real_read_text(path, *args, **kwargs)
+        if path == notify_path:
+            marker_reads += 1
+            if marker_reads == 3:
+                fake_now = 2.0
+        return value
+
+    monkeypatch.setattr(Path, "read_text", _expire_during_dispatch_marker_read)
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(return_value=SendResult(success=True, message_id="too-late"))
+    adapter.send = send
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert marker_reads >= 3
+    send.assert_not_awaited()
+    assert delivered_target is None
+    assert notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_hard_deadline_survives_cancel_suppression(
+    tmp_path, monkeypatch
+):
+    """A provider that swallows cancellation cannot hold the worker past expiry."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_notifications,
+        "_RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS",
+        0.02,
+    )
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send_started = asyncio.Event()
+    send_cancelled = asyncio.Event()
+    release_send = asyncio.Event()
+    send_settled = asyncio.Event()
+
+    async def _cancellation_resistant_send(*_args, **_kwargs):
+        send_started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            send_cancelled.set()
+            await release_send.wait()
+            send_settled.set()
+            return SendResult(success=True, message_id="late")
+
+    adapter.send = AsyncMock(side_effect=_cancellation_resistant_send)
+    worker = asyncio.create_task(runner._send_restart_notification())
+
+    try:
+        await asyncio.wait_for(send_started.wait(), timeout=1.0)
+        done, _pending = await asyncio.wait({worker}, timeout=0.5)
+
+        assert worker in done
+        assert await worker is None
+        assert send_cancelled.is_set()
+        assert not notify_path.exists()
+    finally:
+        release_send.set()
+        await asyncio.wait_for(send_settled.wait(), timeout=1.0)
+        if not worker.done():
+            await asyncio.wait_for(worker, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_cancellation_preserves_marker(
+    tmp_path, monkeypatch
+):
+    """Shutdown during safe backoff leaves the marker for the next process."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            error="send_path_degraded",
+            retryable=True,
+        )
+    )
+    sleeping = asyncio.Event()
+
+    async def _block_in_backoff(_delay):
+        sleeping.set()
+        await asyncio.Future()
+
+    monkeypatch.setattr(gateway_notifications.asyncio, "sleep", _block_in_backoff)
+
+    task = asyncio.create_task(runner._send_restart_notification())
+    await asyncio.wait_for(sleeping.wait(), timeout=1.0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_cancel_before_provider_preserves_marker(
+    tmp_path, monkeypatch
+):
+    """Cancellation before the child task runs is a known-safe no-send outcome."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    marker_payload = json.dumps({"platform": "telegram", "chat_id": "42"})
+    notify_path.write_text(marker_payload, encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(return_value=SendResult(success=True, message_id="never"))
+    adapter.send = send
+
+    async def _cancel_before_child_dispatch(_tasks, *, timeout):
+        del timeout
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(gateway_notifications.asyncio, "wait", _cancel_before_child_dispatch)
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._send_restart_notification()
+
+    send.assert_not_awaited()
+    assert notify_path.read_text(encoding="utf-8") == marker_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_cancel_in_provider_consumes_marker(
+    tmp_path, monkeypatch
+):
+    """Cancellation after provider entry remains ambiguous and consumes the marker."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    entered = asyncio.Event()
+
+    async def _block_in_provider(*_args, **_kwargs):
+        entered.set()
+        await asyncio.Future()
+
+    adapter.send = AsyncMock(side_effect=_block_in_provider)
+    task = asyncio.create_task(runner._send_restart_notification())
+    await asyncio.wait_for(entered.wait(), timeout=1.0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_provider_cancellation_consumes_marker(
+    tmp_path, monkeypatch
+):
+    """A child cancelled after provider entry has an ambiguous send outcome."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+
+    async def _provider_cancels(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    adapter.send = AsyncMock(side_effect=_provider_cancels)
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._send_restart_notification()
+
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_shutdown_before_child_dispatch_preserves_marker(
+    tmp_path, monkeypatch
+):
+    """Shutdown beginning after the parent check still prevents provider entry."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    marker_payload = json.dumps({"platform": "telegram", "chat_id": "42"})
+    notify_path.write_text(marker_payload, encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(return_value=SendResult(success=True, message_id="never"))
+    adapter.send = send
+    real_ensure_future = asyncio.ensure_future
+
+    def _begin_shutdown_after_scheduling(coro):
+        task = real_ensure_future(coro)
+        runner._running = False
+        return task
+
+    monkeypatch.setattr(
+        gateway_notifications.asyncio,
+        "ensure_future",
+        _begin_shutdown_after_scheduling,
+    )
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert notify_path.read_text(encoding="utf-8") == marker_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_cancel_after_retryable_result_preserves_marker(
+    tmp_path, monkeypatch
+):
+    """A completed retryable refusal stays a known-safe no-send outcome."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    marker_payload = json.dumps({"platform": "telegram", "chat_id": "42"})
+    notify_path.write_text(marker_payload, encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            error="cold close",
+            retryable=True,
+        )
+    )
+    adapter.send = send
+
+    async def _cancel_after_child_completed(tasks, *, timeout):
+        del timeout
+        (send_task,) = tasks
+        await send_task
+        assert send_task.done()
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(gateway_notifications.asyncio, "wait", _cancel_after_child_completed)
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._send_restart_notification()
+
+    send.assert_awaited_once()
+    assert notify_path.read_text(encoding="utf-8") == marker_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_shutdown_preserves_marker(
+    tmp_path, monkeypatch
+):
+    """Once teardown starts, leave delivery to the replacement process."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    runner._running = False
+    send = AsyncMock()
+    adapter.send = send
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_preserves_replacement_marker(
+    tmp_path, monkeypatch
+):
+    """A second /restart marker must not be consumed by the older delivery."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps(
+            {
+                "platform": "telegram",
+                "chat_id": "42",
+                "request_id": "old",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+
+    async def _send_while_marker_is_replaced(*_args, **_kwargs):
+        notify_path.write_text(
+            json.dumps(
+                {
+                    "platform": "telegram",
+                    "chat_id": "42",
+                    "request_id": "new",
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SendResult(success=True, message_id="sent")
+
+    adapter.send = AsyncMock(side_effect=_send_while_marker_is_replaced)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "42", None)
+    assert json.loads(notify_path.read_text(encoding="utf-8"))["request_id"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_does_not_unlink_async_replacement(
+    tmp_path, monkeypatch
+):
+    """A worker-thread replacement between final read/unlink must survive."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    old_payload = json.dumps(
+        {"platform": "telegram", "chat_id": "42", "request_id": "old"}
+    )
+    new_payload = json.dumps(
+        {"platform": "telegram", "chat_id": "42", "request_id": "new"}
+    )
+    notify_path.write_text(old_payload, encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    allow_replacement = threading.Event()
+    replacement_done = threading.Event()
+
+    def _replace_marker():
+        allow_replacement.wait(timeout=2)
+        notify_path.write_text(new_payload, encoding="utf-8")
+        replacement_done.set()
+
+    writer = threading.Thread(target=_replace_marker)
+    writer.start()
+
+    real_read_text = Path.read_text
+
+    def _read_while_replacement_completes(path, *args, **kwargs):
+        if (
+            path == notify_path
+            and getattr(runner, "_restart_notification_request_id", None) == "new"
+            and not allow_replacement.is_set()
+        ):
+            allow_replacement.set()
+            assert replacement_done.wait(timeout=2)
+            return old_payload
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _read_while_replacement_completes)
+
+    async def _send_while_replacement_is_queued(*_args, **_kwargs):
+        # Mirrors _handle_restart_command: publish the generation before its
+        # atomic write is dispatched to a worker thread.
+        runner._restart_notification_request_id = "new"
+        return SendResult(success=True, message_id="sent")
+
+    adapter.send = AsyncMock(side_effect=_send_while_replacement_is_queued)
+
+    try:
+        delivered_target = await runner._send_restart_notification()
+    finally:
+        allow_replacement.set()
+        writer.join(timeout=2)
+
+    assert delivered_target == ("telegram", "42", None)
+    assert replacement_done.is_set()
+    assert notify_path.read_text(encoding="utf-8") == new_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_cleans_up_on_send_failure(
+    tmp_path, monkeypatch
+):
+    """An ambiguous send exception consumes the marker to avoid duplicates."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(side_effect=RuntimeError("network down"))
+    adapter.send = send
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_awaited_once()
     assert not notify_path.exists()
 
 

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -1,6 +1,8 @@
 """Tests for /restart notification — the gateway notifies the requester on comeback."""
 
+import asyncio
 import json
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -61,7 +63,36 @@ async def test_restart_command_writes_notify_file(tmp_path, monkeypatch):
     assert data["chat_id"] == "42"
     assert data["chat_type"] == "dm"
     assert data["message_id"] == "m1"
+    assert len(data["request_id"]) == 32
     assert "thread_id" not in data  # no thread → omitted
+
+
+@pytest.mark.asyncio
+async def test_restart_command_gives_identical_route_a_unique_request_id(
+    tmp_path, monkeypatch
+):
+    """Consecutive markers from the same route must remain distinguishable."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="42"),
+    )
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    await runner._handle_restart_command(event)
+    first = json.loads((tmp_path / ".restart_notify.json").read_text(encoding="utf-8"))
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    await runner._handle_restart_command(event)
+    second = json.loads((tmp_path / ".restart_notify.json").read_text(encoding="utf-8"))
+
+    assert first["request_id"] != second["request_id"]
+    assert {k: v for k, v in first.items() if k != "request_id"} == {
+        k: v for k, v in second.items() if k != "request_id"
+    }
 
 
 @pytest.mark.asyncio
@@ -283,6 +314,780 @@ async def test_relay_restart_notification_uses_logical_platform_and_owner(tmp_pa
     metadata = relay.send_for_platform.await_args.kwargs["metadata"]
     assert metadata["user_id"] == "U123"
     assert metadata["scope_id"] == "T123"
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_retries_when_adapter_appears(
+    tmp_path, monkeypatch
+):
+    """A platform reconnect during startup must not lose the notification."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(return_value=SendResult(success=True, message_id="m-1"))
+    adapter.send = send
+    runner.adapters = {}
+
+    async def _restore_adapter(_delay):
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+    monkeypatch.setattr(gateway_run.asyncio, "sleep", _restore_adapter)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "42", None)
+    send.assert_awaited_once()
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_preserves_captured_marker_if_first_read_fails(
+    tmp_path, monkeypatch
+):
+    """A transient first-read failure preserves the captured unsent obligation."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps(
+            {
+                "platform": "telegram",
+                "chat_id": "42",
+                "request_id": "captured",
+            }
+        ),
+        encoding="utf-8",
+    )
+    claimed_payload = notify_path.read_text(encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock()
+    adapter.send = send
+    real_read_text = Path.read_text
+    failed = False
+
+    def _fail_first_marker_read(path, *args, **kwargs):
+        nonlocal failed
+        if path == notify_path and not failed:
+            failed = True
+            raise OSError("temporary marker read failure")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _fail_first_marker_read)
+
+    delivered_target = await runner._send_restart_notification(
+        claimed_marker_payload=claimed_payload
+    )
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert real_read_text(notify_path, encoding="utf-8") == claimed_payload
+
+
+@pytest.mark.parametrize(
+    "marker_payload",
+    [
+        "{not-json",
+        "[]",
+        json.dumps({"platform": "not-a-platform", "chat_id": "42"}),
+        json.dumps({"platform": "telegram"}),
+        json.dumps({"platform": "telegram", "chat_id": "   "}),
+        json.dumps({"platform": "telegram", "chat_id": {"not": "a route"}}),
+        json.dumps({"platform": "telegram", "chat_id": ["42"]}),
+        json.dumps({"platform": "telegram", "chat_id": 42}),
+        json.dumps({"platform": ["telegram"], "chat_id": "42"}),
+        json.dumps(
+            {
+                "platform": "telegram",
+                "chat_id": "42",
+                "thread_id": {"not": "a thread"},
+            }
+        ),
+    ],
+    ids=[
+        "invalid-json",
+        "non-object",
+        "unknown-platform",
+        "missing-route",
+        "blank-chat-id",
+        "object-chat-id",
+        "list-chat-id",
+        "integer-chat-id",
+        "list-platform",
+        "object-thread-id",
+    ],
+)
+@pytest.mark.asyncio
+async def test_send_restart_notification_preserves_malformed_marker(
+    tmp_path, monkeypatch, marker_payload
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(marker_payload, encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock()
+    adapter.send = send
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert notify_path.read_text(encoding="utf-8") == marker_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_preserves_unreadable_marker(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    marker_bytes = b"\xff\xfe"
+    notify_path.write_bytes(marker_bytes)
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock()
+    adapter.send = send
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert notify_path.read_bytes() == marker_bytes
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_retries_retryable_refusal(
+    tmp_path, monkeypatch
+):
+    """A safe pre-send refusal is retried instead of consuming the marker."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(
+        side_effect=[
+            SendResult(
+                success=False,
+                error="send_path_degraded",
+                retryable=True,
+            ),
+            SendResult(success=True, message_id="m-1"),
+        ]
+    )
+    adapter.send = send
+    sleep = AsyncMock()
+    monkeypatch.setattr(gateway_run.asyncio, "sleep", sleep)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "42", None)
+    assert send.await_count == 2
+    sleep.assert_awaited_once_with(1.0)
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_stops_when_marker_replaced_during_backoff(
+    tmp_path, monkeypatch
+):
+    """A newer restart marker supersedes an older worker before its retry."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps(
+            {
+                "platform": "telegram",
+                "chat_id": "42",
+                "request_id": "old",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(
+        side_effect=[
+            SendResult(
+                success=False,
+                error="send_path_degraded",
+                retryable=True,
+            ),
+            SendResult(success=True, message_id="must-not-send"),
+        ]
+    )
+    adapter.send = send
+
+    async def _replace_marker(_delay):
+        notify_path.write_text(
+            json.dumps(
+                {
+                    "platform": "telegram",
+                    "chat_id": "42",
+                    "request_id": "new",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(gateway_run.asyncio, "sleep", _replace_marker)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_awaited_once()
+    assert json.loads(notify_path.read_text(encoding="utf-8"))["request_id"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_revalidates_marker_in_dispatch_task(
+    tmp_path, monkeypatch
+):
+    """A replacement written after scheduling must supersede the stale send."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps(
+            {
+                "platform": "telegram",
+                "chat_id": "42",
+                "request_id": "old",
+            }
+        ),
+        encoding="utf-8",
+    )
+    replacement_payload = json.dumps(
+        {
+            "platform": "telegram",
+            "chat_id": "42",
+            "request_id": "new",
+        }
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(return_value=SendResult(success=True, message_id="must-not-send"))
+    adapter.send = send
+    real_ensure_future = gateway_run.asyncio.ensure_future
+
+    def _schedule_after_replacement(coro):
+        task = real_ensure_future(coro)
+        notify_path.write_text(replacement_payload, encoding="utf-8")
+        return task
+
+    monkeypatch.setattr(gateway_run.asyncio, "ensure_future", _schedule_after_replacement)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert notify_path.read_text(encoding="utf-8") == replacement_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_honors_retry_after(
+    tmp_path, monkeypatch
+):
+    """Provider-requested retry delays take precedence over local backoff."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(
+        side_effect=[
+            SendResult(
+                success=False,
+                error="rate limited",
+                retryable=True,
+                retry_after=5.0,
+            ),
+            SendResult(success=True, message_id="m-1"),
+        ]
+    )
+    adapter.send = send
+    sleep = AsyncMock()
+    monkeypatch.setattr(gateway_run.asyncio, "sleep", sleep)
+
+    await runner._send_restart_notification()
+
+    sleep.assert_awaited_once_with(5.0)
+    assert send.await_count == 2
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_retry_budget_is_bounded(
+    tmp_path, monkeypatch
+):
+    """Persistent retryable failures consume the bounded budget, then clean up."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS",
+        3.0,
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_RESTART_NOTIFICATION_RETRY_MAX_DELAY_SECS",
+        2.0,
+    )
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            error="send_path_degraded",
+            retryable=True,
+        )
+    )
+    adapter.send = send
+    clock = {"now": 0.0}
+    sleeps = []
+
+    async def _advance_clock(delay):
+        sleeps.append(delay)
+        clock["now"] += delay
+
+    monkeypatch.setattr(
+        gateway_run,
+        "time",
+        MagicMock(monotonic=lambda: clock["now"]),
+    )
+    monkeypatch.setattr(gateway_run.asyncio, "sleep", _advance_clock)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    assert sleeps == [1.0, 2.0]
+    # The second sleep reaches the deadline. Do not launch one more send after
+    # the retry budget is already exhausted.
+    assert send.await_count == 2
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_rechecks_deadline_inside_dispatch_task(
+    tmp_path, monkeypatch
+):
+    """Event-loop congestion cannot start the provider after total expiry."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS",
+        0.01,
+    )
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    entered = []
+
+    async def _record_send(*_args, **_kwargs):
+        entered.append(time.monotonic())
+        return SendResult(success=True, message_id="late-dispatch")
+
+    adapter.send = AsyncMock(side_effect=_record_send)
+    real_resolve = gateway_run.resolve_delivery_transport
+
+    def _congest_before_child_dispatch(platform, config, adapters):
+        transport = real_resolve(platform, config, adapters)
+        asyncio.get_running_loop().call_soon(time.sleep, 0.03)
+        return transport
+
+    monkeypatch.setattr(
+        gateway_run,
+        "resolve_delivery_transport",
+        _congest_before_child_dispatch,
+    )
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert entered == []
+    assert delivered_target is None
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_rechecks_deadline_after_marker_read(
+    tmp_path, monkeypatch
+):
+    """A marker read that crosses expiry cannot begin a provider call."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS",
+        1.0,
+    )
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    fake_now = 0.0
+    monkeypatch.setattr(gateway_run.time, "monotonic", lambda: fake_now)
+    real_read_text = Path.read_text
+    marker_reads = 0
+
+    def _expire_during_dispatch_marker_read(path, *args, **kwargs):
+        nonlocal fake_now, marker_reads
+        value = real_read_text(path, *args, **kwargs)
+        if path == notify_path:
+            marker_reads += 1
+            if marker_reads == 3:
+                fake_now = 2.0
+        return value
+
+    monkeypatch.setattr(Path, "read_text", _expire_during_dispatch_marker_read)
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(return_value=SendResult(success=True, message_id="too-late"))
+    adapter.send = send
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert marker_reads >= 3
+    send.assert_not_awaited()
+    assert delivered_target is None
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_hard_deadline_survives_cancel_suppression(
+    tmp_path, monkeypatch
+):
+    """A provider that swallows cancellation cannot hold the worker past expiry."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_RESTART_NOTIFICATION_RETRY_TIMEOUT_SECS",
+        0.02,
+    )
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send_started = asyncio.Event()
+    send_cancelled = asyncio.Event()
+    release_send = asyncio.Event()
+    send_settled = asyncio.Event()
+
+    async def _cancellation_resistant_send(*_args, **_kwargs):
+        send_started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            send_cancelled.set()
+            await release_send.wait()
+            send_settled.set()
+            return SendResult(success=True, message_id="late")
+
+    adapter.send = AsyncMock(side_effect=_cancellation_resistant_send)
+    worker = asyncio.create_task(runner._send_restart_notification())
+
+    try:
+        await asyncio.wait_for(send_started.wait(), timeout=1.0)
+        done, _pending = await asyncio.wait({worker}, timeout=0.5)
+
+        assert worker in done
+        assert await worker is None
+        assert send_cancelled.is_set()
+        assert not notify_path.exists()
+    finally:
+        release_send.set()
+        await asyncio.wait_for(send_settled.wait(), timeout=1.0)
+        if not worker.done():
+            await asyncio.wait_for(worker, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_cancellation_preserves_marker(
+    tmp_path, monkeypatch
+):
+    """Shutdown during safe backoff leaves the marker for the next process."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            error="send_path_degraded",
+            retryable=True,
+        )
+    )
+    sleeping = asyncio.Event()
+
+    async def _block_in_backoff(_delay):
+        sleeping.set()
+        await asyncio.Future()
+
+    monkeypatch.setattr(gateway_run.asyncio, "sleep", _block_in_backoff)
+
+    task = asyncio.create_task(runner._send_restart_notification())
+    await asyncio.wait_for(sleeping.wait(), timeout=1.0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_cancel_before_provider_preserves_marker(
+    tmp_path, monkeypatch
+):
+    """Cancellation before the child task runs is a known-safe no-send outcome."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    marker_payload = json.dumps({"platform": "telegram", "chat_id": "42"})
+    notify_path.write_text(marker_payload, encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(return_value=SendResult(success=True, message_id="never"))
+    adapter.send = send
+
+    async def _cancel_before_child_dispatch(_tasks, *, timeout):
+        del timeout
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(gateway_run.asyncio, "wait", _cancel_before_child_dispatch)
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._send_restart_notification()
+
+    send.assert_not_awaited()
+    assert notify_path.read_text(encoding="utf-8") == marker_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_cancel_in_provider_consumes_marker(
+    tmp_path, monkeypatch
+):
+    """Cancellation after provider entry remains ambiguous and consumes the marker."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    entered = asyncio.Event()
+
+    async def _block_in_provider(*_args, **_kwargs):
+        entered.set()
+        await asyncio.Future()
+
+    adapter.send = AsyncMock(side_effect=_block_in_provider)
+    task = asyncio.create_task(runner._send_restart_notification())
+    await asyncio.wait_for(entered.wait(), timeout=1.0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_shutdown_before_child_dispatch_preserves_marker(
+    tmp_path, monkeypatch
+):
+    """Shutdown beginning after the parent check still prevents provider entry."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    marker_payload = json.dumps({"platform": "telegram", "chat_id": "42"})
+    notify_path.write_text(marker_payload, encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(return_value=SendResult(success=True, message_id="never"))
+    adapter.send = send
+    real_ensure_future = asyncio.ensure_future
+
+    def _begin_shutdown_after_scheduling(coro):
+        task = real_ensure_future(coro)
+        runner._running = False
+        return task
+
+    monkeypatch.setattr(
+        gateway_run.asyncio,
+        "ensure_future",
+        _begin_shutdown_after_scheduling,
+    )
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert notify_path.read_text(encoding="utf-8") == marker_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_cancel_after_retryable_result_preserves_marker(
+    tmp_path, monkeypatch
+):
+    """A completed retryable refusal stays a known-safe no-send outcome."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    marker_payload = json.dumps({"platform": "telegram", "chat_id": "42"})
+    notify_path.write_text(marker_payload, encoding="utf-8")
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            error="cold close",
+            retryable=True,
+        )
+    )
+    adapter.send = send
+
+    async def _cancel_after_child_completed(tasks, *, timeout):
+        del timeout
+        (send_task,) = tasks
+        await send_task
+        assert send_task.done()
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(gateway_run.asyncio, "wait", _cancel_after_child_completed)
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._send_restart_notification()
+
+    send.assert_awaited_once()
+    assert notify_path.read_text(encoding="utf-8") == marker_payload
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_shutdown_preserves_marker(
+    tmp_path, monkeypatch
+):
+    """Once teardown starts, leave delivery to the replacement process."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    runner._running = False
+    send = AsyncMock()
+    adapter.send = send
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_not_awaited()
+    assert notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_preserves_replacement_marker(
+    tmp_path, monkeypatch
+):
+    """A second /restart marker must not be consumed by the older delivery."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps(
+            {
+                "platform": "telegram",
+                "chat_id": "42",
+                "request_id": "old",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+
+    async def _send_while_marker_is_replaced(*_args, **_kwargs):
+        notify_path.write_text(
+            json.dumps(
+                {
+                    "platform": "telegram",
+                    "chat_id": "42",
+                    "request_id": "new",
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SendResult(success=True, message_id="sent")
+
+    adapter.send = AsyncMock(side_effect=_send_while_marker_is_replaced)
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "42", None)
+    assert json.loads(notify_path.read_text(encoding="utf-8"))["request_id"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_cleans_up_on_send_failure(
+    tmp_path, monkeypatch
+):
+    """An ambiguous send exception consumes the marker to avoid duplicates."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42"}),
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    send = AsyncMock(side_effect=RuntimeError("network down"))
+    adapter.send = send
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    send.assert_awaited_once()
     assert not notify_path.exists()
 
 

--- a/tests/gateway/test_restart_redelivery_dedup.py
+++ b/tests/gateway/test_restart_redelivery_dedup.py
@@ -52,6 +52,36 @@ async def test_redelivered_restart_with_older_update_id_is_ignored(tmp_path, mon
 
 
 @pytest.mark.asyncio
+async def test_newer_restart_after_boot_is_not_blocked_by_persistent_marker(
+    tmp_path, monkeypatch
+):
+    """The retained marker distinguishes a legitimate immediate second restart."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+
+    marker = tmp_path / ".restart_last_processed.json"
+    marker.write_text(
+        json.dumps(
+            {
+                "platform": "telegram",
+                "update_id": 100,
+                "requested_at": time.time(),
+            }
+        )
+    )
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    runner._booted_from_restart = True
+    runner._startup_time = time.time()
+
+    result = await runner._handle_restart_command(_make_restart_event(update_id=101))
+
+    assert "Restarting gateway" in result
+    runner.request_restart.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_stale_marker_older_than_5min_does_not_block(tmp_path, monkeypatch):
     """A marker older than the 5-minute window is ignored — fresh /restart proceeds."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -937,7 +937,7 @@ class TestStuckLoopEscalation:
         # Simulate counter already at threshold (3 consecutive interrupted
         # restarts).  _suspend_stuck_loop_sessions will flip suspended=True.
         counts_file = tmp_path / ".restart_failure_counts"
-        counts_file.write_text(json.dumps({entry.session_key: 3}))
+        counts_file.write_text(json.dumps({entry.session_key: 3}), encoding="utf-8")
 
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
         runner = object.__new__(GatewayRunner)
@@ -1214,6 +1214,7 @@ async def test_startup_restore_gate_releases_when_boot_path_send_hangs(
 
     await asyncio.wait_for(
         runner._await_startup_boot_sends(
+            restart_marker_payload="restart-marker",
             planned_restart_notification_pending=False,
         ),
         timeout=5,
@@ -1228,9 +1229,10 @@ async def test_startup_restore_gate_releases_when_boot_path_send_hangs(
     assert runner._startup_restore_in_progress is False
     # The DB half (claim + resume clear) runs inline BEFORE the abandonable
     # send task, so it must have completed even though the boot send hung;
-    # the network half never ran because the hung notification precedes it.
+    # obligation redelivery is a sibling of restart delivery, so a blocked
+    # lifecycle notification cannot hold generated responses behind it.
     runner._claim_pending_obligations.assert_awaited_once()
-    runner._redeliver_claimed_obligations.assert_not_awaited()
+    runner._redeliver_claimed_obligations.assert_awaited_once_with([])
 
     hung.set()
     leftover = [t for t in list(runner._background_tasks) if not t.done()]
@@ -1250,10 +1252,13 @@ async def test_startup_boot_sends_still_run_when_they_finish_quickly(monkeypatch
     runner._redeliver_claimed_obligations = AsyncMock(return_value=0)
 
     await runner._await_startup_boot_sends(
+        restart_marker_payload="restart-marker",
         planned_restart_notification_pending=False,
     )
 
-    runner._send_restart_notification.assert_awaited_once()
+    runner._send_restart_notification.assert_awaited_once_with(
+        claimed_marker_payload="restart-marker"
+    )
     runner._claim_pending_obligations.assert_awaited_once()
     runner._redeliver_claimed_obligations.assert_awaited_once()
 

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -26,6 +26,7 @@ class StartupRaceAdapter(BasePlatformAdapter):
         self.connected = False
         self.disconnected = False
         self.background_cancelled = False
+        self.send_calls = 0
 
     async def connect(self, *, is_reconnect: bool = False):
         if self.on_connect:
@@ -43,6 +44,7 @@ class StartupRaceAdapter(BasePlatformAdapter):
         await super().cancel_background_tasks()
 
     async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.send_calls += 1
         return SendResult(success=True, message_id="1")
 
     async def send_typing(self, chat_id, metadata=None):
@@ -60,6 +62,9 @@ def make_startup_runner(tmp_path):
             Platform.SLACK: PlatformConfig(enabled=True, token="***"),
         },
         sessions_dir=tmp_path / "sessions",
+        # The real loop watchdog is unrelated to these startup lifecycle tests
+        # and owns an out-of-loop thread; keep this fixture deterministic.
+        loop_watchdog=False,
     )
     runner.adapters = {}
     runner._running = False
@@ -127,6 +132,129 @@ def patch_startup_side_effects(monkeypatch, tmp_path):
     monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
     monkeypatch.setattr("agent.shell_hooks.register_from_config", lambda *args, **kwargs: None)
     monkeypatch.setattr("tools.process_registry.process_registry.recover_from_checkpoint", lambda: 0)
+
+    async def _empty_channel_directory(_adapters):
+        return {"platforms": {}}
+
+    monkeypatch.setattr(
+        "gateway.channel_directory.build_channel_directory",
+        _empty_channel_directory,
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_schedules_restart_notification_without_waiting(
+    tmp_path, monkeypatch
+):
+    """A temporarily blocked lifecycle delivery must not hold startup open."""
+    monkeypatch.setenv("HERMES_STARTUP_RESTORE_DRAIN_TIMEOUT", "0.05")
+    patch_startup_side_effects(monkeypatch, tmp_path)
+    (tmp_path / ".restart_notify.json").write_text(
+        '{"platform":"telegram","chat_id":"42"}',
+        encoding="utf-8",
+    )
+    runner = make_startup_runner(tmp_path)
+    runner.config.platforms.pop(Platform.SLACK)
+    runner._create_adapter = MagicMock(
+        return_value=StartupRaceAdapter(Platform.TELEGRAM)
+    )
+    release_notification = asyncio.Event()
+    notification_task = None
+
+    async def _blocked_notification(*, claimed_marker_payload=None):
+        nonlocal notification_task
+        assert claimed_marker_payload == '{"platform":"telegram","chat_id":"42"}'
+        notification_task = asyncio.current_task()
+        await release_notification.wait()
+
+    runner._send_restart_notification = AsyncMock(
+        side_effect=_blocked_notification
+    )
+
+    result = await asyncio.wait_for(runner.start(), timeout=10)
+
+    assert result is True
+    runner._send_restart_notification.assert_awaited_once()
+    assert notification_task in runner._background_tasks
+
+    release_notification.set()
+    await asyncio.sleep(0)
+    tasks = list(runner._background_tasks)
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_startup_preserves_invalid_utf8_restart_marker(tmp_path, monkeypatch):
+    """A malformed marker cannot abort gateway startup or be consumed unsent."""
+    patch_startup_side_effects(monkeypatch, tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    marker_bytes = b"\xff\xfeinvalid"
+    notify_path.write_bytes(marker_bytes)
+
+    runner = make_startup_runner(tmp_path)
+    runner.config.platforms.pop(Platform.SLACK)
+    runner._create_adapter = MagicMock(
+        return_value=StartupRaceAdapter(Platform.TELEGRAM)
+    )
+    send_restart_notification = AsyncMock()
+    runner._send_restart_notification = send_restart_notification
+
+    result = await asyncio.wait_for(runner.start(), timeout=10)
+
+    assert result is True
+    send_restart_notification.assert_not_awaited()
+    assert notify_path.read_bytes() == marker_bytes
+
+    tasks = list(runner._background_tasks)
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_startup_restart_worker_does_not_claim_replacement_before_first_run(
+    tmp_path, monkeypatch
+):
+    """The scheduled worker must stay bound to the marker that created it."""
+    patch_startup_side_effects(monkeypatch, tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        '{"platform":"telegram","chat_id":"42","request_id":"old"}',
+        encoding="utf-8",
+    )
+    runner = make_startup_runner(tmp_path)
+    runner.config.platforms.pop(Platform.SLACK)
+
+    def _replace_marker_during_connect():
+        notify_path.write_text(
+            '{"platform":"telegram","chat_id":"42","request_id":"new"}',
+            encoding="utf-8",
+        )
+
+    adapter = StartupRaceAdapter(
+        Platform.TELEGRAM,
+        on_connect=_replace_marker_during_connect,
+    )
+    runner._create_adapter = MagicMock(return_value=adapter)
+    runner._send_restart_notification = (
+        gateway_run.GatewayRunner._send_restart_notification.__get__(
+            runner,
+            gateway_run.GatewayRunner,
+        )
+    )
+
+    result = await asyncio.wait_for(runner.start(), timeout=10)
+    assert result is True
+
+    assert adapter.send_calls == 0
+    assert '"request_id":"new"' in notify_path.read_text(encoding="utf-8")
+
+    tasks = list(runner._background_tasks)
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -26,6 +26,7 @@ class StartupRaceAdapter(BasePlatformAdapter):
         self.connected = False
         self.disconnected = False
         self.background_cancelled = False
+        self.send_calls = 0
 
     async def connect(self, *, is_reconnect: bool = False):
         if self.on_connect:
@@ -43,6 +44,7 @@ class StartupRaceAdapter(BasePlatformAdapter):
         await super().cancel_background_tasks()
 
     async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.send_calls += 1
         return SendResult(success=True, message_id="1")
 
     async def send_typing(self, chat_id, metadata=None):
@@ -60,6 +62,9 @@ def make_startup_runner(tmp_path):
             Platform.SLACK: PlatformConfig(enabled=True, token="***"),
         },
         sessions_dir=tmp_path / "sessions",
+        # The real loop watchdog is unrelated to these startup lifecycle tests
+        # and owns an out-of-loop thread; keep this fixture deterministic.
+        loop_watchdog=False,
     )
     runner.adapters = {}
     runner._running = False
@@ -127,6 +132,147 @@ def patch_startup_side_effects(monkeypatch, tmp_path):
     monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
     monkeypatch.setattr("agent.shell_hooks.register_from_config", lambda *args, **kwargs: None)
     monkeypatch.setattr("tools.process_registry.process_registry.recover_from_checkpoint", lambda: 0)
+
+    async def _empty_channel_directory(_adapters):
+        return {"platforms": {}}
+
+    monkeypatch.setattr(
+        "gateway.channel_directory.build_channel_directory",
+        _empty_channel_directory,
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_schedules_restart_notification_without_waiting(
+    tmp_path, monkeypatch
+):
+    """A temporarily blocked lifecycle delivery must not hold startup open."""
+    patch_startup_side_effects(monkeypatch, tmp_path)
+    (tmp_path / ".restart_notify.json").write_text(
+        '{"platform":"telegram","chat_id":"42"}',
+        encoding="utf-8",
+    )
+    runner = make_startup_runner(tmp_path)
+    runner.config.platforms.pop(Platform.SLACK)
+    runner._create_adapter = MagicMock(
+        return_value=StartupRaceAdapter(Platform.TELEGRAM)
+    )
+    release_notification = asyncio.Event()
+    notification_task = None
+
+    async def _blocked_notification(*, claimed_marker_payload=None):
+        nonlocal notification_task
+        assert claimed_marker_payload == '{"platform":"telegram","chat_id":"42"}'
+        notification_task = asyncio.current_task()
+        await release_notification.wait()
+
+    runner._send_restart_notification = AsyncMock(
+        side_effect=_blocked_notification
+    )
+
+    result = await asyncio.wait_for(runner.start(), timeout=10)
+
+    assert result is True
+    runner._send_restart_notification.assert_awaited_once()
+    assert notification_task in runner._background_tasks
+
+    release_notification.set()
+    await asyncio.sleep(0)
+    tasks = list(runner._background_tasks)
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_startup_preserves_invalid_utf8_restart_marker(tmp_path, monkeypatch):
+    """A malformed marker cannot abort gateway startup or be consumed unsent."""
+    patch_startup_side_effects(monkeypatch, tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    marker_bytes = b"\xff\xfeinvalid"
+    notify_path.write_bytes(marker_bytes)
+
+    runner = make_startup_runner(tmp_path)
+    runner.config.platforms.pop(Platform.SLACK)
+    runner._create_adapter = MagicMock(
+        return_value=StartupRaceAdapter(Platform.TELEGRAM)
+    )
+    send_restart_notification = AsyncMock()
+    runner._send_restart_notification = send_restart_notification
+
+    result = await asyncio.wait_for(runner.start(), timeout=10)
+
+    assert result is True
+    send_restart_notification.assert_not_awaited()
+    assert notify_path.read_bytes() == marker_bytes
+
+    tasks = list(runner._background_tasks)
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_startup_restart_worker_does_not_claim_replacement_before_first_run(
+    tmp_path, monkeypatch
+):
+    """The scheduled worker must stay bound to the marker that created it."""
+    patch_startup_side_effects(monkeypatch, tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(
+        '{"platform":"telegram","chat_id":"42","request_id":"old"}',
+        encoding="utf-8",
+    )
+    runner = make_startup_runner(tmp_path)
+    runner.config.platforms.pop(Platform.SLACK)
+
+    def _replace_marker_during_connect():
+        notify_path.write_text(
+            '{"platform":"telegram","chat_id":"42","request_id":"new"}',
+            encoding="utf-8",
+        )
+
+    adapter = StartupRaceAdapter(
+        Platform.TELEGRAM,
+        on_connect=_replace_marker_during_connect,
+    )
+    runner._create_adapter = MagicMock(return_value=adapter)
+    runner._send_restart_notification = (
+        gateway_run.GatewayRunner._send_restart_notification.__get__(
+            runner,
+            gateway_run.GatewayRunner,
+        )
+    )
+    scheduled = {}
+
+    def _capture_supervised(
+        coro_factory,
+        name,
+        *,
+        restart=True,
+        _attempt=0,
+        on_spawn=None,
+    ):
+        del restart, _attempt, on_spawn
+        if name == "restart_notification":
+            scheduled[name] = coro_factory
+
+    runner._spawn_supervised = MagicMock(side_effect=_capture_supervised)
+
+    result = await asyncio.wait_for(runner.start(), timeout=10)
+    assert result is True
+    assert "restart_notification" in scheduled
+
+    delivered = await scheduled["restart_notification"]()
+
+    assert delivered is None
+    assert adapter.send_calls == 0
+    assert '"request_id":"new"' in notify_path.read_text(encoding="utf-8")
+
+    tasks = list(runner._background_tasks)
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Rebuilt semantically on current `main` at `5a0b1ba766956a1a16bc2f17dc3b83eb63633402`, preserving the current decomposed gateway startup and delivery-ledger architecture.

- Give each chat-originated `/restart` a unique request ID and publish its durable marker through a cancellation-safe atomic helper.
- Claim the exact boot marker before adapters reconnect or another restart replaces it.
- Run restart delivery, home-channel startup delivery, and claimed delivery-ledger redelivery as sibling boot tasks behind the existing bounded startup gate.
- Retry temporarily missing/degraded transports and retryable provider refusals within one hard deadline, honoring bounded `retry_after` values.
- Preserve known-unsent work after retryable budget exhaustion so a reconnect or later boot can redeliver it.
- Consume the marker only after successful, permanent-failure, or ambiguous provider-dispatch outcomes.
- Serialize marker compare/write/unlink operations with a cross-process file lock so an old worker cannot delete a newer restart request.
- Retain current main's delivery-ledger ownership/reclaim behavior rather than introducing a parallel supervisor.

This hardens the residual restart-notification path described in #72663: current startup/reconnect work removed some original trigger conditions but not the one-shot marker-loss invariant.

## Verification

- `scripts/run_tests.sh tests/gateway/test_restart_notification.py tests/gateway/test_restart_redelivery_dedup.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_startup_restart_race.py`: **98 passed**
- Ruff on all changed Python files: **passed**
- `git diff --check`: **passed**
- Rebased cleanly onto current `main`
- Exact-commit Codex review of `4fa210ab58ab630a5afe34380f13ddd520563a5e`: **no findings** after fixing retry-budget marker loss and cross-process cleanup races found in earlier review rounds

Full hosted CI remains authoritative.

## Scope

No generic delivery-ledger schema/protocol change, new retry supervisor, or gateway configuration option is added.
