### PR TITLE
fix(cron): skip provider-error classification for no_agent job failures

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -98,34 +98,42 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     text = (error or "unknown error").strip()
     lower = text.lower()
 
-    # Provider/API failures are the common noisy path. Keep these short.
-    if "429" in text or "rate limit" in lower or "usage limit" in lower:
-        reason = "rate limit"
-        if "weekly usage limit" in lower:
-            reason = "weekly usage limit"
-        elif "quota" in lower:
-            reason = "quota limit"
-        return (
-            f"⚠️ Cron '{job_name}' failed: provider {reason}. "
-            "Fallback chain was exhausted or unavailable. "
-            "Full details saved in cron output."
-        )
+    # Provider/API failure classification only applies to jobs that actually
+    # talk to a provider. A no_agent job IS its bash script — there is no LLM
+    # call — and its whole stdout becomes this error string, so bare tokens
+    # like 401/403/429/"timeout" in ordinary script output (e.g. a passing
+    # auth-gate test printing "returns 401") would misattribute an unrelated
+    # script failure to a "provider error". Skip these branches for no_agent
+    # jobs and fall through to the generic summary. See #70908.
+    if not job.get("no_agent"):
+        # Provider/API failures are the common noisy path. Keep these short.
+        if "429" in text or "rate limit" in lower or "usage limit" in lower:
+            reason = "rate limit"
+            if "weekly usage limit" in lower:
+                reason = "weekly usage limit"
+            elif "quota" in lower:
+                reason = "quota limit"
+            return (
+                f"⚠️ Cron '{job_name}' failed: provider {reason}. "
+                "Fallback chain was exhausted or unavailable. "
+                "Full details saved in cron output."
+            )
 
-    if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
-        return (
-            f"⚠️ Cron '{job_name}' failed: provider timeout. "
-            "Fallback chain was exhausted or unavailable. "
-            "Full details saved in cron output."
-        )
+        if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
+            return (
+                f"⚠️ Cron '{job_name}' failed: provider timeout. "
+                "Fallback chain was exhausted or unavailable. "
+                "Full details saved in cron output."
+            )
 
-    # Match authentication/authorization wording at a word boundary and the
-    # 401/403 status codes as whole tokens, so "oauth", "4015" and similar do
-    # not trip a misleading auth message.
-    if re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text):
-        return (
-            f"⚠️ Cron '{job_name}' failed: provider authentication error. "
-            "Full details saved in cron output."
-        )
+        # Match authentication/authorization wording at a word boundary and the
+        # 401/403 status codes as whole tokens, so "oauth", "4015" and similar
+        # do not trip a misleading auth message.
+        if re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text):
+            return (
+                f"⚠️ Cron '{job_name}' failed: provider authentication error. "
+                "Full details saved in cron output."
+            )
 
     # Strip common exception wrappers and collapse provider payloads. Bound
     # the input first so a multi-KB provider blob cannot slow the

--- a/tests/cron/test_summarize_cron_failure.py
+++ b/tests/cron/test_summarize_cron_failure.py
@@ -1,0 +1,72 @@
+"""Tests for #70908: the cron failure summarizer must not misattribute a
+``no_agent`` script failure to a provider error.
+
+``no_agent=True`` jobs run a bash script with no LLM/provider involved. When
+such a script exits non-zero, its entire stdout is handed to
+``_summarize_cron_failure_for_delivery`` as the error string. The provider
+classification branches (rate limit / timeout / authentication) match bare
+tokens anywhere in that text, so ordinary script output that merely mentions
+``401``/``403``/``429``/``timeout`` (e.g. a passing auth-gate test printing
+"returns 401") produced a misleading "provider authentication error"
+notification for a failure that had nothing to do with any provider.
+
+These tests pin that a no_agent job never gets a provider-flavoured summary,
+while agent jobs keep the existing classification.
+"""
+
+from cron.scheduler import _summarize_cron_failure_for_delivery
+
+
+# --- no_agent jobs: never classified as a provider error ------------------
+
+def test_no_agent_401_in_stdout_is_not_provider_auth_error():
+    job = {"name": "verify", "no_agent": True}
+    error = "PASS  auth gate returns 401\nFAIL  some other check\n"
+    msg = _summarize_cron_failure_for_delivery(job, error)
+    assert "provider authentication error" not in msg
+    assert "verify" in msg
+
+
+def test_no_agent_403_in_stdout_is_not_provider_auth_error():
+    job = {"name": "verify", "no_agent": True}
+    error = "ok: endpoint returns 403 for anonymous\nunrelated failure\n"
+    msg = _summarize_cron_failure_for_delivery(job, error)
+    assert "provider authentication error" not in msg
+
+
+def test_no_agent_429_in_stdout_is_not_provider_rate_limit():
+    job = {"name": "verify", "no_agent": True}
+    error = "checked that throttled route returns 429\nassertion failed\n"
+    msg = _summarize_cron_failure_for_delivery(job, error)
+    assert "provider" not in msg
+
+
+def test_no_agent_timeout_word_in_stdout_is_not_provider_timeout():
+    job = {"name": "verify", "no_agent": True}
+    error = "config sets request timeout=30\nstep 2 failed\n"
+    msg = _summarize_cron_failure_for_delivery(job, error)
+    assert "provider timeout" not in msg
+
+
+# --- agent jobs: provider classification unchanged ------------------------
+
+def test_agent_job_401_still_classified_as_provider_auth():
+    job = {"name": "chat", "no_agent": False}
+    error = "HTTP 401 Unauthorized from provider"
+    msg = _summarize_cron_failure_for_delivery(job, error)
+    assert "provider authentication error" in msg
+
+
+def test_agent_job_without_flag_401_still_classified_as_provider_auth():
+    # A legacy job dict that predates the no_agent field must still classify.
+    job = {"name": "chat"}
+    error = "401 Unauthorized"
+    msg = _summarize_cron_failure_for_delivery(job, error)
+    assert "provider authentication error" in msg
+
+
+def test_agent_job_429_still_classified_as_provider_rate_limit():
+    job = {"name": "chat", "no_agent": False}
+    error = "429 Too Many Requests"
+    msg = _summarize_cron_failure_for_delivery(job, error)
+    assert "provider rate limit" in msg


### PR DESCRIPTION
## What does this PR do?

Fixes a misleading cron notification. `no_agent=True` jobs run a bash script with no LLM or provider involved. When such a script exits non-zero, its entire stdout is handed to `_summarize_cron_failure_for_delivery` as the error string. The provider classification branches in that function match bare tokens (`401`, `403`, `429`, "timeout") anywhere in the text, so ordinary script output that just happens to mention a status code, for example a passing auth-gate test printing "returns 401", got reported to the user as a "provider authentication error" even though no provider was ever called.

The fix gates all three provider classification branches (rate limit, timeout, authentication) behind `not job.get("no_agent")`. Script-only jobs now fall through to the generic failure summary, which reflects what actually broke. Agent jobs are untouched, so real provider errors are still classified exactly as before.

I widened the guard to cover 429 and timeout in addition to the 401/403 case from the issue because they share the same root cause: bare tokens in script stdout being read as provider diagnostics. This matches the issue's preferred option A ("skip the provider-error classification for no_agent jobs entirely").

## Related Issue

Fixes #70908

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: wrap the rate-limit, timeout, and authentication classification branches in `_summarize_cron_failure_for_delivery` inside `if not job.get("no_agent"):`. Pure re-indentation of the existing branches plus a comment explaining why; agent-job output is unchanged.
- `tests/cron/test_summarize_cron_failure.py`: new test module. Four cases assert a no_agent job whose stdout mentions 401/403/429/timeout is not classified as a provider error, and three regression cases assert agent jobs (including a legacy job dict with no `no_agent` key) still classify 401/429 as before.

## How to Test

1. Reproduce on `main`: build a job dict with `no_agent=True` and pass stdout containing a bare `401` to `_summarize_cron_failure_for_delivery`. It returns "provider authentication error" even though no provider is involved.
2. With this change, the same input falls through to the generic summary and no longer mentions a provider.
3. Run the suite:

   ```
   pytest tests/cron/test_summarize_cron_failure.py tests/cron/test_run_one_job.py tests/cron/test_cron_no_agent.py tests/cron/test_shutdown_interrupt.py -q
   ```

   51 passed. The four no_agent tests fail on `main` and pass with the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the affected cron tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] No documentation changes needed (behavior fix, no config keys or tool schemas touched) - N/A
- [x] No config keys added or changed - N/A
- [x] No architecture or workflow changes - N/A
- [x] Cross-platform impact considered: this is provider-agnostic string classification with no OS-specific behavior
- [x] No tool descriptions or schemas changed - N/A
