### PR TITLE
docs(profiles): export omits credentials, so it is not a full backup

### DIFF
--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -58,7 +58,7 @@ Copies your current profile's `config.yaml`, `.env`, `SOUL.md`, and skills into 
 hermes profile create backup --clone-all
 ```
 
-Copies **everything** — config, API keys, personality, all memories, skills, cron jobs, plugins. A complete working snapshot. Per-profile history is excluded (session history, `state.db`, `backups/`, `state-snapshots/`, `checkpoints/`) — these belong to the source profile and can reach tens of GB. For a full backup including history, use `hermes profile export` or `hermes backup` instead.
+Copies **everything** — config, API keys, personality, all memories, skills, cron jobs, plugins. A complete working snapshot. Per-profile history is excluded (session history, `state.db`, `backups/`, `state-snapshots/`, `checkpoints/`) — these belong to the source profile and can reach tens of GB. For a full backup including history and credentials, use `hermes backup`. `hermes profile export` is for moving a profile to another machine: it includes history but deliberately omits `.env` and `auth.json`, so you will need to re-run setup or copy your credentials across separately on the new machine.
 
 ### Clone from a specific profile
 
@@ -240,6 +240,13 @@ hermes profile rename coder dev-bot   # rename (updates alias + service)
 hermes profile export coder   # export to coder.tar.gz
 hermes profile import coder.tar.gz   # import from archive
 ```
+
+:::note
+`hermes profile export` omits credentials by design: `.env` and `auth.json` are excluded from the
+archive, so an export is safe to move around but is not a restorable backup on its own. After
+importing on a new machine, re-run setup or copy those files across through a channel you would
+trust with a secret. For a backup that keeps credentials, use `hermes backup`.
+:::
 
 ## Deleting a profile
 

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -58,7 +58,7 @@ Copies your current profile's `config.yaml`, `.env`, `SOUL.md`, and skills into 
 hermes profile create backup --clone-all
 ```
 
-Copies **everything** — config, API keys, personality, all memories, skills, cron jobs, plugins. A complete working snapshot. Per-profile history is excluded (session history, `state.db`, `backups/`, `state-snapshots/`, `checkpoints/`) — these belong to the source profile and can reach tens of GB. For a full backup including history and credentials, use `hermes backup`. `hermes profile export` is for moving a profile to another machine: it includes history but deliberately omits `.env` and `auth.json`, so you will need to re-run setup or copy your credentials across separately on the new machine.
+Copies **everything** — config, API keys, personality, all memories, skills, cron jobs, plugins. A complete working snapshot. Per-profile history is excluded (session history, `state.db`, `backups/`, `state-snapshots/`, `checkpoints/`) — these belong to the source profile and can reach tens of GB. For a full backup including history and credentials, use `hermes backup`. `hermes profile export` is for moving a profile to another machine: it never carries `.env` or `auth.json`, so you will need to re-run setup or copy your credentials across separately on the new machine.
 
 ### Clone from a specific profile
 
@@ -246,6 +246,11 @@ hermes profile import coder.tar.gz   # import from archive
 archive, so an export is safe to move around but is not a restorable backup on its own. After
 importing on a new machine, re-run setup or copy those files across through a channel you would
 trust with a secret. For a backup that keeps credentials, use `hermes backup`.
+
+How much else the archive carries depends on which profile you export. A named profile exports
+with its session history. Exporting the default profile also drops `state.db`, `checkpoints/`,
+`logs/`, and the various caches, because the default profile is `~/.hermes` itself and would
+otherwise pull in the repo checkout and multi-GB runtime state.
 :::
 
 ## Deleting a profile


### PR DESCRIPTION
The `--clone-all` note in `website/docs/user-guide/profiles.md` recommends `hermes profile export` for "a full backup". An export deliberately excludes credentials, so restoring from one leaves a profile that cannot authenticate.

### Why

`export_profile` in `hermes_cli/profiles.py` stages a filtered copy for named profiles:

```python
# Named profiles — stage a filtered copy to exclude credentials
_CREDENTIAL_FILES = {"auth.json", ".env"}
```

The default profile takes a different code path and reaches the same result, since `_DEFAULT_EXPORT_EXCLUDE_ROOT` lists both:

```python
"auth.json",            # API keys, OAuth tokens, credential pools
".env",                 # API keys (dotenv)
```

`hermes backup` does keep them. `_SECRET_FILE_NAMES = {".env", "auth.json", "state.db"}` in `hermes_cli/backup.py` exists to re-tighten their permissions to 0600 on restore, which only makes sense if they are in the archive.

### Verification

Round-tripped an export and import in an isolated `HERMES_HOME`. The archive contained `SOUL.md`, `profile.yaml`, `cron/`, `home/`, `logs/`, `memories/`, `plans/`, `sessions/` and `skills/`, and no `.env`. The imported profile had no `.env` either. The exclusion is not a dotfile rule: `skills/.bundled_manifest` is present in the archive.

### Changes

- Point the `--clone-all` note at `hermes backup` for a full backup, and describe `export` as the machine-to-machine move that omits `.env` and `auth.json`.
- Add a note in the Managing profiles section, where people run the command.

No behaviour change proposed. The split looks deliberate and right: an export is an artifact you might send someone, a backup is a local safety net. Only the guidance conflates them.

### Context

Nine users asked about profile portability on r/hermesagent between 2026-07-22 and 2026-07-24, several of them planning multi-machine migrations. A user who reads "full backup", exports, wipes and imports gets a profile that looks complete and cannot authenticate.