### PR TITLE
fix(desktop): prevent voice playback from auto-starting next sentence after stop (#70955)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -10,6 +10,7 @@ import {
   stopVoicePlayback
 } from '@/lib/voice-playback'
 import { notify, notifyError } from '@/store/notifications'
+import { $voicePlayback } from '@/store/voice-playback'
 
 import { useMicRecorder } from './use-mic-recorder'
 
@@ -54,6 +55,7 @@ export function useVoiceConversation({
   const speechSessionRef = useRef<null | SpeechStreamSession>(null)
   const stopBargeMonitorRef = useRef<(() => void) | null>(null)
   const bargeCapturePendingRef = useRef(false)
+  const speechStartSequenceRef = useRef(0)
   const enabledRef = useRef(enabled)
   const mutedRef = useRef(muted)
   const busyRef = useRef(busy)
@@ -211,7 +213,16 @@ export function useVoiceConversation({
 
       dropSpeechSession()
 
-      if (enabledRef.current) {
+      // If stopVoicePlayback() was called externally (Stop button, end), the
+      // voice-playback sequence has advanced past what we captured at speech
+      // start — don't auto-start the next sentence, the user chose to stop.
+      const stoppedByUser =
+        speechStartSequenceRef.current > 0 &&
+        $voicePlayback.get().sequence > speechStartSequenceRef.current
+
+      speechStartSequenceRef.current = 0
+
+      if (enabledRef.current && !stoppedByUser) {
         pendingStartRef.current = true
       }
 
@@ -341,6 +352,8 @@ export function useVoiceConversation({
           barged = true
         })
 
+        speechStartSequenceRef.current = $voicePlayback.get().sequence
+
         void playSpeechText(response.text, { source: 'voice-conversation' })
           .catch(error => notifyError(error, voiceCopy.playbackFailed))
           .finally(() => {
@@ -365,6 +378,7 @@ export function useVoiceConversation({
     (responseId: string) => {
       responseIdRef.current = responseId
       spokenSourceLengthRef.current = 0
+      speechStartSequenceRef.current = $voicePlayback.get().sequence
       setStatus('speaking')
 
       let barged = false


### PR DESCRIPTION
## Summary
Fixes #70955 — clicking Stop on the voice playback waveform didn't truly stop. The audio paused, but `settleAfterSpeech` unconditionally set `pendingStartRef.current = true`, causing the effect loop to immediately auto-start listening for the next sentence.

## Root cause
`apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts` — `settleAfterSpeech` did not check whether playback was externally stopped (via Stop button or `end()`). After `stopVoicePlayback()` resolved the speech promise, the finally/after-speech code always started listening again.

## Fix
Added `speechStartSequenceRef` that captures `$voicePlayback.get().sequence` at speech start. In `settleAfterSpeech`, compares the current sequence — if it advanced (meaning `stopVoicePlayback()` was called externally), we know the user actively stopped and skip the auto-start.

### Changes
- **use-voice-conversation.ts**: Import `$voicePlayback`, add `speechStartSequenceRef`, capture sequence in `openLiveSpeech` and `awaitFallbackSpeech`, check it in `settleAfterSpeech`.

## Testing
1. Start voice conversation (long assistant reply)
2. Click Stop on the voice playback waveform
3. ✅ Playback stops, no auto-start of next sentence
4. Barge-in (talking over assistant) still works as before — `barged=true` path unaffected
5. Natural completion still auto-starts listening for next turn