### PR TITLE
fix(anthropic): prepended leading user turn must be non-whitespace (#70909)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2459,9 +2459,17 @@ def _ensure_leading_user_turn(result: List[Dict[str, Any]]) -> None:
     Mirror the Bedrock Converse adapter, which unconditionally prepends a
     minimal user turn when the first message is not user
     (convert_messages_to_converse).
+
+    The placeholder text must be NON-whitespace. A bare " " here is itself a
+    blank text block, which Anthropic rejects with HTTP 400 "text content
+    blocks must contain non-whitespace text" — so the guard for #52160 would
+    trip the very error class it sits next to, wedging every request for a
+    history whose first message is not a user turn (e.g. after compaction
+    emits an assistant summary first). Bedrock already uses the shared
+    placeholder here; match it.
     """
     if result and result[0].get("role") != "user":
-        result.insert(0, {"role": "user", "content": [{"type": "text", "text": " "}]})
+        result.insert(0, {"role": "user", "content": [{"type": "text", "text": _EMPTY_TEXT_PLACEHOLDER}]})
 
 
 def convert_messages_to_anthropic(

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2526,7 +2526,44 @@ def convert_messages_to_anthropic(
     _manage_thinking_signatures(result, base_url, model)
     _evict_old_screenshots(result)
 
+    # Final backstop: coerce any blank/whitespace-only text block that survived
+    # to this point, on the fully-assembled request. The per-message converters
+    # (_convert_assistant_message etc.) already coerce blanks they produce, but
+    # a blank text block can also be *synthesized after* those run — by context
+    # compression's summary message, role merges, or an upstream message whose
+    # content arrived pre-shaped as blocks — and any one blank block makes
+    # Anthropic reject the WHOLE request with HTTP 400 "text content blocks must
+    # contain non-whitespace text", wedging the session on every retry. Coercing
+    # here guarantees no path can leak a blank block onto the wire regardless of
+    # which layer created it. (#69512 follow-up)
+    _coerce_blank_text_blocks(system, result)
+
     return system, result
+
+
+def _coerce_blank_text_blocks(system: Any, messages: List[Dict[str, Any]]) -> None:
+    """In-place: replace every empty/whitespace-only text block with a
+    non-whitespace placeholder, across the system prompt and all messages.
+
+    A single blank text block anywhere in the request triggers Anthropic's
+    HTTP 400 ``text content blocks must contain non-whitespace text``. This is
+    the last line of defense for that error class — it runs on the final,
+    fully-assembled request so no upstream synthesis path (compression, merges,
+    pre-shaped block content) can slip a blank block past it. Only ``text``
+    blocks are touched; thinking / tool_use / image blocks obey different schema
+    rules and are left intact.
+    """
+    def _walk(blocks: Any) -> None:
+        if not isinstance(blocks, list):
+            return
+        for blk in blocks:
+            if isinstance(blk, dict) and blk.get("type") == "text":
+                blk["text"] = _safe_text(blk.get("text", ""))
+
+    _walk(system)  # system may be a list of content blocks (cache_control path)
+    for m in messages:
+        if isinstance(m, dict):
+            _walk(m.get("content"))
 
 
 def build_anthropic_kwargs(

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1394,7 +1394,14 @@ class TestConvertMessages:
 
         assert system == "You are helpful."
         assert result[0]["role"] == "user"
-        assert result[0]["content"] == [{"type": "text", "text": " "}]
+        # Invariant, not a frozen literal: the prepended turn is a single text
+        # block whose text is NON-whitespace. Anthropic rejects blank text
+        # blocks ("text content blocks must contain non-whitespace text"), so a
+        # whitespace placeholder here would 400 the very request this guard is
+        # meant to make valid.
+        assert len(result[0]["content"]) == 1
+        assert result[0]["content"][0]["type"] == "text"
+        assert result[0]["content"][0]["text"].strip()
         assert result[1]["role"] == "assistant"
         assert any(
             m["role"] == "assistant" and "Context compaction summary" in str(m["content"])
@@ -1418,7 +1425,11 @@ class TestConvertMessages:
 
         assert system is None
         assert result[0]["role"] == "user"
-        assert result[0]["content"] == [{"type": "text", "text": " "}]
+        # Invariant: the prepended placeholder text must be non-whitespace (see
+        # the sibling test above) — a blank text block 400s the whole request.
+        assert len(result[0]["content"]) == 1
+        assert result[0]["content"][0]["type"] == "text"
+        assert result[0]["content"][0]["text"].strip()
         assert result[1]["role"] == "assistant"
         assert "Context compaction summary" in str(result[1]["content"])
 

--- a/tests/agent/test_anthropic_request_blank_block_guard.py
+++ b/tests/agent/test_anthropic_request_blank_block_guard.py
@@ -1,0 +1,90 @@
+"""Regression: the final Anthropic request must carry no blank text block.
+
+`convert_messages_to_anthropic` runs per-message converters that coerce blanks
+they produce, but a blank/whitespace-only text block can be synthesized *after*
+those run — a compression summary message, a role merge, or an upstream message
+whose content arrives pre-shaped as content blocks. Any single blank text block
+makes Anthropic reject the whole request with HTTP 400 "text content blocks must
+contain non-whitespace text", which then replays on every turn and wedges the
+session.
+
+`_coerce_blank_text_blocks` is the final backstop on the fully-assembled request.
+Ref #69512 (follow-up: request-level guard, not just per-message).
+"""
+from agent.anthropic_adapter import (
+    _EMPTY_TEXT_PLACEHOLDER,
+    convert_messages_to_anthropic,
+)
+
+
+def _all_text_blocks(messages):
+    for m in messages:
+        content = m.get("content")
+        if isinstance(content, list):
+            for b in content:
+                if isinstance(b, dict) and b.get("type") == "text":
+                    yield b
+
+
+def _assert_no_blank(system, messages):
+    if isinstance(system, list):
+        for b in system:
+            if isinstance(b, dict) and b.get("type") == "text":
+                assert b["text"].strip(), f"blank text block in system: {b!r}"
+    for b in _all_text_blocks(messages):
+        assert b["text"].strip(), f"blank text block survived: {b!r}"
+
+
+def test_pre_shaped_blank_block_in_user_content_is_coerced():
+    # Content arrives already as blocks with a blank text part — the per-message
+    # user converter does not walk-and-coerce these, so the final guard must.
+    messages = [
+        {"role": "user", "content": [
+            {"type": "text", "text": "   "},
+            {"type": "text", "text": "real question"},
+        ]},
+    ]
+    system, result = convert_messages_to_anthropic(messages)
+    _assert_no_blank(system, result)
+
+
+def test_blank_summary_style_user_message_is_coerced():
+    # A compression summary that came back empty becomes a whitespace user
+    # message; it must not reach the wire as a blank block.
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "user", "content": "\n\n"},  # empty "summary"-style turn
+    ]
+    system, result = convert_messages_to_anthropic(messages)
+    _assert_no_blank(system, result)
+
+
+def test_blank_system_block_is_coerced():
+    messages = [
+        {"role": "system", "content": [
+            {"type": "text", "text": "  ", "cache_control": {"type": "ephemeral"}},
+        ]},
+        {"role": "user", "content": "hello"},
+    ]
+    system, result = convert_messages_to_anthropic(messages)
+    _assert_no_blank(system, result)
+
+
+def test_real_text_is_left_untouched():
+    # A real, non-blank turn keeps its text verbatim and is never replaced by
+    # the placeholder (the guard only touches blank blocks).
+    messages = [
+        {"role": "user", "content": "what is 2+2?"},
+    ]
+    system, result = convert_messages_to_anthropic(messages)
+    # Content may be a plain string or a list of blocks; collect text either way.
+    texts = []
+    for m in result:
+        c = m.get("content")
+        if isinstance(c, str):
+            texts.append(c)
+        elif isinstance(c, list):
+            texts.extend(b.get("text", "") for b in c if isinstance(b, dict) and b.get("type") == "text")
+    assert "what is 2+2?" in texts
+    assert _EMPTY_TEXT_PLACEHOLDER not in texts

--- a/tests/agent/test_anthropic_request_blank_block_guard.py
+++ b/tests/agent/test_anthropic_request_blank_block_guard.py
@@ -71,6 +71,22 @@ def test_blank_system_block_is_coerced():
     _assert_no_blank(system, result)
 
 
+def test_prepended_leading_user_turn_is_not_blank():
+    """The root cause: _ensure_leading_user_turn prepends a placeholder turn when
+    messages[0] is not a user turn (post-compaction histories start with an
+    assistant summary). That placeholder must be NON-whitespace — a bare " "
+    is itself a blank text block and 400s the whole request, wedging every turn.
+    Bedrock's equivalent already uses the shared placeholder.
+    """
+    messages = [
+        {"role": "assistant", "content": "summary of earlier turns"},
+        {"role": "user", "content": "continue"},
+    ]
+    system, result = convert_messages_to_anthropic(messages)
+    assert result[0]["role"] == "user", "a leading user turn must be prepended"
+    _assert_no_blank(system, result)
+
+
 def test_real_text_is_left_untouched():
     # A real, non-blank turn keeps its text verbatim and is never replaced by
     # the placeholder (the guard only touches blank blocks).


### PR DESCRIPTION
## Summary

Fixes #70909. A session wedges behind `HTTP 400: messages: text content blocks must contain non-whitespace text` — endless "thinking", no reply, every retry replaying the same 400.

**Root cause (proven, self-inflicted):** `_ensure_leading_user_turn` prepends a user turn when `messages[0]` is not a user message — which is the normal shape after context compaction emits an assistant summary first. The placeholder it inserted was a bare single space:

```python
result.insert(0, {"role": "user", "content": [{"type": "text", "text": " "}]})
```

A space-only text block is exactly what the Messages API rejects, so the guard added for #52160 trips this 400 itself. Bedrock's equivalent prepend already uses the shared non-whitespace placeholder (`bedrock_adapter.py`), and this function's docstring claims to mirror it, but it diverged on the one detail that matters.

**Verified against a real wedged history:** the assembled request carried exactly **one** blank text block — at index 0, the prepended turn. Stored rows were clean (no blank `content`/`api_content`/`reasoning*`; every stored assistant row run through `_convert_assistant_message` produced zero blanks), which is what pointed at assembly-time synthesis. With this change the same history assembles with **zero** blank blocks.

## Changes

1. **Root-cause fix** — `_ensure_leading_user_turn` uses `_EMPTY_TEXT_PLACEHOLDER` instead of `" "`, matching Bedrock.
2. **Backstop** — `_coerce_blank_text_blocks()` at the end of `convert_messages_to_anthropic` walks the fully-assembled request (system prompt + every message) and coerces any remaining blank `text` block. Independently justified: with the backstop disabled the root-cause fix handles the leading-turn case, but two other real paths still leak blanks — content that arrives **pre-shaped as blocks** with a blank text part, and a blank `cache_control` **system** block (neither is walked by the per-message converters). Only `text` blocks are touched; `thinking`/`tool_use`/`image` obey different schema rules.
3. **Test invariants** — the two #52160 tests asserted the frozen buggy literal (`assert content == [{"type": "text", "text": " "}]`), which would have blocked this fix. Rewritten to assert the invariant: one text block whose text is non-whitespace.

## Testing

```
pytest tests/agent/test_anthropic_request_blank_block_guard.py -q      # 5 passed
pytest tests/agent/test_anthropic_whitespace_text_blocks.py \
       tests/agent/test_anthropic_thinking_block_order.py \
       tests/agent/test_anthropic_adapter.py -q                        # 204 passed
```

Each layer verified independently: disabling the backstop leaves the leading-turn test passing (root cause genuinely fixed) while the pre-shaped-block and system-block tests fail (backstop not redundant). The 3 `TestRunOauthSetupToken` failures in that file are pre-existing on clean `main` (MagicMock/JSON in credential mocking), unrelated to this change.

---
*Root cause identified and both layers verified against a real wedged history.*
