### PR TITLE
fix(cron): preserve no-agent script failure alerts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3904,8 +3904,16 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
 
             # Deliver the final response to the origin/target chat.
             # If the agent responded with [SILENT], skip delivery (but
-            # output is already saved above).  Failed jobs always deliver.
-            deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
+            # output is already saved above). Failed jobs always deliver.
+            # Agent-backed failures can contain huge provider payloads, so
+            # summarize them. no_agent script failures already build a compact
+            # watchdog alert in run_job(); preserve that exact stderr/stdout.
+            if success:
+                deliver_content = final_response
+            elif job.get("no_agent") and final_response.strip():
+                deliver_content = final_response
+            else:
+                deliver_content = _summarize_cron_failure_for_delivery(job, error)
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -28,7 +28,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         return f"/tmp/{jid}.txt"
 
     def fake_deliver(job, content, adapters=None, loop=None):
-        calls.append(("deliver", job["id"]))
+        calls.append(("deliver", job["id"], content))
         return None
 
     def fake_mark(jid, ok, err=None, delivery_error=None):
@@ -89,15 +89,35 @@ def test_run_one_job_empty_response_is_soft_failure(monkeypatch):
 
 
 def test_run_one_job_failed_job_delivers_error(monkeypatch):
-    """A failed job still delivers (the error notice) and marks not-ok."""
+    """A failed agent-backed job still delivers a summarized error notice and marks not-ok."""
     calls = _patch_pipeline(monkeypatch, success=False, final="", error="boom")
 
     s.run_one_job({"id": "j5", "name": "t"})
 
-    kinds = [c[0] for c in calls]
-    assert "deliver" in kinds  # failures always deliver
+    deliveries = [c for c in calls if c[0] == "deliver"]
+    assert deliveries  # failures always deliver
+    assert "boom" in deliveries[0][2]
     mark = [c for c in calls if c[0] == "mark"][0]
     assert mark == ("mark", "j5", False)
+
+
+def test_run_one_job_no_agent_failure_delivers_script_alert(monkeypatch):
+    """no_agent script failures must preserve the script alert, not rewrite timeout text as provider failure."""
+    script_alert = "⚠ Cron watchdog 'thermostat' script failed\n\nCommandError: Timed out waiting for Sensi\n"
+    calls = _patch_pipeline(
+        monkeypatch,
+        success=False,
+        final=script_alert,
+        error="Script exited with code 1\nstderr:\nCommandError: Timed out waiting for Sensi",
+    )
+
+    s.run_one_job({"id": "j5b", "name": "thermostat", "no_agent": True})
+
+    deliveries = [c for c in calls if c[0] == "deliver"]
+    assert deliveries == [("deliver", "j5b", script_alert)]
+    assert "provider timeout" not in deliveries[0][2]
+    mark = [c for c in calls if c[0] == "mark"][0]
+    assert mark == ("mark", "j5b", False)
 
 
 def test_run_one_job_exception_marks_failure(monkeypatch):


### PR DESCRIPTION
## Problem
Failed `no_agent` watchdog jobs already produce a compact script-specific alert, but `run_one_job` discards it and runs the generic provider-failure summarizer. Script text such as `Timed out waiting for Sensi` can then be misreported as a model/provider timeout.

## Fix
Preserve the non-empty `final_response` for failed `no_agent` jobs. Agent-backed failures continue through the generic summarizer.

## Tests
- `tests/cron/test_run_one_job.py`: 11 passed
- `tests/cron`: 748 passed, 3 pre-existing warnings