### PR TITLE
fix(doctor): prevent blanket except from swallowing model validation when config uses scalar model key (#71019)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -932,7 +932,14 @@ def run_doctor(args):
         try:
             import yaml as _yaml
             cfg = _yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-            model_section = cfg.get("model") or {}
+            model_val = cfg.get("model")
+            if isinstance(model_val, dict):
+                model_section = model_val
+            elif isinstance(model_val, str) and model_val.strip():
+                # Scalar model key (e.g. ``model: gpt-4o``) — treat as default
+                model_section = {"default": model_val.strip()}
+            else:
+                model_section = {}
             provider_raw = (model_section.get("provider") or "").strip()
             provider = provider_raw.lower()
             default_model = (model_section.get("default") or model_section.get("model") or "").strip()


### PR DESCRIPTION
## Problem

When `config.yaml` uses a scalar `model:` key (e.g. `model: gpt-4o`), `hermes doctor` silently skips ALL model/provider validation. It shows only a generic warning instead of properly checking provider/config issues.

**Root cause:** A 184-line blanket `except Exception` at line 1046 swallows the `AttributeError` raised when `str.get("provider")` is attempted on the scalar string value. The code at line 864 does:

```python
model_section = cfg.get("model") or {}
```

When `model` is a string like `"gpt-4o"`, `model_section` becomes that string (non-empty string is truthy), and then `model_section.get("provider")` raises `AttributeError`.

## Fix

Add a type guard before treating `model` config as a dict. If the value is a scalar string, treat it as `{"default": scalar_value}` — matching the same pattern already used in the `--fix` migration path at lines 1108–1116.

## Testing

All 75 existing doctor tests pass.