### PR TITLE
feat(honcho): support defaultHeaders in config for proxy auth

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -454,6 +454,8 @@ class HonchoClientConfig:
     session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
     sessions: dict[str, str] = field(default_factory=dict)
+    # Custom HTTP headers to send with every Honcho request (e.g. CF Access)
+    default_headers: dict[str, str] = field(default_factory=dict)
     # Raw global config for anything else consumers need
     raw: dict[str, Any] = field(default_factory=dict)
     # True when Honcho was explicitly configured for this host (hosts.hermes
@@ -730,6 +732,7 @@ class HonchoClientConfig:
             session_strategy=session_strategy,
             session_peer_prefix=session_peer_prefix,
             sessions=raw.get("sessions", {}),
+            default_headers=_parse_string_map(host_block, raw, "defaultHeaders"),
             raw=raw,
             explicitly_configured=_explicitly_configured,
         )
@@ -1096,6 +1099,8 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
             kwargs["base_url"] = resolved_base_url
         if resolved_timeout is not None:
             kwargs["timeout"] = resolved_timeout
+        if config.default_headers:
+            kwargs["default_headers"] = config.default_headers
 
         global _cached_timeout
         _cached_timeout = resolved_timeout


### PR DESCRIPTION
## Summary

Adds `defaultHeaders` support to the Honcho plugin's config, allowing users to pass custom HTTP headers with every Honcho SDK request.

## Motivation

When running self-hosted Honcho behind a reverse proxy with authentication (Cloudflare Access, Tailscale auth, nginx basic auth, custom API gateways, etc.), the client needs to send additional headers that the proxy validates before forwarding traffic to the Honcho server.

The Honcho SDK already supports `default_headers` natively — this change simply plumbs the config through from `honcho.json` to the SDK constructor.

## Changes

- Added `default_headers: dict[str, str]` field to `HonchoClientConfig`
- Parse `defaultHeaders` from config JSON (supports both root-level and host-level overrides via existing `_parse_string_map`)
- Pass `default_headers` to the `Honcho()` constructor when non-empty

## Config Example

```json
{
  "baseUrl": "https://honcho.example.com",
  "defaultHeaders": {
    "CF-Access-Client-Id": "xxx.access",
    "CF-Access-Client-Secret": "xxx"
  },
  "hosts": {
    "hermes": {
      "enabled": true
    }
  }
}
```

Host-level `defaultHeaders` overrides root-level (whole-map replacement, consistent with other map fields like `userPeerAliases`).

## Testing

Verified end-to-end with a self-hosted Honcho instance behind Cloudflare Access + JWT auth. The headers are sent on every request and the proxy authenticates successfully.
