### PR TITLE
fix(delegate): add iteration budget and batching guidance to child system prompt (#70834)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -666,6 +666,7 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    max_iterations: int = 50,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -700,7 +701,25 @@ def _build_child_system_prompt(
         "Keep your final summary tight: lead with outcomes, prefer bullet "
         "points over paragraphs, and don't replay your whole process. Your "
         "response is returned to the parent agent as a summary, and overlong "
-        "summaries crowd out the parent's context window."
+        "summaries crowd out the parent's context window.",
+    )
+    parts.append(
+        f"\n## Iteration Budget\n"
+        f"Your execution is capped at {max_iterations} tool-calling iterations.\n"
+        f"\n"
+        f"**One iteration = one model round-trip.** All tool calls you issue "
+        f"in a single response execute concurrently and count as ONE iteration. "
+        f"Batch independent calls (reads, searches, web fetches) together in "
+        f"the same response to maximize what you accomplish per iteration.\n"
+        f"\n"
+        f"For bulk fan-out — many tool calls whose results you'll process "
+        f"programmatically — use `execute_code` with `from hermes_tools import "
+        f"terminal, read_file, ...` to drive multiple operations inside a single "
+        f"iteration.\n"
+        f"\n"
+        f"Keep an eye on your remaining budget. When it runs low, wrap up your "
+        f"findings and provide your final summary — don't start new investigations "
+        f"you won't have room to finish.",
     )
     if role == "orchestrator":
         child_note = (
@@ -1195,6 +1214,7 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        max_iterations=max_iterations,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)


### PR DESCRIPTION
## Summary

Subagents spawned via `delegate_task` routinely exhaust `delegation.max_iterations` because the child system prompt never tells them about the iteration budget or that batching multiple tool calls into one response costs a single iteration.

**Root cause:** `_build_child_system_prompt()` in `tools/delegate_tool.py` only contains goal, context, workspace path, and summary-format instructions. It never mentions:
1. The iteration budget exists
2. All tool calls in one response = 1 iteration
3. Batch independent calls
4. Wrap up when budget runs low

**Evidence from production (batch ratio ~0.8–1.1 — fully serial):**

| Task | tool calls | tool-call turns | ratio |
|---|---|---|---|
| port feature + test + commit | 128 | 115 | 1.11 |
| wiki extraction + authoring | 88 | 80 | 1.10 |
| implement + tests + commit | 98 | 104 | 0.94 |
| multi-concern fix + verify | 80 | 104 | 0.77 |

## Changes

- **`tools/delegate_tool.py` — `_build_child_system_prompt()`:** Added `max_iterations: int = 50` keyword-only parameter.
- Appended an "Iteration Budget" section to the child system prompt that:
  1. Discloses the concrete budget (the passed `max_iterations` value).
  2. States the iteration-equals-round-trip rule: all tool calls in one response execute concurrently and count as one iteration.
  3. Recommends batching independent calls and using `execute_code` for bulk fan-out.
  4. Tells the subagent to wrap up when budget runs low.
- **`tools/delegate_tool.py` — call site in `_build_child_agent()`:** Threaded `max_iterations` (already in scope) through to the prompt builder.
- Default value of 50 preserves backward compatibility with existing callers including test helpers.

Closes #70834.