### PR TITLE
fix(desktop): enable asar integrity in Windows build by removing signAndEditExecutable false (#69179)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -256,8 +256,7 @@
       "target": [
         "nsis",
         "msi"
-      ],
-      "signAndEditExecutable": false
+      ]
     },
     "linux": {
       "category": "Development",


### PR DESCRIPTION
## Summary

Remove `signAndEditExecutable: false` from the Windows electron-builder config to fix ASAR integrity metadata embedding.

## Root Cause

The `win` build config in `apps/desktop/package.json` has:
```json
"signAndEditExecutable": false
```

When set to `false`, electron-builder **skips embedding ASAR integrity metadata** into the resulting `Hermes.exe`. Without this metadata, the built `resources/app.asar` file is only ~176 bytes (empty/broken) instead of the expected ~42MB. Electron cannot find the app entry point, resulting in:
- 「此应用无法在你的电脑上运行」(This app can't run on your computer) — **#69179**
- Electron help text shown instead of the app — **#70825**

## Fix

Remove `signAndEditExecutable: false` entirely. The default value for this option in electron-builder is `true`, which means ASAR integrity metadata will be properly embedded. If code signing is unavailable, `forceCodeSigning: false` provides the safety valve — the build still embeds integrity metadata and produces a working binary, just without a digital signature.

This is a minimal, targeted fix.

## Files changed
- `apps/desktop/package.json` — Removed `signAndEditExecutable: false` from the `win` build config

Fixes #69179
Fixes #70825