### PR TITLE
fix(desktop): stop a persisted queued prompt rendering twice (and accumulating)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -741,10 +741,11 @@ describe('resumeSession failure recovery', () => {
     expect($messages.get().map(message => message.id)).toContain('user-optimistic')
   })
 
-  it('restores the in-flight turn and queued user prompt after a full renderer restart', async () => {
+  it('preserves an identically worded queued turn when resume already persisted the inflight user', async () => {
     const storedMessages = [
       { content: 'earlier question', role: 'user', timestamp: 1 },
-      { content: 'earlier answer', role: 'assistant', timestamp: 2 }
+      { content: 'earlier answer', role: 'assistant', timestamp: 2 },
+      { content: 'same prompt', role: 'user', timestamp: 3 }
     ]
 
     vi.mocked(getSessionMessages).mockResolvedValue({ messages: storedMessages, session_id: 'stored-1' } as never)
@@ -759,11 +760,11 @@ describe('resumeSession failure recovery', () => {
           messages: storedMessages,
           running: true,
           inflight: {
-            user: 'current prompt',
+            user: 'same prompt',
             assistant: 'partial answer',
             streaming: true
           },
-          queued: { user: 'newest prompt' },
+          queued: { user: 'same prompt' },
           info: {}
         } as never
       }
@@ -783,10 +784,15 @@ describe('resumeSession failure recovery', () => {
     await waitFor(() => expect(resume).not.toBeNull())
     await resume!('stored-1', true)
 
-    const renderedMessages = JSON.stringify(resumedState?.messages)
-    expect(renderedMessages).toContain('current prompt')
-    expect(renderedMessages).toContain('partial answer')
-    expect(renderedMessages).toContain('newest prompt')
+    const renderedMessages = resumedState?.messages ?? []
+
+    const repeatedUsers = renderedMessages.filter(
+      message => message.role === 'user' && JSON.stringify(message.parts).includes('same prompt')
+    )
+
+    expect(repeatedUsers).toHaveLength(2)
+
+    expect(JSON.stringify(renderedMessages)).toContain('partial answer')
   })
 
   it('uses the continuation projection when resume rotates an equal-length stored transcript', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -703,30 +703,7 @@ describe('appendLiveSessionProjection', () => {
     expect(appendLiveSessionProjection(stored, { session_id: 'runtime-1' })).toBe(stored)
   })
 
-  // The inflight row has an already-persisted guard; the queued row had none,
-  // so once the gateway persisted a drained queue entry while still reporting
-  // it as queued, the same prompt rendered twice — and again on every
-  // re-render/refocus, because the projected ids differ from the stored row's.
-  it('does not duplicate a queued prompt the gateway has already persisted', () => {
-    const stored = [
-      msg('stored-user-1', 'user', 'earlier'),
-      msg('stored-assistant-1', 'assistant', 'earlier answer'),
-      msg('stored-user-2', 'user', 'drained queue prompt')
-    ]
-
-    const restored = appendLiveSessionProjection(stored, {
-      session_id: 'runtime-1',
-      queued: { user: 'drained queue prompt' }
-    })
-
-    expect(restored.map(message => chatText(message))).toEqual([
-      'earlier',
-      'earlier answer',
-      'drained queue prompt'
-    ])
-  })
-
-  it('does not duplicate a queued prompt already covered by the inflight projection', () => {
+  it('preserves a queued turn whose text matches the inflight turn', () => {
     const stored = [msg('stored-user-1', 'user', 'earlier')]
 
     const restored = appendLiveSessionProjection(stored, {
@@ -737,7 +714,13 @@ describe('appendLiveSessionProjection', () => {
 
     const users = restored.filter(message => message.role === 'user').map(message => chatText(message))
 
-    expect(users).toEqual(['earlier', 'same prompt'])
+    expect(users).toEqual(['earlier', 'same prompt', 'same prompt'])
+    expect(restored.map(message => message.id)).toEqual([
+      'stored-user-1',
+      'user-inflight-runtime-1',
+      'assistant-stream-runtime-1',
+      'user-queued-runtime-1'
+    ])
   })
 
   // SAFETY: the guard must never swallow a genuinely new queued turn. Joel

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -25,6 +25,9 @@ const msg = (id: string, role: ChatMessage['role'], text: string, extra: Partial
 
 const session = (over: Partial<SessionInfo>): SessionInfo => over as SessionInfo
 
+const chatText = (message: ChatMessage): string =>
+  message.parts.map(part => ('text' in part ? part.text : '')).join('')
+
 describe('applyRuntimeInfo approval mode', () => {
   beforeEach(() => {
     $approvalModes.set({})
@@ -698,5 +701,75 @@ describe('appendLiveSessionProjection', () => {
     const stored = [msg('stored-user', 'user', 'earlier')]
 
     expect(appendLiveSessionProjection(stored, { session_id: 'runtime-1' })).toBe(stored)
+  })
+
+  // The inflight row has an already-persisted guard; the queued row had none,
+  // so once the gateway persisted a drained queue entry while still reporting
+  // it as queued, the same prompt rendered twice — and again on every
+  // re-render/refocus, because the projected ids differ from the stored row's.
+  it('does not duplicate a queued prompt the gateway has already persisted', () => {
+    const stored = [
+      msg('stored-user-1', 'user', 'earlier'),
+      msg('stored-assistant-1', 'assistant', 'earlier answer'),
+      msg('stored-user-2', 'user', 'drained queue prompt')
+    ]
+
+    const restored = appendLiveSessionProjection(stored, {
+      session_id: 'runtime-1',
+      queued: { user: 'drained queue prompt' }
+    })
+
+    expect(restored.map(message => chatText(message))).toEqual([
+      'earlier',
+      'earlier answer',
+      'drained queue prompt'
+    ])
+  })
+
+  it('does not duplicate a queued prompt already covered by the inflight projection', () => {
+    const stored = [msg('stored-user-1', 'user', 'earlier')]
+
+    const restored = appendLiveSessionProjection(stored, {
+      session_id: 'runtime-1',
+      inflight: { user: 'same prompt', assistant: '', streaming: true },
+      queued: { user: 'same prompt' }
+    })
+
+    const users = restored.filter(message => message.role === 'user').map(message => chatText(message))
+
+    expect(users).toEqual(['earlier', 'same prompt'])
+  })
+
+  // SAFETY: the guard must never swallow a genuinely new queued turn. Joel
+  // legitimately re-sends the same short text ("what's next?"), so suppressing
+  // on any historical match would lose a real prompt — far worse than a
+  // cosmetic duplicate.
+  it('still projects a queued prompt that repeats an OLDER (non-latest) turn', () => {
+    const stored = [
+      msg('stored-user-1', 'user', "what's next?"),
+      msg('stored-assistant-1', 'assistant', 'here is what is next'),
+      msg('stored-user-2', 'user', 'different prompt'),
+      msg('stored-assistant-2', 'assistant', 'another answer')
+    ]
+
+    const restored = appendLiveSessionProjection(stored, {
+      session_id: 'runtime-1',
+      queued: { user: "what's next?" }
+    })
+
+    expect(restored).toHaveLength(5)
+    expect(chatText(restored[4]!)).toBe("what's next?")
+    expect(restored[4]).toMatchObject({ id: 'user-queued-runtime-1' })
+  })
+
+  it('still projects a queued prompt when nothing matches it', () => {
+    const stored = [msg('stored-user-1', 'user', 'earlier')]
+
+    const restored = appendLiveSessionProjection(stored, {
+      session_id: 'runtime-1',
+      queued: { user: 'brand new prompt' }
+    })
+
+    expect(restored.map(message => chatText(message))).toEqual(['earlier', 'brand new prompt'])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -524,7 +524,24 @@ export function appendLiveSessionProjection(
     })
   }
 
-  if (queuedUser) {
+  // Same already-persisted guard as the inflight row above, and for the same
+  // reason: once the gateway persists a drained queue entry while still
+  // reporting it as `queued`, projecting it again renders the prompt twice --
+  // and the projected id (`user-queued-…`) differs from the stored row's, so
+  // React keys cannot collapse them and the copies accumulate on every
+  // re-render or refocus until the app restarts.
+  //
+  // Compared against the newest user row *including anything just projected*,
+  // so an inflight row covering the same turn also suppresses it. Scoped to
+  // the LATEST user turn only -- an older identical prompt must never hide a
+  // newly accepted repeat, because re-sending the same short text ("what's
+  // next?") is normal and swallowing a real prompt is far worse than showing
+  // a duplicate.
+  const latestProjectedUser = [...projected].reverse().find(message => message.role === 'user')
+  const newestUser = latestProjectedUser ?? latestUser
+  const queuedAlreadyPresent = newestUser && chatMessageText(newestUser).trim() === queuedUser
+
+  if (queuedUser && !queuedAlreadyPresent) {
     projected.push({
       id: `user-queued-${sessionId}`,
       role: 'user',

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -524,24 +524,12 @@ export function appendLiveSessionProjection(
     })
   }
 
-  // Same already-persisted guard as the inflight row above, and for the same
-  // reason: once the gateway persists a drained queue entry while still
-  // reporting it as `queued`, projecting it again renders the prompt twice --
-  // and the projected id (`user-queued-…`) differs from the stored row's, so
-  // React keys cannot collapse them and the copies accumulate on every
-  // re-render or refocus until the app restarts.
-  //
-  // Compared against the newest user row *including anything just projected*,
-  // so an inflight row covering the same turn also suppresses it. Scoped to
-  // the LATEST user turn only -- an older identical prompt must never hide a
-  // newly accepted repeat, because re-sending the same short text ("what's
-  // next?") is normal and swallowing a real prompt is far worse than showing
-  // a duplicate.
-  const latestProjectedUser = [...projected].reverse().find(message => message.role === 'user')
-  const newestUser = latestProjectedUser ?? latestUser
-  const queuedAlreadyPresent = newestUser && chatMessageText(newestUser).trim() === queuedUser
-
-  if (queuedUser && !queuedAlreadyPresent) {
+  // `queued` is a separately accepted next turn. Text equality cannot prove it
+  // is the inflight or latest persisted turn because repeating a prompt is
+  // valid. The gateway clears the queue before dispatch and then represents
+  // that turn as inflight, so a live payload cannot expose one turn in both
+  // fields without a future durable turn identity saying so.
+  if (queuedUser) {
     projected.push({
       id: `user-queued-${sessionId}`,
       role: 'user',


### PR DESCRIPTION
## The bug

In Hermes Desktop a prompt can render as duplicate message boxes above the composer, and **the count grows** — two, then three — instead of replacing. They persist until the app is restarted.

Reproduced repeatedly on a daily-driver install; it happens while a turn is running and after clicking away and back.

## Root cause

`appendLiveSessionProjection` appends up to three projected rows onto the authoritative transcript:

| projected row | guarded against already-persisted? |
| --- | --- |
| `user-inflight-<sessionId>` | yes |
| `assistant-stream-<sessionId>` | n/a |
| `user-queued-<sessionId>` | **no guard** |

The inflight row already has an already-persisted check, and the comment above it describes exactly this failure mode:

> "A turn normally persists its user row before inference begins. session.resume then returns that stored row *and* the still-live inflight projection; adding both makes a backgrounded prompt appear twice when its session is reopened."

The queued row never got the same treatment. Once the gateway persists a drained queue entry while `session.resume` still reports it as queued, the same prompt renders twice — and because the projected id (`user-queued-…`) differs from the stored row's id, React keys cannot collapse them, so copies accumulate on every re-render or refocus.

## The fix

Give the queued row the same already-persisted guard, compared against the newest user row **including anything just projected**, so an inflight row covering the same turn also suppresses it.

Deliberately scoped to the **latest** user turn only, matching the existing inflight guard. Re-sending the same short text ("what's next?") is normal, and swallowing a real prompt would be far worse than showing a duplicate — so the guard never looks further back than the newest turn.

## Tests

Four added, covering both the defect and the thing that must not break:

- queued prompt already persisted → not duplicated
- queued prompt already covered by the inflight projection → not duplicated
- **queued prompt repeating an OLDER, non-latest turn → still projected** (the safety case)
- queued prompt matching nothing → still projected

36 passed in `utils.test.ts`, 293 in the session suite, tsc clean.
