### PR TITLE
fix(kanban): persist summary-only completion results

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4614,8 +4614,14 @@ def complete_task(
 
     ``summary`` and ``metadata`` are stored on the closing run (if any)
     and surfaced to downstream children via :func:`build_worker_context`.
-    When ``summary`` is omitted we fall back to ``result`` so single-run
-    callers do not have to pass both. ``metadata`` is a free-form dict
+    When ``summary`` is omitted we fall back to ``result`` — and when
+    ``result`` is omitted we fall back to ``summary`` — so single-run
+    callers do not have to pass both. The result backfill is what keeps
+    a successful worker handoff visible on the task row itself
+    (``tasks.result``) when the worker completed via the run protocol
+    with only a summary and posted no completion comment (#t_343e914f:
+    tasks done + task_runs.summary populated + tasks.result NULL).
+    ``metadata`` is a free-form dict
     (e.g. ``{"changed_files": [...], "tests_run": [...]}``) — workers
     are encouraged to use it for structured handoff facts.
 
@@ -4666,6 +4672,12 @@ def complete_task(
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
+    # Backfill tasks.result from the handoff summary when the worker only
+    # passed summary (the common run-protocol shape). Without this the task
+    # closes with result=NULL and the summary is only reachable via the run
+    # row — dashboard/notifier paths that read tasks.result show nothing.
+    if result is None and summary is not None:
+        result = summary
     with write_txn(conn):
         if expected_run_id is None:
             cur = conn.execute(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4959,3 +4959,49 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+def test_complete_task_backfills_result_from_summary(kanban_home):
+    """Summary-only worker completions remain visible on the task row."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="summary-only", assignee="worker")
+        kb.claim_task(conn, tid)
+
+        assert kb.complete_task(conn, tid, summary="rich worker handoff")
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.result == "rich worker handoff"
+        run = conn.execute(
+            "SELECT summary FROM task_runs WHERE task_id=? AND outcome='completed'",
+            (tid,),
+        ).fetchone()
+        assert run is not None
+        assert run["summary"] == "rich worker handoff"
+
+
+def test_complete_task_keeps_explicit_result_when_summary_differs(kanban_home):
+    """The reverse fallback must not overwrite an explicit task result."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="explicit-result", assignee="worker")
+        kb.claim_task(conn, tid)
+
+        assert kb.complete_task(
+            conn, tid, result="short result", summary="long handoff",
+        )
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.result == "short result"
+
+
+def test_complete_task_backfills_result_without_active_run(kanban_home):
+    """Manual completion's synthesized run uses the same reverse fallback."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="manual-summary", assignee="worker")
+
+        assert kb.complete_task(conn, tid, summary="manual handoff")
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.result == "manual handoff"

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2446,8 +2446,8 @@ def test_task_detail_exposes_result_and_latest_summary_separately(client):
     assert "final_result" not in data
 
 
-def test_task_detail_exposes_latest_summary_when_result_is_empty(client):
-    """Summary-only completions remain available to the drawer fallback."""
+def test_task_detail_persists_summary_as_result(client):
+    """Summary-only completions remain available on the task row."""
     conn = kb.connect()
     task_id = kb.create_task(conn, title="Task with only run summary")
     kb.claim_task(conn, task_id)
@@ -2458,7 +2458,7 @@ def test_task_detail_exposes_latest_summary_when_result_is_empty(client):
     assert r.status_code == 200
     data = r.json()["task"]
     assert data["status"] == "done"
-    assert not data["result"]
+    assert data["result"] == "Report written to /output/report.md"
     assert data["latest_summary"] == "Report written to /output/report.md"
 
 
@@ -2519,7 +2519,7 @@ def test_task_detail_includes_child_result_summaries(client):
             "title": "Collect sources",
             "status": "done",
             "latest_summary": "Collected five primary sources.",
-            "result": None,
+            "result": "Collected five primary sources.",
         }
     ]
 


### PR DESCRIPTION
[Bob]

## Summary

- persist `summary` into `tasks.result` when callers omit `result`
- preserve an explicit `result` when both fields are supplied
- cover claimed worker runs and manual completion's synthesized-run path

## Root cause

`complete_task()` already copied `result` into `task_runs.summary` when callers omitted `summary`, but not the reverse. Dispatcher workers commonly complete through the run protocol with only a rich `summary`, so the run row closed successfully while `tasks.result` remained `NULL`. Dashboards and delivery paths that read the task row then had no durable completion text.

## Duplicate search

The notification-inheritance half of the original local fix was removed because open PR #57365 already covers parent-to-child subscription inheritance more comprehensively across `create_task`, `link_tasks`, and triage decomposition. This PR keeps only the distinct summary-to-result persistence bug. Merged PR #20195 addresses dashboard-entered summaries and recovery editing, not summary-only worker completions.

## RED → GREEN

On `origin/main`, the regression cases produced:

```text
2 failed, 2 passed
```

The failures were the claimed-run and synthesized-run paths leaving `task.result` as `None`.

After the fix:

```text
417 passed, 1 skipped
```

## Verification

```text
HERMES_DELEGATED_CHILD_CONTEXT= python -m pytest \
  tests/hermes_cli/test_kanban_notify.py \
  tests/hermes_cli/test_kanban_core_functionality.py \
  tests/hermes_cli/test_kanban_db.py -q

417 passed, 1 skipped
```

```text
python -m ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py
All checks passed!

python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py
git diff HEAD^ HEAD --check
```

Independent fail-closed review passed with no security concerns or logic errors.

[bob]
