### PR TITLE
feat(dashboard): add proper access-control boundary for --isolated mode (#70867)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14722,6 +14722,7 @@ def cmd_dashboard(args):
         allow_public=getattr(args, "insecure", False),
         initial_profile=getattr(args, "open_profile", "") or "",
         headless=_headless_backend,
+        isolated=getattr(args, "isolated", False),
         ssh_session_token=_ssh_session_token,
         ssh_owner_nonce=_ssh_owner_nonce,
     )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11707,6 +11707,7 @@ def _open_session_db_for_profile(profile: Optional[str]):
     from hermes_state import SessionDB
     if not profile:
         return SessionDB()
+    _check_isolated_profile_access(profile)
     _name, home = _cron_profile_home(profile)
     return SessionDB(db_path=Path(home) / "state.db")
 
@@ -15546,6 +15547,7 @@ def _profile_scope(profile: Optional[str]):
     imported the modules before a HERMES_HOME override, or under test
     isolation).
     """
+    _check_isolated_profile_access(profile)
     requested = (profile or "").strip()
 
     from hermes_constants import (
@@ -15599,6 +15601,7 @@ def _config_profile_scope(profile: Optional[str]):
 
     None/""/"current" means the dashboard's own profile — no override.
     """
+    _check_isolated_profile_access(profile)
     requested = (profile or "").strip()
     if not requested or requested.lower() == "current":
         yield None
@@ -15615,6 +15618,29 @@ def _config_profile_scope(profile: Optional[str]):
         yield profile_dir
     finally:
         reset_hermes_home_override(token)
+
+
+def _check_isolated_profile_access(profile: Optional[str]) -> None:
+    if not getattr(app.state, "isolated", False):
+        return
+    requested = (profile or "").strip()
+    if not requested or requested.lower() == "current":
+        return
+    from hermes_constants import get_hermes_home
+
+    isolated_home = Path(str(get_hermes_home()))
+    try:
+        requested_dir = _resolve_profile_dir(requested)
+    except HTTPException:
+        return
+    if requested_dir.resolve() != isolated_home.resolve():
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Isolated mode: profile '" + requested + "' is not accessible. "
+                "This dashboard is scoped to its own profile only."
+            ),
+        )
 
 
 class SkillToggle(BaseModel):
@@ -20021,6 +20047,7 @@ def start_server(
     allow_public: bool = False,
     initial_profile: str = "",
     headless: bool = False,
+    isolated: bool = False,
     ssh_session_token: Optional[str] = None,
     ssh_owner_nonce: Optional[str] = None,
 ):
@@ -20055,6 +20082,7 @@ def start_server(
     # uses this to decide whether to refuse the bind, log the gate-on
     # banner, and enable uvicorn proxy_headers.
     app.state.auth_required = should_require_auth(host)
+    app.state.isolated = isolated
 
     # ``--insecure`` no longer disables the auth gate (June 2026 hardening:
     # the hermes-0day MCP-persistence campaign abused unauthenticated public


### PR DESCRIPTION
## Summary

Turn `dashboard --isolated` from a UI convenience into a proper access-control boundary. Previously, isolated-mode dashboards could be bypassed via the `?profile=` query parameter, allowing users to read/write other profiles' config, sessions, skills, and env vars.

## Changes

- **`_check_isolated_profile_access(profile)`** — new helper that denies access when:
  1. The dashboard is in isolated mode (`app.state.isolated`)
  2. A `?profile=` query parameter targets a profile different from the server's own `HERMES_HOME`
- **Wired into all three profile-scope gateways**:
  - `_profile_scope()` — config, skills, env vars, model info endpoints
  - `_config_profile_scope()` — config schema, status, async-safe config endpoints
  - `_open_session_db_for_profile()` — session listing/search/detail endpoints
- **`start_server()`** accepts an `isolated` parameter stored on `app.state.isolated`
- **`cmd_dashboard`** forwards `--isolated` to `start_server()`

Closes: #70867