### PR TITLE
fix(ssl): detect and repair a missing certifi cacert.pem via existing venv-repair infra

### DIFF
--- a/agent/ssl_guard.py
+++ b/agent/ssl_guard.py
@@ -31,7 +31,8 @@ def _skip_ssl_guard_enabled() -> bool:
 
 def _repair_hint() -> str:
     return (
-        "Repair: python -m pip install --force-reinstall certifi openai httpx\n"
+        "Repair: run `hermes doctor --fix` (auto-reinstalls certifi), or "
+        "manually: python -m pip install --force-reinstall certifi openai httpx\n"
         "If you configured a custom corporate CA bundle, fix or unset the "
         "broken CA bundle environment variable."
     )

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -92,12 +92,37 @@ def _pinned_specs(packages: list[str], project_root: Path) -> list[str]:
     return [name_to_spec.get(pkg.lower(), pkg) for pkg in packages]
 
 
+def _certifi_bundle_broken() -> bool:
+    """True when certifi imports but its ``cacert.pem`` is missing/corrupt.
+
+    A brew Python upgrade or an interrupted venv rebuild can leave certifi's
+    distribution metadata (and even the module) intact while the bundled
+    ``cacert.pem`` is gone or a dangling symlink — every TLS connection then
+    fails with an opaque ``Could not find a suitable TLS CA certificate
+    bundle`` from deep inside httpx/requests (#29866). An attribute probe
+    alone passes in that state, so validate the bundle path itself.
+    """
+    try:
+        import certifi
+
+        bundle = Path(certifi.where())
+        # <1 KiB cannot hold a single PEM certificate — treat as corrupt.
+        return not bundle.is_file() or bundle.stat().st_size < 1024
+    except Exception:
+        # Import failure is caught by the regular probe table; a failure to
+        # even stat is treated as broken.
+        return True
+
+
 def _probe_broken_packages() -> list[str]:
     """Import-probe the fragile core packages in THIS process.
 
     Returns repair package names (deduped, probe order) for modules that fail
     to import or lack their sentinel attribute.  Failed imports leave nothing
     in ``sys.modules``, so a post-repair retry in the same process works.
+
+    certifi additionally gets a bundle-file check: the module can import
+    cleanly while ``cacert.pem`` is missing (#29866).
     """
     broken: list[str] = []
     for mod_name, attr in LAZY_REFRESH_IMPORT_PROBES:
@@ -105,6 +130,8 @@ def _probe_broken_packages() -> list[str]:
             mod = importlib.import_module(mod_name)
             if not hasattr(mod, attr):
                 raise ImportError(f"{mod_name} missing {attr}")
+            if mod_name == "certifi" and _certifi_bundle_broken():
+                raise ImportError("certifi cacert.pem missing or corrupt")
         except Exception:
             pkg = LAZY_REFRESH_REPAIR_PACKAGES.get(mod_name)
             if pkg and pkg not in broken:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -423,21 +423,90 @@ def _check_s6_supervision(issues: list[str]) -> None:
     )
 
 
-def check_certificates() -> None:
+def check_certificates(should_fix: bool = False, issues: "list | None" = None) -> None:
     """Verify the certifi CA bundle is loadable.
 
     Surfaces the SSLConfigurationError user-friendly path before they hit
     a wall of tracebacks on the first outbound HTTPS call.
+
+    With ``--fix``, a broken bundle (missing/corrupt ``cacert.pem`` — e.g.
+    after a brew Python upgrade rebuilt the venv, #29866) is repaired by
+    force-reinstalling certifi into THIS interpreter's environment and
+    re-verifying.
     """
     try:
         from agent.ssl_guard import verify_ca_bundle_with_fallback
         from agent.errors import SSLConfigurationError
-        verify_ca_bundle_with_fallback()
-        check_ok("SSL CA certificate bundle is valid")
-    except SSLConfigurationError as e:
-        check_fail("SSL CA certificate bundle is broken", str(e))
     except Exception as e:
         check_warn("SSL certificate check skipped", str(e))
+        return
+
+    try:
+        verify_ca_bundle_with_fallback()
+        check_ok("SSL CA certificate bundle is valid")
+        return
+    except SSLConfigurationError as e:
+        first_error = str(e)
+    except Exception as e:
+        check_warn("SSL certificate check skipped", str(e))
+        return
+
+    if not should_fix:
+        check_fail("SSL CA certificate bundle is broken", first_error)
+        if issues is not None:
+            issues.append(
+                "Repair the CA bundle: run `hermes doctor --fix`, or "
+                f"`{sys.executable} -m pip install --force-reinstall certifi`"
+            )
+        return
+
+    # --fix: force-reinstall certifi into the running interpreter's env and
+    # re-verify. importlib caches are invalidated so certifi.where() resolves
+    # the fresh install without a process restart.
+    check_fail("SSL CA certificate bundle is broken", first_error)
+    print("    → Repairing: force-reinstalling certifi...")
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--force-reinstall", "certifi"],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except Exception as exc:
+        check_fail("certifi repair could not run pip", str(exc))
+        if issues is not None:
+            issues.append(
+                f"Reinstall certifi manually: {sys.executable} -m pip install "
+                "--force-reinstall certifi"
+            )
+        return
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout or "")[-500:]
+        check_fail("certifi reinstall failed", tail)
+        if issues is not None:
+            issues.append(
+                f"Reinstall certifi manually: {sys.executable} -m pip install "
+                "--force-reinstall certifi"
+            )
+        return
+
+    # Drop any cached certifi module so where() re-resolves the new bundle.
+    import importlib
+    for mod_name in [m for m in sys.modules if m == "certifi" or m.startswith("certifi.")]:
+        sys.modules.pop(mod_name, None)
+    importlib.invalidate_caches()
+
+    try:
+        verify_ca_bundle_with_fallback()
+        check_ok("SSL CA certificate bundle repaired (certifi reinstalled)")
+    except SSLConfigurationError as e:
+        check_fail("SSL CA certificate bundle still broken after reinstall", str(e))
+        if issues is not None:
+            issues.append(
+                "certifi reinstall did not restore the CA bundle — check for a "
+                "custom CA env var (SSL_CERT_FILE/REQUESTS_CA_BUNDLE) pointing "
+                "at a missing file, or recreate the venv."
+            )
 
 
 def _check_gateway_service_linger(issues: list[str]) -> None:
@@ -779,7 +848,7 @@ def run_doctor(args):
     _check_version_consistency(issues)
 
     _section("SSL / CA Certificates")
-    check_certificates()
+    check_certificates(should_fix=should_fix, issues=manual_issues)
 
     _section("Required Packages")
     required_packages = [

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8523,6 +8523,7 @@ def _detect_broken_lazy_refresh_imports(
         f"    ({mod!r}, {attr!r})," for mod, attr in _LAZY_REFRESH_IMPORT_PROBES
     )
     check_script = (
+        "import os\n"
         "import sys\n"
         "probes = [\n"
         f"{probe_lines}\n"
@@ -8533,6 +8534,13 @@ def _detect_broken_lazy_refresh_imports(
         "        imported = __import__(mod)\n"
         "        if not hasattr(imported, attr):\n"
         "            broken.append(mod)\n"
+        "        elif mod == 'certifi':\n"
+        "            # The module can import cleanly while cacert.pem is\n"
+        "            # missing/corrupt (brew Python upgrade, interrupted venv\n"
+        "            # rebuild) - every TLS call then fails (#29866).\n"
+        "            bundle = imported.where()\n"
+        "            if not os.path.isfile(bundle) or os.path.getsize(bundle) < 1024:\n"
+        "                broken.append(mod)\n"
         "    except Exception:\n"
         "        broken.append(mod)\n"
         "print('\\n'.join(broken))\n"

--- a/tests/hermes_cli/test_certifi_repair.py
+++ b/tests/hermes_cli/test_certifi_repair.py
@@ -1,0 +1,250 @@
+"""Regression tests for issue #29866.
+
+A brew Python upgrade (or an interrupted venv rebuild — see also the v0.19.0
+report in the same issue) can leave ``certifi`` importable while its bundled
+``cacert.pem`` is missing or a dangling symlink. Every TLS connection then
+fails with an opaque ``Could not find a suitable TLS CA certificate bundle``
+and the gateway is down on all platforms.
+
+Behavior contracts pinned here:
+
+1. The venv-repair import probes (early recovery + `hermes update`) must
+   classify certifi as BROKEN when the module imports but ``cacert.pem`` is
+   missing or corrupt — an attribute probe alone passes in that state.
+2. ``hermes doctor`` must fail the certificate check in that state, and
+   ``hermes doctor --fix`` must repair by force-reinstalling certifi and
+   re-verifying.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import hermes_cli._early_recovery as er
+
+
+def _fake_certifi(monkeypatch, bundle_path: Path):
+    """Install a fake certifi module whose where() points at bundle_path."""
+    fake = types.ModuleType("certifi")
+    fake.contents = lambda: ""  # satisfies the ('certifi', 'contents') probe
+    fake.where = lambda: str(bundle_path)
+    monkeypatch.setitem(sys.modules, "certifi", fake)
+    return fake
+
+
+# =========================================================================
+# 1. Import probes detect a missing/corrupt cacert.pem
+# =========================================================================
+
+
+class TestEarlyRecoveryCertifiBundleProbe:
+    def test_missing_bundle_flags_certifi_broken(self, monkeypatch, tmp_path):
+        _fake_certifi(monkeypatch, tmp_path / "nonexistent" / "cacert.pem")
+        broken = er._probe_broken_packages()
+        assert "certifi" in broken, (
+            "certifi imports but cacert.pem is missing — the probe must flag "
+            "it broken (#29866); the attribute check alone passes here"
+        )
+
+    def test_tiny_bundle_flags_certifi_broken(self, monkeypatch, tmp_path):
+        bundle = tmp_path / "cacert.pem"
+        bundle.write_text("truncated", encoding="utf-8")
+        _fake_certifi(monkeypatch, bundle)
+        broken = er._probe_broken_packages()
+        assert "certifi" in broken
+
+    def test_healthy_bundle_not_flagged(self, monkeypatch):
+        import certifi as real_certifi
+
+        # Real certifi with a real bundle: probe must NOT flag it.
+        monkeypatch.setitem(sys.modules, "certifi", real_certifi)
+        broken = er._probe_broken_packages()
+        assert "certifi" not in broken
+
+    def test_where_raising_flags_certifi_broken(self, monkeypatch):
+        fake = types.ModuleType("certifi")
+        fake.contents = lambda: ""
+
+        def _boom():
+            raise OSError("simulated broken installation")
+
+        fake.where = _boom
+        monkeypatch.setitem(sys.modules, "certifi", fake)
+        broken = er._probe_broken_packages()
+        assert "certifi" in broken
+
+
+class TestUpdateProbeScriptChecksBundle:
+    """The subprocess probe used by `hermes update`'s venv repair must apply
+    the same bundle-file check inside the target venv's interpreter."""
+
+    def _run_probe_script(self, monkeypatch, tmp_path, bundle_path):
+        """Extract the generated probe script and run it in-process against a
+        fake certifi that points at bundle_path."""
+        from hermes_cli import main as main_mod
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["script"] = cmd[-1]
+
+            class _R:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _R()
+
+        monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            main_mod, "_resolve_install_target_python", lambda *a, **k: sys.executable
+        )
+        main_mod._detect_broken_lazy_refresh_imports(["pip"])
+        script = captured["script"]
+
+        # Execute the probe script with a fake certifi installed.
+        _fake_certifi(monkeypatch, bundle_path)
+        printed = []
+        namespace = {"__builtins__": __builtins__}
+        import builtins as _b
+
+        real_print = _b.print
+        monkeypatch.setattr(
+            _b, "print", lambda *a, **k: printed.append(" ".join(map(str, a)))
+        )
+        try:
+            exec(script, namespace)
+        finally:
+            monkeypatch.setattr(_b, "print", real_print)
+        return "\n".join(printed)
+
+    def test_probe_script_reports_certifi_when_bundle_missing(
+        self, monkeypatch, tmp_path
+    ):
+        out = self._run_probe_script(
+            monkeypatch, tmp_path, tmp_path / "missing" / "cacert.pem"
+        )
+        assert "certifi" in out.splitlines()
+
+    def test_probe_script_quiet_when_bundle_healthy(self, monkeypatch, tmp_path):
+        import certifi as real_certifi
+
+        out = self._run_probe_script(
+            monkeypatch, tmp_path, Path(real_certifi.where())
+        )
+        assert "certifi" not in out.splitlines()
+
+
+# =========================================================================
+# 2. hermes doctor: detection and --fix repair
+# =========================================================================
+
+
+class TestDoctorCertificates:
+    def test_broken_bundle_fails_without_fix(self, monkeypatch, capsys, tmp_path):
+        from hermes_cli import doctor as doctor_mod
+
+        monkeypatch.setenv("SSL_CERT_FILE", str(tmp_path / "missing.pem"))
+        issues = []
+        doctor_mod.check_certificates(should_fix=False, issues=issues)
+        out = capsys.readouterr().out
+        assert "broken" in out.lower()
+        assert issues, "a broken bundle must be funneled into the action list"
+        assert any("doctor --fix" in i for i in issues)
+
+    def test_fix_reinstalls_certifi_and_reverifies(self, monkeypatch, capsys, tmp_path):
+        from hermes_cli import doctor as doctor_mod
+
+        # First verification fails, post-reinstall verification succeeds.
+        calls = {"verify": 0, "pip": []}
+
+        def fake_verify():
+            calls["verify"] += 1
+            if calls["verify"] == 1:
+                from agent.errors import SSLConfigurationError
+
+                raise SSLConfigurationError("certifi points to a missing CA bundle")
+
+        def fake_run(cmd, **kwargs):
+            calls["pip"].append(cmd)
+
+            class _R:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _R()
+
+        monkeypatch.setattr(
+            "agent.ssl_guard.verify_ca_bundle_with_fallback", fake_verify
+        )
+        monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+        issues = []
+        doctor_mod.check_certificates(should_fix=True, issues=issues)
+        out = capsys.readouterr().out
+
+        assert calls["pip"], "--fix must run a pip force-reinstall of certifi"
+        pip_cmd = calls["pip"][0]
+        assert "--force-reinstall" in pip_cmd and "certifi" in pip_cmd
+        assert calls["verify"] == 2, "must re-verify after the reinstall"
+        assert "repaired" in out.lower()
+        assert not issues
+
+    def test_fix_failure_surfaces_manual_command(self, monkeypatch, capsys):
+        from hermes_cli import doctor as doctor_mod
+
+        def fake_verify():
+            from agent.errors import SSLConfigurationError
+
+            raise SSLConfigurationError("certifi points to a missing CA bundle")
+
+        def fake_run(cmd, **kwargs):
+            class _R:
+                returncode = 1
+                stdout = ""
+                stderr = "simulated pip failure"
+
+            return _R()
+
+        monkeypatch.setattr(
+            "agent.ssl_guard.verify_ca_bundle_with_fallback", fake_verify
+        )
+        monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+        issues = []
+        doctor_mod.check_certificates(should_fix=True, issues=issues)
+        assert any("force-reinstall certifi" in i for i in issues)
+
+    def test_healthy_bundle_never_touches_pip(self, monkeypatch, capsys):
+        from hermes_cli import doctor as doctor_mod
+
+        def _fail_run(*a, **k):
+            raise AssertionError("healthy bundle must not trigger a reinstall")
+
+        monkeypatch.setattr(doctor_mod.subprocess, "run", _fail_run)
+        doctor_mod.check_certificates(should_fix=True, issues=[])
+        out = capsys.readouterr().out
+        assert "valid" in out.lower()
+
+
+# =========================================================================
+# 3. Startup error message stays actionable
+# =========================================================================
+
+
+class TestSslGuardRepairHint:
+    def test_missing_bundle_error_mentions_doctor_fix(self, monkeypatch, tmp_path):
+        import certifi
+
+        from agent.errors import SSLConfigurationError
+        from agent.ssl_guard import verify_ca_bundle
+
+        monkeypatch.setattr(certifi, "where", lambda: str(tmp_path / "gone.pem"))
+        with pytest.raises(SSLConfigurationError) as excinfo:
+            verify_ca_bundle()
+        message = str(excinfo.value)
+        assert "hermes doctor --fix" in message
+        assert "certifi" in message


### PR DESCRIPTION
## Summary
A brew/python upgrade that leaves certifi's cacert.pem missing no longer takes down every TLS platform with cryptic SSL errors — the existing venv self-heal path detects the missing bundle, repairs it, and startup prints a clear message.

## Changes
- Extends the existing venv-repair/doctor infra: certifi.where() existence check + reinstall path; clear startup error instead of raw SSLError

## Validation
New behavior-contract tests green.

Also addresses the v0.19.0 Linux report in-thread.

Fixes #29866


## Infographic

![certifi-repair](https://v3b.fal.media/files/b/0aa394db/4KdVKEQSOG4SQCN02O55v_Ni3UBF75.png)
