### PR TITLE
fix(url_safety): allow DNS failure in proxy/sandbox environments (salvage of #68469 by @kuangmi-bit)

### DIFF
--- a/contributors/emails/kuangmi@nudge.com.cn
+++ b/contributors/emails/kuangmi@nudge.com.cn
@@ -1,0 +1,1 @@
+kuangmi-bit

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -135,9 +135,65 @@ class TestIsSafeUrl:
         ]):
             assert is_safe_url("http://[::1]:8080/") is False
 
-    def test_dns_failure_blocked(self):
-        """DNS failures now fail closed — block the request."""
+    def test_dns_failure_blocked(self, monkeypatch):
+        """DNS failures fail closed — block the request (no proxy configured)."""
+        for var in ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"):
+            monkeypatch.delenv(var, raising=False)
         with patch("socket.getaddrinfo", side_effect=socket.gaierror("Name resolution failed")):
+            assert is_safe_url("https://nonexistent.example.com") is False
+
+
+class TestProxyEnvironmentDnsDelegation:
+    """When an HTTP proxy is configured, DNS is delegated to the proxy.
+
+    Sandbox / proxy-only environments (Docker + Squid, NVIDIA OpenShell,
+    iron-proxy egress sandboxes) block direct DNS at the network level;
+    only HTTP(S) via the proxy works. is_safe_url must not fail closed on
+    the pre-flight DNS check there — the proxy is the egress boundary.
+    Regression tests for #32217 / PR #68469.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_proxy_env(self, monkeypatch):
+        for var in ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_dns_failure_allowed_when_proxy_configured(self, monkeypatch):
+        monkeypatch.setenv("HTTPS_PROXY", "http://host.docker.internal:9090")
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("blocked at network level")):
+            assert is_safe_url("https://api.openai.com/v1/models") is True
+
+    def test_lowercase_proxy_var_also_recognized(self, monkeypatch):
+        monkeypatch.setenv("http_proxy", "http://proxy.internal:3128")
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("no dns")):
+            assert is_safe_url("https://example.com/") is True
+
+    def test_metadata_hostname_still_blocked_with_proxy(self, monkeypatch):
+        """The blocked-hostname floor runs BEFORE the DNS skip."""
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("no dns")):
+            assert is_safe_url("http://metadata.google.internal/computeMetadata/v1/") is False
+
+    def test_literal_metadata_ip_still_blocked_with_proxy(self, monkeypatch):
+        """Literal IPs never take the DNS-failure path — floor intact."""
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+        assert is_safe_url("http://169.254.169.254/latest/meta-data/") is False
+
+    def test_literal_private_ip_still_blocked_with_proxy(self, monkeypatch):
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+        assert is_safe_url("http://192.168.1.1/admin") is False
+
+    def test_dns_success_path_unchanged_with_proxy(self, monkeypatch):
+        """When DNS resolves, the normal IP checks still apply under a proxy."""
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:3128")
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("10.0.0.5", 0)),
+        ]):
+            assert is_safe_url("https://internal.corp/") is False
+
+    def test_empty_proxy_var_does_not_trigger_delegation(self, monkeypatch):
+        monkeypatch.setenv("HTTPS_PROXY", "")
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("fail")):
             assert is_safe_url("https://nonexistent.example.com") is False
 
     def test_empty_url_blocked(self):
@@ -275,7 +331,9 @@ class TestIsSafeUrl:
         ]):
             assert is_safe_url("http://multimedia.nt.qq.com.cn/download?id=123") is False
 
-    def test_qq_multimedia_hostname_dns_failure_still_blocked(self):
+    def test_qq_multimedia_hostname_dns_failure_still_blocked(self, monkeypatch):
+        for var in ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"):
+            monkeypatch.delenv(var, raising=False)
         with patch("socket.getaddrinfo", side_effect=socket.gaierror("Name resolution failed")):
             assert is_safe_url("https://multimedia.nt.qq.com.cn/download?id=123") is False
 
@@ -637,6 +695,8 @@ class TestAllowPrivateUrlsIntegration:
     def test_dns_failure_still_blocked_with_toggle(self, monkeypatch):
         """DNS failures are still blocked even with toggle on."""
         monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "true")
+        for var in ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"):
+            monkeypatch.delenv(var, raising=False)
         with patch("socket.getaddrinfo", side_effect=socket.gaierror("fail")):
             assert is_safe_url("https://nonexistent.example.com") is False
 

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -442,8 +442,16 @@ def is_safe_url(url: str) -> bool:
             # the proxy rather than blocking the request outright.
             # The hostname was already checked against
             # _BLOCKED_HOSTNAMES above so metadata endpoints remain
-            # blocked regardless.
-            if _proxy_is_configured():
+            # blocked regardless.  Literal IPs never qualify — they
+            # need no DNS, so a getaddrinfo failure on one is not a
+            # proxy-environment symptom; keep them on the fail-closed
+            # path (and the blocked-IP floor) instead of delegating.
+            _is_literal_ip = True
+            try:
+                ipaddress.ip_address(hostname)
+            except ValueError:
+                _is_literal_ip = False
+            if not _is_literal_ip and _proxy_is_configured():
                 logger.debug(
                     "DNS resolution failed for %s — proxy configured, "
                     "allowing through for proxy-side resolution",

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -39,6 +39,21 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 
 
+# ── Proxy detection ──────────────────────────────────────────
+# Proxy environment variables that indicate the runtime should
+# delegate DNS to a proxy rather than attempting direct resolution.
+_PROXY_ENV_VARS = (
+    "HTTPS_PROXY", "https_proxy",
+    "HTTP_PROXY", "http_proxy",
+    "ALL_PROXY", "all_proxy",
+)
+
+
+def _proxy_is_configured() -> bool:
+    """Return True when at least one HTTP proxy env var is set."""
+    return any(os.environ.get(v) for v in _PROXY_ENV_VARS)
+
+
 def normalize_url_for_request(url: str) -> str:
     """Return an ASCII-safe HTTP URL for Hermes-owned URL tools.
 
@@ -420,8 +435,21 @@ def is_safe_url(url: str) -> bool:
         try:
             addr_info = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
         except socket.gaierror:
-            # DNS resolution failed — fail closed. If DNS can't resolve it,
-            # the HTTP client will also fail, so blocking loses nothing.
+            # DNS resolution failed.  In sandbox / proxy environments
+            # (NVIDIA OpenShell, Docker + Squid, etc.) the host may
+            # block direct DNS — only HTTP(S) through the proxy is
+            # permitted.  When a proxy is configured, delegate DNS to
+            # the proxy rather than blocking the request outright.
+            # The hostname was already checked against
+            # _BLOCKED_HOSTNAMES above so metadata endpoints remain
+            # blocked regardless.
+            if _proxy_is_configured():
+                logger.debug(
+                    "DNS resolution failed for %s — proxy configured, "
+                    "allowing through for proxy-side resolution",
+                    hostname,
+                )
+                return True
             logger.warning("Blocked request — DNS resolution failed for: %s", hostname)
             return False
 


### PR DESCRIPTION
## Summary

Web tools work again in proxy-only sandboxes (Docker + Squid, NVIDIA OpenShell, iron-proxy egress containers) where direct DNS is blocked at the network level: when an HTTP proxy env var is configured, `is_safe_url()` delegates hostname resolution to the proxy instead of failing closed on the pre-flight DNS check. Fixes #32217. Salvage of #68469 by @kuangmi-bit with authorship preserved, plus a hardening pass.

Root cause: `is_safe_url()` requires `socket.getaddrinfo()` to succeed before allowing any outbound request. In proxy-only environments DNS is intentionally unavailable — only HTTP(S) through the proxy works — so every web tool call was blocked even though the request would succeed. This includes our own iron-proxy egress sandboxes (#70848) when the container has no direct DNS.

## Changes

- `tools/url_safety.py` (salvaged from #68469): on `gaierror`, if `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` (any case) is set, delegate resolution to the proxy and allow; otherwise fail closed as before. Blocked-hostname floor (cloud metadata) runs before the skip.
- `tools/url_safety.py` (our hardening): literal-IP hostnames never take the delegation path — an IP needs no DNS, so a resolution failure on one is not a proxy symptom; they stay on the fail-closed path and the blocked-IP floor.
- `tests/tools/test_url_safety.py`: new `TestProxyEnvironmentDnsDelegation` class (7 regression tests: delegation fires, floor intact for metadata hostname + literal metadata IP + private IP, DNS-success path unchanged under proxy, empty proxy var ignored) and ambient-proxy-env guards on the 3 pre-existing DNS-failure tests.

## Validation

| Check | Result |
|---|---|
| `tests/tools/test_url_safety.py` | 144 passed, 0 failed |
| E2E: proxy env + broken DNS → public hostname | allowed (proxy-side resolution) |
| E2E: proxy env + broken DNS → metadata hostname / metadata IP / private IP | all blocked |
| E2E: no proxy + broken DNS | blocked (fail-closed preserved) |

## Infographic

![url_safety proxy DNS delegation](https://v3b.fal.media/files/b/0aa38fba/4zjc2EYxY592BIKOMxG0i_pjlgCqJ5.png)
