### PR TITLE
fix(browser): keep configured CDP endpoints schema-eligible without discovery I/O

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1766,10 +1766,12 @@ def run_doctor(args):
             else:
                 # Only warn about Chromium if the installed engine actually
                 # requires it: Camofox, CDP override, a cloud provider, or
-                # Lightpanda all bypass the local Chromium requirement.
+                # Lightpanda all bypass the local Chromium requirement. Use the
+                # configuration-only CDP probe: doctor must not perform HTTP
+                # discovery against a configured endpoint.
                 skip_chromium_check = (
                     _is_camofox_mode()
-                    or bool(_get_cdp_override())
+                    or bool(_get_cdp_override(resolve=False))
                     or _get_cloud_provider() is not None
                     or _using_lightpanda_engine()
                 )

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10350,17 +10350,17 @@ def test_browser_manage_status_falls_back_to_config_cdp_url(monkeypatch):
     assert resp["result"] == {"connected": True, "url": "http://lan:9222"}
 
 
-def test_browser_manage_status_does_not_call_get_cdp_override(monkeypatch):
+def test_browser_manage_status_does_not_resolve_cdp_endpoint(monkeypatch):
     """Regression guard for Copilot's "status must not block" review:
-    status must NOT route through `_get_cdp_override`, which performs a
-    `/json/version` HTTP probe with a multi-second timeout."""
+    status may read the configured override, but must NOT perform the
+    `/json/version` HTTP probe (multi-second timeout)."""
     monkeypatch.setenv("BROWSER_CDP_URL", "http://127.0.0.1:9222")
 
-    fake = types.SimpleNamespace(
-        _get_cdp_override=lambda: pytest.fail(  # noqa: PT015 — fail loudly if called
-            "_get_cdp_override must not run on /browser status (network I/O)"
-        )
-    )
+    def _get_cdp_override(resolve: bool = True):
+        assert resolve is False, "/browser status must use resolve=False"
+        return os.environ.get("BROWSER_CDP_URL", "")
+
+    fake = types.SimpleNamespace(_get_cdp_override=_get_cdp_override)
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         resp = server.handle_request(
             {"id": "1", "method": "browser.manage", "params": {"action": "status"}}

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -187,6 +187,47 @@ class TestGetCdpOverride:
         with patch("hermes_cli.config.read_raw_config", return_value={}):
             assert bc.is_camofox_mode() is False
 
+    def test_get_cdp_override_unresolved_skips_discovery(self, monkeypatch):
+        """resolve=False returns the configured endpoint without HTTP I/O."""
+        import tools.browser_tool as browser_tool
+
+        monkeypatch.setenv("BROWSER_CDP_URL", HTTP_URL)
+
+        def _fail_resolve(*args, **kwargs):
+            raise AssertionError("resolve=False must not perform HTTP discovery")
+
+        monkeypatch.setattr(browser_tool, "_resolve_cdp_override", _fail_resolve)
+        assert browser_tool._get_cdp_override(resolve=False) == HTTP_URL
+
+    def test_get_cdp_override_unresolved_reads_config_without_discovery(self, monkeypatch):
+        import tools.browser_tool as browser_tool
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+        def _fail_resolve(*args, **kwargs):
+            raise AssertionError("resolve=False must not perform HTTP discovery")
+
+        monkeypatch.setattr(browser_tool, "_resolve_cdp_override", _fail_resolve)
+        with patch("hermes_cli.config.read_raw_config",
+                   return_value={"browser": {"cdp_url": HTTP_URL}}):
+            assert browser_tool._get_cdp_override(resolve=False) == HTTP_URL
+
+    def test_check_browser_requirements_does_not_probe_configured_endpoint(self, monkeypatch):
+        """check_browser_requirements() is schema-time: a configured CDP
+        endpoint must not trigger /json/version discovery."""
+        import tools.browser_tool as browser_tool
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+        def _fail_resolve(*args, **kwargs):
+            raise AssertionError("schema check must not resolve CDP endpoints")
+
+        monkeypatch.setattr(browser_tool, "_resolve_cdp_override", _fail_resolve)
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        with patch("hermes_cli.config.read_raw_config",
+                   return_value={"browser": {"cdp_url": HTTP_URL}}):
+            assert browser_tool.check_browser_requirements() is True
+
 class TestCreateCdpSession:
     """_create_cdp_session() must sanitize the CDP URL before logging.
 

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -555,24 +555,46 @@ def test_private_guard_inactive_does_not_probe(monkeypatch, cdp_server):
 # ---------------------------------------------------------------------------
 
 
+def _stub_cdp_override(monkeypatch, value: str):
+    import tools.browser_tool as bt
+
+    def _fake_get_cdp_override(resolve: bool = True) -> str:
+        assert resolve is False, "schema-time check must not resolve CDP endpoints"
+        return value
+
+    monkeypatch.setattr(bt, "_get_cdp_override", _fake_get_cdp_override)
+
+
 def test_check_fn_false_when_no_cdp_url(monkeypatch):
     """Gate closes when no CDP URL is set — even if the browser toolset is
     otherwise configured."""
     import tools.browser_tool as bt
 
     monkeypatch.setattr(bt, "check_browser_requirements", lambda: True)
-    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+    _stub_cdp_override(monkeypatch, "")
     assert browser_cdp_tool._browser_cdp_check() is False
 
 
 def test_check_fn_true_when_cdp_url_set(monkeypatch):
-    """Gate opens as soon as a CDP URL is resolvable."""
+    """Gate opens as soon as a CDP URL is configured."""
     import tools.browser_tool as bt
 
     monkeypatch.setattr(bt, "check_browser_requirements", lambda: True)
-    monkeypatch.setattr(
-        bt, "_get_cdp_override", lambda: "ws://localhost:9222/devtools/browser/x"
-    )
+    _stub_cdp_override(monkeypatch, "ws://localhost:9222/devtools/browser/x")
+    assert browser_cdp_tool._browser_cdp_check() is True
+
+
+def test_check_fn_true_for_unreachable_http_endpoint(monkeypatch):
+    """A configured HTTP discovery endpoint stays schema-eligible even when
+    Chrome is stopped: the gate must not perform /json/version I/O."""
+    import tools.browser_tool as bt
+
+    def _fail_resolve(*args, **kwargs):
+        raise AssertionError("check_fn must not resolve CDP endpoints over HTTP")
+
+    monkeypatch.setattr(bt, "check_browser_requirements", lambda: True)
+    monkeypatch.setattr(bt, "_resolve_cdp_override", _fail_resolve)
+    monkeypatch.setenv("BROWSER_CDP_URL", "http://localhost:9223")
     assert browser_cdp_tool._browser_cdp_check() is True
 
 
@@ -582,7 +604,5 @@ def test_check_fn_false_when_browser_requirements_fail(monkeypatch):
     import tools.browser_tool as bt
 
     monkeypatch.setattr(bt, "check_browser_requirements", lambda: False)
-    monkeypatch.setattr(
-        bt, "_get_cdp_override", lambda: "ws://localhost:9222/devtools/browser/x"
-    )
+    _stub_cdp_override(monkeypatch, "ws://localhost:9222/devtools/browser/x")
     assert browser_cdp_tool._browser_cdp_check() is False

--- a/tests/tools/test_browser_hybrid_routing.py
+++ b/tests/tools/test_browser_hybrid_routing.py
@@ -29,7 +29,7 @@ def _reset_routing_state(monkeypatch):
     monkeypatch.setattr(browser_tool, "_start_browser_cleanup_thread", lambda: None)
     monkeypatch.setattr(browser_tool, "_update_session_activity", lambda t: None)
     # Default: no CDP override, no Camofox
-    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: None)
+    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda resolve=True: None)
     monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
 
 
@@ -91,7 +91,9 @@ class TestNavigationSessionKey:
     def test_cdp_override_stays_on_bare_task_id(self, monkeypatch):
         """A user-supplied CDP endpoint owns the whole session — no hybrid."""
         monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: Mock())
-        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://localhost:9222")
+        monkeypatch.setattr(
+            browser_tool, "_get_cdp_override", lambda resolve=True: "ws://localhost:9222"
+        )
         key = browser_tool._navigation_session_key("default", "http://localhost:3000/")
         assert key == "default"
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -122,6 +122,11 @@ def is_camofox_mode() -> bool:
     ``browser_tool._get_cdp_override()``'s precedence. (Previously only the env
     var suppressed Camofox, so ``CAMOFOX_URL`` + a config CDP override still
     routed navigation through Camofox.)
+
+    This is a routing/configuration check, not a reachability probe: it reads
+    the configured CDP URL without HTTP discovery so a temporarily stopped
+    Chrome endpoint does not flip routing back to Camofox or mutate schema
+    eligibility.
     """
     if os.getenv("BROWSER_CDP_URL", "").strip():
         return False

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -104,6 +104,11 @@ def _resolve_cdp_endpoint() -> str:
 
     1. ``BROWSER_CDP_URL`` env var (live override from ``/browser connect``)
     2. ``browser.cdp_url`` in ``config.yaml``
+
+    This is the invocation-time path: it performs bounded HTTP discovery for
+    ``http://`` endpoints so the WebSocket call receives a concrete
+    ``ws://`` URL. Schema-time checks use ``_has_configured_cdp_endpoint``
+    instead and never call this helper.
     """
     try:
         from tools.browser_tool import _get_cdp_override  # type: ignore[import-not-found]
@@ -634,12 +639,31 @@ BROWSER_CDP_SCHEMA: Dict[str, Any] = {
 }
 
 
+def _has_configured_cdp_endpoint() -> bool:
+    """Whether a CDP endpoint is configured, without network I/O.
+
+    Schema-time availability must be a pure configuration/dependency check.
+    Resolving an HTTP discovery endpoint through ``/json/version`` belongs to
+    invocation time; a temporarily unreachable Chrome must not mutate the
+    tool schema.
+    """
+    try:
+        from tools.browser_tool import _get_cdp_override  # type: ignore[import-not-found]
+
+        return bool((_get_cdp_override(resolve=False) or "").strip())
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.debug("browser_cdp: failed to read configured CDP endpoint: %s", exc)
+        return False
+
+
 def _browser_cdp_check() -> bool:
     """Availability check for browser_cdp.
 
-    The tool is only offered when the Python side can actually reach a CDP
-    endpoint right now — meaning a static URL is set via ``/browser connect``
-    (``BROWSER_CDP_URL``) or ``browser.cdp_url`` in ``config.yaml``.
+    The tool is only offered when a static CDP URL is configured via
+    ``/browser connect`` (``BROWSER_CDP_URL``) or ``browser.cdp_url`` in
+    ``config.yaml``. This check performs no HTTP/WebSocket I/O, so a
+    configured but temporarily dead endpoint stays schema-eligible and
+    reports endpoint unavailability at invocation time.
 
     Backends that do *not* currently expose CDP to us — Camofox (REST-only),
     the default local agent-browser mode (Playwright hides its internal CDP
@@ -653,7 +677,6 @@ def _browser_cdp_check() -> bool:
     """
     try:
         from tools.browser_tool import (  # type: ignore[import-not-found]
-            _get_cdp_override,
             check_browser_requirements,
         )
     except ImportError as exc:  # pragma: no cover — defensive
@@ -661,7 +684,7 @@ def _browser_cdp_check() -> bool:
         return False
     if not check_browser_requirements():
         return False
-    return bool(_get_cdp_override())
+    return _has_configured_cdp_endpoint()
 
 
 registry.register(

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -457,8 +457,8 @@ def _resolve_cdp_override(cdp_url: str) -> str:
     return raw
 
 
-def _get_cdp_override() -> str:
-    """Return a normalized CDP URL override, or empty string.
+def _get_cdp_override(resolve: bool = True) -> str:
+    """Return a CDP URL override, or empty string.
 
     Precedence is:
     1. ``BROWSER_CDP_URL`` env var (live override from ``/browser connect``)
@@ -467,10 +467,16 @@ def _get_cdp_override() -> str:
     When either is set, we skip both Browserbase and the local headless
     launcher and connect directly to the supplied Chrome DevTools Protocol
     endpoint.
+
+    ``resolve`` controls HTTP discovery. Connection paths keep the default
+    (``True``) so they receive a concrete ``ws://`` endpoint. Schema-time
+    availability checks pass ``resolve=False``: a configured endpoint must
+    stay tool-eligible even when Chrome is temporarily stopped, instead of
+    disappearing from the tool schema after a failed ``/json/version`` probe.
     """
     env_override = os.environ.get("BROWSER_CDP_URL", "").strip()
     if env_override:
-        return _resolve_cdp_override(env_override)
+        return _resolve_cdp_override(env_override) if resolve else env_override
 
     try:
         from hermes_cli.config import read_raw_config
@@ -478,7 +484,9 @@ def _get_cdp_override() -> str:
         cfg = read_raw_config()
         browser_cfg = cfg.get("browser", {})
         if isinstance(browser_cfg, dict):
-            return _resolve_cdp_override(str(browser_cfg.get("cdp_url", "") or ""))
+            configured = str(browser_cfg.get("cdp_url", "") or "").strip()
+            if configured:
+                return _resolve_cdp_override(configured) if resolve else configured
     except Exception as e:
         logger.debug("Could not read browser.cdp_url from config: %s", e)
 
@@ -789,7 +797,7 @@ def _termux_browser_install_error() -> str:
 
 def _is_local_mode() -> bool:
     """Return True when the browser tool will use a local browser backend."""
-    if _get_cdp_override():
+    if _get_cdp_override(resolve=False):
         return False
     return _get_cloud_provider() is None
 
@@ -820,8 +828,9 @@ def _is_local_backend() -> bool:
     # either the BROWSER_CDP_URL env var or a persistent `browser.cdp_url`
     # config (both via _get_cdp_override(), and both now suppress camofox in
     # browser_camofox.py). _is_local_mode() already treats any CDP override as
-    # non-local; keep the two helpers in agreement.
-    if _get_cdp_override():
+    # non-local; keep the two helpers in agreement. Use the configuration-only
+    # probe so routing decisions do not perform endpoint discovery I/O.
+    if _get_cdp_override(resolve=False):
         return False
     if _is_camofox_mode():
         return True
@@ -1313,7 +1322,7 @@ def _navigation_session_key(task_id: str, url: str) -> str:
     """
     if task_id is None:
         task_id = "default"
-    if _get_cdp_override():
+    if _get_cdp_override(resolve=False):
         return task_id
     if _is_camofox_mode():
         return task_id
@@ -4739,8 +4748,11 @@ def check_browser_requirements() -> bool:
         return True
 
     # CDP override mode can connect to an existing remote/local browser endpoint
-    # without requiring the local agent-browser binary on PATH.
-    if _get_cdp_override():
+    # without requiring the local agent-browser binary on PATH. Use the
+    # configuration-only probe here: schema assembly must not perform HTTP
+    # discovery against the endpoint, so a temporarily stopped Chrome does not
+    # hide the browser tools.
+    if _get_cdp_override(resolve=False):
         return True
 
     # The agent-browser CLI is required for local launch and cloud-provider flows.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -16596,21 +16596,23 @@ def _(rid, params: dict) -> dict:
 def _resolve_browser_cdp_url() -> str:
     """Return the configured browser CDP override without network I/O.
 
-    ``/browser status`` must be fast — calling
-    ``tools.browser_tool._get_cdp_override`` would invoke
-    ``_resolve_cdp_override``, which performs an HTTP probe to
-    ``.../json/version`` for discovery-style URLs.  That probe has
-    a multi-second timeout and would block the TUI on a slow or
-    unreachable host even though status only needs to report whether
+    ``/browser status`` must be fast — resolving discovery-style URLs through
+    ``.../json/version`` has a multi-second timeout and would block the TUI on
+    a slow or unreachable host even though status only needs to report whether
     an override is set.
 
-    Mirrors the env/config precedence of ``_get_cdp_override`` (env
-    var first, then ``browser.cdp_url`` from config.yaml) without the
-    websocket-resolution step, so the answer reflects user intent
-    even when the configured host is not currently reachable.  The
-    actual WS normalization happens in ``browser_navigate`` on the
-    next tool call.
+    Uses ``tools.browser_tool._get_cdp_override(resolve=False)`` so the
+    env/config precedence stays in one place and the answer reflects user
+    intent even when the configured host is not currently reachable. The
+    actual WS normalization happens in ``browser_navigate`` on the next tool
+    call.
     """
+    try:
+        from tools.browser_tool import _get_cdp_override
+
+        return (_get_cdp_override(resolve=False) or "").strip()
+    except Exception:
+        pass
     env_url = os.environ.get("BROWSER_CDP_URL", "").strip()
     if env_url:
         return env_url


### PR DESCRIPTION
## What does this PR do?

`browser_cdp` availability (and the wider browser toolset gate) no longer performs HTTP discovery during schema-time checks.

Previously `_browser_cdp_check()` called `_get_cdp_override()`, which resolves HTTP discovery endpoints through `/json/version`. Because `check_fn` participates in tool-schema resolution, a temporarily offline Chrome endpoint could make `browser_cdp` disappear from the schema instead of remaining available and reporting endpoint unavailability at invocation time. That also made the per-conversation tool prefix unstable.

This separates configuration presence from runtime reachability:

- schema-time checks use `_get_cdp_override(resolve=False)` — env/config only, no network I/O
- invocation/connection paths keep the default resolving behavior so they still receive a concrete `ws://` endpoint

The same configuration-only probe is used by `check_browser_requirements()`, local/SSRF routing helpers, `hermes doctor`, and TUI `/browser status`, so a dead configured endpoint no longer triggers multi-second discovery probes on those paths.

## Related Issue

Fixes #70811

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/browser_tool.py`
  - `_get_cdp_override(resolve: bool = True)` returns the configured endpoint without `_resolve_cdp_override()` HTTP discovery when `resolve=False`
  - `check_browser_requirements()`, `_is_local_mode()`, `_is_local_backend()`, and `_navigation_session_key()` use `resolve=False`
- `tools/browser_cdp_tool.py`
  - new `_has_configured_cdp_endpoint()` helper for schema-time checks
  - `_browser_cdp_check()` uses the configuration-only helper; docstrings clarify invocation-time resolution
- `tools/browser_camofox.py`
  - docstring clarifies Camofox routing is configuration-only, not a reachability probe
- `hermes_cli/doctor.py`
  - Chromium-skip check uses `_get_cdp_override(resolve=False)`
- `tui_gateway/server.py`
  - `_resolve_browser_cdp_url()` uses `_get_cdp_override(resolve=False)` with the previous manual env/config fallback retained defensively
- Tests
  - `tests/tools/test_browser_cdp_tool.py`: check_fn must not resolve endpoints; unreachable HTTP endpoint stays schema-eligible
  - `tests/tools/test_browser_cdp_override.py`: `resolve=False` skips discovery for env and config; `check_browser_requirements()` does not probe
  - `tests/tools/test_browser_hybrid_routing.py`: mocks updated for the new `resolve` keyword
  - `tests/test_tui_gateway_server.py`: `/browser status` regression guard updated to require `resolve=False`

## How to Test

1. Set `browser.cdp_url: http://localhost:9223` (or `BROWSER_CDP_URL=http://localhost:9223`) while Chrome is not running.
2. Resolve browser tools / start a session: `browser_cdp` remains schema-eligible and no `/json/version` probe runs during `check_fn`.
3. Invoke `browser_cdp`: it fails once with the existing structured endpoint/WebSocket error rather than disappearing from the schema.
4. Automated proof:
   ```bash
   scripts/run_tests.sh tests/tools/test_browser_cdp_tool.py tests/tools/test_browser_cdp_override.py tests/tools/test_browser_hybrid_routing.py tests/tools/test_browser_camofox.py tests/tools/test_browser_headed_mode.py tests/tools/test_browser_cloud_fallback.py tests/tools/test_browser_lightpanda.py tests/test_tui_gateway_server.py -q
   ```
   Result: 8 files, 606 tests passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Notes on related PR #8257

#8257 fixes `/browser status` reachability checking against the configured CDP host in `cli.py`. It does not change tool-schema `check_fn` behavior or `_get_cdp_override()` discovery I/O. This PR is the schema-time gap described in #70811: a configured but temporarily dead endpoint must not mutate tool eligibility. Happy to align/fold if maintainers consolidate the two CDP-status paths.

## Screenshots / Logs

Test run:

```text
=== Summary: 8 files, 606 tests passed, 0 failed (100% complete) in 30.0s (16 workers) ===
```
