### PR TITLE
fix(acp): don't lose queued prompts when the drain echo hits a dead connection

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2193,11 +2193,24 @@ class HermesACPAgent(acp.Agent):
                 if not state.queued_prompts:
                     break
                 next_prompt = state.queued_prompts.pop(0)
+            # The echo is best-effort: the text was already popped from the
+            # queue, so a raise here (e.g. ConnectionResetError from a client
+            # that disconnected mid-turn) escaping prompt() would LOSE it —
+            # neither run nor re-queued. Echo failure must never prevent the
+            # queued turn from running.
             if conn:
-                await conn.session_update(
-                    session_id,
-                    acp.update_user_message_text(next_prompt),
-                )
+                try:
+                    await conn.session_update(
+                        session_id,
+                        acp.update_user_message_text(next_prompt),
+                    )
+                except Exception:
+                    logger.debug(
+                        "Queued-prompt drain echo failed for %s; running the "
+                        "queued turn anyway",
+                        session_id,
+                        exc_info=True,
+                    )
             await self.prompt(
                 prompt=[TextContentBlock(type="text", text=next_prompt)],
                 session_id=session_id,

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1778,11 +1778,24 @@ class HermesACPAgent(acp.Agent):
                 if not state.queued_prompts:
                     break
                 next_prompt = state.queued_prompts.pop(0)
+            # The echo is best-effort: the text was already popped from the
+            # queue, so a raise here (e.g. ConnectionResetError from a client
+            # that disconnected mid-turn) escaping prompt() would LOSE it —
+            # neither run nor re-queued. Echo failure must never prevent the
+            # queued turn from running.
             if conn:
-                await conn.session_update(
-                    session_id,
-                    acp.update_user_message_text(next_prompt),
-                )
+                try:
+                    await conn.session_update(
+                        session_id,
+                        acp.update_user_message_text(next_prompt),
+                    )
+                except Exception:
+                    logger.debug(
+                        "Queued-prompt drain echo failed for %s; running the "
+                        "queued turn anyway",
+                        session_id,
+                        exc_info=True,
+                    )
             await self.prompt(
                 prompt=[TextContentBlock(type="text", text=next_prompt)],
                 session_id=session_id,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -446,14 +446,41 @@ class TestPrompt:
 
         assert captured.get("child") == resp.session_id
 
+    @pytest.mark.asyncio
+    async def test_queued_prompt_survives_drain_echo_failure(self, agent):
+        """A failed drain echo must not prevent the queued turn from running."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        queued_text = "follow-up typed while the first turn was running"
 
+        calls = []
 
+        def _run(**kwargs):
+            calls.append(kwargs["user_message"])
+            if len(calls) == 1:
+                with state.runtime_lock:
+                    state.queued_prompts.append(queued_text)
+            return {"final_response": "ok", "messages": []}
 
+        state.agent.run_conversation = MagicMock(side_effect=_run)
 
+        mock_conn = MagicMock(spec=acp.Client)
 
+        async def _session_update(session_id, update):
+            if isinstance(update, UserMessageChunk):
+                raise ConnectionResetError("client went away")
 
+        mock_conn.session_update = AsyncMock(side_effect=_session_update)
+        agent._conn = mock_conn
 
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="kick off")],
+            session_id=new_resp.session_id,
+        )
 
+        assert len(calls) == 2, "queued text was LOST when the drain echo raised"
+        assert queued_text in calls[1]
+        assert state.queued_prompts == []
 
 
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1171,6 +1171,52 @@ class TestPrompt:
         assert state.agent.thinking_callback is None
 
     @pytest.mark.asyncio
+    async def test_queued_prompt_survives_drain_echo_failure(self, agent):
+        """A client disconnect during the post-turn drain's user-message echo
+        must not lose the queued text — the queued turn still runs.
+
+        The drain pops the queued prompt and THEN echoes it via
+        conn.session_update. If that echo raises (e.g. ConnectionResetError
+        from a client that went away mid-turn), the exception must not escape
+        before ``await self.prompt(...)`` runs the popped text: the message
+        would be neither run nor re-queued — permanently lost.
+        """
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        queued_text = "follow-up typed while the first turn was running"
+
+        calls = []
+
+        def _run(**kwargs):
+            calls.append(kwargs["user_message"])
+            if len(calls) == 1:
+                # A prompt arrives mid-turn: the busy path queues it.
+                with state.runtime_lock:
+                    state.queued_prompts.append(queued_text)
+            return {"final_response": "ok", "messages": []}
+
+        state.agent.run_conversation = MagicMock(side_effect=_run)
+
+        mock_conn = MagicMock(spec=acp.Client)
+
+        async def _session_update(session_id, update):
+            # The drain echo is the only UserMessageChunk this turn sends.
+            if isinstance(update, UserMessageChunk):
+                raise ConnectionResetError("client went away")
+
+        mock_conn.session_update = AsyncMock(side_effect=_session_update)
+        agent._conn = mock_conn
+
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="kick off")],
+            session_id=new_resp.session_id,
+        )
+
+        assert len(calls) == 2, "queued text was LOST when the drain echo raised"
+        assert queued_text in calls[1]
+        assert state.queued_prompts == []
+
+    @pytest.mark.asyncio
     async def test_prompt_updates_history(self, agent):
         """After a prompt, session history should be updated."""
         new_resp = await agent.new_session(cwd=".")


### PR DESCRIPTION
## What & why

The post-turn queued-prompt drain in `acp_adapter/server.py` can permanently lose a user's queued message when the client disconnects mid-drain:

```python
next_prompt = state.queued_prompts.pop(0)
if conn:
    await conn.session_update(              # <-- unguarded
        session_id,
        acp.update_user_message_text(next_prompt),
    )
await self.prompt(...)                      # <-- never reached
```

The drain **pops** the queued text and *then* awaits the user-message echo unguarded. If the client goes away at that instant, `session_update` raises (e.g. `ConnectionResetError`) and the exception escapes `prompt()` **after the pop**: the queued text is neither run nor re-queued — permanently lost. User-visible symptom: you type a message while a turn is running, see it acknowledged as "Queued for the next turn (1 queued)", and it silently evaporates.

The fix wraps the drain echo in `try/except Exception` with a debug log. The echo is cosmetic — the popped prompt is the payload — so a dying connection must never prevent `await self.prompt(...)` from running the popped text. The transcript persists server-side and replays on reattach, so a missed echo is harmless while a missed turn is data loss. No other `session_update` call sites are touched: this is the only echo site in the drain flow with the pop-then-lose shape.

## Reproduction sketch

1. Start a turn in an ACP session; while it runs, submit another prompt so it lands in `state.queued_prompts`.
2. Have the client connection die right as the first turn finishes (before the drain's user-message echo completes).
3. Without this fix, the echo raises out of `prompt()` after the pop — the queued prompt never runs and is gone from the queue.

The regression test reproduces this deterministically by exercising the real `prompt()` path with `run_conversation` mocked (first turn enqueues a prompt) and a mock conn whose `session_update` raises `ConnectionResetError` on exactly the drain's `UserMessageChunk` echo. On upstream/main before the fix it fails with the `ConnectionResetError` escaping and only one `run_conversation` call; with the fix it asserts the queued text runs as the second turn and the queue is drained.

## How to test

```bash
bash scripts/run_tests.sh tests/acp/test_server.py -q
# => 87 tests passed, 0 failed

bash scripts/run_tests.sh tests/acp/test_server.py -q -k test_queued_prompt_survives_drain_echo_failure
# RED on upstream/main without the server.py change (ConnectionResetError escapes prompt());
# GREEN with it.

python3 scripts/check-windows-footguns.py acp_adapter/server.py tests/acp/test_server.py
# => No Windows footguns found
```

## Platforms tested

Linux fully verified; Windows/macOS not manually tested (change is pure Python exception handling, no platform-specific I/O; footguns check clean).

## Related

- Related context: #62548 (found while working on background-completion notification delivery in the same drain area — independent; this PR does not fix that issue).
- Prior art: same fix shape running in a downstream fork — YallaPlay/hermes-agent@077e6728c8ecdcb03cf5d36317b5fa55b0895dd7.
