### PR TITLE
feat(desktop): filter the Logs pane by session

### DIFF
--- a/apps/desktop/src/app/contrib/panes.test.ts
+++ b/apps/desktop/src/app/contrib/panes.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveLogsSessionQueryValue } from './panes'
+
+describe('LogsPane session filter routing', () => {
+  it('serializes Current as the stored/logged session id, not the runtime id', () => {
+    expect(
+      resolveLogsSessionQueryValue({
+        activeSessionId: 'runtime-session-after-resume',
+        selectedStoredSessionId: 'stored-lineage-session',
+        resolvedFilter: 'current'
+      })
+    ).toBe('stored-lineage-session')
+  })
+
+  it('falls back to the runtime id only before a stored id is known', () => {
+    expect(
+      resolveLogsSessionQueryValue({
+        activeSessionId: 'runtime-session-during-create',
+        selectedStoredSessionId: null,
+        resolvedFilter: 'current'
+      })
+    ).toBe('runtime-session-during-create')
+  })
+
+  it('omits the query session for All and passes explicit stored sessions through', () => {
+    expect(
+      resolveLogsSessionQueryValue({
+        activeSessionId: 'runtime-session',
+        selectedStoredSessionId: 'stored-session',
+        resolvedFilter: 'all'
+      })
+    ).toBeUndefined()
+
+    expect(
+      resolveLogsSessionQueryValue({
+        activeSessionId: 'runtime-session',
+        selectedStoredSessionId: 'stored-session',
+        resolvedFilter: 'picked-stored-session'
+      })
+    ).toBe('picked-stored-session')
+  })
+})

--- a/apps/desktop/src/app/contrib/panes.tsx
+++ b/apps/desktop/src/app/contrib/panes.tsx
@@ -12,6 +12,7 @@ import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import { atom } from 'nanostores'
 import type { CSSProperties } from 'react'
+import { useMemo, useState } from 'react'
 
 import { ChatPreviewRail } from '@/app/chat/right-rail/preview'
 import { RightSidebarPane } from '@/app/right-sidebar'
@@ -20,28 +21,93 @@ import type { GroupSetter } from '@/app/shell/group-setter'
 import type { StatusbarItem } from '@/app/shell/statusbar-controls'
 import { TITLEBAR_HEIGHT } from '@/app/shell/titlebar'
 import type { TitlebarTool } from '@/app/shell/titlebar-controls'
+import { ResponsiveTabs } from '@/components/ui/tab-dropdown'
 import { DecodeText } from '@/components/ui/decode-text'
 import { ContribBoundary } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { registry } from '@/contrib/registry'
 import { getLogs } from '@/hermes'
+import { sessionTitle } from '@/lib/chat-runtime'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
 import { $previewTarget, openPreview } from '@/store/preview'
-import { $currentCwd } from '@/store/session'
+import { $activeSessionId, $currentCwd, $selectedStoredSessionId, $sessions } from '@/store/session'
 
 // ---------------------------------------------------------------------------
-// Logs — live agent-log tail. ⌘K-only chrome: the pane contribution exists
-// only while the "Toggle logs" palette command has it summoned ($logsOpen in
-// the controller) — never in a default layout, never a standing tab.
+// Logs — live agent-log tail. OPTIONAL chrome: not in any default layout,
+// hidden until the ⌘K "Toggle logs" command opens it ($logsOpen).
+//
+// Session filter: log lines are already stamped with " [session_id]" by
+// hermes_logging's record factory (set_session_context()), so filtering here
+// is just passing that id through to GET /api/logs?session=... — no new
+// backend plumbing beyond exposing the CLI's existing `--session` filter on
+// the endpoint (#70828).
 // ---------------------------------------------------------------------------
+
+const LOGS_SESSION_FILTER_ALL = 'all'
+const LOGS_SESSION_FILTER_CURRENT = 'current'
+
+export function resolveLogsSessionQueryValue({
+  activeSessionId,
+  selectedStoredSessionId,
+  resolvedFilter
+}: {
+  activeSessionId: null | string
+  selectedStoredSessionId: null | string
+  resolvedFilter: string
+}): string | undefined {
+  if (resolvedFilter === LOGS_SESSION_FILTER_ALL) {
+    return undefined
+  }
+
+  if (resolvedFilter === LOGS_SESSION_FILTER_CURRENT) {
+    return selectedStoredSessionId ?? activeSessionId ?? undefined
+  }
+
+  return resolvedFilter
+}
 
 export function LogsPane() {
+  const activeSessionId = useStore($activeSessionId)
+  const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const sessions = useStore($sessions)
+  const [sessionFilter, setSessionFilter] = useState<string>(LOGS_SESSION_FILTER_ALL)
+
+  // A specific picked session id can go stale (session closed/deleted) —
+  // fall back to "all" rather than silently filtering on a dead id forever.
+  const resolvedFilter = useMemo(() => {
+    if (sessionFilter === LOGS_SESSION_FILTER_ALL || sessionFilter === LOGS_SESSION_FILTER_CURRENT) {
+      return sessionFilter
+    }
+    return sessions.some(session => session.id === sessionFilter) ? sessionFilter : LOGS_SESSION_FILTER_ALL
+  }, [sessionFilter, sessions])
+
+  const sessionQueryValue = resolveLogsSessionQueryValue({
+    activeSessionId,
+    selectedStoredSessionId,
+    resolvedFilter
+  })
+
   const { data, error } = useQuery({
-    queryKey: ['contrib-logs-tail'],
-    queryFn: () => getLogs({ lines: 300 }),
+    queryKey: ['contrib-logs-tail', sessionQueryValue],
+    queryFn: () => getLogs({ lines: 300, session: sessionQueryValue }),
     refetchInterval: 5000
   })
+
+  const tabs = useMemo(() => {
+    const base = [
+      { id: LOGS_SESSION_FILTER_ALL, label: 'All' },
+      { id: LOGS_SESSION_FILTER_CURRENT, label: 'Current' }
+    ]
+    // Recent sessions beyond "current", most-recently-active first, capped
+    // so the picker stays usable rather than listing every stored session.
+    const recents = [...sessions]
+      .sort((a, b) => (b.last_active || b.started_at || 0) - (a.last_active || a.started_at || 0))
+      .filter(session => session.id !== (selectedStoredSessionId ?? activeSessionId))
+      .slice(0, 8)
+      .map(session => ({ id: session.id, label: sessionTitle(session) }))
+    return [...base, ...recents]
+  }, [activeSessionId, selectedStoredSessionId, sessions])
 
   if (error) {
     return <div className="p-3 text-xs text-(--ui-text-quaternary)">log unavailable: {String(error)}</div>
@@ -55,12 +121,17 @@ export function LogsPane() {
     )
   }
 
-  // No chrome of its own — the zone header (when the user summons it) is the
-  // pane's only label. Just the tail.
   return (
-    <pre className="h-full min-h-0 overflow-auto whitespace-pre-wrap break-words p-2.5 font-mono text-[0.66rem] leading-relaxed text-(--ui-text-secondary)">
-      {data.lines.join('\n')}
-    </pre>
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center border-b border-(--ui-border-primary) px-2.5 py-1">
+        <ResponsiveTabs align="end" onChange={setSessionFilter} tabs={tabs} value={resolvedFilter} />
+      </div>
+      {/* No further chrome of its own — the zone header (when the user
+         summons it) is the pane's only other label. Just the tail. */}
+      <pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words p-2.5 font-mono text-[0.66rem] leading-relaxed text-(--ui-text-secondary)">
+        {data.lines.length ? data.lines.join('\n') : 'no matching log lines'}
+      </pre>
+    </div>
   )
 }
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -682,6 +682,7 @@ export function getLogs(params: {
   level?: string
   lines?: number
   search?: string
+  session?: string
 }): Promise<LogsResponse> {
   const query = new URLSearchParams()
 
@@ -703,6 +704,10 @@ export function getLogs(params: {
 
   if (params.search) {
     query.set('search', params.search)
+  }
+
+  if (params.session) {
+    query.set('session', params.session)
   }
 
   const suffix = query.toString()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11348,6 +11348,7 @@ async def get_logs(
     level: Optional[str] = None,
     component: Optional[str] = None,
     search: Optional[str] = None,
+    session: Optional[str] = None,
 ):
     from hermes_cli.logs import _read_tail, LOG_FILES
 
@@ -11378,12 +11379,20 @@ async def get_logs(
     else:
         comp_prefixes = None
 
-    has_filters = bool(min_level or comp_prefixes or search)
+    # Session filter: records are tagged " [session_id]" by
+    # hermes_logging._install_session_record_factory(), so a plain substring
+    # match against the formatted line (same approach the CLI's `hermes logs
+    # --session` already uses via _matches_filters) is sufficient — no
+    # separate parsing path needed.
+    session_filter = session.strip() if session and session.strip() else None
+
+    has_filters = bool(min_level or comp_prefixes or search or session_filter)
     result = _read_tail(
         log_path, min(lines, 500) if not search else 2000,
         has_filters=has_filters,
         min_level=min_level,
         component_prefixes=comp_prefixes,
+        session_filter=session_filter,
     )
     # Post-filter by search term (case-insensitive substring match).
     # _read_tail doesn't support free-text search, so we filter here and

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1807,6 +1807,61 @@ class TestNewEndpoints:
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
+    def test_get_logs_default(self):
+        resp = self.client.get("/api/logs")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "file" in data
+        assert "lines" in data
+        assert isinstance(data["lines"], list)
+
+    def test_get_logs_invalid_file(self):
+        resp = self.client.get("/api/logs?file=nonexistent")
+        assert resp.status_code == 400
+
+    def test_get_logs_session_filter(self):
+        """GET /api/logs?session=<id> narrows to lines tagged with that
+        session (#70828). Log lines get " [session_id]" stamped by
+        hermes_logging's record factory via set_session_context(); the
+        endpoint's session_filter is a plain substring match against the
+        formatted line, mirroring `hermes logs --session` (_matches_filters
+        in hermes_cli/logs.py)."""
+        from hermes_constants import get_hermes_home
+
+        log_path = get_hermes_home() / "logs" / "agent.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(
+            "2026-07-24 12:00:00 INFO [session-alpha] agent: alpha line one\n"
+            "2026-07-24 12:00:01 INFO [session-beta] agent: beta line one\n"
+            "2026-07-24 12:00:02 INFO [session-alpha] agent: alpha line two\n"
+        )
+
+        resp = self.client.get("/api/logs?file=agent&session=session-alpha")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["lines"]) == 2
+        assert all("session-alpha" in line for line in data["lines"])
+        assert not any("session-beta" in line for line in data["lines"])
+
+    def test_get_logs_session_filter_no_match(self):
+        from hermes_constants import get_hermes_home
+
+        log_path = get_hermes_home() / "logs" / "agent.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("2026-07-24 12:00:00 INFO [session-alpha] agent: alpha line one\n")
+
+        resp = self.client.get("/api/logs?file=agent&session=session-nonexistent")
+        assert resp.status_code == 200
+        assert resp.json()["lines"] == []
+
+    def test_cron_list(self):
+        resp = self.client.get("/api/cron/jobs")
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_cron_job_not_found(self):
+        resp = self.client.get("/api/cron/jobs/nonexistent-id")
+        assert resp.status_code == 404
 
     # --- Automation Blueprints ---
 


### PR DESCRIPTION
Fixes #70828

## Summary

The desktop Logs pane showed one merged stream from the entire
backend — all sessions, gateway, cron jobs, inference calls —
interleaved chronologically, with no way to narrow it to a single
conversation.

The data needed for a session filter already existed:

- Log records are stamped with `" [session_id]"` by
  `hermes_logging`'s record factory (`set_session_context()`).
- `hermes_cli/logs.py`'s `_read_tail()` / `_matches_filters()` already
  accept a `session_filter` — it's what powers `hermes logs --session`
  on the CLI.

The `GET /api/logs` endpoint just never exposed that filter to callers.

## Changes

- **Backend** (`hermes_cli/web_server.py`): `GET /api/logs` now
  accepts an optional `session` query param, threaded through to the
  existing `_read_tail(session_filter=...)`. Same plain
  substring-against-the-formatted-line approach the CLI already uses
  — no new parsing path.
- **Frontend** (`apps/desktop/src/hermes.ts`): `getLogs()` passes
  `session` through as a query param.
- **`LogsPane`** (`apps/desktop/src/app/contrib/panes.tsx`): adds a
  `ResponsiveTabs` filter row — **All** / **Current** / recent
  sessions (capped at 8, most-recently-active first) — reusing the
  existing `$activeSessionId` / `$sessions` stores and the
  `sessionTitle()` helper already used by the sessions list elsewhere
  in the app. A picked session id that goes stale (session
  closed/deleted) falls back to **All** rather than silently filtering
  on a dead id forever.

No schema or backend architecture changes — this is exactly the
"cheap to implement" shape the issue describes.

## Tests

Added `test_get_logs_session_filter` and
`test_get_logs_session_filter_no_match` to
`tests/hermes_cli/test_web_server.py::TestNewEndpoints`, covering the
narrowing behavior and the no-match case.

Ran the full `TestNewEndpoints` class (86 tests):

```
86 passed except test_terminal_ssh_probe_reports_missing_keys
```

That one failure is pre-existing and unrelated — it fails identically
on `main` before this change (SSH-key-in-environment-dependent, not
touched by this PR).