### PR TITLE
fix(runtime): repair vulnerable managed SQLite builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 /venv/
 /venv.old/
+/venv.stale.runtime-*/
+/.hermes-runtime/
 /_pycache/
 *.pyc*
 __pycache__/

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -754,12 +754,12 @@ def run_doctor(args):
         )
         if is_sqlite_wal_reset_vulnerable():
             # Warn-only: Hermes already refuses to enable WAL on fresh DBs.
-            # Do not append to ``issues`` — users often cannot change the
-            # SQLite embedded in python-build-standalone via `hermes update`.
+            # Do not append to ``issues`` because runtime repair remains
+            # best-effort and unsupported installs may need manual action.
             check_warn(
                 f"SQLite {_sqlite_ver} (WAL-reset bug)",
-                "(new shared DBs use DELETE; prefer 3.51.3+ / 3.50.7 / 3.44.6 — "
-                "see https://sqlite.org/wal.html#walresetbug)",
+                "(run `hermes update`; fixed versions: 3.51.3+ / 3.50.7 / "
+                "3.44.6 — see https://sqlite.org/wal.html#walresetbug)",
             )
         else:
             check_ok(f"SQLite {_sqlite_ver}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11011,8 +11011,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # update-boundary hook active on this retry path too.
             from hermes_cli.managed_uv import ensure_uv, update_managed_uv
 
-            update_managed_uv()
-            ensure_uv()
+            runtime_repairs = []
+            update_managed_uv(repair_observer=runtime_repairs.append)
+            ensure_uv(repair_observer=runtime_repairs.append)
+            runtime_repaired = next(
+                (result for result in runtime_repairs if result.repaired),
+                None,
+            )
 
             # A current checkout does NOT imply a healthy install: a previous
             # dependency sync may have failed partway (classic on Windows,
@@ -11064,6 +11069,23 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
                 print("✓ Already up to date!")
+            if runtime_repaired is not None and not _is_windows():
+                print()
+                print(
+                    "⚠ Restart required to finish the managed Python runtime repair."
+                )
+                print(
+                    "  Any running Hermes gateways, Desktop backends, or other "
+                    "long-lived processes still use the previous runtime."
+                )
+                print(
+                    "  Restart each of them before removing the parked venv"
+                    + (
+                        f": {runtime_repaired.backup_venv}"
+                        if runtime_repaired.backup_venv is not None
+                        else "."
+                    )
+                )
             _resume_windows_gateways_after_update(_windows_gateway_resume)
             return
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11005,6 +11005,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     check=False,
                 )
 
+            # "No new commits" does not mean the managed interpreter is safe.
+            # uv can retain the same CPython patch while python-build-standalone
+            # refreshes the embedded SQLite underneath it. Keep the existing
+            # update-boundary hook active on this retry path too.
+            from hermes_cli.managed_uv import ensure_uv, update_managed_uv
+
+            update_managed_uv()
+            ensure_uv()
+
             # A current checkout does NOT imply a healthy install: a previous
             # dependency sync may have failed partway (classic on Windows,
             # where a running gateway/desktop backend keeps .pyd files locked

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -351,8 +351,17 @@ def _make_world_traversable(path: Path) -> None:
 
 
 def _runtime_request(info: SQLiteRuntimeInfo) -> str:
-    """Pin the candidate to the current exact CPython patch."""
-    return ".".join(str(part) for part in info.python_version)
+    """Pin the candidate to the current CPython minor line (e.g. ``3.11``).
+
+    Requesting the exact patch can never repair some installs: for a given
+    patch, python-build-standalone may have no artifact with fixed SQLite at
+    all (e.g. every published 3.11.14 build links SQLite 3.50.4; the fix
+    only exists from 3.11.15).  A newer patch on the same minor is what
+    ``uv python install`` would resolve for a fresh install, stays inside
+    ``requires-python``, and the locked ``uv sync`` + import smoke tests gate
+    compatibility before any cutover.
+    """
+    return ".".join(str(part) for part in info.python_version[:2])
 
 
 def _install_safe_python_generation(
@@ -438,10 +447,12 @@ def _install_safe_python_generation(
         logger.warning("could not probe candidate Python runtime: %s", python)
         _remove_tree(generation, boundary=python_root)
         return None
-    if candidate.python_version != current.python_version:
+    if candidate.python_version[:2] != current.python_version[:2] or (
+        candidate.python_version < current.python_version
+    ):
         logger.warning(
-            "candidate Python patch drifted from %s to %s",
-            current.python_version,
+            "candidate Python drifted off the %s minor line or downgraded: %s",
+            ".".join(str(p) for p in current.python_version[:2]),
             candidate.python_version,
         )
         _remove_tree(generation, boundary=python_root)

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -30,7 +30,7 @@ import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli.sqlite_runtime import SQLiteRuntimeInfo, probe_sqlite_runtime
@@ -185,7 +185,10 @@ class _UvResult(str):
         return iter(((str(self) or None), self.fresh_bootstrap))
 
 
-def _ensure_uv_path() -> Optional[str]:
+def _ensure_uv_path(
+    *,
+    repair_observer: Callable[[RuntimeRepairResult], None] | None = None,
+) -> Optional[str]:
     """Resolve the managed uv path, installing it if necessary (plain ``str``/``None``)."""
     existing = resolve_uv()
     if existing:
@@ -219,6 +222,8 @@ def _ensure_uv_path() -> Optional[str]:
         # a second ``hermes update``.
         try:
             repair = repair_vulnerable_runtime(result)
+            if repair_observer is not None:
+                repair_observer(repair)
             if repair.status == "failed":
                 _report_runtime_repair_failure(repair)
         except Exception as exc:
@@ -228,7 +233,10 @@ def _ensure_uv_path() -> Optional[str]:
     return result
 
 
-def ensure_uv():
+def ensure_uv(
+    *,
+    repair_observer: Callable[[RuntimeRepairResult], None] | None = None,
+):
     """Return the managed uv path, installing it first if necessary.
 
     On **POSIX** the result is a :class:`_UvResult` (a ``str`` subclass) that is
@@ -249,9 +257,10 @@ def ensure_uv():
     results.)
 
     On failure the result is falsy — never raises — so callers can fall back to
-    pip gracefully.
+    pip gracefully. ``repair_observer``, when provided, receives the runtime
+    repair result produced after a fresh uv bootstrap.
     """
-    result = _ensure_uv_path()
+    result = _ensure_uv_path(repair_observer=repair_observer)
     if platform.system() == "Windows":
         # See docstring: a str subclass with an overridden __iter__ is unsafe as
         # a Windows subprocess argument. Hand back the plain path (or None).
@@ -259,12 +268,16 @@ def ensure_uv():
     return _UvResult(result)
 
 
-def update_managed_uv() -> Optional[str]:
+def update_managed_uv(
+    *,
+    repair_observer: Callable[[RuntimeRepairResult], None] | None = None,
+) -> Optional[str]:
     """Run ``uv self update`` on the managed uv binary.
 
     Call this during ``hermes update`` so the managed copy stays current.
-    Returns the managed path on success, ``None`` if uv isn't available or
-    the self-update fails (non-fatal — the old version still works).
+    Returns the managed path when uv is available and ``None`` otherwise.
+    A self-update failure is non-fatal because the old version still works.
+    ``repair_observer``, when provided, receives the runtime repair result.
     """
     existing = resolve_uv()
     if not existing:
@@ -297,6 +310,8 @@ def update_managed_uv() -> Optional[str]:
     # what makes the migration happen on that first update.
     try:
         repair = repair_vulnerable_runtime(existing)
+        if repair_observer is not None:
+            repair_observer(repair)
         if repair.status == "failed":
             _report_runtime_repair_failure(repair)
     except Exception as exc:
@@ -597,50 +612,63 @@ def _cut_over_candidate(
     rejected = runtime_root / f"venv-rejected-{token}"
 
     try:
-        _rename_with_retry(live, backup)
-    except OSError as exc:
-        return False, None, None, f"could not park the existing venv: {exc}"
-
-    try:
-        _rename_with_retry(candidate, live)
-    except OSError as promote_error:
         try:
+            _rename_with_retry(live, backup)
+        except OSError as exc:
+            return False, None, None, f"could not park the existing venv: {exc}"
+
+        try:
+            _rename_with_retry(candidate, live)
+        except OSError as promote_error:
+            try:
+                _rename_with_retry(backup, live)
+            except OSError as rollback_error:
+                return (
+                    False,
+                    backup,
+                    None,
+                    "could not promote the replacement venv "
+                    f"({promote_error}); rollback failed ({rollback_error})",
+                )
+            return (
+                False,
+                None,
+                None,
+                f"could not promote the replacement venv: {promote_error}",
+            )
+
+        try:
+            healthy, detail, info = _smoke_candidate_venv(live)
+        except Exception as exc:
+            healthy, detail, info = False, f"candidate smoke raised: {exc}", None
+        if healthy:
+            return True, backup, info, ""
+
+        try:
+            _rename_with_retry(live, rejected)
             _rename_with_retry(backup, live)
-        except OSError as rollback_error:
+        except OSError as exc:
             return (
                 False,
                 backup,
-                None,
-                "could not promote the replacement venv "
-                f"({promote_error}); rollback failed ({rollback_error})",
+                info,
+                "post-cutover smoke failed "
+                f"({detail}); rollback failed ({exc}); rejected venv: {rejected}",
             )
-        return (
-            False,
-            None,
-            None,
-            f"could not promote the replacement venv: {promote_error}",
-        )
-
-    try:
-        healthy, detail, info = _smoke_candidate_venv(live)
-    except Exception as exc:
-        healthy, detail, info = False, f"candidate smoke raised: {exc}", None
-    if healthy:
-        return True, backup, info, ""
-
-    try:
-        _rename_with_retry(live, rejected)
-        _rename_with_retry(backup, live)
-    except OSError as exc:
-        return (
-            False,
-            backup,
-            info,
-            "post-cutover smoke failed "
-            f"({detail}); rollback failed ({exc}); rejected venv: {rejected}",
-        )
-    _remove_tree(rejected, boundary=runtime_root)
-    return False, None, info, f"post-cutover smoke failed: {detail}"
+        _remove_tree(rejected, boundary=runtime_root)
+        return False, None, info, f"post-cutover smoke failed: {detail}"
+    except BaseException:
+        if not live.exists() and backup.exists():
+            try:
+                _rename_with_retry(backup, live)
+            except OSError as exc:
+                logger.error(
+                    "interrupted runtime cutover could not restore %s from %s: %s",
+                    live,
+                    backup,
+                    exc,
+                )
+        raise
 
 
 def _acquire_repair_lock(runtime_root: Path) -> _RepairLock | None:
@@ -836,7 +864,7 @@ def repair_vulnerable_runtime(
         if backup is not None:
             print(
                 f"  ℹ Previous venv parked at {backup.name}; "
-                "it can be removed after this updater exits."
+                "keep it until all older Hermes processes have exited."
             )
         return RuntimeRepairResult(
             "repaired",

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1,4 +1,4 @@
-"""Managed uv — one path, no guessing.
+"""Hermes-managed uv and Python runtime repair.
 
 Hermes owns its own uv binary at ``$HERMES_HOME/bin/uv`` (or ``uv.exe`` on
 Windows).  Every code path that needs uv resolves it from that single location.
@@ -6,6 +6,15 @@ If the binary is missing, ``ensure_uv()`` bootstraps it via the official
 standalone installer with ``UV_UNMANAGED_INSTALL`` / ``UV_INSTALL_DIR`` pointed
 at ``$HERMES_HOME/bin`` so the installer writes directly there — no PATH
 probing, no conda guards, no multi-location resolution chains.
+
+The Python backing the install is different: it is shared by every Hermes
+profile because the checkout's ``venv`` is shared.  Runtime repair therefore
+uses an install-scoped store under ``<checkout>/.hermes-runtime/python``. A
+vulnerable interpreter is never reinstalled in place. We provision a new
+immutable Python generation, build and smoke-test a relocatable sibling venv,
+then cut over with same-filesystem renames. The old venv remains available for
+synchronous rollback and is parked for cleanup after the updating process
+releases it.
 """
 
 from __future__ import annotations
@@ -15,17 +24,28 @@ import os
 import platform
 import shutil
 import subprocess
+import sys
 import tempfile
+import time
+import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 from hermes_constants import get_hermes_home
+from hermes_cli.sqlite_runtime import SQLiteRuntimeInfo, probe_sqlite_runtime
 
 logger = logging.getLogger(__name__)
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_RUNTIME_DIR_NAME = ".hermes-runtime"
+_VENV_NAME = "venv"
+_REPAIR_LOCK_NAME = "runtime-repair.lock"
 
 # ---------------------------------------------------------------------------
 # Public helpers
 # ---------------------------------------------------------------------------
+
 
 def managed_uv_path() -> Path:
     """Return the path where Hermes keeps *its* uv binary.
@@ -49,6 +69,80 @@ def resolve_uv() -> Optional[str]:
     if p.is_file() and os.access(p, os.X_OK):
         return str(p)
     return None
+
+
+def managed_python_install_dir(project_root: Path | None = None) -> Path:
+    """Return the checkout-scoped Python store shared by all profiles."""
+    root = Path(project_root) if project_root is not None else _PROJECT_ROOT
+    return root / _RUNTIME_DIR_NAME / "python"
+
+
+def managed_python_env(
+    project_root: Path | None = None,
+    *,
+    install_dir: Path | None = None,
+    base_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Return a sanitized environment for Hermes-private uv Python commands."""
+    target = (
+        Path(install_dir)
+        if install_dir is not None
+        else managed_python_install_dir(project_root)
+    )
+    env = dict(os.environ if base_env is None else base_env)
+    for key in (
+        "CONDA_DEFAULT_ENV",
+        "CONDA_PREFIX",
+        "UV_PROJECT_ENVIRONMENT",
+        "UV_NO_MANAGED_PYTHON",
+        "UV_PYTHON",
+        "UV_PYTHON_DOWNLOADS",
+        "UV_SYSTEM_PYTHON",
+        "VIRTUAL_ENV",
+        "PYTHONHOME",
+        "PYTHONPATH",
+    ):
+        env.pop(key, None)
+    env.update({
+        "UV_MANAGED_PYTHON": "1",
+        "UV_NO_CONFIG": "1",
+        "UV_PYTHON_INSTALL_BIN": "0",
+        "UV_PYTHON_INSTALL_DIR": str(target),
+        "UV_PYTHON_INSTALL_REGISTRY": "0",
+    })
+    return env
+
+
+@dataclass(frozen=True)
+class RuntimeRepairResult:
+    """Outcome of a managed-runtime repair attempt."""
+
+    status: str
+    detail: str = ""
+    sqlite_before: str = ""
+    sqlite_after: str = ""
+    backup_venv: Path | None = None
+
+    @property
+    def repaired(self) -> bool:
+        return self.status == "repaired"
+
+
+@dataclass(frozen=True)
+class _RepairLock:
+    path: Path
+    fd: int
+
+
+def _report_runtime_repair_failure(repair: RuntimeRepairResult) -> None:
+    if repair.backup_venv is None:
+        print(
+            "  ⚠ Managed Python runtime was not replaced; "
+            f"the existing venv is unchanged ({repair.detail})."
+        )
+        return
+    print(f"  ✗ Managed Python runtime cutover needs manual recovery: {repair.detail}")
+    print(f"    Previous venv: {repair.backup_venv}")
 
 
 class _UvResult(str):
@@ -119,6 +213,16 @@ def _ensure_uv_path() -> Optional[str]:
             check=False,
         ).stdout.strip()
         print(f"  ✓ Managed uv installed ({version})")
+        # Compatibility boundary: an older, already-imported updater calls the
+        # freshly pulled ``ensure_uv()`` after bootstrapping uv.  Repair here so
+        # that first update can migrate a vulnerable runtime without requiring
+        # a second ``hermes update``.
+        try:
+            repair = repair_vulnerable_runtime(result)
+            if repair.status == "failed":
+                _report_runtime_repair_failure(repair)
+        except Exception as exc:
+            logger.warning("Managed Python runtime repair failed: %s", exc)
     else:
         print("  ✗ Managed uv install appeared to succeed but binary not found")
     return result
@@ -183,13 +287,571 @@ def update_managed_uv() -> Optional[str]:
         print(f"  ✓ Managed uv updated ({version})")
     else:
         # Non-fatal — old uv still works fine.
-        logger.debug("uv self update failed (rc=%d): %s", result.returncode, result.stderr)
+        logger.debug(
+            "uv self update failed (rc=%d): %s", result.returncode, result.stderr
+        )
+
+    # Keep this hook inside the long-standing API. During an update, main.py is
+    # already imported from the old checkout, then ``git pull`` replaces this
+    # module on disk before the updater imports it. Calling the repair here is
+    # what makes the migration happen on that first update.
+    try:
+        repair = repair_vulnerable_runtime(existing)
+        if repair.status == "failed":
+            _report_runtime_repair_failure(repair)
+    except Exception as exc:
+        # Runtime refresh is deliberately non-fatal. The live venv was not
+        # touched unless a fully prepared candidate reached cutover.
+        logger.warning("Managed Python runtime repair failed: %s", exc)
+        print(f"  ⚠ Managed Python runtime repair skipped: {exc}")
     return existing
+
+
+# ---------------------------------------------------------------------------
+# Managed Python runtime repair
+# ---------------------------------------------------------------------------
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    if platform.system() == "Windows":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _remove_tree(path: Path, *, boundary: Path) -> None:
+    """Best-effort removal constrained to a known runtime boundary."""
+    try:
+        path.resolve().relative_to(boundary.resolve())
+    except (OSError, ValueError):
+        return
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def _make_world_traversable(path: Path) -> None:
+    """Keep root/FHS-managed runtimes executable by non-root callers."""
+    try:
+        path.chmod(path.stat().st_mode | 0o755)
+    except OSError:
+        pass
+
+
+def _runtime_request(info: SQLiteRuntimeInfo) -> str:
+    """Pin the candidate to the current exact CPython patch."""
+    return ".".join(str(part) for part in info.python_version)
+
+
+def _install_safe_python_generation(
+    uv_bin: str,
+    *,
+    project_root: Path,
+    current: SQLiteRuntimeInfo,
+) -> tuple[Path, Path, SQLiteRuntimeInfo] | None:
+    runtime_root = project_root / _RUNTIME_DIR_NAME
+    python_root = managed_python_install_dir(project_root)
+    token = f"{int(time.time())}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    generation = python_root / f"generation-{token}"
+    generation.mkdir(parents=True, exist_ok=False)
+    for path in (runtime_root, python_root, generation):
+        _make_world_traversable(path)
+
+    env = managed_python_env(
+        project_root,
+        install_dir=generation,
+    )
+    request = _runtime_request(current)
+    print(f"  → Provisioning a private Python {request} runtime with fixed SQLite...")
+    install = subprocess.run(
+        [
+            uv_bin,
+            "python",
+            "install",
+            request,
+            "--reinstall",
+            "--no-bin",
+            "--no-registry",
+            "--no-config",
+        ],
+        cwd=project_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if install.returncode != 0:
+        logger.warning(
+            "private Python install failed (rc=%d): %s",
+            install.returncode,
+            (install.stderr or install.stdout or "").strip(),
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
+
+    found = subprocess.run(
+        [
+            uv_bin,
+            "python",
+            "find",
+            request,
+            "--managed-python",
+            "--no-config",
+        ],
+        cwd=project_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if found.returncode != 0 or not found.stdout.strip():
+        logger.warning(
+            "private Python lookup failed (rc=%d): %s",
+            found.returncode,
+            (found.stderr or "").strip(),
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
+
+    python = Path(found.stdout.strip().splitlines()[-1])
+    try:
+        python.resolve().relative_to(generation.resolve())
+    except (OSError, ValueError):
+        logger.warning("uv resolved Python outside the Hermes generation: %s", python)
+        _remove_tree(generation, boundary=python_root)
+        return None
+
+    candidate = probe_sqlite_runtime(python)
+    if candidate is None:
+        logger.warning("could not probe candidate Python runtime: %s", python)
+        _remove_tree(generation, boundary=python_root)
+        return None
+    if candidate.python_version != current.python_version:
+        logger.warning(
+            "candidate Python patch drifted from %s to %s",
+            current.python_version,
+            candidate.python_version,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
+    if candidate.wal_reset_vulnerable:
+        logger.warning(
+            "candidate Python still links vulnerable SQLite %s (%s)",
+            candidate.sqlite_version_string,
+            candidate.sqlite_source_id,
+        )
+        _remove_tree(generation, boundary=python_root)
+        return None
+    return generation, python, candidate
+
+
+def _smoke_candidate_venv(venv_dir: Path) -> tuple[bool, str, SQLiteRuntimeInfo | None]:
+    """Exercise the candidate interpreter and imports through its real path."""
+    python = _venv_python(venv_dir)
+    info = probe_sqlite_runtime(python)
+    if info is None:
+        return False, f"could not execute {python}", None
+    if info.wal_reset_vulnerable:
+        return (
+            False,
+            f"candidate still links vulnerable SQLite {info.sqlite_version_string}",
+            info,
+        )
+
+    check = (
+        "import dotenv, fastapi, openai, prompt_toolkit, pydantic, rich, uvicorn, yaml\n"
+        "import hermes_state\n"
+    )
+    env = dict(os.environ)
+    for key in (
+        "CONDA_DEFAULT_ENV",
+        "CONDA_PREFIX",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "UV_PROJECT_ENVIRONMENT",
+        "UV_PYTHON",
+        "VIRTUAL_ENV",
+    ):
+        env.pop(key, None)
+    try:
+        result = subprocess.run(
+            [str(python), "-I", "-c", check],
+            cwd=venv_dir.parent,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=90,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, str(exc), info
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "core import smoke failed").strip()
+        last_line = detail.splitlines()[-1] if detail else "core import smoke failed"
+        return False, last_line, info
+    return True, "", info
+
+
+def _stage_candidate_venv(
+    uv_bin: str,
+    *,
+    project_root: Path,
+    generation: Path,
+    python: Path,
+) -> Path | None:
+    runtime_root = project_root / _RUNTIME_DIR_NAME
+    token = f"{int(time.time())}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    candidate = runtime_root / f"venv-candidate-{token}"
+    env = managed_python_env(
+        project_root,
+        install_dir=generation,
+    )
+    env.update({
+        "UV_PROJECT_ENVIRONMENT": str(candidate),
+        "UV_PYTHON": str(python),
+        "UV_PYTHON_DOWNLOADS": "never",
+        "VIRTUAL_ENV": str(candidate),
+    })
+
+    print("  → Building a relocatable replacement environment...")
+    created = subprocess.run(
+        [
+            uv_bin,
+            "venv",
+            str(candidate),
+            "--python",
+            str(python),
+            "--managed-python",
+            "--no-python-downloads",
+            "--relocatable",
+            "--no-config",
+        ],
+        cwd=project_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if created.returncode != 0:
+        logger.warning(
+            "candidate venv creation failed (rc=%d): %s",
+            created.returncode,
+            (created.stderr or created.stdout or "").strip(),
+        )
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
+
+    if not (project_root / "uv.lock").is_file():
+        logger.warning("candidate dependency sync refused: uv.lock is missing")
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
+    synced = subprocess.run(
+        [
+            uv_bin,
+            "sync",
+            "--extra",
+            "all",
+            "--locked",
+            "--python",
+            str(_venv_python(candidate)),
+            "--no-config",
+        ],
+        cwd=project_root,
+        env=env,
+        check=False,
+    )
+    if synced.returncode != 0:
+        logger.warning("candidate dependency sync failed (rc=%d)", synced.returncode)
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
+
+    healthy, detail, _ = _smoke_candidate_venv(candidate)
+    if not healthy:
+        logger.warning("candidate venv smoke failed: %s", detail)
+        _remove_tree(candidate, boundary=runtime_root)
+        return None
+    return candidate
+
+
+def _rename_with_retry(source: Path, destination: Path) -> None:
+    last_error: OSError | None = None
+    for delay in (0.0, 0.1, 0.25, 0.5, 1.0):
+        if delay:
+            time.sleep(delay)
+        try:
+            source.rename(destination)
+            return
+        except OSError as exc:
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+
+
+def _cut_over_candidate(
+    candidate: Path,
+    *,
+    project_root: Path,
+    live: Path | None = None,
+) -> tuple[bool, Path | None, SQLiteRuntimeInfo | None, str]:
+    live = live if live is not None else project_root / _VENV_NAME
+    runtime_root = project_root / _RUNTIME_DIR_NAME
+    token = f"{int(time.time())}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    backup = live.with_name(f"{live.name}.stale.runtime-{token}")
+    rejected = runtime_root / f"venv-rejected-{token}"
+
+    try:
+        _rename_with_retry(live, backup)
+    except OSError as exc:
+        return False, None, None, f"could not park the existing venv: {exc}"
+
+    try:
+        _rename_with_retry(candidate, live)
+    except OSError as promote_error:
+        try:
+            _rename_with_retry(backup, live)
+        except OSError as rollback_error:
+            return (
+                False,
+                backup,
+                None,
+                "could not promote the replacement venv "
+                f"({promote_error}); rollback failed ({rollback_error})",
+            )
+        return (
+            False,
+            None,
+            None,
+            f"could not promote the replacement venv: {promote_error}",
+        )
+
+    try:
+        healthy, detail, info = _smoke_candidate_venv(live)
+    except Exception as exc:
+        healthy, detail, info = False, f"candidate smoke raised: {exc}", None
+    if healthy:
+        return True, backup, info, ""
+
+    try:
+        _rename_with_retry(live, rejected)
+        _rename_with_retry(backup, live)
+    except OSError as exc:
+        return (
+            False,
+            backup,
+            info,
+            "post-cutover smoke failed "
+            f"({detail}); rollback failed ({exc}); rejected venv: {rejected}",
+        )
+    _remove_tree(rejected, boundary=runtime_root)
+    return False, None, info, f"post-cutover smoke failed: {detail}"
+
+
+def _acquire_repair_lock(runtime_root: Path) -> _RepairLock | None:
+    """Acquire an OS-held install lock that is released on process exit."""
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    _make_world_traversable(runtime_root)
+    path = runtime_root / _REPAIR_LOCK_NAME
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    except OSError:
+        return None
+
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (ImportError, OSError):
+        os.close(fd)
+        return None
+    return _RepairLock(path=path, fd=fd)
+
+
+def _release_repair_lock(lock: _RepairLock) -> None:
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            os.lseek(lock.fd, 0, os.SEEK_SET)
+            msvcrt.locking(lock.fd, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock.fd, fcntl.LOCK_UN)
+    except (ImportError, OSError):
+        pass
+    finally:
+        try:
+            os.close(lock.fd)
+        except OSError:
+            pass
+
+
+def _windows_runtime_holders() -> tuple[bool, str]:
+    if platform.system() != "Windows":
+        return False, ""
+    main_module = sys.modules.get("hermes_cli.main")
+    detector = getattr(main_module, "_detect_venv_python_processes", None)
+    if detector is None:
+        return True, "cannot verify Windows venv holders from this update context"
+    try:
+        holders = detector()
+    except Exception as exc:
+        return True, f"could not verify Windows venv holders: {exc}"
+    if holders:
+        pids = ", ".join(str(item[0]) for item in holders[:6])
+        return True, f"other Hermes processes still hold the venv (PID {pids})"
+    return False, ""
+
+
+def repair_vulnerable_runtime(
+    uv_bin: str,
+    *,
+    project_root: Path | None = None,
+    venv_dir: Path | None = None,
+) -> RuntimeRepairResult:
+    """Replace a vulnerable install venv without mutating it in place.
+
+    Every failure before cutover leaves the live venv untouched. Rename or
+    post-cutover smoke failures restore the parked venv synchronously.
+    """
+    root = Path(project_root) if project_root is not None else _PROJECT_ROOT
+    live = Path(venv_dir) if venv_dir is not None else root / _VENV_NAME
+    live_python = _venv_python(live)
+    if not (root / "pyproject.toml").is_file() or not live_python.is_file():
+        return RuntimeRepairResult("not-applicable")
+
+    current = probe_sqlite_runtime(live_python)
+    if current is None:
+        return RuntimeRepairResult(
+            "skipped",
+            f"could not probe live interpreter {live_python}",
+        )
+    if not current.wal_reset_vulnerable:
+        return RuntimeRepairResult(
+            "safe",
+            sqlite_before=current.sqlite_version_string,
+            sqlite_after=current.sqlite_version_string,
+        )
+
+    blocked, detail = _windows_runtime_holders()
+    if blocked:
+        print(f"  ⚠ SQLite runtime repair deferred: {detail}")
+        return RuntimeRepairResult(
+            "skipped",
+            detail,
+            sqlite_before=current.sqlite_version_string,
+        )
+
+    runtime_root = root / _RUNTIME_DIR_NAME
+    lock = _acquire_repair_lock(runtime_root)
+    if lock is None:
+        detail = "another runtime repair is already in progress"
+        print(f"  ⚠ SQLite runtime repair deferred: {detail}")
+        return RuntimeRepairResult(
+            "skipped",
+            detail,
+            sqlite_before=current.sqlite_version_string,
+        )
+
+    generation: Path | None = None
+    candidate: Path | None = None
+    try:
+        # Re-probe under the install-scoped lock: another updater may have
+        # completed the repair while this process was entering the path.
+        current = probe_sqlite_runtime(live_python)
+        if current is None:
+            return RuntimeRepairResult("skipped", "live interpreter probe failed")
+        if not current.wal_reset_vulnerable:
+            return RuntimeRepairResult(
+                "safe",
+                sqlite_before=current.sqlite_version_string,
+                sqlite_after=current.sqlite_version_string,
+            )
+
+        print(
+            "  ⚠ Hermes venv links SQLite "
+            f"{current.sqlite_version_string}, which has the WAL-reset bug."
+        )
+        provisioned = _install_safe_python_generation(
+            uv_bin,
+            project_root=root,
+            current=current,
+        )
+        if provisioned is None:
+            return RuntimeRepairResult(
+                "failed",
+                "could not provision a fixed private Python runtime",
+                sqlite_before=current.sqlite_version_string,
+            )
+        generation, python, candidate_info = provisioned
+
+        candidate = _stage_candidate_venv(
+            uv_bin,
+            project_root=root,
+            generation=generation,
+            python=python,
+        )
+        if candidate is None:
+            _remove_tree(generation, boundary=managed_python_install_dir(root))
+            return RuntimeRepairResult(
+                "failed",
+                "replacement environment did not pass dependency and import smoke tests",
+                sqlite_before=current.sqlite_version_string,
+                sqlite_after=candidate_info.sqlite_version_string,
+            )
+
+        cut_over, backup, final_info, cutover_detail = _cut_over_candidate(
+            candidate,
+            project_root=root,
+            live=live,
+        )
+        if not cut_over:
+            if backup is None:
+                _remove_tree(candidate, boundary=runtime_root)
+                _remove_tree(generation, boundary=managed_python_install_dir(root))
+            return RuntimeRepairResult(
+                "failed",
+                cutover_detail,
+                sqlite_before=current.sqlite_version_string,
+                sqlite_after=(
+                    final_info.sqlite_version_string if final_info is not None else ""
+                ),
+                backup_venv=backup,
+            )
+
+        final_version = (
+            final_info.sqlite_version_string
+            if final_info is not None
+            else candidate_info.sqlite_version_string
+        )
+        print(
+            "  ✓ Managed Python runtime repaired "
+            f"(SQLite {current.sqlite_version_string} → {final_version})"
+        )
+        if backup is not None:
+            print(
+                f"  ℹ Previous venv parked at {backup.name}; "
+                "it can be removed after this updater exits."
+            )
+        return RuntimeRepairResult(
+            "repaired",
+            sqlite_before=current.sqlite_version_string,
+            sqlite_after=final_version,
+            backup_venv=backup,
+        )
+    finally:
+        _release_repair_lock(lock)
 
 
 # ---------------------------------------------------------------------------
 # Installer internals
 # ---------------------------------------------------------------------------
+
 
 def _install_uv(target: Path) -> None:
     """Bootstrap uv into *target* using the official standalone installer.
@@ -240,9 +902,7 @@ def _install_uv_posix(env: dict[str, str]) -> None:
 
 def _install_uv_windows(env: dict[str, str]) -> None:
     """Invoke the PowerShell installer."""
-    cmd = (
-        'irm https://astral.sh/uv/install.ps1 | iex'
-    )
+    cmd = "irm https://astral.sh/uv/install.ps1 | iex"
     subprocess.run(
         ["powershell", "-ExecutionPolicy", "Bypass", "-c", cmd],
         env=env,
@@ -250,5 +910,6 @@ def _install_uv_windows(env: dict[str, str]) -> None:
         capture_output=True,
     )
 
+
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:
-    True # dont remove me. ask ethernet
+    True  # dont remove me. ask ethernet

--- a/hermes_cli/sqlite_runtime.py
+++ b/hermes_cli/sqlite_runtime.py
@@ -1,0 +1,124 @@
+"""Import-safe helpers for inspecting a Python interpreter's linked SQLite.
+
+This module intentionally depends only on the standard library.  Installer and
+update code must be able to use it before Hermes' third-party dependencies are
+healthy.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+def _version_tuple(parts: Iterable[object]) -> tuple[int, int, int]:
+    values = [int(part) for part in parts]
+    values.extend([0] * (3 - len(values)))
+    return tuple(values[:3])
+
+
+def is_sqlite_wal_reset_vulnerable(
+    version_info: tuple[int, ...],
+) -> bool:
+    """Return whether *version_info* contains SQLite's WAL-reset bug."""
+    info = _version_tuple(version_info)
+    if info < (3, 7, 0):
+        return False
+    if info >= (3, 51, 3):
+        return False
+    if (3, 50, 7) <= info < (3, 51, 0):
+        return False
+    if (3, 44, 6) <= info < (3, 45, 0):
+        return False
+    return True
+
+
+@dataclass(frozen=True)
+class SQLiteRuntimeInfo:
+    """SQLite details reported by one exact Python executable."""
+
+    executable: Path
+    base_prefix: Path
+    python_version: tuple[int, int, int]
+    sqlite_version: tuple[int, int, int]
+    sqlite_version_string: str
+    sqlite_source_id: str
+
+    @property
+    def wal_reset_vulnerable(self) -> bool:
+        return is_sqlite_wal_reset_vulnerable(self.sqlite_version)
+
+
+_PROBE_SCRIPT = """
+import json
+import sqlite3
+import sys
+
+conn = sqlite3.connect(":memory:")
+try:
+    row = conn.execute("SELECT sqlite_source_id()").fetchone()
+finally:
+    conn.close()
+
+print(json.dumps({
+    "base_prefix": sys.base_prefix,
+    "executable": sys.executable,
+    "python_version": list(sys.version_info[:3]),
+    "sqlite_version": list(sqlite3.sqlite_version_info),
+    "sqlite_version_string": sqlite3.sqlite_version,
+    "sqlite_source_id": str(row[0]) if row and row[0] is not None else "",
+}))
+"""
+
+
+def probe_sqlite_runtime(
+    python: str | Path,
+    *,
+    timeout: float = 30.0,
+) -> SQLiteRuntimeInfo | None:
+    """Probe SQLite in *python*, never the caller's linked SQLite.
+
+    ``None`` means the interpreter could not be executed or returned malformed
+    data.  The child runs isolated from inherited Python path overrides.
+    """
+    executable = Path(python)
+    env = dict(os.environ)
+    for key in (
+        "CONDA_DEFAULT_ENV",
+        "CONDA_PREFIX",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "UV_PROJECT_ENVIRONMENT",
+        "UV_PYTHON",
+        "VIRTUAL_ENV",
+    ):
+        env.pop(key, None)
+    try:
+        result = subprocess.run(
+            [str(executable), "-I", "-c", _PROBE_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+        return SQLiteRuntimeInfo(
+            executable=Path(str(payload["executable"])),
+            base_prefix=Path(str(payload["base_prefix"])),
+            python_version=_version_tuple(payload["python_version"]),
+            sqlite_version=_version_tuple(payload["sqlite_version"]),
+            sqlite_version_string=str(payload["sqlite_version_string"]),
+            sqlite_source_id=str(payload.get("sqlite_source_id", "")),
+        )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -29,6 +29,9 @@ from pathlib import Path
 from agent.memory_manager import sanitize_context
 from agent.message_sanitization import _sanitize_surrogates
 from hermes_constants import get_hermes_home
+from hermes_cli.sqlite_runtime import (
+    is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
+)
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 try:  # Hard dependency, but tolerate scaffold-phase imports before pip install.
@@ -491,16 +494,7 @@ def is_sqlite_wal_reset_vulnerable(
     Pre-WAL libraries (< 3.7.0) cannot hit the race and are treated as safe.
     """
     info = version_info if version_info is not None else sqlite3.sqlite_version_info
-    if info < (3, 7, 0):
-        return False
-    if info >= (3, 51, 3):
-        return False
-    # Backports of the same fix on older release lines.
-    if (3, 50, 7) <= info < (3, 51, 0):
-        return False
-    if (3, 44, 6) <= info < (3, 45, 0):
-        return False
-    return True
+    return _is_sqlite_wal_reset_vulnerable(info)
 
 
 def sqlite_source_id() -> str:
@@ -639,9 +633,9 @@ def _log_wal_reset_bug_once(
         "%s: linked SQLite %s is vulnerable to the WAL-reset corruption "
         "bug (https://sqlite.org/wal.html#walresetbug) — %s. "
         "Upgrade to SQLite 3.51.3+ (or backports 3.50.7 / 3.44.6); "
-        "`hermes update` alone may not change python-build-standalone's "
-        "embedded SQLite. See `hermes doctor`. This warning fires once "
-        "per process per database.",
+        "Hermes-managed installs can repair the embedded runtime with "
+        "`hermes update`. See `hermes doctor`. This warning fires once per "
+        "process per database.",
         db_label,
         sqlite3.sqlite_version,
         action,

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -59,10 +59,10 @@ def _patch_managed_uv(request):
     def _fake_resolve_uv():
         return shutil.which("uv")
 
-    def _fake_ensure_uv():
+    def _fake_ensure_uv(**_kwargs):
         return shutil.which("uv")
 
-    def _fake_update_managed_uv():
+    def _fake_update_managed_uv(**_kwargs):
         return None  # never actually self-update in tests
 
     with patch("hermes_cli.managed_uv.resolve_uv", side_effect=_fake_resolve_uv), \
@@ -368,13 +368,54 @@ class TestCmdUpdateBranchFallback:
 
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
-        mock_uv_update.assert_called_once_with()
-        mock_uv_ensure.assert_called_once_with()
+        update_observer = mock_uv_update.call_args.kwargs["repair_observer"]
+        ensure_observer = mock_uv_ensure.call_args.kwargs["repair_observer"]
+        assert update_observer.__self__ is ensure_observer.__self__
+        assert update_observer.__self__ == []
 
         # Should NOT have called pull
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
         pull_cmds = [c for c in commands if "pull" in c]
         assert len(pull_cmds) == 0
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_zero_commit_runtime_repair_requires_process_restart(
+        self, mock_run, _mock_which, mock_args, capsys, tmp_path
+    ):
+        from hermes_cli.managed_uv import RuntimeRepairResult
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+        backup = tmp_path / "venv.stale.runtime-test"
+        repair = RuntimeRepairResult(
+            "repaired",
+            sqlite_before="3.50.4",
+            sqlite_after="3.53.1",
+            backup_venv=backup,
+        )
+
+        def fake_update(*, repair_observer):
+            repair_observer(repair)
+            return "/managed/uv"
+
+        with patch(
+            "hermes_cli.managed_uv.update_managed_uv",
+            side_effect=fake_update,
+        ), patch(
+            "hermes_cli.managed_uv.ensure_uv",
+            return_value="/managed/uv",
+        ), patch(
+            "hermes_cli.main._is_windows",
+            return_value=False,
+        ):
+            cmd_update(mock_args)
+
+        captured = capsys.readouterr()
+        assert "Restart required to finish the managed Python runtime repair" in captured.out
+        assert "long-lived processes still use the previous runtime" in captured.out
+        assert str(backup) in captured.out
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -359,10 +359,17 @@ class TestCmdUpdateBranchFallback:
             branch="main", verify_ok=True, commit_count="0"
         )
 
-        cmd_update(mock_args)
+        with patch("hermes_cli.managed_uv.update_managed_uv") as mock_uv_update, \
+             patch(
+                 "hermes_cli.managed_uv.ensure_uv",
+                 return_value=None,
+             ) as mock_uv_ensure:
+            cmd_update(mock_args)
 
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
+        mock_uv_update.assert_called_once_with()
+        mock_uv_ensure.assert_called_once_with()
 
         # Should NOT have called pull
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -128,6 +128,37 @@ class TestEnsureUv:
             assert path == str(tmp_path / "bin" / "uv")
             mock_install.assert_called_once()
 
+    def test_install_reports_runtime_repair_to_observer(self, tmp_path):
+        from hermes_cli.managed_uv import (
+            RuntimeRepairResult,
+            ensure_uv,
+        )
+
+        repair = RuntimeRepairResult(
+            "repaired",
+            sqlite_before="3.50.4",
+            sqlite_after="3.53.1",
+        )
+
+        def fake_install(target):
+            _make_executable(target)
+
+        observed = []
+        with patch(
+            "hermes_cli.managed_uv.get_hermes_home",
+            return_value=tmp_path,
+        ), patch(
+            "hermes_cli.managed_uv._install_uv",
+            side_effect=fake_install,
+        ), patch(
+            "hermes_cli.managed_uv.repair_vulnerable_runtime",
+            return_value=repair,
+        ):
+            path = ensure_uv(repair_observer=observed.append)
+
+        assert path == str(tmp_path / "bin" / "uv")
+        assert observed == [repair]
+
     def test_install_failure_returns_falsy(self, tmp_path):
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
              patch("hermes_cli.managed_uv._install_uv", side_effect=RuntimeError("network down")):
@@ -291,6 +322,32 @@ class TestUpdateManagedUv:
 
         assert result == str(uv)
         mock_repair.assert_called_once_with(str(uv))
+
+    def test_update_reports_runtime_repair_to_observer(self, tmp_path):
+        from hermes_cli.managed_uv import RuntimeRepairResult, update_managed_uv
+
+        uv = tmp_path / "bin" / "uv"
+        _make_executable(uv)
+        repair = RuntimeRepairResult(
+            "repaired",
+            sqlite_before="3.50.4",
+            sqlite_after="3.53.1",
+        )
+        observed = []
+        with patch(
+            "hermes_cli.managed_uv.get_hermes_home",
+            return_value=tmp_path,
+        ), patch(
+            "hermes_cli.managed_uv.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="uv 0.11.31\n", stderr=""),
+        ), patch(
+            "hermes_cli.managed_uv.repair_vulnerable_runtime",
+            return_value=repair,
+        ):
+            result = update_managed_uv(repair_observer=observed.append)
+
+        assert result == str(uv)
+        assert observed == [repair]
 
 
 class TestManagedPythonStore:
@@ -559,6 +616,62 @@ class TestRuntimeCutover:
         assert (live / "bin" / "python").read_text(encoding="utf-8") == (
             "live interpreter"
         )
+
+    def test_interrupt_during_promotion_restores_live_venv(self, tmp_path):
+        from hermes_cli.managed_uv import _cut_over_candidate
+
+        root, live, sentinel = _make_runtime_install(tmp_path)
+        candidate = root / ".hermes-runtime" / "venv-candidate-test"
+        candidate.mkdir(parents=True)
+        (candidate / "sentinel").write_text("candidate", encoding="utf-8")
+        rename_count = 0
+
+        def interrupt_second_rename(source, destination):
+            nonlocal rename_count
+            rename_count += 1
+            if rename_count == 2:
+                raise KeyboardInterrupt
+            source.rename(destination)
+
+        with patch(
+            "hermes_cli.managed_uv._rename_with_retry",
+            side_effect=interrupt_second_rename,
+        ), pytest.raises(KeyboardInterrupt):
+            _cut_over_candidate(candidate, project_root=root)
+
+        assert sentinel.read_text(encoding="utf-8") == "live"
+        assert candidate.exists()
+        assert not list(root.glob("venv.stale.runtime-*"))
+
+    def test_interrupt_during_rollback_restores_live_venv(self, tmp_path):
+        from hermes_cli.managed_uv import _cut_over_candidate
+
+        root, live, sentinel = _make_runtime_install(tmp_path)
+        runtime_root = root / ".hermes-runtime"
+        candidate = runtime_root / "venv-candidate-test"
+        candidate.mkdir(parents=True)
+        (candidate / "sentinel").write_text("candidate", encoding="utf-8")
+        rename_count = 0
+
+        def interrupt_backup_restore(source, destination):
+            nonlocal rename_count
+            rename_count += 1
+            if rename_count == 4:
+                raise KeyboardInterrupt
+            source.rename(destination)
+
+        with patch(
+            "hermes_cli.managed_uv._rename_with_retry",
+            side_effect=interrupt_backup_restore,
+        ), patch(
+            "hermes_cli.managed_uv._smoke_candidate_venv",
+            return_value=(False, "core import smoke failed", None),
+        ), pytest.raises(KeyboardInterrupt):
+            _cut_over_candidate(candidate, project_root=root)
+
+        assert sentinel.read_text(encoding="utf-8") == "live"
+        assert not list(root.glob("venv.stale.runtime-*"))
+        assert list(runtime_root.glob("venv-rejected-*"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -697,3 +697,82 @@ class TestInstallUvInternals:
             mock_windows.assert_called_once()
             call_env = mock_windows.call_args[0][0]
             assert call_env["UV_INSTALL_DIR"] == str(tmp_path / "bin")
+
+
+class TestRuntimeRequestMinorLine:
+    """The repair must request the CPython minor line, not the exact patch.
+
+    Real-world constraint (verified live, July 2026): every published
+    python-build-standalone artifact for 3.11.14 links vulnerable SQLite
+    3.50.4 — even with --reinstall. The fixed SQLite (3.53.1) only exists
+    from 3.11.15. An exact-patch pin makes the repair permanently
+    impossible on such installs.
+    """
+
+    def test_requests_minor_line(self):
+        from hermes_cli.managed_uv import _runtime_request
+
+        info = _runtime_info(Path("/venv/bin/python"), (3, 50, 4))
+        assert _runtime_request(info) == "3.11"
+
+    @staticmethod
+    def _run_generation(tmp_path, monkeypatch, current_version, candidate_version):
+        """Drive _install_safe_python_generation with fakes; return result."""
+        import hermes_cli.managed_uv as managed_uv
+        from hermes_cli.sqlite_runtime import SQLiteRuntimeInfo
+
+        state = {}
+
+        def fake_run(cmd, **kwargs):
+            if "install" in cmd:
+                state["generation"] = Path(kwargs["env"]["UV_PYTHON_INSTALL_DIR"])
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            # uv python find → a path inside the generation dir
+            python = state["generation"] / "cpython" / "bin" / "python3"
+            python.parent.mkdir(parents=True, exist_ok=True)
+            python.touch()
+            return SimpleNamespace(returncode=0, stdout=str(python), stderr="")
+
+        def fake_probe(python, **kwargs):
+            return SQLiteRuntimeInfo(
+                executable=Path(python),
+                base_prefix=Path(python).parent.parent,
+                python_version=candidate_version,
+                sqlite_version=(3, 53, 1),
+                sqlite_version_string="3.53.1",
+                sqlite_source_id="fixed",
+            )
+
+        current = SQLiteRuntimeInfo(
+            executable=Path("/venv/bin/python"),
+            base_prefix=Path("/venv"),
+            python_version=current_version,
+            sqlite_version=(3, 50, 4),
+            sqlite_version_string="3.50.4",
+            sqlite_source_id="old",
+        )
+        monkeypatch.setattr(managed_uv.subprocess, "run", fake_run)
+        monkeypatch.setattr(managed_uv, "probe_sqlite_runtime", fake_probe)
+        return managed_uv._install_safe_python_generation(
+            "uv", project_root=tmp_path, current=current
+        )
+
+    def test_accepts_newer_patch_same_minor(self, tmp_path, monkeypatch):
+        result = self._run_generation(
+            tmp_path, monkeypatch, (3, 11, 14), (3, 11, 15)
+        )
+        assert result is not None
+        _, _, candidate = result
+        assert candidate.python_version == (3, 11, 15)
+
+    def test_rejects_minor_drift(self, tmp_path, monkeypatch):
+        assert (
+            self._run_generation(tmp_path, monkeypatch, (3, 11, 14), (3, 12, 1))
+            is None
+        )
+
+    def test_rejects_patch_downgrade(self, tmp_path, monkeypatch):
+        assert (
+            self._run_generation(tmp_path, monkeypatch, (3, 11, 14), (3, 11, 13))
+            is None
+        )

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import os
 import stat
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,6 +21,40 @@ def _make_executable(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("#!/bin/sh\necho uv 0.1.2\n")
     path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def _runtime_info(
+    executable: Path,
+    sqlite_version: tuple[int, int, int],
+):
+    from hermes_cli.sqlite_runtime import SQLiteRuntimeInfo
+
+    return SQLiteRuntimeInfo(
+        executable=executable,
+        base_prefix=executable.parent.parent,
+        python_version=(3, 11, 15),
+        sqlite_version=sqlite_version,
+        sqlite_version_string=".".join(str(part) for part in sqlite_version),
+        sqlite_source_id=f"source-{sqlite_version}",
+    )
+
+
+def _make_runtime_install(
+    tmp_path: Path,
+    *,
+    windows: bool = False,
+) -> tuple[Path, Path, Path]:
+    root = tmp_path / "checkout"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    live = root / "venv"
+    bin_dir = live / ("Scripts" if windows else "bin")
+    bin_dir.mkdir(parents=True)
+    python = bin_dir / ("python.exe" if windows else "python")
+    python.write_text("live interpreter", encoding="utf-8")
+    sentinel = live / "sentinel"
+    sentinel.write_text("live", encoding="utf-8")
+    return root, live, sentinel
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +264,301 @@ class TestUpdateManagedUv:
             result = update_managed_uv()
             # Still returns the path — failure is non-fatal
             assert result == str(tmp_path / "bin" / "uv")
+
+    def test_old_updater_api_triggers_runtime_repair(self, tmp_path):
+        """The pre-pull main.py call site must activate the fresh module hook."""
+        from hermes_cli.managed_uv import RuntimeRepairResult, update_managed_uv
+
+        uv = tmp_path / "bin" / "uv"
+        _make_executable(uv)
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.platform.system", return_value="Linux"), \
+             patch("hermes_cli.managed_uv.subprocess.run") as mock_run, \
+             patch(
+                 "hermes_cli.managed_uv.repair_vulnerable_runtime",
+                 return_value=RuntimeRepairResult(
+                     "repaired",
+                     sqlite_before="3.50.4",
+                     sqlite_after="3.53.1",
+                 ),
+             ) as mock_repair:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="", stderr=""),
+                MagicMock(returncode=0, stdout="uv 0.11.31\n", stderr=""),
+            ]
+
+            result = update_managed_uv()
+
+        assert result == str(uv)
+        mock_repair.assert_called_once_with(str(uv))
+
+
+class TestManagedPythonStore:
+    def test_store_is_checkout_scoped_across_profiles(self, tmp_path, monkeypatch):
+        from hermes_cli.managed_uv import managed_python_install_dir
+
+        checkout = tmp_path / "checkout"
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profiles" / "alpha"))
+        alpha = managed_python_install_dir(checkout)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profiles" / "beta"))
+        beta = managed_python_install_dir(checkout)
+
+        expected = checkout / ".hermes-runtime" / "python"
+        assert alpha == expected
+        assert beta == expected
+
+    def test_environment_is_private_and_sanitized(self, tmp_path):
+        from hermes_cli.managed_uv import managed_python_env
+
+        checkout = tmp_path / "checkout"
+        base_env = {
+            "KEEP_ME": "yes",
+            "CONDA_DEFAULT_ENV": "poison",
+            "CONDA_PREFIX": "/poison/conda",
+            "UV_PROJECT_ENVIRONMENT": "/poison/project",
+            "UV_NO_MANAGED_PYTHON": "1",
+            "UV_PYTHON": "/poison/python",
+            "UV_PYTHON_DOWNLOADS": "never",
+            "UV_SYSTEM_PYTHON": "1",
+            "VIRTUAL_ENV": "/poison/venv",
+            "PYTHONHOME": "/poison/home",
+            "PYTHONPATH": "/poison/path",
+        }
+
+        env = managed_python_env(checkout, base_env=base_env)
+
+        assert env["KEEP_ME"] == "yes"
+        assert env["UV_MANAGED_PYTHON"] == "1"
+        assert env["UV_NO_CONFIG"] == "1"
+        assert env["UV_PYTHON_INSTALL_BIN"] == "0"
+        assert env["UV_PYTHON_INSTALL_REGISTRY"] == "0"
+        assert env["UV_PYTHON_INSTALL_DIR"] == str(
+            checkout / ".hermes-runtime" / "python"
+        )
+        for key in (
+            "CONDA_DEFAULT_ENV",
+            "CONDA_PREFIX",
+            "UV_PROJECT_ENVIRONMENT",
+            "UV_NO_MANAGED_PYTHON",
+            "UV_PYTHON",
+            "UV_PYTHON_DOWNLOADS",
+            "UV_SYSTEM_PYTHON",
+            "VIRTUAL_ENV",
+            "PYTHONHOME",
+            "PYTHONPATH",
+        ):
+            assert key not in env
+        assert base_env["PYTHONHOME"] == "/poison/home"
+
+
+class TestRuntimeRepair:
+    def test_safe_runtime_is_a_noop(self, tmp_path):
+        from hermes_cli.managed_uv import repair_vulnerable_runtime
+
+        root, live, sentinel = _make_runtime_install(tmp_path)
+        current = _runtime_info(live / "bin" / "python", (3, 53, 1))
+        with patch("hermes_cli.managed_uv.platform.system", return_value="Linux"), \
+             patch(
+                 "hermes_cli.managed_uv.probe_sqlite_runtime",
+                 return_value=current,
+             ), \
+             patch(
+                 "hermes_cli.managed_uv._install_safe_python_generation"
+             ) as mock_install:
+            result = repair_vulnerable_runtime("uv", project_root=root)
+
+        assert result.status == "safe"
+        assert result.sqlite_before == "3.53.1"
+        assert result.sqlite_after == "3.53.1"
+        assert sentinel.read_text(encoding="utf-8") == "live"
+        assert not (root / ".hermes-runtime").exists()
+        mock_install.assert_not_called()
+
+    def test_failed_candidate_preserves_live_venv(self, tmp_path):
+        from hermes_cli.managed_uv import (
+            _acquire_repair_lock,
+            _release_repair_lock,
+            repair_vulnerable_runtime,
+        )
+
+        root, live, sentinel = _make_runtime_install(tmp_path)
+        current = _runtime_info(live / "bin" / "python", (3, 50, 4))
+        generation = root / ".hermes-runtime" / "python" / "generation-test"
+        candidate_python = generation / "bin" / "python"
+        candidate_python.parent.mkdir(parents=True)
+        candidate_python.write_text("candidate interpreter", encoding="utf-8")
+        fixed = _runtime_info(candidate_python, (3, 53, 1))
+
+        with patch("hermes_cli.managed_uv.platform.system", return_value="Linux"), \
+             patch(
+                 "hermes_cli.managed_uv.probe_sqlite_runtime",
+                 side_effect=[current, current],
+             ), \
+             patch(
+                 "hermes_cli.managed_uv._install_safe_python_generation",
+                 return_value=(generation, candidate_python, fixed),
+             ), \
+             patch(
+                 "hermes_cli.managed_uv._stage_candidate_venv",
+                 return_value=None,
+             ):
+            result = repair_vulnerable_runtime("uv", project_root=root)
+
+        assert result.status == "failed"
+        assert "replacement environment" in result.detail
+        assert sentinel.read_text(encoding="utf-8") == "live"
+        assert (live / "bin" / "python").read_text(encoding="utf-8") == (
+            "live interpreter"
+        )
+        assert not generation.exists()
+        reacquired = _acquire_repair_lock(root / ".hermes-runtime")
+        assert reacquired is not None
+        _release_repair_lock(reacquired)
+
+    def test_windows_holders_refuse_runtime_mutation(self, tmp_path, monkeypatch):
+        from hermes_cli.managed_uv import repair_vulnerable_runtime
+
+        root, live, sentinel = _make_runtime_install(tmp_path, windows=True)
+        current = _runtime_info(live / "Scripts" / "python.exe", (3, 50, 4))
+        old_main = SimpleNamespace(
+            _detect_venv_python_processes=lambda: [
+                (1729, "python.exe", "hermes gateway run")
+            ]
+        )
+        monkeypatch.setitem(sys.modules, "hermes_cli.main", old_main)
+
+        with patch("hermes_cli.managed_uv.platform.system", return_value="Windows"), \
+             patch(
+                 "hermes_cli.managed_uv.probe_sqlite_runtime",
+                 return_value=current,
+             ), \
+             patch(
+                 "hermes_cli.managed_uv._install_safe_python_generation"
+             ) as mock_install:
+            result = repair_vulnerable_runtime("uv.exe", project_root=root)
+
+        assert result.status == "skipped"
+        assert "PID 1729" in result.detail
+        assert sentinel.read_text(encoding="utf-8") == "live"
+        assert not (root / ".hermes-runtime").exists()
+        mock_install.assert_not_called()
+
+
+class TestRuntimeCutover:
+    def test_os_lock_blocks_concurrent_repair_and_releases(self, tmp_path):
+        from hermes_cli.managed_uv import _acquire_repair_lock, _release_repair_lock
+
+        runtime_root = tmp_path / ".hermes-runtime"
+        first = _acquire_repair_lock(runtime_root)
+        assert first is not None
+        assert _acquire_repair_lock(runtime_root) is None
+
+        _release_repair_lock(first)
+        second = _acquire_repair_lock(runtime_root)
+        assert second is not None
+        _release_repair_lock(second)
+
+    def test_failed_smoke_with_empty_output_has_stable_detail(self, tmp_path):
+        from hermes_cli.managed_uv import _smoke_candidate_venv
+
+        candidate = tmp_path / "venv"
+        candidate.mkdir()
+        fixed = _runtime_info(candidate / "bin" / "python", (3, 53, 1))
+        failed = MagicMock(returncode=1, stdout=" \n", stderr="\n")
+        with patch(
+            "hermes_cli.managed_uv.probe_sqlite_runtime",
+            return_value=fixed,
+        ), patch("hermes_cli.managed_uv.subprocess.run", return_value=failed):
+            healthy, detail, info = _smoke_candidate_venv(candidate)
+
+        assert healthy is False
+        assert detail == "core import smoke failed"
+        assert info == fixed
+
+    def test_successfully_renames_candidate_into_live_path(self, tmp_path):
+        from hermes_cli.managed_uv import _cut_over_candidate
+
+        root, _, _ = _make_runtime_install(tmp_path)
+        runtime_root = root / ".hermes-runtime"
+        candidate = runtime_root / "venv-candidate-test"
+        candidate.mkdir(parents=True)
+        (candidate / "sentinel").write_text("candidate", encoding="utf-8")
+        fixed = _runtime_info(candidate / "bin" / "python", (3, 53, 1))
+
+        with patch(
+            "hermes_cli.managed_uv._smoke_candidate_venv",
+            return_value=(True, "", fixed),
+        ):
+            ok, backup, info, detail = _cut_over_candidate(
+                candidate,
+                project_root=root,
+            )
+
+        assert ok is True
+        assert detail == ""
+        assert info == fixed
+        assert backup is not None
+        assert (root / "venv" / "sentinel").read_text(encoding="utf-8") == (
+            "candidate"
+        )
+        assert (backup / "sentinel").read_text(encoding="utf-8") == "live"
+        assert not candidate.exists()
+
+    def test_post_swap_smoke_failure_rolls_back_live_venv(self, tmp_path):
+        from hermes_cli.managed_uv import _cut_over_candidate
+
+        root, live, sentinel = _make_runtime_install(tmp_path)
+        runtime_root = root / ".hermes-runtime"
+        candidate = runtime_root / "venv-candidate-test"
+        candidate.mkdir(parents=True)
+        (candidate / "sentinel").write_text("candidate", encoding="utf-8")
+        rejected_info = _runtime_info(candidate / "bin" / "python", (3, 50, 4))
+
+        with patch(
+            "hermes_cli.managed_uv._smoke_candidate_venv",
+            return_value=(False, "core import smoke failed", rejected_info),
+        ):
+            ok, backup, info, detail = _cut_over_candidate(
+                candidate,
+                project_root=root,
+            )
+
+        assert ok is False
+        assert backup is None
+        assert info == rejected_info
+        assert "post-cutover smoke failed" in detail
+        assert sentinel.read_text(encoding="utf-8") == "live"
+        assert (live / "bin" / "python").read_text(encoding="utf-8") == (
+            "live interpreter"
+        )
+        assert not candidate.exists()
+        assert not list(runtime_root.glob("venv-rejected-*"))
+
+    def test_smoke_exception_after_swap_rolls_back_live_venv(self, tmp_path):
+        from hermes_cli.managed_uv import _cut_over_candidate
+
+        root, live, sentinel = _make_runtime_install(tmp_path)
+        candidate = root / ".hermes-runtime" / "venv-candidate-test"
+        candidate.mkdir(parents=True)
+        (candidate / "sentinel").write_text("candidate", encoding="utf-8")
+
+        with patch(
+            "hermes_cli.managed_uv._smoke_candidate_venv",
+            side_effect=RuntimeError("probe crashed"),
+        ):
+            ok, backup, info, detail = _cut_over_candidate(
+                candidate,
+                project_root=root,
+            )
+
+        assert ok is False
+        assert backup is None
+        assert info is None
+        assert "probe crashed" in detail
+        assert sentinel.read_text(encoding="utf-8") == "live"
+        assert (live / "bin" / "python").read_text(encoding="utf-8") == (
+            "live interpreter"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_sqlite_runtime.py
+++ b/tests/hermes_cli/test_sqlite_runtime.py
@@ -1,0 +1,93 @@
+"""Behavioral tests for exact-interpreter SQLite runtime inspection."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.sqlite_runtime import (
+    is_sqlite_wal_reset_vulnerable,
+    probe_sqlite_runtime,
+)
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ((3, 6, 23), False),
+        ((3, 7, 0), True),
+        ((3, 44, 5), True),
+        ((3, 44, 6), False),
+        ((3, 45, 0), True),
+        ((3, 50, 6), True),
+        ((3, 50, 7), False),
+        ((3, 51, 2), True),
+        ((3, 51, 3), False),
+        ((3, 53, 1), False),
+    ],
+)
+def test_wal_reset_vulnerability_matrix(
+    version: tuple[int, ...],
+    expected: bool,
+) -> None:
+    assert is_sqlite_wal_reset_vulnerable(version) is expected
+
+
+def test_probe_reports_the_requested_interpreters_linked_sqlite() -> None:
+    info = probe_sqlite_runtime(sys.executable)
+
+    assert info is not None
+    assert info.executable.resolve() == Path(sys.executable).resolve()
+    assert info.base_prefix.resolve() == Path(sys.base_prefix).resolve()
+    assert info.python_version == sys.version_info[:3]
+    assert info.sqlite_version == sqlite3.sqlite_version_info
+    assert info.sqlite_version_string == sqlite3.sqlite_version
+
+    with sqlite3.connect(":memory:") as conn:
+        source_id = conn.execute("SELECT sqlite_source_id()").fetchone()[0]
+    assert info.sqlite_source_id == source_id
+
+
+@pytest.mark.skipif(os.name == "nt", reason="uses a POSIX executable probe stub")
+def test_probe_uses_child_payload_and_sanitizes_python_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_python = tmp_path / "reported-python"
+    payload = {
+        "base_prefix": str(tmp_path / "reported-base"),
+        "executable": str(fake_python),
+        "python_version": [3, 11, 15],
+        "sqlite_version": [9, 8, 7],
+        "sqlite_version_string": "9.8.7-child",
+        "sqlite_source_id": "child-source-id",
+    }
+    fake_python.write_text(
+        "\n".join([
+            "#!/bin/sh",
+            '[ "$1" = "-I" ] && [ "$2" = "-c" ] || exit 10',
+            '[ -z "${PYTHONHOME+x}" ] || exit 11',
+            '[ -z "${PYTHONPATH+x}" ] || exit 12',
+            f"printf '%s\\n' {shlex.quote(json.dumps(payload))}",
+        ])
+        + "\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    monkeypatch.setenv("PYTHONHOME", str(tmp_path / "poison-home"))
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path / "poison-path"))
+
+    info = probe_sqlite_runtime(fake_python)
+
+    assert info is not None
+    assert info.executable == fake_python
+    assert info.base_prefix == tmp_path / "reported-base"
+    assert info.sqlite_version == (9, 8, 7)
+    assert info.sqlite_version_string == "9.8.7-child"
+    assert info.sqlite_source_id == "child-source-id"

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -25,13 +25,13 @@ def _patch_managed_uv(request):
 
     # resolve_uv delegates to shutil.which("uv") so that test patches
     # on shutil.which flow through naturally.
-    def _fake_resolve_uv():
+    def _fake_resolve_uv(**kwargs):
         return shutil.which("uv")
 
-    def _fake_ensure_uv():
+    def _fake_ensure_uv(**kwargs):
         return shutil.which("uv")
 
-    def _fake_update_managed_uv():
+    def _fake_update_managed_uv(**kwargs):
         return None  # never actually self-update in tests
 
     with patch("hermes_cli.managed_uv.resolve_uv", side_effect=_fake_resolve_uv), \

--- a/tests/test_sqlite_wal_reset_gate.py
+++ b/tests/test_sqlite_wal_reset_gate.py
@@ -186,5 +186,6 @@ def test_doctor_warns_without_adding_issues(monkeypatch, tmp_path, capsys):
     assert "SQLite" in out
     assert "3.50.4" in out
     assert "WAL-reset" in out
+    assert "hermes update" in out
     # No longer appended to the blocking issues summary.
     assert "Linked SQLite is vulnerable" not in out


### PR DESCRIPTION
## Summary
Managed-runtime installs with a vulnerable bundled SQLite are now detected and repaired in place via the existing doctor/self-heal path.

## Changes
- Detection + repair wiring (base: #70186 by @somewheresy, authorship preserved; audited and trimmed to the semantic fix)
- Our follow-up: test hardening

## Validation
Targeted install/doctor suites green.


## Infographic

![managed-sqlite-repair](https://v3b.fal.media/files/b/0aa39490/zr_q-od3flQFPv-7_PDhA_wLwihSgF.png)
