### PR TITLE
feat(weixin): add POST /api/weixin/send endpoint

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1412,6 +1412,9 @@ class APIServerAdapter(BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
+        # Peer adapters registry: Platform -> BasePlatformAdapter instance.
+        # Set by GatewayRunner at startup; used by /api/weixin/send.
+        self._peer_adapters: Dict[str, Any] = {}
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
         # Creation timestamps for orphaned-run TTL sweep
@@ -2023,6 +2026,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
             ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
             ("POST", "/v1/runs/{run_id}/stop", self._handle_stop_run),
+            ("POST", "/api/weixin/send", self._handle_weixin_send),
         ]
         if _CRON_AVAILABLE:
             # Chronos managed-cron fire webhook (NAS → agent). Authenticated
@@ -5722,6 +5726,112 @@ class APIServerAdapter(BasePlatformAdapter):
 
             return web.json_response({"status": "accepted", "job_id": job_id}, status=202)
 
+    # ------------------------------------------------------------------
+    # Weixin send proxy
+    # ------------------------------------------------------------------
+
+    async def _handle_weixin_send(self, request: "web.Request") -> "web.Response":
+        """POST /api/weixin/send - send a WeChat message via the gateway's
+        WeixinAdapter, avoiding the duplicate-session (ret=-2) problem.
+
+        Body: {"chat_id": "...", "message": "..."}
+        Returns: {"success": true/false, "message_id": "...", "error": "..."}
+        """
+        caller = (
+            request.headers.get("X-Forwarded-For", "").split(",")[0].strip()
+            or request.headers.get("X-Real-IP", "")
+            or request.remote
+            or "unknown"
+        )
+
+        auth_err = self._check_auth(request)
+        if auth_err:
+            logger.info(
+                "[weixin-send-audit] ts=%s caller=%s result=auth_failed",
+                time.strftime("%Y-%m-%dT%H:%M:%S%z"), caller,
+            )
+            return auth_err
+
+        if request.content_type != "application/json":
+            return web.json_response(
+                {"success": False, "error": "Content-Type must be application/json"},
+                status=415,
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(
+                {"success": False, "error": "invalid JSON body"},
+                status=400,
+            )
+
+        chat_id = (body.get("chat_id") or "").strip()
+        message = (body.get("message") or "").strip()
+
+        if not chat_id or not message:
+            return web.json_response(
+                {"success": False, "error": "chat_id and message are required"},
+                status=400,
+            )
+        if not (chat_id.endswith("@im.wechat") or chat_id.endswith("@chatroom")):
+            return web.json_response(
+                {"success": False, "error": "chat_id must end with @im.wechat or @chatroom"},
+                status=400,
+            )
+        if len(message) > 4096:
+            return web.json_response(
+                {"success": False, "error": "message too long (max 4096 chars)"},
+                status=400,
+            )
+
+        from gateway.config import Platform as _Plat
+        weixin_adapter = self._peer_adapters.get(_Plat.WEIXIN)
+        if weixin_adapter is None:
+            logger.info(
+                "[weixin-send-audit] ts=%s caller=%s chat=%s len=%d result=adapter_unavailable",
+                time.strftime("%Y-%m-%dT%H:%M:%S%z"), caller,
+                chat_id, len(message),
+            )
+            return web.json_response(
+                {"success": False, "error": "weixin adapter not connected"},
+                status=503,
+            )
+
+        try:
+            result = await weixin_adapter.send(chat_id=chat_id, content=message)
+            logger.info(
+                "[weixin-send-audit] ts=%s caller=%s chat=%s len=%d result=%s msg_id=%s error=%s",
+                time.strftime("%Y-%m-%dT%H:%M:%S%z"), caller,
+                chat_id, len(message),
+                "ok" if result.success else "send_failed",
+                result.message_id or "",
+                result.error or "",
+            )
+            resp: Dict[str, Any] = {"success": result.success}
+            if result.message_id:
+                resp["message_id"] = result.message_id
+            if result.error:
+                resp["error"] = result.error
+            status = 200 if result.success else 502
+            return web.json_response(resp, status=status)
+        except Exception as exc:
+            error_str = str(exc)
+            logger.info(
+                "[weixin-send-audit] ts=%s caller=%s chat=%s len=%d result=exception error=%s",
+                time.strftime("%Y-%m-%dT%H:%M:%S%z"), caller,
+                chat_id, len(message), error_str,
+            )
+            logger.exception("weixin send failed for %s", chat_id)
+            if "ret=-2" in error_str or "session" in error_str.lower():
+                return web.json_response(
+                    {"success": False, "error": error_str},
+                    status=503,
+                )
+            return web.json_response(
+                {"success": False, "error": error_str},
+                status=500,
+            )
 
     # ------------------------------------------------------------------
     # Output extraction helper

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11229,6 +11229,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self.delivery_router.adapters = self.adapters
         self._wire_teams_pipeline_runtime()
 
+        # Wire peer adapters into API server for /api/weixin/send proxy
+        if Platform.API_SERVER in self.adapters:
+            self.adapters[Platform.API_SERVER]._peer_adapters = self.adapters
+
         self._running = True
         self._update_runtime_status("running")
 

--- a/tests/gateway/test_api_server_weixin_send.py
+++ b/tests/gateway/test_api_server_weixin_send.py
@@ -1,0 +1,432 @@
+"""
+Tests for POST /api/weixin/send input validation and audit logging.
+
+Covers:
+- chat_id validation (empty, wrong format)
+- message validation (empty, too long)
+- Content-Type enforcement
+- Structured audit log output
+"""
+
+import logging
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.platforms.base import SendResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    """Create an adapter with optional API key."""
+    extra = {}
+    if api_key:
+        extra["key"] = api_key
+    config = PlatformConfig(enabled=True, extra=extra)
+    return APIServerAdapter(config)
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    """Create a minimal aiohttp app with just the weixin send endpoint."""
+    app = web.Application()
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/api/weixin/send", adapter._handle_weixin_send)
+    return app
+
+
+def _fake_weixin_adapter(*, success: bool = True, message_id: str = "mid-123",
+                          error: str = "") -> MagicMock:
+    """Create a mock WeixinAdapter."""
+    adapter = MagicMock()
+    adapter.send = AsyncMock(return_value=SendResult(
+        success=success, message_id=message_id, error=error,
+    ))
+    return adapter
+
+
+VALID_CHAT_ID = "user123@im.wechat"
+VALID_GROUP_ID = "group456@chatroom"
+VALID_MESSAGE = "hello"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Content-Type
+# ---------------------------------------------------------------------------
+
+
+class TestContentType:
+    @pytest.mark.asyncio
+    async def test_rejects_non_json_content_type(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                data="not json",
+                headers={"Content-Type": "text/plain"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 415
+        assert "application/json" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_accepts_json_content_type(self):
+        adapter = _make_adapter()
+        wx = _fake_weixin_adapter()
+        adapter._peer_adapters[Platform.WEIXIN] = wx
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                json={"chat_id": VALID_CHAT_ID, "message": VALID_MESSAGE},
+            )
+            body = await resp.json()
+
+        assert resp.status == 200
+        assert body["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: chat_id validation
+# ---------------------------------------------------------------------------
+
+
+class TestChatIdValidation:
+    @pytest.mark.asyncio
+    async def test_missing_chat_id(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                json={"message": "hello"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert "required" in body["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_chat_id(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                json={"chat_id": "", "message": "hello"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert "required" in body["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_chat_id_format_no_at_suffix(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                json={"chat_id": "user123", "message": "hello"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert "@im.wechat" in body["error"] or "@chatroom" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_chat_id_wrong_suffix(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                json={"chat_id": "user@slack.com", "message": "hello"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert "@im.wechat" in body["error"] or "@chatroom" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_valid_im_wechat_id(self):
+        adapter = _make_adapter()
+        wx = _fake_weixin_adapter()
+        adapter._peer_adapters[Platform.WEIXIN] = wx
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                json={"chat_id": VALID_CHAT_ID, "message": VALID_MESSAGE},
+            )
+            body = await resp.json()
+
+        assert resp.status == 200
+        wx.send.assert_awaited_once_with(chat_id=VALID_CHAT_ID, content=VALID_MESSAGE)
+
+    @pytest.mark.asyncio
+    async def test_valid_chatroom_id(self):
+        adapter = _make_adapter()
+        wx = _fake_weixin_adapter()
+        adapter._peer_adapters[Platform.WEIXIN] = wx
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                json={"chat_id": VALID_GROUP_ID, "message": VALID_MESSAGE},
+            )
+            body = await resp.json()
+
+        assert resp.status == 200
+        wx.send.assert_awaited_once_with(chat_id=VALID_GROUP_ID, content=VALID_MESSAGE)
+
+
+# ---------------------------------------------------------------------------
+# Tests: message validation
+# ---------------------------------------------------------------------------
+
+
+class TestMessageValidation:
+    @pytest.mark.asyncio
+    async def test_missing_message(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                json={"chat_id": VALID_CHAT_ID},
+            )
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert "required" in body["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_message(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                json={"chat_id": VALID_CHAT_ID, "message": ""},
+            )
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert "required" in body["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_message_too_long(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                json={"chat_id": VALID_CHAT_ID, "message": "x" * 4097},
+            )
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert "4096" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_message_at_max_length_accepted(self):
+        adapter = _make_adapter()
+        wx = _fake_weixin_adapter()
+        adapter._peer_adapters[Platform.WEIXIN] = wx
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/weixin/send",
+                json={"chat_id": VALID_CHAT_ID, "message": "x" * 4096},
+            )
+            body = await resp.json()
+
+        assert resp.status == 200
+        assert body["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: audit logging
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLogging:
+    @pytest.mark.asyncio
+    async def test_audit_log_on_success(self, caplog):
+        adapter = _make_adapter()
+        wx = _fake_weixin_adapter(success=True, message_id="mid-99")
+        adapter._peer_adapters[Platform.WEIXIN] = wx
+        app = _create_app(adapter)
+
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.api_server"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/api/weixin/send",
+                    json={"chat_id": VALID_CHAT_ID, "message": "test msg"},
+                )
+
+        assert resp.status == 200
+
+        # Find the audit log line
+        audit_lines = [r.message for r in caplog.records
+                       if "[weixin-send-audit]" in r.message]
+        assert len(audit_lines) == 1
+        line = audit_lines[0]
+        assert "caller=" in line
+        assert f"chat={VALID_CHAT_ID}" in line
+        assert "len=8" in line
+        assert "result=ok" in line
+
+    @pytest.mark.asyncio
+    async def test_audit_log_uses_x_forwarded_for(self, caplog):
+        adapter = _make_adapter()
+        wx = _fake_weixin_adapter(success=True, message_id="msg-1")
+        adapter._peer_adapters[Platform.WEIXIN] = wx
+        app = _create_app(adapter)
+
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.api_server"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/api/weixin/send",
+                    json={"chat_id": VALID_CHAT_ID, "message": "test"},
+                    headers={"X-Forwarded-For": "203.0.113.1, 10.0.0.1"},
+                )
+
+        assert resp.status == 200
+
+        audit_lines = [r.message for r in caplog.records
+                       if "[weixin-send-audit]" in r.message]
+        assert len(audit_lines) == 1
+        assert "caller=203.0.113.1" in audit_lines[0]
+
+    @pytest.mark.asyncio
+    async def test_audit_log_on_auth_failed(self, caplog):
+        adapter = _make_adapter()
+        adapter._api_key = "correct-key"
+        app = _create_app(adapter)
+
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.api_server"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/api/weixin/send",
+                    json={"chat_id": VALID_CHAT_ID, "message": "test"},
+                    headers={"Authorization": "Bearer wrong-key"},
+                )
+
+        assert resp.status == 401
+
+        audit_lines = [r.message for r in caplog.records
+                       if "[weixin-send-audit]" in r.message]
+        assert len(audit_lines) == 1
+        assert "result=auth_failed" in audit_lines[0]
+        assert "caller=" in audit_lines[0]
+
+    @pytest.mark.asyncio
+    async def test_audit_log_on_failure(self, caplog):
+        adapter = _make_adapter()
+        wx = _fake_weixin_adapter(success=False, error="timeout")
+        adapter._peer_adapters[Platform.WEIXIN] = wx
+        app = _create_app(adapter)
+
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.api_server"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/api/weixin/send",
+                    json={"chat_id": VALID_CHAT_ID, "message": "fail msg"},
+                )
+
+        assert resp.status == 502
+
+        audit_lines = [r.message for r in caplog.records
+                       if "[weixin-send-audit]" in r.message]
+        assert len(audit_lines) == 1
+        line = audit_lines[0]
+        assert "result=send_failed" in line
+        assert "error=timeout" in line
+
+    @pytest.mark.asyncio
+    async def test_audit_log_on_adapter_unavailable(self, caplog):
+        adapter = _make_adapter()
+        # No weixin adapter registered
+        app = _create_app(adapter)
+
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.api_server"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/api/weixin/send",
+                    json={"chat_id": VALID_CHAT_ID, "message": "test"},
+                )
+
+        assert resp.status == 503
+
+        audit_lines = [r.message for r in caplog.records
+                       if "[weixin-send-audit]" in r.message]
+        assert len(audit_lines) == 1
+        assert "result=adapter_unavailable" in audit_lines[0]
+
+    @pytest.mark.asyncio
+    async def test_audit_log_on_exception(self, caplog):
+        adapter = _make_adapter()
+        wx = MagicMock()
+        wx.send = AsyncMock(side_effect=RuntimeError("connection lost"))
+        adapter._peer_adapters[Platform.WEIXIN] = wx
+        app = _create_app(adapter)
+
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.api_server"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/api/weixin/send",
+                    json={"chat_id": VALID_CHAT_ID, "message": "boom"},
+                )
+
+        assert resp.status == 500
+
+        audit_lines = [r.message for r in caplog.records
+                       if "[weixin-send-audit]" in r.message]
+        assert len(audit_lines) == 1
+        assert "result=exception" in audit_lines[0]
+        assert "connection lost" in audit_lines[0]
+
+    @pytest.mark.asyncio
+    async def test_audit_log_never_contains_message_content(self, caplog):
+        """Privacy: the message body must not appear in any log line."""
+        adapter = _make_adapter()
+        wx = _fake_weixin_adapter()
+        adapter._peer_adapters[Platform.WEIXIN] = wx
+        app = _create_app(adapter)
+        secret = "super-secret-password-12345"
+
+        with caplog.at_level(logging.DEBUG, logger="gateway.platforms.api_server"):
+            async with TestClient(TestServer(app)) as cli:
+                await cli.post(
+                    "/api/weixin/send",
+                    json={"chat_id": VALID_CHAT_ID, "message": secret},
+                )
+
+        for record in caplog.records:
+            assert secret not in record.message, (
+                f"Message content leaked in log: {record.message}"
+            )


### PR DESCRIPTION
## What

Stateless HTTP send endpoint for WeChat messages, enabling external clients (alert-bridge, cron) to send without an agent session.

### POST /api/weixin/send

- **Auth**: Bearer token via API_SERVER_KEY
- **Input validation**: Content-Type (415), chat_id format @im.wechat/@chatroom (400), message length max 4096 (400)
- **Audit logging**: [weixin-send-audit] with caller/chat/len/result/msg_id (never logs message content)
- **Caller identity**: X-Forwarded-For support for reverse proxy deployments

### Why

Current WeChat sends require an agent session (send_message tool -> send_weixin_direct). alert-bridge and cron jobs need a stateless HTTP path that uses the live WeixinAdapter directly, avoiding duplicate-session (ret=-2) problems.

### Testing

- 19 unit tests: auth, validation (chat_id/message/Content-Type), success/failure/adapter-unavailable/exception audit, X-Forwarded-For
- Forge review: PASS (4 rounds converged)

### Diff

3 files changed, 546 insertions (no deletions).

Supersedes #70796 (which had api_server.py based on an old version, causing misleading +984/-4325 diff).

Signed-off-by: Minxi Hou <houminxi@gmail.com>