### PR TITLE
fix(kanban): board default_workdir inheritance for CLI/tool-created tasks

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -95,13 +95,15 @@ def _run_state_kwargs(args: argparse.Namespace) -> Optional[dict[str, str]]:
     return {"state_type": st, "state_name": sn}
 
 
-def _parse_workspace_flag(value: str) -> tuple[str, Optional[str]]:
+def _parse_workspace_flag(value: Optional[str]) -> tuple[Optional[str], Optional[str]]:
     """Parse ``--workspace`` into ``(kind, path|None)``.
 
     Accepts: ``scratch``, ``worktree``, ``worktree:<path>``, ``dir:<path>``.
+    When ``value`` is ``None`` or empty, returns ``(None, None)`` so the
+    board's ``default_workdir`` can be resolved by :func:`kanban_db.create_task`.
     """
     if not value:
-        return ("scratch", None)
+        return (None, None)
     v = value.strip()
     if v in {"scratch", "worktree"}:
         return (v, None)
@@ -1457,7 +1459,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
     except argparse.ArgumentTypeError as exc:
         print(f"kanban: {exc}", file=sys.stderr)
         return 2
-    if branch_name and ws_kind != "worktree":
+    if ws_kind is not None and branch_name and ws_kind != "worktree":
         print("kanban: --branch is only valid with --workspace worktree", file=sys.stderr)
         return 2
     try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2777,7 +2777,7 @@ def create_task(
     body: Optional[str] = None,
     assignee: Optional[str] = None,
     created_by: Optional[str] = None,
-    workspace_kind: str = "scratch",
+    workspace_kind: Optional[str] = "scratch",
     workspace_path: Optional[str] = None,
     branch_name: Optional[str] = None,
     tenant: Optional[str] = None,
@@ -2843,7 +2843,7 @@ def create_task(
         raise ValueError(
             f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}"
         )
-    if workspace_kind not in VALID_WORKSPACE_KINDS:
+    if workspace_kind is not None and workspace_kind not in VALID_WORKSPACE_KINDS:
         raise ValueError(
             f"workspace_kind must be one of {sorted(VALID_WORKSPACE_KINDS)}, "
             f"got {workspace_kind!r}"
@@ -3005,6 +3005,31 @@ def create_task(
             return row["id"]
 
     now = int(time.time())
+
+    # Resolve workspace_kind from the board's default_workdir when the
+    # caller did not specify one explicitly (CLI --workspace omitted or
+    # tool workspace_kind omitted). This ensures CLI/tool-created tasks
+    # inherit the board's default_workdir the same way the dashboard does:
+    #   * default_workdir inside a git repo toplevel -> worktree
+    #   * default_workdir as a plain directory -> dir
+    #   * no default_workdir -> scratch (legacy behaviour preserved)
+    # An explicit --workspace scratch bypasses this entirely.
+    if workspace_kind is None:
+        _board_slug = board if board else get_current_board()
+        _board_meta = read_board_metadata(_board_slug)
+        _board_default = _board_meta.get("default_workdir")
+        if _board_default:
+            try:
+                _default_path = Path(str(_board_default)).expanduser().resolve()
+                if _git_toplevel(_default_path):
+                    workspace_kind = "worktree"
+                else:
+                    workspace_kind = "dir"
+                workspace_path = str(_default_path)
+            except (OSError, ValueError):
+                workspace_kind = "scratch"
+        else:
+            workspace_kind = "scratch"
 
     # Resolve workspace_path from board-level default_workdir when the
     # caller did not specify one explicitly. Board defaults represent

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1151,21 +1151,16 @@ def _handle_create(args: dict, **kw) -> str:
         or os.environ.get("HERMES_SESSION_ID")
     )
     priority = args.get("priority")
-    # Resolve workspace. Workspace sharing is always explicit: omitted fields
-    # mean a fresh scratch workspace, even when a dispatcher-spawned worker
-    # creates the task. Reusing a parent's literal path would let a child
-    # mutate review evidence or race the parent's checkout (#67567).
-    #
-    # Project identity is the one safe context to inherit implicitly. The DB
-    # resolves a project-linked scratch request into a fresh per-task worktree,
+    # Resolve workspace. Omitted workspace_kind/workspace_path is passed as None
+    # to create_task, which resolves it from the board's default_workdir.
+    # Project identity is inherited when omitted: the DB resolves a
+    # project-linked scratch request into a fresh per-task worktree,
     # preserving the repository/branch convention without sharing a checkout.
     workspace_kind = args.get("workspace_kind")
     workspace_path = args.get("workspace_path")
     project_id = args.get("project") or args.get("project_id")
     project_source_task_id = None
     _inherit_project = workspace_kind is None and workspace_path is None
-    if workspace_kind is None:
-        workspace_kind = "scratch"
     triage, bool_error = _parse_bool_arg(args, "triage")
     if bool_error:
         return tool_error(bool_error)
@@ -1216,7 +1211,7 @@ def _handle_create(args: dict, **kw) -> str:
                 parents=tuple(parents),
                 tenant=tenant,
                 priority=int(priority) if priority is not None else 0,
-                workspace_kind=str(workspace_kind),
+                workspace_kind=str(workspace_kind) if workspace_kind is not None else None,
                 workspace_path=workspace_path,
                 project_id=project_id,
                 project_source_task_id=project_source_task_id,


### PR DESCRIPTION
## Summary
CLI and tool-created kanban tasks now inherit the board's `default_workdir` when `--workspace` is omitted, matching the dashboard's behavior.

## Changes
- `hermes_cli/kanban.py`: `_parse_workspace_flag(None)` returns `(None, None)` instead of `("scratch", None)` — lets `create_task` resolve from board config
- `hermes_cli/kanban_db.py`: `create_task()` resolves `workspace_kind` from board's `default_workdir` when caller passes `None` — git repo → worktree, plain dir → dir, none → scratch
- `tools/kanban_tools.py`: Pass `workspace_kind=None` instead of defaulting to `"scratch"` when omitted

Fixes #69787.

Salvaged from @webtecnica's PR #70530 (commit 1 of 3).

## Validation
| | Before | After |
|---|---|---|
| test_kanban_db | 228 passed | 228 passed (1 pre-existing failure: missing cryptography module) |
