### PR TITLE
fix(sessions): gate cascade archive behind explicit confirm

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11516,6 +11516,13 @@ async def delete_session_endpoint(session_id: str, profile: Optional[str] = None
 class SessionRename(BaseModel):
     title: Optional[str] = None
     archived: Optional[bool] = None
+    # Caller opt-in to archiving when the compression-lineage CTE would
+    # cascade the flag to more than one session. Required (=True) when the
+    # targeted row participates in a chain with siblings; otherwise the
+    # endpoint returns 409 with the lineage preview so the caller can either
+    # send `confirm_cascade=True` or back out. Single-session updates
+    # (no compression lineage) still go through silently.
+    confirm_cascade: Optional[bool] = None
     # Mutate a session belonging to another profile (opens its state.db). Omit
     # for the current/default profile.
     profile: Optional[str] = None
@@ -11546,6 +11553,33 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
                 # Title too long, invalid characters, or already in use.
                 raise HTTPException(status_code=400, detail=str(e))
         if body.archived is not None:
+            # The CTE behind ``set_session_archived`` walks the whole
+            # compression lineage in one shot — archiving a single session
+            # in a chain silently flips every sibling. Refuse any cascade
+            # unless the caller explicitly opts in, and surface the blast
+            # radius (count + age span + affected ids) so a UI can render a
+            # real confirmation dialog instead of pretending one session
+            # is being archived in isolation. (#70185)
+            if body.archived is True:
+                preview = db.preview_session_archive_lineage(sid, archived=True)
+                if preview["cascade_extra"] > 0 and not body.confirm_cascade:
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "reason": "archive_cascade",
+                            "session_id": sid,
+                            "cascade_count": preview["cascade_count"],
+                            "cascade_extra": preview["cascade_extra"],
+                            "oldest_started_at": preview["oldest_started_at"],
+                            "newest_started_at": preview["newest_started_at"],
+                            "affected_ids": preview["affected_ids"],
+                            "advice": (
+                                "Resend the request with confirm_cascade=True "
+                                "to archive the whole lineage, or archive an "
+                                "explicit id that has no compression siblings."
+                            ),
+                        },
+                    )
             db.set_session_archived(sid, body.archived)
         result = {"ok": True, "title": db.get_session_title(sid) or ""}
         if body.archived is not None:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -34,6 +34,48 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 logger = logging.getLogger(__name__)
 
 
+def _log_session_archive(
+    db_path: "Path | None",
+    target_session_id: str,
+    archived: bool,
+    rowcount: int,
+) -> None:
+    """Append a one-line JSON record for a successful archive/unarchive.
+
+    Used by :meth:`SessionDB.set_session_archived` so an unexpected cascade
+    leaves a recoverable audit trail outside the SQLite database itself
+    (the ``state.db`` row is the only record of what was archived, and a
+    user's own data dir is the only durable place an investigation can look
+    after the fact). The write is intentionally best-effort — a write
+    failure must never fail an archive call, since a downstream file-system
+    hiccup does not justify a refused user action.
+
+    Profile-aware: ``db_path`` resolves the specific profile directory when
+    a profile-scoped state.db is in use, so two profiles don't share a log
+    file. Falls back to the shared ``~/.hermes`` root when ``db_path`` is
+    unset (the default ``SessionDB()`` constructor path).
+    """
+    try:
+        if db_path is None:
+            log_dir = get_hermes_home() / "logs"
+        else:
+            log_dir = Path(db_path).resolve().parent / "logs"
+
+        log_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "ts": time.time(),
+            "target": target_session_id,
+            "archived": bool(archived),
+            "rowcount": int(rowcount),
+        }
+        with (log_dir / "archives.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload))
+            handle.write("\n")
+    except Exception as exc:
+        # Never fail an archive call because of the audit append.
+        logger.debug("archive audit log failed: %s", exc)
+
+
 def _scrub_surrogates(value: Any) -> Any:
     """Replace lone surrogates when *value* is text; pass anything else through.
 
@@ -4942,6 +4984,14 @@ class SessionDB:
         chains, archive the whole logical conversation. Desktop lists compression
         roots projected forward to their latest continuation; updating only the
         displayed tip lets the still-unarchived root resurrect it on refresh.
+
+        Because the ancestral CTE silently walks the compression lineage, this
+        call can flip tens of sessions in one round-trip. Every successful call
+        is appended to ``<hermes_home>/logs/archives.jsonl`` so an unexpected
+        cascade leaves a recoverable audit trail instead of vanishing silently.
+        Callers who need the blast radius before committing should run
+        :meth:`preview_session_archive_lineage` first.
+
         Returns True when at least one row was updated.
         """
         def _do(conn):
@@ -4982,7 +5032,86 @@ class SessionDB:
                 rowcount = conn.execute("SELECT changes()").fetchone()[0]
             return rowcount
         rowcount = self._execute_write(_do)
+        if rowcount > 0:
+            _log_session_archive(self.db_path, session_id, archived, rowcount)
         return rowcount > 0
+
+    def preview_session_archive_lineage(
+        self, session_id: str, archived: bool = True
+    ) -> Dict[str, Any]:
+        """Report the lineage that ``set_session_archived`` would mutate.
+
+        The CTE in :meth:`set_session_archived` is recursive: archiving one
+        session in a compression chain flips the whole chain in a single
+        statement, with no confirmation step. This helper runs the same walk
+        in read-only mode so callers (HTTP API, bulk CLI, curator) can surface
+        the blast radius — session count plus the oldest/newest timestamps in
+        the affected set — *before* committing.
+
+        Returns a dict with keys:
+          * ``cascade_count`` — number of rows that would change.
+          * ``cascade_extra`` — how many of those are NOT the targeted row
+            (``cascade_count - 1``; ``0`` when the lineage has no siblings).
+          * ``oldest_started_at`` / ``newest_started_at`` — epoch seconds from
+            the ``sessions.started_at`` column, useful for an "oldest: 12d,
+            newest: 4h" confirmation string.
+          * ``affected_ids`` — the full session-id list, in CTE order, for a
+            preview that names every row that would change.
+
+        A targeted row that has no compression ancestors/descendants returns
+        ``cascade_count == 1`` and a single-element ``affected_ids``. A
+        non-existent session id returns ``cascade_count == 0``.
+        """
+        def _do(conn):
+            cursor = conn.execute(
+                """
+                WITH RECURSIVE
+                  ancestors(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT parent.id
+                    FROM ancestors a
+                    JOIN sessions child ON child.id = a.id
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  descendants(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT child.id
+                    FROM descendants d
+                    JOIN sessions parent ON parent.id = d.id
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  lineage(id) AS (
+                    SELECT id FROM ancestors
+                    UNION
+                    SELECT id FROM descendants
+                  )
+                SELECT id, started_at
+                FROM sessions
+                WHERE id IN (SELECT id FROM lineage)
+                  AND archived IS NOT ?
+                """,
+                (session_id, session_id, 1 if archived else 0),
+            )
+            return cursor.fetchall()
+
+        rows = self._execute_write(_do)
+        affected_ids = [row["id"] for row in rows]
+        started = [
+            row["started_at"]
+            for row in rows
+            if row["started_at"] is not None
+        ]
+        return {
+            "cascade_count": len(affected_ids),
+            "cascade_extra": max(0, len(affected_ids) - 1),
+            "oldest_started_at": min(started) if started else None,
+            "newest_started_at": max(started) if started else None,
+            "affected_ids": affected_ids,
+        }
 
     def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1788,6 +1788,161 @@ class TestWebServerEndpoints:
         restored = self.client.get("/api/sessions").json()
         assert any(s["id"] == "arch-me" for s in restored["sessions"])
 
+    def test_patch_session_archive_cascade_returns_409_without_confirm(self):
+        """Archiving a compression lineage returns 409 unless confirm_cascade=True.
+
+        Replaces the silent "one tiny click silently hides 10 days of work"
+        with a real, machine-readable conflict so the desktop sidebar (and any
+        future orchestrator UI) can render a confirmation dialog keyed to the
+        exact lineage count and age span. (#70185)
+        """
+        import time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("cascade-root", source="desktop")
+            db.create_session("cascade-tip", source="desktop", parent_session_id="cascade-root")
+            base = time.time() - 100
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'cascade-root'",
+                (base, base + 10),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'cascade-tip'",
+                (base + 20,),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.patch("/api/sessions/cascade-tip", json={"archived": True})
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        assert detail["reason"] == "archive_cascade"
+        assert detail["cascade_count"] == 2
+        assert detail["cascade_extra"] == 1
+        assert set(detail["affected_ids"]) == {"cascade-root", "cascade-tip"}
+        assert detail["oldest_started_at"] is not None
+        assert detail["newest_started_at"] is not None
+
+        # And nothing was actually archived — the cascade was refused, not silently half-applied.
+        # Read straight from the DB because the listing endpoint collapses
+        # compression projections (the root is shown via its later-touched
+        # child, so it won't necessarily appear by id on `/api/sessions`).
+        from hermes_state import SessionDB
+        verify_db = SessionDB()
+        try:
+            for sid in ("cascade-root", "cascade-tip"):
+                assert verify_db.get_session(sid)["archived"] == 0, sid
+        finally:
+            verify_db.close()
+
+    def test_patch_session_archive_cascade_with_confirm_proceeds(self):
+        """Passing confirm_cascade=True past the gate keeps the cascade archive working."""
+        import time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("allow-root", source="desktop")
+            db.create_session("allow-tip", source="desktop", parent_session_id="allow-root")
+            base = time.time() - 100
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'allow-root'",
+                (base, base + 10),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'allow-tip'",
+                (base + 20,),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.patch(
+            "/api/sessions/allow-tip",
+            json={"archived": True, "confirm_cascade": True},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["archived"] is True
+
+        # The cascade really walked both rows. Verify straight from the DB
+        # because the listings endpoint collapses a compression lineage
+        # into a single projected row.
+        from hermes_state import SessionDB
+        verify_db = SessionDB()
+        try:
+            for sid in ("allow-tip", "allow-root"):
+                assert verify_db.get_session(sid)["archived"] == 1, sid
+        finally:
+            verify_db.close()
+
+    def test_patch_session_archive_single_session_no_cascade_gate(self):
+        """Lonely sessions (no compression lineage) don't trigger the new 409 gate.
+
+        The whole point of the fix is to keep the previous behaviour for the
+        common case while adding a checkpoint for the dangerous one.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("lonely", source="desktop")
+            db.append_message(session_id="lonely", role="user", content="hi")
+        finally:
+            db.close()
+
+        resp = self.client.patch("/api/sessions/lonely", json={"archived": True})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["archived"] is True
+
+        listed = self.client.get("/api/sessions").json()
+        assert all(s["id"] != "lonely" for s in listed["sessions"])
+
+    def test_patch_session_unarchive_cascade_bypasses_gate(self):
+        """The 409 gate is archive-direction only — restoring a lineage must keep working.
+
+        A user wanting their archived sessions back would hate to be prompted
+        for confirmation before each unarchive, and a click that *fails to*
+        unarchive is far more recoverable than the inverse.
+        """
+        import time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("revive-root", source="desktop")
+            db.create_session("revive-tip", source="desktop", parent_session_id="revive-root")
+            base = time.time() - 100
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'revive-root'",
+                (base, base + 10),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'revive-tip'",
+                (base + 20,),
+            )
+            db._conn.commit()
+            db.set_session_archived("revive-tip", True)
+        finally:
+            db.close()
+
+        # No confirm_cascade field — restore must not gate behind the new safety net.
+        resp = self.client.patch("/api/sessions/revive-tip", json={"archived": False})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["archived"] is False
+
+        # Both rows were restored; verify via the DB because listings project
+        # compression lineages onto the latest touched endpoint.
+        from hermes_state import SessionDB
+        verify_db = SessionDB()
+        try:
+            for sid in ("revive-tip", "revive-root"):
+                assert verify_db.get_session(sid)["archived"] == 0, sid
+        finally:
+            verify_db.close()
+
     def test_patch_session_without_fields_is_400(self):
         """An existing session + empty body is a bad request, not a 404."""
         from hermes_state import SessionDB

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -1,4 +1,6 @@
+import json
 import time
+from pathlib import Path
 
 import pytest
 
@@ -29,6 +31,41 @@ def _compression_pair(db: SessionDB):
     db._conn.commit()
 
 
+def _compression_chain(db: SessionDB, length: int):
+    """Build a length-N compression chain rooted at ``ids[0]``.
+
+    Returns the list of session ids in lineage order. Each intermediate edge
+    needs ``end_reason='compression'`` on the parent side — without it the
+    CTE stops walking. Easiest model: every session ends as compression and
+    every session after the first points its ``parent_session_id`` back at
+    the previous step, so walking ``child → parent`` always crosses a
+    compression-tagged edge for this lineage.
+    """
+    base = time.time() - 1000
+    ids = [f"s{i}" for i in range(length)]
+    db.create_session(ids[0], source="cli")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = ?",
+        (base, base + 10, ids[0]),
+    )
+    for index, sid in enumerate(ids[1:], start=1):
+        db.create_session(sid, source="cli", parent_session_id=ids[index - 1])
+        # Tag the just-closed edge as compression so the CTE walks both
+        # ancestors AND descendants through every step in the lineage.
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = ?",
+            (base + 20 * index, base + 20 * index + 10, ids[index - 1]),
+        )
+        # And the new step itself, so a descendant walk that picks ``sid``
+        # as the seed still has a compression-tagged "parent" edge to recurse on.
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = ?",
+            (base + 20 * index, sid),
+        )
+    db._conn.commit()
+    return ids
+
+
 def test_archiving_compression_tip_archives_projected_root(db):
     _compression_pair(db)
 
@@ -49,3 +86,111 @@ def test_unarchiving_compression_tip_unarchives_projected_root(db):
     assert db.get_session("root")["archived"] == 0
     assert db.get_session("tip")["archived"] == 0
     assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["tip"]
+
+
+def test_preview_archive_single_session_no_cascade(db):
+    """A session with no compression ancestors/descendants reports a 1-row, 0-extra preview."""
+    db.create_session("solo", source="cli")
+
+    preview = db.preview_session_archive_lineage("solo", archived=True)
+
+    assert preview["cascade_count"] == 1
+    assert preview["cascade_extra"] == 0
+    assert preview["affected_ids"] == ["solo"]
+    assert preview["oldest_started_at"] is not None
+    assert preview["newest_started_at"] is not None
+
+
+def test_preview_archive_missing_session_reports_zero(db):
+    """Calling preview with a non-existent id returns 0, not a misleading 1-row cascade."""
+    preview = db.preview_session_archive_lineage("does-not-exist", archived=True)
+
+    assert preview == {
+        "cascade_count": 0,
+        "cascade_extra": 0,
+        "oldest_started_at": None,
+        "newest_started_at": None,
+        "affected_ids": [],
+    }
+
+
+def test_preview_archive_compression_pair_reports_two_rows(db):
+    """A compression pair must surface the full lineage, not the targeted row alone."""
+    _compression_pair(db)
+
+    preview = db.preview_session_archive_lineage("tip", archived=True)
+
+    assert preview["cascade_count"] == 2
+    assert preview["cascade_extra"] == 1
+    assert set(preview["affected_ids"]) == {"tip", "root"}
+
+
+def test_preview_archive_compression_chain_reports_full_set(db, tmp_path):
+    """A multi-step chain reports every legacy session, not just neighbours."""
+    ids = _compression_chain(db, 5)
+
+    db.close()
+    db = SessionDB(tmp_path / "state.db")
+
+    preview = db.preview_session_archive_lineage(ids[2], archived=True)
+
+    assert preview["cascade_count"] == 5
+    assert preview["cascade_extra"] == 4
+    assert set(preview["affected_ids"]) == set(ids)
+
+
+def test_preview_archive_already_archived_reports_zero_rows(db):
+    """Already-archived rows don't appear in the preview — they're not new mutations."""
+    _compression_pair(db)
+    db.set_session_archived("tip", True)
+
+    preview = db.preview_session_archive_lineage("tip", archived=True)
+
+    assert preview["cascade_count"] == 0
+    assert preview["affected_ids"] == []
+
+
+def test_preview_unarchive_skips_still_archived_rows(db):
+    """Unarchive preview only includes rows that aren't already unarchived."""
+    _compression_pair(db)
+    db.set_session_archived("tip", True)
+
+    preview = db.preview_session_archive_lineage("tip", archived=False)
+
+    # Both rows are currently archived (cascade forced both in tests above),
+    # so the unarchive preview should see the full lineage.
+    assert preview["cascade_count"] == 2
+    assert preview["cascade_extra"] == 1
+
+
+def test_set_session_archived_writes_audit_log(db, tmp_path):
+    """Successful archive calls append a JSON line under <hermes_home>/logs/archives.jsonl."""
+    _compression_pair(db)
+
+    db.set_session_archived("tip", True)
+
+    db.close()
+    log_path = tmp_path / "logs" / "archives.jsonl"
+    assert log_path.exists()
+    lines = [line for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(lines) == 1
+
+    record = json.loads(lines[0])
+    assert record["target"] == "tip"
+    assert record["archived"] is True
+    assert record["rowcount"] == 2  # the cascade flips both rows
+
+
+def test_set_session_archived_returns_false_for_missing_target(db, tmp_path):
+    """A non-existent session id produces no audit-log entry either.
+
+    ``set_session_archived`` returns ``False`` when zero rows were updated,
+    and the audit append is gated on ``rowcount > 0`` so the log file is
+    not created for an obviously failed call.
+    """
+    result = db.set_session_archived("does-not-exist", True)
+    assert result is False
+
+    db.close()
+    log_path = tmp_path / "logs" / "archives.jsonl"
+    assert not log_path.exists()


### PR DESCRIPTION
## Summary

`set_session_archived` walks the compression lineage in a single recursive CTE — one sidebar archive can silently hide days of work without confirmation, audit log, or undo. This commit makes the blast radius visible before it happens and leaves a recoverable trail after.

## Changes

- **`hermes_state.py`**: new `preview_session_archive_lineage(session_id, archived)` runs the same CTE read-only and returns cascade_count/cascade_extra/oldest/newest timestamps plus the affected_ids list. `set_session_archived` keeps its bool contract and now appends one JSON line per successful call to the logs directory next to state.db (or ~/.hermes/logs when DB path is unset).
- **`hermes_cli/web_server.py`**: `SessionRename` gains an optional `confirm_cascade` field. The PATCH endpoint runs the preview when `archived=True`; if the lineage has siblings and the caller did not opt in, it returns HTTP 409 with the preview payload.
- **`tests/hermes_state/test_session_archiving.py`**: 10 tests covering single-session, missing-id, compression pair, multi-step chain, idempotent-already-archived, unarchive-direction, audit log write, and missing-target no-op cases.
- **`tests/hermes_cli/test_web_server.py`**: 4 tests covering the 409 gate, the confirm_cascade=True path, single-session passthrough, and unarchive bypassing the gate.

## How to Test

```
venv/bin/python -m pytest tests/hermes_state/test_session_archiving.py -xvs      # 10/10
venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -k "archive or unarchive" -xvs  # 22/22
venv/bin/python -m pytest tests/hermes_state/ tests/test_hermes_state.py        # 488/488
```

## Checklist

- [x] Tests pass — 488 hermes_state + 22 archive/unarchive
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (uses db_path parent / logs — profile-aware path, no hardcoded profile)
- [x] profile-safe paths used
- [x] .env not used for non-credential settings (HTTP body field is the contract)
- [x] Backward compatible: set_session_archived(...) -> bool

## Risk & Impact

Low. Read-only preview is fully additive. The 409 gate is archive-direction only; unarchive and single-session archives pass through unchanged. The audit-log append is silent-fail so a filesystem hiccup cannot fail a user's archive call.

Type: Bug fix
Closes: #70185