### PR TITLE
fix(telegram): restore 2×2 exec-approval button layout

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5149,7 +5149,10 @@ class TelegramAdapter(BasePlatformAdapter):
                         InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}")
                     )
             buttons.append(InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"))
-            keyboard = InlineKeyboardMarkup([buttons])
+            # Pair into rows (2x2 for the full set) so labels stay readable on
+            # mobile — a single 4-button row truncates to "Allo… / Ses… / …".
+            rows = [buttons[i:i + 2] for i in range(0, len(buttons), 2)]
+            keyboard = InlineKeyboardMarkup(rows)
 
             kwargs: Dict[str, Any] = {
                 "chat_id": normalize_telegram_chat_id(chat_id),

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -149,6 +149,54 @@ class TestTelegramExecApproval:
         assert buttons == ["✅ Allow Once", "✅ Session", "❌ Deny"]
 
     @pytest.mark.asyncio
+    async def test_full_approval_keyboard_is_two_by_two(self, monkeypatch):
+        """Regression: d48bf743f flattened all buttons into one row (4x1)."""
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+        captured_rows = []
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: text,
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup",
+            lambda rows: captured_rows.extend(rows) or rows,
+        )
+
+        await adapter.send_exec_approval(
+            chat_id="12345", command="curl example.test", session_key="s",
+        )
+
+        assert captured_rows == [
+            ["✅ Allow Once", "✅ Session"],
+            ["✅ Always", "❌ Deny"],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_three_button_keyboard_pairs_then_singleton(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+        captured_rows = []
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: text,
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup",
+            lambda rows: captured_rows.extend(rows) or rows,
+        )
+
+        await adapter.send_exec_approval(
+            chat_id="12345", command="curl example.test", session_key="s",
+            allow_permanent=False,
+        )
+
+        assert captured_rows == [
+            ["✅ Allow Once", "✅ Session"],
+            ["❌ Deny"],
+        ]
+
+    @pytest.mark.asyncio
     async def test_stores_approval_state(self):
         adapter = _make_adapter()
         mock_msg = MagicMock()

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -197,6 +197,30 @@ class TestTelegramExecApproval:
         ]
 
     @pytest.mark.asyncio
+    async def test_smart_deny_two_buttons_share_one_row(self, monkeypatch):
+        """smart_deny yields 2 buttons — they pair into a single readable row."""
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+        captured_rows = []
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: text,
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup",
+            lambda rows: captured_rows.extend(rows) or rows,
+        )
+
+        await adapter.send_exec_approval(
+            chat_id="12345", command="curl example.test", session_key="s",
+            allow_permanent=False, smart_denied=True,
+        )
+
+        assert captured_rows == [
+            ["✅ Allow Once", "❌ Deny"],
+        ]
+
+    @pytest.mark.asyncio
     async def test_stores_approval_state(self):
         adapter = _make_adapter()
         mock_msg = MagicMock()


### PR DESCRIPTION
## Summary
Exec-approval buttons on Telegram were flattened into a single 4-button row after the smart-deny conditional keyboard change (d48bf743f), truncating labels on mobile. This pairs them into rows of 2, restoring the readable 2×2 grid.

Root cause: commit d48bf743f refactored the hardcoded 2×2 keyboard into a dynamic `buttons` list but wrapped it as `InlineKeyboardMarkup([buttons])` — one single row instead of the original 2×2 layout.

## Changes
- `plugins/platforms/telegram/adapter.py`: Replace `InlineKeyboardMarkup([buttons])` with `InlineKeyboardMarkup([buttons[i:i+2] for i in range(0, len(buttons), 2)])` — pairs buttons into rows of 2, matching the existing `send_choice_picker` convention.
- `tests/gateway/test_telegram_approval_buttons.py`: Regression tests for 4-button (2×2), 3-button (2+1), and 2-button smart_deny (1×2) row layouts.

## Validation
| | Before | After |
|---|---|---|
| Button layout | 1 row × 4 buttons (truncated) | 2 rows × 2 buttons (readable) |
| Tests | 25 passed | 26 passed |
| Ruff | clean | clean |

Salvage of #70615 by @HexLab98 — contributor commits cherry-picked with authorship preserved. Added one follow-up test for the 2-button smart_deny row-structure case.

Closes #70615
