### PR TITLE
docs(contributing): fix stale Build a Hermes Plugin link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ The reason is maintenance load, not quality. Every external product absorbed int
 
 Publish these as a **standalone plugin repo** instead:
 
-- Implement the relevant ABC and use the existing plugin discovery path (`~/.hermes/plugins/`, project `.hermes/plugins/`, or a pip entry point) — see [Build a Hermes Plugin](https://hermes-agent.nousresearch.com/docs/guides/build-a-hermes-plugin)
+- Implement the relevant ABC and use the existing plugin discovery path (`~/.hermes/plugins/`, project `.hermes/plugins/`, or a pip entry point) — see [Build a Hermes Plugin](https://hermes-agent.nousresearch.com/docs/developer-guide/plugins)
 - Register lifecycle hooks (`pre_tool_call`, `post_tool_call`, `pre_llm_call`, `post_llm_call`, `on_session_start`, `on_session_end`), tools (`ctx.register_tool`), and CLI subcommands (`ctx.register_cli_command`) through the surface we already expose — no core changes needed
 - If your plugin needs a capability the framework doesn't expose, that's a feature request to **widen the generic plugin surface** (a new hook or `ctx` method) — never special-case your plugin in core
 - Promote it in the [Nous Research Discord](https://discord.gg/NousResearch) `#plugins-skills-and-skins` channel so users can find and install it


### PR DESCRIPTION
## Problem

`CONTRIBUTING.md` line 96 links to:

> https://hermes-agent.nousresearch.com/docs/guides/build-a-hermes-plugin

This path 404s. The "Build a Hermes Plugin" guide was moved to the `developer-guide` section, and the file lives at `website/docs/developer-guide/plugins/index.md` with slug `/developer-guide/plugins`.

## Triage

The plugin docs were reorganized at some point (likely during the plugin surface expansion). The old `guides/build-a-hermes-plugin` path no longer has a corresponding markdown file. Confirmed by:

- `git ls-tree -r upstream/main website/docs/guides/` — no `build-a-hermes-plugin.md`
- `git show upstream/main:website/docs/developer-guide/plugins/index.md` — exists, with `slug: /developer-guide/plugins`

## Fix

Updated the single link on line 96 from `/docs/guides/build-a-hermes-plugin` to `/docs/developer-guide/plugins`.

## Verification

- Confirmed `website/docs/developer-guide/plugins/index.md` exists on `upstream/main` with `slug: /developer-guide/plugins`
- Confirmed no file exists at `website/docs/guides/build-a-hermes-plugin.md`
- Checked no other broken doc links in CONTRIBUTING.md (the only other hermes-agent.nousresearch.com link is the installer script URL, which is correct)
- `git diff` shows a clean 1-line change
