### PR TITLE
fix(installer): point update failures at the log we actually write

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -313,14 +313,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
             return Err(anyhow!(msg));
         }
         other => {
-            let msg = format!(
-                "hermes update failed (exit {:?}). See {} for details.",
-                other,
-                crate::paths::hermes_home()
-                    .join("logs")
-                    .join("update.log")
-                    .display()
-            );
+            let msg = update_failure_message(other, &crate::paths::log_path());
             emit_stage(
                 &app,
                 "update",
@@ -1040,9 +1033,34 @@ fn emit_log(app: &AppHandle, stage: Option<&str>, stream: LogStream, line: &str)
     );
 }
 
+/// Message shown when `hermes update` exits non-zero.
+///
+/// The log this points at MUST be `paths::log_path()`
+/// (`HERMES_HOME/logs/bootstrap-installer.log`) — the file `init_logging`
+/// creates and that `run_streamed` mirrors the child's stdout/stderr into. It
+/// is emphatically NOT `logs/update.log`: that one is written by
+/// `_install_hangup_protection` in hermes_cli/main.py, which returns early
+/// under `--gateway` — and we always pass `--gateway`, so it is never written
+/// on this path. Pointing there sent operators to a file months out of date.
+fn update_failure_message(exit_code: Option<i32>, log_path: &Path) -> String {
+    format!(
+        "hermes update failed (exit {:?}). See {} for details.",
+        exit_code,
+        log_path.display()
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn update_failure_message_names_the_installer_log() {
+        let msg = update_failure_message(Some(1), &crate::paths::log_path());
+        assert!(msg.contains("bootstrap-installer.log"), "{msg}");
+        // Pin against re-drift to the phantom path.
+        assert!(!msg.contains("update.log"), "{msg}");
+    }
 
     #[test]
     fn venv_hermes_is_under_install_root() {


### PR DESCRIPTION
## Problem

When `hermes update` exits non-zero, the bootstrap installer tells the user:

```
hermes update failed (exit Some(1)). See ~/.hermes/logs/update.log for details.
```

That file is written by `_install_hangup_protection` in `hermes_cli/main.py`, which returns early when `gateway_mode` is set — and the installer always invokes `hermes update --yes --gateway`. So `logs/update.log` is **never written on this path**.

On the install where this surfaced, the referenced log was two months stale while the actual failure output sat in `logs/bootstrap-installer.log`. That misdirection cost a full debugging cycle: the real error (`✗ Could not rebase committed local patches automatically`) was sitting in a file nobody was pointed at.

## Fix

Use `paths::log_path()` — the file `init_logging` creates and that `run_streamed` mirrors the child's stdout/stderr into. It is also the path the failure screen already surfaces via `get_log_path`, so the error text and the UI footer now agree instead of naming two different files.

Extracted into `update_failure_message` so the log choice is unit-testable, with a test asserting the message does **not** name `update.log`, to pin against re-drift.

## ⚠️ Not compiled locally

Please treat CI as the source of truth for this one. It was authored on a machine with no Rust toolchain (`cargo` unavailable), so it has not been built or test-run; the repo's CI does not appear to build the Tauri crate either.

The change is mechanical — extracting an existing `format!` and swapping the path expression — and the referenced symbols were checked by inspection: `paths::log_path()` is `pub`, `Path` is already imported in `update.rs`, and the `other` binding in that match arm is `Option<i32>`, so `{:?}` renders identically to before (`exit Some(1)`).

## Note on reach

This only helps users after a rebuilt and re-signed installer ships. `paths::copy_self_to_hermes_home()` deliberately no-ops during an `--update` run, so nothing in `hermes update` replaces an already-staged `hermes-setup` binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)