### PR TITLE
fix(cli): align branded box headers

### DIFF
--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -773,6 +773,7 @@ class AgentImporter:
 
 def import_agent_command(args) -> None:
     """Handle ``hermes import-agent`` (invoked from hermes_cli.main)."""
+    from hermes_cli.cli_output import format_box
     from hermes_cli.config import get_config_path, load_config, save_config
     from hermes_constants import get_hermes_home
     from hermes_cli.setup import (
@@ -809,9 +810,8 @@ def import_agent_command(args) -> None:
     source_dir = Path(explicit_source) if explicit_source else default_source_dir(agent)
 
     print()
-    print(color("┌─────────────────────────────────────────────────────────┐", Colors.MAGENTA))
-    print(color("│          ⚕ Hermes — Import From Another Agent          │", Colors.MAGENTA))
-    print(color("└─────────────────────────────────────────────────────────┘", Colors.MAGENTA))
+    for line in format_box([("⚕ Hermes — Import From Another Agent", 10)]):
+        print(color(line, Colors.MAGENTA))
 
     if not source_dir.is_dir():
         print()

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+from hermes_cli.cli_output import format_box
 from hermes_cli.config import get_hermes_home, get_config_path, load_config, save_config
 from hermes_constants import get_optional_skills_dir
 from hermes_cli.setup import (
@@ -340,24 +341,8 @@ def _cmd_migrate(args):
     # importing API keys that the user may not have intended to copy.
 
     print()
-    print(
-        color(
-            "┌─────────────────────────────────────────────────────────┐",
-            Colors.MAGENTA,
-        )
-    )
-    print(
-        color(
-            "│          ⚕ Hermes — OpenClaw Migration                 │",
-            Colors.MAGENTA,
-        )
-    )
-    print(
-        color(
-            "└─────────────────────────────────────────────────────────┘",
-            Colors.MAGENTA,
-        )
-    )
+    for line in format_box([("⚕ Hermes — OpenClaw Migration", 10)]):
+        print(color(line, Colors.MAGENTA))
 
     # Check source directory
     if not source_dir.is_dir():
@@ -566,24 +551,8 @@ def _cmd_cleanup(args):
     explicit_source = getattr(args, "source", None)
 
     print()
-    print(
-        color(
-            "┌─────────────────────────────────────────────────────────┐",
-            Colors.MAGENTA,
-        )
-    )
-    print(
-        color(
-            "│          ⚕ Hermes — OpenClaw Cleanup                   │",
-            Colors.MAGENTA,
-        )
-    )
-    print(
-        color(
-            "└─────────────────────────────────────────────────────────┘",
-            Colors.MAGENTA,
-        )
-    )
+    for line in format_box([("⚕ Hermes — OpenClaw Cleanup", 10)]):
+        print(color(line, Colors.MAGENTA))
 
     # Find OpenClaw directories
     if explicit_source:

--- a/hermes_cli/cli_output.py
+++ b/hermes_cli/cli_output.py
@@ -5,8 +5,50 @@ functions previously duplicated across setup.py, tools_config.py,
 mcp_config.py, and memory_setup.py.
 """
 
+from collections.abc import Collection, Sequence
+
+from wcwidth import wcswidth
+
 from hermes_cli.colors import Colors, color
 from hermes_cli.secret_prompt import masked_secret_prompt
+
+
+STANDARD_BOX_WIDTH = 59
+
+
+# ─── Box Formatting ──────────────────────────────────────────────────────────
+
+
+def format_box(
+    rows: Sequence[tuple[str, int]],
+    *,
+    divider_after: Collection[int] = (),
+    width: int = STANDARD_BOX_WIDTH,
+) -> tuple[str, ...]:
+    """Return a complete box whose rows all have the requested cell width.
+
+    Each row is a ``(content, left_padding)`` pair. ``divider_after`` contains
+    zero-based row indexes after which a horizontal divider should be added.
+    """
+    if width < 2:
+        raise ValueError("box width must leave room for both borders")
+
+    inner_width = width - 2
+    lines = [f"┌{'─' * inner_width}┐"]
+    for index, (content, left_padding) in enumerate(rows):
+        content_width = wcswidth(content)
+        if content_width < 0:
+            raise ValueError("box content contains a non-printable character")
+
+        right_padding = inner_width - left_padding - content_width
+        if left_padding < 0 or right_padding < 0:
+            raise ValueError("box content does not fit within the requested width")
+
+        lines.append(f"│{' ' * left_padding}{content}{' ' * right_padding}│")
+        if index in divider_after:
+            lines.append(f"├{'─' * inner_width}┤")
+    lines.append(f"└{'─' * inner_width}┘")
+    return tuple(lines)
 
 
 # ─── Print Helpers ────────────────────────────────────────────────────────────

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple, Set
 
+from hermes_cli.cli_output import format_box
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.secret_prompt import masked_secret_prompt
 
@@ -4203,9 +4204,8 @@ def show_config():
     config = load_config()
 
     print()
-    print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
-    print(color("│              ⚕ Hermes Configuration                    │", Colors.CYAN))
-    print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
+    for line in format_box([("⚕ Hermes Configuration", 14)]):
+        print(color(line, Colors.CYAN))
 
     # Managed scope: surface that some settings are administrator-pinned so the
     # user understands why their config.yaml value may not be the effective one.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -61,6 +61,7 @@ from hermes_cli.setup import (
     prompt_choice,
     prompt_yes_no,
 )
+from hermes_cli.cli_output import format_box
 from hermes_cli.colors import Colors, color
 
 logger = logging.getLogger(__name__)
@@ -4890,12 +4891,15 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
 
     from gateway.run import start_gateway
 
-    print("┌─────────────────────────────────────────────────────────┐")
-    print("│           ⚕ Hermes Gateway Starting...                 │")
-    print("├─────────────────────────────────────────────────────────┤")
-    print("│  Messaging platforms + cron scheduler                    │")
-    print("│  Press Ctrl+C to stop                                   │")
-    print("└─────────────────────────────────────────────────────────┘")
+    for line in format_box(
+        [
+            ("⚕ Hermes Gateway Starting...", 11),
+            ("Messaging platforms + cron scheduler", 2),
+            ("Press Ctrl+C to stop", 2),
+        ],
+        divider_after={0},
+    ):
+        print(line)
     print()
 
     # Exit with code 1 if gateway fails to connect any platform,
@@ -6266,40 +6270,15 @@ def gateway_setup():
         return
 
     print()
-    print(
-        color(
-            "┌─────────────────────────────────────────────────────────┐",
-            Colors.MAGENTA,
-        )
-    )
-    print(
-        color(
-            "│             ⚕ Gateway Setup                            │", Colors.MAGENTA
-        )
-    )
-    print(
-        color(
-            "├─────────────────────────────────────────────────────────┤",
-            Colors.MAGENTA,
-        )
-    )
-    print(
-        color(
-            "│  Configure messaging platforms and the gateway service. │",
-            Colors.MAGENTA,
-        )
-    )
-    print(
-        color(
-            "│  Press Ctrl+C at any time to exit.                     │", Colors.MAGENTA
-        )
-    )
-    print(
-        color(
-            "└─────────────────────────────────────────────────────────┘",
-            Colors.MAGENTA,
-        )
-    )
+    for line in format_box(
+        [
+            ("⚕ Gateway Setup", 13),
+            ("Configure messaging platforms and the gateway service.", 2),
+            ("Press Ctrl+C at any time to exit.", 2),
+        ],
+        divider_after={0},
+    ):
+        print(color(line, Colors.MAGENTA))
 
     # ── Gateway service status ──
     print()

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -161,6 +161,7 @@ def print_header(title: str):
 
 
 from hermes_cli.cli_output import (  # noqa: E402
+    format_box,
     print_error,
     print_info,
     print_success,
@@ -2844,19 +2845,8 @@ def _run_portal_one_shot(config: dict) -> None:
     from hermes_cli.config import load_config
 
     print()
-    print(
-        color(
-            "┌─────────────────────────────────────────────────────────┐",
-            Colors.MAGENTA,
-        )
-    )
-    print(color("│     ⚕ Hermes Setup — Nous Portal (one-shot)             │", Colors.MAGENTA))
-    print(
-        color(
-            "└─────────────────────────────────────────────────────────┘",
-            Colors.MAGENTA,
-        )
-    )
+    for line in format_box([("⚕ Hermes Setup — Nous Portal (one-shot)", 5)]):
+        print(color(line, Colors.MAGENTA))
     print()
     print_info("  One subscription, 300+ models, plus the Tool Gateway:")
     print_info("    web search, image generation, TTS, browser automation")
@@ -2975,19 +2965,8 @@ def run_setup_wizard(args):
         for key, label, func in SETUP_SECTIONS:
             if key == section:
                 print()
-                print(
-                    color(
-                        "┌─────────────────────────────────────────────────────────┐",
-                        Colors.MAGENTA,
-                    )
-                )
-                print(color(f"│     ⚕ Hermes Setup — {label:<34s} │", Colors.MAGENTA))
-                print(
-                    color(
-                        "└─────────────────────────────────────────────────────────┘",
-                        Colors.MAGENTA,
-                    )
-                )
+                for line in format_box([(f"⚕ Hermes Setup — {label}", 5)]):
+                    print(color(line, Colors.MAGENTA))
                 func(config)
                 save_config(config)
                 print()
@@ -3009,39 +2988,15 @@ def run_setup_wizard(args):
     )
 
     print()
-    print(
-        color(
-            "┌─────────────────────────────────────────────────────────┐",
-            Colors.MAGENTA,
-        )
-    )
-    print(
-        color(
-            "│             ⚕ Hermes Agent Setup Wizard                │", Colors.MAGENTA
-        )
-    )
-    print(
-        color(
-            "├─────────────────────────────────────────────────────────┤",
-            Colors.MAGENTA,
-        )
-    )
-    print(
-        color(
-            "│  Let's configure your Hermes Agent installation.       │", Colors.MAGENTA
-        )
-    )
-    print(
-        color(
-            "│  Press Ctrl+C at any time to exit.                     │", Colors.MAGENTA
-        )
-    )
-    print(
-        color(
-            "└─────────────────────────────────────────────────────────┘",
-            Colors.MAGENTA,
-        )
-    )
+    for line in format_box(
+        [
+            ("⚕ Hermes Agent Setup Wizard", 13),
+            ("Let's configure your Hermes Agent installation.", 2),
+            ("Press Ctrl+C at any time to exit.", 2),
+        ],
+        divider_after={0},
+    ):
+        print(color(line, Colors.MAGENTA))
 
     migration_ran = False
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -14,6 +14,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
 from hermes_cli.auth import AuthError, resolve_provider
+from hermes_cli.cli_output import format_box
 from hermes_cli.colors import Colors, color
 from hermes_cli.config import get_env_path, get_env_value, get_hermes_home, load_config
 from hermes_cli.models import provider_label
@@ -110,9 +111,8 @@ def show_status(args):
     deep = getattr(args, 'deep', False)
 
     print()
-    print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
-    print(color("│                 ⚕ Hermes Agent Status                  │", Colors.CYAN))
-    print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
+    for line in format_box([("⚕ Hermes Agent Status", 17)]):
+        print(color(line, Colors.CYAN))
 
     # =========================================================================
     # Environment

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from hermes_constants import get_hermes_home
 
+from hermes_cli.cli_output import format_box
 from hermes_cli.colors import Colors, color
 
 def log_info(msg: str):
@@ -513,9 +514,8 @@ def run_gui_uninstall(args):
     skip_confirm = bool(getattr(args, "yes", False))
 
     print()
-    print(color("┌─────────────────────────────────────────────────────────┐", Colors.MAGENTA, Colors.BOLD))
-    print(color("│         ⚕ Hermes Chat GUI Uninstaller                  │", Colors.MAGENTA, Colors.BOLD))
-    print(color("└─────────────────────────────────────────────────────────┘", Colors.MAGENTA, Colors.BOLD))
+    for line in format_box([("⚕ Hermes Chat GUI Uninstaller", 9)]):
+        print(color(line, Colors.MAGENTA, Colors.BOLD))
     print()
 
     if not summary["gui_installed"]:
@@ -610,9 +610,8 @@ def run_uninstall(args):
         return
 
     print()
-    print(color("┌─────────────────────────────────────────────────────────┐", Colors.MAGENTA, Colors.BOLD))
-    print(color("│            ⚕ Hermes Agent Uninstaller                  │", Colors.MAGENTA, Colors.BOLD))
-    print(color("└─────────────────────────────────────────────────────────┘", Colors.MAGENTA, Colors.BOLD))
+    for line in format_box([("⚕ Hermes Agent Uninstaller", 12)]):
+        print(color(line, Colors.MAGENTA, Colors.BOLD))
     print()
     
     # Show what will be affected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dependencies = [
   "pydantic==2.13.4",
   # Interactive CLI (prompt_toolkit is used directly by cli.py)
   "prompt_toolkit==3.0.52",
+  # Terminal cell widths for CLI boxes and Markdown tables.
+  "wcwidth==0.6.0",
   # Cron scheduler (built-in feature — scheduled cron/interval jobs use croniter).
   "croniter==6.0.0",
   # ``packaging`` is imported directly on three production paths but was never

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from wcwidth import wcswidth
 
 from hermes_cli.agent_import import (
     ENTRY_DELIMITER,
@@ -26,6 +27,7 @@ from hermes_cli.agent_import import (
     parse_existing_memory_entries,
     sanitize_mcp_env,
 )
+from hermes_cli.cli_output import STANDARD_BOX_WIDTH
 
 
 # ---------------------------------------------------------------------------
@@ -508,6 +510,16 @@ class TestCliWiring:
             overwrite=False, yes=False)
         import_agent_command(args)
         out = capsys.readouterr().out
+        lines = out.splitlines()
+        title_index = next(
+            index
+            for index, line in enumerate(lines)
+            if "Hermes — Import From Another Agent" in line
+        )
+        assert all(
+            wcswidth(line) == STANDARD_BOX_WIDTH
+            for line in lines[title_index - 1:title_index + 2]
+        )
         assert "Dry Run Results" in out
         assert "command-allowlist" in out
         # Baseline config.yaml/SOUL.md may be seeded by save_config() before

--- a/tests/hermes_cli/test_cli_output.py
+++ b/tests/hermes_cli/test_cli_output.py
@@ -1,3 +1,5 @@
+from wcwidth import wcswidth
+
 from hermes_cli import cli_output
 
 
@@ -18,3 +20,18 @@ def test_empty_password_prompt_returns_default(monkeypatch):
     monkeypatch.setattr(cli_output, "masked_secret_prompt", lambda _display: "")
 
     assert cli_output.prompt("API key", default="old", password=True) == "old"
+
+
+def test_format_box_uses_terminal_cell_width_for_every_line():
+    lines = cli_output.format_box(
+        [
+            ("⚕ Single-cell symbol", 4),
+            ("🦋 Double-cell symbol", 4),
+        ],
+        divider_after={0},
+    )
+
+    assert all(wcswidth(line) == cli_output.STANDARD_BOX_WIDTH for line in lines)
+    assert lines[1].startswith("│    ⚕ Single-cell symbol")
+    assert lines[2].startswith("├")
+    assert lines[3].startswith("│    🦋 Double-cell symbol")

--- a/uv.lock
+++ b/uv.lock
@@ -1581,6 +1581,7 @@ dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "wcwidth" },
     { name = "websockets" },
 ]
 
@@ -1909,6 +1910,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0,<1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = "==0.41.0" },
     { name = "vercel", marker = "extra == 'vercel'", specifier = "==0.7.2" },
+    { name = "wcwidth", specifier = "==0.6.0" },
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]


### PR DESCRIPTION
## What does this PR do?

Fixes one-cell alignment regressions in branded CLI boxes introduced by commit
[`5c4c0c0`](https://github.com/NousResearch/hermes-agent/commit/5c4c0c0).

That commit replaced the two-cell `🦋` branding glyph with the one-cell `⚕`
glyph in manually padded box rows without updating the padding. For example,
`hermes config show` rendered 59-cell borders around a 58-cell title row.

This PR adds one shared `format_box()` helper that generates the complete box
(top border, content rows, optional dividers, and bottom border) using terminal
cell widths from `wcwidth`. All affected branded boxes now use the helper,
including setup, status, gateway, uninstall, OpenClaw, and import-agent paths.

## Related Issue

No dedicated issue. The regression was traced to commit
[`5c4c0c0`](https://github.com/NousResearch/hermes-agent/commit/5c4c0c0).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `format_box()` to `hermes_cli/cli_output.py` to render complete,
  fixed-cell-width boxes.
- Replace manually padded branded boxes in `config.py`, `status.py`,
  `gateway.py`, `setup.py`, `uninstall.py`, `claw.py`, and `agent_import.py`.
- Correct an existing 60-cell Gateway content row while normalizing the box.
- Add helper-level and import-agent command-level behavioral width tests.
- Declare the already-resolved `wcwidth==0.6.0` package as a direct runtime
  dependency and refresh `uv.lock`.

## How to Test

1. On the affected code, compare the terminal-cell width of a branded title row
   with its top and bottom borders.
2. Apply this change and run:
   `scripts/run_tests.sh tests/hermes_cli/test_cli_output.py tests/hermes_cli/test_agent_import.py -q`
3. Run `hermes config show`; the top border, title row, and bottom border are
   all 59 terminal cells.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

Focused validation after rebasing onto current `main`:

- 40 tests passed across `test_cli_output.py` and `test_agent_import.py`
- Ruff passed for all changed Python files
- `uv lock --check` passed
- `git diff --check` passed

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before:

```text
top border:    59 cells
title row:     58 cells
bottom border: 59 cells
```

After:

```text
┌─────────────────────────────────────────────────────────┐
│              ⚕ Hermes Configuration                     │
└─────────────────────────────────────────────────────────┘

top border:    59 cells
title row:     59 cells
bottom border: 59 cells
```
