### PR TITLE
fix(gateway): detect launchd service via print

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1252,7 +1252,7 @@ def _recover_pending_systemd_restart(
 
 
 def _parse_launchd_pid_from_list_output(output: str) -> int | None:
-    """Extract the PID from ``launchctl list <label>`` output.
+    """Extract the PID from ``launchctl list`` or ``launchctl print`` output.
 
     When launchd is actively supervising a process, the output includes a
     ``"PID" = <number>;`` line.  When the service definition is only *registered*
@@ -1262,9 +1262,8 @@ def _parse_launchd_pid_from_list_output(output: str) -> int | None:
     """
     for line in output.splitlines():
         stripped = line.strip()
-        if stripped.startswith('"PID"') or stripped.startswith("PID"):
-            parts = stripped.split("=", 1)
-            if len(parts) == 2:
+        parts = stripped.split("=", 1)
+        if len(parts) == 2 and parts[0].strip().strip('"').lower() == "pid":
                 val = parts[1].strip().rstrip(";").strip('"')
                 try:
                     pid = int(val)
@@ -1272,6 +1271,33 @@ def _parse_launchd_pid_from_list_output(output: str) -> int | None:
                 except ValueError:
                     return None
     return None
+
+
+def _query_launchd_service_status(label: str | None = None) -> tuple[bool, str]:
+    """Return registration state and output from the authoritative launchd query.
+
+    Older macOS releases support ``launchctl list <label>`` while newer hosts
+    can reject that lookup even when the per-user launchd domain owns the job.
+    Fall back to ``launchctl print`` before reporting a loaded service missing.
+    """
+    label = label or get_launchd_label()
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            result = subprocess.run(
+                ["launchctl", "print", f"{_launchd_domain()}/{label}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+    except subprocess.TimeoutExpired:
+        return False, ""
+    return result.returncode == 0, result.stdout
 
 
 def _probe_launchd_service_running() -> bool:
@@ -1284,18 +1310,10 @@ def _probe_launchd_service_running() -> bool:
     """
     if not get_launchd_plist_path().exists():
         return False
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except subprocess.TimeoutExpired:
+    service_listed, output = _query_launchd_service_status()
+    if not service_listed:
         return False
-    if result.returncode != 0:
-        return False
-    return _parse_launchd_pid_from_list_output(result.stdout) is not None
+    return _parse_launchd_pid_from_list_output(output) is not None
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -4475,18 +4493,7 @@ def launchd_restart():
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        service_listed = result.returncode == 0
-        list_output = result.stdout
-    except subprocess.TimeoutExpired:
-        service_listed = False
-        list_output = ""
+    service_listed, list_output = _query_launchd_service_status(label)
 
     # Determine whether launchd is actively supervising a process.
     # ``launchctl list`` returns exit 0 whenever the service definition is

--- a/tests/hermes_cli/test_gateway_launchd_status.py
+++ b/tests/hermes_cli/test_gateway_launchd_status.py
@@ -1,0 +1,51 @@
+"""Regression tests for launchd-owned gateway status detection."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import hermes_cli.gateway as gateway_cli
+from gateway import status
+
+
+def test_launchd_status_falls_back_to_authoritative_print(tmp_path, monkeypatch, capsys):
+    calls = []
+    plist = tmp_path / "ai.hermes.gateway.plist"
+    plist.write_text("plist", encoding="utf-8")
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        if command[:2] == ["launchctl", "list"]:
+            return SimpleNamespace(returncode=113, stdout="", stderr="not found")
+        if command[:2] == ["launchctl", "print"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="state = running\n\tpid = 7957\nlast exit code = (never exited)\n",
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/502")
+    monkeypatch.setattr(
+        gateway_cli,
+        "get_launchd_plist_path",
+        lambda: plist,
+    )
+    monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: True)
+    monkeypatch.setattr(gateway_cli, "_launchd_unsupported_marker_exists", lambda: False)
+    monkeypatch.setattr(status, "get_running_pid", lambda cleanup_stale=False: 7957)
+
+    assert gateway_cli._probe_launchd_service_running() is True
+    gateway_cli.launchd_status()
+
+    output = capsys.readouterr().out
+    assert calls == [
+        ["launchctl", "list", "ai.hermes.gateway"],
+        ["launchctl", "print", "gui/502/ai.hermes.gateway"],
+        ["launchctl", "list", "ai.hermes.gateway"],
+        ["launchctl", "print", "gui/502/ai.hermes.gateway"],
+    ]
+    assert "Gateway is supervised by launchd (PID 7957)" in output
+    assert "Gateway service is not loaded" not in output
+    assert "detached gateway process" not in output


### PR DESCRIPTION
## Summary
- fall back to `launchctl print gui/<uid>/<label>` when legacy `launchctl list <label>` cannot resolve a loaded service
- parse launchd PID output from both query formats
- share the query path between status and process supervision detection

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_launchd_status.py`
- `uv run python -m hermes_cli.main gateway status` reports the live gateway as supervised by launchd (PID 7957)