### PR TITLE
fix(desktop): remove Electron launch deprecations

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -131,6 +131,7 @@ import { createKeepAwake } from './power-save'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import * as remoteLifecycle from './remote-lifecycle'
 import { RemoteLivenessTracker, RemoteRevalidationCoordinator, revalidateRemoteConnection } from './remote-liveness'
+import { formatRendererConsoleError } from './renderer-console'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -609,11 +610,15 @@ const WINDOW_BUTTON_POSITION = {
 // (pure + unit-testable); computeNativeOverlayWidth() applies it per platform.
 // It's only the pre-layout fallback — the renderer measures the exact overlay
 // width live via the Window Controls Overlay API.
-const APP_ICON_PATHS = [
-  path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
-  path.join(APP_ROOT, 'dist', 'apple-touch-icon.png'),
-  path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png')
-]
+const APP_ICON_PATHS = IS_PACKAGED
+  ? [
+      // Prefer the real unpacked file. statSync on an app.asar path makes
+      // Electron's ASAR shim construct deprecated fs.Stats objects (DEP0180).
+      path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png'),
+      path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
+      path.join(APP_ROOT, 'dist', 'apple-touch-icon.png')
+    ]
+  : [path.join(APP_ROOT, 'public', 'apple-touch-icon.png'), path.join(APP_ROOT, 'dist', 'apple-touch-icon.png')]
 
 let rendererTitleBarTheme = null
 const terminalSessions = new Map()
@@ -3269,7 +3274,10 @@ function resolveWebDist() {
 }
 
 function resolveRendererIndex() {
-  const candidates = [path.join(APP_ROOT, 'dist', 'index.html'), path.join(resolveWebDist(), 'index.html')]
+  // resolveWebDist() prefers app.asar.unpacked in packaged builds. Check that
+  // real file before the app.asar fallback to avoid Electron's deprecated
+  // fs.Stats construction in the ASAR stat shim (DEP0180).
+  const candidates = [path.join(resolveWebDist(), 'index.html'), path.join(APP_ROOT, 'dist', 'index.html')]
   const found = candidates.find(fileExists)
 
   if (found) {
@@ -8534,22 +8542,15 @@ function createWindow() {
 
   mainWindow.webContents.on('unresponsive', () => rememberLog('[renderer] webContents became unresponsive'))
 
-  // Electron always passes the event first. The canonical (Electron 36+) shape
-  // is (event, messageDetails); the deprecated positional shape is
-  // (event, level, message, line, sourceId). Handle both. `level` is numeric
-  // (0..3), where 3 === error.
-  mainWindow.webContents.on('console-message', (_event, detailsOrLevel, message, line, sourceId) => {
-    const details = detailsOrLevel && typeof detailsOrLevel === 'object' ? detailsOrLevel : null
-    const level = details ? details.level : detailsOrLevel
+  // Electron 36+ passes messageDetails as the second argument. Keep the
+  // listener at the canonical two-argument shape: declaring the deprecated
+  // positional fields makes Electron populate them and warn on every launch.
+  mainWindow.webContents.on('console-message', (_event, details) => {
+    const line = formatRendererConsoleError(details)
 
-    if (level !== 3) {
-      return
+    if (line) {
+      rememberLog(line)
     }
-
-    const text = details ? details.message : message
-    const src = details ? details.sourceUrl : sourceId
-    const lineNo = details ? details.lineNumber : line
-    rememberLog(`[renderer console] ${text} (${src}:${lineNo})`)
   })
 
   if (DEV_SERVER) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8542,10 +8542,10 @@ function createWindow() {
 
   mainWindow.webContents.on('unresponsive', () => rememberLog('[renderer] webContents became unresponsive'))
 
-  // Electron 36+ passes messageDetails as the second argument. Keep the
-  // listener at the canonical two-argument shape: declaring the deprecated
+  // Electron 36+ passes message details as the first argument. Keep the
+  // listener at the canonical one-argument shape: declaring the deprecated
   // positional fields makes Electron populate them and warn on every launch.
-  mainWindow.webContents.on('console-message', (_event, details) => {
+  mainWindow.webContents.on('console-message', details => {
     const line = formatRendererConsoleError(details)
 
     if (line) {

--- a/apps/desktop/electron/renderer-console.test.ts
+++ b/apps/desktop/electron/renderer-console.test.ts
@@ -4,13 +4,13 @@ import { test } from 'vitest'
 
 import { formatRendererConsoleError } from './renderer-console'
 
-test('formats renderer console errors from Electron message details', () => {
+test('formats renderer console errors from Electron webContents details', () => {
   assert.equal(
     formatRendererConsoleError({
-      level: 3,
+      level: 'error',
       lineNumber: 17,
       message: 'renderer failed',
-      sourceUrl: 'file:///renderer.js'
+      sourceId: 'file:///renderer.js'
     }),
     '[renderer console] renderer failed (file:///renderer.js:17)'
   )
@@ -22,13 +22,13 @@ test('ignores missing renderer console details', () => {
 })
 
 test('ignores non-error renderer console messages', () => {
-  for (const level of [0, 1, 2]) {
+  for (const level of ['info', 'warning', 'debug'] as const) {
     assert.equal(
       formatRendererConsoleError({
         level,
         lineNumber: 1,
         message: 'not an error',
-        sourceUrl: 'file:///renderer.js'
+        sourceId: 'file:///renderer.js'
       }),
       null
     )

--- a/apps/desktop/electron/renderer-console.test.ts
+++ b/apps/desktop/electron/renderer-console.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { formatRendererConsoleError } from './renderer-console'
+
+test('formats renderer console errors from Electron message details', () => {
+  assert.equal(
+    formatRendererConsoleError({
+      level: 3,
+      lineNumber: 17,
+      message: 'renderer failed',
+      sourceUrl: 'file:///renderer.js'
+    }),
+    '[renderer console] renderer failed (file:///renderer.js:17)'
+  )
+})
+
+test('ignores missing renderer console details', () => {
+  assert.equal(formatRendererConsoleError(null), null)
+  assert.equal(formatRendererConsoleError(undefined), null)
+})
+
+test('ignores non-error renderer console messages', () => {
+  for (const level of [0, 1, 2]) {
+    assert.equal(
+      formatRendererConsoleError({
+        level,
+        lineNumber: 1,
+        message: 'not an error',
+        sourceUrl: 'file:///renderer.js'
+      }),
+      null
+    )
+  }
+})

--- a/apps/desktop/electron/renderer-console.ts
+++ b/apps/desktop/electron/renderer-console.ts
@@ -1,13 +1,13 @@
-import type { MessageDetails } from 'electron'
+import type { WebContentsConsoleMessageEventParams } from 'electron'
 
 function formatRendererConsoleError(
-  details: Pick<MessageDetails, 'level' | 'lineNumber' | 'message' | 'sourceUrl'> | null | undefined
+  details: Pick<WebContentsConsoleMessageEventParams, 'level' | 'lineNumber' | 'message' | 'sourceId'> | null | undefined
 ): string | null {
-  if (!details || details.level !== 3) {
+  if (!details || details.level !== 'error') {
     return null
   }
 
-  return `[renderer console] ${details.message} (${details.sourceUrl}:${details.lineNumber})`
+  return `[renderer console] ${details.message} (${details.sourceId}:${details.lineNumber})`
 }
 
 export { formatRendererConsoleError }

--- a/apps/desktop/electron/renderer-console.ts
+++ b/apps/desktop/electron/renderer-console.ts
@@ -1,0 +1,13 @@
+import type { MessageDetails } from 'electron'
+
+function formatRendererConsoleError(
+  details: Pick<MessageDetails, 'level' | 'lineNumber' | 'message' | 'sourceUrl'> | null | undefined
+): string | null {
+  if (!details || details.level !== 3) {
+    return null
+  }
+
+  return `[renderer console] ${details.message} (${details.sourceUrl}:${details.lineNumber})`
+}
+
+export { formatRendererConsoleError }


### PR DESCRIPTION
## What does this PR do?

Removes the Electron 40.10.2 deprecation warnings emitted when Hermes Desktop starts, without changing Electron or any dependency.

Packaged builds now resolve the real `app.asar.unpacked/dist` renderer assets before ASAR-internal fallbacks, avoiding Electron's deprecated `fs.Stats` compatibility shim. The renderer console listener now uses Electron's canonical single `details` argument (`Event<WebContentsConsoleMessageEventParams>`) while preserving error-only logging.

## Related Issue

No matching issue or PR found after searching the warning text, `DEP0180`, `console-message`, and `app.asar.unpacked`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/main.ts`
  - Prefer unpacked icon and renderer files before ASAR paths in packaged builds.
  - Use Electron 40's single-argument `console-message` details event; deprecated positional arguments are no longer requested.
- `apps/desktop/electron/renderer-console.ts`
  - Preserve error-level filtering and formatting in a pure helper.
  - Safely ignore missing event details.
- `apps/desktop/electron/renderer-console.test.ts`
  - Cover error formatting, missing details, and non-error levels.

## How to Test

1. `npm run typecheck`
2. `npm run lint`
3. `npx vitest run --project electron electron/renderer-console.test.ts`
4. `npm run test:ui`
5. `npm run pack`
6. Launch `release/win-unpacked/Hermes.exe` with `ELECTRON_ENABLE_LOGGING=1` and verify the three warning signatures are absent.

Verified on Windows x64 (`10.0.26200`):

- Typecheck: passed
- Lint: `0` errors (`21` existing warnings)
- Focused regression tests: `3/3` passed
- Electron 40.10.2 runtime probe confirmed the first argument carries `level`, `message`, `lineNumber`, and `sourceId`; the second argument is the deprecated numeric level.
- UI suite: `2,078` passed, `1` skipped
- Electron suite: `683` passed, `2` skipped; `17` existing cross-platform failures reproduced on clean `origin/main`
- Packaged build: passed with clean commit stamp
- Packaged runtime smoke: `0` `DEP0180`, `0` `console-message` deprecation, `0` `fs.Stats` constructor deprecation
- Verified unpacked `index.html` and `apple-touch-icon.png` are present

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — not applicable to this Desktop-only TypeScript change
- [x] I've added tests for my changes
- [x] I've tested on Windows x64 (`10.0.26200`)

### Documentation and Housekeeping

- [x] Documentation update — N/A; no user-facing behavior or configuration changed
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; all path construction remains through Node's `path` API
- [x] Tool descriptions/schemas update — N/A; no tool behavior changed

## Screenshots / Logs

Packaged runtime smoke result:

```text
commit: c99e4d99f834 (clean)
DEP0180: 0
'console-message' arguments are deprecated: 0
Use of the fs.Stats constructor is deprecated: 0
app.asar: present
app.asar.unpacked/dist/index.html: present
app.asar.unpacked/dist/apple-touch-icon.png: present
```
