### PR TITLE
fix(kanban): prevent worker board mutations and preserve initial holds

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -963,6 +963,12 @@ def kanban_command(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
+    if _is_kanban_worker_cli_mutation(args):
+        print(
+            "kanban: running Kanban workers cannot mutate board state through the CLI; use the structured Kanban tools",
+            file=sys.stderr,
+        )
+        return 1
 
     # Board-management commands operate on board metadata and the persisted
     # current-board pointer itself. They must ignore the shared `--board`
@@ -1149,6 +1155,23 @@ def _is_delegated_child_cli_mutation(args: argparse.Namespace) -> bool:
         return is_delegated_child_process_context()
     except Exception:
         return bool(os.environ.get("HERMES_DELEGATED_CHILD_CONTEXT"))
+
+
+def _is_kanban_worker_cli_mutation(args: argparse.Namespace) -> bool:
+    """Reject shell-based board mutations from a running Kanban worker.
+
+    Workers receive structured Kanban tools whose calls can be inspected by
+    plugin policy hooks. Allowing the same worker to invoke mutating CLI
+    commands through ``terminal`` would bypass those hooks.
+    """
+    action = getattr(args, "kanban_action", None)
+    if action == "boards":
+        boards_action = getattr(args, "boards_action", None) or "list"
+        if boards_action not in _DELEGATED_CHILD_DENIED_BOARD_ACTIONS:
+            return False
+    elif action not in _DELEGATED_CHILD_DENIED_ACTIONS:
+        return False
+    return bool(os.environ.get("HERMES_KANBAN_TASK"))
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1102,6 +1102,7 @@ _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "create",
     "swarm",
     "assign",
+    "set-model",
     "reclaim",
     "reassign",
     "link",
@@ -1577,9 +1578,11 @@ def _cmd_list(args: argparse.Namespace) -> int:
     if args.mine and not assignee:
         assignee = _profile_author()
     with kb.connect_closing() as conn:
-        # Cheap "mini-dispatch": recompute ready so list output reflects
-        # dependencies that may have cleared since the last dispatcher tick.
-        kb.recompute_ready(conn)
+        # Cheap "mini-dispatch" for interactive callers. Running workers get a
+        # genuinely read-only list path so terminal-based reads cannot mutate the
+        # board behind structured tool policy hooks.
+        if not os.environ.get("HERMES_KANBAN_TASK"):
+            kb.recompute_ready(conn)
         tasks = kb.list_tasks(
             conn,
             assignee=assignee,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3089,9 +3089,8 @@ def create_task(
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
-                        goal_mode, goal_max_turns, session_id,
-                        block_kind, block_recurrences
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3116,8 +3115,6 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
-                        "needs_input" if task_status == "blocked" else None,
-                        1 if task_status == "blocked" else 0,
                     ),
                 )
                 for pid in parents:
@@ -3156,8 +3153,11 @@ def create_task(
                         "blocked",
                         {
                             "reason": "created with initial_status=blocked",
-                            "kind": "needs_input",
-                            "recurrences": 1,
+                            # An initial human-ops hold is not a worker
+                            # failure and must not consume the unblock-loop
+                            # recurrence budget.
+                            "kind": None,
+                            "recurrences": 0,
                         },
                     )
             return task_id

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3141,6 +3141,22 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if task_status == "blocked":
+                    # ``recompute_ready`` intentionally auto-recovers legacy
+                    # blocked rows that have no explicit block event. Record
+                    # the caller's initial human-ops hold atomically so a
+                    # dispatcher cannot promote and claim the task between
+                    # create and a later CLI ``block`` call.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": "created with initial_status=blocked",
+                            "kind": "needs_input",
+                            "recurrences": 1,
+                        },
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3089,8 +3089,9 @@ def create_task(
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id,
+                        block_kind, block_recurrences
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3115,6 +3116,8 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        "needs_input" if task_status == "blocked" else None,
+                        1 if task_status == "blocked" else 0,
                     ),
                 )
                 for pid in parents:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4511,7 +4511,10 @@ def cmd_kanban(args):
     """Multi-profile collaboration board."""
     from hermes_cli.kanban import kanban_command
 
-    return kanban_command(args)
+    status = kanban_command(args)
+    if isinstance(status, int) and status != 0:
+        raise SystemExit(status)
+    return status
 
 
 def cmd_project(args):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4511,10 +4511,7 @@ def cmd_kanban(args):
     """Multi-profile collaboration board."""
     from hermes_cli.kanban import kanban_command
 
-    status = kanban_command(args)
-    if isinstance(status, int) and status != 0:
-        raise SystemExit(status)
-    return status
+    return kanban_command(args)
 
 
 def cmd_project(args):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -236,12 +236,13 @@ def test_create_task_initial_block_is_atomic_and_survives_recompute(kanban_home)
 
     assert task is not None
     assert task.status == "blocked"
-    assert task.block_kind == "needs_input"
-    assert task.block_recurrences == 1
+    assert task.block_kind is None
+    assert task.block_recurrences == 0
     assert promoted == 0
     assert [event.kind for event in events[-2:]] == ["created", "blocked"]
     assert events[-1].payload is not None
-    assert events[-1].payload["kind"] == "needs_input"
+    assert events[-1].payload["kind"] is None
+    assert events[-1].payload["recurrences"] == 0
 
     with kb.connect() as conn:
         assert kb.unblock_task(conn, tid)
@@ -250,9 +251,9 @@ def test_create_task_initial_block_is_atomic_and_survives_recompute(kanban_home)
         task = kb.get_task(conn, tid)
 
     assert task is not None
-    assert task.status == "triage"
+    assert task.status == "blocked"
     assert task.block_kind == "needs_input"
-    assert task.block_recurrences == 2
+    assert task.block_recurrences == 1
 
 
 def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -222,6 +222,26 @@ def test_create_task_no_parents_is_ready(kanban_home):
     assert t.workspace_kind == "scratch"
 
 
+def test_create_task_initial_block_is_atomic_and_survives_recompute(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="hold for release",
+            assignee="alice",
+            initial_status="blocked",
+        )
+        events = kb.list_events(conn, tid)
+        promoted = kb.recompute_ready(conn)
+        task = kb.get_task(conn, tid)
+
+    assert task is not None
+    assert task.status == "blocked"
+    assert promoted == 0
+    assert [event.kind for event in events[-2:]] == ["created", "blocked"]
+    assert events[-1].payload is not None
+    assert events[-1].payload["kind"] == "needs_input"
+
+
 def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):
     with kb.connect() as conn:
         p = kb.create_task(conn, title="parent")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -236,10 +236,23 @@ def test_create_task_initial_block_is_atomic_and_survives_recompute(kanban_home)
 
     assert task is not None
     assert task.status == "blocked"
+    assert task.block_kind == "needs_input"
+    assert task.block_recurrences == 1
     assert promoted == 0
     assert [event.kind for event in events[-2:]] == ["created", "blocked"]
     assert events[-1].payload is not None
     assert events[-1].payload["kind"] == "needs_input"
+
+    with kb.connect() as conn:
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        assert kb.block_task(conn, tid, reason="still held", kind="needs_input")
+        task = kb.get_task(conn, tid)
+
+    assert task is not None
+    assert task.status == "triage"
+    assert task.block_kind == "needs_input"
+    assert task.block_recurrences == 2
 
 
 def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):

--- a/tests/hermes_cli/test_kanban_worker_cli_mutation_guard.py
+++ b/tests/hermes_cli/test_kanban_worker_cli_mutation_guard.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from argparse import Namespace
+from contextlib import nullcontext
 
+from hermes_cli import kanban
 from hermes_cli.kanban import _is_kanban_worker_cli_mutation
 
 
@@ -10,6 +12,22 @@ def test_running_kanban_worker_cannot_mutate_board_through_cli(monkeypatch):
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
     assert _is_kanban_worker_cli_mutation(Namespace(kanban_action="complete")) is True
     assert _is_kanban_worker_cli_mutation(Namespace(kanban_action="promote")) is True
+    assert _is_kanban_worker_cli_mutation(Namespace(kanban_action="set-model")) is True
+
+
+def test_every_declared_mutating_action_is_denied_to_running_workers(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    for action in kanban._DELEGATED_CHILD_DENIED_ACTIONS:
+        assert _is_kanban_worker_cli_mutation(Namespace(kanban_action=action)) is True
+
+
+def test_worker_command_dispatch_blocks_set_model_before_handler(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    called = []
+    monkeypatch.setattr(kanban, "_cmd_set_model", lambda _args: called.append(True) or 0)
+    assert kanban.kanban_command(Namespace(kanban_action="set-model")) == 1
+    assert called == []
+    assert "cannot mutate board state through the CLI" in capsys.readouterr().err
 
 
 def test_running_kanban_worker_can_use_read_only_cli(monkeypatch):
@@ -22,3 +40,28 @@ def test_interactive_caller_can_mutate_board(monkeypatch):
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
     assert _is_kanban_worker_cli_mutation(Namespace(kanban_action="complete")) is False
+
+
+def test_worker_list_path_does_not_recompute_or_mutate_ready_state(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    monkeypatch.setattr(kanban.kb, "connect_closing", lambda: nullcontext(object()))
+    monkeypatch.setattr(
+        kanban.kb,
+        "recompute_ready",
+        lambda _conn: (_ for _ in ()).throw(AssertionError("worker list mutated board")),
+    )
+    monkeypatch.setattr(kanban.kb, "list_tasks", lambda _conn, **_kwargs: [])
+    args = Namespace(
+        assignee=None,
+        mine=False,
+        status=None,
+        tenant=None,
+        session=None,
+        archived=False,
+        sort=None,
+        workflow_template_id=None,
+        current_step_key=None,
+        json=True,
+    )
+    assert kanban._cmd_list(args) == 0
+    assert capsys.readouterr().out.strip() == "[]"

--- a/tests/hermes_cli/test_kanban_worker_cli_mutation_guard.py
+++ b/tests/hermes_cli/test_kanban_worker_cli_mutation_guard.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from argparse import Namespace
+
+from hermes_cli.kanban import _is_kanban_worker_cli_mutation
+
+
+def test_running_kanban_worker_cannot_mutate_board_through_cli(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    assert _is_kanban_worker_cli_mutation(Namespace(kanban_action="complete")) is True
+    assert _is_kanban_worker_cli_mutation(Namespace(kanban_action="promote")) is True
+
+
+def test_running_kanban_worker_can_use_read_only_cli(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    assert _is_kanban_worker_cli_mutation(Namespace(kanban_action="show")) is False
+    assert _is_kanban_worker_cli_mutation(Namespace(kanban_action="list")) is False
+
+
+def test_interactive_caller_can_mutate_board(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    assert _is_kanban_worker_cli_mutation(Namespace(kanban_action="complete")) is False

--- a/tests/hermes_cli/test_kanban_worker_cli_mutation_guard.py
+++ b/tests/hermes_cli/test_kanban_worker_cli_mutation_guard.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from argparse import Namespace
 from contextlib import nullcontext
 
+import pytest
+
 from hermes_cli import kanban
+from hermes_cli import main as hermes_main
 from hermes_cli.kanban import _is_kanban_worker_cli_mutation
 
 
@@ -28,6 +31,15 @@ def test_worker_command_dispatch_blocks_set_model_before_handler(monkeypatch, ca
     assert kanban.kanban_command(Namespace(kanban_action="set-model")) == 1
     assert called == []
     assert "cannot mutate board state through the CLI" in capsys.readouterr().err
+
+
+def test_top_level_kanban_command_propagates_a_rejected_exit_status(monkeypatch):
+    monkeypatch.setattr(kanban, "kanban_command", lambda _args: 1)
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.cmd_kanban(Namespace())
+
+    assert exc_info.value.code == 1
 
 
 def test_running_kanban_worker_can_use_read_only_cli(monkeypatch):

--- a/tests/hermes_cli/test_kanban_worker_cli_mutation_guard.py
+++ b/tests/hermes_cli/test_kanban_worker_cli_mutation_guard.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import os
 from argparse import Namespace
 from contextlib import nullcontext
-
-import pytest
+from pathlib import Path
+import subprocess
+import sys
 
 from hermes_cli import kanban
-from hermes_cli import main as hermes_main
 from hermes_cli.kanban import _is_kanban_worker_cli_mutation
 
 
@@ -33,13 +34,26 @@ def test_worker_command_dispatch_blocks_set_model_before_handler(monkeypatch, ca
     assert "cannot mutate board state through the CLI" in capsys.readouterr().err
 
 
-def test_top_level_kanban_command_propagates_a_rejected_exit_status(monkeypatch):
-    monkeypatch.setattr(kanban, "kanban_command", lambda _args: 1)
+def test_top_level_cli_propagates_worker_guard_rejection_without_mutation(tmp_path):
+    env = os.environ.copy()
+    env["HERMES_KANBAN_TASK"] = "t_parent"
+    env["HERMES_KANBAN_RUN_ID"] = "42"
+    env.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
+    env["HERMES_HOME"] = str(tmp_path / "hermes-home")
+    env["HOME"] = str(tmp_path / "user-home")
 
-    with pytest.raises(SystemExit) as exc_info:
-        hermes_main.cmd_kanban(Namespace())
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "kanban", "complete", "t_target"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
 
-    assert exc_info.value.code == 1
+    assert result.returncode == 1
+    assert "cannot mutate board state through the CLI" in result.stderr
+    assert not (Path(env["HERMES_HOME"]) / "kanban.db").exists()
 
 
 def test_running_kanban_worker_can_use_read_only_cli(monkeypatch):


### PR DESCRIPTION
Summarizes worker/delegated-child mutation denial, read-only worker list, atomic initial blocked event, and staging holds outside the recurrence budget.\n\nIndependent exact-SHA review: PASS at `05c691b59bab5cd3dc7fb0e914104683102d9536`.\n\n367 relevant tests plus Ruff/diff checks passed.