### PR TITLE
fix(mcp): prevent endless warning when no mcp_servers configured (#70881)

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -39,6 +39,12 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
             thread = _mcp_discovery_thread
             if thread is not None and thread.is_alive():
                 return
+            if not _has_configured_mcp_servers():
+                # No MCP servers configured: the first call intentionally
+                # returned without spawning a thread, so a threadless
+                # "started" state is expected here — not a failed
+                # discovery run to warn about and retry.
+                return
             try:
                 from tools.mcp_tool import get_mcp_status
 


### PR DESCRIPTION
Fixes #70881

## Problem

With no `mcp_servers` block in `config.yaml`, logs fill with:
```
WARNING tui_gateway.ws: Background MCP discovery previously exited with no connected servers; retrying discovery thread
```
One line per WebSocket (re)connect — every ~10-15 seconds, indefinitely.

## Root cause

In `start_background_mcp_discovery` (`hermes_cli/mcp_startup.py`):
1. First call sets `_mcp_discovery_started = True`, then `_has_configured_mcp_servers()` returns `False` → returns without spawning a thread
2. Every later call sees `_mcp_discovery_started == True` with `_mcp_discovery_thread is None` → logs warning, then the same config probe returns `False` again
3. Repeat forever

## Fix

In the retry branch, treat "no MCP servers configured" as the expected threadless state rather than a failed run. Add an early `_has_configured_mcp_servers()` check before the warning — if no servers are configured, return silently instead of logging a misleading warning.

The genuine-failure retry path (servers configured but none connected) is unchanged. If `mcp_servers` are added to the config while the process is running, the probe returns `True` and the retry path resumes working.