### PR TITLE
fix(hindsight): allow local LLM without API key (#70814)

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -75,6 +75,24 @@ _PROVIDER_DEFAULT_MODELS = {
     "openai_compatible": "your-model-name",
 }
 
+# Providers that don't need an API key (mirrors ``_PROVIDERS_WITHOUT_API_KEY``
+# in the upstream hindsight llm_wrapper.py). When one of these is used
+# without an explicit key, we pass the provider name as a sentinel so the
+# hindsight-api daemon doesn't raise ValueError on early versions that
+# lack the ``requires_api_key()`` check (hindsight-client < 0.6.1 edge).
+_LOCAL_PROVIDERS = frozenset({
+    "ollama",
+    "lmstudio",
+    "llamacpp",
+    "vertexai",
+    "litellm",
+    "litellmrouter",
+    "bedrock",
+    "nous",
+    "mock",
+    "none",
+})
+
 
 def _parse_int_setting(value: Any, default: int) -> int:
     """Parse an integer config/env value, falling back on invalid input."""
@@ -523,7 +541,7 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
 
     env_values = {
         "HINDSIGHT_API_LLM_PROVIDER": str(daemon_provider),
-        "HINDSIGHT_API_LLM_API_KEY": str(current_key or ""),
+        "HINDSIGHT_API_LLM_API_KEY": str(current_key or (daemon_provider if daemon_provider in _LOCAL_PROVIDERS else "")),
         "HINDSIGHT_API_LLM_MODEL": str(current_model),
         "HINDSIGHT_API_LOG_LEVEL": "info",
     }
@@ -1036,7 +1054,12 @@ class HindsightMemoryProvider(MemoryProvider):
                 kwargs = dict(
                     profile=self._config.get("profile", "hermes"),
                     llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
+                    llm_api_key=(
+                        self._config.get("llmApiKey")
+                        or self._config.get("llm_api_key")
+                        or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
+                        or (llm_provider if llm_provider in _LOCAL_PROVIDERS else "")
+                    ),
                     llm_model=self._config.get("llm_model", ""),
                 )
                 if self._llm_base_url:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -101,6 +101,27 @@ _PROVIDER_DEFAULT_MODELS = {
     "openai_compatible": "your-model-name",
 }
 
+# Providers that don't need an API key (mirrors ``_PROVIDERS_WITHOUT_API_KEY``
+# in the upstream hindsight llm_wrapper.py). When one of these is used
+# without an explicit key, we pass the provider name as a sentinel so the
+# hindsight-api daemon doesn't raise ValueError on early versions that
+# lack the ``requires_api_key()`` check (hindsight-client < 0.6.1 edge).
+# ``openai_compatible`` is included because it commonly points at a local
+# server (e.g. LM Studio) that requires no key.
+_LOCAL_PROVIDERS = frozenset({
+    "ollama",
+    "lmstudio",
+    "llamacpp",
+    "vertexai",
+    "litellm",
+    "litellmrouter",
+    "bedrock",
+    "nous",
+    "mock",
+    "none",
+    "openai_compatible",
+})
+
 
 def _parse_int_setting(value: Any, default: int) -> int:
     """Parse an integer config/env value, falling back on invalid input."""
@@ -585,7 +606,10 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
 
     env_values = {
         "HINDSIGHT_API_LLM_PROVIDER": str(daemon_provider),
-        "HINDSIGHT_API_LLM_API_KEY": str(current_key or ""),
+        # Check the ORIGINAL provider name against _LOCAL_PROVIDERS: the
+        # normalization above maps openai_compatible -> openai, which would
+        # otherwise drop LM Studio (openai_compatible) out of the no-key set.
+        "HINDSIGHT_API_LLM_API_KEY": str(current_key or (daemon_provider if current_provider in _LOCAL_PROVIDERS else "")),
         "HINDSIGHT_API_LLM_MODEL": str(current_model),
         "HINDSIGHT_API_LOG_LEVEL": "info",
     }
@@ -1228,7 +1252,8 @@ class HindsightMemoryProvider(MemoryProvider):
                     raise ImportError(str(_e))
                 from hindsight import HindsightEmbedded
                 HindsightEmbedded.__del__ = lambda self: None
-                llm_provider = self._config.get("llm_provider", "")
+                configured_provider = self._config.get("llm_provider", "")
+                llm_provider = configured_provider
                 if llm_provider in {"openai_compatible", "openrouter"}:
                     llm_provider = "openai"
                 logger.debug("Creating HindsightEmbedded client (profile=%s, provider=%s)",
@@ -1236,7 +1261,15 @@ class HindsightMemoryProvider(MemoryProvider):
                 kwargs = dict(
                     profile=self._config.get("profile", "hermes"),
                     llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or get_secret("HINDSIGHT_LLM_API_KEY", ""),
+                    # Sentinel decision uses the ORIGINAL provider name: the
+                    # normalization above maps openai_compatible -> openai,
+                    # which would otherwise drop LM Studio out of the no-key set.
+                    llm_api_key=(
+                        self._config.get("llmApiKey")
+                        or self._config.get("llm_api_key")
+                        or get_secret("HINDSIGHT_LLM_API_KEY", "")
+                        or (llm_provider if configured_provider in _LOCAL_PROVIDERS else "")
+                    ),
                     llm_model=self._config.get("llm_model", ""),
                 )
                 if self._llm_base_url:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -370,6 +370,102 @@ class TestConfig:
         assert captured["llm_provider"] == "openai"
 
 
+class TestLocalLlmNoApiKey:
+    """Local LLM providers must not require an API key (PR #70886).
+
+    Covers the sentinel fix (provider name passed as the key when none is
+    configured) plus the openai_compatible/LM Studio normalization gap:
+    ``daemon_provider = "openai" if provider in {"openai_compatible", ...}``
+    used to drop openai_compatible out of ``_LOCAL_PROVIDERS``, so LM Studio
+    via openai_compatible still crashed on an empty key.
+    """
+
+    def test_build_env_local_provider_uses_sentinel_when_no_key(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "ollama",
+            "llm_model": "qwen3:8b",
+        })
+        assert env["HINDSIGHT_API_LLM_PROVIDER"] == "ollama"
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == "ollama"
+
+    def test_build_env_openai_compatible_lmstudio_uses_sentinel_when_no_key(self):
+        # Regression: the daemon_provider normalization maps openai_compatible
+        # -> openai, which previously dropped it out of _LOCAL_PROVIDERS and
+        # made LM Studio crash with "LLM API key is required".
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai_compatible",
+            "llm_model": "local-model",
+            "llm_base_url": "http://localhost:1234/v1",
+        })
+        assert env["HINDSIGHT_API_LLM_PROVIDER"] == "openai"  # daemon wire format
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == "openai"   # sentinel, not ""
+
+    def test_build_env_cloud_provider_still_requires_key(self):
+        # Cloud providers must NOT receive the sentinel: empty key stays empty
+        # so the daemon's requires_api_key() check keeps enforcing it.
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == ""
+
+    def test_build_env_explicit_key_wins_over_sentinel(self):
+        env = _build_embedded_profile_env(
+            {"llm_provider": "ollama", "llm_model": "qwen3:8b"},
+            llm_api_key="secret-key",
+        )
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == "secret-key"
+
+    def test_get_client_openai_compatible_lmstudio_no_key_passes_sentinel(self, monkeypatch):
+        captured = {}
+
+        class FakeHindsightEmbedded:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
+        monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **k: None)
+        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = {
+            "profile": "hermes",
+            "llm_provider": "openai_compatible",
+            "llm_model": "local-model",
+        }
+        p._llm_base_url = "http://localhost:1234/v1"
+
+        p._get_client()
+
+        assert captured["llm_provider"] == "openai"
+        assert captured["llm_api_key"] == "openai"  # sentinel, not ""
+
+    def test_get_client_cloud_provider_no_key_passes_empty(self, monkeypatch):
+        captured = {}
+
+        class FakeHindsightEmbedded:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
+        monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **k: None)
+        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = {
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        }
+
+        p._get_client()
+
+        assert captured["llm_provider"] == "openai"
+        assert captured["llm_api_key"] == ""
+
+
 class TestPostSetup:
     def test_setup_cancel_at_mode_picker_writes_nothing(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes-home"


### PR DESCRIPTION
Fixes #70814 — Hindsight Memory refused to start when configured to use a local LLM (ollama, lmstudio, llamacpp, etc.) but no API key was provided, raising:

```
ValueError: LLM API key is required. Set HINDSIGHT_API_LLM_API_KEY environment variable.
```

## Root cause

Both `_build_embedded_profile_env()` and `_get_client()` passed an empty string for the LLM API key when none was configured. The daemon embed manager in `hindsight-embed` propagates all `HINDSIGHT_*` config keys into the daemon's environment (including those with empty values via the catch-all loop). This meant `HINDSIGHT_API_LLM_API_KEY=""` was set in the daemon environment, and older/unpatched versions of `hindsight-api` unconditionally validate that the key is non-empty, regardless of provider.

(Note: newer versions of the upstream `hindsight-api` package do have a `requires_api_key()` function that returns `False` for local providers, but the Hermes plugin should be resilient to older installed versions.)

## Fix

1. Add `_LOCAL_PROVIDERS` frozenset listing providers that don't need an API key (mirrors `_PROVIDERS_WITHOUT_API_KEY` in the upstream hindsight `llm_wrapper.py`).
2. In `_build_embedded_profile_env()`: when the provider is local and no explicit key was given, use the provider name as a sentinel value (e.g. `ollama`, `lmstudio`) instead of empty string — matching the pattern used in the upstream `.env.example`.
3. In `_get_client()`: same sentinel fallback when creating the `HindsightEmbedded` client.

## Testing

- [x] Python syntax verified (`ast.parse`)
- [x] Local providers (ollama, lmstudio, llamacpp, vertexai, litellm, bedrock, nous) get sentinel API key instead of empty string
- [x] Cloud providers (openai, anthropic, groq, gemini, minimax) still require explicit key
- [x] Explicitly configured keys still take priority over sentinel fallback