### PR TITLE
fix(agent): touch activity between tool completion and next API call (inactivity-kill hang)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5865,6 +5865,17 @@ def run_conversation(
                 # Save session log incrementally (so progress is visible even if interrupted)
                 agent._session_messages = messages
                 
+                # Touch activity before continuing so the gateway's
+                # inactivity monitor never sees a stale timestamp
+                # between tool completion and the start of the next
+                # API call.  Without this, a tool-call result (which
+                # takes ~0s to process) followed by slow post-tool
+                # processing (compression, persist) and a slow
+                # follow-up API call can exceed the gateway inactivity
+                # timeout (HERMES_AGENT_TIMEOUT, default 1800s) and the
+                # gateway kills the session before the next activity
+                # touch fires (#69559, #69131).
+                agent._touch_activity(f"tool results posted, continuing iteration #{api_call_count}")
                 # Continue loop for next response
                 continue
             

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -964,7 +964,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 print(f"  ✅ Tool {i+1} completed in {tool_duration:.2f}s - {response_preview}")
 
         agent._current_tool = None
-        agent._touch_activity(f"tool completed: {name} ({tool_duration:.1f}s)")
+        _status_suffix = " (error)" if is_error else ""
+        agent._touch_activity(f"tool completed: {name} ({tool_duration:.1f}s){_status_suffix}")
 
         if not blocked and agent.tool_complete_callback:
             try:
@@ -1655,7 +1656,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 logging.debug(f"Tool progress callback error: {cb_err}")
 
         agent._current_tool = None
-        agent._touch_activity(f"tool completed: {function_name} ({tool_duration:.1f}s)")
+        _status_suffix = " (error)" if _is_error_result else ""
+        agent._touch_activity(f"tool completed: {function_name} ({tool_duration:.1f}s){_status_suffix}")
 
         if agent.verbose_logging:
             logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")


### PR DESCRIPTION
## Summary
The gateway inactivity monitor no longer kills an agent mid-turn during the silent window between 'tool completed' and 'starting API call' (guardrails, compression, prune, persist) — activity is touched at the loop continue, and tool errors are visible in the activity feed.

## Changes
- agent/conversation_loop.py: _touch_activity at the tool-call continue (base: #69577 by @webtecnica; #69467's identical hunk deduped)
- tools/tool_executor.py: '(error)' suffix on tool-completion activity (salvaged from #69467)
- Excluded per reviews: #69577's unrelated cron commit and #69467's profiles.py commit

## Validation
Persistence regression test green; timeout comment corrected (real default 1800s).

Supersedes #69467 (same hunk; its distinct error-suffix piece is included here with credit).

Fixes #69559
Fixes #69131


## Infographic

![agent-hang-after-tool-call](https://v3b.fal.media/files/b/0aa3949d/ZY8LydD88swV9qRBnRr_9_Yb8HMuNg.png)
