### PR TITLE
fix(agent): recover from provider-dropped tool calls (finish_reason=tool_calls, empty array)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -892,6 +892,7 @@ _SYNTHETIC_USER_FLAGS = (
     "_empty_recovery_synthetic",
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    "_dropped_toolcall_nudge",
 )
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5617,6 +5617,10 @@ def run_conversation(
                 # flag so it can fire again if the model goes empty on
                 # a LATER tool round.
                 agent._post_tool_empty_retried = False
+                # A landed tool call means any earlier dropped-tool-call stall
+                # was recovered — refresh that budget too so it guards each
+                # stall independently rather than capping the whole run.
+                agent._dropped_toolcall_retries = 0
 
                 previous_msg = messages[-1] if messages else None
                 current_interim_visible = agent._interim_assistant_visible_text(assistant_msg)
@@ -5869,8 +5873,54 @@ def run_conversation(
                 continue
             
             else:
+                # ── Dropped tool-call recovery (copilot/Claude) ────────
+                # Some providers (observed: claude-opus-4.8 / claude-sonnet-4.5
+                # on GitHub Copilot, ~2026-07) return finish_reason="tool_calls"
+                # while the parsed tool_calls array is empty. The model INTENDED
+                # to act but the payload shipped no call — the narration may land
+                # in `content` OR only in the `reasoning` field (empty content).
+                # Either way, treating it as a final answer silently ends the
+                # turn with the task unstarted. The invariant we key on is the
+                # provider contract violation itself: finish_reason=="tool_calls"
+                # with zero tool_calls. Re-prompt (bounded) to make the model
+                # emit the call. finish_reason=="stop" text finishes are
+                # unaffected. The retry budget resets after any successful tool
+                # round (see the post-tool reset), so it guards each stall, not
+                # the whole run.
+                _dropped_tc_mismatch = (
+                    finish_reason == "tool_calls"
+                    and not assistant_message.tool_calls
+                )
+                if _dropped_tc_mismatch and getattr(agent, "_dropped_toolcall_retries", 0) < 3:
+                    agent._dropped_toolcall_retries = getattr(agent, "_dropped_toolcall_retries", 0) + 1
+                    logger.warning(
+                        "finish_reason=tool_calls with empty tool_calls array "
+                        "(narration only) — re-prompting to emit the call "
+                        "(retry %d/3, model=%s provider=%s)",
+                        agent._dropped_toolcall_retries, agent.model, agent.provider,
+                    )
+                    agent._emit_status(
+                        "↻ Model signaled a tool call but sent none — "
+                        f"re-prompting ({agent._dropped_toolcall_retries}/3)"
+                    )
+                    interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                    messages.append(interim_msg)
+                    messages.append({
+                        "role": "user",
+                        "content": (
+                            "Your previous turn indicated a tool call but none was "
+                            "included. Do not narrate a plan or restate intent — issue "
+                            "the actual tool call now to continue the task."
+                        ),
+                        "_dropped_toolcall_nudge": True,
+                    })
+                    agent._session_messages = messages
+                    continue
+
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
+                # A real final answer resets the dropped-tool-call retry budget.
+                agent._dropped_toolcall_retries = 0
                 
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5873,54 +5873,12 @@ def run_conversation(
                 continue
             
             else:
-                # ── Dropped tool-call recovery (copilot/Claude) ────────
-                # Some providers (observed: claude-opus-4.8 / claude-sonnet-4.5
-                # on GitHub Copilot, ~2026-07) return finish_reason="tool_calls"
-                # while the parsed tool_calls array is empty. The model INTENDED
-                # to act but the payload shipped no call — the narration may land
-                # in `content` OR only in the `reasoning` field (empty content).
-                # Either way, treating it as a final answer silently ends the
-                # turn with the task unstarted. The invariant we key on is the
-                # provider contract violation itself: finish_reason=="tool_calls"
-                # with zero tool_calls. Re-prompt (bounded) to make the model
-                # emit the call. finish_reason=="stop" text finishes are
-                # unaffected. The retry budget resets after any successful tool
-                # round (see the post-tool reset), so it guards each stall, not
-                # the whole run.
-                _dropped_tc_mismatch = (
-                    finish_reason == "tool_calls"
-                    and not assistant_message.tool_calls
-                )
-                if _dropped_tc_mismatch and getattr(agent, "_dropped_toolcall_retries", 0) < 3:
-                    agent._dropped_toolcall_retries = getattr(agent, "_dropped_toolcall_retries", 0) + 1
-                    logger.warning(
-                        "finish_reason=tool_calls with empty tool_calls array "
-                        "(narration only) — re-prompting to emit the call "
-                        "(retry %d/3, model=%s provider=%s)",
-                        agent._dropped_toolcall_retries, agent.model, agent.provider,
-                    )
-                    agent._emit_status(
-                        "↻ Model signaled a tool call but sent none — "
-                        f"re-prompting ({agent._dropped_toolcall_retries}/3)"
-                    )
-                    interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                    messages.append(interim_msg)
-                    messages.append({
-                        "role": "user",
-                        "content": (
-                            "Your previous turn indicated a tool call but none was "
-                            "included. Do not narrate a plan or restate intent — issue "
-                            "the actual tool call now to continue the task."
-                        ),
-                        "_dropped_toolcall_nudge": True,
-                    })
-                    agent._session_messages = messages
-                    continue
-
-                # No tool calls - this is the final response
+                # No tool calls - this is the final response.
+                # (Dropped tool-call recovery — finish_reason=="tool_calls" with
+                # an empty tool_calls array — is handled at the finalization
+                # chokepoint below, after final_msg is built, so it catches
+                # every path that reaches turn finalization, not just this one.)
                 final_response = assistant_message.content or ""
-                # A real final answer resets the dropped-tool-call retry budget.
-                agent._dropped_toolcall_retries = 0
                 
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery
@@ -6250,6 +6208,53 @@ def run_conversation(
                 final_response = agent._strip_think_blocks(final_response).strip()
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+
+                # ── Dropped tool-call recovery (copilot/Claude) ────────
+                # Some providers (observed: claude-opus-4.8 / claude-sonnet-4.5
+                # on GitHub Copilot, ~2026-07) return finish_reason="tool_calls"
+                # while the parsed tool_calls array is empty — the model
+                # signalled it wanted to act but the payload shipped no call.
+                # Reaching finalization with that mismatch means the turn is
+                # about to end with the task unstarted (the narration, which may
+                # be in content or only in the reasoning field, gets treated as
+                # the final answer). Re-prompt (bounded to 3 CONSECUTIVE stalls;
+                # the budget resets after any successful tool round) to make the
+                # model emit the call instead of exiting. finish_reason="stop"
+                # text finishes never enter this guard.
+                if (
+                    finish_reason == "tool_calls"
+                    and not assistant_message.tool_calls
+                    and getattr(agent, "_dropped_toolcall_retries", 0) < 3
+                ):
+                    agent._dropped_toolcall_retries = getattr(agent, "_dropped_toolcall_retries", 0) + 1
+                    logger.warning(
+                        "finish_reason=tool_calls with empty tool_calls array "
+                        "(narration only) — re-prompting to emit the call "
+                        "(retry %d/3, model=%s provider=%s)",
+                        agent._dropped_toolcall_retries, agent.model, agent.provider,
+                    )
+                    agent._emit_status(
+                        "↻ Model signaled a tool call but sent none — "
+                        f"re-prompting ({agent._dropped_toolcall_retries}/3)"
+                    )
+                    messages.append(final_msg)
+                    messages.append({
+                        "role": "user",
+                        "content": (
+                            "Your previous turn indicated a tool call but none was "
+                            "included. Do not narrate a plan or restate intent — issue "
+                            "the actual tool call now to continue the task."
+                        ),
+                        "_dropped_toolcall_nudge": True,
+                    })
+                    agent._session_messages = messages
+                    final_response = None
+                    continue
+
+                # Reached finalization without the dropped-tool-call mismatch —
+                # a genuine turn end. Clear the consecutive-stall budget so the
+                # next turn starts fresh.
+                agent._dropped_toolcall_retries = 0
 
                 # Pop thinking-only prefill and empty-response retry
                 # scaffolding before appending either a final response or a

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6237,6 +6237,17 @@ def run_conversation(
                         "↻ Model signaled a tool call but sent none — "
                         f"re-prompting ({agent._dropped_toolcall_retries}/3)"
                     )
+                    # Both halves of the re-prompt pair are ephemeral recovery
+                    # scaffolding (mirrors the empty-response nudge pattern):
+                    # the interim narration-only assistant turn exists solely to
+                    # keep role alternation valid for the nudge, and the nudge
+                    # exists solely to drive the retry. Flag both so the
+                    # persistence layer never writes them to the durable
+                    # transcript and the finalization pop below can strip an
+                    # unanswered tail pair. A recovered (answered) pair stays
+                    # buried mid-list in live memory but is skipped by the
+                    # flush regardless of position.
+                    final_msg["_dropped_toolcall_nudge"] = True
                     messages.append(final_msg)
                     messages.append({
                         "role": "user",
@@ -6268,6 +6279,7 @@ def run_conversation(
                         messages[-1].get("_thinking_prefill")
                         or messages[-1].get("_empty_recovery_synthetic")
                         or messages[-1].get("_empty_terminal_sentinel")
+                        or messages[-1].get("_dropped_toolcall_nudge")
                     )
                 ):
                     messages.pop()

--- a/run_agent.py
+++ b/run_agent.py
@@ -239,6 +239,12 @@ _EPHEMERAL_SCAFFOLDING_FLAGS = (
     "_pre_verify_synthetic",
     # kanban worker stop-guard: narrated exit without kanban_complete/block
     "_kanban_stop_synthetic",
+    # dropped tool-call re-prompt pair (finish_reason=tool_calls with an
+    # empty tool_calls array): the interim narration-only assistant turn
+    # and the "issue the actual tool call now" user nudge exist only to
+    # drive the bounded retry. Persisting them would replay the internal
+    # retry instruction as user-authored context on resume.
+    "_dropped_toolcall_nudge",
 )
 
 

--- a/tests/run_agent/test_dropped_tool_call_recovery.py
+++ b/tests/run_agent/test_dropped_tool_call_recovery.py
@@ -150,9 +150,14 @@ class TestDroppedToolCallRecovery:
     def test_persistent_dropped_tool_calls_are_bounded(self, loop_agent):
         """If the model never emits a call, the recovery must give up after a
         bounded number of consecutive stalls instead of looping forever."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        # Stage plenty of dropped-tool-call responses followed by a clean stop,
+        # so that if the bound is respected the loop exits on its own well
+        # before exhausting the staged responses (no StopIteration).
         loop_agent.client.chat.completions.create.side_effect = [
-            _dropped_tool_call_response("Let me check.") for _ in range(10)
-        ]
+            _dropped_tool_call_response("Let me check.") for _ in range(9)
+        ] + [_mock_response(content="done", finish_reason="stop")]
 
         with (
             patch.object(loop_agent, "_persist_session"),
@@ -161,7 +166,8 @@ class TestDroppedToolCallRecovery:
         ):
             result = loop_agent.run_conversation("review the PR")
 
-        # 1 initial call + 3 bounded re-prompts = 4 total, then it stops.
+        # 1 initial call + at most 3 bounded re-prompts = 4 total before the
+        # guard stops firing. It must NOT consume all 9 staged stalls.
         assert loop_agent.client.chat.completions.create.call_count <= 4, (
             "Consecutive dropped tool calls must be bounded (no infinite loop)."
         )

--- a/tests/run_agent/test_dropped_tool_call_recovery.py
+++ b/tests/run_agent/test_dropped_tool_call_recovery.py
@@ -1,0 +1,168 @@
+"""Regression tests for dropped tool-call recovery.
+
+Some providers (observed: claude-opus-4.8 / claude-sonnet-4.5 on GitHub
+Copilot, ~2026-07) return ``finish_reason="tool_calls"`` while the parsed
+``tool_calls`` array is empty — the model signalled it wanted to act but the
+payload shipped no call. Before the fix, the conversation loop took the
+no-tool-calls ``else`` branch, treated the turn's narration as the final
+answer, and exited with the task unstarted. On an unattended multi-step job
+(e.g. a scheduled PR reviewer) this silently did nothing.
+
+The fix keys on the provider contract violation itself
+(``finish_reason == "tool_calls"`` with zero ``tool_calls``) and re-prompts,
+bounded to 3 consecutive stalls, with the budget resetting after any
+successful tool round so it guards each stall rather than the whole run. A
+genuine ``finish_reason="stop"`` text turn is unaffected.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def loop_agent():
+    """AIAgent with a mocked OpenAI client (mirrors test_run_agent's fixture)
+    so we can stage a dropped-tool-call response + continuation pair on
+    ``.chat.completions.create``."""
+    from run_agent import AIAgent
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        return agent
+
+
+def _dropped_tool_call_response(content: str):
+    """A response whose finish_reason claims a tool call, but tool_calls is
+    empty — the provider contract violation this fix recovers from."""
+    from tests.run_agent.test_run_agent import _mock_assistant_msg
+    return SimpleNamespace(
+        id="chatcmpl-dropped",
+        model="test/model",
+        choices=[SimpleNamespace(
+            index=0,
+            message=_mock_assistant_msg(content=content, tool_calls=None),
+            finish_reason="tool_calls",
+        )],
+        usage=None,
+    )
+
+
+class TestDroppedToolCallRecovery:
+    def test_dropped_tool_call_reprompts_instead_of_exiting(self, loop_agent):
+        """finish_reason=tool_calls with an empty tool_calls array must
+        re-prompt the model to emit the call rather than exiting the loop
+        with the narration as the final answer."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _dropped_tool_call_response("Let me verify the PR and gather evidence."),
+            _mock_response(content="All checks pass. Approved.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("review the PR")
+
+        assert loop_agent.client.chat.completions.create.call_count == 2, (
+            "A dropped tool call must trigger a re-prompt (second API call), "
+            "not exit the loop after one call."
+        )
+
+        # The loop must have injected a nudge user-message telling the model to
+        # issue the actual tool call.
+        second_call = loop_agent.client.chat.completions.create.call_args_list[1]
+        msgs = second_call.kwargs.get("messages") or second_call.args[0].get("messages")
+        last_user = next(
+            (m for m in reversed(msgs) if m.get("role") == "user"), None,
+        )
+        assert last_user is not None
+        assert "tool call" in (last_user.get("content") or "").lower(), (
+            "The nudge must explicitly ask the model to issue the tool call."
+        )
+        assert "All checks pass" in result["final_response"]
+
+    def test_empty_content_dropped_tool_call_still_reprompts(self, loop_agent):
+        """The narration may live only in the reasoning field, leaving content
+        empty. The recovery must still fire — it keys on the finish_reason /
+        tool_calls mismatch, not on content being present."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _dropped_tool_call_response(""),  # no visible content at all
+            _mock_response(content="Done.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("review the PR")
+
+        assert loop_agent.client.chat.completions.create.call_count == 2, (
+            "An empty-content dropped tool call must still re-prompt."
+        )
+        assert result["completed"] is True
+
+    def test_clean_stop_text_turn_is_unaffected(self, loop_agent):
+        """A genuine finish_reason=stop text response must exit normally — the
+        recovery path must not fire on ordinary final answers."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="Here is your answer.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("hello")
+
+        assert loop_agent.client.chat.completions.create.call_count == 1, (
+            "A clean finish_reason=stop turn must not trigger a re-prompt."
+        )
+        assert "Here is your answer." in result["final_response"]
+
+    def test_persistent_dropped_tool_calls_are_bounded(self, loop_agent):
+        """If the model never emits a call, the recovery must give up after a
+        bounded number of consecutive stalls instead of looping forever."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _dropped_tool_call_response("Let me check.") for _ in range(10)
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("review the PR")
+
+        # 1 initial call + 3 bounded re-prompts = 4 total, then it stops.
+        assert loop_agent.client.chat.completions.create.call_count <= 4, (
+            "Consecutive dropped tool calls must be bounded (no infinite loop)."
+        )
+        assert result is not None

--- a/tests/run_agent/test_dropped_tool_call_recovery.py
+++ b/tests/run_agent/test_dropped_tool_call_recovery.py
@@ -172,3 +172,68 @@ class TestDroppedToolCallRecovery:
             "Consecutive dropped tool calls must be bounded (no infinite loop)."
         )
         assert result is not None
+
+    def test_nudge_pair_is_ephemeral_scaffolding(self, loop_agent):
+        """The re-prompt pair (interim assistant turn + synthetic user nudge)
+        must be flagged as ephemeral scaffolding so persistence never writes
+        it to the durable transcript — a resumed session must not replay the
+        internal "issue the actual tool call now" instruction as user-authored
+        context (#69630 review follow-up)."""
+        from run_agent import _is_ephemeral_scaffolding
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _dropped_tool_call_response("Let me verify the PR."),
+            _mock_response(content="All checks pass. Approved.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("review the PR")
+
+        assert result["completed"] is True
+        # The finalization pop strips the answered pair from the live list —
+        # no flagged scaffolding may survive into the returned transcript.
+        leftover = [
+            m for m in result["messages"]
+            if isinstance(m, dict) and m.get("_dropped_toolcall_nudge")
+        ]
+        assert not leftover, (
+            "The re-prompt pair must be stripped at finalization, not kept "
+            "in the returned transcript."
+        )
+        # And the persistence filter must classify the flag as ephemeral so a
+        # mid-turn flush can never write the pair to the durable store either.
+        assert _is_ephemeral_scaffolding(
+            {"role": "user", "content": "nudge", "_dropped_toolcall_nudge": True}
+        ), (
+            "_dropped_toolcall_nudge messages must be classified as "
+            "ephemeral scaffolding so they are never persisted."
+        )
+
+    def test_unanswered_nudge_tail_is_stripped_at_finalization(self, loop_agent):
+        """If the model answers the nudge with a genuine final text turn, the
+        trailing scaffolding must not leave the transcript tail on a synthetic
+        user message (strict role alternation on the next turn)."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _dropped_tool_call_response("Let me check."),
+            _mock_response(content="Final answer.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("review the PR")
+
+        tail = result["messages"][-1]
+        assert tail.get("role") == "assistant", (
+            "The turn must end on the real assistant answer, not scaffolding."
+        )
+        assert not tail.get("_dropped_toolcall_nudge")


### PR DESCRIPTION
## Summary
When a provider returns finish_reason=tool_calls but drops the tool_calls array on the wire, the turn no longer wedges — recovery happens at the finalization chokepoint. This is wire-level drop recovery, not model-output repair.

## Changes
- Finalization-chokepoint recovery (base: #69630 by @s905060, authorship preserved; moved from the original call site to the chokepoint so all paths are covered)

## Validation
Targeted run_agent suites green; policy check done — this recovers a provider wire drop (legitimate empty-content recovery class), it does not synthesize or repair model output.


## Infographic

![empty-toolcalls-recovery](https://v3b.fal.media/files/b/0aa394a3/LhCWFTa39nxdfwUBFew-__3xk21LFi.png)
