### PR TITLE
fix(desktop): highlight bottom-most timeline tick when scrolled to end

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/timeline-data.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-data.test.ts
@@ -48,4 +48,27 @@ describe('activeTimelineIndex', () => {
     expect(activeTimelineIndex([null, 120, 480])).toBe(1)
     expect(activeTimelineIndex([null, null])).toBe(0)
   })
+
+  it('highlights the last entry when scrolled to the bottom', () => {
+    // Messages 0-1 are above the viewport, 2-3 are visible inside it.
+    // User is at the bottom (isAtBottom=true). Last entry (index 3) wins.
+    expect(activeTimelineIndex([-400, -10, 150, 450], 8, 800, true)).toBe(3)
+  })
+
+  it('preserves existing behaviour when viewportHeight is 0 (backward compatible)', () => {
+    // Same offsets but viewportHeight=0 — shortcut doesn't fire.
+    expect(activeTimelineIndex([-400, -10, 150, 450], 8, 0)).toBe(1)
+  })
+
+  it('does not highlight last entry when not at bottom (short thread, all visible)', () => {
+    // All messages visible in a tall viewport, but user is NOT at the bottom
+    // (e.g. short thread, or scrolled to top). Falls through to mid-scroll.
+    expect(activeTimelineIndex([50, 180, 310, 440, 570], 8, 1000, false)).toBe(0)
+  })
+
+  it('does not highlight last entry when it is scrolled below the viewport', () => {
+    // Last entry is 1000px below the top, viewport only 800px tall —
+    // it is offscreen. Even at bottom, shortcut does not fire.
+    expect(activeTimelineIndex([-400, -10, 320, 1000], 8, 800, true)).toBe(1)
+  })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-data.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-data.ts
@@ -46,8 +46,27 @@ export function deriveTimelineEntries(messages: readonly TimelineSourceMessage[]
   return entries
 }
 
-/** Last user prompt at/above the viewport top (with slack); else first rendered. */
-export function activeTimelineIndex(offsets: readonly (number | null)[], slack: number = 8): number {
+/** Active timeline index: when scrolled to the bottom, the last prompt;
+ *  else the last prompt at/above the viewport top (mid-scroll);
+ *  else the first rendered entry. */
+export function activeTimelineIndex(
+  offsets: readonly (number | null)[],
+  slack: number = 8,
+  viewportHeight: number = 0,
+  isAtBottom: boolean = false
+): number {
+  // When scrolled to the bottom, highlight the last rendered entry —
+  // even when its top edge is far from the viewport top. Without this
+  // the bottom-most tick stays dark while an older tick near the top
+  // of the viewport claims the active highlight.
+  if (isAtBottom && viewportHeight > 0) {
+    const lastOffset = offsets[offsets.length - 1]
+
+    if (lastOffset != null && lastOffset > slack && lastOffset <= viewportHeight + slack) {
+      return offsets.length - 1
+    }
+  }
+
   let active = -1
   let firstRendered = -1
 

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -187,7 +187,13 @@ export const ThreadTimeline: FC = () => {
     const compute = () => {
       raf = 0
 
-      const top = viewport.getBoundingClientRect().top
+      const rect = viewport.getBoundingClientRect()
+      const top = rect.top
+      const height = rect.height
+      const scrollable = viewport.scrollHeight > viewport.clientHeight
+      const atBottom =
+        scrollable &&
+        viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 8
 
       const offsets = entries.map(entry => {
         const node = viewport.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(entry.id)}"]`)
@@ -195,7 +201,7 @@ export const ThreadTimeline: FC = () => {
         return node ? node.getBoundingClientRect().top - top : null
       })
 
-      const next = activeTimelineIndex(offsets)
+      const next = activeTimelineIndex(offsets, 8, height, atBottom)
 
       setActiveIndex(prev => (prev === next ? prev : next))
     }


### PR DESCRIPTION
## Problem

The `ThreadTimeline` tick highlight (the white line on the right edge tracking user messages) shows the wrong tick when scrolled to the bottom of a conversation. The 3rd-from-bottom tick is highlighted instead of the bottom-most one.

## Root cause

`activeTimelineIndex()` highlights the last user message at/above the viewport top (`offset ≤ 8px`). When scrolled to the bottom, the last 2-3 messages are all visible but far below the top edge — the function picks the message near the top of the viewport instead of the bottom-most one.

## Fix

Add two parameters to `activeTimelineIndex()`:

- **`viewportHeight`** — the viewport pixel height, used to determine whether the last entry is visible within bounds
- **`isAtBottom`** — whether the scroll container is at (or very near) the bottom, computed as `scrollHeight - scrollTop - clientHeight ≤ 8px` **and the container is scrollable** (`scrollHeight > clientHeight`)

When both conditions are met (we're at the bottom AND the last entry is rendered in the viewport), highlight the last entry. Otherwise fall through to the existing mid-scroll behaviour.

Also optimised the caller to use a single `getBoundingClientRect()` call instead of two.

## Files changed

| File | Change |
|---|---|
| `timeline-data.ts` | Added `viewportHeight` + `isAtBottom` params, bottom-of-thread guard |
| `timeline-data.test.ts` | 4 new tests: bottom highlight, backward compat, short-thread guard, offscreen guard |
| `timeline.tsx` | Pass viewport rect + scroll-position to `activeTimelineIndex`, single rect call |

## Testing

- ✅ 10/10 tests pass (6 existing + 4 new)
- ✅ Live tested on macOS desktop build — bottom tick highlights correctly, no regression on short threads
- ✅ Cross-vendor review: Gemini 3.6 Flash + GPT-OSS 120B both approve (two review rounds, addressed `isAtBottom` guard + `isScrollable` check + single rect optimisation)

Closes #70933
