### PR TITLE
fix(browser): prevent network I/O in browser_cdp check_fn from destabilizing tool schema (#70811)

### DIFF
--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -556,33 +556,25 @@ def test_private_guard_inactive_does_not_probe(monkeypatch, cdp_server):
 
 
 def test_check_fn_false_when_no_cdp_url(monkeypatch):
-    """Gate closes when no CDP URL is set — even if the browser toolset is
-    otherwise configured."""
-    import tools.browser_tool as bt
-
-    monkeypatch.setattr(bt, "check_browser_requirements", lambda: True)
-    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+    """Gate closes when no CDP URL is configured (env var nor config.yaml)."""
+    monkeypatch.setattr(
+        browser_cdp_tool, "_has_configured_cdp_endpoint", lambda: False
+    )
     assert browser_cdp_tool._browser_cdp_check() is False
 
 
 def test_check_fn_true_when_cdp_url_set(monkeypatch):
-    """Gate opens as soon as a CDP URL is resolvable."""
-    import tools.browser_tool as bt
-
-    monkeypatch.setattr(bt, "check_browser_requirements", lambda: True)
+    """Gate opens when a CDP URL is configured — no I/O needed."""
     monkeypatch.setattr(
-        bt, "_get_cdp_override", lambda: "ws://localhost:9222/devtools/browser/x"
+        browser_cdp_tool, "_has_configured_cdp_endpoint", lambda: True
     )
     assert browser_cdp_tool._browser_cdp_check() is True
 
 
-def test_check_fn_false_when_browser_requirements_fail(monkeypatch):
-    """Even with a CDP URL, gate closes if the overall browser toolset is
-    unavailable (e.g. agent-browser not installed)."""
-    import tools.browser_tool as bt
-
-    monkeypatch.setattr(bt, "check_browser_requirements", lambda: False)
+def test_check_fn_false_when_websockets_missing(monkeypatch):
+    """Gate closes when websockets dependency is unavailable."""
+    monkeypatch.setattr(browser_cdp_tool, "_WS_AVAILABLE", False)
     monkeypatch.setattr(
-        bt, "_get_cdp_override", lambda: "ws://localhost:9222/devtools/browser/x"
+        browser_cdp_tool, "_has_configured_cdp_endpoint", lambda: True
     )
     assert browser_cdp_tool._browser_cdp_check() is False

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from typing import Any, Dict, Optional
 
 from tools.registry import registry, tool_error
@@ -346,7 +347,7 @@ def _browser_cdp_via_supervisor(
             f"frame_id {frame_id!r} is not an out-of-process iframe (no "
             f"dedicated CDP session). For same-origin iframes, use "
             f"`browser_cdp(method='Runtime.evaluate', params={{'expression': "
-            f"\"document.querySelector('iframe').contentDocument.title\"}})` "
+            f"\\\"document.querySelector('iframe').contentDocument.title\\\"}})` "
             f"at the top-level page instead."
         )
 
@@ -634,34 +635,57 @@ BROWSER_CDP_SCHEMA: Dict[str, Any] = {
 }
 
 
+def _has_configured_cdp_endpoint() -> bool:
+    """Check whether a CDP endpoint is configured — env var or config.yaml.
+
+    **Pure configuration check — no HTTP/WebSocket I/O.**
+
+    Reads ``BROWSER_CDP_URL`` (set by ``/browser connect``) and
+    ``browser.cdp_url`` from ``config.yaml`` directly, without resolving
+    the endpoint via ``/json/version``.  A configured but temporarily offline
+    endpoint does **not** make the tool disappear from the schema.
+    """
+    if os.environ.get("BROWSER_CDP_URL", "").strip():
+        return True
+    try:
+        from hermes_cli.config import read_raw_config  # type: ignore[import-not-found]
+
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {}) if isinstance(cfg, dict) else {}
+        if isinstance(browser_cfg, dict):
+            raw = str(browser_cfg.get("cdp_url", "") or "").strip()
+            if raw:
+                return True
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.debug("browser_cdp config read: %s", exc)
+    return False
+
+
 def _browser_cdp_check() -> bool:
-    """Availability check for browser_cdp.
+    """Availability check for browser_cdp — dependency + config only.
 
-    The tool is only offered when the Python side can actually reach a CDP
-    endpoint right now — meaning a static URL is set via ``/browser connect``
-    (``BROWSER_CDP_URL``) or ``browser.cdp_url`` in ``config.yaml``.
+    The tool is offered when:
+    1. The ``websockets`` dependency is available (``_WS_AVAILABLE``), AND
+    2. A CDP endpoint URL is **configured** (via ``BROWSER_CDP_URL`` env var
+       or ``browser.cdp_url`` in ``config.yaml``).
 
-    Backends that do *not* currently expose CDP to us — Camofox (REST-only),
-    the default local agent-browser mode (Playwright hides its internal CDP
+    This is a **pure schema-time gate** with **zero network I/O**.  The
+    endpoint may be offline at this point — reachability is checked at
+    invocation time and returns a structured ``cdp_unavailable`` error.
+
+    Backends that do *not* currently expose CDP — Camofox (REST-only),
+    default local agent-browser mode (Playwright hides its internal CDP
     port), and cloud providers whose per-session ``cdp_url`` is not yet
     surfaced — are gated out so the model doesn't see a tool that would
-    reliably fail.  Cloud-provider CDP routing is a follow-up.
+    reliably fail.
 
     Kept in a thin wrapper so the registration statement stays at module top
     level (the tool-discovery AST scan only picks up top-level
     ``registry.register(...)`` calls).
     """
-    try:
-        from tools.browser_tool import (  # type: ignore[import-not-found]
-            _get_cdp_override,
-            check_browser_requirements,
-        )
-    except ImportError as exc:  # pragma: no cover — defensive
-        logger.debug("browser_cdp check: browser_tool import failed: %s", exc)
+    if not _WS_AVAILABLE:
         return False
-    if not check_browser_requirements():
-        return False
-    return bool(_get_cdp_override())
+    return _has_configured_cdp_endpoint()
 
 
 registry.register(


### PR DESCRIPTION
## Summary

Fixes #70811.

`browser_cdp`'s `check_fn` (`_browser_cdp_check()`) performed network I/O by calling `_get_cdp_override()` → `_resolve_cdp_override()`, which issues an HTTP GET to `/json/version` on the configured CDP endpoint. Because `check_fn` runs during tool-schema resolution, a temporarily offline Chrome endpoint made `browser_cdp` disappear from the schema instead of returning a structured runtime error.

## Fix

Separate configuration-check from runtime-reachability-probe:

- **New function `_has_configured_cdp_endpoint()`** — reads `BROWSER_CDP_URL` env var and `browser.cdp_url` from `config.yaml` directly, **without** calling `_resolve_cdp_override()` (which does HTTP I/O). Returns `True`/`False` — pure config check.

- **Rewritten `_browser_cdp_check()`** — checks only `_WS_AVAILABLE` (websockets dep) + `_has_configured_cdp_endpoint()`. **Zero network I/O at schema time.**

- **Invocation-time probe unchanged** — `browser_cdp()` already calls `_resolve_cdp_endpoint()` → `_get_cdp_override()` → `_resolve_cdp_override()` → HTTP GET, and returns a structured `tool_error` with `/browser connect` guidance on failure. A dead endpoint fails at call time, not schema time.

## Tests

Updated three `check_fn` tests:
- `test_check_fn_false_when_no_cdp_url` — patch `_has_configured_cdp_endpoint` → `False`
- `test_check_fn_true_when_cdp_url_set` — patch `_has_configured_cdp_endpoint` → `True`  
- `test_check_fn_false_when_websockets_missing` — patch `_WS_AVAILABLE` → `False` (replaces old `test_check_fn_false_when_browser_requirements_fail` which tested a removed gate)

All 25 `test_browser_cdp_tool.py` tests pass.

## Verification

- A configured but temporarily offline CDP endpoint **no longer** makes `browser_cdp` disappear from the schema.
- At invocation time, a dead endpoint still returns `{"error": "No CDP endpoint is available. ..."}` via the existing `_resolve_cdp_endpoint()` probe.