### PR TITLE
fix(update): ancestor-based update detection, explicit client/backend targets, and visible failed updates

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -153,7 +153,7 @@ import {
   SshConnection
 } from './ssh-connection'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
-import { resolveBehindCount, shouldCountCommits } from './update-count'
+import { resolveBehindCount, resolveBinaryBehindCount, shouldCountCommits } from './update-count'
 import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
 import {
@@ -2363,11 +2363,17 @@ async function checkUpdates() {
       }
     }
 
+    const ancestor = await runGit(['merge-base', '--is-ancestor', targetSha, 'HEAD'], { cwd: updateRoot })
+
     return {
       supported: true,
       branch,
       currentBranch,
-      behind: currentSha && currentSha === targetSha ? 0 : 1,
+      behind: resolveBinaryBehindCount({
+        currentSha,
+        targetSha,
+        ancestorExitCode: ancestor.code
+      }),
       currentSha,
       targetSha,
       commits: [],
@@ -2414,10 +2420,15 @@ async function checkUpdates() {
     ? await git(['rev-list', `HEAD..origin/${branch}`, '--count'])
     : ''
 
+  const ancestorExitCode = shouldCountCommits({ isShallow, hasMergeBase })
+    ? undefined
+    : (await runGit(['merge-base', '--is-ancestor', targetSha, 'HEAD'], { cwd: updateRoot })).code
+
   const behind = resolveBehindCount({
     countStr,
     currentSha,
     targetSha,
+    ancestorExitCode,
     isShallow,
     hasMergeBase
   })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -156,6 +156,7 @@ import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeig
 import { resolveBehindCount, resolveBinaryBehindCount, shouldCountCommits } from './update-count'
 import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
+import { reconcileUpdateReceipt, writeUpdateAttempt } from './update-receipt'
 import {
   buildRelaunchScript,
   collectRelaunchArgs,
@@ -2828,6 +2829,22 @@ async function applyUpdates(opts = {}) {
     if (Number.isInteger(child.pid)) {
       writeUpdateMarker(HERMES_HOME, child.pid)
     }
+
+    // Record what we attempted. The updater replaces the binary we're running
+    // from and force-kills stragglers, so we can never await its exit code (see
+    // update-receipt.ts). Instead we reconcile this against git HEAD on the next
+    // check: if HEAD never moved, the update did not land — and we surface that
+    // rather than cheerfully re-offering the same doomed update forever.
+    const [attemptHead, attemptTarget] = await Promise.all([
+      runGit(['rev-parse', 'HEAD'], { cwd: updateRoot }),
+      runGit(['rev-parse', `origin/${branch}`], { cwd: updateRoot })
+    ])
+
+    writeUpdateAttempt(HERMES_HOME, {
+      branch,
+      currentSha: (attemptHead.stdout || '').trim(),
+      targetSha: (attemptTarget.stdout || '').trim()
+    })
 
     rememberLog(`[updates] launched updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release venv shim`)
 
@@ -10343,15 +10360,29 @@ ipcMain.handle('hermes:terminal:cwd', async (_event, id) => {
 
 ipcMain.handle('hermes:terminal:dispose', (_event, id) => disposeTerminalSession(String(id || '')))
 
-ipcMain.handle('hermes:updates:check', async () =>
-  checkUpdates().catch(error => ({
+ipcMain.handle('hermes:updates:check', async () => {
+  const status = await checkUpdates().catch(error => ({
     supported: true,
     branch: readDesktopUpdateConfig().branch,
     error: 'check-failed',
     message: error?.message || String(error),
     fetchedAt: Date.now()
   }))
-)
+
+  // An update is still running (the user relaunched mid-update): HEAD legitimately
+  // hasn't moved yet, so don't misread that as a failed attempt. Reuse the marker
+  // gate that already answers "is an update live right now?".
+  if (readLiveUpdateMarker(HERMES_HOME)) {
+    return status
+  }
+
+  return {
+    ...status,
+    lastUpdateFailure: reconcileUpdateReceipt(HERMES_HOME, {
+      currentSha: (status as any)?.currentSha
+    })
+  }
+})
 
 ipcMain.handle('hermes:updates:apply', async (_event, payload) =>
   applyUpdates(payload || {}).catch(error => ({

--- a/apps/desktop/electron/update-count.test.ts
+++ b/apps/desktop/electron/update-count.test.ts
@@ -2,7 +2,51 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { resolveBehindCount, shouldCountCommits } from './update-count'
+import { resolveBehindCount, resolveBinaryBehindCount, shouldCountCommits } from './update-count'
+
+test('binary check reports identical tips as up-to-date', () => {
+  assert.equal(
+    resolveBinaryBehindCount({
+      currentSha: 'same',
+      targetSha: 'same',
+      ancestorExitCode: 128
+    }),
+    0
+  )
+})
+
+test('binary check accepts an upstream ancestor beneath local commits', () => {
+  assert.equal(
+    resolveBinaryBehindCount({
+      currentSha: 'local-commit',
+      targetSha: 'upstream-tip',
+      ancestorExitCode: 0
+    }),
+    0
+  )
+})
+
+test('binary check reports a non-ancestor as an update', () => {
+  assert.equal(
+    resolveBinaryBehindCount({
+      currentSha: 'local-tip',
+      targetSha: 'upstream-tip',
+      ancestorExitCode: 1
+    }),
+    1
+  )
+})
+
+test('binary check reports a missing upstream object (exit 128) as an update', () => {
+  assert.equal(
+    resolveBinaryBehindCount({
+      currentSha: 'local-tip',
+      targetSha: 'missing-upstream-tip',
+      ancestorExitCode: 128
+    }),
+    1
+  )
+})
 
 // FAIL-BEFORE: pre-fix the function did `Number.parseInt(countStr) || 0`
 // unconditionally, so a shallow checkout with no merge-base surfaced the bogus
@@ -26,6 +70,20 @@ test('shallow checkout with no merge-base but identical SHA reports up-to-date',
       countStr: '12104',
       currentSha: 'abc',
       targetSha: 'abc',
+      isShallow: true,
+      hasMergeBase: false
+    }),
+    0
+  )
+})
+
+test('shallow checkout with local commits atop the target reports up-to-date', () => {
+  assert.equal(
+    resolveBehindCount({
+      countStr: '',
+      currentSha: 'local-commit',
+      targetSha: 'upstream-tip',
+      ancestorExitCode: 0,
       isShallow: true,
       hasMergeBase: false
     }),

--- a/apps/desktop/electron/update-count.ts
+++ b/apps/desktop/electron/update-count.ts
@@ -10,21 +10,34 @@ function shouldCountCommits({ isShallow, hasMergeBase }) {
   return !(isShallow && !hasMergeBase)
 }
 
+// Resolve a presence-only update check when an exact commit count is not
+// available. A checkout with local commits is still current when the upstream
+// tip is already in its history.
+function resolveBinaryBehindCount({ currentSha, targetSha, ancestorExitCode }) {
+  if (currentSha && targetSha && (currentSha === targetSha || ancestorExitCode === 0)) {
+    return 0
+  }
+
+  return 1
+}
+
 // Resolve how many commits the local checkout is behind origin for the desktop
 // update indicator. When the count isn't meaningful (shallow + no merge-base)
-// fall back to a binary up-to-date check by SHA, exactly like the official-SSH
-// path in checkUpdates() and the CLI guard in hermes_cli/banner.py. Full clones
-// (developers / Docker dev images) keep the exact count path unchanged.
-function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, hasMergeBase }) {
+// fall back to a binary up-to-date check. Full clones (developers / Docker dev
+// images) keep the exact count path unchanged.
+function resolveBehindCount({
+  countStr,
+  currentSha,
+  targetSha,
+  ancestorExitCode = undefined,
+  isShallow,
+  hasMergeBase
+}) {
   if (!shouldCountCommits({ isShallow, hasMergeBase })) {
-    if (currentSha && targetSha && currentSha === targetSha) {
-      return 0
-    }
-
-    return 1 // behind by an unknown amount — show a generic "update available"
+    return resolveBinaryBehindCount({ currentSha, targetSha, ancestorExitCode })
   }
 
   return Number.parseInt(countStr, 10) || 0
 }
 
-export { resolveBehindCount, shouldCountCommits }
+export { resolveBehindCount, resolveBinaryBehindCount, shouldCountCommits }

--- a/apps/desktop/electron/update-receipt.test.ts
+++ b/apps/desktop/electron/update-receipt.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for electron/update-receipt.ts — the durable record of an attempted
+ * update, reconciled against git HEAD on the next check.
+ *
+ * Why this matters: the staged updater is spawned detached with stdio ignored
+ * and the desktop quits before it even starts, so a failed `hermes update` was
+ * completely invisible to the app. The poller then saw `behind > 0` again and
+ * re-offered the identical doomed update on every relaunch. Reconciling the
+ * receipt is what converts that silent loop into a visible, actionable state.
+ *
+ * The load-bearing rule: compare against the recorded `currentSha` ("did HEAD
+ * move at all?"), never `targetSha` — upstream moves hundreds of commits a day,
+ * so a successful update routinely lands past the sha that was checked.
+ */
+
+import fs from 'fs'
+import assert from 'node:assert/strict'
+import os from 'os'
+import path from 'path'
+
+import { test } from 'vitest'
+
+import {
+  clearUpdateReceipt,
+  RECEIPT_MAX_AGE_MS,
+  receiptPath,
+  reconcileUpdateReceipt,
+  writeUpdateAttempt
+} from './update-receipt'
+
+function tmpHome(tag) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `hermes-receipt-${tag}-`))
+}
+
+const ATTEMPT = { branch: 'main', currentSha: 'aaa111', targetSha: 'bbb222' }
+
+test('absent receipt => nothing to report', () => {
+  const home = tmpHome('absent')
+
+  assert.equal(reconcileUpdateReceipt(home, { currentSha: 'aaa111' }), null)
+})
+
+test('HEAD moved => update landed; receipt is cleared', () => {
+  const home = tmpHome('landed')
+
+  writeUpdateAttempt(home, ATTEMPT)
+
+  // Note ccc333 is NOT the targetSha we recorded — upstream moved on. This is
+  // the normal success case and must NOT be reported as a failure.
+  assert.equal(reconcileUpdateReceipt(home, { currentSha: 'ccc333' }), null)
+  assert.equal(fs.existsSync(receiptPath(home)), false)
+})
+
+test('HEAD unchanged => the update did not land; receipt is returned and kept', () => {
+  const home = tmpHome('failed')
+
+  writeUpdateAttempt(home, ATTEMPT)
+
+  const failure = reconcileUpdateReceipt(home, { currentSha: 'aaa111' })
+
+  assert.equal(failure.branch, 'main')
+  assert.equal(failure.targetSha, 'bbb222')
+  assert.equal(fs.existsSync(receiptPath(home)), true)
+})
+
+test('expired receipt self-heals', () => {
+  const home = tmpHome('expired')
+
+  writeUpdateAttempt(home, ATTEMPT, { now: () => 1_000 })
+
+  const later = 1_000 + RECEIPT_MAX_AGE_MS + 1
+
+  assert.equal(reconcileUpdateReceipt(home, { currentSha: 'aaa111', now: () => later }), null)
+  assert.equal(fs.existsSync(receiptPath(home)), false)
+})
+
+test('unknown HEAD is undecidable => keep the receipt for the next check', () => {
+  const home = tmpHome('undecidable')
+
+  writeUpdateAttempt(home, ATTEMPT)
+
+  assert.notEqual(reconcileUpdateReceipt(home, {}), null)
+  assert.equal(fs.existsSync(receiptPath(home)), true)
+})
+
+test('malformed receipt self-heals', () => {
+  const home = tmpHome('malformed')
+
+  fs.writeFileSync(receiptPath(home), '{not json', 'utf8')
+
+  assert.equal(reconcileUpdateReceipt(home, { currentSha: 'aaa111' }), null)
+  assert.equal(fs.existsSync(receiptPath(home)), false)
+})
+
+test('write/clear round-trip', () => {
+  const home = tmpHome('roundtrip')
+
+  writeUpdateAttempt(home, ATTEMPT)
+  assert.equal(fs.existsSync(receiptPath(home)), true)
+
+  clearUpdateReceipt(home)
+  assert.equal(fs.existsSync(receiptPath(home)), false)
+  // Clearing twice must not throw.
+  clearUpdateReceipt(home)
+})

--- a/apps/desktop/electron/update-receipt.ts
+++ b/apps/desktop/electron/update-receipt.ts
@@ -1,0 +1,131 @@
+/**
+ * Durable "we attempted an update" receipt.
+ *
+ * The staged updater is spawned `detached` with `stdio: 'ignore'` and the
+ * desktop calls `app.quit()` ~2.5s later (see `applyUpdates` in main.ts), so
+ * Electron can never observe the updater's exit code. That is not an oversight
+ * we can fix by waiting: the updater force-kills surviving Hermes processes,
+ * replaces the very `.app` bundle we are executing from, and relaunches us at
+ * the end. Waiting is actively defended against.
+ *
+ * The consequence was a silent loop. When `hermes update` failed (e.g. a
+ * committed local patch that no longer rebases cleanly), nothing recorded the
+ * failure. On the next launch the poller saw `behind > 0` again and re-fired
+ * the cheerful "update available" toast — walking the user straight back into
+ * the identical failure, with no error surfaced anywhere in the desktop app.
+ *
+ * So instead of observing the child, we record what we *attempted* and
+ * reconcile it against git HEAD on the next check. If HEAD never moved, the
+ * update did not land.
+ *
+ * This module holds the PURE, side-effect-light logic (path, parse, staleness,
+ * reconcile) so it is unit-testable without booting Electron — same split as
+ * update-marker.ts.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+// A receipt older than this is self-healed away. It only exists to answer "did
+// the update we just launched land?", so anything this old is a leftover from
+// a machine that was shut down mid-update, not a signal worth acting on.
+export const RECEIPT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
+
+export function receiptPath(hermesHome) {
+  // Beside .hermes-update-in-progress, directly under HERMES_HOME, so it
+  // survives the checkout being deleted and recreated by a repair install.
+  return path.join(hermesHome, '.hermes-update-receipt.json')
+}
+
+/**
+ * Record an update attempt, immediately after spawning the updater.
+ *
+ * `currentSha` is the HEAD we are leaving FROM — that is the field reconcile
+ * compares against, because "did HEAD move at all?" is the only question we can
+ * answer reliably. Best-effort: a failure to write must never block the update.
+ */
+export function writeUpdateAttempt(
+  hermesHome,
+  { branch, currentSha, targetSha },
+  { now = Date.now } = {}
+) {
+  try {
+    fs.writeFileSync(
+      receiptPath(hermesHome),
+      JSON.stringify({ attemptedAt: now(), branch, currentSha, targetSha }),
+      'utf8'
+    )
+  } catch {
+    // Best-effort: proceed with the update regardless.
+  }
+}
+
+export function clearUpdateReceipt(hermesHome) {
+  try {
+    fs.unlinkSync(receiptPath(hermesHome))
+  } catch {
+    void 0
+  }
+}
+
+/**
+ * Decide whether the last recorded attempt actually landed.
+ *
+ * Returns the receipt when the attempt provably did NOT land (so callers can
+ * surface a persistent failure), and `null` in every other case.
+ *
+ * Compares against the recorded `currentSha` ("did we move at all?") rather
+ * than `targetSha` ("did we reach the exact tip we saw?"). Upstream advances
+ * constantly — often hundreds of commits a day — so a perfectly successful
+ * update routinely lands on a newer sha than the one that was checked, and
+ * comparing against `targetSha` would report false failures.
+ */
+export function reconcileUpdateReceipt(
+  hermesHome,
+  {
+    currentSha,
+    now = Date.now,
+    maxAgeMs = RECEIPT_MAX_AGE_MS
+  }: { currentSha?: string; now?: () => number; maxAgeMs?: number } = {}
+) {
+  const file = receiptPath(hermesHome)
+  let receipt
+
+  try {
+    receipt = JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch {
+    // Absent is the common case. Malformed is a corrupt leftover — drop it so
+    // it cannot wedge the check forever.
+    clearUpdateReceipt(hermesHome)
+
+    return null
+  }
+
+  if (!receipt || typeof receipt !== 'object') {
+    clearUpdateReceipt(hermesHome)
+
+    return null
+  }
+
+  const attemptedAt = Number(receipt.attemptedAt)
+
+  if (!Number.isFinite(attemptedAt) || now() - attemptedAt > maxAgeMs) {
+    clearUpdateReceipt(hermesHome)
+
+    return null
+  }
+
+  // Undecidable: we could not read HEAD this time round. Keep the receipt and
+  // try again on the next check rather than guessing either way.
+  if (!currentSha) {
+    return receipt
+  }
+
+  if (currentSha !== receipt.currentSha) {
+    clearUpdateReceipt(hermesHome) // HEAD moved => the update landed.
+
+    return null
+  }
+
+  return receipt
+}

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -50,7 +50,7 @@ export function useDesktopIntegrations({
   // process's "open updates" menu request.
   useEffect(() => {
     startUpdatePoller()
-    const unsubscribe = window.hermesDesktop?.onOpenUpdatesRequested?.(() => openUpdatesWindow())
+    const unsubscribe = window.hermesDesktop?.onOpenUpdatesRequested?.(() => openUpdatesWindow('client'))
 
     return () => {
       unsubscribe?.()

--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -144,10 +144,10 @@ export function AboutSettings() {
 
             {behind > 0 && supported && !applying && (
               <>
-                <Button onClick={() => startActiveUpdate()} size="sm">
+                <Button onClick={() => startActiveUpdate('client')} size="sm">
                   {a.updateNow}
                 </Button>
-                <Button onClick={() => openUpdatesWindow()} size="sm" variant="textStrong">
+                <Button onClick={() => openUpdatesWindow('client')} size="sm" variant="textStrong">
                   {a.seeWhatsNew}
                 </Button>
               </>

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -327,6 +327,20 @@ export interface DesktopUpdateStatus {
   commits?: DesktopUpdateCommit[]
   dirty?: boolean
   fetchedAt?: number
+  /**
+   * Set when the previous update attempt was recorded but never landed. The
+   * updater replaces the app we run from, so its exit code is unobservable —
+   * see electron/update-receipt.ts. Drives a persistent "last update failed"
+   * state instead of a fresh optimistic "update available" toast.
+   */
+  lastUpdateFailure?: DesktopUpdateFailure
+}
+
+export interface DesktopUpdateFailure {
+  attemptedAt: number
+  branch?: string
+  currentSha?: string
+  targetSha?: string
 }
 
 export type DesktopUpdateDirtyStrategy = 'abort' | 'stash' | 'force'

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -51,7 +51,10 @@ const {
   applyUpdates,
   $updateApply,
   $updateOverlayOpen,
+  $updateOverlayTarget,
+  openUpdatesWindow,
   resetUpdateApplyState,
+  startActiveUpdate,
   startUpdatePoller,
   stopUpdatePoller,
   $updateStatus
@@ -67,7 +70,23 @@ const status = (over: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus =>
   ...over
 })
 
-const lastToast = () => notifySpy.mock.calls.at(-1)?.[0] as { onDismiss: () => void }
+const lastToast = () =>
+  notifySpy.mock.calls.at(-1)?.[0] as {
+    action?: { onClick: () => void }
+    onDismiss: () => void
+  }
+
+const setRemote = (on: boolean) =>
+  setConnection({
+    baseUrl: 'http://box:9119',
+    isFullscreen: false,
+    mode: on ? 'remote' : 'local',
+    nativeOverlayWidth: 0,
+    token: 't',
+    wsUrl: 'ws://box:9119',
+    logs: [],
+    windowButtonPosition: null
+  })
 
 describe('maybeNotifyUpdateAvailable', () => {
   beforeEach(() => {
@@ -77,18 +96,18 @@ describe('maybeNotifyUpdateAvailable', () => {
   })
 
   it('shows when an update is available and not snoozed', () => {
-    maybeNotifyUpdateAvailable(status())
+    maybeNotifyUpdateAvailable(status(), 'client')
     expect(notifySpy).toHaveBeenCalledTimes(1)
     expect(notifySpy.mock.calls[0]?.[0]).toMatchObject({ icon: 'gift' })
   })
 
   it('stays quiet for new commits once the toast was closed', () => {
-    maybeNotifyUpdateAvailable(status())
+    maybeNotifyUpdateAvailable(status(), 'client')
     lastToast().onDismiss() // user closes it → cooldown starts
     notifySpy.mockClear()
 
     // A different commit lands while still within the cooldown window.
-    maybeNotifyUpdateAvailable(status({ targetSha: 'sha-b', behind: 9 }))
+    maybeNotifyUpdateAvailable(status({ targetSha: 'sha-b', behind: 9 }), 'client')
     expect(notifySpy).not.toHaveBeenCalled()
   })
 
@@ -96,18 +115,79 @@ describe('maybeNotifyUpdateAvailable', () => {
     vi.useFakeTimers()
     vi.setSystemTime(0)
 
-    maybeNotifyUpdateAvailable(status())
+    maybeNotifyUpdateAvailable(status(), 'client')
     lastToast().onDismiss()
     notifySpy.mockClear()
 
     vi.setSystemTime(25 * 60 * 60 * 1000) // > 24h cooldown
-    maybeNotifyUpdateAvailable(status({ targetSha: 'sha-b' }))
+    maybeNotifyUpdateAvailable(status({ targetSha: 'sha-b' }), 'client')
     expect(notifySpy).toHaveBeenCalledTimes(1)
   })
 
   it('does nothing when already up to date', () => {
-    maybeNotifyUpdateAvailable(status({ behind: 0 }))
+    maybeNotifyUpdateAvailable(status({ behind: 0 }), 'client')
     expect(notifySpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('update target routing', () => {
+  const clientCheckSpy = vi.fn()
+  const clientApplySpy = vi.fn()
+
+  beforeEach(() => {
+    storage.clear()
+    notifySpy.mockClear()
+    checkHermesUpdateSpy.mockReset()
+    updateHermesSpy.mockReset()
+    clientCheckSpy.mockReset()
+    clientApplySpy.mockReset()
+    clientCheckSpy.mockResolvedValue(status({ behind: 0 }))
+    clientApplySpy.mockResolvedValue({ ok: true, manual: true, command: 'hermes update' })
+    resetUpdateApplyState()
+    $updateOverlayOpen.set(false)
+    $updateOverlayTarget.set('backend')
+    setRemote(true)
+    ;(globalThis as unknown as { window: unknown }).window = {
+      hermesDesktop: {
+        updates: {
+          apply: clientApplySpy,
+          check: clientCheckSpy
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it('opens a client update on the client even in remote mode', () => {
+    openUpdatesWindow('client')
+
+    expect($updateOverlayTarget.get()).toBe('client')
+    expect($updateOverlayOpen.get()).toBe(true)
+    expect(clientCheckSpy).toHaveBeenCalled()
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
+  })
+
+  it('starts a client update on the client even in remote mode', () => {
+    startActiveUpdate('client')
+
+    expect($updateOverlayTarget.get()).toBe('client')
+    expect(clientApplySpy).toHaveBeenCalled()
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+  })
+
+  it('routes client and backend update toasts to their own overlays', () => {
+    maybeNotifyUpdateAvailable(status(), 'client')
+    lastToast().action?.onClick()
+    expect($updateOverlayTarget.get()).toBe('client')
+
+    storage.clear()
+    notifySpy.mockClear()
+    maybeNotifyUpdateAvailable(status({ targetSha: 'backend:1' }), 'backend')
+    lastToast().action?.onClick()
+    expect($updateOverlayTarget.get()).toBe('backend')
   })
 })
 
@@ -174,18 +254,6 @@ describe('checkBackendUpdates', () => {
     $backendUpdateStatus.set(null)
     vi.useRealTimers()
   })
-
-  const setRemote = (on: boolean) =>
-    setConnection({
-      baseUrl: 'http://box:9119',
-      isFullscreen: false,
-      mode: on ? 'remote' : 'local',
-      nativeOverlayWidth: 0,
-      token: 't',
-      wsUrl: 'ws://box:9119',
-      logs: [],
-      windowButtonPosition: null
-    })
 
   it('maps the backend /update/check onto the backend status, including commits', async () => {
     setRemote(true)

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -128,6 +128,24 @@ describe('maybeNotifyUpdateAvailable', () => {
     maybeNotifyUpdateAvailable(status({ behind: 0 }), 'client')
     expect(notifySpy).not.toHaveBeenCalled()
   })
+
+  it('stays quiet when the last attempt at this same sha never landed', () => {
+    // Re-offering it walks the user straight back into the identical failure,
+    // and the dismissal-based snooze never engages for a failed apply.
+    maybeNotifyUpdateAvailable(
+      status({ lastUpdateFailure: { attemptedAt: 0, targetSha: 'sha-a' } }),
+      'client'
+    )
+    expect(notifySpy).not.toHaveBeenCalled()
+  })
+
+  it('offers again once upstream advances past the sha that failed', () => {
+    maybeNotifyUpdateAvailable(
+      status({ lastUpdateFailure: { attemptedAt: 0, targetSha: 'sha-old' } }),
+      'client'
+    )
+    expect(notifySpy).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('update target routing', () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -198,7 +198,7 @@ export function reportInstallMethodWarning(message: string | undefined): void {
  * (re)starts the cooldown, so a busy upstream branch doesn't re-spam the user
  * on every new commit. The snooze is persisted, so it survives relaunches too.
  */
-export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
+export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null, target: UpdateTarget) {
   if (!status || status.supported === false || status.error || !status.targetSha) {
     return
   }
@@ -211,7 +211,9 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
     return
   }
 
-  if ($updateApply.get().applying) {
+  const applyState = target === 'backend' ? $backendUpdateApply.get() : $updateApply.get()
+
+  if (applyState.applying) {
     return
   }
 
@@ -222,7 +224,7 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
       label: translateNow('notifications.seeWhatsNew'),
       onClick: () => {
         snoozeUpdateToast()
-        openUpdatesWindow()
+        openUpdatesWindow(target)
       }
     },
     durationMs: 0,
@@ -235,8 +237,8 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
   })
 }
 
-export function openUpdatesWindow(): void {
-  openUpdateOverlayFor(isRemoteMode() ? 'backend' : 'client')
+export function openUpdatesWindow(target: UpdateTarget): void {
+  openUpdateOverlayFor(target)
 }
 
 /**
@@ -246,8 +248,7 @@ export function openUpdatesWindow(): void {
  * Used by the "Update now" affordance on the About panel, which would otherwise
  * only be able to open the changelog overlay.
  */
-export function startActiveUpdate(): void {
-  const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
+export function startActiveUpdate(target: UpdateTarget): void {
   $updateOverlayTarget.set(target)
   $updateOverlayOpen.set(true)
   void (target === 'backend' ? applyBackendUpdate() : applyUpdates())
@@ -309,7 +310,7 @@ export async function checkBackendUpdates(): Promise<DesktopUpdateStatus | null>
   try {
     const status = mapBackendCheck(await checkHermesUpdate(true))
     $backendUpdateStatus.set(status)
-    maybeNotifyUpdateAvailable(status)
+    maybeNotifyUpdateAvailable(status, 'backend')
 
     return status
   } catch (error) {
@@ -340,7 +341,7 @@ export async function checkUpdates(): Promise<DesktopUpdateStatus | null> {
   try {
     const status = await bridge.check()
     $updateStatus.set(status)
-    maybeNotifyUpdateAvailable(status)
+    maybeNotifyUpdateAvailable(status, 'client')
     void refreshDesktopVersion()
 
     return status

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -207,6 +207,15 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null, t
     return
   }
 
+  // The previous attempt at THIS upstream sha never landed. Re-firing the
+  // cheerful "update ready" toast just walks the user back into the identical
+  // failure — and the snooze below never engages, because it only starts when a
+  // toast is DISMISSED, not when an apply fails. Stay quiet until upstream
+  // advances past the sha we failed on; the next commit may well be the fix.
+  if (status.lastUpdateFailure && status.lastUpdateFailure.targetSha === status.targetSha) {
+    return
+  }
+
   if (isUpdateToastSnoozed()) {
     return
   }
@@ -341,6 +350,23 @@ export async function checkUpdates(): Promise<DesktopUpdateStatus | null> {
   try {
     const status = await bridge.check()
     $updateStatus.set(status)
+
+    // Surface an attempt that never landed. Without this the failure is
+    // invisible in the desktop app entirely — it happens after we've quit, so
+    // only the separate installer window ever saw it. Reuses the existing
+    // 'error' stage, which updates-overlay.tsx already renders as a retryable
+    // card, so there's no new component or store to maintain.
+    if (status?.lastUpdateFailure && !$updateApply.get().applying) {
+      // Empty message on purpose: ErrorView already falls back to its own
+      // localized copy, so this adds no new i18n keys to keep in sync.
+      $updateApply.set({
+        ...IDLE,
+        stage: 'error',
+        error: 'last-update-failed',
+        message: ''
+      })
+    }
+
     maybeNotifyUpdateAvailable(status, 'client')
     void refreshDesktopVersion()
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -201,11 +201,38 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
     if _is_official_ssh_remote(origin_url):
-        head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
-        checked = _check_via_rev(head_rev) if head_rev else None
-        if checked == UPDATE_AVAILABLE_NO_COUNT:
+        try:
+            target = subprocess.run(
+                ["git", "ls-remote", _UPSTREAM_REPO_URL, "refs/heads/main"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except Exception:
+            return None
+        if target.returncode != 0 or not target.stdout:
+            return None
+
+        upstream_rev = target.stdout.split()[0]
+        if not upstream_rev:
+            return None
+
+        try:
+            ancestor = subprocess.run(
+                ["git", "merge-base", "--is-ancestor", upstream_rev, "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                cwd=str(repo_dir),
+            )
+        except Exception:
+            return None
+
+        if ancestor.returncode == 0:
+            return 0
+        if ancestor.returncode in (1, 128):
             return 1
-        return checked
+        return None
 
     # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
     # clone the history stops at a single commit, so a plain `git fetch` would

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -96,8 +96,21 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
     assert mock_run.call_count == 4
 
 
-def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
-    """Passive update checks must not trigger SSH auth for official installs."""
+@pytest.mark.parametrize(
+    ("upstream_sha", "ancestor_exit", "expected"),
+    [
+        pytest.param("local-sha", 0, 0, id="equal"),
+        pytest.param("upstream-ancestor", 0, 0, id="upstream-is-ancestor"),
+        pytest.param("new-upstream", 1, 1, id="genuinely-behind"),
+        pytest.param("diverged-upstream", 1, 1, id="diverged"),
+        pytest.param("missing-object", 128, 1, id="upstream-object-missing"),
+        pytest.param("unknown-failure", 2, None, id="unexpected-git-failure"),
+    ],
+)
+def test_check_for_updates_official_ssh_origin_uses_https_ancestor_probe(
+    tmp_path, upstream_sha, ancestor_exit, expected
+):
+    """Official SSH checks avoid auth and tolerate commits on top of upstream."""
     import hermes_cli.banner as banner
 
     repo_dir = tmp_path / "hermes-agent"
@@ -110,22 +123,49 @@ def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
         calls.append(cmd)
         if cmd == ["git", "remote", "get-url", "origin"]:
             return MagicMock(returncode=0, stdout="git@github.com:NousResearch/hermes-agent.git\n")
-        if cmd == ["git", "rev-parse", "HEAD"]:
-            return MagicMock(returncode=0, stdout="local-sha\n")
         if cmd == [
             "git",
             "ls-remote",
             "https://github.com/NousResearch/hermes-agent.git",
             "refs/heads/main",
         ]:
-            return MagicMock(returncode=0, stdout="upstream-sha\trefs/heads/main\n")
+            return MagicMock(returncode=0, stdout=f"{upstream_sha}\trefs/heads/main\n")
+        if cmd == ["git", "merge-base", "--is-ancestor", upstream_sha, "HEAD"]:
+            return MagicMock(returncode=ancestor_exit, stdout="")
         raise AssertionError(f"unexpected git command: {cmd!r}")
 
     with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
         result = banner._check_via_local_git(repo_dir)
 
-    assert result == 1
+    assert result == expected
     assert ["git", "fetch", "origin", "--quiet"] not in calls
+
+
+def test_check_via_rev_keeps_embedded_revision_exact_match_semantics():
+    """The checkout-free Nix helper must not start running merge-base."""
+    import hermes_cli.banner as banner
+
+    with patch(
+        "hermes_cli.banner.subprocess.run",
+        return_value=MagicMock(
+            returncode=0,
+            stdout="upstream-sha\trefs/heads/main\n",
+        ),
+    ) as mock_run:
+        result = banner._check_via_rev("embedded-sha")
+
+    assert result == banner.UPDATE_AVAILABLE_NO_COUNT
+    # Assert the command shape only. The point of this test is that the
+    # checkout-free Nix path never shells out to merge-base; pinning the full
+    # kwargs makes it fail on unrelated upstream subprocess sweeps (e.g. the
+    # utf-8 encoding/errors guard added to every git call in banner.py).
+    assert mock_run.call_count == 1
+    assert mock_run.call_args.args[0] == [
+        "git",
+        "ls-remote",
+        "https://github.com/NousResearch/hermes-agent.git",
+        "refs/heads/main",
+    ]
 
 
 def test_check_via_local_git_shallow_clone_behind_reports_no_count(tmp_path):


### PR DESCRIPTION
## Problem

Three related update-surface bugs, all observed on real installs:

1. **False "update available".** The official-SSH passive banner and Electron's status check compared upstream and local tip SHAs for *equality*. An install carrying local commits therefore looked perpetually out of date even when the upstream tip was already an ancestor of `HEAD`.

2. **Update target inferred from connection mode.** About/toast state described the local client, but the apply action chose client vs backend purely from remote mode — so a client update on a remotely-connected machine could invoke the *remote backend's* updater.

3. **A failed update was completely invisible, and looped.** The staged updater is spawned `detached` with `stdio: 'ignore'`, and the desktop calls `app.quit()` ~2.5s later — before `hermes update` has even started. Electron never observes the exit code and nothing records the failure. On the next launch the poller sees `behind > 0` again and re-fires the "update available" toast, walking the user straight back into the identical failure. The 24h snooze never helps: it starts when a toast is *dismissed*, not when an apply fails.

## What this does

**Commit 1 — detection and routing.** Ancestor containment, not SHA equality, is the correct "am I current?" invariant for a locally patched checkout. Python now does an HTTPS `ls-remote` plus a local `merge-base --is-ancestor <upstream> HEAD`, only inside the official-SSH checkout branch; the shared checkout-free `_check_via_rev` Nix path is unchanged (exit 0 = current; 1 and 128 = update available). Electron uses the same ancestor-aware rule, and shallow fallbacks accept a confirmed ancestor. Update notifications, overlays, and apply actions now carry an explicit `client` or `backend` target rather than deriving one from remote mode.

**Commit 2 — surface updates that never landed.** We cannot fix this by awaiting the child: the updater force-kills surviving Hermes processes, replaces the `.app` bundle we are executing from, and relaunches us. Waiting is actively defended against. So the desktop records what it *attempted* and reconciles that against git HEAD on the next check.

- New `electron/update-receipt.ts`, modelled on the existing `update-marker.ts`: pure, injectable clock, unit-testable without booting Electron.
- Reconcile compares the recorded `currentSha` — "did HEAD move at all?" — and never `targetSha`. Upstream moves hundreds of commits a day, so a successful update routinely lands *past* the sha that was checked; comparing tips would report constant false failures.
- Attached in the `hermes:updates:check` IPC handler (one chokepoint, versus four return sites inside `checkUpdates()`), gated on the existing `readLiveUpdateMarker` so a mid-update relaunch isn't misread as a failure.
- `maybeNotifyUpdateAvailable` stays quiet while the failing `targetSha` is still the tip, and offers again once upstream advances past it.
- The failure reuses the existing `$updateApply` `'error'` stage, which `updates-overlay.tsx` already renders as a retryable card — no new component, store, stage, or i18n key.

Self-heals on malformed JSON and on receipts older than 30 days.

## Testing

On this branch against current `main`: 22 electron tests (`update-receipt.test.ts` — 7 new cases covering absent / HEAD-moved / HEAD-unchanged / expired / undecidable / malformed / round-trip — plus `update-count.test.ts`), 60 UI tests including new suppression coverage, and a clean `npm run typecheck` across all three TS projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)