### PR TITLE
fix(auth): classify non-JWT tokens as InvalidCodeError instead of JWKS lookup failed (#70947)

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -615,6 +615,12 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             )
         except jwt.PyJWKClientError as exc:
             raise ProviderError(f"JWKS lookup failed: {exc}") from exc
+        except jwt.InvalidTokenError as exc:
+            # Non-JWT token (e.g. a session issued by a different provider)
+            # or otherwise malformed — this is not an IDP/JWKS reachability
+            # problem. verify_session() catches this and returns None so the
+            # next registered provider in the chain gets a clean turn.
+            raise InvalidCodeError(f"token is not a valid JWT: {exc}") from exc
         except Exception as exc:  # pragma: no cover - defensive
             raise ProviderError(f"JWKS lookup failed: {exc!r}") from exc
 

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -940,6 +940,17 @@ class TestVerifySession:
         with pytest.raises(ProviderError, match="JWKS"):
             provider.verify_session(access_token=token)
 
+    def test_non_jwt_token_returns_none(self, provider):
+        """Non-JWT token (e.g. from a different provider) returns None, not a ProviderError."""
+        # Make get_signing_key_from_jwt raise DecodeError (subclass of InvalidTokenError)
+        # as it would for a non-JWT token that can't even be parsed.
+        bad_client = MagicMock()
+        bad_client.get_signing_key_from_jwt.side_effect = jwt.DecodeError(
+            "Not enough segments"
+        )
+        provider._jwks_client = bad_client
+        assert provider.verify_session(access_token="not-a-valid-jwt-token") is None
+
 
 # ---------------------------------------------------------------------------
 # refresh_session + revoke_session


### PR DESCRIPTION
## Description

Fixes #70947 — when multiple dashboard-auth providers are registered, a non-JWT token (e.g. a basic-auth session token) tried against the self-hosted OIDC provider raises `DecodeError` from `get_signing_key_from_jwt()`, which was caught only by the generic `except Exception` clause and misclassified as `"JWKS lookup failed"`.

## Root cause

`plugins/dashboard_auth/self_hosted/__init__.py` — `_verify_id_token()`

The `get_signing_key_from_jwt()` call raises `jwt.DecodeError` (a subclass of `jwt.InvalidTokenError`) for non-JWT tokens. This was caught by the fallback `except Exception` and wrapped as `ProviderError("JWKS lookup failed")` — misleading, since the IDP/JWKS was never contacted.

## Fix

Added `except jwt.InvalidTokenError` before the generic `except Exception`, raising `InvalidCodeError` so `verify_session()` catches it and returns `None`, allowing the next registered provider in the chain to try verifying the token.

## Changes

- **`plugins/dashboard_auth/self_hosted/__init__.py`**: Added `except jwt.InvalidTokenError` handler in `_verify_id_token()` that raises `InvalidCodeError` for non-JWT tokens
- **`tests/plugins/dashboard_auth/test_self_hosted_provider.py`**: Added `test_non_jwt_token_returns_none` test verifying this behaviour

## Testing

All 84 tests in `test_self_hosted_provider.py` pass, including the new test.