### PR TITLE
fix: rebuild MoA guidance after context compression

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -973,11 +973,6 @@ def run_conversation(
     # reused as the final response — not merely because any interim was
     # streamed. (#65919 review: response-loss blocker)
     _pending_verification_response_previewed = False
-    # If pre-API compression fires after MoA advisors have produced guidance,
-    # retain that ephemeral output and rebase it onto the compacted transcript
-    # on the next loop iteration. This prevents a second advisor fan-out.
-    pending_moa_prepared_request = None
-
     # Per-turn tally of consecutive successful credential-pool token refreshes,
     # keyed by (provider, pool-entry-id). A persistent upstream 401 lets
     # ``try_refresh_current()`` "succeed" forever on a single-entry OAuth pool,
@@ -1445,17 +1440,9 @@ def run_conversation(
         _moa_prepared_request = None
         if agent.provider == "moa":
             _moa_completions = getattr(getattr(agent.client, "chat", None), "completions", None)
-            if pending_moa_prepared_request is not None:
-                _rebase_moa_request = getattr(_moa_completions, "rebase_prepared_request", None)
-                if callable(_rebase_moa_request):
-                    _moa_prepared_request = _rebase_moa_request(
-                        pending_moa_prepared_request, api_messages
-                    )
-                pending_moa_prepared_request = None
-            if _moa_prepared_request is None:
-                _prepare_moa_request = getattr(_moa_completions, "prepare", None)
-                if callable(_prepare_moa_request):
-                    _moa_prepared_request = _prepare_moa_request(api_messages)
+            _prepare_moa_request = getattr(_moa_completions, "prepare", None)
+            if callable(_prepare_moa_request):
+                _moa_prepared_request = _prepare_moa_request(api_messages)
             if _moa_prepared_request is not None:
                 api_messages = _moa_prepared_request["messages"]
 
@@ -1551,8 +1538,6 @@ def run_conversation(
             and not _compression_cooldown
             and _compressor.should_compress(request_pressure_tokens)
         ):
-            if _moa_prepared_request is not None:
-                pending_moa_prepared_request = _moa_prepared_request
             compression_attempts += 1
             # Compression is actually running (block cleared / was never
             # blocked) — reset the blocked-overflow warning dedup so a future
@@ -1612,8 +1597,6 @@ def run_conversation(
                 # soft compression_deferred result with that stronger signal.
                 compression_attempts -= 1
                 _last_preflight_pressure = None
-                if pending_moa_prepared_request is _moa_prepared_request:
-                    pending_moa_prepared_request = None
             else:
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1522,22 +1522,6 @@ class MoAChatCompletions:
         """
         return self.create(messages=messages, _moa_prepare_only=True)
 
-    def rebase_prepared_request(
-        self, prepared: dict[str, Any], messages: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        """Apply already-generated advisor guidance to a rebuilt API transcript.
-
-        Context compression changes the persisted transcript but not the
-        ephemeral advisor result.  Reusing the guidance avoids a second costly
-        fan-out while keeping the aggregator request aligned with the compacted
-        history.
-        """
-        guidance = prepared.get("guidance")
-        agg_messages = [dict(message) for message in messages]
-        if guidance:
-            _attach_reference_guidance(agg_messages, str(guidance))
-        return {**prepared, "messages": agg_messages}
-
     def _call_prepared_aggregator(
         self, prepared: dict[str, Any], api_kwargs: dict[str, Any]
     ) -> Any:

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -1832,13 +1832,15 @@ def test_reference_messages_drops_whitespace_only_string_user_turn():
     assert all(str(m["content"]).strip() for m in view)
 
 def test_moa_pre_api_compression_includes_reference_guidance(monkeypatch, tmp_path):
-    """The aggregator must not receive guidance that pushes it past compression.
+    """Compression must rebuild MoA guidance from the compacted transcript.
 
     The normal pre-API check sees only the persisted conversation.  MoA adds
     reference guidance later, inside ``MoAChatCompletions.create()``, so this
     regression drives a raw request just below the threshold and makes the
-    injected guidance cross it.  Compression must occur before the aggregator
-    request and leave the rebuilt request below the threshold.
+    injected guidance cross it.  The prepared request is bound to the original
+    transcript and must be discarded after compression; rebasing that stale
+    guidance made repeated compression passes remove almost no real prompt
+    tokens and eventually exhaust the retry guardrail.
     """
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -1909,7 +1911,10 @@ moa:
 
     assert result["final_response"] == "aggregator acted"
     assert events.index("compress") < events.index("aggregator")
-    assert events.count("reference") == 1
+    assert events.count("reference") == 2
+    assert events.index("compress") < max(
+        index for index, event in enumerate(events) if event == "reference"
+    )
     assert all("Mixture of Agents reference context" not in str(item) for item in compression_inputs)
     assert aggregator_request_tokens == [60]
 


### PR DESCRIPTION
## What changed

- Treat prepared MoA requests as bound to the transcript used to build them.
- Discard prepared advisor guidance when context compression changes that transcript.
- Rebuild advisor context from the compacted transcript before measuring and dispatching the aggregator request.
- Update the regression test to require a post-compression advisor preparation.

## Why

Reusing pre-compression guidance defeats compression.

The reproduced session sent a 66,004-token aggregator request against a 65,536-token context window. After compression, the real request was still 65,830 tokens. Three bounded attempts made almost no progress and ended with:

`Context length exceeded: max compression attempts (3) reached.`

The persisted conversation had changed. The ephemeral advisor guidance had not. Rebasing that stale guidance kept most of the original request pressure alive.

## Impact

Compression now invalidates the prepared MoA request. The next loop iteration rebuilds guidance against the compacted transcript and measures the request that will actually be sent.

This can run the advisor fan-out a second time when compression occurs. That cost is limited to the recovery path. It avoids repeated oversized aggregator requests and bounded-attempt exhaustion.

## Validation

- `333 passed` across:
  - `tests/run_agent/test_moa_loop_mode.py`
  - `tests/run_agent/test_413_compression.py`
  - `tests/agent/test_context_compressor.py`
- Ruff passed on the changed source and test files.
- Live reproduction compressed the affected session from an estimated 66,312 tokens to 55,038, followed by a completed MoA request with 55,331 input tokens against the 65,536-token limit.

## Scope

This PR addresses stale MoA guidance after transcript compression. A separate local reference-model chat-template failure observed during validation is not part of this change.
