### PR TITLE
fix(mem0): check SDK import in is_available() instead of config only (#70979)

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -227,10 +227,19 @@ class Mem0MemoryProvider(MemoryProvider):
         cfg = _load_config()
         mode = cfg.get("mode", "platform")
         if mode == "oss":
-            return bool(cfg.get("oss", {}).get("vector_store"))
-        # Platform needs an api_key; self-hosted needs a host (api_key optional
-        # when the server runs with AUTH_DISABLED).
-        return bool(cfg.get("api_key") or cfg.get("host"))
+            config_ok = bool(cfg.get("oss", {}).get("vector_store"))
+        else:
+            # Platform needs an api_key; self-hosted needs a host (api_key optional
+            # when the server runs with AUTH_DISABLED).
+            config_ok = bool(cfg.get("api_key") or cfg.get("host"))
+        if not config_ok:
+            return False
+        # Verify the mem0 SDK is actually installed — config alone is not enough.
+        try:
+            import mem0  # noqa: F401
+            return True
+        except ImportError:
+            return False
 
     def save_config(self, values, hermes_home):
         """Write config to $HERMES_HOME/mem0.json."""

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -1,11 +1,21 @@
 """Tests for Mem0 v3 API — new tool names, paginated responses, update/delete tools."""
 
 import json
+import sys
 import time
+import types
+
 import pytest
 
 import plugins.memory.mem0 as mem0_plugin
 from plugins.memory.mem0 import Mem0MemoryProvider
+
+
+def _mock_mem0_sdk(monkeypatch):
+    """Stub the mem0 module in sys.modules so is_available()'s import check passes."""
+    mod = types.ModuleType("mem0")
+    mod.__version__ = "0.0.0"
+    monkeypatch.setitem(sys.modules, "mem0", mod)
 
 
 class FakeBackend:
@@ -422,6 +432,7 @@ class TestMem0ModeSwitch:
         assert provider.is_available() is False
 
     def test_is_available_oss_needs_vector(self, monkeypatch, tmp_path):
+        _mock_mem0_sdk(monkeypatch)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         config_path = tmp_path / "mem0.json"
         config_path.write_text('{"mode": "oss", "oss": {"vector_store": {"provider": "qdrant"}}}')
@@ -609,6 +620,7 @@ class TestSelfHostedConfig:
         assert mem0_plugin._load_config()["host"] == "http://localhost:8888"
 
     def test_is_available_true_with_host_only(self, monkeypatch):
+        _mock_mem0_sdk(monkeypatch)
         monkeypatch.delenv("MEM0_API_KEY", raising=False)
         monkeypatch.setenv("MEM0_MODE", "platform")
         monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")


### PR DESCRIPTION
## Summary

Fixes issue #70979 — `hermes memory status` reported mem0 as "available" even when the `mem0ai` SDK was not installed, because `is_available()` only checked configuration (api_key/host) without verifying the SDK could be imported.

## Changes

**`plugins/memory/mem0/__init__.py`** — `is_available()` now:
1. Checks config as before (api_key for platform, host for self-hosted, vector_store for OSS mode)
2. **New**: Tries `import mem0` — returns `False` on `ImportError` if the SDK is not installed

The import check runs only after config passes, so a missing SDK does not interfere with the "SDK not installed, need to configure" distinction.

**`tests/plugins/memory/test_mem0_v3.py`** — Added `_mock_mem0_sdk()` helper that stubs the `mem0` module in `sys.modules` so the two tests that assert `is_available() is True` continue to pass in environments without the actual SDK. The three tests that assert `is_available() is False` (config missing) do not reach the import check and need no mock.

## Verification

- All 55 tests in `test_mem0_v3.py` pass
- `hermes memory status` now correctly reports "dependency missing" when mem0ai is not installed