### PR TITLE
fix(gateway): preserve queued follow-up media continuity

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2588,6 +2588,22 @@ def _is_control_interrupt_message(message: Optional[str]) -> bool:
     return normalized in _CONTROL_INTERRUPT_MESSAGES
 
 
+def _strip_response_attachments_for_direct_send(response: str, adapter) -> str:
+    """Return the visible text portion of a response before direct send().
+
+    Queued follow-up resends only replay attachments we can deliver natively in
+    this path: ``MEDIA:`` tags, bare local files, and internal directives. Keep
+    ordinary image URLs in the visible text until the queued path grows native
+    image-URL delivery too.
+    """
+    _, cleaned = adapter.extract_media(response)
+    cleaned = cleaned.replace("[[audio_as_voice]]", "").strip()
+    cleaned = cleaned.replace("[[as_document]]", "").strip()
+    cleaned = re.sub(r"MEDIA:\s*\S+", "", cleaned).strip()
+    _, cleaned = adapter.extract_local_files(cleaned)
+    return cleaned.strip()
+
+
 def _skill_slug_from_frontmatter(skill_md: Path) -> tuple[str | None, str | None]:
     """Derive the /command slug and declared frontmatter name from a SKILL.md.
 
@@ -15487,7 +15503,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
 
+    async def _deliver_queued_first_response(
+        self,
+        response: str,
+        source: SessionSource,
+        adapter,
+        metadata: Optional[Dict[str, Any]] = None,
+        event_message_id: Optional[str] = None,
+    ) -> None:
+        """Deliver a queued response using the normal text+attachment split."""
+        text_content = _strip_response_attachments_for_direct_send(response, adapter)
+        if text_content:
+            await adapter.send(
+                source.chat_id,
+                text_content,
+                metadata=metadata,
+            )
 
+        synthetic_event = MessageEvent(
+            text="",
+            source=source,
+            message_id=event_message_id,
+        )
+        await self._deliver_media_from_response(response, synthetic_event, adapter)
 
     async def _run_background_task(
         self,
@@ -22979,10 +23017,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
                                 session_key or "?",
                             )
-                            await adapter.send(
-                                source.chat_id,
+                            await self._deliver_queued_first_response(
                                 first_response,
+                                source=source,
+                                adapter=adapter,
                                 metadata=_status_thread_metadata,
+                                event_message_id=event_message_id,
                             )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2591,10 +2591,9 @@ def _is_control_interrupt_message(message: Optional[str]) -> bool:
 def _strip_response_attachments_for_direct_send(response: str, adapter) -> str:
     """Return the visible text portion of a response before direct send().
 
-    Queued follow-up resends only replay attachments we can deliver natively in
-    this path: ``MEDIA:`` tags, bare local files, and internal directives. Keep
-    ordinary image URLs in the visible text until the queued path grows native
-    image-URL delivery too.
+    Queued follow-up resends only replay explicit ``MEDIA:`` attachments in
+    this path. Keep bare local paths and ordinary image URLs visible because
+    the post-stream uploader intentionally ignores them (#20834).
 
     Do not apply a broad ``MEDIA:`` regex after ``extract_media()`` — the
     extractor deliberately preserves protected code/inline spans and
@@ -2603,7 +2602,6 @@ def _strip_response_attachments_for_direct_send(response: str, adapter) -> str:
     _, cleaned = adapter.extract_media(response)
     cleaned = cleaned.replace("[[audio_as_voice]]", "").strip()
     cleaned = cleaned.replace("[[as_document]]", "").strip()
-    _, cleaned = adapter.extract_local_files(cleaned)
     return cleaned.strip()
 
 
@@ -15410,6 +15408,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         response: str,
         event: MessageEvent,
         adapter,
+        thread_metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Extract explicit MEDIA: tags from a response and deliver them.
 
@@ -15448,7 +15447,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # stale inspected content), not an attachment request.
             adapter.extract_images(cleaned)
 
-            _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+            _thread_meta = (
+                dict(thread_metadata)
+                if thread_metadata is not None
+                else self._thread_metadata_for_source(
+                    event.source,
+                    self._reply_anchor_for_event(event),
+                )
+            )
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
@@ -15513,22 +15519,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter,
         metadata: Optional[Dict[str, Any]] = None,
         event_message_id: Optional[str] = None,
+        text_already_delivered: bool = False,
     ) -> None:
         """Deliver a queued response using the normal text+attachment split."""
-        text_content = _strip_response_attachments_for_direct_send(response, adapter)
-        if text_content:
-            await adapter.send(
-                source.chat_id,
-                text_content,
-                metadata=metadata,
-            )
+        if not text_already_delivered:
+            text_content = _strip_response_attachments_for_direct_send(response, adapter)
+            if text_content:
+                await adapter.send(
+                    source.chat_id,
+                    text_content,
+                    metadata=metadata,
+                )
 
         synthetic_event = MessageEvent(
             text="",
             source=source,
             message_id=event_message_id,
         )
-        await self._deliver_media_from_response(response, synthetic_event, adapter)
+        await self._deliver_media_from_response(
+            response,
+            synthetic_event,
+            adapter,
+            thread_metadata=metadata,
+        )
 
     async def _run_background_task(
         self,
@@ -23014,26 +23027,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Queued follow-up for session %s: suppressing intentional silence marker before continuing.",
                             session_key or "?",
                         )
-                    elif first_response and not _already_streamed:
+                    elif first_response:
                         try:
-                            logger.info(
-                                "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
-                                session_key or "?",
-                            )
+                            if _already_streamed:
+                                logger.info(
+                                    "Queued follow-up for session %s: final text delivery confirmed; delivering explicit media before continuing.",
+                                    session_key or "?",
+                                )
+                            else:
+                                logger.info(
+                                    "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
+                                    session_key or "?",
+                                )
                             await self._deliver_queued_first_response(
                                 first_response,
                                 source=source,
                                 adapter=adapter,
                                 metadata=_status_thread_metadata,
                                 event_message_id=event_message_id,
+                                text_already_delivered=_already_streamed,
                             )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
-                    elif first_response:
-                        logger.info(
-                            "Queued follow-up for session %s: skipping resend because final streamed delivery was confirmed.",
-                            session_key or "?",
-                        )
                     # Release deferred bg-review notifications now that the
                     # first response has been delivered.  Pop from the
                     # adapter's callback dict (prevents double-fire in

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2595,11 +2595,14 @@ def _strip_response_attachments_for_direct_send(response: str, adapter) -> str:
     this path: ``MEDIA:`` tags, bare local files, and internal directives. Keep
     ordinary image URLs in the visible text until the queued path grows native
     image-URL delivery too.
+
+    Do not apply a broad ``MEDIA:`` regex after ``extract_media()`` — the
+    extractor deliberately preserves protected code/inline spans and
+    unsupported or unvalidated tags in the cleaned text.
     """
     _, cleaned = adapter.extract_media(response)
     cleaned = cleaned.replace("[[audio_as_voice]]", "").strip()
     cleaned = cleaned.replace("[[as_document]]", "").strip()
-    cleaned = re.sub(r"MEDIA:\s*\S+", "", cleaned).strip()
     _, cleaned = adapter.extract_local_files(cleaned)
     return cleaned.strip()
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -59,6 +59,25 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
         return {"id": chat_id}
 
 
+class MediaCaptureProgressAdapter(ProgressCaptureAdapter):
+    """Capture native image batches without contacting a platform API."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.image_batches = []
+
+    async def send_multiple_images(
+        self, chat_id, images, metadata=None, human_delay=0.0
+    ) -> None:
+        self.image_batches.append(
+            {
+                "chat_id": chat_id,
+                "images": images,
+                "metadata": metadata,
+            }
+        )
+
+
 class SmallLimitProgressAdapter(ProgressCaptureAdapter):
     """Adapter with a tiny platform limit to exercise progress rollover."""
 
@@ -779,6 +798,33 @@ class QueuedCommentaryAgent:
         }
 
 
+class QueuedMediaAgent:
+    """Return an explicit image attachment before a queued follow-up."""
+
+    calls = 0
+    media_path = None
+
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls += 1
+        if type(self).calls == 1:
+            final_response = f"first response\nMEDIA:{type(self).media_path}"
+            if self.stream_delta_callback:
+                self.stream_delta_callback("first response")
+        else:
+            final_response = "follow-up processed"
+            if self.stream_delta_callback:
+                self.stream_delta_callback(final_response)
+        return {
+            "final_response": final_response,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class QueuedSilenceAgent:
     """First turn is intentionally silent; queued follow-up still runs."""
 
@@ -1273,6 +1319,84 @@ async def test_run_agent_queued_message_does_not_treat_commentary_as_final(monke
     assert result["final_response"] == "final response 2"
     assert "I'll inspect the repo first." in sent_texts
     assert "final response 1" in sent_texts
+
+
+@pytest.mark.asyncio
+async def test_run_agent_queued_message_delivers_first_response_media(monkeypatch, tmp_path):
+    """Queued follow-ups must preserve explicit attachments from the first turn."""
+    media_path = tmp_path / "queued-first-response.png"
+    media_path.write_bytes(b"not-a-real-png-but-a-real-file")
+    QueuedMediaAgent.calls = 0
+    QueuedMediaAgent.media_path = media_path
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedMediaAgent,
+        session_id="sess-queued-media",
+        pending_text="queued follow-up",
+        platform=Platform.DISCORD,
+        chat_id="discord-thread",
+        chat_type="group",
+        thread_id="discord-thread",
+        adapter_cls=MediaCaptureProgressAdapter,
+    )
+
+    assert result["final_response"] == "follow-up processed"
+    assert isinstance(adapter, MediaCaptureProgressAdapter)
+    assert {
+        "sent_texts": [call["content"] for call in adapter.sent],
+        "image_batches": adapter.image_batches,
+    } == {
+        "sent_texts": ["first response"],
+        "image_batches": [
+            {
+                "chat_id": "discord-thread",
+                "images": [(media_path.as_uri(), "")],
+                "metadata": {"thread_id": "discord-thread"},
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_agent_queued_message_delivers_streamed_first_response_media(
+    monkeypatch, tmp_path,
+):
+    """Streaming first-turn text must not suppress its explicit attachment."""
+    media_path = tmp_path / "queued-streamed-first-response.png"
+    media_path.write_bytes(b"not-a-real-png-but-a-real-file")
+    QueuedMediaAgent.calls = 0
+    QueuedMediaAgent.media_path = media_path
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedMediaAgent,
+        session_id="sess-queued-streamed-media",
+        pending_text="queued follow-up",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.DISCORD,
+        chat_id="discord-thread",
+        chat_type="group",
+        thread_id="discord-thread",
+        adapter_cls=MediaCaptureProgressAdapter,
+    )
+
+    assert result["final_response"] == "follow-up processed"
+    assert isinstance(adapter, MediaCaptureProgressAdapter)
+    all_text = [call["content"] for call in adapter.sent + adapter.edits]
+    assert all("MEDIA:" not in text for text in all_text)
+    assert adapter.image_batches == [
+        {
+            "chat_id": "discord-thread",
+            "images": [(media_path.as_uri(), "")],
+            "metadata": {"thread_id": "discord-thread"},
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -264,8 +264,11 @@ async def test_streaming_delivery_blocks_media_path_outside_allowed_roots(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_image():
+async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_image(
+    tmp_path, monkeypatch,
+):
     event = _event(thread_id="topic-1")
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "pricelist.png")
     runner = object.__new__(GatewayRunner)
     runner._thread_metadata_for_source = lambda source, anchor=None: {"thread_id": "topic-1"}
     runner._reply_anchor_for_event = lambda event: event.message_id
@@ -284,7 +287,7 @@ async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_ima
 
     await GatewayRunner._deliver_queued_first_response(
         runner,
-        "Quote here\nMEDIA:/tmp/pricelist.png",
+        f"Quote here\nMEDIA:{media_file}",
         source=event.source,
         adapter=adapter,
         metadata={"thread_id": "topic-1"},
@@ -298,7 +301,7 @@ async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_ima
     )
     adapter.send_multiple_images.assert_awaited_once_with(
         chat_id="chat-1",
-        images=[("file:///tmp/pricelist.png", "")],
+        images=[(f"file://{media_file.as_posix()}", "")],
         metadata={"thread_id": "topic-1"},
     )
 

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -261,3 +261,80 @@ async def test_streaming_delivery_blocks_media_path_outside_allowed_roots(tmp_pa
 
     adapter.send_document.assert_not_awaited()
     adapter.send_voice.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_image():
+    event = _event(thread_id="topic-1")
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = lambda source, anchor=None: {"thread_id": "topic-1"}
+    runner._reply_anchor_for_event = lambda event: event.message_id
+
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        "Quote here\nMEDIA:/tmp/pricelist.png",
+        source=event.source,
+        adapter=adapter,
+        metadata={"thread_id": "topic-1"},
+        event_message_id=event.message_id,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        "Quote here",
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_multiple_images.assert_awaited_once_with(
+        chat_id="chat-1",
+        images=[("file:///tmp/pricelist.png", "")],
+        metadata={"thread_id": "topic-1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_delivery_keeps_remote_image_url_in_text():
+    event = _event(thread_id="topic-1")
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = lambda source, anchor=None: {"thread_id": "topic-1"}
+    runner._reply_anchor_for_event = lambda event: event.message_id
+
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    response = "See this mockup\nhttps://example.com/mockup.png"
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        response,
+        source=event.source,
+        adapter=adapter,
+        metadata={"thread_id": "topic-1"},
+        event_message_id=event.message_id,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        response,
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_multiple_images.assert_not_awaited()

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -7,6 +7,9 @@ only renders as a voice bubble when explicitly flagged) and via
 ``GatewayRunner._deliver_media_from_response``.
 """
 
+import importlib
+import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -341,3 +344,172 @@ async def test_queued_followup_delivery_keeps_remote_image_url_in_text():
         metadata={"thread_id": "topic-1"},
     )
     adapter.send_multiple_images.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_delivery_preserves_protected_media_example():
+    """Inline-code MEDIA examples must remain visible after queued text cleanup."""
+    event = _event(thread_id="topic-1")
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = lambda source, anchor=None: {"thread_id": "topic-1"}
+    runner._reply_anchor_for_event = lambda event: event.message_id
+
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    response = "Tag files like `MEDIA:/tmp/example.png` in tool output."
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        response,
+        source=event.source,
+        adapter=adapter,
+        metadata={"thread_id": "topic-1"},
+        event_message_id=event.message_id,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        response,
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+
+
+class _QueuedMediaCaptureAdapter(BasePlatformAdapter):
+    """Adapter that records text + native image delivery for queued-resend tests."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.sent = []
+        self.images = []
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return SendResult(success=True, message_id=f"text-{len(self.sent)}")
+
+    async def send_image_file(self, chat_id, image_path, caption=None, reply_to=None, metadata=None, **kwargs):
+        self.images.append({"chat_id": chat_id, "image_path": image_path, "metadata": metadata})
+        return SendResult(success=True, message_id=f"img-{len(self.images)}")
+
+    async def send_multiple_images(self, chat_id, images, metadata=None, human_delay=0.0):
+        for image_url, _alt in images:
+            path = image_url
+            if path.startswith("file://"):
+                path = path[len("file://"):]
+            self.images.append({"chat_id": chat_id, "image_path": path, "metadata": metadata})
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+class _QueuedMediaAgent:
+    calls = 0
+    first_response = ""
+
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls += 1
+        if type(self).calls == 1:
+            return {
+                "final_response": type(self).first_response,
+                "messages": [],
+                "api_calls": 1,
+            }
+        return {
+            "final_response": "follow-up processed",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+@pytest.mark.asyncio
+async def test_queued_resend_branch_delivers_media_and_preserves_protected_example(
+    tmp_path, monkeypatch,
+):
+    """Exercise the real queued first-response resend path in ``_run_agent``."""
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "quote.png")
+    protected = "Tag files like `MEDIA:/tmp/example.png` in tool output."
+    _QueuedMediaAgent.calls = 0
+    _QueuedMediaAgent.first_response = f"Quote here\nMEDIA:{media_file}\n{protected}"
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _QueuedMediaAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = _QueuedMediaCaptureAdapter()
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.session_store = SimpleNamespace(_entries={}, _save=lambda: None)
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        chat_type="dm",
+        thread_id="topic-1",
+    )
+    session_key = build_session_key(source)
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="queued follow-up",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="queued-1",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-queued-media",
+        session_key=session_key,
+    )
+
+    assert _QueuedMediaAgent.calls == 2
+    assert result["final_response"] == "follow-up processed"
+    first_texts = [call["content"] for call in adapter.sent if "Quote here" in call["content"]]
+    assert first_texts, f"expected queued resend of first response, got: {adapter.sent!r}"
+    assert f"MEDIA:{media_file}" not in first_texts[0]
+    assert "`MEDIA:/tmp/example.png`" in first_texts[0]
+    assert any(str(media_file) in img["image_path"] for img in adapter.images), (
+        f"expected native image delivery via queued resend, got: {adapter.images!r}"
+    )

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -347,6 +347,50 @@ async def test_queued_followup_delivery_keeps_remote_image_url_in_text():
 
 
 @pytest.mark.asyncio
+async def test_queued_followup_delivery_keeps_bare_local_path_in_text(
+    tmp_path, monkeypatch,
+):
+    """Queued delivery must not strip paths its explicit-only uploader ignores."""
+    event = _event(thread_id="topic-1")
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "inspected.png")
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = (
+        lambda source, reply_to_message_id=None: {"thread_id": "topic-1"}
+    )
+    runner._reply_anchor_for_event = lambda event: event.message_id
+
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    response = f"The inspected file is at {media_file}."
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        response,
+        source=event.source,
+        adapter=adapter,
+        metadata={"thread_id": "topic-1"},
+        event_message_id=event.message_id,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        response,
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_queued_followup_delivery_preserves_protected_media_example():
     """Inline-code MEDIA examples must remain visible after queued text cleanup."""
     event = _event(thread_id="topic-1")

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -310,6 +310,56 @@ async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_ima
 
 
 @pytest.mark.asyncio
+async def test_queued_followup_delivery_reuses_routing_metadata_for_media(
+    tmp_path, monkeypatch,
+):
+    """Queued text and media must stay on the same precomputed reply route."""
+    event = _event(thread_id="source-topic")
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "threaded.png")
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = (
+        lambda source, reply_to_message_id=None: {"thread_id": "recomputed-topic"}
+    )
+    runner._reply_anchor_for_event = lambda event: event.message_id
+    routing_metadata = {
+        "thread_id": "queued-topic",
+        "reply_to_message_id": "trigger-message",
+    }
+
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        f"Threaded image\nMEDIA:{media_file}",
+        source=event.source,
+        adapter=adapter,
+        metadata=routing_metadata,
+        event_message_id=event.message_id,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        "Threaded image",
+        metadata=routing_metadata,
+    )
+    adapter.send_multiple_images.assert_awaited_once_with(
+        chat_id="chat-1",
+        images=[(f"file://{media_file.as_posix()}", "")],
+        metadata=routing_metadata,
+    )
+
+
+@pytest.mark.asyncio
 async def test_queued_followup_delivery_keeps_remote_image_url_in_text():
     event = _event(thread_id="topic-1")
     runner = object.__new__(GatewayRunner)
@@ -495,11 +545,11 @@ async def test_queued_resend_branch_delivers_media_and_preserves_protected_examp
     _QueuedMediaAgent.first_response = f"Quote here\nMEDIA:{media_file}\n{protected}"
 
     fake_dotenv = types.ModuleType("dotenv")
-    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    setattr(fake_dotenv, "load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
-    fake_run_agent.AIAgent = _QueuedMediaAgent
+    setattr(fake_run_agent, "AIAgent", _QueuedMediaAgent)
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
     adapter = _QueuedMediaCaptureAdapter()


### PR DESCRIPTION
## What does this PR do?

Queued follow-up delivery had a separate direct-send path from normal final-response delivery. That path could expose a literal `MEDIA:` directive instead of uploading the attachment, and it skipped explicit media entirely when the first response text had already been streamed.

This PR keeps queued text and attachment delivery continuous across both fallback and streamed cases:

- strip explicit attachment directives from fallback text before sending it;
- deliver explicit attachments exactly once even when the text was already streamed;
- reuse the queued turn's precomputed thread/reply metadata for the attachment;
- preserve bare local paths as visible text because post-stream uploads are intentionally explicit-only;
- keep intentional-silence filtering and the existing first-response-before-follow-up ordering.

This is an attribution-preserving consolidation of #25119. Its three commits remain in the branch with Kong Ka Weng (`vKongv`) as author; the additional commits add current-`main` compatibility and cover the streamed sibling path.

## Related Issue

Fixes #60845

Related: #18539, #55806, #19011, #25119, #46223, #51805

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - route queued first responses through the existing explicit-media delivery flow;
  - skip only duplicate text after confirmed streaming, not its attachments;
  - reuse precomputed thread/reply metadata for text and media;
  - retain bare local paths in visible text rather than silently deleting paths that will not be uploaded.
- `tests/gateway/test_run_progress_topics.py`
  - cover fallback and streamed queued-follow-up delivery through the real recursive path;
  - assert text cleanup, exactly-once native attachment delivery, follow-up completion, and Discord thread metadata.
- `tests/gateway/test_tts_media_routing.py`
  - preserve the #25119 media-routing coverage;
  - add bare-path and precomputed routing-metadata regressions.

## How to Test

1. Run the related gateway files:
   ```bash
   pytest tests/gateway/test_run_progress_topics.py tests/gateway/test_post_stream_media_delivery.py tests/gateway/test_tts_media_routing.py -p no:cacheprovider -o 'addopts=' -q
   ```
   Expected: `63 passed`.
2. Run queued-follow-up coverage across gateway tests:
   ```bash
   pytest tests/gateway -k 'queued_followup or queued_message or queued_resend' -p no:cacheprovider -o 'addopts=' -q
   ```
   Expected: `14 passed, 1 skipped`.
3. Run blocking static gates:
   ```bash
   ruff check .
   python scripts/check-windows-footguns.py --all
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Python 3.11; focused gateway integration tests and blocking static gates)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: no user-facing configuration or API change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: no config change
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `check-windows-footguns.py --all` passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: no tool schema change

## Screenshots / Logs

Not applicable. The regression is covered by gateway integration tests that assert observable text, attachment, recursion, and routing behavior.
