### PR TITLE
feat(agent): add live upgrade — checkpoint subagents before restart and adopt orphans on startup (#71023)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12775,6 +12775,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if agent is None:
             return None
 
+        # Auto-recreate any orphaned subagents from a prior process
+        # checkpoint.  The orphans were detected by adopt_orphaned_subagents()
+        # at startup; now that the agent is ready, we re-delegate them.
+        try:
+            from tools.delegate_tool import recreate_pending_subagents
+            recreated = recreate_pending_subagents(agent)
+            if recreated > 0:
+                _cprint(
+                    f"  [yellow]🔄 Auto-recreated {recreated} orphaned "
+                    f"subagent(s) from previous session[/yellow]"
+                )
+        except Exception:
+            pass
+
         # Route image attachments based on the active model's vision capability.
         # "native" → pass pixels as OpenAI-style content parts (adapters
         #            translate for Anthropic/Gemini/Bedrock).

--- a/cli.py
+++ b/cli.py
@@ -1177,6 +1177,15 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
     # can't skip the reset (#36823). No-op unless the TUI actually ran.
     _reset_terminal_input_modes_on_exit()
 
+    # Checkpoint active subagents before restart/relaunch so their
+    # metadata survives across os.execvp() / process replacement and
+    # can be surfaced by adopt_orphaned_subagents() on next startup.
+    try:
+        from tools.delegate_tool import checkpoint_active_subagents
+        checkpoint_active_subagents()
+    except Exception:
+        pass
+
     try:
         _cleanup_all_terminals()
     except Exception:
@@ -13967,6 +13976,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _welcome_text = "Welcome to Hermes Agent! Type your message or /help for commands."
             _welcome_color = "#FFF8DC"
         self._console_print(f"[{_welcome_color}]{_welcome_text}[/]")
+
+        # Adopt any orphaned subagents from a prior process that was
+        # restarted (e.g. after /update).  The checkpoint file left by
+        # the old process is consumed and removed here; any previously
+        # running subagents are logged so the user knows to re-delegate.
+        try:
+            from tools.delegate_tool import adopt_orphaned_subagents
+            adopt_orphaned_subagents()
+        except Exception:
+            pass
 
         # Warm the /model picker's provider-models cache off-thread during this
         # idle window (banner shown, user about to type). The no-args picker

--- a/tests/tools/test_delegate_checkpoint.py
+++ b/tests/tools/test_delegate_checkpoint.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Tests for subagent checkpoint / orphan adoption (live upgrade).
+
+Verifies that:
+  - checkpoint_active_subagents() writes a valid JSON file
+  - adopt_orphaned_subagents() consumes and removes the checkpoint
+  - No checkpoint file means adopt_orphaned_subagents() is a no-op
+  - Corrupted checkpoint is handled gracefully
+
+Run with:  python -m pytest tests/tools/test_delegate_checkpoint.py -v
+"""
+
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.delegate_tool import (
+    _CHECKPOINT_FILE_NAME,
+    _checkpoint_dir,
+    _checkpoint_path,
+    _remove_checkpoint_safe,
+    adopt_orphaned_subagents,
+    checkpoint_active_subagents,
+    list_active_subagents,
+    _register_subagent,
+    _active_subagents,
+    _active_subagents_lock,
+)
+
+
+def _clean_active_subagents():
+    """Remove all entries from the module-level active subagents dict."""
+    with _active_subagents_lock:
+        _active_subagents.clear()
+
+
+class TestCheckpointPath(unittest.TestCase):
+    """Path resolution for the checkpoint file."""
+
+    @patch("hermes_constants.get_hermes_home")
+    def test_checkpoint_path_under_hermes_home(self, mock_home):
+        mock_home.return_value = Path("/tmp/hermes_test")
+        path = _checkpoint_path()
+        self.assertIn("state", path)
+        self.assertIn(_CHECKPOINT_FILE_NAME, path)
+        self.assertTrue(path.endswith(_CHECKPOINT_FILE_NAME))
+
+
+class TestCheckpointWrite(unittest.TestCase):
+    """checkpoint_active_subagents serialization."""
+
+    def setUp(self):
+        _clean_active_subagents()
+
+    def tearDown(self):
+        _clean_active_subagents()
+        p = _checkpoint_path()
+        if p and os.path.isfile(p):
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+
+    @patch("hermes_constants.get_hermes_home")
+    def test_no_subagents_returns_none(self, mock_home):
+        with tempfile.TemporaryDirectory() as td:
+            mock_home.return_value = Path(td)
+            result = checkpoint_active_subagents()
+            self.assertIsNone(result)
+
+    @patch("hermes_constants.get_hermes_home")
+    def test_writes_checkpoint_file(self, mock_home):
+        with tempfile.TemporaryDirectory() as td:
+            mock_home.return_value = Path(td)
+            # Register a fake subagent
+            _register_subagent({
+                "subagent_id": "test-sa-1",
+                "parent_id": None,
+                "depth": 0,
+                "goal": "Test task",
+                "model": "test-model",
+                "started_at": time.time(),
+                "status": "running",
+                "tool_count": 0,
+            })
+            result = checkpoint_active_subagents()
+            self.assertIsNotNone(result)
+            self.assertTrue(os.path.isfile(result))
+
+            # Validate JSON content
+            with open(result) as f:
+                payload = json.load(f)
+            self.assertIn("pid", payload)
+            self.assertIn("parent_pid", payload)
+            self.assertIn("created_at", payload)
+            self.assertIn("subagents", payload)
+            self.assertEqual(len(payload["subagents"]), 1)
+            self.assertEqual(payload["subagents"][0]["subagent_id"], "test-sa-1")
+            self.assertEqual(payload["subagents"][0]["goal"], "Test task")
+
+    @patch("hermes_constants.get_hermes_home")
+    def test_multiple_subagents(self, mock_home):
+        with tempfile.TemporaryDirectory() as td:
+            mock_home.return_value = Path(td)
+            _register_subagent({
+                "subagent_id": "sa-a",
+                "parent_id": None,
+                "depth": 0,
+                "goal": "Research A",
+                "model": "gpt-4",
+                "started_at": time.time(),
+                "status": "running",
+                "tool_count": 2,
+            })
+            _register_subagent({
+                "subagent_id": "sa-b",
+                "parent_id": "sa-a",
+                "depth": 1,
+                "goal": "Research B",
+                "model": "claude-3",
+                "started_at": time.time(),
+                "status": "running",
+                "tool_count": 5,
+            })
+            path = checkpoint_active_subagents()
+            self.assertIsNotNone(path)
+            with open(path) as f:
+                payload = json.load(f)
+            self.assertEqual(len(payload["subagents"]), 2)
+            ids = {sa["subagent_id"] for sa in payload["subagents"]}
+            self.assertEqual(ids, {"sa-a", "sa-b"})
+
+
+class TestOrphanAdoption(unittest.TestCase):
+    """adopt_orphaned_subagents consuming checkpoints."""
+
+    def _create_checkpoint(self, directory, subagents, pid=12345):
+        """Helper: write a valid checkpoint under *directory*."""
+        state_dir = os.path.join(directory, "state")
+        os.makedirs(state_dir, exist_ok=True)
+        path = os.path.join(state_dir, _CHECKPOINT_FILE_NAME)
+        payload = {
+            "pid": pid,
+            "parent_pid": pid - 1,
+            "created_at": time.time(),
+            "subagents": subagents,
+        }
+        with open(path, "w") as f:
+            json.dump(payload, f)
+        return path
+
+    @patch("hermes_constants.get_hermes_home")
+    def test_no_checkpoint_returns_zero(self, mock_home):
+        with tempfile.TemporaryDirectory() as td:
+            mock_home.return_value = Path(td)
+            count = adopt_orphaned_subagents()
+            self.assertEqual(count, 0)
+
+    @patch("hermes_constants.get_hermes_home")
+    def test_adopts_and_removes_checkpoint(self, mock_home):
+        with tempfile.TemporaryDirectory() as td:
+            mock_home.return_value = Path(td)
+            path = self._create_checkpoint(td, [
+                {
+                    "subagent_id": "orphan-1",
+                    "parent_id": None,
+                    "depth": 0,
+                    "goal": "Lost research task",
+                    "model": "gpt-4",
+                    "started_at": time.time(),
+                    "status": "running",
+                    "tool_count": 3,
+                }
+            ])
+            self.assertTrue(os.path.isfile(path))
+            count = adopt_orphaned_subagents()
+            self.assertEqual(count, 1)
+            # Checkpoint must be removed after adoption
+            self.assertFalse(os.path.isfile(path))
+
+    @patch("hermes_constants.get_hermes_home")
+    def test_adopts_multiple_orphans(self, mock_home):
+        with tempfile.TemporaryDirectory() as td:
+            mock_home.return_value = Path(td)
+            self._create_checkpoint(td, [
+                {
+                    "subagent_id": "orphan-1",
+                    "parent_id": None,
+                    "depth": 0,
+                    "goal": "Task 1",
+                    "model": "gpt-4",
+                    "started_at": time.time() - 3600,
+                    "status": "running",
+                    "tool_count": 5,
+                },
+                {
+                    "subagent_id": "orphan-2",
+                    "parent_id": "orphan-1",
+                    "depth": 1,
+                    "goal": "Task 2",
+                    "model": "claude-3",
+                    "started_at": time.time() - 1800,
+                    "status": "running",
+                    "tool_count": 2,
+                },
+                {
+                    "subagent_id": "orphan-3",
+                    "parent_id": None,
+                    "depth": 0,
+                    "goal": "Task 3",
+                    "model": "gemini-pro",
+                    "started_at": time.time() - 600,
+                    "status": "running",
+                    "tool_count": 0,
+                },
+            ])
+            count = adopt_orphaned_subagents()
+            self.assertEqual(count, 3)
+
+    @patch("hermes_constants.get_hermes_home")
+    def test_corrupt_checkpoint_does_not_crash(self, mock_home):
+        with tempfile.TemporaryDirectory() as td:
+            mock_home.return_value = Path(td)
+            # Write invalid JSON
+            state_dir = os.path.join(td, "state")
+            os.makedirs(state_dir, exist_ok=True)
+            bad_path = os.path.join(state_dir, _CHECKPOINT_FILE_NAME)
+            with open(bad_path, "w") as f:
+                f.write("{invalid json!!!}")
+            self.assertTrue(os.path.isfile(bad_path))
+            count = adopt_orphaned_subagents()
+            self.assertEqual(count, 0)
+            # Should have cleaned up the corrupt file
+            self.assertFalse(os.path.isfile(bad_path))
+
+    @patch("hermes_constants.get_hermes_home")
+    def test_empty_subagents_list_cleans_up(self, mock_home):
+        with tempfile.TemporaryDirectory() as td:
+            mock_home.return_value = Path(td)
+            self._create_checkpoint(td, [])
+            count = adopt_orphaned_subagents()
+            self.assertEqual(count, 0)
+            # Empty list should have been cleaned up
+            path = os.path.join(td, "state", _CHECKPOINT_FILE_NAME)
+            self.assertFalse(os.path.isfile(path))
+
+    @patch("hermes_constants.get_hermes_home")
+    def test_minimal_goal_does_not_crash(self, mock_home):
+        """Edge case: subagent with minimal fields (just goal)."""
+        with tempfile.TemporaryDirectory() as td:
+            mock_home.return_value = Path(td)
+            path = self._create_checkpoint(td, [
+                {"goal": "Short task"},
+            ])
+            count = adopt_orphaned_subagents()
+            self.assertEqual(count, 1)
+            self.assertFalse(os.path.isfile(path))
+
+
+class TestRemoveCheckpointSafe(unittest.TestCase):
+    """_remove_checkpoint_safe should never raise."""
+
+    def test_nonexistent_file(self):
+        _remove_checkpoint_safe("/nonexistent/path.json")
+
+    def test_valid_file(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            tmp = f.name
+        self.assertTrue(os.path.isfile(tmp))
+        _remove_checkpoint_safe(tmp)
+        self.assertFalse(os.path.isfile(tmp))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_delegate_checkpoint.py
+++ b/tests/tools/test_delegate_checkpoint.py
@@ -2,8 +2,10 @@
 """Tests for subagent checkpoint / orphan adoption (live upgrade).
 
 Verifies that:
-  - checkpoint_active_subagents() writes a valid JSON file
-  - adopt_orphaned_subagents() consumes and removes the checkpoint
+  - checkpoint_active_subagents() writes a valid JSON file with full state
+  - adopt_orphaned_subagents() consumes, removes, and stores orphans
+  - get_pending_orphans() returns stored orphan data
+  - recreate_pending_subagents() re-delegates orphans (with mock)
   - No checkpoint file means adopt_orphaned_subagents() is a no-op
   - Corrupted checkpoint is handled gracefully
 
@@ -16,16 +18,20 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from tools.delegate_tool import (
     _CHECKPOINT_FILE_NAME,
     _checkpoint_dir,
     _checkpoint_path,
+    _pending_orphans,
     _remove_checkpoint_safe,
+    _safe_serialize_messages,
     adopt_orphaned_subagents,
     checkpoint_active_subagents,
     list_active_subagents,
+    get_pending_orphans,
+    recreate_pending_subagents,
     _register_subagent,
     _active_subagents,
     _active_subagents_lock,
@@ -36,6 +42,62 @@ def _clean_active_subagents():
     """Remove all entries from the module-level active subagents dict."""
     with _active_subagents_lock:
         _active_subagents.clear()
+    global _pending_orphans
+    try:
+        from tools.delegate_tool import _pending_orphans as _po
+        _po.clear()
+    except (ImportError, AttributeError):
+        pass
+
+
+class TestSafeSerializeMessages(unittest.TestCase):
+    """_safe_serialize_messages edge cases."""
+
+    def test_none_messages(self):
+        self.assertEqual(_safe_serialize_messages(None), [])
+
+    def test_empty_list(self):
+        self.assertEqual(_safe_serialize_messages([]), [])
+
+    def test_skips_non_dict(self):
+        result = _safe_serialize_messages(["bad", 42, {"role": "user", "content": "hello"}])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["role"], "user")
+
+    def test_truncates_long_content(self):
+        long_content = "x" * 20000
+        result = _safe_serialize_messages([{"role": "user", "content": long_content}])
+        self.assertIn("... [truncated]", result[0]["content"])
+        self.assertLess(len(result[0]["content"]), 20000)
+
+    def test_strips_callbacks(self):
+        result = _safe_serialize_messages([{
+            "role": "assistant",
+            "content": "OK",
+            "callback": lambda: None,
+            "stream": object(),
+        }])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["role"], "assistant")
+        self.assertNotIn("callback", result[0])
+        self.assertNotIn("stream", result[0])
+
+    def test_handles_binary_bytes(self):
+        result = _safe_serialize_messages([{"role": "tool", "content": b"\x00\x01\x02"}])
+        result_content = result[0]["content"]
+        # bytes should be decoded, not crash
+        self.assertIsInstance(result_content, str)
+
+    def test_handles_tool_calls(self):
+        result = _safe_serialize_messages([{
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "function": {"name": "web_search", "arguments": "{}"},
+            }],
+        }])
+        self.assertEqual(len(result), 1)
+        self.assertIn("tool_calls", result[0])
 
 
 class TestCheckpointPath(unittest.TestCase):
@@ -73,10 +135,58 @@ class TestCheckpointWrite(unittest.TestCase):
             self.assertIsNone(result)
 
     @patch("hermes_constants.get_hermes_home")
-    def test_writes_checkpoint_file(self, mock_home):
+    def test_writes_checkpoint_file_v2(self, mock_home):
         with tempfile.TemporaryDirectory() as td:
             mock_home.return_value = Path(td)
-            # Register a fake subagent
+            # Register a fake subagent WITH a mock agent that has messages
+            mock_agent = MagicMock()
+            mock_agent._session_messages = [
+                {"role": "user", "content": "Do research"},
+                {"role": "assistant", "content": "Researching...", "tool_calls": []},
+                {"role": "tool", "content": "Result: data"},
+            ]
+            mock_agent._subagent_goal = "Research task context"
+            _register_subagent({
+                "subagent_id": "test-sa-1",
+                "parent_id": None,
+                "depth": 0,
+                "goal": "Test task with full state",
+                "model": "test-model",
+                "started_at": time.time(),
+                "status": "running",
+                "tool_count": 0,
+                "agent": mock_agent,
+            })
+            result = checkpoint_active_subagents()
+            self.assertIsNotNone(result)
+            self.assertTrue(os.path.isfile(result))
+
+            # Validate JSON content includes full state
+            with open(result) as f:
+                payload = json.load(f)
+            self.assertIn("pid", payload)
+            self.assertIn("parent_pid", payload)
+            self.assertIn("created_at", payload)
+            self.assertIn("version", payload)
+            self.assertEqual(payload["version"], 2)
+            self.assertIn("subagents", payload)
+            self.assertEqual(len(payload["subagents"]), 1)
+
+            sa = payload["subagents"][0]
+            self.assertEqual(sa["subagent_id"], "test-sa-1")
+            self.assertEqual(sa["goal"], "Test task with full state")
+            # Should have saved messages
+            self.assertIn("saved_messages", sa)
+            self.assertGreater(sa["saved_message_count"], 0)
+            # Should have resolved_context
+            self.assertIn("resolved_context", sa)
+            self.assertEqual(sa["resolved_context"], "Research task context")
+
+    @patch("hermes_constants.get_hermes_home")
+    def test_writes_v2_even_without_agent_object(self, mock_home):
+        """Version 2 checkpoint is written even when agent field is missing."""
+        with tempfile.TemporaryDirectory() as td:
+            mock_home.return_value = Path(td)
             _register_subagent({
                 "subagent_id": "test-sa-1",
                 "parent_id": None,
@@ -86,21 +196,17 @@ class TestCheckpointWrite(unittest.TestCase):
                 "started_at": time.time(),
                 "status": "running",
                 "tool_count": 0,
+                # no agent field
             })
             result = checkpoint_active_subagents()
             self.assertIsNotNone(result)
-            self.assertTrue(os.path.isfile(result))
-
-            # Validate JSON content
             with open(result) as f:
                 payload = json.load(f)
-            self.assertIn("pid", payload)
-            self.assertIn("parent_pid", payload)
-            self.assertIn("created_at", payload)
-            self.assertIn("subagents", payload)
-            self.assertEqual(len(payload["subagents"]), 1)
-            self.assertEqual(payload["subagents"][0]["subagent_id"], "test-sa-1")
-            self.assertEqual(payload["subagents"][0]["goal"], "Test task")
+            self.assertEqual(payload["version"], 2)
+            sa = payload["subagents"][0]
+            self.assertEqual(sa["subagent_id"], "test-sa-1")
+            # When no agent, saved_messages is absent
+            self.assertNotIn("saved_messages", sa)
 
     @patch("hermes_constants.get_hermes_home")
     def test_multiple_subagents(self, mock_home):
@@ -138,7 +244,15 @@ class TestCheckpointWrite(unittest.TestCase):
 class TestOrphanAdoption(unittest.TestCase):
     """adopt_orphaned_subagents consuming checkpoints."""
 
-    def _create_checkpoint(self, directory, subagents, pid=12345):
+    def setUp(self):
+        """Clear pending orphans before each test."""
+        try:
+            from tools.delegate_tool import _pending_orphans as _po
+            _po.clear()
+        except (ImportError, AttributeError):
+            pass
+
+    def _create_checkpoint(self, directory, subagents, pid=12345, version=2):
         """Helper: write a valid checkpoint under *directory*."""
         state_dir = os.path.join(directory, "state")
         os.makedirs(state_dir, exist_ok=True)
@@ -147,6 +261,7 @@ class TestOrphanAdoption(unittest.TestCase):
             "pid": pid,
             "parent_pid": pid - 1,
             "created_at": time.time(),
+            "version": version,
             "subagents": subagents,
         }
         with open(path, "w") as f:
@@ -159,6 +274,8 @@ class TestOrphanAdoption(unittest.TestCase):
             mock_home.return_value = Path(td)
             count = adopt_orphaned_subagents()
             self.assertEqual(count, 0)
+            # No pending orphans
+            self.assertEqual(get_pending_orphans(), [])
 
     @patch("hermes_constants.get_hermes_home")
     def test_adopts_and_removes_checkpoint(self, mock_home):
@@ -174,6 +291,11 @@ class TestOrphanAdoption(unittest.TestCase):
                     "started_at": time.time(),
                     "status": "running",
                     "tool_count": 3,
+                    "saved_messages": [
+                        {"role": "user", "content": "Research topic X"},
+                        {"role": "assistant", "content": "Found results"},
+                    ],
+                    "saved_message_count": 2,
                 }
             ])
             self.assertTrue(os.path.isfile(path))
@@ -181,6 +303,11 @@ class TestOrphanAdoption(unittest.TestCase):
             self.assertEqual(count, 1)
             # Checkpoint must be removed after adoption
             self.assertFalse(os.path.isfile(path))
+            # Pending orphans should be populated
+            orphans = get_pending_orphans()
+            self.assertEqual(len(orphans), 1)
+            self.assertEqual(orphans[0]["subagent_id"], "orphan-1")
+            self.assertIn("saved_messages", orphans[0])
 
     @patch("hermes_constants.get_hermes_home")
     def test_adopts_multiple_orphans(self, mock_home):
@@ -220,6 +347,8 @@ class TestOrphanAdoption(unittest.TestCase):
             ])
             count = adopt_orphaned_subagents()
             self.assertEqual(count, 3)
+            orphans = get_pending_orphans()
+            self.assertEqual(len(orphans), 3)
 
     @patch("hermes_constants.get_hermes_home")
     def test_corrupt_checkpoint_does_not_crash(self, mock_home):
@@ -236,6 +365,7 @@ class TestOrphanAdoption(unittest.TestCase):
             self.assertEqual(count, 0)
             # Should have cleaned up the corrupt file
             self.assertFalse(os.path.isfile(bad_path))
+            self.assertEqual(get_pending_orphans(), [])
 
     @patch("hermes_constants.get_hermes_home")
     def test_empty_subagents_list_cleans_up(self, mock_home):
@@ -244,9 +374,7 @@ class TestOrphanAdoption(unittest.TestCase):
             self._create_checkpoint(td, [])
             count = adopt_orphaned_subagents()
             self.assertEqual(count, 0)
-            # Empty list should have been cleaned up
-            path = os.path.join(td, "state", _CHECKPOINT_FILE_NAME)
-            self.assertFalse(os.path.isfile(path))
+            self.assertEqual(get_pending_orphans(), [])
 
     @patch("hermes_constants.get_hermes_home")
     def test_minimal_goal_does_not_crash(self, mock_home):
@@ -259,6 +387,91 @@ class TestOrphanAdoption(unittest.TestCase):
             count = adopt_orphaned_subagents()
             self.assertEqual(count, 1)
             self.assertFalse(os.path.isfile(path))
+            orphans = get_pending_orphans()
+            self.assertEqual(len(orphans), 1)
+            self.assertEqual(orphans[0]["goal"], "Short task")
+
+
+class TestOrphanRecreation(unittest.TestCase):
+    """recreate_pending_subagents auto-re-delegation."""
+
+    def setUp(self):
+        try:
+            from tools.delegate_tool import _pending_orphans as _po
+            _po.clear()
+        except (ImportError, AttributeError):
+            pass
+
+    @patch("tools.delegate_tool._pending_orphans", [])
+    def test_no_orphans_returns_zero(self):
+        count = recreate_pending_subagents(MagicMock())
+        self.assertEqual(count, 0)
+
+    @patch("tools.delegate_tool.delegate_task")
+    def test_recreates_with_goal(self, mock_delegate):
+        # Manually set pending orphans
+        import tools.delegate_tool as dt
+        dt._pending_orphans = [
+            {
+                "subagent_id": "orphan-1",
+                "goal": "Research topic X",
+                "model": "gpt-4",
+                "depth": 0,
+                "started_at": time.time(),
+            }
+        ]
+        parent = MagicMock()
+        count = recreate_pending_subagents(parent)
+        self.assertEqual(count, 1)
+        mock_delegate.assert_called_once()
+        args, kwargs = mock_delegate.call_args
+        self.assertEqual(kwargs.get("goal"), "Research topic X")
+
+    @patch("tools.delegate_tool.delegate_task")
+    def test_recreates_with_saved_messages_as_context(self, mock_delegate):
+        import tools.delegate_tool as dt
+        dt._pending_orphans = [
+            {
+                "subagent_id": "orphan-2",
+                "goal": "Continue research",
+                "model": "claude-3",
+                "depth": 0,
+                "started_at": time.time(),
+                "saved_messages": [
+                    {"role": "user", "content": "Find data on X"},
+                    {"role": "assistant", "content": "Found partial data"},
+                    {"role": "tool", "content": "Search result: some info"},
+                ],
+                "saved_message_count": 3,
+            }
+        ]
+        parent = MagicMock()
+        count = recreate_pending_subagents(parent)
+        self.assertEqual(count, 1)
+        mock_delegate.assert_called_once()
+        args, kwargs = mock_delegate.call_args
+        self.assertEqual(kwargs.get("goal"), "Continue research")
+        # Context should include saved messages
+        ctx = kwargs.get("context", "")
+        self.assertIn("CONTINUATION", ctx)
+        self.assertIn("Find data on X", ctx)
+        self.assertIn("Found partial data", ctx)
+        self.assertIn("Do NOT re-do work", ctx)
+
+    @patch("tools.delegate_tool.delegate_task")
+    def test_skips_orphan_without_goal(self, mock_delegate):
+        import tools.delegate_tool as dt
+        dt._pending_orphans = [
+            {
+                "subagent_id": "orphan-empty",
+                "goal": "",
+                "depth": 0,
+            }
+        ]
+        parent = MagicMock()
+        count = recreate_pending_subagents(parent)
+        self.assertEqual(count, 0)
+        mock_delegate.assert_not_called()
 
 
 class TestRemoveCheckpointSafe(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -23,6 +23,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 import os
+import sys
 import threading
 import time
 from concurrent.futures import (
@@ -3886,6 +3887,154 @@ DELEGATE_TASK_SCHEMA = {
         "required": [],
     },
 }
+
+
+# ---------------------------------------------------------------------------
+# Live upgrade: checkpoint active subagents before restart / adopt orphans
+# ---------------------------------------------------------------------------
+
+_CHECKPOINT_DIR_NAME = "state"
+_CHECKPOINT_FILE_NAME = "subagent_checkpoints.json"
+
+
+def _checkpoint_dir() -> str:
+    """Return the path to the state directory under HERMES_HOME."""
+    try:
+        from hermes_constants import get_hermes_home
+        d = str(get_hermes_home() / _CHECKPOINT_DIR_NAME)
+    except Exception:
+        d = ""
+    if d and not os.path.isdir(d):
+        try:
+            os.makedirs(d, exist_ok=True)
+        except OSError:
+            pass
+    return d
+
+
+def _checkpoint_path() -> str:
+    return os.path.join(_checkpoint_dir(), _CHECKPOINT_FILE_NAME)
+
+
+def checkpoint_active_subagents() -> str | None:
+    """Serialize info about currently running subagents before a restart.
+
+    Writes a JSON file ``$HERMES_HOME/state/subagent_checkpoints.json``
+    with one record per active subagent.  The ``agent`` field is excluded
+    (not serializable).  The current process PID is recorded so the orphan
+    adopt path can distinguish a post-upgrade restart from a fresh start.
+
+    Returns the path to the checkpoint file, or ``None`` if nothing was
+    written (no active subagents or path resolution failed).
+    """
+    snap = list_active_subagents()
+    if not snap:
+        return None
+    path = _checkpoint_path()
+    if not path:
+        return None
+    # Attach the parent PID so the adopter knows this checkpoint belongs to
+    # a fresh restart of the same process group.
+    payload = {
+        "pid": os.getpid(),
+        "parent_pid": os.getppid(),
+        "created_at": time.time(),
+        "subagents": snap,
+    }
+    try:
+        tmp = path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False, default=str)
+        os.replace(tmp, path)
+        logger.info(
+            "Checkpointed %d running subagent(s) to %s (pid=%d)",
+            len(snap),
+            path,
+            os.getpid(),
+        )
+        return path
+    except (OSError, TypeError) as exc:
+        logger.warning("Failed to write subagent checkpoint: %s", exc)
+        return None
+
+
+def adopt_orphaned_subagents() -> int:
+    """Check for a checkpoint file from a previous process and log results.
+
+    Reads ``$HERMES_HOME/state/subagent_checkpoints.json`` left by a prior
+    process that restarted (e.g. after ``/update``).  Because subagents run
+    as in-process threads, the old process's children were terminated by the
+    exec/sys.exit.  This function logs their metadata so the user can
+    re-delegate lost work, then removes the checkpoint file.
+
+    Returns the number of previously running subagents that were recorded
+    (0 means no checkpoint was found, or it was empty).
+    """
+    path = _checkpoint_path()
+    if not path or not os.path.isfile(path):
+        return 0
+
+    try:
+        with open(path) as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Corrupt subagent checkpoint at %s: %s", path, exc)
+        _remove_checkpoint_safe(path)
+        return 0
+
+    subagents = payload.get("subagents", [])
+    if not subagents:
+        _remove_checkpoint_safe(path)
+        return 0
+
+    old_pid = payload.get("pid", "<unknown>")
+    created = payload.get("created_at", 0)
+    ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(created)) if created else "<unknown>"
+
+    count = len(subagents)
+    logger.warning(
+        "Live upgrade detected: %d subagent(s) were running when the "
+        "previous process (pid=%s) restarted at %s.  Their work was "
+        "terminated by the restart and should be re-delegated.",
+        count,
+        old_pid,
+        ts,
+    )
+    for i, sa in enumerate(subagents):
+        goal = (sa.get("goal") or "<no goal>")[:120]
+        sid = sa.get("subagent_id") or "<unknown>"
+        started = sa.get("started_at", 0)
+        started_str = (
+            time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(started))
+            if started
+            else "<unknown>"
+        )
+        model = sa.get("model") or "<default>"
+        logger.warning(
+            "  Orphan subagent [%d/%d] id=%s goal=%s started=%s model=%s",
+            i + 1,
+            count,
+            sid,
+            goal,
+            started_str,
+            model,
+        )
+        print(
+            f"  ⚠ Orphan subagent [{i+1}/{count}]: \"{goal}\" "
+            f"(started {started_str}, model={model})",
+            file=sys.stderr,
+        )
+
+    _remove_checkpoint_safe(path)
+    return count
+
+
+def _remove_checkpoint_safe(path: str) -> None:
+    """Remove the checkpoint file, ignoring errors."""
+    try:
+        os.remove(path)
+    except OSError:
+        pass
 
 
 # --- Registry ---

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -217,6 +217,44 @@ def list_active_subagents() -> List[Dict[str, Any]]:
         ]
 
 
+def _safe_serialize_messages(messages) -> list:
+    """Safely serialize conversation messages for checkpoint storage.
+
+    Strips non-serializable fields (callable callbacks, live objects) and
+    truncates oversized tool results to keep the checkpoint file bounded.
+    """
+    if not isinstance(messages, (list, tuple)):
+        return []
+    safe = []
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        entry = {}
+        for k, v in m.items():
+            # Skip non-serializable / internal fields
+            if k in ("callback", "stream", "_callbacks", "raw_partial"):
+                continue
+            # Truncate long string content
+            if isinstance(v, str) and len(v) > 10000:
+                entry[k] = v[:10000] + "... [truncated]"
+            # Skip unserializable objects
+            elif isinstance(v, (dict, list, tuple, str, int, float, bool, type(None))):
+                entry[k] = v
+            elif isinstance(v, bytes):
+                try:
+                    entry[k] = v.decode("utf-8", errors="replace")
+                except Exception:
+                    entry[k] = "<binary data>"
+            else:
+                try:
+                    entry[k] = str(v)
+                except Exception:
+                    pass
+        if entry:
+            safe.append(entry)
+    return safe
+
+
 def _extract_output_tail(
     result: Dict[str, Any],
     *,
@@ -3917,28 +3955,57 @@ def _checkpoint_path() -> str:
 
 
 def checkpoint_active_subagents() -> str | None:
-    """Serialize info about currently running subagents before a restart.
+    """Serialize FULL state of currently running subagents before a restart.
 
     Writes a JSON file ``$HERMES_HOME/state/subagent_checkpoints.json``
-    with one record per active subagent.  The ``agent`` field is excluded
-    (not serializable).  The current process PID is recorded so the orphan
-    adopt path can distinguish a post-upgrade restart from a fresh start.
+    with one record per active subagent, including:
+    - goal (full text, not truncated), context, model
+    - conversation messages (tool calls + results) from each child agent
+    - timing and metadata (subagent_id, parent_id, depth, tool_count, status)
+
+    The ``agent`` field (the live AIAgent object) is excluded — it is not
+    serializable.  Instead, the conversation history is extracted from
+    ``agent._session_messages`` and serialized as ``saved_messages``.
 
     Returns the path to the checkpoint file, or ``None`` if nothing was
     written (no active subagents or path resolution failed).
     """
-    snap = list_active_subagents()
-    if not snap:
-        return None
+    # Snapshot with full state — capture messages from each agent object
+    with _active_subagents_lock:
+        if not _active_subagents:
+            return None
+        snap = []
+        for sid, rec in _active_subagents.items():
+            record = {
+                k: v for k, v in rec.items()
+                if k not in ("agent",)
+            }
+            # Extract conversation messages from the live agent object
+            agent = rec.get("agent")
+            if agent is not None:
+                try:
+                    messages = getattr(agent, "_session_messages", None)
+                    if messages:
+                        safe = _safe_serialize_messages(messages)
+                        if safe:
+                            record["saved_messages"] = safe
+                            record["saved_message_count"] = len(safe)
+                    # Capture the subagent's context
+                    raw_context = getattr(agent, "_subagent_goal", None)
+                    if raw_context:
+                        record["resolved_context"] = str(raw_context)
+                except Exception:
+                    pass
+            snap.append(record)
+
     path = _checkpoint_path()
     if not path:
         return None
-    # Attach the parent PID so the adopter knows this checkpoint belongs to
-    # a fresh restart of the same process group.
     payload = {
         "pid": os.getpid(),
         "parent_pid": os.getppid(),
         "created_at": time.time(),
+        "version": 2,  # version 2 = full state with messages
         "subagents": snap,
     }
     try:
@@ -3958,18 +4025,32 @@ def checkpoint_active_subagents() -> str | None:
         return None
 
 
+# Module-level storage for orphan state from a prior process.
+# Populated by adopt_orphaned_subagents() and consumed by
+# recreate_pending_subagents().  Repopulates on every adoption call.
+_pending_orphans: List[Dict[str, Any]] = []
+
+
 def adopt_orphaned_subagents() -> int:
-    """Check for a checkpoint file from a previous process and log results.
+    """Adopt orphaned subagents from a checkpoint left by a prior process.
 
     Reads ``$HERMES_HOME/state/subagent_checkpoints.json`` left by a prior
     process that restarted (e.g. after ``/update``).  Because subagents run
     as in-process threads, the old process's children were terminated by the
-    exec/sys.exit.  This function logs their metadata so the user can
-    re-delegate lost work, then removes the checkpoint file.
+    exec/sys.exit.
+
+    This function:
+    1. Reads the checkpoint and logs orphan metadata
+    2. Stores the full orphan records in ``_pending_orphans`` for later
+       recreation by ``recreate_pending_subagents(parent_agent)``
+    3. Removes the checkpoint file
 
     Returns the number of previously running subagents that were recorded
     (0 means no checkpoint was found, or it was empty).
     """
+    global _pending_orphans
+    _pending_orphans = []
+
     path = _checkpoint_path()
     if not path or not os.path.isfile(path):
         return 0
@@ -3983,23 +4064,46 @@ def adopt_orphaned_subagents() -> int:
         return 0
 
     subagents = payload.get("subagents", [])
+    checkpoint_pid = payload.get("pid", "<unknown>")
+    checkpoint_created = payload.get("created_at", 0)
+    checkpoint_version = payload.get("version", 1)
+
     if not subagents:
         _remove_checkpoint_safe(path)
         return 0
 
-    old_pid = payload.get("pid", "<unknown>")
-    created = payload.get("created_at", 0)
+    old_pid = checkpoint_pid
+    created = checkpoint_created
     ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(created)) if created else "<unknown>"
 
     count = len(subagents)
-    logger.warning(
-        "Live upgrade detected: %d subagent(s) were running when the "
-        "previous process (pid=%s) restarted at %s.  Their work was "
-        "terminated by the restart and should be re-delegated.",
-        count,
-        old_pid,
-        ts,
-    )
+
+    # Log the orphan information
+    if checkpoint_version >= 2:
+        has_messages = sum(1 for sa in subagents if sa.get("saved_messages"))
+        logger.warning(
+            "Live upgrade detected: %d subagent(s) were running when the "
+            "previous process (pid=%s) restarted at %s.  "
+            "%d have saved conversation state (version %d).  "
+            "Call recreate_pending_subagents() with the parent agent to "
+            "auto-re-delegate them and preserve progress.",
+            count,
+            old_pid,
+            ts,
+            has_messages,
+            checkpoint_version,
+        )
+    else:
+        logger.warning(
+            "Live upgrade detected: %d subagent(s) were running when the "
+            "previous process (pid=%s) restarted at %s.  "
+            "Checkpoint is version 1 (metadata only).  "
+            "Their work was terminated by the restart and should be re-delegated.",
+            count,
+            old_pid,
+            ts,
+        )
+
     for i, sa in enumerate(subagents):
         goal = (sa.get("goal") or "<no goal>")[:120]
         sid = sa.get("subagent_id") or "<unknown>"
@@ -4010,23 +4114,164 @@ def adopt_orphaned_subagents() -> int:
             else "<unknown>"
         )
         model = sa.get("model") or "<default>"
+        msgs = sa.get("saved_message_count", 0)
         logger.warning(
-            "  Orphan subagent [%d/%d] id=%s goal=%s started=%s model=%s",
+            "  Orphan subagent [%d/%d] id=%s goal=%s started=%s model=%s saved_msgs=%d",
             i + 1,
             count,
             sid,
             goal,
             started_str,
             model,
+            msgs,
         )
         print(
             f"  ⚠ Orphan subagent [{i+1}/{count}]: \"{goal}\" "
-            f"(started {started_str}, model={model})",
+            f"(started {started_str}, model={model}, saved_msgs={msgs})",
             file=sys.stderr,
         )
 
+    # Store the full orphan data for later recreation
+    _pending_orphans = list(subagents)
+
+    # Remove the checkpoint file — data is now in memory
     _remove_checkpoint_safe(path)
     return count
+
+
+def get_pending_orphans() -> List[Dict[str, Any]]:
+    """Return the list of orphan subagent records from the last adoption.
+
+    Returns an empty list if no orphans were found or if
+    adopt_orphaned_subagents() has not been called yet.
+    Each record contains: goal, context (if available), model, parent_id,
+    depth, tool_count, started_at, and optionally saved_messages (the
+    conversation history from the previous process).
+    """
+    global _pending_orphans
+    return list(_pending_orphans)
+
+
+def recreate_pending_subagents(parent_agent) -> int:
+    """Recreate orphaned subagents from a prior process checkpoint.
+
+    Reads the orphan data stored by ``adopt_orphaned_subagents()`` and
+    auto-re-delegates each orphan by calling ``delegate_task`` with the
+    saved goal and context.  When saved conversation messages are available
+    from the previous process (version 2+ checkpoints), they are appended
+    as context so the new subagent knows what was already done and can
+    pick up where the previous process left off.
+
+    This should be called once the parent agent is fully initialized,
+    typically on the first user turn after adoption.
+
+    Returns the number of subagents that were re-delegated (0 means no
+    pending orphans existed).
+    """
+    global _pending_orphans
+    orphans = list(_pending_orphans)
+    if not orphans:
+        return 0
+    _pending_orphans = []
+
+    count = len(orphans)
+    logger.info(
+        "Recreating %d orphaned subagent(s) from checkpoint...",
+        count,
+    )
+
+    recreated = 0
+    for i, sa in enumerate(orphans):
+        try:
+            goal = sa.get("goal") or ""
+            if not goal:
+                logger.warning(
+                    "  Skipping orphan [%d/%d]: no goal found",
+                    i + 1, count,
+                )
+                continue
+
+            # Build enriched context from saved messages
+            saved_msgs = sa.get("saved_messages", [])
+            msg_count = len(saved_msgs)
+            # Build context that includes previous progress
+            enriched_context = sa.get("resolved_context") or sa.get("context") or ""
+
+            if saved_msgs:
+                # Format previous conversation as context
+                prev_work_lines = [
+                    "The following work was already completed in a previous agent session "
+                    "before the process was restarted.",
+                    "",
+                ]
+                for msg in saved_msgs:
+                    role = msg.get("role", "unknown")
+                    content = msg.get("content") or msg.get("text") or ""
+                    if isinstance(content, str) and content:
+                        # Truncate very long messages for context
+                        if len(content) > 2000:
+                            content = content[:2000] + "... [truncated]"
+                        prev_work_lines.append(f"[{role}]: {content}")
+                    # Also pick up tool_calls
+                    tc = msg.get("tool_calls")
+                    if tc:
+                        for t in (tc if isinstance(tc, list) else [tc]):
+                            fn = t.get("function", {})
+                            tname = fn.get("name", "") if isinstance(fn, dict) else ""
+                            if tname:
+                                prev_work_lines.append(f"[tool_call]: {tname}")
+
+                if enriched_context:
+                    enriched_context += "\n\n" + "\n".join(prev_work_lines)
+                else:
+                    enriched_context = "\n".join(prev_work_lines)
+
+                context_suffix = (
+                    "\n\nNOTE: This is a CONTINUATION of previous work. "
+                    "Review the context above to understand what has already been "
+                    "done, then continue from where you left off. "
+                    "Do NOT re-do work that has already been completed."
+                )
+                enriched_context += context_suffix
+
+            # Extract subagent configuration
+            sa_model = sa.get("model") or None
+            sa_depth = sa.get("depth", 0)
+
+            # Call delegate_task to recreate the subagent
+            from tools.delegate_tool import delegate_task as _dt
+
+            _dt(
+                goal=goal,
+                context=enriched_context if enriched_context.strip() else None,
+                parent_agent=parent_agent,
+            )
+            recreated += 1
+            logger.info(
+                "  Recreated orphan [%d/%d] id=%s goal=\"%s\" model=%s msgs=%d",
+                i + 1,
+                count,
+                sa.get("subagent_id", "<unknown>"),
+                goal[:80],
+                sa_model or "<inherited>",
+                msg_count,
+            )
+        except Exception as exc:
+            logger.warning(
+                "  Failed to recreate orphan [%d/%d] id=%s: %s",
+                i + 1,
+                count,
+                sa.get("subagent_id", "<unknown>"),
+                exc,
+            )
+
+    if recreated > 0:
+        print(
+            f"  🔄 Recreated {recreated}/{count} orphaned subagent(s) from "
+            f"previous session (checkpoint preserved progress)",
+            file=sys.stderr,
+        )
+    return recreated
 
 
 def _remove_checkpoint_safe(path: str) -> None:


### PR DESCRIPTION
## What

Implements **live upgrade** support for Hermes Agent: when the process restarts (e.g. via `/update`), running subagents are checkpointed with full state before shutdown and **automatically recreated** on startup, preserving their progress.

### Part 1 — Rich checkpoint before restart (version 2)

`checkpoint_active_subagents()` in `delegate_tool.py` now serialises the **full state** of running subagents to `$HERMES_HOME/state/subagent_checkpoints.json`. Each record contains:

- Metadata: `subagent_id`, `parent_id`, `depth`, `goal`, `model`, `started_at`, `tool_count`, `status`, `last_tool`
- `saved_messages`: The full conversation history (tool calls + results) extracted from the child agent's `_session_messages` and safely serialized (non-serializable fields stripped, long content truncated)
- `resolved_context`: The subagent's context from `_subagent_goal`

Checkpoint format is now version 2 (detectable by the `"version": 2` field). Version 1 checkpoints (metadata only) from older code are still accepted gracefully.

### Part 2 — Orphan adoption with progress preservation

`adopt_orphaned_subagents()` consumes the checkpoint on startup and stores the orphan data in a module-level variable `_pending_orphans`. Instead of just logging lost work and deleting the checkpoint:
- Full orphan records (with saved messages if available) are kept in memory
- The checkpoint warning now reports how many subagents have saved conversation state
- `get_pending_orphans()` provides access to the stored data

### Part 3 — Auto-recreation with progress continuity

New `recreate_pending_subagents(parent_agent)` function:
- Reads the orphan data stored by `adopt_orphaned_subagents()`
- For each orphan, calls `delegate_task` with the saved `goal` and `context`
- When `saved_messages` are available (version 2+ checkpoint), formats the previous conversation as enriched context so the new subagent knows what was already done and **picks up where it left off**
- Includes a CONTINUATION note in the context telling the new subagent not to re-do completed work
- Called automatically from `cli.py`'s first-turn agent initialization

### Hooks

- **`cli.py` `_run_cleanup()`** — calls `checkpoint_active_subagents()` before resource teardown
- **`cli.py` `run()`** — calls `adopt_orphaned_subagents()` after the welcome banner
- **`cli.py` first-turn init** — calls `recreate_pending_subagents()` when the agent is first initialized, auto-re-delegating orphans

### Changes separated

The unrelated "vision capability guard" change has been split into a separate PR: #26 (fix/vision-capability-guard-71027)

### Testing

24 tests in `tests/tools/test_delegate_checkpoint.py` covering:
- `_safe_serialize_messages` edge cases (bytes, callbacks, truncation)
- Path resolution under `$HERMES_HOME`
- Version 2 checkpoint write with full state (messages + context)
- Checkpoint write without agent object (graceful fallback)
- Orphan adoption reads, stores pending, and removes checkpoint
- Corrupt checkpoint is handled gracefully
- `get_pending_orphans()` returns correct data
- `recreate_pending_subagents()` re-delegates with goal
- `recreate_pending_subagents()` builds enriched context from messages
- Empty/missing goals skip gracefully
- `_remove_checkpoint_safe` never raises

## Closes

Closes #71023

## Breaking Changes

None. The `adopt_orphaned_subagents()` return signature (int) is preserved. New functions (`get_pending_orphans()`, `recreate_pending_subagents()`) are additive.