### PR TITLE
fix(memory): report mem0 unavailable when SDK missing and lazy installs disabled

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2667,18 +2667,57 @@ def run_doctor(args):
     elif _active_memory_provider == "mem0":
         try:
             from plugins.memory.mem0 import _load_config as _load_mem0_config
+            from plugins.memory.mem0 import _lazy_installs_enabled as _mem0_lazy_ok
+            from plugins.memory.mem0 import _mem0_sdk_installed as _mem0_sdk_ok
             mem0_cfg = _load_mem0_config()
             mem0_key = mem0_cfg.get("api_key", "")
-            if mem0_key:
-                check_ok("Mem0 API key configured")
-                check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
+            mem0_host = mem0_cfg.get("host", "")
+            mem0_mode = mem0_cfg.get("mode", "platform")
+            # Mirror is_available(): OSS needs a vector store, self-hosted
+            # uses its HTTP endpoint directly, and platform needs an API key.
+            if mem0_mode == "oss":
+                config_ok = bool(mem0_cfg.get("oss", {}).get("vector_store"))
+                success_label = "Mem0 OSS vector store configured"
+                missing_label = "Mem0 OSS vector store not configured"
+                missing_hint = "run hermes memory setup to configure an OSS vector store"
+                missing_issue = "Mem0 is set to OSS mode but no vector store is configured"
+                sdk_required = True
+            elif mem0_host:
+                config_ok = True
+                success_label = "Mem0 self-hosted endpoint configured"
+                missing_label = "Mem0 self-hosted endpoint not configured"
+                missing_hint = "set MEM0_HOST in .env or run hermes memory setup"
+                missing_issue = "Mem0 is set to self-hosted mode but MEM0_HOST is missing"
+                sdk_required = False
             else:
+                config_ok = bool(mem0_key)
+                success_label = "Mem0 API key configured"
+                missing_label = "Mem0 API key not set"
+                missing_hint = "set MEM0_API_KEY in .env or run hermes memory setup"
+                missing_issue = "Mem0 is set as memory provider but API key is missing"
+                sdk_required = True
+            if not config_ok:
                 _fail_and_issue(
-                    "Mem0 API key not set",
-                    "(set MEM0_API_KEY in .env or run hermes memory setup)",
-                    "Mem0 is set as memory provider but API key is missing",
+                    missing_label,
+                    missing_hint,
+                    missing_issue,
                     issues,
                 )
+            elif sdk_required and not _mem0_lazy_ok() and not _mem0_sdk_ok():
+                # Config is present but the SDK is not installed and cannot
+                # be lazy-installed (security.allow_lazy_installs=false or
+                # sealed Docker venv). Same false-positive as #70979 in
+                # is_available() — the doctor must not claim "configured"
+                # when the provider can never initialize.
+                _fail_and_issue(
+                    "Mem0 SDK not installed",
+                    "pip install mem0ai",
+                    "Mem0 is configured but the mem0ai SDK is not installed and lazy installs are disabled",
+                    issues,
+                )
+            else:
+                check_ok(success_label)
+                check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
         except ImportError:
             _fail_and_issue(
                 "Mem0 plugin not loadable",

--- a/hermes_cli/doctor_state.py
+++ b/hermes_cli/doctor_state.py
@@ -324,13 +324,57 @@ def _memory_provider_honcho(issues: list) -> None:
 
 def _memory_provider_mem0(issues: list) -> None:
     from plugins.memory.mem0 import _load_config as _load_mem0_config
+    from plugins.memory.mem0 import _lazy_installs_enabled as _mem0_lazy_ok
+    from plugins.memory.mem0 import _mem0_sdk_installed as _mem0_sdk_ok
     mem0_cfg = _load_mem0_config()
-    if mem0_cfg.get("api_key", ""):
-        check_ok("Mem0 API key configured")
-        check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
+    mem0_key = mem0_cfg.get("api_key", "")
+    mem0_host = mem0_cfg.get("host", "")
+    mem0_mode = mem0_cfg.get("mode", "platform")
+    # Mirror is_available(): OSS needs a vector store, self-hosted
+    # uses its HTTP endpoint directly, and platform needs an API key.
+    if mem0_mode == "oss":
+        config_ok = bool(mem0_cfg.get("oss", {}).get("vector_store"))
+        success_label = "Mem0 OSS vector store configured"
+        missing_label = "Mem0 OSS vector store not configured"
+        missing_hint = "run hermes memory setup to configure an OSS vector store"
+        missing_issue = "Mem0 is set to OSS mode but no vector store is configured"
+        sdk_required = True
+    elif mem0_host:
+        config_ok = True
+        success_label = "Mem0 self-hosted endpoint configured"
+        missing_label = "Mem0 self-hosted endpoint not configured"
+        missing_hint = "set MEM0_HOST in .env or run hermes memory setup"
+        missing_issue = "Mem0 is set to self-hosted mode but MEM0_HOST is missing"
+        sdk_required = False
     else:
-        _fail_and_issue("Mem0 API key not set", "(set MEM0_API_KEY in .env or run hermes memory setup)",
-                        "Mem0 is set as memory provider but API key is missing", issues)
+        config_ok = bool(mem0_key)
+        success_label = "Mem0 API key configured"
+        missing_label = "Mem0 API key not set"
+        missing_hint = "set MEM0_API_KEY in .env or run hermes memory setup"
+        missing_issue = "Mem0 is set as memory provider but API key is missing"
+        sdk_required = True
+    if not config_ok:
+        _fail_and_issue(
+            missing_label,
+            missing_hint,
+            missing_issue,
+            issues,
+        )
+    elif sdk_required and not _mem0_lazy_ok() and not _mem0_sdk_ok():
+        # Config is present but the SDK is not installed and cannot
+        # be lazy-installed (security.allow_lazy_installs=false or
+        # sealed Docker venv). Same false-positive as #70979 in
+        # is_available() — the doctor must not claim "configured"
+        # when the provider can never initialize.
+        _fail_and_issue(
+            "Mem0 SDK not installed",
+            "pip install mem0ai",
+            "Mem0 is configured but the mem0ai SDK is not installed and lazy installs are disabled",
+            issues,
+        )
+    else:
+        check_ok(success_label)
+        check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
 
 
 # provider -> (checker, ImportError row, ImportError issue, label for "check failed")

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -62,6 +62,35 @@ _CLIENT_ERROR_TYPES = ("MemoryNotFoundError", "ValidationError")
 _DEFAULT_USER_ID = "hermes-user"
 
 
+def _lazy_installs_enabled() -> bool:
+    """Return True if the mem0 SDK can be installed on demand.
+
+    Wraps ``tools.lazy_deps._allow_lazy_installs`` so callers (is_available,
+    doctor) share one resolution path. Fails open (True) when the check
+    itself raises — refusing to install would lock users out of their own
+    backend, and the lazy-install gate already handles the sealed case.
+    """
+    try:
+        from tools.lazy_deps import _allow_lazy_installs
+        return _allow_lazy_installs()
+    except Exception:
+        return True
+
+
+def _mem0_sdk_installed() -> bool:
+    """Return True if the mem0 SDK is importable right now.
+
+    Uses ``importlib.util.find_spec`` (no side effects) instead of a bare
+    ``import mem0`` so we don't trigger import-time side effects or pollute
+    ``sys.modules`` from a status/doctor probe.
+    """
+    try:
+        import importlib.util
+        return importlib.util.find_spec("mem0") is not None
+    except Exception:
+        return False
+
+
 def _is_client_error(exc: Exception) -> bool:
     """True for user-caused errors (bad ID, not found) that should NOT trip circuit breaker."""
     etype = type(exc).__name__
@@ -228,10 +257,30 @@ class Mem0MemoryProvider(MemoryProvider):
         cfg = _load_config()
         mode = cfg.get("mode", "platform")
         if mode == "oss":
-            return bool(cfg.get("oss", {}).get("vector_store"))
-        # Platform needs an api_key; self-hosted needs a host (api_key optional
-        # when the server runs with AUTH_DISABLED).
-        return bool(cfg.get("api_key") or cfg.get("host"))
+            if not cfg.get("oss", {}).get("vector_store"):
+                return False
+        elif cfg.get("host"):
+            # SelfHostedBackend talks HTTP directly and does not import the
+            # mem0 SDK, so host-only setups remain available even when lazy
+            # installs are disabled and mem0ai is absent.
+            return True
+        elif not cfg.get("api_key"):
+            # Platform needs an API key when no self-hosted endpoint is set.
+            return False
+        # Platform and OSS are configured. The mem0 SDK is lazy-installed by
+        # _create_backend() via ensure("memory.mem0"). Gating availability
+        # on the SDK being importable here would be a chicken-and-egg trap
+        # — the provider must be activated (is_available() → True) for
+        # ensure() to run. So we only verify the SDK when the lazy-install
+        # escape hatch is closed (security.allow_lazy_installs=false): in
+        # that sealed state the SDK can never be installed at runtime, and
+        # reporting "available" would mislead `hermes memory status` and
+        # `hermes doctor` (#70979). The direct-HTTP self-hosted path above is
+        # intentionally exempt. See the same design note in
+        # supermemory.is_available().
+        if _lazy_installs_enabled():
+            return True
+        return _mem0_sdk_installed()
 
     def save_config(self, values, hermes_home):
         """Write config to $HERMES_HOME/mem0.json."""

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -60,6 +60,35 @@ def _truncate_for_sync(text: str, max_len: int = _SYNC_MSG_MAX_CHARS) -> str:
     return text[:max_len]
 
 
+def _lazy_installs_enabled() -> bool:
+    """Return True if the mem0 SDK can be installed on demand.
+
+    Wraps ``tools.lazy_deps._allow_lazy_installs`` so callers (is_available,
+    doctor) share one resolution path. Fails open (True) when the check
+    itself raises — refusing to install would lock users out of their own
+    backend, and the lazy-install gate already handles the sealed case.
+    """
+    try:
+        from tools.lazy_deps import _allow_lazy_installs
+        return _allow_lazy_installs()
+    except Exception:
+        return True
+
+
+def _mem0_sdk_installed() -> bool:
+    """Return True if the mem0 SDK is importable right now.
+
+    Uses ``importlib.util.find_spec`` (no side effects) instead of a bare
+    ``import mem0`` so we don't trigger import-time side effects or pollute
+    ``sys.modules`` from a status/doctor probe.
+    """
+    try:
+        import importlib.util
+        return importlib.util.find_spec("mem0") is not None
+    except Exception:
+        return False
+
+
 def _is_client_error(exc: Exception) -> bool:
     """True for user-caused errors (bad ID, not found) that should NOT trip circuit breaker."""
     err_str = str(exc).lower()
@@ -129,9 +158,32 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def is_available(self) -> bool:
         cfg = _load_config()
-        if cfg.get("mode", "platform") == "oss":
-            return bool(cfg.get("oss", {}).get("vector_store"))
-        return bool(cfg.get("api_key") or cfg.get("host"))  # platform needs a key; self-hosted a host (key optional with AUTH_DISABLED)
+        mode = cfg.get("mode", "platform")
+        if mode == "oss":
+            if not cfg.get("oss", {}).get("vector_store"):
+                return False
+        elif cfg.get("host"):
+            # SelfHostedBackend talks HTTP directly and does not import the
+            # mem0 SDK, so host-only setups remain available even when lazy
+            # installs are disabled and mem0ai is absent.
+            return True
+        elif not cfg.get("api_key"):
+            # Platform needs an API key when no self-hosted endpoint is set.
+            return False
+        # Platform and OSS are configured. The mem0 SDK is lazy-installed by
+        # _create_backend() via ensure("memory.mem0"). Gating availability
+        # on the SDK being importable here would be a chicken-and-egg trap
+        # — the provider must be activated (is_available() → True) for
+        # ensure() to run. So we only verify the SDK when the lazy-install
+        # escape hatch is closed (security.allow_lazy_installs=false): in
+        # that sealed state the SDK can never be installed at runtime, and
+        # reporting "available" would mislead `hermes memory status` and
+        # `hermes doctor` (#70979). The direct-HTTP self-hosted path above is
+        # intentionally exempt. See the same design note in
+        # supermemory.is_available().
+        if _lazy_installs_enabled():
+            return True
+        return _mem0_sdk_installed()
 
     def save_config(self, values, hermes_home):
         """Merge-write config to $HERMES_HOME/mem0.json."""

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -279,6 +279,77 @@ class TestDoctorMemoryProviderSection:
         assert "Memory Provider" in out
         assert "Built-in memory active" not in out
 
+    def test_mem0_sdk_missing_and_lazy_disabled_shows_fail(self, monkeypatch, tmp_path):
+        """When mem0 config is present but the SDK is not installed and lazy
+        installs are disabled, doctor must report the SDK failure — not
+        'API key configured' (#70979 sibling path in doctor.py)."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        # Stub the lazy-install check and SDK probe at the source module
+        # so doctor's imports of the helpers see the stubbed values.
+        import plugins.memory.mem0 as _mem0_mod
+        monkeypatch.setattr(_mem0_mod, "_lazy_installs_enabled", lambda: False)
+        monkeypatch.setattr(_mem0_mod, "_mem0_sdk_installed", lambda: False)
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+        assert "Mem0 SDK not installed" in out
+        assert "Mem0 API key configured" not in out
+
+    def test_mem0_sdk_missing_but_lazy_enabled_shows_ok(self, monkeypatch, tmp_path):
+        """When lazy installs are enabled, doctor should report config OK
+        even if the SDK is not yet installed — it will be installed on
+        demand. This is the chicken-and-egg guard."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        import plugins.memory.mem0 as _mem0_mod
+        monkeypatch.setattr(_mem0_mod, "_lazy_installs_enabled", lambda: True)
+        monkeypatch.setattr(_mem0_mod, "_mem0_sdk_installed", lambda: False)
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+        assert "Mem0 API key configured" in out
+        assert "Mem0 SDK not installed" not in out
+
+    def test_mem0_self_hosted_without_api_key_or_sdk_shows_ok(self, monkeypatch, tmp_path):
+        """Self-hosted Mem0 uses its HTTP endpoint without the mem0ai SDK."""
+        monkeypatch.delenv("MEM0_API_KEY", raising=False)
+        monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
+        import plugins.memory.mem0 as _mem0_mod
+        monkeypatch.setattr(_mem0_mod, "_lazy_installs_enabled", lambda: False)
+        monkeypatch.setattr(_mem0_mod, "_mem0_sdk_installed", lambda: False)
+
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+
+        assert "Mem0 self-hosted endpoint configured" in out
+        assert "Mem0 API key configured" not in out
+        assert "Mem0 SDK not installed" not in out
+
+    def test_mem0_oss_vector_store_shows_mode_specific_success(self, monkeypatch, tmp_path):
+        """A valid OSS setup must not be described as an API-key setup."""
+        home = self._make_hermes_home(tmp_path, provider="mem0")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "mem0.json").write_text(
+            '{"mode": "oss", "oss": {"vector_store": {"provider": "qdrant"}}}'
+        )
+        import plugins.memory.mem0 as _mem0_mod
+        monkeypatch.setattr(_mem0_mod, "_lazy_installs_enabled", lambda: True)
+        monkeypatch.setattr(_mem0_mod, "_mem0_sdk_installed", lambda: False)
+
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+
+        assert "Mem0 OSS vector store configured" in out
+        assert "Mem0 API key configured" not in out
+        assert "Mem0 SDK not installed" not in out
+
+    def test_mem0_oss_without_vector_store_shows_oss_remediation(self, monkeypatch, tmp_path):
+        """Missing OSS config should never point users at MEM0_API_KEY."""
+        home = self._make_hermes_home(tmp_path, provider="mem0")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "mem0.json").write_text('{"mode": "oss", "oss": {}}')
+
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+
+        assert "Mem0 OSS vector store not configured" in out
+        assert "configure an OSS vector store" in out
+        assert "MEM0_API_KEY" not in out
+
 
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):
     helper = TestDoctorMemoryProviderSection()

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -387,6 +387,77 @@ class TestDoctorMemoryProviderSection:
         assert "USER.md exists" not in out
         assert ("Built-in memory files disabled by config" in out) is not memory_enabled
 
+    def test_mem0_sdk_missing_and_lazy_disabled_shows_fail(self, monkeypatch, tmp_path):
+        """When mem0 config is present but the SDK is not installed and lazy
+        installs are disabled, doctor must report the SDK failure — not
+        'API key configured' (#70979 sibling path in doctor.py)."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        # Stub the lazy-install check and SDK probe at the source module
+        # so doctor's imports of the helpers see the stubbed values.
+        import plugins.memory.mem0 as _mem0_mod
+        monkeypatch.setattr(_mem0_mod, "_lazy_installs_enabled", lambda: False)
+        monkeypatch.setattr(_mem0_mod, "_mem0_sdk_installed", lambda: False)
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+        assert "Mem0 SDK not installed" in out
+        assert "Mem0 API key configured" not in out
+
+    def test_mem0_sdk_missing_but_lazy_enabled_shows_ok(self, monkeypatch, tmp_path):
+        """When lazy installs are enabled, doctor should report config OK
+        even if the SDK is not yet installed — it will be installed on
+        demand. This is the chicken-and-egg guard."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        import plugins.memory.mem0 as _mem0_mod
+        monkeypatch.setattr(_mem0_mod, "_lazy_installs_enabled", lambda: True)
+        monkeypatch.setattr(_mem0_mod, "_mem0_sdk_installed", lambda: False)
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+        assert "Mem0 API key configured" in out
+        assert "Mem0 SDK not installed" not in out
+
+    def test_mem0_self_hosted_without_api_key_or_sdk_shows_ok(self, monkeypatch, tmp_path):
+        """Self-hosted Mem0 uses its HTTP endpoint without the mem0ai SDK."""
+        monkeypatch.delenv("MEM0_API_KEY", raising=False)
+        monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
+        import plugins.memory.mem0 as _mem0_mod
+        monkeypatch.setattr(_mem0_mod, "_lazy_installs_enabled", lambda: False)
+        monkeypatch.setattr(_mem0_mod, "_mem0_sdk_installed", lambda: False)
+
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+
+        assert "Mem0 self-hosted endpoint configured" in out
+        assert "Mem0 API key configured" not in out
+        assert "Mem0 SDK not installed" not in out
+
+    def test_mem0_oss_vector_store_shows_mode_specific_success(self, monkeypatch, tmp_path):
+        """A valid OSS setup must not be described as an API-key setup."""
+        home = self._make_hermes_home(tmp_path, provider="mem0")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "mem0.json").write_text(
+            '{"mode": "oss", "oss": {"vector_store": {"provider": "qdrant"}}}'
+        )
+        import plugins.memory.mem0 as _mem0_mod
+        monkeypatch.setattr(_mem0_mod, "_lazy_installs_enabled", lambda: True)
+        monkeypatch.setattr(_mem0_mod, "_mem0_sdk_installed", lambda: False)
+
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+
+        assert "Mem0 OSS vector store configured" in out
+        assert "Mem0 API key configured" not in out
+        assert "Mem0 SDK not installed" not in out
+
+    def test_mem0_oss_without_vector_store_shows_oss_remediation(self, monkeypatch, tmp_path):
+        """Missing OSS config should never point users at MEM0_API_KEY."""
+        home = self._make_hermes_home(tmp_path, provider="mem0")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "mem0.json").write_text('{"mode": "oss", "oss": {}}')
+
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+
+        assert "Mem0 OSS vector store not configured" in out
+        assert "configure an OSS vector store" in out
+        assert "MEM0_API_KEY" not in out
+
 
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):
     helper = TestDoctorMemoryProviderSection()

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -9,6 +9,37 @@ import plugins.memory.mem0 as mem0_plugin
 from plugins.memory.mem0 import Mem0MemoryProvider
 
 
+# ---------------------------------------------------------------------------
+# Test helpers for the lazy-install / SDK-availability matrix (#70979)
+# ---------------------------------------------------------------------------
+
+def _stub_sdk_absent(monkeypatch):
+    """Make find_spec("mem0") return None — simulates SDK not installed."""
+    import importlib.util
+    real = importlib.util.find_spec
+    monkeypatch.setattr(
+        "importlib.util.find_spec",
+        lambda name: None if name == "mem0" else real(name),
+    )
+
+
+def _stub_sdk_present(monkeypatch):
+    """Make find_spec("mem0") return a non-None spec — simulates SDK installed."""
+    from unittest.mock import MagicMock
+    monkeypatch.setattr(
+        "importlib.util.find_spec",
+        lambda name: MagicMock() if name == "mem0" else None,
+    )
+
+
+def _stub_lazy_enabled(monkeypatch):
+    monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: True)
+
+
+def _stub_lazy_disabled(monkeypatch):
+    monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: False)
+
+
 class FakeBackend:
     """Fake Mem0Backend for provider-level tests."""
 
@@ -287,6 +318,74 @@ class TestMem0ModeSwitch:
         provider = Mem0MemoryProvider()
         assert provider.is_available() is False
 
+    def test_is_available_false_when_sdk_missing_and_lazy_disabled(self, monkeypatch, tmp_path):
+        """When lazy installs are disabled and the mem0 SDK is not installed,
+        is_available() must return False — otherwise `hermes memory status`
+        falsely reports "available" for a provider that can never initialize
+        (#70979)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        _stub_sdk_absent(monkeypatch)
+        _stub_lazy_disabled(monkeypatch)
+        assert Mem0MemoryProvider().is_available() is False
+
+    def test_is_available_false_oss_mode_when_sdk_missing_and_lazy_disabled(self, monkeypatch, tmp_path):
+        """OSS mode with lazy installs disabled and SDK missing → False.
+        Covers the OSS branch of the config check + SDK gate."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = tmp_path / "mem0.json"
+        config_path.write_text('{"mode": "oss", "oss": {"vector_store": {"provider": "qdrant"}}}')
+        _stub_sdk_absent(monkeypatch)
+        _stub_lazy_disabled(monkeypatch)
+        assert Mem0MemoryProvider().is_available() is False
+
+    def test_is_available_true_self_hosted_when_sdk_missing_and_lazy_disabled(self, monkeypatch, tmp_path):
+        """The direct-HTTP self-hosted backend does not require mem0ai."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("MEM0_API_KEY", raising=False)
+        monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
+        _stub_sdk_absent(monkeypatch)
+        _stub_lazy_disabled(monkeypatch)
+        assert Mem0MemoryProvider().is_available() is True
+
+    def test_is_available_true_when_sdk_present_and_lazy_disabled(self, monkeypatch, tmp_path):
+        """Even with lazy installs disabled, if the SDK IS installed the
+        provider is genuinely available."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        _stub_sdk_present(monkeypatch)
+        _stub_lazy_disabled(monkeypatch)
+        assert Mem0MemoryProvider().is_available() is True
+
+    def test_is_available_true_when_lazy_enabled_even_if_sdk_missing(self, monkeypatch, tmp_path):
+        """When lazy installs are enabled (default), is_available() must
+        return True as long as config is present — the SDK will be
+        installed on demand by _create_backend(). Gating on find_spec here
+        would be a chicken-and-egg trap (provider must be activated for
+        ensure() to run)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        _stub_sdk_absent(monkeypatch)
+        _stub_lazy_enabled(monkeypatch)
+        assert Mem0MemoryProvider().is_available() is True
+
+    def test_is_available_fails_open_if_lazy_check_raises(self, monkeypatch, tmp_path):
+        """If _allow_lazy_installs() itself raises (e.g. config unreadable),
+        is_available() must fail open (True) — refusing would lock users
+        out of their own backend. The lazy-install gate handles the sealed
+        case; a probe error should not be stricter than the gate."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        _stub_sdk_absent(monkeypatch)
+
+        def _boom():
+            raise RuntimeError("config unreadable")
+        monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", _boom)
+        assert Mem0MemoryProvider().is_available() is True
 
 class TestMem0UserIdResolution:
     """user_id resolution: configured override > gateway-native id > placeholder.
@@ -407,5 +506,3 @@ class TestSelfHostedConfig:
     def test_load_config_reads_mem0_host_env(self, monkeypatch):
         monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
         assert mem0_plugin._load_config()["host"] == "http://localhost:8888"
-
-

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -9,6 +9,37 @@ import plugins.memory.mem0 as mem0_plugin
 from plugins.memory.mem0 import Mem0MemoryProvider
 
 
+# ---------------------------------------------------------------------------
+# Test helpers for the lazy-install / SDK-availability matrix (#70979)
+# ---------------------------------------------------------------------------
+
+def _stub_sdk_absent(monkeypatch):
+    """Make find_spec("mem0") return None — simulates SDK not installed."""
+    import importlib.util
+    real = importlib.util.find_spec
+    monkeypatch.setattr(
+        "importlib.util.find_spec",
+        lambda name: None if name == "mem0" else real(name),
+    )
+
+
+def _stub_sdk_present(monkeypatch):
+    """Make find_spec("mem0") return a non-None spec — simulates SDK installed."""
+    from unittest.mock import MagicMock
+    monkeypatch.setattr(
+        "importlib.util.find_spec",
+        lambda name: MagicMock() if name == "mem0" else None,
+    )
+
+
+def _stub_lazy_enabled(monkeypatch):
+    monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: True)
+
+
+def _stub_lazy_disabled(monkeypatch):
+    monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: False)
+
+
 class FakeBackend:
     """Fake Mem0Backend for provider-level tests."""
 
@@ -333,6 +364,74 @@ class TestMem0ModeSwitch:
         provider = Mem0MemoryProvider()
         assert provider.is_available() is False
 
+    def test_is_available_false_when_sdk_missing_and_lazy_disabled(self, monkeypatch, tmp_path):
+        """When lazy installs are disabled and the mem0 SDK is not installed,
+        is_available() must return False — otherwise `hermes memory status`
+        falsely reports "available" for a provider that can never initialize
+        (#70979)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        _stub_sdk_absent(monkeypatch)
+        _stub_lazy_disabled(monkeypatch)
+        assert Mem0MemoryProvider().is_available() is False
+
+    def test_is_available_false_oss_mode_when_sdk_missing_and_lazy_disabled(self, monkeypatch, tmp_path):
+        """OSS mode with lazy installs disabled and SDK missing → False.
+        Covers the OSS branch of the config check + SDK gate."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = tmp_path / "mem0.json"
+        config_path.write_text('{"mode": "oss", "oss": {"vector_store": {"provider": "qdrant"}}}')
+        _stub_sdk_absent(monkeypatch)
+        _stub_lazy_disabled(monkeypatch)
+        assert Mem0MemoryProvider().is_available() is False
+
+    def test_is_available_true_self_hosted_when_sdk_missing_and_lazy_disabled(self, monkeypatch, tmp_path):
+        """The direct-HTTP self-hosted backend does not require mem0ai."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("MEM0_API_KEY", raising=False)
+        monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
+        _stub_sdk_absent(monkeypatch)
+        _stub_lazy_disabled(monkeypatch)
+        assert Mem0MemoryProvider().is_available() is True
+
+    def test_is_available_true_when_sdk_present_and_lazy_disabled(self, monkeypatch, tmp_path):
+        """Even with lazy installs disabled, if the SDK IS installed the
+        provider is genuinely available."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        _stub_sdk_present(monkeypatch)
+        _stub_lazy_disabled(monkeypatch)
+        assert Mem0MemoryProvider().is_available() is True
+
+    def test_is_available_true_when_lazy_enabled_even_if_sdk_missing(self, monkeypatch, tmp_path):
+        """When lazy installs are enabled (default), is_available() must
+        return True as long as config is present — the SDK will be
+        installed on demand by _create_backend(). Gating on find_spec here
+        would be a chicken-and-egg trap (provider must be activated for
+        ensure() to run)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        _stub_sdk_absent(monkeypatch)
+        _stub_lazy_enabled(monkeypatch)
+        assert Mem0MemoryProvider().is_available() is True
+
+    def test_is_available_fails_open_if_lazy_check_raises(self, monkeypatch, tmp_path):
+        """If _allow_lazy_installs() itself raises (e.g. config unreadable),
+        is_available() must fail open (True) — refusing would lock users
+        out of their own backend. The lazy-install gate handles the sealed
+        case; a probe error should not be stricter than the gate."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        _stub_sdk_absent(monkeypatch)
+
+        def _boom():
+            raise RuntimeError("config unreadable")
+        monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", _boom)
+        assert Mem0MemoryProvider().is_available() is True
 
 class TestMem0UserIdResolution:
     """user_id resolution: configured override > gateway-native id > placeholder.
@@ -453,5 +552,3 @@ class TestSelfHostedConfig:
     def test_load_config_reads_mem0_host_env(self, monkeypatch):
         monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
         assert mem0_plugin._load_config()["host"] == "http://localhost:8888"
-
-


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive in Mem0 availability checks when Platform or OSS mode is configured, the `mem0ai` SDK is absent, and runtime installation is disabled. The lazy-install activation path remains unchanged when installs are allowed, while self-hosted HTTP mode correctly remains available without the SDK.

## Related Issue

Fixes #70979

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/__init__.py` — added `_lazy_installs_enabled()` and `_mem0_sdk_installed()` helpers; `is_available()` now checks SDK importability only when lazy installs are disabled (sealed Docker venv / `security.allow_lazy_installs=false`). Self-hosted HTTP mode is exempt (no SDK needed).
- `hermes_cli/doctor_state.py` — `_memory_provider_mem0` now reports mode-specific status (Platform, OSS, self-hosted) and flags SDK-missing+lazy-disabled as a failure instead of "configured".
- `tests/hermes_cli/test_doctor.py` — regression tests for SDK-missing+lazy-disabled, SDK-missing+lazy-enabled, and self-hosted-no-SDK paths.
- `tests/plugins/memory/test_mem0_v3.py` — regression tests for `is_available()` across all mode/SDK/lazy combinations.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_doctor.py tests/plugins/memory/test_mem0_v3.py` — all pass.
2. Full project checker passes.
3. Manual: with `MEM0_API_KEY` set, `security.allow_lazy_installs: false`, and `mem0ai` uninstalled — `hermes memory status` reports unavailable; `hermes doctor` shows "Mem0 SDK not installed".

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing
- [x] No new core tools or env vars introduced
- [x] Prompt caching and role alternation preserved