### PR TITLE
fix(update): preserve and rebase committed local patches, and report real rebase conflicts

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -353,7 +353,8 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'tts.elevenlabs.model_id': ['eleven_multilingual_v2', 'eleven_turbo_v2_5', 'eleven_flash_v2_5'],
   // NeuTTS local inference device.
   'tts.neutts.device': ['cpu', 'cuda', 'mps'],
-  'updates.non_interactive_local_changes': ['stash', 'discard']
+  'updates.non_interactive_local_changes': ['stash', 'discard'],
+  'updates.committed_local_changes': ['refuse', 'rebase']
 }
 
 // Voice/model name fields render as a free-input combobox (Input + datalist)
@@ -545,7 +546,8 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     reasoningEffort: 'Subagent Reasoning Effort'
   },
   updates: {
-    nonInteractiveLocalChanges: 'In-App Update Local Changes'
+    nonInteractiveLocalChanges: 'In-App Update Local Changes',
+    committedLocalChanges: 'Committed Update Patches'
   }
 })
 
@@ -626,7 +628,9 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   },
   updates: {
     nonInteractiveLocalChanges:
-      'When Hermes updates itself from the app (no terminal prompt), keep local source edits (stash) or throw them away (discard). Terminal updates always ask.'
+      'When Hermes updates itself from the app (no terminal prompt), keep local source edits (stash) or throw them away (discard). Terminal updates always ask.',
+    committedLocalChanges:
+      'When the update branch has local commits, stop safely (refuse) or back up and rebase a linear patch stack (rebase).'
   }
 })
 
@@ -772,7 +776,8 @@ export const SECTIONS: DesktopConfigSection[] = [
       'delegation.max_concurrent_children',
       'delegation.child_timeout_seconds',
       'delegation.reasoning_effort',
-      'updates.non_interactive_local_changes'
+      'updates.non_interactive_local_changes',
+      'updates.committed_local_changes'
     ]
   }
 ]

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -87,6 +87,9 @@ describe('settings helpers', () => {
       expect(schemaKeyToFieldCopyKey('updates.non_interactive_local_changes')).toBe(
         'updates.nonInteractiveLocalChanges'
       )
+      expect(schemaKeyToFieldCopyKey('updates.committed_local_changes')).toBe(
+        'updates.committedLocalChanges'
+      )
     })
 
     it('looks up camelCase field copy by schema key with legacy fallback', () => {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3343,6 +3343,12 @@ DEFAULT_CONFIG = {
         #               ignored paths — node_modules, venv, build outputs —
         #               are never touched.
         "non_interactive_local_changes": "stash",
+        # What `hermes update` does when the update branch contains committed
+        # local patches and has diverged from origin. "refuse" is the safe
+        # default. "rebase" first creates a durable backup ref, then rebases a
+        # linear patch stack while dropping upstream-equivalent/empty commits;
+        # genuine conflicts abort and restore the original HEAD.
+        "committed_local_changes": "refuse",
         # Refresh an already-installed cua-driver during `hermes update`.
         # The refresh is best-effort and macOS-only. Turn this off if the
         # upstream installer is not appropriate for the machine, for example

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -424,6 +424,7 @@ import shlex
 import shutil
 import stat
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -7380,6 +7381,249 @@ def _discard_stashed_changes(
     return True
 
 
+@dataclass(frozen=True)
+class _CommittedLocalChangesOutcome:
+    """Result of reconciling commits that exist only on the local branch."""
+
+    status: str
+    ahead_count: int = 0
+    backup_ref: Optional[str] = None
+    detail: Optional[str] = None
+
+
+def _backup_ref_created_at(
+    git_cmd: list[str], cwd: Path, ref: str
+) -> Optional[int]:
+    """Return a backup ref's reflog creation time, or ``None`` if unknown."""
+    result = subprocess.run(
+        git_cmd
+        + ["reflog", "show", "-n", "1", "--date=unix", "--format=%gd", ref],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    selector = result.stdout.strip()
+    marker = selector.rpartition("@{")
+    if not marker[1] or not marker[2].endswith("}"):
+        return None
+    try:
+        return int(marker[2][:-1])
+    except ValueError:
+        return None
+
+
+def _create_committed_local_changes_backup(
+    git_cmd: list[str],
+    cwd: Path,
+    branch: str,
+    head_sha: str,
+    *,
+    keep: int = 5,
+) -> Optional[str]:
+    """Create and prune durable pre-rebase refs without trusting ref names.
+
+    Each ref gets an explicit reflog, whose timestamp is the source of truth
+    for retention. Refs with missing/unparseable creation metadata are kept.
+    """
+    from datetime import datetime, timezone
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    prefix = f"refs/hermes/update-backups/{branch}/"
+    backup_ref = f"{prefix}{timestamp}"
+    created = subprocess.run(
+        git_cmd + ["update-ref", "--create-reflog", backup_ref, head_sha],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if created.returncode != 0:
+        return None
+
+    listed = subprocess.run(
+        git_cmd + ["for-each-ref", "--format=%(refname)", prefix],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if listed.returncode != 0:
+        return backup_ref
+
+    dated_refs: list[tuple[int, str]] = []
+    for ref in listed.stdout.splitlines():
+        ref = ref.strip()
+        if not ref:
+            continue
+        created_at = _backup_ref_created_at(git_cmd, cwd, ref)
+        if created_at is not None:
+            dated_refs.append((created_at, ref))
+
+    dated_refs.sort(key=lambda item: item[0])
+    for _created_at, stale_ref in dated_refs[: max(0, len(dated_refs) - keep)]:
+        subprocess.run(
+            git_cmd + ["update-ref", "-d", stale_ref],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+    return backup_ref
+
+
+def _reconcile_committed_local_changes(
+    git_cmd: list[str],
+    cwd: Path,
+    branch: str,
+    mode: str,
+    pre_pull_sha: Optional[str],
+) -> _CommittedLocalChangesOutcome:
+    """Safely reconcile commits that prevent an ff-only update.
+
+    ``refuse`` is the default. ``rebase`` creates a durable backup ref, then
+    rebases a linear local patch stack while dropping commits that are empty or
+    already equivalent upstream. The caller owns the existing hard-reset path
+    when this returns ``no_local_commits``.
+    """
+    remote_ref = f"origin/{branch}"
+    ahead = subprocess.run(
+        git_cmd + ["rev-list", "--count", f"{remote_ref}..HEAD"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if ahead.returncode != 0:
+        detail = (ahead.stderr or ahead.stdout or "could not count local commits").strip()
+        print("✗ Could not inspect committed local changes safely.")
+        if detail:
+            print(f"  {detail.splitlines()[0]}")
+        return _CommittedLocalChangesOutcome("failed", detail=detail)
+
+    try:
+        ahead_count = int(ahead.stdout.strip())
+    except ValueError:
+        detail = f"invalid local commit count: {ahead.stdout.strip()!r}"
+        print(f"✗ Could not inspect committed local changes safely ({detail}).")
+        return _CommittedLocalChangesOutcome("failed", detail=detail)
+
+    if ahead_count == 0:
+        return _CommittedLocalChangesOutcome("no_local_commits")
+
+    if mode != "rebase":
+        print(
+            f"  ✗ Local {branch} is ahead of {remote_ref} by {ahead_count} commit(s) "
+            "— refusing to reset committed local work."
+        )
+        print(
+            "    Set updates.committed_local_changes: rebase in config.yaml "
+            "to preserve and rebase a linear local patch stack automatically."
+        )
+        return _CommittedLocalChangesOutcome("refused", ahead_count=ahead_count)
+
+    merges = subprocess.run(
+        git_cmd + ["rev-list", "--merges", "--count", f"{remote_ref}..HEAD"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    try:
+        merge_count = int(merges.stdout.strip()) if merges.returncode == 0 else -1
+    except ValueError:
+        merge_count = -1
+    if merge_count < 0:
+        detail = (merges.stderr or "could not inspect the local commit graph").strip()
+        print("✗ Could not verify that the local patch stack is linear.")
+        return _CommittedLocalChangesOutcome(
+            "failed", ahead_count=ahead_count, detail=detail
+        )
+    if merge_count:
+        detail = f"local patch stack contains {merge_count} merge commit(s)"
+        print(f"  ✗ {detail}; automatic rebase is disabled for this history.")
+        print(f"    Reconcile manually, then re-run `hermes update --branch {branch}`.")
+        return _CommittedLocalChangesOutcome(
+            "refused", ahead_count=ahead_count, detail=detail
+        )
+
+    if not pre_pull_sha:
+        detail = "could not capture the pre-rebase HEAD"
+        print(f"✗ {detail}; refusing to rewrite committed local work.")
+        return _CommittedLocalChangesOutcome(
+            "failed", ahead_count=ahead_count, detail=detail
+        )
+
+    backup_ref = _create_committed_local_changes_backup(
+        git_cmd, cwd, branch, pre_pull_sha
+    )
+    if backup_ref is None:
+        detail = "could not create durable pre-rebase backup ref"
+        print(f"✗ {detail}; refusing to rewrite committed local work.")
+        return _CommittedLocalChangesOutcome(
+            "failed", ahead_count=ahead_count, detail=detail
+        )
+
+    print(
+        f"  → Rebasing {ahead_count} committed local patch(es) onto {remote_ref}..."
+    )
+    print(f"    Backup: {backup_ref}")
+    rebased = subprocess.run(
+        git_cmd
+        + ["rebase", "--empty=drop", "--no-keep-empty", remote_ref],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if rebased.returncode == 0:
+        remaining = subprocess.run(
+            git_cmd + ["rev-list", "--count", f"{remote_ref}..HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        remaining_count = remaining.stdout.strip() if remaining.returncode == 0 else "?"
+        print(
+            f"  ✓ Local patches rebased ({remaining_count} remain; "
+            "upstream-equivalent patches were dropped)."
+        )
+        return _CommittedLocalChangesOutcome(
+            "rebased", ahead_count=ahead_count, backup_ref=backup_ref
+        )
+
+    detail = (rebased.stderr or rebased.stdout or "git rebase failed").strip()
+    print("✗ Could not rebase committed local patches automatically.")
+    if detail:
+        print(f"  {detail.splitlines()[0]}")
+    aborted = subprocess.run(
+        git_cmd + ["rebase", "--abort"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    current = subprocess.run(
+        git_cmd + ["rev-parse", "HEAD"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    restored = (
+        aborted.returncode == 0
+        and current.returncode == 0
+        and current.stdout.strip() == pre_pull_sha
+    )
+    if restored:
+        print("  ✓ Rebase aborted; the original committed state is restored.")
+    else:
+        print("  ✗ Automatic rebase abort did not restore the original HEAD.")
+        print("    Do not run another update. Recover with:")
+        print(f"      git -C {cwd} rebase --abort")
+        print(f"      git -C {cwd} reset --hard {backup_ref}")
+    print(f"  Durable backup: {backup_ref}")
+    return _CommittedLocalChangesOutcome(
+        "failed",
+        ahead_count=ahead_count,
+        backup_ref=backup_ref,
+        detail=detail,
+    )
+
+
 # =========================================================================
 # Fork detection and upstream management for `hermes update`
 # =========================================================================
@@ -10748,18 +10992,25 @@ def _cmd_update_impl(args, gateway_mode: bool):
         or not (sys.stdin.isatty() and sys.stdout.isatty())
     )
     discard_local_changes = False
-    if _non_interactive_update:
-        try:
-            from hermes_cli.config import load_config
+    committed_local_changes_mode = "refuse"
+    try:
+        from hermes_cli.config import load_config
 
-            _update_cfg = (load_config() or {}).get("updates", {})
-            if isinstance(_update_cfg, dict):
+        _update_cfg = (load_config() or {}).get("updates", {})
+        if isinstance(_update_cfg, dict):
+            _committed_mode = str(
+                _update_cfg.get("committed_local_changes", "refuse")
+            ).lower()
+            if _committed_mode in {"refuse", "rebase"}:
+                committed_local_changes_mode = _committed_mode
+            if _non_interactive_update:
                 _mode = str(_update_cfg.get("non_interactive_local_changes", "stash")).lower()
                 discard_local_changes = _mode == "discard"
-        except Exception as exc:
-            # Never let a config read failure change the safe default.
-            logger.debug("Could not read updates.non_interactive_local_changes: %s", exc)
-            discard_local_changes = False
+    except Exception as exc:
+        # Never let a config read failure change either safe default.
+        logger.debug("Could not read update behavior settings: %s", exc)
+        discard_local_changes = False
+        committed_local_changes_mode = "refuse"
 
     print("⚕ Updating Hermes Agent...")
     print()
@@ -11077,25 +11328,36 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                # force-pushed or rebase). Reconcile committed local patches
+                # according to config before retaining the historical reset
+                # fallback for histories with no local commits to preserve.
+                reconciliation = _reconcile_committed_local_changes(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    branch,
+                    committed_local_changes_mode,
+                    pre_pull_sha,
                 )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True, encoding="utf-8", errors="replace",
-                )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
-                    print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
-                    )
+                if reconciliation.status in {"refused", "failed"}:
                     sys.exit(1)
+                if reconciliation.status == "no_local_commits":
+                    print(
+                        "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    )
+                    reset_result = subprocess.run(
+                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                    )
+                    if reset_result.returncode != 0:
+                        print(f"✗ Failed to reset to origin/{branch}.")
+                        if reset_result.stderr.strip():
+                            print(f"  {reset_result.stderr.strip()}")
+                        print(
+                            f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        )
+                        sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7470,6 +7470,54 @@ def _create_committed_local_changes_backup(
     return backup_ref
 
 
+def _rebase_conflict_summary(
+    git_cmd: list[str],
+    cwd: Path,
+    result: subprocess.CompletedProcess,
+) -> tuple[str, list[str]]:
+    """Summarize a failed ``git rebase`` BEFORE ``--abort`` destroys the state.
+
+    git splits rebase-conflict output across streams: stdout carries
+    ``Auto-merging`` / ``CONFLICT (content): Merge conflict in <path>``, while
+    stderr carries ``Rebasing (n/m)``, ``error: could not apply <sha>...`` and
+    ``hint:`` lines. Reading ``stderr or stdout`` always discards stdout (stderr
+    is non-empty), and taking only its first line then yields ``Rebasing (1/6)``
+    — which tells the user nothing about what actually conflicted. Scan both
+    streams for the failing commit, and read the unmerged paths out of the index
+    while the conflicted rebase is still in progress.
+    """
+    combined = f"{result.stdout or ''}\n{result.stderr or ''}"
+    lines = [ln.strip() for ln in combined.splitlines() if ln.strip()]
+    detail = next(
+        (
+            ln
+            for ln in lines
+            if ln.startswith(("error: could not apply", "Could not apply"))
+        ),
+        "",
+    )
+    if not detail:
+        detail = next(
+            (ln for ln in lines if not ln.startswith(("hint:", "Rebasing ("))),
+            "",
+        )
+    unmerged = subprocess.run(
+        git_cmd + ["diff", "--name-only", "--diff-filter=U"],
+        cwd=cwd,
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+    )
+    files = [path.strip() for path in unmerged.stdout.splitlines() if path.strip()]
+    if not files:
+        # Rename/delete conflicts do not always leave unmerged index entries.
+        files = [
+            ln.rpartition(" in ")[2]
+            for ln in lines
+            if ln.startswith("CONFLICT") and " in " in ln
+        ]
+    return detail or "git rebase failed", files
+
+
 def _reconcile_committed_local_changes(
     git_cmd: list[str],
     cwd: Path,
@@ -7587,10 +7635,17 @@ def _reconcile_committed_local_changes(
             "rebased", ahead_count=ahead_count, backup_ref=backup_ref
         )
 
-    detail = (rebased.stderr or rebased.stdout or "git rebase failed").strip()
+    detail, conflicts = _rebase_conflict_summary(git_cmd, cwd, rebased)
     print("✗ Could not rebase committed local patches automatically.")
-    if detail:
-        print(f"  {detail.splitlines()[0]}")
+    print(f"  {detail}")
+    if conflicts:
+        shown = conflicts[:5]
+        extra = (
+            f" (+{len(conflicts) - len(shown)} more)"
+            if len(conflicts) > len(shown)
+            else ""
+        )
+        print(f"  Conflicting file(s): {', '.join(shown)}{extra}")
     aborted = subprocess.run(
         git_cmd + ["rebase", "--abort"],
         cwd=cwd,
@@ -7610,6 +7665,10 @@ def _reconcile_committed_local_changes(
     )
     if restored:
         print("  ✓ Rebase aborted; the original committed state is restored.")
+        print("    Resolve by hand with:")
+        print(
+            f"      git -C {cwd} rebase --empty=drop --no-keep-empty {remote_ref}"
+        )
     else:
         print("  ✗ Automatic rebase abort did not restore the original HEAD.")
         print("    Do not run another update. Recover with:")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -919,6 +919,15 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         ),
         "options": ["stash", "discard"],
     },
+    "updates.committed_local_changes": {
+        "type": "select",
+        "description": (
+            "What to do when the update branch has committed local patches. "
+            "'refuse' stops safely; 'rebase' backs up and rebases a linear "
+            "patch stack, dropping patches already present upstream."
+        ),
+        "options": ["refuse", "rebase"],
+    },
     "updates.refresh_cua_driver": {
         "type": "bool",
         "description": (

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -398,6 +398,7 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     monkeypatch.setattr(hermes_config, "check_config_version", lambda: (5, 5))
     monkeypatch.setattr(hermes_config, "migrate_config", lambda **kw: {"env_added": [], "config_added": []})
     monkeypatch.setattr(hermes_main, "_upgrade_pip_before_lazy_refresh", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_config, "load_config", lambda *a, **kw: {})
     monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", lambda *a, **kw: True)
 
 
@@ -535,6 +536,7 @@ def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch,
 def _make_update_side_effect(
     current_branch="main",
     commit_count="3",
+    local_ahead_count="0",
     ff_only_fails=False,
     reset_fails=False,
     fetch_fails=False,
@@ -554,6 +556,8 @@ def _make_update_side_effect(
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rev-list" in joined and "origin/main..HEAD" in joined:
+            return SimpleNamespace(stdout=f"{local_ahead_count}\n", stderr="", returncode=0)
         if "rev-list" in joined:
             return SimpleNamespace(stdout=f"{commit_count}\n", stderr="", returncode=0)
         if "--ff-only" in joined:
@@ -603,6 +607,102 @@ def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
 
     reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
     assert len(reset_calls) == 0
+
+
+def test_cmd_update_rebased_changes_fall_through_full_pipeline(monkeypatch, tmp_path):
+    """A successful reconciliation needs no separate pipeline-forcing path."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda *a, **kw: {"updates": {"committed_local_changes": "rebase"}},
+    )
+    reconcile_calls = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_reconcile_committed_local_changes",
+        lambda *args: reconcile_calls.append(args)
+        or hermes_main._CommittedLocalChangesOutcome("rebased", ahead_count=2),
+    )
+    syntax_checks = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_validate_critical_files_syntax",
+        lambda root: syntax_checks.append(root) or (True, None, None),
+    )
+    post_pull_steps = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_refresh_active_lazy_features",
+        lambda *args, **kwargs: post_pull_steps.append("lazy-features"),
+    )
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True, local_ahead_count="2"
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    assert len(reconcile_calls) == 1
+    assert reconcile_calls[0][3] == "rebase"
+    assert syntax_checks == [tmp_path]
+    assert post_pull_steps == ["lazy-features"]
+    assert not [c for c in recorded if "reset" in c and "--hard" in c]
+
+
+@pytest.mark.parametrize("status", ["refused", "failed"])
+def test_cmd_update_never_resets_when_reconciliation_stops(
+    monkeypatch, tmp_path, status
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        hermes_main,
+        "_reconcile_committed_local_changes",
+        lambda *args: hermes_main._CommittedLocalChangesOutcome(status),
+    )
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True, local_ahead_count="2"
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    assert not [c for c in recorded if "reset" in c and "--hard" in c]
+
+
+def test_cmd_update_preserves_update_stash_when_reconciliation_stops(
+    monkeypatch, tmp_path, capsys
+):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        hermes_main,
+        "_stash_local_changes_if_needed",
+        lambda *a, **kw: "abc123deadbeef",
+    )
+    restores = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_restore_stashed_changes",
+        lambda *a, **kw: restores.append(1) or True,
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_reconcile_committed_local_changes",
+        lambda *args: hermes_main._CommittedLocalChangesOutcome("failed"),
+    )
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True, local_ahead_count="2"
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    assert restores == []
+    assert not [c for c in recorded if "reset" in c and "--hard" in c]
+    assert "preserved in stash" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_update_committed_changes.py
+++ b/tests/hermes_cli/test_update_committed_changes.py
@@ -139,6 +139,53 @@ def test_reconcile_conflict_aborts_and_restores_original_head(tmp_path):
     assert not (local / ".git" / "rebase-merge").exists()
 
 
+def test_reconcile_conflict_reports_the_conflicting_files(tmp_path, capsys):
+    """A failed rebase must name the failing commit and the conflicting paths.
+
+    Regression: git puts ``CONFLICT (content): ...`` on stdout and
+    ``Rebasing (n/m)`` first on stderr, so ``(stderr or stdout).splitlines()[0]``
+    surfaced only the progress banner and the operator learned nothing.
+    """
+    local, seed = _diverged_repositories(tmp_path)
+    _commit(local, "conflict.txt", "base\n", "shared starting point")
+    _git(local, "push", "origin", "main")
+    _git(seed, "pull", "--ff-only", "origin", "main")
+    original_head = _commit(local, "conflict.txt", "local\n", "local conflict")
+    _commit(seed, "conflict.txt", "upstream\n", "upstream conflict")
+    _git(seed, "push", "origin", "main")
+    _git(local, "fetch", "origin", "main")
+
+    outcome = hermes_main._reconcile_committed_local_changes(
+        ["git"], local, "main", "rebase", original_head
+    )
+    output = capsys.readouterr().out
+
+    assert outcome.status == "failed"
+    # The unmerged path is read before --abort destroys it.
+    assert "conflict.txt" in output
+    # The progress banner must no longer be the whole story.
+    assert "could not apply" in (outcome.detail or "").lower()
+    assert not (outcome.detail or "").startswith("Rebasing (")
+    # And the operator gets a copy-pasteable way to finish by hand.
+    assert f"git -C {local} rebase --empty=drop --no-keep-empty" in output
+
+
+def test_rebase_conflict_summary_falls_back_to_stdout_conflict_lines(tmp_path):
+    """Rename/delete conflicts leave no unmerged index entry — scrape stdout."""
+    repo = tmp_path / "empty"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    result = SimpleNamespace(
+        stdout="Auto-merging a/b.py\nCONFLICT (content): Merge conflict in a/b.py\n",
+        stderr="Rebasing (1/3)\nerror: could not apply deadbee... some patch\nhint: blah\n",
+    )
+
+    detail, files = hermes_main._rebase_conflict_summary(["git"], repo, result)
+
+    assert detail == "error: could not apply deadbee... some patch"
+    assert files == ["a/b.py"]
+
+
 def test_reconcile_abort_failure_preserves_backup_without_reset(
     tmp_path, monkeypatch, capsys
 ):

--- a/tests/hermes_cli/test_update_committed_changes.py
+++ b/tests/hermes_cli/test_update_committed_changes.py
@@ -1,0 +1,234 @@
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli import main as hermes_main
+
+
+_REAL_SUBPROCESS_RUN = subprocess.run
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return _REAL_SUBPROCESS_RUN(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _commit(repo: Path, path: str, content: str, message: str) -> str:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+    _git(repo, "add", path)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def _diverged_repositories(tmp_path: Path) -> tuple[Path, Path]:
+    remote = tmp_path / "remote.git"
+    seed = tmp_path / "seed"
+    local = tmp_path / "local"
+    _git(tmp_path, "init", "--bare", str(remote))
+    _git(tmp_path, "init", "-b", "main", str(seed))
+    _git(seed, "config", "user.email", "tests@example.com")
+    _git(seed, "config", "user.name", "Hermes Tests")
+    _commit(seed, "base.txt", "base\n", "base")
+    _git(seed, "remote", "add", "origin", str(remote))
+    _git(seed, "push", "-u", "origin", "main")
+    _git(tmp_path, "clone", "-b", "main", str(remote), str(local))
+    _git(local, "config", "user.email", "tests@example.com")
+    _git(local, "config", "user.name", "Hermes Tests")
+    return local, seed
+
+
+def _advance_and_fetch(local: Path, seed: Path, path: str = "upstream.txt") -> str:
+    remote_head = _commit(seed, path, "upstream\n", "upstream change")
+    _git(seed, "push", "origin", "main")
+    _git(local, "fetch", "origin", "main")
+    return remote_head
+
+
+def test_reconcile_reports_no_local_commits(tmp_path):
+    local, seed = _diverged_repositories(tmp_path)
+    _advance_and_fetch(local, seed)
+
+    outcome = hermes_main._reconcile_committed_local_changes(
+        ["git"],
+        local,
+        "main",
+        "rebase",
+        _git(local, "rev-parse", "HEAD").stdout.strip(),
+    )
+
+    assert outcome.status == "no_local_commits"
+    assert outcome.backup_ref is None
+
+
+def test_reconcile_defaults_to_refusal(tmp_path):
+    local, seed = _diverged_repositories(tmp_path)
+    _commit(local, "local.txt", "local\n", "local patch")
+    _advance_and_fetch(local, seed)
+
+    outcome = hermes_main._reconcile_committed_local_changes(
+        ["git"],
+        local,
+        "main",
+        "refuse",
+        _git(local, "rev-parse", "HEAD").stdout.strip(),
+    )
+
+    assert outcome.status == "refused"
+    assert outcome.ahead_count == 1
+    assert outcome.backup_ref is None
+
+
+def test_reconcile_successfully_rebases_linear_patches(tmp_path):
+    local, seed = _diverged_repositories(tmp_path)
+    original_head = _commit(local, "local.txt", "local\n", "local patch")
+    remote_head = _advance_and_fetch(local, seed)
+
+    outcome = hermes_main._reconcile_committed_local_changes(
+        ["git"], local, "main", "rebase", original_head
+    )
+
+    assert outcome.status == "rebased"
+    assert outcome.backup_ref
+    assert _git(local, "rev-parse", outcome.backup_ref).stdout.strip() == original_head
+    assert (
+        _git(local, "merge-base", "--is-ancestor", remote_head, "HEAD").returncode == 0
+    )
+    assert (local / "local.txt").read_text() == "local\n"
+
+
+def test_reconcile_auto_drops_upstream_equivalent_patch(tmp_path):
+    local, seed = _diverged_repositories(tmp_path)
+    original_head = _commit(local, "equivalent.txt", "same\n", "local wording")
+    remote_head = _commit(seed, "equivalent.txt", "same\n", "upstream wording")
+    _git(seed, "push", "origin", "main")
+    _git(local, "fetch", "origin", "main")
+
+    outcome = hermes_main._reconcile_committed_local_changes(
+        ["git"], local, "main", "rebase", original_head
+    )
+
+    assert outcome.status == "rebased"
+    assert _git(local, "rev-parse", "HEAD").stdout.strip() == remote_head
+    assert _git(local, "rev-list", "--count", "origin/main..HEAD").stdout.strip() == "0"
+
+
+def test_reconcile_conflict_aborts_and_restores_original_head(tmp_path):
+    local, seed = _diverged_repositories(tmp_path)
+    _commit(local, "conflict.txt", "base\n", "shared starting point")
+    _git(local, "push", "origin", "main")
+    _git(seed, "pull", "--ff-only", "origin", "main")
+    original_head = _commit(local, "conflict.txt", "local\n", "local conflict")
+    _commit(seed, "conflict.txt", "upstream\n", "upstream conflict")
+    _git(seed, "push", "origin", "main")
+    _git(local, "fetch", "origin", "main")
+
+    outcome = hermes_main._reconcile_committed_local_changes(
+        ["git"], local, "main", "rebase", original_head
+    )
+
+    assert outcome.status == "failed"
+    assert outcome.backup_ref
+    assert _git(local, "rev-parse", "HEAD").stdout.strip() == original_head
+    assert not (local / ".git" / "rebase-merge").exists()
+
+
+def test_reconcile_abort_failure_preserves_backup_without_reset(
+    tmp_path, monkeypatch, capsys
+):
+    local, seed = _diverged_repositories(tmp_path)
+    _commit(local, "conflict.txt", "base\n", "shared starting point")
+    _git(local, "push", "origin", "main")
+    _git(seed, "pull", "--ff-only", "origin", "main")
+    original_head = _commit(local, "conflict.txt", "local\n", "local conflict")
+    _commit(seed, "conflict.txt", "upstream\n", "upstream conflict")
+    _git(seed, "push", "origin", "main")
+    _git(local, "fetch", "origin", "main")
+    calls = []
+
+    def run_with_failed_abort(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1:] == ["rebase", "--abort"]:
+            return SimpleNamespace(returncode=1, stdout="", stderr="abort failed")
+        return _REAL_SUBPROCESS_RUN(cmd, **kwargs)
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", run_with_failed_abort)
+    outcome = hermes_main._reconcile_committed_local_changes(
+        ["git"], local, "main", "rebase", original_head
+    )
+
+    assert outcome.status == "failed"
+    assert outcome.backup_ref
+    assert _git(local, "rev-parse", outcome.backup_ref).stdout.strip() == original_head
+    assert not [cmd for cmd in calls if cmd[1:3] == ["reset", "--hard"]]
+    output = capsys.readouterr().out
+    assert f"git -C {local} rebase --abort" in output
+    assert f"git -C {local} reset --hard {outcome.backup_ref}" in output
+
+    _REAL_SUBPROCESS_RUN(
+        ["git", "rebase", "--abort"], cwd=local, capture_output=True, text=True
+    )
+
+
+def test_reconcile_refuses_local_merge_commits(tmp_path):
+    local, seed = _diverged_repositories(tmp_path)
+    _git(local, "checkout", "-b", "feature")
+    _commit(local, "feature.txt", "feature\n", "feature patch")
+    _git(local, "checkout", "main")
+    _commit(local, "main-local.txt", "main\n", "main patch")
+    _git(local, "merge", "--no-ff", "feature", "-m", "local merge")
+    original_head = _git(local, "rev-parse", "HEAD").stdout.strip()
+    _advance_and_fetch(local, seed)
+
+    outcome = hermes_main._reconcile_committed_local_changes(
+        ["git"], local, "main", "rebase", original_head
+    )
+
+    assert outcome.status == "refused"
+    assert "merge commit" in (outcome.detail or "")
+    refs = _git(
+        local, "for-each-ref", "--format=%(refname)", "refs/hermes/update-backups"
+    )
+    assert refs.stdout == ""
+
+
+def test_backup_refs_prune_by_reflog_creation_time_and_keep_unknown_metadata(
+    tmp_path, monkeypatch
+):
+    local, _seed = _diverged_repositories(tmp_path)
+    head = _git(local, "rev-parse", "HEAD").stdout.strip()
+    prefix = "refs/hermes/update-backups/main/"
+    refs = [f"{prefix}{name}" for name in ["z", "a", "y", "b", "x", "unknown"]]
+    for ref in refs:
+        _git(local, "update-ref", "--create-reflog", ref, head)
+    creation_times = {
+        refs[0]: 1,
+        refs[1]: 5,
+        refs[2]: 2,
+        refs[3]: 4,
+        refs[4]: 3,
+        refs[5]: None,
+    }
+    monkeypatch.setattr(
+        hermes_main,
+        "_backup_ref_created_at",
+        lambda _git_cmd, _cwd, ref: creation_times.get(ref, 100),
+    )
+
+    new_ref = hermes_main._create_committed_local_changes_backup(
+        ["git"], local, "main", head, keep=5
+    )
+
+    remaining = set(
+        _git(local, "for-each-ref", "--format=%(refname)", prefix).stdout.splitlines()
+    )
+    assert new_ref in remaining
+    assert refs[0] not in remaining
+    assert refs[5] in remaining
+    assert remaining == {refs[1], refs[2], refs[3], refs[4], refs[5], new_ref}

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -53,7 +53,10 @@ When the update runs **without a terminal** — from the desktop/chat app's "Upd
 updates:
   non_interactive_local_changes: stash   # default: keep + auto-restore
   # non_interactive_local_changes: discard  # throw local source edits away
+  committed_local_changes: refuse        # set to rebase to preserve local commits
 ```
+
+Committed local patches are handled separately. `updates.committed_local_changes` defaults to `refuse`; set it to `rebase` to back up and rebase a linear patch stack automatically. Upstream-equivalent and empty patches are dropped, while merge commits and genuine conflicts stop the update safely.
 
 - `stash` (default) — auto-stash, pull, then auto-restore your changes on top of the updated code. Nothing is lost; if a restore hits conflicts they're preserved in a git stash for manual recovery.
 - `discard` — auto-stash and drop the stash after the pull, so the update always lands on a clean tree. Use this only on machines where you never intend to keep local edits to the Hermes source. It stash-drops (not `git reset --hard` + `git clean -fd`), so ignored paths like `node_modules`, `venv`, and build outputs are never touched.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -104,11 +104,14 @@ updates:
   pre_update_backup: quick       # quick (state snapshot, default) | full (snapshot + HERMES_HOME zip) | off
   backup_keep: 5                 # Keep this many full pre-update backup zips
   non_interactive_local_changes: stash  # stash | discard
+  committed_local_changes: refuse       # refuse | rebase
 ```
 
 `pre_update_backup` is the single pre-update safety knob: `quick` (default) snapshots critical state files (pairing data, cron jobs, config, auth; files over 1 GiB are skipped) into `state-snapshots/`; `full` additionally zips all of `HERMES_HOME` into `backups/` and can add minutes on large homes; `off` disables both. Legacy booleans are honored (`true` → `full`, `false` → `off`).
 
 For git installs, Hermes auto-stashes dirty tracked files and untracked files before checking out the update branch or pulling. Interactive terminal updates prompt before restoring that stash. Non-interactive updates (desktop/chat app, gateway, or `--yes`) use `updates.non_interactive_local_changes`: `stash` restores local source edits after a successful pull, while `discard` drops the update-created stash after a successful pull. Use `discard` only on managed installs where local source edits are never meant to persist.
+
+Committed local patches use a separate, opt-in setting: `updates.committed_local_changes` defaults to `refuse`. Set it to `rebase` to create a durable backup ref and automatically rebase a linear local patch stack onto the update branch. Patches already present upstream and originally empty commits are dropped; merge commits or genuine conflicts stop safely without a hard reset.
 
 Before that stash step, Hermes also restores tracked `package-lock.json` diffs left by npm install/build churn. Commit or manually stash intentional lockfile edits before updating.
 


### PR DESCRIPTION
## Problem

`hermes update` assumes all local work is uncommitted (and therefore stashed). An install whose `main` is deliberately *ahead* of origin — carrying committed local patches — hits the ff-only-pull failure path, which unconditionally runs a hard reset to `origin/<branch>` and silently destroys that work.

## What this does

**Commit 1 — preserve committed local patches.** Adds `updates.committed_local_changes` (`refuse` | `rebase`, default `refuse`, so behavior is unchanged unless opted in):

- `refuse` — if local `main` is ahead, stop with reconcile instructions instead of discarding commits.
- `rebase` — create a durable backup ref (`refs/hermes/update-backups/<branch>/<ts>`, pruned to the newest 5 by reflog time), rebase the patch stack onto the remote, and continue the normal pipeline. On any failure it aborts, verifies HEAD is restored to the pre-pull SHA, and keeps the backup ref.

The historical reset is retained verbatim for the `no_local_commits` case, which is the only situation it was ever correct for.

**Commit 2 — report what actually conflicted.** When the rebase fails, the operator was shown one line: `Rebasing (1/6)`.

git splits rebase-conflict output across streams: stdout carries `CONFLICT (content): Merge conflict in <path>`; stderr carries `Rebasing (n/m)`, `error: could not apply <sha>...` and `hint:` lines. The failure path read `(stderr or stdout)` — stderr is non-empty, so stdout was discarded wholesale — and then took `.splitlines()[0]`, which is the progress banner. Every actionable detail was dropped twice.

`_rebase_conflict_summary` scans both streams for the failing commit and reads unmerged paths from the index **before** `git rebase --abort` destroys that state, falling back to scraping stdout `CONFLICT` lines for rename/delete conflicts that leave no unmerged entries.

Before:
```
✗ Could not rebase committed local patches automatically.
  Rebasing (1/6)
```
After:
```
✗ Could not rebase committed local patches automatically.
  error: could not apply f231e8d... local patch
  Conflicting file(s): conflict.txt
  ✓ Rebase aborted; the original committed state is restored.
    Resolve by hand with:
      git -C <root> rebase --empty=drop --no-keep-empty origin/main
```

## Testing

103 tests pass on this branch against current `main` (`test_update_committed_changes.py`, `test_update_autostash.py`, `test_cmd_update.py`), including new coverage for the conflict-reporting path and the rename/delete fallback.

## Context

Both commits have been running in production on a self-hosted install that carries local patches; the rebase path reconciled a 332-commit upstream jump successfully, and the conflict reporting was what made a real two-patch conflict diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)