### PR TITLE
feat(providers): add apiario-dev provider support

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -98,6 +98,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
     ),
+    "apiario-dev": HermesOverlay(
+        transport="openai_chat",
+        auth_type="api_key",
+        base_url_override="https://api.apiario.dev/v1",
+        base_url_env_var="APIARIO_BASE_URL",
+        extra_env_vars=("APIARIO_API_KEY",),
+    ),
     "anthropic": HermesOverlay(
         transport="anthropic_messages",
         extra_env_vars=("ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),


### PR DESCRIPTION
## What does this PR do?
- Adds native configuration support for the `apiario-dev` model provider in `hermes_cli/providers.py`.
- Sets up the proper endpoint override (`https://api.apiario.dev/v1`), authentication type (`api_key`), and associated environment variables (`APIARIO_BASE_URL` and `APIARIO_API_KEY`).

## Related Issue
- N/A

## Type of Change
- [x] New feature (non-breaking change which adds functionality)