### PR TITLE
fix(kanban): reject un-dispatchable worktree cards at mint in create_task

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -137,6 +137,121 @@ KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
 
+WORKTREE_KIND = "worktree"
+
+
+def _path_is_git_repo(path: Optional[str]) -> bool:
+    """True if *path* is (or is) a git working tree or a bare repo.
+
+    Cheap filesystem probe — no subprocess. A worktree card branches from this
+    directory, so it must resolve to something git can operate on: a dir
+    containing ``.git`` (normal or linked worktree), or a bare repo (``HEAD`` +
+    ``objects``). We deliberately do NOT shell out to ``git rev-parse`` so the
+    check stays pure, fast, and usable in the mint path.
+    """
+    if not path:
+        return False
+    try:
+        p = Path(path).expanduser()
+    except (ValueError, OSError):
+        return False
+    if not p.is_dir():
+        return False
+    if (p / ".git").exists():
+        return True
+    # Bare repo shape.
+    return (p / "HEAD").is_file() and (p / "objects").is_dir()
+
+
+def _worktree_workspace_path_resolvable(workspace_path: Optional[str]) -> bool:
+    """A worktree ``workspace_path`` git can actually create a worktree at.
+
+    Non-empty is necessary but NOT sufficient — a garbage/relative/nonexistent
+    path is just as un-dispatchable as an empty one. Mirror what
+    ``_resolve_worktree_workspace`` actually does with an explicit path: the
+    target is dispatchable iff it is already a linked worktree checkout, iff it
+    is itself a git repo root, or iff walking up from its nearest existing
+    ancestor finds a git repo (``_repo_root_for_worktree_target``). A path with
+    no git repo anywhere in its ancestry can only ``spawn_failed`` at dispatch.
+    """
+    if not workspace_path or not workspace_path.strip():
+        return False
+    raw = workspace_path.strip()
+    # Relative paths are rejected at dispatch by resolve_workspace; treat them
+    # as un-resolvable at mint time too.
+    if not os.path.isabs(raw):
+        return False
+    try:
+        requested = Path(raw).expanduser()
+    except (ValueError, OSError):
+        return False
+    if _path_is_git_repo(raw):
+        return True
+    # Walk up from the nearest existing ancestor looking for a git repo, exactly
+    # as _repo_root_for_worktree_target does at dispatch. No subprocess: a git
+    # repo root/worktree carries a ``.git`` entry (or bare-repo HEAD+objects).
+    try:
+        current: Optional[Path] = requested
+        while current is not None:
+            if current.exists():
+                probe: Optional[Path] = current
+                while probe is not None:
+                    if _path_is_git_repo(str(probe)):
+                        return True
+                    probe = probe.parent if probe != probe.parent else None
+                return False
+            current = current.parent if current != current.parent else None
+    except (ValueError, OSError):
+        return False
+    return False
+
+
+def worktree_mint_is_broken(
+    workspace_kind: Optional[str],
+    workspace_path: Optional[str],
+    board_default_workdir: Optional[str],
+) -> Optional[str]:
+    """Return a reason string if a worktree mint can never dispatch, else None.
+
+    A ``workspace_kind=worktree`` card is dispatchable only if EITHER:
+      * ``workspace_path`` is a non-empty, absolute, resolvable path (a git
+        repo, or a path whose parent dir exists so git can create the worktree
+        there), OR
+      * the board carries a ``default_workdir`` that is itself a git repo (the
+        dispatcher falls back to it when the card omits a path).
+
+    Non-worktree kinds (scratch, dir, unset) are never flagged here — scratch is
+    the safe default and ``dir`` has its own absolute-path rule. Returns None
+    (OK) for those.
+
+    Mirrors ``coord/card_mint_guard.worktree_mint_is_broken`` in the pantheon
+    repo; inlined here (no pantheon import) so the reject fires for the raw
+    ``kanban_create`` tool / CLI path that pantheon's mint helpers cannot wrap.
+    """
+    kind = (workspace_kind or "").strip().lower()
+    if kind != WORKTREE_KIND:
+        return None
+    if _worktree_workspace_path_resolvable(workspace_path):
+        return None
+    if board_default_workdir and _path_is_git_repo(board_default_workdir):
+        return None
+    path_desc = (
+        "empty" if not (workspace_path or "").strip()
+        else f"unresolvable ({workspace_path!r})"
+    )
+    workdir_desc = (
+        "null" if not (board_default_workdir or "").strip()
+        else f"not a git repo ({board_default_workdir!r})"
+    )
+    return (
+        f"workspace_kind=worktree with {path_desc} workspace_path and a board "
+        f"default_workdir that is {workdir_desc} — the card can never dispatch "
+        f"(a worktree needs a git repo to branch from). Provide a non-empty "
+        f"resolvable workspace_path or set the board's default_workdir to a git "
+        f"repo, or use workspace_kind=scratch."
+    )
+
+
 
 def _assert_not_delegated_child_mutation() -> None:
     """Reject Kanban state mutations from ``delegate_task`` child contexts.
@@ -3015,6 +3130,7 @@ def create_task(
     # task would point cleanup at the user's source tree (#28818). The
     # containment guard in ``_cleanup_workspace`` is the safety rail, but
     # we also stop the bad state from being created in the first place.
+    board_default_workdir: Optional[str] = None
     if (
         workspace_path is None
         and project_repo is None
@@ -3024,7 +3140,32 @@ def create_task(
         board_meta = read_board_metadata(board_slug)
         board_default = board_meta.get("default_workdir")
         if board_default:
-            workspace_path = str(board_default)
+            board_default_workdir = str(board_default)
+            workspace_path = board_default_workdir
+
+    # Reject an un-dispatchable worktree mint at the source (loud, no row
+    # written). A ``workspace_kind=worktree`` card needs a git repo to branch
+    # from: without a resolvable explicit ``workspace_path`` AND without a
+    # git-repo board ``default_workdir`` to fall back to, dispatch can only
+    # ``spawn_failed`` until the breaker trips and parks the card silently
+    # blocked. Project-linked worktrees (``project_repo`` set) are exempt: their
+    # concrete path is derived from the project's primary repo inside the insert
+    # loop below, so ``workspace_path`` is legitimately still None here. This is
+    # the mint-gate counterpart to the pantheon card_mint_guard, covering the
+    # raw kanban_create tool / CLI path that pantheon's mint helpers cannot wrap.
+    #
+    # Pass the *explicit* path and the board default separately: an explicit
+    # worktree path is accepted when its parent dir exists (git creates the
+    # worktree there), but an inherited board default must be an actual git repo
+    # — it is meant to BE the repo to branch from, so a plain non-repo dir is
+    # still un-dispatchable even though its parent exists.
+    if project_repo is None:
+        _explicit_path = None if board_default_workdir else workspace_path
+        _worktree_reason = worktree_mint_is_broken(
+            workspace_kind, _explicit_path, board_default_workdir
+        )
+        if _worktree_reason is not None:
+            raise ValueError(_worktree_reason)
 
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -92,7 +92,18 @@ def test_run_slash_create_and_list(kanban_home):
 
 
 def test_run_slash_create_worktree_path_and_branch(kanban_home, tmp_path):
-    target = tmp_path / ".worktrees" / "t6-wire"
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@t"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "t"], check=True, capture_output=True)
+    (repo / "README.md").write_text("hi\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True)
+
+    target = repo / ".worktrees" / "t6-wire"
     target_arg = target.as_posix()
     out = kc.run_slash(
         f"create 'ship worktree' --workspace worktree:{target_arg} --branch wt/t6-wire"

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2639,14 +2639,24 @@ def test_resolve_workspace_accepts_absolute_dir_path(kanban_home, tmp_path):
 
 
 def test_resolve_workspace_rejects_relative_worktree_path(kanban_home):
-    """Worktree paths also must be absolute when explicitly set."""
+    """Worktree paths also must be absolute when explicitly set.
+
+    ``create_task`` now rejects a relative worktree path at mint (it can never
+    dispatch), so to still exercise ``resolve_workspace``'s own absolute-path
+    guard — the defense-in-depth rail for any legacy/pre-guard row — we create
+    a valid scratch task and rewrite the row to the bad worktree state directly.
+    """
     conn = kb.connect()
     try:
         tid = kb.create_task(
-            conn, title="wt", assignee="worker",
-            workspace_kind="worktree",
-            workspace_path="../escape",
+            conn, title="wt", assignee="worker", workspace_kind="scratch",
         )
+        conn.execute(
+            "UPDATE tasks SET workspace_kind='worktree', workspace_path='../escape' "
+            "WHERE id=?",
+            (tid,),
+        )
+        conn.commit()
         with pytest.raises(ValueError, match=r"non-absolute"):
             kb.resolve_workspace(kb.get_task(conn, tid))
     finally:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -242,7 +242,9 @@ def test_workspace_kind_validation(kanban_home):
 
 
 def test_create_task_persists_worktree_branch_name(kanban_home, tmp_path):
-    target = tmp_path / ".worktrees" / "t6-wire"
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    target = repo / ".worktrees" / "t6-wire"
     with kb.connect() as conn:
         tid = kb.create_task(
             conn,
@@ -268,6 +270,133 @@ def test_branch_name_requires_worktree_workspace(kanban_home):
             workspace_kind="scratch",
             branch_name="wt/bad",
         )
+
+
+# ---------------------------------------------------------------------------
+# Worktree mint hygiene — reject un-dispatchable worktree cards at mint time.
+# A ``workspace_kind=worktree`` card needs a git repo to branch from. If the
+# caller supplies no resolvable ``workspace_path`` AND the board carries no
+# git-repo ``default_workdir``, the card can never dispatch: it would
+# ``spawn_failed`` until the breaker trips and parks it silently blocked. Refuse
+# to write the row instead (regression: fleet-heal bad-worktree-mint incident,
+# residual after the pantheon card_mint_guard which only covered pantheon's own
+# mint helpers, not the raw ``kanban_create`` tool / CLI path).
+# ---------------------------------------------------------------------------
+
+def test_worktree_mint_rejects_empty_path_on_null_default_board(kanban_home):
+    with kb.connect() as conn, pytest.raises(ValueError, match="worktree"):
+        kb.create_task(
+            conn,
+            title="broken worktree",
+            assignee="hephaestus",
+            workspace_kind="worktree",
+        )
+
+
+def test_worktree_mint_rejects_relative_path(kanban_home):
+    with kb.connect() as conn, pytest.raises(ValueError, match="worktree"):
+        kb.create_task(
+            conn,
+            title="relative worktree",
+            workspace_kind="worktree",
+            workspace_path="relative/wt/path",
+        )
+
+
+def test_worktree_mint_rejects_nonexistent_parent_path(kanban_home):
+    # Absolute path whose PARENT does not exist and which is not itself a repo:
+    # git cannot create a worktree there, so the card is un-dispatchable.
+    with kb.connect() as conn, pytest.raises(ValueError, match="worktree"):
+        kb.create_task(
+            conn,
+            title="dangling worktree",
+            workspace_kind="worktree",
+            workspace_path="/nonexistent-abcxyz/deeper/still/wt",
+        )
+
+
+def test_worktree_mint_accepts_absolute_path_with_existing_parent(kanban_home, tmp_path):
+    # Explicit target under a real git repo whose .worktrees dir does not exist
+    # yet — dispatch walks up to the repo root, so mint must accept it.
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    target = repo / ".worktrees" / "t-ok"
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="ok worktree",
+            workspace_kind="worktree",
+            workspace_path=str(target),
+        )
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.workspace_kind == "worktree"
+    assert task.workspace_path == str(target)
+
+
+def test_worktree_mint_accepts_path_that_is_a_git_repo(kanban_home, tmp_path):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="repo worktree",
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+        )
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.workspace_path == str(repo)
+
+
+def test_worktree_mint_accepts_when_board_default_workdir_is_git_repo(kanban_home, tmp_path):
+    # No explicit workspace_path, but the board's default_workdir is a real git
+    # repo the dispatcher will fall back to — this is dispatchable, so accept.
+    repo = tmp_path / "board-repo"
+    _init_git_repo(repo)
+    kb.write_board_metadata("default", default_workdir=str(repo))
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="board-default worktree",
+            workspace_kind="worktree",
+        )
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    # create_task inherits the board default_workdir into workspace_path.
+    assert task.workspace_path == str(repo)
+
+
+def test_worktree_mint_rejects_when_board_default_workdir_not_a_repo(kanban_home, tmp_path):
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    kb.write_board_metadata("default", default_workdir=str(plain))
+    # The board default is inherited into workspace_path, but it is not a git
+    # repo and its own parent (tmp_path) exists — so the containment/parent rule
+    # would otherwise accept it. It must still be rejected because a worktree
+    # needs an actual git repo to branch from.
+    with kb.connect() as conn, pytest.raises(ValueError, match="git repo"):
+        kb.create_task(
+            conn,
+            title="non-repo board default worktree",
+            workspace_kind="worktree",
+        )
+
+
+def test_scratch_and_dir_mints_are_not_affected_by_worktree_guard(kanban_home, tmp_path):
+    with kb.connect() as conn:
+        # scratch with no path is always fine.
+        s = kb.create_task(conn, title="scratch ok", workspace_kind="scratch")
+        assert kb.get_task(conn, s).workspace_kind == "scratch"
+        # dir with an absolute path is governed by its own rules, not the
+        # worktree guard.
+        d = kb.create_task(
+            conn,
+            title="dir ok",
+            workspace_kind="dir",
+            workspace_path=str(tmp_path),
+        )
+        assert kb.get_task(conn, d).workspace_kind == "dir"
 
 
 # ---------------------------------------------------------------------------
@@ -2187,22 +2316,22 @@ def test_worktree_no_path_anchors_on_board_default_workdir(kanban_home, tmp_path
 
 
 def test_worktree_no_path_no_board_default_raises(kanban_home, tmp_path, monkeypatch):
-    """With neither an explicit workspace_path nor a board default_workdir,
-    resolution fails loudly pointing at default_workdir / worktree:<path> —
-    rather than silently materializing under the dispatcher's CWD (the old
-    behavior that scattered worktrees under whatever dir launched the
-    gateway)."""
-    # Park the dispatcher CWD inside a real git repo so the OLD cwd-anchored
-    # code would have "succeeded" — proving the new code does NOT use cwd.
+    """With neither an explicit workspace_path nor a board default_workdir, the
+    mint is rejected at ``create_task`` — the card can never dispatch (a worktree
+    needs a git repo to branch from), so we refuse to write the row rather than
+    let it ``spawn_failed`` until the breaker parks it silently blocked.
+
+    Previously the row was written and only ``resolve_workspace`` failed later;
+    the mint-time reject closes that green-when-broken gap. Park the dispatcher
+    CWD inside a real git repo so the OLD cwd-anchored code would have
+    "succeeded" — proving the new code does NOT use cwd to rescue the mint.
+    """
     decoy_repo = tmp_path / "decoy"
     _init_git_repo(decoy_repo)
     monkeypatch.chdir(decoy_repo)
     with kb.connect() as conn:
-        t = kb.create_task(conn, title="ship", workspace_kind="worktree")
-        task = kb.get_task(conn, t)
-        assert task is not None
-        with pytest.raises(ValueError, match="default_workdir"):
-            kb.resolve_workspace(task)
+        with pytest.raises(ValueError, match="worktree"):
+            kb.create_task(conn, title="ship", workspace_kind="worktree")
 
 
 def test_worktree_workspace_explicit_target_materializes_linked_worktree(kanban_home, tmp_path):


### PR DESCRIPTION

## Problem

A `workspace_kind=worktree` card needs a git repo to branch from. Today `create_task` accepts a worktree row even when the caller supplied no resolvable `workspace_path` and the board has no git-repo `default_workdir`. The row is written and looks created and routed, but `resolve_workspace` / `_resolve_worktree_workspace` can only fail at dispatch time: `spawn_failed` repeats until the circuit breaker trips `failure_limit` and parks the card silently `blocked`, with no comment and no signal. It sits invisible until someone sweeps for orphans.

We hit this repeatedly in production (8-gateway deployment, kanban-driven work): cards minted through the raw `kanban_create` tool or the `hermes kanban create` CLI with a bad or missing workspace path went dark this way. We first tried guarding it in our own orchestration helpers, but that only covers our wrappers; both the tool and the CLI funnel through `create_task` directly, so the gap belongs in the mint gate itself.

## Fix

After board `default_workdir` inheritance, `create_task` raises `ValueError` (no row written) when a worktree mint can never dispatch. Failing at mint time turns a silent dead card into an immediate, actionable error for the caller.

The resolvability predicate mirrors `_resolve_worktree_workspace` so the gate cannot reject anything dispatch would have accepted:

- an explicit path is dispatchable iff it is a git repo, an existing linked worktree checkout, or has a git repo somewhere in the ancestry of its nearest existing parent (`_repo_root_for_worktree_target`);
- an inherited board default must itself be an actual git repo;
- empty, relative, and repo-less paths are all rejected;
- project-linked worktrees are exempt: their concrete path is derived from the project's primary repo inside the insert loop, so there is nothing to validate at this point.

`scratch` and `dir` workspace kinds are untouched.

## Tests

New coverage in `tests/hermes_cli/test_kanban_db.py`: reject cases (empty path, relative path, repo-less absolute path, board default that is not a repo) and happy paths (path under a repo, path that is a repo, board default that is a repo, scratch/dir unaffected). Three pre-existing tests whose worktree fixtures relied on the old accept-then-fail-at-dispatch contract were updated to anchor their targets in a real git repo, or, for the `resolve_workspace` relative-path guard, to rewrite the row directly so that defense-in-depth rail stays covered.

Ran locally on top of current main: `tests/hermes_cli/test_kanban_db.py`, `tests/hermes_cli/test_kanban_cli.py`, `tests/hermes_cli/test_kanban_core_functionality.py` (458 passed).

## Production experience

Running in production across our 8-gateway deployment since 2026-07-22. The silent-blocked class this addresses has not recurred; bad mints now fail loudly at creation, where the caller can fix the path and retry.

(Earlier reports from this deployment: #30896, #30897, #31618, #32730.)
