### PR TITLE
fix(gateway): detect and escape silent event-loop freezes

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -930,6 +930,13 @@ class GatewayConfig:
     # disables sd_notify at runtime.
     systemd_watchdog_seconds: int = 0
 
+    # In-process event-loop liveness watchdog (#69089). A daemon OS thread
+    # probes the gateway loop with call_soon_threadsafe; after consecutive
+    # missed probes it dumps all-thread stacks and hard-exits with the
+    # service-restart code so the supervisor can revive the process. On by
+    # default; set gateway.loop_watchdog: false in config.yaml to disable.
+    loop_watchdog: bool = True
+
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
 
@@ -1064,6 +1071,7 @@ class GatewayConfig:
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "multiplex_profiles": self.multiplex_profiles,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
+            "loop_watchdog": self.loop_watchdog,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
@@ -1135,6 +1143,11 @@ class GatewayConfig:
         systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(
             systemd_watchdog_raw, systemd_watchdog_key
         )
+        if "loop_watchdog" in data:
+            loop_watchdog_raw = data.get("loop_watchdog")
+        else:
+            loop_watchdog_raw = nested_gateway.get("loop_watchdog")
+        loop_watchdog = _coerce_bool(loop_watchdog_raw, True)
         if multiplex_profiles is None and isinstance(nested_gateway, dict):
             # Also honor gateway.multiplex_profiles written by
             # ``hermes config set gateway.multiplex_profiles true``.
@@ -1195,6 +1208,7 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             systemd_watchdog_seconds=systemd_watchdog_seconds,
+            loop_watchdog=loop_watchdog,
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2129,9 +2129,11 @@ from gateway.platforms.base import (
 )
 from gateway.shutdown_watchdog import (
     DEFAULT_HEARTBEAT_INTERVAL_S,
+    _arm_loop_floor_timer,
     arm_shutdown_watchdog,
     loop_heartbeat_forever,
     resolve_shutdown_watchdog_delay,
+    start_loop_liveness_watchdog,
 )
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
@@ -3285,10 +3287,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _session_ephemeral_pin: Dict[str, tuple] = {}
     _session_vc_last: Dict[str, str] = {}
     _startup_restore_in_progress: bool = False
-    # Loop-liveness heartbeat / shutdown-watchdog handles (#66892). Class-level
+    # Loop-liveness heartbeat / watchdog handles (#66892, #69089). Class-level
     # defaults so partial construction in tests doesn't blow up on access; the
     # real values are set in __init__ / start() / stop().
     _loop_heartbeat_task: Optional["asyncio.Task"] = None
+    _loop_floor_timer_handle: Optional[Any] = None
+    _loop_liveness_watchdog: Optional[Any] = None
     _gateway_started_at: float = 0.0
     _shutdown_watchdog_done: Optional["threading.Event"] = None
     _platform_lock_takeover_on_start: bool = False
@@ -3665,6 +3669,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # updated_at to distinguish "process alive" from "loop frozen".
         self._gateway_started_at: float = time.time()
         self._loop_heartbeat_task: Optional[asyncio.Task] = None
+        self._loop_floor_timer_handle = None
+        self._loop_liveness_watchdog = None
 
         # scale-to-zero (Phase 0, F13): gateway-scoped "last inbound seen" clock.
         # There is no such clock today (only a per-agent _last_activity_ts), so the
@@ -7729,6 +7735,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         return True
 
+    def _start_loop_liveness_guards(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Arm the selector floor and out-of-loop watchdog before adapters."""
+        if getattr(self, "_loop_floor_timer_handle", None) is None:
+            try:
+                self._loop_floor_timer_handle = _arm_loop_floor_timer(loop)
+            except Exception:
+                logger.debug("Failed to arm gateway loop floor timer", exc_info=True)
+
+        watchdog = getattr(self, "_loop_liveness_watchdog", None)
+        if watchdog is None or not watchdog.is_alive():
+            try:
+                self._loop_liveness_watchdog = start_loop_liveness_watchdog(loop)
+            except Exception:
+                logger.debug("Failed to start gateway loop liveness watchdog", exc_info=True)
+
+    def _stop_loop_liveness_guards(self) -> None:
+        """Disarm lifetime liveness guards before shutdown can load the loop."""
+        watchdog = getattr(self, "_loop_liveness_watchdog", None)
+        self._loop_liveness_watchdog = None
+        if watchdog is not None:
+            try:
+                watchdog.stop()
+            except Exception:
+                logger.debug("Failed to stop gateway loop liveness watchdog", exc_info=True)
+
+        floor_timer = getattr(self, "_loop_floor_timer_handle", None)
+        self._loop_floor_timer_handle = None
+        if floor_timer is not None:
+            try:
+                floor_timer.cancel()
+            except Exception:
+                logger.debug("Failed to cancel gateway loop floor timer", exc_info=True)
+
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
@@ -7740,6 +7779,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._gateway_loop = asyncio.get_running_loop()
         except RuntimeError:
             self._gateway_loop = None
+        if self._gateway_loop is not None:
+            self._start_loop_liveness_guards(self._gateway_loop)
         logger.info("Session storage: %s", self.config.sessions_dir)
 
         # Sanity-check that systemd's TimeoutStopSec covers our drain
@@ -9277,6 +9318,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         service_restart: bool = False,
     ) -> None:
         """Stop the gateway and disconnect all adapters."""
+        self._stop_loop_liveness_guards()
         if restart:
             self._restart_requested = True
             self._restart_detached = detached_restart

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7736,7 +7736,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return True
 
     def _start_loop_liveness_guards(self, loop: asyncio.AbstractEventLoop) -> None:
-        """Arm the selector floor and out-of-loop watchdog before adapters."""
+        """Arm the selector floor and out-of-loop watchdog before adapters.
+
+        Disabled entirely with ``gateway.loop_watchdog: false`` in config.yaml
+        (no env override — config-only knob, #69089).
+        """
+        config = getattr(self, "config", None)
+        if config is not None and not getattr(config, "loop_watchdog", True):
+            return
         if getattr(self, "_loop_floor_timer_handle", None) is None:
             try:
                 self._loop_floor_timer_handle = _arm_loop_floor_timer(loop)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9325,7 +9325,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         service_restart: bool = False,
     ) -> None:
         """Stop the gateway and disconnect all adapters."""
-        self._stop_loop_liveness_guards()
+        # getattr-guard: shutdown-path tests build bare runners via
+        # object.__new__ that lack the liveness-guard machinery.
+        _stop_guards = getattr(self, "_stop_loop_liveness_guards", None)
+        if callable(_stop_guards):
+            _stop_guards()
         if restart:
             self._restart_requested = True
             self._restart_detached = detached_restart

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -208,6 +208,8 @@ def start_loop_liveness_watchdog(
                 faulthandler.dump_traceback(all_threads=True)
             except Exception:
                 logger.debug("Loop liveness faulthandler dump failed", exc_info=True)
+            if stop_event.is_set():
+                return
             os._exit(exit_code)
             return
 

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -186,10 +186,14 @@ def start_loop_liveness_watchdog(
                 strikes = 0
                 continue
 
+            if stop_event.is_set():
+                return
             strikes += 1
             if strikes < strikes_limit:
                 continue
 
+            if stop_event.is_set():
+                return
             try:
                 logger.critical(
                     "Gateway event loop missed %d consecutive liveness probes; "

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -1,4 +1,4 @@
-"""Out-of-loop shutdown backstop + event-loop liveness heartbeat (#66892).
+"""Out-of-loop shutdown and event-loop liveness backstops (#66892, #69089).
 
 When the asyncio loop freezes mid-drain, every asyncio-based recovery path is
 structurally unable to fire: the drain deadline, status rewrites, and forensics
@@ -15,6 +15,10 @@ This module provides:
 2. An event-loop heartbeat file at ``<HERMES_HOME>/state/gateway.heartbeat`` so
    external supervision can distinguish "process alive" from "loop frozen"
    (``gateway_state.json`` alone can't — it only rewrites on transitions/turns).
+3. A lifetime thread watchdog that can still diagnose and hard-exit when the
+   event loop is too frozen to run its own heartbeat or timeout callbacks.
+4. A self-rescheduling floor timer that keeps the loop selector's timeout
+   finite, giving existing async recovery tasks a chance to resume.
 """
 
 from __future__ import annotations
@@ -31,6 +35,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
+from gateway.restart import GATEWAY_SERVICE_RESTART_EXIT_CODE
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
 
@@ -40,8 +45,179 @@ logger = logging.getLogger(__name__)
 # drain is not cut short. Matches the issue #66892 suggested hardening.
 DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S = 60.0
 DEFAULT_HEARTBEAT_INTERVAL_S = 30.0
+DEFAULT_LOOP_FLOOR_TIMER_INTERVAL_S = 5.0
+DEFAULT_LOOP_WATCHDOG_INTERVAL_S = 30.0
+DEFAULT_LOOP_WATCHDOG_TIMEOUT_S = 10.0
+DEFAULT_LOOP_WATCHDOG_MAX_STRIKES = 3
 _HEARTBEAT_RELATIVE = ("state", "gateway.heartbeat")
 _WATCHDOG_DUMP_RELATIVE = ("logs", "gateway-shutdown-watchdog.log")
+
+
+class _LoopFloorTimerHandle:
+    """Cancelable owner for the currently scheduled selector floor timer."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop, interval: float):
+        self._loop = loop
+        self._interval = interval
+        self._cancelled = False
+        self._timer: Optional[asyncio.TimerHandle] = None
+        self._schedule()
+
+    def _schedule(self) -> None:
+        self._timer = self._loop.call_later(self._interval, self._tick)
+
+    def _tick(self) -> None:
+        if not self._cancelled:
+            self._schedule()
+
+    def cancel(self) -> None:
+        self._cancelled = True
+        if self._timer is not None:
+            self._timer.cancel()
+
+
+class _LoopLivenessWatchdogHandle:
+    """Small lifecycle handle for the daemon liveness thread."""
+
+    def __init__(self, stop_event: threading.Event, thread: threading.Thread):
+        self._stop_event = stop_event
+        self._thread = thread
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        self._thread.join(timeout=timeout)
+
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
+
+
+def _arm_loop_floor_timer(
+    loop: asyncio.AbstractEventLoop,
+    interval: float = DEFAULT_LOOP_FLOOR_TIMER_INTERVAL_S,
+) -> _LoopFloorTimerHandle:
+    """Keep at least one timer pending so selector waits remain bounded."""
+    try:
+        resolved_interval = float(interval)
+        if resolved_interval <= 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        resolved_interval = DEFAULT_LOOP_FLOOR_TIMER_INTERVAL_S
+    return _LoopFloorTimerHandle(loop, resolved_interval)
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    try:
+        value = float(raw) if raw else float(default)
+    except (TypeError, ValueError):
+        return float(default)
+    return value if value > 0 else float(default)
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    try:
+        value = int(raw) if raw else int(default)
+    except (TypeError, ValueError):
+        return int(default)
+    return value if value > 0 else int(default)
+
+
+def start_loop_liveness_watchdog(
+    loop: asyncio.AbstractEventLoop,
+    *,
+    probe_interval: float = DEFAULT_LOOP_WATCHDOG_INTERVAL_S,
+    probe_timeout: float = DEFAULT_LOOP_WATCHDOG_TIMEOUT_S,
+    max_strikes: int = DEFAULT_LOOP_WATCHDOG_MAX_STRIKES,
+    exit_code: int = GATEWAY_SERVICE_RESTART_EXIT_CODE,
+) -> Optional[_LoopLivenessWatchdogHandle]:
+    """Start an out-of-loop watchdog that hard-exits after missed probes.
+
+    Environment overrides are intentionally read here, the owner module, like
+    other gateway runtime-only safety knobs. Set
+    ``HERMES_GATEWAY_LOOP_WATCHDOG=0`` to disable it.
+    """
+    enabled = os.environ.get("HERMES_GATEWAY_LOOP_WATCHDOG", "1").strip().lower()
+    if enabled in {"0", "false", "no", "off"}:
+        return None
+
+    interval = _positive_float_env(
+        "HERMES_GATEWAY_LOOP_WATCHDOG_INTERVAL", probe_interval
+    )
+    timeout = _positive_float_env("HERMES_GATEWAY_LOOP_WATCHDOG_TIMEOUT", probe_timeout)
+    strikes_limit = _positive_int_env(
+        "HERMES_GATEWAY_LOOP_WATCHDOG_STRIKES", max_strikes
+    )
+    stop_event = threading.Event()
+
+    def _wait_for_probe(probe_event: threading.Event) -> Optional[bool]:
+        deadline = time.monotonic() + timeout
+        while True:
+            if stop_event.is_set():
+                return None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return probe_event.is_set()
+            if probe_event.wait(timeout=min(remaining, 0.05)):
+                return True
+
+    def _watchdog() -> None:
+        strikes = 0
+        while not stop_event.wait(timeout=interval):
+            probe_event = threading.Event()
+            try:
+                loop.call_soon_threadsafe(probe_event.set)
+            except RuntimeError:
+                # A normally closed loop cannot be probed and no longer needs
+                # a process-liveness backstop.
+                return
+            except Exception:
+                logger.debug(
+                    "Failed to schedule gateway loop liveness probe", exc_info=True
+                )
+                return
+
+            responded = _wait_for_probe(probe_event)
+            if responded is None:
+                return
+            if responded:
+                strikes = 0
+                continue
+
+            strikes += 1
+            if strikes < strikes_limit:
+                continue
+
+            try:
+                logger.critical(
+                    "Gateway event loop missed %d consecutive liveness probes; "
+                    "dumping all thread stacks and exiting with code %d so the "
+                    "service supervisor can restart it.",
+                    strikes,
+                    exit_code,
+                )
+            except Exception:
+                pass
+            try:
+                faulthandler.dump_traceback(all_threads=True)
+            except Exception:
+                logger.debug("Loop liveness faulthandler dump failed", exc_info=True)
+            os._exit(exit_code)
+            return
+
+    thread = threading.Thread(
+        target=_watchdog,
+        daemon=True,
+        name="gateway-loop-liveness-watchdog",
+    )
+    try:
+        thread.start()
+    except Exception:
+        logger.debug("Failed to start gateway loop liveness watchdog", exc_info=True)
+        return None
+    return _LoopLivenessWatchdogHandle(stop_event, thread)
 
 
 def _process_hermes_home() -> Path:

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -107,24 +107,6 @@ def _arm_loop_floor_timer(
     return _LoopFloorTimerHandle(loop, resolved_interval)
 
 
-def _positive_float_env(name: str, default: float) -> float:
-    raw = os.environ.get(name, "").strip()
-    try:
-        value = float(raw) if raw else float(default)
-    except (TypeError, ValueError):
-        return float(default)
-    return value if value > 0 else float(default)
-
-
-def _positive_int_env(name: str, default: int) -> int:
-    raw = os.environ.get(name, "").strip()
-    try:
-        value = int(raw) if raw else int(default)
-    except (TypeError, ValueError):
-        return int(default)
-    return value if value > 0 else int(default)
-
-
 def start_loop_liveness_watchdog(
     loop: asyncio.AbstractEventLoop,
     *,
@@ -135,21 +117,14 @@ def start_loop_liveness_watchdog(
 ) -> Optional[_LoopLivenessWatchdogHandle]:
     """Start an out-of-loop watchdog that hard-exits after missed probes.
 
-    Environment overrides are intentionally read here, the owner module, like
-    other gateway runtime-only safety knobs. Set
-    ``HERMES_GATEWAY_LOOP_WATCHDOG=0`` to disable it.
+    The guard is on by default; operators opt out with
+    ``gateway.loop_watchdog: false`` in config.yaml (enforced by the caller,
+    ``GatewayRunner._start_loop_liveness_guards`` — this module stays
+    config-agnostic so bare-loop tests can drive it directly).
     """
-    enabled = os.environ.get("HERMES_GATEWAY_LOOP_WATCHDOG", "1").strip().lower()
-    if enabled in {"0", "false", "no", "off"}:
-        return None
-
-    interval = _positive_float_env(
-        "HERMES_GATEWAY_LOOP_WATCHDOG_INTERVAL", probe_interval
-    )
-    timeout = _positive_float_env("HERMES_GATEWAY_LOOP_WATCHDOG_TIMEOUT", probe_timeout)
-    strikes_limit = _positive_int_env(
-        "HERMES_GATEWAY_LOOP_WATCHDOG_STRIKES", max_strikes
-    )
+    interval = probe_interval
+    timeout = probe_timeout
+    strikes_limit = max_strikes
     stop_event = threading.Event()
 
     def _wait_for_probe(probe_event: threading.Event) -> Optional[bool]:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3051,6 +3051,13 @@ DEFAULT_CONFIG = {
         # works as a manual override and wins if set explicitly.
         "platform_connect_timeout": 30,
 
+        # In-process event-loop liveness watchdog (#69089). A daemon OS thread
+        # probes the gateway asyncio loop; after consecutive missed probes it
+        # dumps all-thread stacks and hard-exits with the service-restart exit
+        # code so the supervisor (systemd/launchd) revives the process instead
+        # of leaving a wedged-but-alive zombie. Set to false to disable.
+        "loop_watchdog": True,
+
         # Whether the gateway keeps writing the legacy sessions.json mirror of
         # its routing index. The primary copy lives in state.db (the
         # gateway_routing table). Default True for backward compatibility with

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -71,6 +71,69 @@ def test_loop_liveness_watchdog_exits_after_consecutive_misses():
     assert exit_codes == [75]
 
 
+def test_loop_liveness_watchdog_stop_during_critical_log_disarms_hard_exit():
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    handle_ready = threading.Event()
+    handle_ref = {}
+    exit_codes = []
+
+    def stop_during_critical(*_args) -> None:
+        assert handle_ready.wait(timeout=2.0)
+        handle_ref["handle"].stop()
+
+    with (
+        patch(
+            "gateway.shutdown_watchdog.logger.critical",
+            side_effect=stop_during_critical,
+        ) as critical,
+        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback"),
+        patch("gateway.shutdown_watchdog.os._exit", side_effect=exit_codes.append),
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=1
+        )
+        assert handle is not None
+        handle_ref["handle"] = handle
+        handle_ready.set()
+        handle.join(timeout=2.0)
+
+    assert not handle.is_alive()
+    critical.assert_called_once()
+    assert exit_codes == []
+
+
+def test_loop_liveness_watchdog_stop_during_dump_disarms_hard_exit():
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    handle_ready = threading.Event()
+    handle_ref = {}
+    exit_codes = []
+
+    def stop_during_dump(*_args, **_kwargs) -> None:
+        assert handle_ready.wait(timeout=2.0)
+        handle_ref["handle"].stop()
+
+    with (
+        patch("gateway.shutdown_watchdog.logger.critical") as critical,
+        patch(
+            "gateway.shutdown_watchdog.faulthandler.dump_traceback",
+            side_effect=stop_during_dump,
+        ) as dump,
+        patch("gateway.shutdown_watchdog.os._exit", side_effect=exit_codes.append),
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=1
+        )
+        assert handle is not None
+        handle_ref["handle"] = handle
+        handle_ready.set()
+        handle.join(timeout=2.0)
+
+    assert not handle.is_alive()
+    critical.assert_called_once()
+    dump.assert_called_once_with(all_threads=True)
+    assert exit_codes == []
+
+
 def test_loop_liveness_watchdog_stop_during_final_miss_disarms_hard_exit():
     loop = MagicMock(spec=asyncio.AbstractEventLoop)
     probe_scheduled = threading.Event()

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -71,6 +71,104 @@ def test_loop_liveness_watchdog_exits_after_consecutive_misses():
     assert exit_codes == [75]
 
 
+def test_loop_liveness_watchdog_stop_during_final_miss_disarms_hard_exit():
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    probe_scheduled = threading.Event()
+    release_probe = threading.Event()
+    probe_event_ref = {}
+    handle_ref = {}
+    exit_codes = []
+
+    class FinalStrikeLimit:
+        def __gt__(self, _strikes: int) -> bool:
+            # If strike evaluation is reached, keep recheck #2 from masking a
+            # missing post-probe recheck #1 in this boundary test.
+            handle_ref["handle"]._stop_event.clear()
+            return False
+
+    def hold_scheduled_probe(callback) -> None:
+        probe_event_ref["event"] = callback.__self__
+        probe_scheduled.set()
+        assert release_probe.wait(timeout=2.0)
+
+    loop.call_soon_threadsafe.side_effect = hold_scheduled_probe
+    with (
+        patch(
+            "gateway.shutdown_watchdog._positive_int_env",
+            return_value=FinalStrikeLimit(),
+        ),
+        patch("gateway.shutdown_watchdog.logger.critical") as critical,
+        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback") as dump,
+        patch("gateway.shutdown_watchdog.os._exit", side_effect=exit_codes.append),
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=1
+        )
+        assert handle is not None
+        handle_ref["handle"] = handle
+        assert probe_scheduled.wait(timeout=2.0), "watchdog did not schedule a probe"
+
+        def stop_during_miss() -> bool:
+            handle.stop()
+            return False
+
+        probe_event_ref["event"].is_set = stop_during_miss
+        release_probe.set()
+        handle.join(timeout=1.0)
+
+    assert not handle.is_alive()
+    assert exit_codes == []
+    critical.assert_not_called()
+    dump.assert_not_called()
+
+
+def test_loop_liveness_watchdog_stop_after_first_recheck_skips_final_actions():
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    probe_scheduled = threading.Event()
+    release_probe = threading.Event()
+
+    def hold_scheduled_probe(callback) -> None:
+        probe_scheduled.set()
+        assert release_probe.wait(timeout=2.0)
+
+    loop.call_soon_threadsafe.side_effect = hold_scheduled_probe
+    with (
+        patch("gateway.shutdown_watchdog.logger.critical") as critical,
+        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback") as dump,
+        patch("gateway.shutdown_watchdog.os._exit") as hard_exit,
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=1
+        )
+        assert handle is not None
+        assert probe_scheduled.wait(timeout=2.0), "watchdog did not schedule a probe"
+
+        original_is_set = handle._stop_event.is_set
+        is_set_calls = 0
+
+        def stop_on_final_recheck() -> bool:
+            nonlocal is_set_calls
+            is_set_calls += 1
+            # With the forced immediate timeout: _wait_for_probe is call 1,
+            # recheck #1 is call 2, and recheck #2 is call 3.
+            if is_set_calls == 3:
+                handle.stop()
+            return original_is_set()
+
+        handle._stop_event.is_set = stop_on_final_recheck
+        with patch(
+            "gateway.shutdown_watchdog.time.monotonic", side_effect=[0.0, 1.0]
+        ):
+            release_probe.set()
+            handle.join(timeout=1.0)
+
+    assert is_set_calls == 3
+    assert not handle.is_alive()
+    critical.assert_not_called()
+    dump.assert_not_called()
+    hard_exit.assert_not_called()
+
+
 def test_loop_liveness_watchdog_recovery_resets_strikes():
     loop = MagicMock(spec=asyncio.AbstractEventLoop)
     four_probes = threading.Event()

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -1,0 +1,264 @@
+"""Gateway event-loop freeze backstops for issue #69089."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.shutdown_watchdog import (
+    _arm_loop_floor_timer,
+    start_loop_liveness_watchdog,
+)
+
+
+def _immediate_loop() -> MagicMock:
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    loop.call_soon_threadsafe.side_effect = lambda callback: callback()
+    return loop
+
+
+def test_loop_liveness_watchdog_responsive_probe_does_not_fire():
+    loop = _immediate_loop()
+    exit_codes = []
+
+    with (
+        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback") as dump,
+        patch("gateway.shutdown_watchdog.os._exit", side_effect=exit_codes.append),
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=2
+        )
+        assert handle is not None
+        deadline = time.monotonic() + 2.0
+        while loop.call_soon_threadsafe.call_count < 3 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        handle.stop()
+        handle.join(timeout=1.0)
+
+    assert loop.call_soon_threadsafe.call_count >= 3
+    assert not handle.is_alive()
+    dump.assert_not_called()
+    assert exit_codes == []
+
+
+def test_loop_liveness_watchdog_exits_after_consecutive_misses():
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    fired = threading.Event()
+    exit_codes = []
+
+    def fake_exit(code: int) -> None:
+        exit_codes.append(code)
+        fired.set()
+
+    with (
+        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback") as dump,
+        patch("gateway.shutdown_watchdog.os._exit", side_effect=fake_exit),
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=2
+        )
+        assert handle is not None
+        assert fired.wait(timeout=2.0), "loop liveness watchdog did not fire"
+        handle.join(timeout=1.0)
+
+    assert not handle.is_alive()
+    assert loop.call_soon_threadsafe.call_count == 2
+    dump.assert_called_once_with(all_threads=True)
+    assert exit_codes == [75]
+
+
+def test_loop_liveness_watchdog_recovery_resets_strikes():
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    four_probes = threading.Event()
+
+    def alternate_response(callback) -> None:
+        count = loop.call_soon_threadsafe.call_count
+        if count in {2, 4}:
+            callback()
+        if count >= 4:
+            four_probes.set()
+
+    loop.call_soon_threadsafe.side_effect = alternate_response
+    with (
+        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback") as dump,
+        patch("gateway.shutdown_watchdog.os._exit") as hard_exit,
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=2
+        )
+        assert handle is not None
+        assert four_probes.wait(
+            timeout=2.0
+        ), "watchdog did not complete recovery probes"
+        handle.stop()
+        handle.join(timeout=1.0)
+
+    assert not handle.is_alive()
+    dump.assert_not_called()
+    hard_exit.assert_not_called()
+
+
+def test_loop_liveness_watchdog_stop_exits_thread_and_stops_probes():
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    first_probe = threading.Event()
+    loop.call_soon_threadsafe.side_effect = lambda callback: first_probe.set()
+
+    handle = start_loop_liveness_watchdog(
+        loop, probe_interval=0.01, probe_timeout=0.5, max_strikes=10
+    )
+    assert handle is not None
+    assert first_probe.wait(timeout=2.0)
+    handle.stop()
+    handle.join(timeout=1.0)
+    calls_after_stop = loop.call_soon_threadsafe.call_count
+    time.sleep(0.05)
+
+    assert not handle.is_alive()
+    assert loop.call_soon_threadsafe.call_count == calls_after_stop
+
+
+def test_loop_liveness_watchdog_env_can_disable(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_LOOP_WATCHDOG", "0")
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+    handle = start_loop_liveness_watchdog(
+        loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=1
+    )
+
+    assert handle is None
+    loop.call_soon_threadsafe.assert_not_called()
+
+
+def test_loop_liveness_watchdog_env_overrides_probe_settings(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_LOOP_WATCHDOG_INTERVAL", "0.01")
+    monkeypatch.setenv("HERMES_GATEWAY_LOOP_WATCHDOG_TIMEOUT", "0.01")
+    monkeypatch.setenv("HERMES_GATEWAY_LOOP_WATCHDOG_STRIKES", "1")
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    fired = threading.Event()
+
+    with (
+        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback"),
+        patch(
+            "gateway.shutdown_watchdog.os._exit",
+            side_effect=lambda code: fired.set(),
+        ),
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=10.0, probe_timeout=10.0, max_strikes=10
+        )
+        assert handle is not None
+        assert fired.wait(timeout=2.0), "env overrides were not applied"
+        handle.join(timeout=1.0)
+
+    assert not handle.is_alive()
+    assert loop.call_soon_threadsafe.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_liveness_watchdog_detects_real_loop_sync_freeze():
+    loop = asyncio.get_running_loop()
+    fired = threading.Event()
+    exit_codes = []
+
+    def fake_exit(code: int) -> None:
+        exit_codes.append(code)
+        fired.set()
+
+    with (
+        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback") as dump,
+        patch("gateway.shutdown_watchdog.os._exit", side_effect=fake_exit),
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=0.02, probe_timeout=0.03, max_strikes=2
+        )
+        assert handle is not None
+        await asyncio.sleep(0.03)
+        time.sleep(0.25)
+        assert fired.wait(timeout=1.0), "watchdog did not detect the frozen real loop"
+        handle.stop()
+        handle.join(timeout=1.0)
+
+    dump.assert_called_once_with(all_threads=True)
+    assert exit_codes == [75]
+
+
+@pytest.mark.asyncio
+async def test_loop_liveness_watchdog_leaves_responsive_real_loop_running():
+    loop = asyncio.get_running_loop()
+    with (
+        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback") as dump,
+        patch("gateway.shutdown_watchdog.os._exit") as hard_exit,
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=0.02, probe_timeout=0.03, max_strikes=2
+        )
+        assert handle is not None
+        await asyncio.sleep(0.25)
+        handle.stop()
+        handle.join(timeout=1.0)
+
+    assert not handle.is_alive()
+    dump.assert_not_called()
+    hard_exit.assert_not_called()
+
+
+def test_loop_floor_timer_reschedules_until_cancelled():
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    scheduled = []
+
+    def fake_call_later(delay, callback):
+        timer = MagicMock(spec=asyncio.TimerHandle)
+        scheduled.append((delay, callback, timer))
+        return timer
+
+    loop.call_later.side_effect = fake_call_later
+    handle = _arm_loop_floor_timer(loop, interval=5.0)
+
+    assert len(scheduled) == 1
+    assert scheduled[0][0] == 5.0
+    scheduled[0][1]()
+    assert len(scheduled) == 2
+    assert scheduled[1][0] == 5.0
+
+    handle.cancel()
+    scheduled[1][2].cancel.assert_called_once_with()
+    scheduled[1][1]()
+    assert len(scheduled) == 2
+
+
+def test_gateway_runner_liveness_guards_start_and_stop():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._loop_floor_timer_handle = None
+    runner._loop_liveness_watchdog = None
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    floor_timer = MagicMock()
+    watchdog = MagicMock()
+    watchdog.is_alive.return_value = True
+
+    with (
+        patch(
+            "gateway.run._arm_loop_floor_timer", return_value=floor_timer
+        ) as arm_floor,
+        patch(
+            "gateway.run.start_loop_liveness_watchdog", return_value=watchdog
+        ) as start_watchdog,
+    ):
+        runner._start_loop_liveness_guards(loop)
+
+    arm_floor.assert_called_once_with(loop)
+    start_watchdog.assert_called_once_with(loop)
+    assert runner._loop_floor_timer_handle is floor_timer
+    assert runner._loop_liveness_watchdog is watchdog
+
+    runner._stop_loop_liveness_guards()
+
+    watchdog.stop.assert_called_once_with()
+    floor_timer.cancel.assert_called_once_with()
+    assert runner._loop_liveness_watchdog is None
+    assert runner._loop_floor_timer_handle is None

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -156,16 +156,15 @@ def test_loop_liveness_watchdog_stop_during_final_miss_disarms_hard_exit():
 
     loop.call_soon_threadsafe.side_effect = hold_scheduled_probe
     with (
-        patch(
-            "gateway.shutdown_watchdog._positive_int_env",
-            return_value=FinalStrikeLimit(),
-        ),
         patch("gateway.shutdown_watchdog.logger.critical") as critical,
         patch("gateway.shutdown_watchdog.faulthandler.dump_traceback") as dump,
         patch("gateway.shutdown_watchdog.os._exit", side_effect=exit_codes.append),
     ):
         handle = start_loop_liveness_watchdog(
-            loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=1
+            loop,
+            probe_interval=0.01,
+            probe_timeout=0.01,
+            max_strikes=FinalStrikeLimit(),
         )
         assert handle is not None
         handle_ref["handle"] = handle
@@ -282,41 +281,43 @@ def test_loop_liveness_watchdog_stop_exits_thread_and_stops_probes():
     assert loop.call_soon_threadsafe.call_count == calls_after_stop
 
 
-def test_loop_liveness_watchdog_env_can_disable(monkeypatch):
-    monkeypatch.setenv("HERMES_GATEWAY_LOOP_WATCHDOG", "0")
+def test_loop_liveness_guards_config_can_disable():
+    """gateway.loop_watchdog: false must skip arming both guards."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._loop_floor_timer_handle = None
+    runner._loop_liveness_watchdog = None
+    runner.config = MagicMock()
+    runner.config.loop_watchdog = False
     loop = MagicMock(spec=asyncio.AbstractEventLoop)
-
-    handle = start_loop_liveness_watchdog(
-        loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=1
-    )
-
-    assert handle is None
-    loop.call_soon_threadsafe.assert_not_called()
-
-
-def test_loop_liveness_watchdog_env_overrides_probe_settings(monkeypatch):
-    monkeypatch.setenv("HERMES_GATEWAY_LOOP_WATCHDOG_INTERVAL", "0.01")
-    monkeypatch.setenv("HERMES_GATEWAY_LOOP_WATCHDOG_TIMEOUT", "0.01")
-    monkeypatch.setenv("HERMES_GATEWAY_LOOP_WATCHDOG_STRIKES", "1")
-    loop = MagicMock(spec=asyncio.AbstractEventLoop)
-    fired = threading.Event()
 
     with (
-        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback"),
-        patch(
-            "gateway.shutdown_watchdog.os._exit",
-            side_effect=lambda code: fired.set(),
-        ),
+        patch("gateway.run._arm_loop_floor_timer") as arm_floor,
+        patch("gateway.run.start_loop_liveness_watchdog") as start_watchdog,
     ):
-        handle = start_loop_liveness_watchdog(
-            loop, probe_interval=10.0, probe_timeout=10.0, max_strikes=10
-        )
-        assert handle is not None
-        assert fired.wait(timeout=2.0), "env overrides were not applied"
-        handle.join(timeout=1.0)
+        runner._start_loop_liveness_guards(loop)
 
-    assert not handle.is_alive()
-    assert loop.call_soon_threadsafe.call_count == 1
+    arm_floor.assert_not_called()
+    start_watchdog.assert_not_called()
+    assert runner._loop_floor_timer_handle is None
+    assert runner._loop_liveness_watchdog is None
+
+
+def test_gateway_config_loop_watchdog_round_trip():
+    """loop_watchdog is a config.yaml knob: default on, nested-gateway form honored."""
+    from gateway.config import GatewayConfig
+
+    assert GatewayConfig.from_dict({}).loop_watchdog is True
+    assert GatewayConfig.from_dict({"loop_watchdog": False}).loop_watchdog is False
+    assert (
+        GatewayConfig.from_dict(
+            {"gateway": {"loop_watchdog": "off"}}
+        ).loop_watchdog
+        is False
+    )
+    config = GatewayConfig.from_dict({"loop_watchdog": False})
+    assert config.to_dict()["loop_watchdog"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
A wedged asyncio event loop (e.g. Telegram CLOSE-WAIT socket deadlock) no longer silently kills the gateway forever — a selector floor timer plus an out-of-loop thread watchdog detects the freeze and exits 75 for service restart.

## Changes
- gateway/shutdown_watchdog.py + gateway/run.py: two-layer freeze detection (base: #69164 by @bounce12340, all 3 commits with authorship preserved, incl. the shutdown-race fix from review)
- Policy fix (our commit): dropped the PR's four HERMES_GATEWAY_LOOP_WATCHDOG* env vars; one config.yaml boolean gateway.loop_watchdog (default true) plumbed through GatewayConfig + DEFAULT_CONFIG
- getattr-guarded for object.__new__ bare-runner tests

## Validation
New tests/gateway/test_loop_liveness_watchdog.py green; ruff + windows-footgun checker clean.

Note: #67498 (connect hang, threads idle) is a distinct startup symptom — the watchdog escapes frozen-loop states but the connect-hang readiness gap is tracked separately (see #69240 evaluation in the review).

Fixes #69089


## Infographic

![gateway-event-loop-freeze](https://v3b.fal.media/files/b/0aa3944f/H6LVCeCpphf5LzeKxNrhx_ZLLnsYzY.png)
