### PR TITLE
feat(dashboard): optional nav section grouping for sidebar (#70969)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -119,6 +119,7 @@ const CHAT_NAV_ITEM: NavItem = {
   labelKey: "chat",
   label: "Chat",
   icon: Terminal,
+  section: "Workspace",
 };
 
 /**
@@ -166,37 +167,41 @@ const BUILTIN_NAV_REST: NavItem[] = [
     labelKey: "sessions",
     label: "Sessions",
     icon: MessageSquare,
+    section: "Workspace",
   },
-  { path: "/files", label: "Files", icon: FolderOpen },
+  { path: "/files", label: "Files", icon: FolderOpen, section: "Workspace" },
   {
     path: "/analytics",
     labelKey: "analytics",
     label: "Analytics",
     icon: BarChart3,
+    section: "Monitoring",
   },
   {
     path: "/models",
     labelKey: "models",
     label: "Models",
     icon: Cpu,
+    section: "Configuration",
   },
-  { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
-  { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
-  { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
-  { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
-  { path: "/mcp", label: "MCP", icon: Plug },
-  { path: "/channels", label: "Channels", icon: Radio },
-  { path: "/webhooks", label: "Webhooks", icon: Webhook },
-  { path: "/pairing", label: "Pairing", icon: ShieldCheck },
-  { path: "/profiles", labelKey: "profiles", label: "Profiles", icon: Users },
-  { path: "/config", labelKey: "config", label: "Config", icon: Settings },
-  { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound },
-  { path: "/system", label: "System", icon: Wrench },
+  { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText, section: "Monitoring" },
+  { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock, section: "Automation" },
+  { path: "/skills", labelKey: "skills", label: "Skills", icon: Package, section: "Extensions" },
+  { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle, section: "Extensions" },
+  { path: "/mcp", label: "MCP", icon: Plug, section: "Extensions" },
+  { path: "/channels", label: "Channels", icon: Radio, section: "Integrations" },
+  { path: "/webhooks", label: "Webhooks", icon: Webhook, section: "Integrations" },
+  { path: "/pairing", label: "Pairing", icon: ShieldCheck, section: "Configuration" },
+  { path: "/profiles", labelKey: "profiles", label: "Profiles", icon: Users, section: "Configuration" },
+  { path: "/config", labelKey: "config", label: "Config", icon: Settings, section: "Configuration" },
+  { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound, section: "Configuration" },
+  { path: "/system", label: "System", icon: Wrench, section: "System" },
   {
     path: "/docs",
     labelKey: "documentation",
     label: "Documentation",
     icon: BookOpen,
+    section: "System",
   },
 ];
 
@@ -244,6 +249,7 @@ function buildNavItems(
       path: manifest.tab.path,
       label: manifest.label,
       icon: resolveIcon(manifest.icon),
+      section: manifest.tab.section,
     };
 
     const pos = manifest.tab.position ?? "end";
@@ -615,18 +621,45 @@ export default function App() {
               className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden border-t border-current/10 py-2"
               aria-label={t.app.navigation}
             >
-              <ul className="flex flex-col">
-                {sidebarNav.coreItems.map((item) => (
-                  <SidebarNavLink
-                    closeMobile={closeMobile}
-                    collapsed={isDesktopCollapsed}
-                    item={item}
-                    key={item.path}
-                    t={t}
-                    tooltipWarmRef={tooltipWarmRef}
-                  />
-                ))}
-              </ul>
+              {(() => {
+                let lastSection: string | undefined;
+                const groups: { section?: string; items: NavItem[] }[] = [];
+                for (const item of sidebarNav.coreItems) {
+                  if (item.section !== lastSection) {
+                    groups.push({ section: item.section, items: [item] });
+                    lastSection = item.section;
+                  } else {
+                    groups[groups.length - 1].items.push(item);
+                  }
+                }
+                return groups.map((group) => (
+                  <div key={group.section ?? "__ungrouped"}>
+                    {group.section && (
+                      <span
+                        className={cn(
+                          "block px-5 pt-2.5 pb-1",
+                          "font-sans text-display text-xs tracking-[0.12em] text-text-tertiary",
+                          isDesktopCollapsed && "lg:hidden",
+                        )}
+                      >
+                        {group.section}
+                      </span>
+                    )}
+                    <ul className="flex flex-col">
+                      {group.items.map((item) => (
+                        <SidebarNavLink
+                          closeMobile={closeMobile}
+                          collapsed={isDesktopCollapsed}
+                          item={item}
+                          key={item.path}
+                          t={t}
+                          tooltipWarmRef={tooltipWarmRef}
+                        />
+                      ))}
+                    </ul>
+                  </div>
+                ));
+              })()}
 
               {sidebarNav.pluginItems.length > 0 && (
                 <div
@@ -1307,6 +1340,8 @@ interface NavItem {
   label: string;
   labelKey?: string;
   path: string;
+  /** Optional section/group label. When set, sidebar groups consecutive items with the same section under a header. */
+  section?: string;
 }
 
 interface SidebarIconWithTooltipProps {

--- a/web/src/plugins/types.ts
+++ b/web/src/plugins/types.ts
@@ -16,6 +16,9 @@ export interface PluginManifest {
     override?: string;
     /** When true, the plugin may register without a sidebar tab (slot-only, etc.). */
     hidden?: boolean;
+    /** Optional section/group name. When set and the sidebar supports section grouping,
+     * the plugin nav item renders under the named section header. */
+    section?: string;
   };
   /** Declared for discovery; actual slots use registerSlot in the plugin bundle. */
   slots?: string[];


### PR DESCRIPTION
## Summary

Adds optional section/group support to the dashboard sidebar. When `NavItem.section` is set, consecutive items with the same section are rendered under a section header. Items without a section render as-is (backward compatible).

## Changes

### `NavItem` interface (`web/src/App.tsx`)
- Added optional `section?: string` field

### `PluginManifest.tab` (`web/src/plugins/types.ts`)
- Added optional `section?: string` field — plugins can declare `tab.section` to place themselves in a named sidebar section

### `buildNavItems()`
- Carries through `manifest.tab.section` to the plugin's `NavItem`

### Sidebar rendering
- Core nav items are now grouped by `section`; section headers render at group boundaries
- Section headers are hidden in collapsed mode (`lg:hidden`)
- Plugin items section remains unchanged (still renders under "Plugins" header)

### Built-in section assignments
| Section | Items |
|---|---|
| Workspace | Chat, Sessions, Files |
| Monitoring | Analytics, Logs |
| Configuration | Models, Config, Keys, Profiles, Pairing |
| Automation | Cron |
| Extensions | Skills, Plugins, MCP |
| Integrations | Channels, Webhooks |
| System | System, Documentation |

Closes #70969