### PR TITLE
fix(error_classifier): detect upstream provider errors on 403

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1050,6 +1050,19 @@ def _classify_by_status(
                 should_rotate_credential=True,
                 should_fallback=True,
             )
+        # Check for OpenRouter-aggregator upstream 403 (e.g. DeepSeek, Anthropic, etc.)
+        # wraps upstream errors with the outer message "Provider returned error"
+        # and the real error nested in metadata.raw.
+        if _is_openrouter_upstream_error(body, provider):
+            upstream_provider = _extract_upstream_provider_name(body)
+            ctx = {"upstream_provider": upstream_provider} if upstream_provider else {}
+            return result_fn(
+                FailoverReason.upstream_rate_limit,
+                retryable=True,
+                should_rotate_credential=False,
+                should_fallback=True,
+                error_context=ctx,
+            )
         return result_fn(
             FailoverReason.auth,
             retryable=False,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -912,6 +912,28 @@ class TestOpenRouterUpstreamRateLimit:
     different model, NOT mark the credential exhausted.
     """
 
+    def test_openrouter_upstream_429_classified_as_upstream_rate_limit(self):
+        """OpenRouter 429 with 'Provider returned error' → upstream_rate_limit."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=429,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "code": 429,
+                    "metadata": {
+                        "provider_name": "DeepSeek",
+                        "raw": '{"error":{"message":"Rate limit exceeded"}}',
+                    },
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="deepseek/deepseek-v4-flash")
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+        assert result.error_context.get("upstream_provider") == "DeepSeek"
+
     def test_openrouter_upstream_403_classified_as_upstream_rate_limit(self):
         """OpenRouter 403 with 'Provider returned error' → upstream_rate_limit."""
         e = MockAPIError(

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -912,27 +912,27 @@ class TestOpenRouterUpstreamRateLimit:
     different model, NOT mark the credential exhausted.
     """
 
-    def test_openrouter_upstream_429_classified_as_upstream_rate_limit(self):
-        """OpenRouter 429 with 'Provider returned error' → upstream_rate_limit."""
+    def test_openrouter_upstream_403_classified_as_upstream_rate_limit(self):
+        """OpenRouter 403 with 'Provider returned error' → upstream_rate_limit."""
         e = MockAPIError(
             "Provider returned error",
-            status_code=429,
+            status_code=403,
             body={
                 "error": {
                     "message": "Provider returned error",
-                    "code": 429,
+                    "code": 403,
                     "metadata": {
-                        "provider_name": "DeepSeek",
+                        "provider_name": "Anthropic",
                         "raw": '{"error":{"message":"Rate limit exceeded"}}',
                     },
                 }
             },
         )
-        result = classify_api_error(e, provider="openrouter", model="deepseek/deepseek-v4-flash")
+        result = classify_api_error(e, provider="openrouter", model="anthropic/claude-3-opus")
         assert result.reason == FailoverReason.upstream_rate_limit
         assert result.should_rotate_credential is False
         assert result.should_fallback is True
-        assert result.error_context.get("upstream_provider") == "DeepSeek"
+        assert result.error_context.get("upstream_provider") == "Anthropic"
 
 
     def test_account_level_429_still_rotates_credential(self):


### PR DESCRIPTION
Fixes a bug where aggregator-wrapped 403 errors (e.g. from OpenRouter upstream providers like DeepSeek, Anthropic) were not being handled as upstream rate limits, leading to incorrect credential rotation.

Changes:
- Map 403 errors wrapped with 'Provider returned error' to upstream_rate_limit
- Preserve existing TestOpenRouterUpstreamRateLimit and add 403 test case
- Exclude unrelated hermes_cli/auth.py hunk

This PR addresses feedback from teknium1 in #57887.