### PR TITLE
fix(kanban): don't count deploy/gateway-restart worker kills as task crashes

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2463,6 +2463,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(json.dumps({
             "reclaimed": res.reclaimed,
             "crashed": res.crashed,
+            "interrupted": res.interrupted,
             "timed_out": res.timed_out,
             "stale": res.stale,
             "auto_blocked": res.auto_blocked,
@@ -2484,6 +2485,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     print(f"Crashed:      {len(res.crashed)}")
     if res.crashed:
         print(f"  {', '.join(res.crashed)}")
+    if res.interrupted:
+        print(f"Interrupted:  {len(res.interrupted)} (deploy/restart, requeued)")
+        print(f"  {', '.join(res.interrupted)}")
     print(f"Timed out:    {len(res.timed_out)}")
     if res.timed_out:
         print(f"  {', '.join(res.timed_out)}")
@@ -2614,12 +2618,13 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             return
         did_work = (
             res.reclaimed or res.crashed or res.timed_out or res.promoted
-            or res.spawned or res.auto_blocked or res.stale
+            or res.spawned or res.auto_blocked or res.stale or res.interrupted
         )
         if did_work:
             print(
                 f"[{_fmt_ts(int(time.time()))}] "
                 f"reclaimed={res.reclaimed} crashed={len(res.crashed)} "
+                f"interrupted={len(res.interrupted)} "
                 f"timed_out={len(res.timed_out)} stale={len(res.stale)} "
                 f"promoted={res.promoted} spawned={len(res.spawned)} "
                 f"auto_blocked={len(res.auto_blocked)}",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -258,6 +258,20 @@ DEFAULT_CRASH_GRACE_SECONDS = 30
 KANBAN_RATE_LIMIT_EXIT_CODE = 75
 
 
+# Signals that mean "gracefully asked to stop", NOT "the task failed".
+# A worker reaped as killed by one of these was almost certainly torn down
+# by systemd on a unit stop/restart (deploy, cv-hermes-update, operator
+# `systemctl restart`) or Ctrl-C'd from a parent shell — an infrastructure
+# event, not a task-logic failure. ``detect_crashed_workers`` releases such
+# tasks back to ``ready`` WITHOUT counting a failure (like the rate-limit
+# carve-out) so one restart window can't trip the circuit breaker and park an
+# otherwise-healthy card. Genuine crash signals (SIGKILL from the OOM killer,
+# SIGSEGV, SIGABRT, SIGBUS, SIGFPE, …) are deliberately EXCLUDED and still
+# count. SIGTERM==15, SIGINT==2 on every POSIX platform; hardcode so the set
+# is importable without a `signal` module dependency at module load.
+_GRACEFUL_TERMINATION_SIGNALS = frozenset({15, 2})  # SIGTERM, SIGINT
+
+
 def _resolve_crash_grace_seconds() -> int:
     """Return the crash-detection grace period in seconds.
 
@@ -6605,6 +6619,17 @@ class DispatchResult:
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
     counting a failure. These never trip the circuit breaker — a long quota
     window just makes the task bounce cheaply until the window clears."""
+    interrupted: list[str] = field(default_factory=list)
+    """Task ids whose workers were killed by a graceful-termination signal
+    (SIGTERM / SIGINT — see ``_GRACEFUL_TERMINATION_SIGNALS``) and were
+    released back to ``ready`` WITHOUT counting a failure. This is the
+    infrastructure-kill carve-out: a systemd unit stop/restart (deploy,
+    ``cv-hermes-update``, operator ``systemctl restart``) SIGTERMs both the
+    in-flight workers and the embedded dispatcher, so on restart the
+    dispatcher would otherwise score every torn-down worker as ``crashed``
+    and, on the second such kill inside ``failure_limit``, permanently
+    ``gave_up`` an otherwise-healthy card. Genuine crashes (SIGKILL/OOM,
+    SIGSEGV, …) are NOT in this bucket and still count."""
     skipped_locked: bool = False
     """True when this tick was skipped because another process already held
     the board's dispatch lock (issue #35240). A losing dispatcher does no
@@ -6663,15 +6688,31 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
       provider rate-limited / exhausted quota, NOT because the task failed.
       ``detect_crashed_workers`` releases the task back to ``ready`` without
       counting a failure, so a long quota window can't trip the breaker.
+    * ``"interrupted"`` — ``WIFSIGNALED`` by a *graceful-termination* signal
+      (``SIGTERM`` / ``SIGINT``, see ``_GRACEFUL_TERMINATION_SIGNALS``). This
+      is overwhelmingly an infrastructure event — a systemd unit stop/restart
+      (a deploy, ``cv-hermes-update``, an operator ``systemctl restart``), or
+      a parent shell ``Ctrl-C`` — NOT a task-logic failure. The dispatcher is
+      itself embedded in a gateway unit, so a fleet-wide restart SIGTERMs both
+      the workers and the dispatcher; when the dispatcher comes back it must
+      not count those graceful kills against the task's failure budget, or a
+      single deploy window that catches a task mid-run twice would permanently
+      ``gave_up`` it (regression: a 2026-07-20 deploy parked a productive
+      skill-revise card after two SIGTERMs inside ``failure_limit=2``).
+      ``detect_crashed_workers`` releases the task back to ``ready`` without
+      counting a failure, exactly like ``rate_limited``.
     * ``"nonzero_exit"`` — ``WIFEXITED`` with non-zero status. Real error.
-    * ``"signaled"`` — ``WIFSIGNALED`` (OOM killer, SIGKILL, etc). Real crash.
+    * ``"signaled"`` — ``WIFSIGNALED`` by any *other* signal (OOM killer /
+      ``SIGKILL``, ``SIGSEGV``, ``SIGABRT``, ``SIGBUS``, ``SIGFPE``, …). A
+      genuine crash: still counts toward the breaker. The OOM killer uses
+      ``SIGKILL``, so out-of-memory deaths correctly stay in this bucket.
     * ``"unknown"`` — pid was not in the reap registry (either reaped by
       something else, or died between reap tick and liveness check). Fall
       back to existing crashed-counter behavior.
 
     ``code`` is the exit status (for ``clean_exit`` / ``rate_limited`` /
-    ``nonzero_exit``) or the signal number (for ``signaled``), or ``None``
-    for ``unknown``.
+    ``nonzero_exit``) or the signal number (for ``signaled`` /
+    ``interrupted``), or ``None`` for ``unknown``.
     """
     entry = _recent_worker_exits.get(int(pid))
     if entry is None:
@@ -6686,7 +6727,10 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
                 return ("rate_limited", code)
             return ("nonzero_exit", code)
         if os.WIFSIGNALED(raw):
-            return ("signaled", os.WTERMSIG(raw))
+            sig = os.WTERMSIG(raw)
+            if sig in _GRACEFUL_TERMINATION_SIGNALS:
+                return ("interrupted", sig)
+            return ("signaled", sig)
     except Exception:
         pass
     return ("unknown", None)
@@ -7311,6 +7355,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
+    interrupted: list[str] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the
@@ -7344,6 +7389,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
+            interrupted_exit = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
@@ -7391,6 +7437,34 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     "claimer": row["claim_lock"],
                     "exit_code": code,
                 }
+            elif kind == "interrupted":
+                # Worker was killed by a graceful-termination signal
+                # (SIGTERM / SIGINT). This is an infrastructure event — a
+                # systemd unit stop/restart (deploy, cv-hermes-update,
+                # operator ``systemctl restart``) or a parent-shell Ctrl-C —
+                # NOT a task failure. Because the dispatcher is embedded in a
+                # gateway unit, a fleet restart SIGTERMs the workers AND the
+                # dispatcher together; without this carve-out the restarted
+                # dispatcher scores every torn-down worker as ``crashed`` and
+                # a second such kill inside ``failure_limit`` permanently
+                # ``gave_up``s an otherwise-healthy card (2026-07-20 deploy
+                # incident). Release back to ``ready`` and do NOT count a
+                # failure (skip ``_record_task_failure``), exactly like the
+                # rate-limit carve-out. Genuine crashes (SIGKILL/OOM, SIGSEGV,
+                # …) are classified ``signaled`` and still count.
+                protocol_violation = False
+                interrupted_exit = True
+                error_text = (
+                    f"pid {pid} killed by signal {code} "
+                    f"(graceful termination — likely deploy/gateway restart) — "
+                    f"requeued without counting a failure"
+                )
+                event_kind = "interrupted"
+                event_payload = {
+                    "pid": pid,
+                    "claimer": row["claim_lock"],
+                    "signal": code,
+                }
             else:
                 protocol_violation = False
                 if kind == "nonzero_exit":
@@ -7413,10 +7487,16 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 (row["id"], pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
-                # Rate-limited requeues are a clean release, not a crash —
-                # record the run outcome as ``rate_limited`` so the board
-                # history doesn't show a phantom crash for a quota wall.
-                _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
+                # Rate-limited requeues and graceful-termination interrupts
+                # are clean releases, not crashes — record a matching run
+                # outcome so the board history doesn't show a phantom crash
+                # for a quota wall or a deploy/restart.
+                if rate_limited_exit:
+                    _run_outcome = "rate_limited"
+                elif interrupted_exit:
+                    _run_outcome = "interrupted"
+                else:
+                    _run_outcome = "crashed"
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
@@ -7428,17 +7508,23 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload,
                     run_id=run_id,
                 )
-                if rate_limited_exit:
-                    # Stamp the failure-error column so ``check_respawn_guard``
-                    # recognizes this as a quota blocker and defers the
-                    # respawn until the window clears — WITHOUT touching
-                    # ``consecutive_failures`` (that's the whole point: no
-                    # breaker trip on a throttle).
+                if rate_limited_exit or interrupted_exit:
+                    # No-fault release: stamp last_failure_error for board/
+                    # operator visibility, but crucially do NOT touch
+                    # ``consecutive_failures`` — a quota window (rate-limit) or
+                    # a deploy/restart window (interrupt) must never trip the
+                    # breaker. The respawn guard reads this column; the
+                    # rate-limit text triggers a cooldown, while the interrupt
+                    # text is benign (no quota/auth blocker match) so the task
+                    # is immediately re-spawnable on the next healthy tick.
                     conn.execute(
                         "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
                         (error_text[:500], row["id"]),
                     )
-                    rate_limited.append(row["id"])
+                    if rate_limited_exit:
+                        rate_limited.append(row["id"])
+                    else:
+                        interrupted.append(row["id"])
                 else:
                     if protocol_violation:
                         # Stamp the failure error now: a below-budget
@@ -7548,6 +7634,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # Same side-channel for rate-limited requeues — these did NOT count a
     # failure and are NOT crashes, so they stay out of the ``crashed`` return.
     detect_crashed_workers._last_rate_limited = rate_limited  # type: ignore[attr-defined]
+    # Same side-channel for graceful-termination interrupts (SIGTERM/SIGINT,
+    # e.g. a deploy/gateway restart) — also released without counting a
+    # failure and kept out of the ``crashed`` return.
+    detect_crashed_workers._last_interrupted = interrupted  # type: ignore[attr-defined]
     return crashed
 
 
@@ -8106,6 +8196,15 @@ def _dispatch_once_locked(
     )
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
+    # Graceful-termination interrupts (SIGTERM/SIGINT — deploy / gateway
+    # restart, no failure counted) — surface for telemetry / tests. These
+    # tasks went back to ``ready`` and are immediately re-spawnable once the
+    # host settles; unlike rate-limits they carry no cooldown.
+    _crash_interrupted = getattr(
+        detect_crashed_workers, "_last_interrupted", []
+    )
+    if _crash_interrupted:
+        result.interrupted.extend(_crash_interrupted)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -876,6 +876,15 @@ def _exited_status(code: int) -> int:
     return code << 8
 
 
+def _signaled_status(sig: int, core: bool = False) -> int:
+    """Raw wait-status for a WIFSIGNALED child killed by ``sig``.
+
+    Low 7 bits carry the signal number; 0x80 is the core-dump flag. This is
+    the encoding ``os.WIFSIGNALED`` / ``os.WTERMSIG`` decode.
+    """
+    return sig | (0x80 if core else 0)
+
+
 def test_classify_worker_exit_recognizes_rate_limit_sentinel(kanban_home):
     import hermes_cli.kanban_db as _kb
 
@@ -979,6 +988,156 @@ def test_real_crash_still_counts_and_trips_breaker(kanban_home, monkeypatch):
         assert task.status == "blocked", (
             f"genuine crashes should still trip the breaker, got {task.status}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Deploy / gateway-restart carve-out: a worker killed by a graceful-
+# termination signal (SIGTERM / SIGINT) was torn down by an infrastructure
+# event (a systemd unit stop/restart during a deploy or cv-hermes-update, or
+# an operator Ctrl-C), NOT by a task failure. Because the dispatcher is
+# embedded in a gateway unit, a fleet-wide restart SIGTERMs the in-flight
+# workers AND the dispatcher together; on restart the dispatcher must not
+# score those graceful kills as crashes, or a single deploy window that
+# catches a task mid-run twice permanently ``gave_up``s an otherwise-healthy
+# card. Regression coverage for the 2026-07-20 deploy incident (a productive
+# skill-revise card parked after two SIGTERMs inside failure_limit=2).
+# ---------------------------------------------------------------------------
+
+
+def test_classify_worker_exit_recognizes_graceful_termination_signals(
+    kanban_home,
+):
+    import hermes_cli.kanban_db as _kb
+
+    # SIGTERM (15) and SIGINT (2) → interrupted, with or without a core bit.
+    for sig in (15, 2):
+        pid = 41000 + sig
+        _kb._record_worker_exit(pid, _signaled_status(sig))
+        assert _kb._classify_worker_exit(pid) == ("interrupted", sig)
+
+    # Genuine crash signals stay ``signaled`` and still count as crashes:
+    # SIGKILL (9, what the OOM killer sends), SIGSEGV (11), SIGABRT (6).
+    for sig in (9, 11, 6):
+        pid = 42000 + sig
+        _kb._record_worker_exit(pid, _signaled_status(sig, core=True))
+        assert _kb._classify_worker_exit(pid) == ("signaled", sig)
+
+
+def test_graceful_termination_requeues_without_counting_failure(
+    kanban_home, monkeypatch,
+):
+    """A SIGTERM/SIGINT kill releases the task to ``ready`` and leaves
+    ``consecutive_failures`` untouched — a deploy/restart window must never
+    trip the breaker, even when it catches the same task more times than
+    ``failure_limit``."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="deploy-kill", assignee="a")
+
+        # More SIGTERMs than DEFAULT_FAILURE_LIMIT (2). If any counted as a
+        # failure the task would be blocked well before the loop ends —
+        # exactly the incident being fixed.
+        for i in range(5):
+            pid = 50000 + i
+            kb.claim_task(conn, tid, claimer=f"{host}:w{i}")
+            conn.execute(
+                "UPDATE tasks SET worker_pid=?, consecutive_failures=? "
+                "WHERE id=?",
+                (pid, 0, tid),
+            )
+            conn.commit()
+            # Alternate SIGTERM / SIGINT to prove both are carved out.
+            sig = 15 if i % 2 == 0 else 2
+            _kb._record_worker_exit(pid, _signaled_status(sig))
+
+            crashed = kb.detect_crashed_workers(conn)
+            # Interrupts are NOT crashes.
+            assert tid not in crashed
+            interrupted = getattr(
+                _kb.detect_crashed_workers, "_last_interrupted", []
+            )
+            assert tid in interrupted
+
+            task = kb.get_task(conn, tid)
+            assert task.status == "ready", (
+                f"kill {i}: should requeue ready, got {task.status}"
+            )
+            assert task.consecutive_failures == 0, (
+                f"kill {i}: graceful termination must not count a failure, "
+                f"got {task.consecutive_failures}"
+            )
+
+        # An ``interrupted`` run outcome was recorded (never ``crashed``).
+        outcomes = [
+            r["outcome"] for r in conn.execute(
+                "SELECT outcome FROM task_runs WHERE task_id=?", (tid,),
+            ).fetchall()
+        ]
+        assert "interrupted" in outcomes
+        assert "crashed" not in outcomes
+
+
+def test_respawn_guard_allows_interrupted_task_immediately(
+    kanban_home, monkeypatch,
+):
+    """An interrupt requeue carries no cooldown and no auth-blocker text, so
+    the respawn guard lets the dispatcher re-spawn on the next healthy tick
+    (unlike a rate-limit requeue, which defers on a cooldown)."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="deploy-kill-guard", assignee="a")
+        kb.claim_task(conn, tid, claimer=f"{host}:w")
+        conn.execute(
+            "UPDATE tasks SET worker_pid=? WHERE id=?", (51000, tid),
+        )
+        conn.commit()
+        _kb._record_worker_exit(51000, _signaled_status(15))  # SIGTERM
+
+        kb.detect_crashed_workers(conn)
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        # The stamped last_failure_error must not match the quota/auth
+        # blocker regex (which would defer the task forever with no failure
+        # counter to free it).
+        assert task.last_failure_error
+        assert not _kb._RESPAWN_BLOCKER_RE.search(task.last_failure_error)
+        # No rate-limit cooldown and no auth blocker → respawnable now.
+        assert kb.check_respawn_guard(conn, tid) is None
+
+
+def test_dispatch_result_surfaces_interrupted(kanban_home, monkeypatch):
+    """``dispatch_once`` populates ``DispatchResult.interrupted`` for graceful
+    kills and keeps them out of ``crashed``/``rate_limited``."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="dispatch-interrupt", assignee="a")
+        kb.claim_task(conn, tid, claimer=f"{host}:w")
+        conn.execute(
+            "UPDATE tasks SET worker_pid=? WHERE id=?", (52000, tid),
+        )
+        conn.commit()
+        _kb._record_worker_exit(52000, _signaled_status(15))  # SIGTERM
+
+        # Stub spawn so the freed task isn't immediately re-claimed this tick.
+        result = kb.dispatch_once(conn, spawn_fn=lambda *a, **k: None)
+        assert tid in result.interrupted
+        assert tid not in result.crashed
+        assert tid not in result.rate_limited
 
 
 def test_respawn_guard_defers_rate_limited_within_cooldown(


### PR DESCRIPTION

## Problem

The kanban dispatcher counts every dead worker found by `detect_crashed_workers` as a `crashed` task failure and ticks `consecutive_failures`. But a worker killed by SIGTERM or SIGINT was torn down by an infrastructure event (a systemd unit stop or restart during a deploy, an operator `systemctl restart`, a parent-shell Ctrl-C), not by anything the task did.

This bites hard when the dispatcher runs embedded in a gateway process, which is how we run it. A fleet-wide deploy SIGTERMs the in-flight workers and the dispatcher together. When the dispatcher comes back it finds the torn-down worker PIDs dead, classifies them as crashes, and ticks the failure counter. A single deploy window that catches the same card mid-run twice reaches `failure_limit` and permanently gives the card up.

We hit exactly this in production: a deploy restarted every gateway, a healthy worker that had already pushed its fix commits was killed mid-run twice inside the restart window, and its card was parked `blocked` with `consecutive_failures=2` and `pid ... not alive` as the recorded error, even though the work was essentially done. Nothing was wrong with the task; the circuit breaker just could not tell a deploy from a crash.

## Fix

Modeled exactly on the existing rate-limit (EX_TEMPFAIL) carve-out:

- `_classify_worker_exit` gains an `interrupted` kind for WIFSIGNALED deaths by SIGTERM (15) or SIGINT (2), the signals systemd sends on unit stop/restart. Genuine crash signals (SIGKILL including the OOM killer, SIGSEGV, SIGABRT, SIGBUS, SIGFPE) stay `signaled` and still count, so real crashes and out-of-memory kills are unaffected.
- `detect_crashed_workers` releases an `interrupted` worker back to `ready` without calling `_record_task_failure` (no `consecutive_failures` increment), records an `interrupted` run outcome and event instead of a phantom `crashed`, and stamps a benign `last_failure_error`. Unlike a rate-limit requeue it carries no cooldown and does not match the auth/quota blocker regex, so the task is immediately re-spawnable once the host settles.
- `DispatchResult.interrupted` surfaces the affected ids; the CLI dispatch summary and JSON output report them.

## Tests

- SIGTERM and SIGINT classify as `interrupted`; SIGKILL, SIGSEGV, and SIGABRT stay `signaled`.
- Five alternating SIGTERM/SIGINT kills of one card never trip the breaker: the card stays `ready` with `consecutive_failures=0`, records `interrupted` outcomes, and never records `crashed`.
- A genuine non-zero exit still trips the breaker at `failure_limit`.
- The respawn guard lets an interrupted task run again immediately.
- `dispatch_once` populates `DispatchResult.interrupted`.

Ran locally on top of current main: `tests/hermes_cli/test_kanban_db.py` (234 passed) and `tests/hermes_cli/test_kanban_cli.py` (47 passed).

## Production experience

We have been running this in production across an 8-gateway deployment since 2026-07-20. Deploy windows no longer park healthy cards; genuine crashes still trip the breaker as before. Note the boundary honestly: if the dispatcher itself restarts together with the workers, its in-memory exit map cannot classify the already-dead PIDs, so for planned fleet-wide restarts we additionally quiesce and requeue cards before stopping units. This change is the correct classification for every case the live dispatcher can actually observe, and it removes the false-crash accounting entirely for worker-only terminations.

(Earlier reports from this deployment: #30896, #30897, #31618, #32730.)
