### PR TITLE
feat(models): add anthropic/claude-opus-5 to OpenRouter and Nous Portal catalogs

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -215,6 +215,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenRouter-prefixed models resolve via OpenRouter live API or models.dev.
     "claude-fable-5": 1000000,
     "claude-fable": 1000000,
+    "claude-opus-5": 1000000,
     "claude-sonnet-5": 1000000,
     "claude-opus-4-8": 1000000,
     "claude-opus-4.8": 1000000,

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -102,6 +102,7 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     # ``claude-opus-4`` so non-thinking Claude 3.x or future
     # non-reasoning Claude variants don't match.
     ("claude-opus-4", 240),
+    ("claude-opus-5", 240),
     ("claude-sonnet-5", 180),
     ("claude-sonnet-4.5", 180),
     ("claude-sonnet-4.6", 180),

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -41,6 +41,8 @@ def _urlopen_model_catalog_request(req: urllib.request.Request, *, timeout: floa
 OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Anthropic
     ("anthropic/claude-fable-5",               ""),
+    ("anthropic/claude-opus-5",                ""),
+    ("anthropic/claude-opus-5-fast",           "2x price, higher output speed"),
     ("anthropic/claude-opus-4.8",              ""),
     ("anthropic/claude-opus-4.8-fast",         "2x price, higher output speed"),
     ("anthropic/claude-sonnet-5",              ""),
@@ -192,6 +194,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
         # Anthropic
         "anthropic/claude-fable-5",
+        "anthropic/claude-opus-5",
         "anthropic/claude-opus-4.8",
         "anthropic/claude-sonnet-5",
         "anthropic/claude-haiku-4.5",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-20T08:23:45Z",
+  "updated_at": "2026-07-24T19:06:06Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -15,6 +15,14 @@
         {
           "id": "anthropic/claude-fable-5",
           "description": ""
+        },
+        {
+          "id": "anthropic/claude-opus-5",
+          "description": ""
+        },
+        {
+          "id": "anthropic/claude-opus-5-fast",
+          "description": "2x price, higher output speed"
         },
         {
           "id": "anthropic/claude-opus-4.8",
@@ -179,6 +187,9 @@
       "models": [
         {
           "id": "anthropic/claude-fable-5"
+        },
+        {
+          "id": "anthropic/claude-opus-5"
         },
         {
           "id": "anthropic/claude-opus-4.8"


### PR DESCRIPTION
## Summary
`anthropic/claude-opus-5` now appears in the OpenRouter and Nous Portal `/model` picker catalogs (with the `-fast` variant on OpenRouter), keeping Opus 4.8 in place.

Verified live before adding: both `openrouter.ai/api/v1/models` and the Nous Portal `/v1/models` endpoint already serve `anthropic/claude-opus-5` and `anthropic/claude-opus-5-fast` (1M context, $5/$25 per MTok, fast variant at 2x).

## Changes
- `hermes_cli/models.py`: `claude-opus-5` + `claude-opus-5-fast` in `OPENROUTER_MODELS`; `claude-opus-5` in `_PROVIDER_MODELS["nous"]`. Ordered below the fable-5 flagship, above opus-4.8 (newest-family-first convention).
- `agent/model_metadata.py`: `claude-opus-5` → 1,000,000 context (matches live OpenRouter metadata).
- `agent/reasoning_timeouts.py`: `claude-opus-5` → 240s stale-timeout floor, same as the opus-4.x thinking family (prefix match also covers `-fast`).
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`.

No pricing snapshot entry needed: OpenRouter and Nous both bill via `official_models_api` (live pricing), and the Anthropic-direct picker list was deliberately left untouched per scope (OpenRouter + Nous only).

## Validation
| Check | Result |
|---|---|
| Targeted catalog suites (test_models, test_anthropic_picker_curated, test_gmi_provider, test_model_catalog, test_usage_pricing, test_minimax_provider) | 225/225 passed |
| E2E (temp HERMES_HOME, creds stripped): both lists contain opus-5, no dupes, ordering fable-5 → opus-5 → opus-4.8 | passed |
| AST duplicate-entry check on models.py | clean |
| `resolve_billing_route` for opus-5 on openrouter/nous | `official_models_api` |

## Infographic

![opus-5-catalog](https://v3b.fal.media/files/b/0aa3926d/2U90zz4a7F7S_WP6b8UbT_icjApb9p.png)
