### PR TITLE
fix(ui): add stream stall watchdog and live context meter in TUI/desktop (#70871)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3105,7 +3105,20 @@ class SessionStore:
             return False
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
-        """Load all messages from a session's transcript.
+        """Load all messages from a session's transcript for human viewing.
+
+        Includes compaction-archived rows (``active=0, compacted=1``) so
+        human-readable chat history preserves the full pre-compaction
+        conversation even after in-place context compaction. The agent's own
+        prompt still sees only the compacted summary.
+
+        Also walks the parent-session chain (``include_ancestors``) so that
+        legacy rotation-based compaction — where the old session is ended and a
+        child session carries the compressed transcript — still surfaces the
+        original messages in the human-facing display.
+
+        Rewind/undo rows (``active=0, compacted=0``) are NOT included since
+        those represent user-taken-back content, not archived history.
 
         state.db is the canonical store. The legacy JSONL fallback was removed
         in spec 002 — pre-DB sessions on existing disks have already been
@@ -3119,7 +3132,10 @@ class SessionStore:
             # would otherwise re-trigger the pre-request repair on every
             # request forever — heal it once at the restore boundary.
             return self._db.get_messages_as_conversation(
-                session_id, repair_alternation=True
+                session_id,
+                repair_alternation=True,
+                include_compaction_archived=True,
+                include_ancestors=True,
             )
         except Exception as e:
             logger.debug("Could not load messages from DB: %s", e)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6523,6 +6523,7 @@ class SessionDB:
         include_ancestors: bool = False,
         include_inactive: bool = False,
         repair_alternation: bool = False,
+        include_compaction_archived: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         Load messages in the OpenAI conversation format (role + content dicts).
@@ -6531,6 +6532,16 @@ class SessionDB:
         By default only active messages are returned. Pass
         ``include_inactive=True`` to load soft-deleted (rewound) rows
         as well. See :meth:`rewind_to_message`.
+
+        Pass ``include_compaction_archived=True`` to also include
+        compaction-archived rows (``active = 0 AND compacted = 1``) from the
+        same session — the pre-compaction transcript that in-place compaction
+        soft-archived via :meth:`archive_and_compact`. This gives human-facing
+        displays the full message history even after context compaction, while
+        the agent's own prompt still sees only the compacted summary. Rewind
+        and undo rows (``active = 0 AND compacted = 0``) are NOT included
+        unless ``include_inactive`` is also set, since those represent
+        user-taken-back messages, not archived history.
 
         ``repair_alternation=True`` runs ``repair_message_sequence`` over the
         loaded list before returning it. Callers that restore a session for
@@ -6546,7 +6557,14 @@ class SessionDB:
         if include_ancestors:
             session_ids = self._session_lineage_root_to_tip(session_id)
 
-        active_clause = "" if include_inactive else " AND active = 1"
+        if include_compaction_archived:
+            # Include active rows AND compaction-archived rows, but NOT
+            # rewind/undo rows (active=0, compacted=0). See #70846.
+            active_clause = " AND (active = 1 OR compacted = 1)"
+        elif include_inactive:
+            active_clause = ""
+        else:
+            active_clause = " AND active = 1"
         with self._lock:
             placeholders = ",".join("?" for _ in session_ids)
             rows = self._conn.execute(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -833,6 +833,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # API call (e.g. a set_my_commands stall for certain tokens) cannot
         # blow the gateway's connect timeout (#46298).
         self._post_connect_task: Optional[asyncio.Task] = None
+        # Proactive pool maintenance task — periodically drains the general
+        # request pool to prevent CLOSE-WAIT socket accumulation (#70830).
+        self._proactive_maintenance_task: Optional[asyncio.Task] = None
 
     def _mark_connected(self) -> None:
         self._drop_delayed_deliveries = False
@@ -2235,6 +2238,71 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] General request re-initialize failed after pool timeout (non-fatal)",
                     self.name, exc_info=True,
                 )
+
+    async def _proactive_pool_maintenance_loop(self) -> None:
+        """Periodically drain the general request pool to prevent CLOSE-WAIT
+        accumulation.
+
+        When Telegram's server closes a connection after responding, the local
+        TCP stack transitions to CLOSE-WAIT, waiting for the application (httpx)
+        to call close(). httpx's keepalive pool holds onto these connections
+        expecting to reuse them, but since the server already closed them they
+        sit in CLOSE-WAIT indefinitely — httpx's keepalive_expiry only affects
+        ESTABLISHED connections, not CLOSE-WAIT.
+
+        This loop runs on a 30s timer and calls shutdown() + initialize() on the
+        general request pool (``_request[1]``), which forces close of all
+        CLOSE-WAIT sockets before the pool can be exhausted.
+
+        Unlike the reactive ``_drain_general_connections_after_pool_timeout``
+        which only fires after httpx throws "All connections in the connection
+        pool are occupied", this runs proactively before the pool reaches
+        capacity.
+        """
+        MAINTENANCE_INTERVAL = 30  # seconds between proactive drains
+        while True:
+            try:
+                await asyncio.sleep(MAINTENANCE_INTERVAL)
+            except asyncio.CancelledError:
+                return
+
+            if getattr(self, "_polling_teardown_started", False):
+                return
+            if self.has_fatal_error:
+                return
+
+            bot = getattr(getattr(self, "_app", None), "bot", None) or getattr(self, "_bot", None)
+            if bot is None:
+                continue
+            try:
+                # PTB 22.x: _request is (get_updates_request, general_request).
+                general_req = bot._request[1]  # noqa: SLF001
+            except Exception:
+                continue
+
+            async with self._get_general_request_drain_lock():
+                try:
+                    await asyncio.wait_for(
+                        general_req.shutdown(), timeout=_DRAIN_TIMEOUT
+                    )
+                except Exception:
+                    logger.debug(
+                        "[%s] Proactive pool shutdown failed/timed out (non-fatal)",
+                        self.name, exc_info=True,
+                    )
+                try:
+                    await asyncio.wait_for(
+                        general_req.initialize(), timeout=_DRAIN_TIMEOUT
+                    )
+                    logger.debug(
+                        "[%s] Proactive pool drain completed (CLOSE-WAIT prevention)",
+                        self.name,
+                    )
+                except Exception:
+                    logger.debug(
+                        "[%s] Proactive pool re-initialize failed/timed out (non-fatal)",
+                        self.name, exc_info=True,
+                    )
 
     def _schedule_polling_recovery(self, error: Exception, *, reason: str) -> None:
         """Schedule polling recovery without failing gateway startup.
@@ -3874,6 +3942,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._polling_heartbeat_task = asyncio.ensure_future(
                     self._polling_heartbeat_loop()
                 )
+
+            # Proactive pool maintenance runs in both webhook and polling modes
+            # — the general request pool (_request[1]) is used for all Bot API
+            # calls (send_message, edit_message_text, etc.) regardless of how
+            # updates are received. Periodic shutdown + initialize forces close
+            # of CLOSE-WAIT sockets created when Telegram's server initiates a
+            # close after responding. Ref: #70830.
+            if self._proactive_maintenance_task and not self._proactive_maintenance_task.done():
+                self._proactive_maintenance_task.cancel()
+            self._proactive_maintenance_task = asyncio.ensure_future(
+                self._proactive_pool_maintenance_loop()
+            )
 
             # Command-menu registration, DM-topic setup, and the status
             # indicator each make Bot API calls that can stall for certain


### PR DESCRIPTION
Fixes #70871

## Problem 1 — UI freeze (busy stuck)

When the backend does not emit `message.complete` (context-compression abort, upstream disconnect mid-stream, interrupted response), the TUI/desktop stays in busy state indefinitely. The input box is frozen and the only workaround is typing another message to "wake" it.

### Fix
Add a stall watchdog timer (`STREAM_STALL_TIMEOUT_MS = 45000`) to the TUI's `TurnController`:
- **Armed** on every streaming delta/activity (`recordMessageDelta`, `recordInterimMessage`, `pushActivity`)
- **Disarmed** in `idle()`
- If the timer fires while still busy → force `idle()` and push a warning notice

**Backend** (`tui_gateway/server.py`):
- Added `_message_start_usage()` helper that extracts context fields from `context_compressor`
- All 5 `_emit("message.start")` call sites now send context payload

**TUI**:
- `gatewayTypes.ts`: allow `message.start` to carry context payload
- `createGatewayEventHandler.ts`: seed `usage.context_max` at `message.start`

**Desktop**:
- `gateway-event.ts`: seed `.context_max` at `message.start`
- Project `context_used` live via char-to-token estimate on `message.delta`