### PR TITLE
fix(tui): refuse empty prompt.submit truncation without confirm

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -38,7 +38,8 @@ import {
   planEdit,
   planReload,
   planRestore,
-  runRewindSubmit
+  runRewindSubmit,
+  truncateSubmitParams
 } from '../session/hooks/use-prompt-actions/rewind'
 import { useSubmitPrompt } from '../session/hooks/use-prompt-actions/submit'
 import { type SubmitTextOptions } from '../session/hooks/use-prompt-actions/utils'
@@ -274,7 +275,11 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       try {
         await requestGateway(
           'prompt.submit',
-          { session_id: runtimeIdRef.current, text: plan.text, truncate_before_user_ordinal: plan.truncateOrdinal },
+          {
+            session_id: runtimeIdRef.current,
+            text: plan.text,
+            ...truncateSubmitParams(plan.truncateOrdinal)
+          },
           PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
         )
       } catch (err) {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1450,7 +1450,8 @@ describe('usePromptActions restoreToMessage', () => {
       {
         session_id: RUNTIME_SESSION_ID,
         text: 'first prompt',
-        truncate_before_user_ordinal: 0
+        truncate_before_user_ordinal: 0,
+        confirm_empty_truncate: true
       },
       1_800_000
     )
@@ -1517,7 +1518,8 @@ describe('usePromptActions restoreToMessage', () => {
       {
         session_id: RUNTIME_SESSION_ID,
         text: 'first prompt',
-        truncate_before_user_ordinal: 0
+        truncate_before_user_ordinal: 0,
+        confirm_empty_truncate: true
       },
       1_800_000
     )
@@ -1562,7 +1564,8 @@ describe('usePromptActions restoreToMessage', () => {
       {
         session_id: RUNTIME_SESSION_ID,
         text: 'first prompt',
-        truncate_before_user_ordinal: 0
+        truncate_before_user_ordinal: 0,
+        confirm_empty_truncate: true
       },
       1_800_000
     )

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -53,7 +53,8 @@ import {
   planEdit,
   planReload,
   planRestore,
-  runRewindSubmit
+  runRewindSubmit,
+  truncateSubmitParams
 } from './rewind'
 import { useSlashCommand } from './slash'
 import { useSubmitPrompt } from './submit'
@@ -756,7 +757,11 @@ export function usePromptActions({
       try {
         await requestGateway(
           'prompt.submit',
-          { session_id: activeSessionId, text: plan.text, truncate_before_user_ordinal: plan.truncateOrdinal },
+          {
+            session_id: activeSessionId,
+            text: plan.text,
+            ...truncateSubmitParams(plan.truncateOrdinal)
+          },
           PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
         )
       } catch (err) {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { truncateSubmitParams } from './rewind'
+
+describe('truncateSubmitParams', () => {
+  it('omits truncation fields when no ordinal is set', () => {
+    expect(truncateSubmitParams(undefined)).toEqual({})
+  })
+
+  it('requires confirm_empty_truncate only for ordinal 0', () => {
+    expect(truncateSubmitParams(0)).toEqual({
+      truncate_before_user_ordinal: 0,
+      confirm_empty_truncate: true
+    })
+    expect(truncateSubmitParams(1)).toEqual({
+      truncate_before_user_ordinal: 1
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -26,6 +26,23 @@ import {
 type RequestGateway = <T = unknown>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
 
 /**
+ * Build `prompt.submit` truncation params. Ordinal 0 truncates to an empty
+ * transcript (restore/regenerate the first user turn) — the gateway refuses
+ * that edge unless `confirm_empty_truncate` is set, so stale clients cannot
+ * silently wipe a session via a leftover ordinal.
+ */
+export function truncateSubmitParams(truncateOrdinal: number | undefined): Record<string, unknown> {
+  if (truncateOrdinal === undefined) {
+    return {}
+  }
+
+  return {
+    truncate_before_user_ordinal: truncateOrdinal,
+    ...(truncateOrdinal === 0 ? { confirm_empty_truncate: true } : {})
+  }
+}
+
+/**
  * Rewind a turn: `prompt.submit` with an optional `truncate_before_user_ordinal`
  * (drops that user turn + everything after). Idle rewinds submit directly
  * (interrupting an idle agent can leave a stale interrupt flag that cancels the
@@ -53,7 +70,7 @@ export async function runRewindSubmit(
       {
         session_id: sessionId,
         text,
-        ...(truncateOrdinal !== undefined && { truncate_before_user_ordinal: truncateOrdinal })
+        ...truncateSubmitParams(truncateOrdinal)
       },
       PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
     )

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3280,7 +3280,7 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
                 },
             }
         )
-        assert resp["error"]["code"] == 4025
+        assert resp["error"]["code"] == 4028
         assert "confirm_empty_truncate" in resp["error"]["message"]
         # Explicit falsey values must not satisfy the opt-in either.
         for falsey in (False, 0, "", "false", "no"):
@@ -3296,7 +3296,7 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
                     },
                 }
             )
-            assert resp["error"]["code"] == 4025, falsey
+            assert resp["error"]["code"] == 4028, falsey
         assert server._sessions["empty-trunc-sid"]["history"] == history
         assert server._sessions["empty-trunc-sid"]["running"] is False
         assert server._sessions["empty-trunc-sid"]["history_version"] == 0

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3239,6 +3239,145 @@ def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
         server._sessions.pop("trunc-sid", None)
 
 
+def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
+    """Stale truncate_before_user_ordinal=0 must not wipe a non-empty transcript.
+
+    Desktop desync can attach ordinal 0 to an ordinary fresh submit. That cuts
+    at the first user message (history[:0] == []) and replace_messages() would
+    DELETE every durable row. Refuse unless confirm_empty_truncate is set.
+    """
+    replaced = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "done"},
+    ]
+    server._sessions["empty-trunc-sid"] = _session(history=list(history))
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    try:
+        # Missing confirm → refuse.
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "empty-trunc-sid",
+                    "text": "fresh typed message",
+                    "truncate_before_user_ordinal": 0,
+                },
+            }
+        )
+        assert resp["error"]["code"] == 4025
+        assert "confirm_empty_truncate" in resp["error"]["message"]
+        # Explicit falsey values must not satisfy the opt-in either.
+        for falsey in (False, 0, "", "false", "no"):
+            resp = server.handle_request(
+                {
+                    "id": "1",
+                    "method": "prompt.submit",
+                    "params": {
+                        "session_id": "empty-trunc-sid",
+                        "text": "fresh typed message",
+                        "truncate_before_user_ordinal": 0,
+                        "confirm_empty_truncate": falsey,
+                    },
+                }
+            )
+            assert resp["error"]["code"] == 4025, falsey
+        assert server._sessions["empty-trunc-sid"]["history"] == history
+        assert server._sessions["empty-trunc-sid"]["running"] is False
+        assert server._sessions["empty-trunc-sid"]["history_version"] == 0
+        assert replaced == []
+    finally:
+        server._sessions.pop("empty-trunc-sid", None)
+
+
+def test_prompt_submit_empty_truncation_allowed_with_confirm(monkeypatch):
+    """Intentional restore/regenerate of the first user turn may wipe history."""
+
+    seen = {}
+    replaced = []
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            seen["prompt"] = prompt
+            seen["history"] = conversation_history
+            return {
+                "final_response": "regenerated",
+                "messages": [
+                    *(conversation_history or []),
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "regenerated"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    class _FakeDB:
+        def replace_messages(self, key, messages):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "done"},
+    ]
+    server._sessions["confirm-empty-sid"] = _session(
+        agent=_Agent(), history=list(history)
+    )
+
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_emit", lambda *a: None)
+        monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "confirm-empty-sid",
+                    "text": "first",
+                    "truncate_before_user_ordinal": 0,
+                    "confirm_empty_truncate": True,
+                },
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert seen["prompt"] == "first"
+        assert seen["history"] == []
+        assert replaced == [("session-key", [])]
+        assert server._sessions["confirm-empty-sid"]["history"] == [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "regenerated"},
+        ]
+    finally:
+        server._sessions.pop("confirm-empty-sid", None)
+
+
 class _StopAfterOneNotificationPoll:
     def __init__(self):
         self._checks = 0

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10245,7 +10245,7 @@ def _(rid, params: dict) -> dict:
                 )
                 return _err(
                     rid,
-                    4025,
+                    4028,
                     "truncation would erase the entire session transcript; "
                     "resubmit with confirm_empty_truncate=true if this is intended",
                 )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10225,6 +10225,41 @@ def _(rid, params: dict) -> dict:
             if ordinal < 0 or ordinal >= len(user_indices):
                 return _err(rid, 4018, "target user message is no longer in session history")
             truncated = history[: user_indices[ordinal]]
+            # Stale clients can attach truncate_before_user_ordinal=0 to an
+            # ordinary submit. That resolves to history[:0] == [] and
+            # replace_messages() DELETEs every durable row — silent total
+            # transcript loss. Refuse the empty-truncation edge unless the
+            # client explicitly opts in (legitimate restore/regenerate of the
+            # first user turn).
+            if (
+                not truncated
+                and history
+                and not is_truthy_value(params.get("confirm_empty_truncate"))
+            ):
+                logger.warning(
+                    "prompt.submit: REFUSED empty truncation of session %s "
+                    "(%d messages would be wiped; ordinal=%d).",
+                    sid,
+                    len(history),
+                    ordinal,
+                )
+                return _err(
+                    rid,
+                    4025,
+                    "truncation would erase the entire session transcript; "
+                    "resubmit with confirm_empty_truncate=true if this is intended",
+                )
+            # Info for routine rewind/edit cuts; warning only when the client
+            # explicitly opts into wiping the whole transcript.
+            log_fn = logger.warning if not truncated else logger.info
+            log_fn(
+                "prompt.submit: truncating session %s history %d -> %d messages "
+                "(ordinal=%d)",
+                sid,
+                len(history),
+                len(truncated),
+                ordinal,
+            )
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
             if (db := _get_db()) is not None:


### PR DESCRIPTION
## Summary
Refuses empty `prompt.submit` truncation (ordinal=0) without explicit `confirm_empty_truncate=true`, preventing stale Desktop clients from silently wiping an entire session transcript via `replace_messages()`.

Root cause: a stale `truncate_before_user_ordinal=0` attached to an ordinary fresh submit resolved to `history[:0] == []`, and `replace_messages(session, [])` DELETEd every durable row — 308 messages lost in production (#70516).

## Changes
- `tui_gateway/server.py`: guard refusing `truncated == []` on non-empty history unless `confirm_empty_truncate` is set; logging every truncation (`history N -> M`)
- `apps/desktop/.../rewind.ts`: `truncateSubmitParams()` helper sends `confirm_empty_truncate: true` for ordinal 0 (legitimate restore/regenerate)
- `apps/desktop/.../session-tile-actions.ts` + `index.ts`: both `prompt.submit` callers updated to use the shared helper
- Tests: 2 Python regression tests (refuse without confirm, allow with confirm) + TS unit test for `truncateSubmitParams()`
- Salvage fix: error code 4028 instead of 4025 (4025 already used by `session.handoff`)

Credit: @HexLab98's original commits cherry-picked with authorship preserved.

## Validation
| | Before | After |
|---|---|---|
| ordinal=0 without confirm | silent transcript wipe | error 4028, history unchanged |
| ordinal=0 with confirm=true | works | works |
| ordinal>0 without confirm | works | works |
| Targeted tests | — | 4 passed |
| E2E (real imports) | — | 17/17 assertions passed |

Closes #70516

## Infographic

Image generation is unavailable in this environment (no FAL_KEY / portal credits). The infographic will be attached once available.