### PR TITLE
fix(security): add auth.json to build_write_denied_paths

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -63,7 +63,11 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Webhook subscription HMAC secrets (read-denied alongside auth.json).
             str(hermes_home / "webhook_subscriptions.json"),
             str(hermes_root / "webhook_subscriptions.json"),
-            # Bitwarden Secrets Manager encrypted disk cache.
+            # Bitwarden Secrets Manager disk caches. The plaintext cache stores
+            # secret values and is read-denied via get_read_block_error(); keep
+            # the write side symmetric with the encrypted cache variant.
+            str(hermes_home / "cache" / "bws_cache.json"),
+            str(hermes_root / "cache" / "bws_cache.json"),
             str(hermes_home / "cache" / "bws_cache.enc.json"),
             str(hermes_root / "cache" / "bws_cache.enc.json"),
             os.path.join(home, ".netrc"),

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -46,6 +46,23 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Top-level Anthropic PKCE credential store remains sensitive even
             # when a profile is active; default/non-profile sessions still read it.
             str(hermes_root / ".anthropic_oauth.json"),
+            # Provider credential store (OAuth refresh tokens, API keys, the
+            # whole credential_pool). Already read-denied via
+            # get_read_block_error()'s credential_file_names tuple; the write
+            # side was missing this entry (#70942), so the agent's own
+            # write_file/patch/delete/move could destroy every stored
+            # provider credential at once with no recovery path short of
+            # re-running each provider's interactive OAuth flow.
+            str(hermes_home / "auth.json"),
+            str(hermes_root / "auth.json"),
+            str(hermes_home / "auth.lock"),
+            str(hermes_root / "auth.lock"),
+            # Google OAuth token store (read-denied alongside auth.json).
+            str(hermes_home / "auth" / "google_oauth.json"),
+            str(hermes_root / "auth" / "google_oauth.json"),
+            # Webhook subscription HMAC secrets (read-denied alongside auth.json).
+            str(hermes_home / "webhook_subscriptions.json"),
+            str(hermes_root / "webhook_subscriptions.json"),
             # Bitwarden Secrets Manager encrypted disk cache.
             str(hermes_home / "cache" / "bws_cache.enc.json"),
             str(hermes_root / "cache" / "bws_cache.enc.json"),

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -22,6 +22,27 @@ class TestWriteDenyExactPaths:
         assert _is_write_denied(path) is True
 
 
+    def test_hermes_env(self):
+        # ``.env`` under the active HERMES_HOME (profile-aware, not just
+        # ``~/.hermes``) must be write-denied. The hermetic test conftest
+        # points HERMES_HOME at a tempdir — resolve via get_hermes_home()
+        # to match the denylist.
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / ".env")
+        assert _is_write_denied(path) is True
+
+    def test_plaintext_bitwarden_cache(self):
+        from hermes_constants import get_hermes_home
+
+        path = get_hermes_home() / "cache" / "bws_cache.json"
+        assert _is_write_denied(str(path)) is True
+
+    def test_encrypted_bitwarden_cache(self):
+        from hermes_constants import get_hermes_home
+
+        path = get_hermes_home() / "cache" / "bws_cache.enc.json"
+        assert _is_write_denied(str(path)) is True
+
     def test_hermes_root_env_when_running_under_profile(self, tmp_path, monkeypatch):
         """Top-level ``<root>/.env`` stays write-denied even when running under
         a profile (#15981).
@@ -142,3 +163,23 @@ class TestWriteDenyCredentialStore:
         assert get_default_hermes_root() == root
 
         assert _is_write_denied(str(global_auth)) is True
+
+    def test_plaintext_bitwarden_cache_denied_at_root_when_running_under_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """Top-level <root>/cache/bws_cache.json stores plaintext Bitwarden
+        secret values and stays write-denied even when a profile is active."""
+        root = tmp_path / "hermes_root"
+        profile_home = root / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        global_cache = root / "cache" / "bws_cache.json"
+        global_cache.parent.mkdir(parents=True)
+        global_cache.write_text('{"item": "PLAINTEXT_SECRET_VALUE"}\n')
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        from hermes_constants import get_hermes_home, get_default_hermes_root
+        assert get_hermes_home() == profile_home
+        assert get_default_hermes_root() == root
+
+        assert _is_write_denied(str(global_cache)) is True

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -91,5 +91,54 @@ class TestWriteAllowed:
         from hermes_constants import get_hermes_home
 
         home = get_hermes_home()
-        for name in ["auth.json", "config.yaml", "webhook_subscriptions.json"]:
+        for name in ["config.yaml"]:
             assert _is_write_denied(str(home / name)) is False, f"{name} should be writable"
+
+
+class TestWriteDenyCredentialStore:
+    """auth.json is the provider credential store (OAuth refresh tokens, API
+    keys, the whole credential_pool). It was already read-denied via
+    get_read_block_error()'s credential_file_names tuple, but missing from
+    build_write_denied_paths() meant write_file/patch/delete/move could
+    destroy it with no read-based warning first (#70942)."""
+
+    def test_auth_json_denied(self):
+        from hermes_constants import get_hermes_home
+
+        path = get_hermes_home() / "auth.json"
+        assert _is_write_denied(str(path)) is True
+
+    def test_auth_lock_denied(self):
+        from hermes_constants import get_hermes_home
+
+        path = get_hermes_home() / "auth.lock"
+        assert _is_write_denied(str(path)) is True
+
+    def test_google_oauth_json_denied(self):
+        from hermes_constants import get_hermes_home
+
+        path = get_hermes_home() / "auth" / "google_oauth.json"
+        assert _is_write_denied(str(path)) is True
+
+    def test_webhook_subscriptions_json_denied(self):
+        from hermes_constants import get_hermes_home
+
+        path = get_hermes_home() / "webhook_subscriptions.json"
+        assert _is_write_denied(str(path)) is True
+
+    def test_auth_json_denied_at_root_when_running_under_profile(self, tmp_path, monkeypatch):
+        """Top-level <root>/auth.json stays write-denied even when running
+        under a profile, mirroring the existing .env root-widening (#15981)."""
+        root = tmp_path / "hermes_root"
+        profile_home = root / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        global_auth = root / "auth.json"
+        global_auth.write_text('{"anthropic-oauth": {"refresh_token": "rt-real"}}\n')
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        from hermes_constants import get_hermes_home, get_default_hermes_root
+        assert get_hermes_home() == profile_home
+        assert get_default_hermes_root() == root
+
+        assert _is_write_denied(str(global_auth)) is True


### PR DESCRIPTION
Fixes #70942

## Summary

`build_write_denied_paths()` in `agent/file_safety.py` protects `.env`,
`.anthropic_oauth.json`, SSH keys, and a handful of other credential
files against writes/deletes/moves by the agent's own file tools.
`auth.json` — the actual provider credential store (OAuth refresh
tokens, API keys, the whole `credential_pool`) — was missing from that
list entirely.

The asymmetry that gave this away: `get_read_block_error()` in the
same module already treats `auth.json` as a credential store and
blocks *reads* of it. So the agent could not read `auth.json`, but
could freely overwrite or delete it via `write_file`, `patch_replace`,
`delete_path`, `move_file`, or the ACP `fs/write_text_file` shim —
the read-deny arguably made this worse, since the agent can't inspect
what it's about to destroy before destroying it.

## Fix

Mirrors the existing `.env` / `.anthropic_oauth.json` handling:

- Adds `auth.json` at both the active-profile path and the top-level
  root path (same root-widening shape as #15981, so the store stays
  protected whether or not a profile is active).
- Also adds `auth.lock`, `auth/google_oauth.json`, and
  `webhook_subscriptions.json` — these were already read-denied
  alongside `auth.json` in `get_read_block_error()`'s
  `credential_file_names` tuple but had the same write-side gap.

## Tests

- Updated `test_hermes_control_files_requested_writable` — it
  previously asserted `auth.json` and `webhook_subscriptions.json`
  were writable, which encoded the bug. Now only asserts `config.yaml`
  is writable (still correct — config isn't a credential store).
- Added `TestWriteDenyCredentialStore` with 5 new tests: each new path
  individually, plus a root-widening-under-profile case matching the
  existing `.env` coverage.

Ran the full file-safety/credential test surface locally, no
regressions:

```
tests/agent/test_file_safety_sandbox_mirror.py
tests/agent/test_file_safety_credentials.py
tests/agent/test_file_safety.py
tests/agent/test_file_safety_container_mirror.py
tests/agent/test_file_safety_session_state.py
tests/agent/test_file_safety_cross_profile.py
tests/tools/test_credential_files.py
tests/tools/test_cross_profile_guard.py
tests/tools/test_write_deny.py
tests/tools/test_file_write_safety.py

213 passed in 4.28s
```
