### PR TITLE
feat(tui): configurable welcome banner sections, default-open, plugin sections (#70916)

### DIFF
--- a/_apply_patches.py
+++ b/_apply_patches.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""Apply all welcome banner config patches."""
+import os
+
+REPO = os.path.dirname(os.path.abspath(__file__))
+PATHS = {
+    'gatewayTypes.ts': 'ui-tui/src/gatewayTypes.ts',
+    'types.ts': 'ui-tui/src/types.ts',
+    'interfaces.ts': 'ui-tui/src/app/interfaces.ts',
+    'uiStore.ts': 'ui-tui/src/app/uiStore.ts',
+    'details.ts': 'ui-tui/src/domain/details.ts',
+    'useConfigSync.ts': 'ui-tui/src/app/useConfigSync.ts',
+    'branding.tsx': 'ui-tui/src/components/branding.tsx',
+    'appLayout.tsx': 'ui-tui/src/components/appLayout.tsx',
+    'config.yaml': 'cli-config.yaml.example',
+}
+
+def read(name):
+    with open(os.path.join(REPO, PATHS[name])) as f:
+        return f.read()
+
+def write(name, content):
+    with open(os.path.join(REPO, PATHS[name]), 'w') as f:
+        f.write(content)
+    print(f'  OK {PATHS[name]}')
+
+# 1. gatewayTypes.ts
+content = read('gatewayTypes.ts')
+old = (
+    '  /** Theme mode pin: \'light\' / \'dark\' beat background auto-detection; \'auto\'\n'
+    '   *  (default) trusts the OSC-11 probe + env signals. */\n'
+    '  tui_theme?: string\n'
+    '}'
+)
+new = old + (
+    '\n'
+    '\n'
+    '  /**\n'
+    '   * Welcome banner section configuration.\n'
+    '   *\n'
+    '   * Controls which accordion sections appear in the TUI welcome panel, their\n'
+    '   * default open/closed state, and custom plugin-provided sections.\n'
+    '   *\n'
+    '   * Sections omitted from config use their built-in defaults (tools=open,\n'
+    '   * skills=closed, system_prompt=closed, mcp_servers=closed). Set\n'
+    '   * `enabled: false` to hide a section entirely.\n'
+    '   *\n'
+    '   * `plugin_sections` renders custom Accordion sections after the built-in\n'
+    '   * ones. Data for plugin sections is expected on SessionInfo under the\n'
+    '   * matching key (future - currently renders a placeholder label).\n'
+    '   */\n'
+    '  welcome_banner?: {\n'
+    '    sections?: Record<string, { default_open?: boolean; enabled?: boolean }>\n'
+    '    plugin_sections?: Array<{ id: string; title: string; default_open?: boolean }>\n'
+    '  }\n'
+    '}'
+)
+assert old in content, 'gatewayTypes.ts: old not found'
+content = content.replace(old, new, 1)
+write('gatewayTypes.ts', content)
+
+# 2. types.ts
+content = read('types.ts')
+old2 = (
+    'export interface SlashCatalog {\n'
+    '  canon: Record<string, string>\n'
+    '  categories: SlashCategory[]\n'
+    '  pairs: [string, string][]\n'
+    '  skillCount: number\n'
+    '  sub: Record<string, string[]>\n'
+    '}'
+)
+new2 = (
+    old2 + '\n'
+    '\n'
+    '/**\n'
+    ' * Welcome banner section config as resolved from display.welcome_banner.\n'
+    ' * Each built-in section (tools, skills, system_prompt, mcp_servers) can be\n'
+    ' * independently enabled/disabled and default-open/closed.\n'
+    ' *\n'
+    ' * Plugin sections render custom Accordion entries after built-in sections.\n'
+    ' */\n'
+    'export interface WelcomeBannerSectionConfig {\n'
+    '  default_open: boolean\n'
+    '  enabled: boolean\n'
+    '}\n'
+    '\n'
+    'export interface WelcomeBannerPluginSection {\n'
+    '  id: string\n'
+    '  title: string\n'
+    '  default_open: boolean\n'
+    '}\n'
+    '\n'
+    'export interface WelcomeBannerConfig {\n'
+    '  sections: Record<string, WelcomeBannerSectionConfig>\n'
+    '  plugin_sections: WelcomeBannerPluginSection[]\n'
+    '}\n'
+    '\n'
+    '/**\n'
+    ' * Welcome banner section default defaults for each built-in section.\n'
+    ' * These match the hardcoded values in branding.tsx before this feature.\n'
+    ' */\n'
+    'export const WELCOME_BANNER_DEFAULTS: Record<string, WelcomeBannerSectionConfig> = {\n'
+    '  tools: { default_open: true, enabled: true },\n'
+    '  skills: { default_open: false, enabled: true },\n'
+    '  system_prompt: { default_open: false, enabled: true },\n'
+    '  mcp_servers: { default_open: false, enabled: true }\n'
+    '}'
+)
+assert old2 in content, 'types.ts: old not found'
+content = content.replace(old2, new2, 1)
+write('types.ts', content)
+
+# 3. interfaces.ts
+content = read('interfaces.ts')
+old3 = (
+    "import type {\n"
+    "  ApprovalReq,\n"
+    "  ClarifyReq,\n"
+    "  ConfirmReq,\n"
+    "  DetailsMode,\n"
+    "  Msg,\n"
+    "  PanelSection,\n"
+    "  SecretReq,\n"
+    "  SectionVisibility,\n"
+    "  SessionInfo,\n"
+    "  SlashCatalog,\n"
+    "  SudoReq,\n"
+    "  Usage\n"
+    "} from '../types.js'"
+)
+new3 = (
+    "import type {\n"
+    "  ApprovalReq,\n"
+    "  ClarifyReq,\n"
+    "  ConfirmReq,\n"
+    "  DetailsMode,\n"
+    "  Msg,\n"
+    "  PanelSection,\n"
+    "  SecretReq,\n"
+    "  SectionVisibility,\n"
+    "  SessionInfo,\n"
+    "  SlashCatalog,\n"
+    "  SudoReq,\n"
+    "  Usage,\n"
+    "  WelcomeBannerConfig\n"
+    "} from '../types.js'"
+)
+assert old3 in content, 'interfaces.ts import: old not found'
+content = content.replace(old3, new3, 1)
+
+old3b = (
+    "  streaming: boolean\n"
+    "  theme: Theme\n"
+    "  usage: Usage"
+)
+new3b = (
+    "  streaming: boolean\n"
+    "  theme: Theme\n"
+    "\n"
+    "  /** Resolved welcome banner section configuration. */\n"
+    "  welcomeBanner: WelcomeBannerConfig\n"
+    "  usage: Usage"
+)
+assert old3b in content, 'interfaces.ts field: old not found'
+content = content.replace(old3b, new3b, 1)
+write('interfaces.ts', content)
+
+# 4. uiStore.ts
+content = read('uiStore.ts')
+old4 = (
+    "import { DEFAULT_THEME } from '../theme.js'\n"
+    "\n"
+    "import { DEFAULT_INDICATOR_STYLE, type UiState } from './interfaces.js'"
+)
+new4 = (
+    "import { DEFAULT_THEME } from '../theme.js'\n"
+    "import { WELCOME_BANNER_DEFAULTS } from '../types.js'\n"
+    "import { DEFAULT_INDICATOR_STYLE, type UiState } from './interfaces.js'"
+)
+assert old4 in content, 'uiStore.ts import: old not found'
+content = content.replace(old4, new4, 1)
+
+old4b = (
+    "  theme: bootTheme ?? DEFAULT_THEME,\n"
+    "  usage: ZERO\n"
+    "})"
+)
+new4b = (
+    "  theme: bootTheme ?? DEFAULT_THEME,\n"
+    "  usage: ZERO,\n"
+    "  welcomeBanner: { sections: { ...WELCOME_BANNER_DEFAULTS }, plugin_sections: [] }\n"
+    "})"
+)
+assert old4b in content, 'uiStore.ts default: old not found'
+content = content.replace(old4b, new4b, 1)
+write('uiStore.ts', content)
+
+# 5. details.ts
+content = read('details.ts')
+old5 = "import type { DetailsMode, SectionName, SectionVisibility } from '../types.js'"
+new5 = old5 + "\nimport type { WelcomeBannerConfig, WelcomeBannerPluginSection, WelcomeBannerSectionConfig } from '../types.js'\nimport { WELCOME_BANNER_DEFAULTS } from '../types.js'"
+assert old5 in content, 'details.ts import: old not found'
+content = content.replace(old5, new5, 1)
+
+old5b = "export const nextDetailsMode = (m: DetailsMode): DetailsMode => MODES[(MODES.indexOf(m) + 1) % MODES.length]!"
+new5b = (
+    "export const nextDetailsMode = (m: DetailsMode): DetailsMode => MODES[(MODES.indexOf(m) + 1) % MODES.length]\n"
+    "\n"
+    "/**\n"
+    " * Build a WelcomeBannerConfig from the raw display.welcome_banner blob.\n"
+    " * Merges user overrides atop the built-in defaults, dropping unknown keys.\n"
+    " * Plugin sections are validated for required fields.\n"
+    " */\n"
+    "export const resolveWelcomeBanner = (raw: unknown): WelcomeBannerConfig => {\n"
+    "  const sections: Record<string, WelcomeBannerSectionConfig> = { ...WELCOME_BANNER_DEFAULTS }\n"
+    "  const plugin_sections: WelcomeBannerPluginSection[] = []\n"
+    "\n"
+    "  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {\n"
+    "    return { sections, plugin_sections }\n"
+    "  }\n"
+    "\n"
+    "  const cfg = raw as Record<string, unknown>\n"
+    "\n"
+    "  // Merge user section overrides\n"
+    "  if (cfg.sections && typeof cfg.sections === 'object' && !Array.isArray(cfg.sections)) {\n"
+    "    for (const [key, val] of Object.entries(cfg.sections as Record<string, unknown>)) {\n"
+    "      if (!sections[key]) continue\n"
+    "      if (val && typeof val === 'object' && !Array.isArray(val)) {\n"
+    "        const entry = val as Record<string, unknown>\n"
+    "        if (typeof entry.default_open === 'boolean') {\n"
+    "          sections[key] = { ...sections[key], default_open: entry.default_open }\n"
+    "        }\n"
+    "        if (typeof entry.enabled === 'boolean') {\n"
+    "          sections[key] = { ...sections[key], enabled: entry.enabled }\n"
+    "        }\n"
+    "      }\n"
+    "    }\n"
+    "  }\n"
+    "\n"
+    "  if (cfg.plugin_sections && Array.isArray(cfg.plugin_sections)) {\n"
+    "    for (const item of cfg.plugin_sections) {\n"
+    "      if (item && typeof item === 'object' && typeof item.id === 'string' && typeof item.title === 'string') {\n"
+    "        plugin_sections.push({\n"
+    "          id: item.id,\n"
+    "          title: item.title,\n"
+    "          default_open: typeof item.default_open === 'boolean' ? item.default_open : false\n"
+    "        })\n"
+    "      }\n"
+    "    }\n"
+    "  }\n"
+    "\n"
+    "  return { sections, plugin_sections }\n"
+    "}"
+)
+assert old5b in content, 'details.ts resolver: old not found'
+content = content.replace(old5b, new5b, 1)
+write('details.ts', content)
+
+# 6. useConfigSync.ts
+content = read('useConfigSync.ts')
+old6 = "import { resolveDetailsMode, resolveSections } from '../domain/details.js'"
+new6 = "import { resolveDetailsMode, resolveSections, resolveWelcomeBanner } from '../domain/details.js'"
+assert old6 in content, 'useConfigSync.ts import: old not found'
+content = content.replace(old6, new6, 1)
+
+old6b = (
+    "    sections: resolveSections(d.sections),\n"
+    "    showReasoning: !!d.show_reasoning,\n"
+    "    statusBar: normalizeStatusBar(d.tui_statusbar),\n"
+    "    streaming: d.streaming !== false\n"
+    "  })"
+)
+new6b = (
+    "    sections: resolveSections(d.sections),\n"
+    "    showReasoning: !!d.show_reasoning,\n"
+    "    statusBar: normalizeStatusBar(d.tui_statusbar),\n"
+    "    streaming: d.streaming !== false,\n"
+    "    welcomeBanner: resolveWelcomeBanner(d.welcome_banner)\n"
+    "  })"
+)
+assert old6b in content, 'useConfigSync.ts patch: old not found'
+content = content.replace(old6b, new6b, 1)
+write('useConfigSync.ts', content)
+
+# 7. branding.tsx
+content = read('branding.tsx')
+
+old7a = "import type { Theme } from '../theme.js'\nimport type { PanelSection, SessionInfo } from '../types.js'"
+new7a = "import type { Theme } from '../theme.js'\nimport type { PanelSection, SessionInfo, WelcomeBannerConfig } from '../types.js'"
+assert old7a in content, 'branding.tsx import: old not found'
+content = content.replace(old7a, new7a, 1)
+
+old7b = 'export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {'
+new7b = 'export function SessionPanel({ info, maxWidth, sid, t, welcomeBanner }: SessionPanelProps) {'
+assert old7b in content, 'branding.tsx sig: old not found'
+content = content.replace(old7b, new7b, 1)
+
+old7c = (
+    "  // ── Local collapse state for each section ──\n"
+    "  const [toolsOpen, setToolsOpen] = useState(true)\n"
+    "  const [skillsOpen, setSkillsOpen] = useState(false)\n"
+    "  const [systemOpen, setSystemOpen] = useState(false)\n"
+    "  const [mcpOpen, setMcpOpen] = useState(false)"
+)
+new7c = (
+    "  // ── Collapse state for each section, driven by config defaults ──\n"
+    "  const [toolsOpen, setToolsOpen] = useState(welcomeBanner.sections.tools?.default_open ?? true)\n"
+    "  const [skillsOpen, setSkillsOpen] = useState(welcomeBanner.sections.skills?.default_open ?? false)\n"
+    "  const [systemOpen, setSystemOpen] = useState(welcomeBanner.sections.system_prompt?.default_open ?? false)\n"
+    "  const [mcpOpen, setMcpOpen] = useState(welcomeBanner.sections.mcp_servers?.default_open ?? false)\n"
+    "  // Dynamic state for plugin sections\n"
+    "  const [pluginOpen, setPluginOpen] = useState<Record<string, boolean>>(() =>\n"
+    "    Object.fromEntries(\n"
+    "      welcomeBanner.plugin_sections.map(s => [s.id, s.default_open])\n"
+    "    )\n"
+    "  )"
+)
+assert old7c in content, 'branding.tsx state: old not found'
+content = content.replace(old7c, new7c, 1)
+
+old7d = (
+    "      {/* ── Tools (expanded by default) ── */}\n"
+    '      <Box flexDirection="column" marginTop={1}>\n'
+    "        <Accordion onToggle={() => setToolsOpen(v => !v)} open={toolsOpen} t={t} title=\"Available Tools\">\n"
+    "          {toolsBody()}\n"
+    "        </Accordion>\n"
+    "      </Box>\n"
+    "\n"
+    "      {/* ── Skills (collapsed by default) ── */}\n"
+    '      <Box flexDirection="column" marginTop={1}>\n'
+    "        <Accordion\n"
+    "          count={skillsTotal}\n"
+    "          onToggle={() => setSkillsOpen(v => !v)}\n"
+    "          open={skillsOpen}\n"
+    "          suffix={skillsCatCount > 0 ? `in ${skillsCatCount} categor${skillsCatCount === 1 ? 'y' : 'ies'}` : undefined}\n"
+    "          t={t}\n"
+    "          title=\"Available Skills\"\n"
+    "        >\n"
+    "          {skillsBody()}\n"
+    "        </Accordion>\n"
+    "      </Box>\n"
+    "\n"
+    "      {/* ── System Prompt (collapsed by default) ── */}\n"
+    "      {sysPromptLen > 0 && (\n"
+    '        <Box flexDirection="column" marginTop={1}>\n'
+    "          <Accordion\n"
+    "            onToggle={() => setSystemOpen(v => !v)}\n"
+    "            open={systemOpen}\n"
+    "            suffix={`— ${sysPromptLen.toLocaleString()} chars`}\n"
+    "            t={t}\n"
+    "            title=\"System Prompt\"\n"
+    "          >\n"
+    "            {systemBody()}\n"
+    "          </Accordion>\n"
+    "        </Box>\n"
+    "      )}\n"
+    "\n"
+    "      {/* ── MCP Servers (collapsed by default) ── */}\n"
+    "      {mcpServers.length > 0 && (\n"
+    '        <Box flexDirection="column" marginTop={1}>\n'
+    "          <Accordion\n"
+    "            count={mcpConnected}\n"
+    "            onToggle={() => setMcpOpen(v => !v)}\n"
+    "            open={mcpOpen}\n"
+    '            suffix="connected"\n'
+    "            t={t}\n"
+    "            title=\"MCP Servers\"\n"
+    "          >\n"
+    "            {mcpBody()}\n"
+    "          </Accordion>\n"
+    "        </Box>\n"
+    "      )}"
+)
+new7d = (
+    "      {/* ── Tools (default: expanded) ── */}\n"
+    "      {welcomeBanner.sections.tools?.enabled !== false && (\n"
+    '        <Box flexDirection="column" marginTop={1}>\n'
+    "        <Accordion onToggle={() => setToolsOpen(v => !v)} open={toolsOpen} t={t} title=\"Available Tools\">\n"
+    "          {toolsBody()}\n"
+    "        </Accordion>\n"
+    "      </Box>\n"
+    "      )}\n"
+    "\n"
+    "      {/* ── Skills (default: collapsed) ── */}\n"
+    "      {welcomeBanner.sections.skills?.enabled !== false && (\n"
+    '        <Box flexDirection="column" marginTop={1}>\n'
+    "        <Accordion\n"
+    "          count={skillsTotal}\n"
+    "          onToggle={() => setSkillsOpen(v => !v)}\n"
+    "          open={skillsOpen}\n"
+    "          suffix={skillsCatCount > 0 ? `in ${skillsCatCount} categor${skillsCatCount === 1 ? 'y' : 'ies'}` : undefined}\n"
+    "          t={t}\n"
+    "          title=\"Available Skills\"\n"
+    "        >\n"
+    "          {skillsBody()}\n"
+    "        </Accordion>\n"
+    "      </Box>\n"
+    "      )}\n"
+    "\n"
+    "      {/* ── System Prompt (default: collapsed) ── */}\n"
+    "      {sysPromptLen > 0 && welcomeBanner.sections.system_prompt?.enabled !== false && (\n"
+    '        <Box flexDirection="column" marginTop={1}>\n'
+    "        <Accordion\n"
+    "          onToggle={() => setSystemOpen(v => !v)}\n"
+    "          open={systemOpen}\n"
+    "          suffix={`— ${sysPromptLen.toLocaleString()} chars`}\n"
+    "          t={t}\n"
+    "          title=\"System Prompt\"\n"
+    "        >\n"
+    "          {systemBody()}\n"
+    "        </Accordion>\n"
+    "      </Box>\n"
+    "      )}\n"
+    "\n"
+    "      {/* ── MCP Servers (default: collapsed) ── */}\n"
+    "      {mcpServers.length > 0 && welcomeBanner.sections.mcp_servers?.enabled !== false && (\n"
+    '        <Box flexDirection="column" marginTop={1}>\n'
+    "        <Accordion\n"
+    "          count={mcpConnected}\n"
+    "          onToggle={() => setMcpOpen(v => !v)}\n"
+    "          open={mcpOpen}\n"
+    '          suffix="connected"\n'
+    "          t={t}\n"
+    "          title=\"MCP Servers\"\n"
+    "        >\n"
+    "          {mcpBody()}\n"
+    "        </Accordion>\n"
+    "      </Box>\n"
+    "      )}\n"
+    "\n"
+    "      {/* ── Plugin sections ── */}\n"
+    "      {welcomeBanner.plugin_sections.map(ps => {\n"
+    "        const isOpen = pluginOpen[ps.id] ?? ps.default_open\n"
+    "        const toggle = () => setPluginOpen(p => ({ ...p, [ps.id]: !(p[ps.id] ?? ps.default_open) }))\n"
+    "        return (\n"
+    '          <Box flexDirection="column" key={ps.id} marginTop={1}>\n'
+    "            <Accordion onToggle={toggle} open={isOpen} t={t} title={ps.title}>\n"
+    "              <Text color={t.color.muted}>\n"
+    '                Plugin section \u2014 data binding for &ldquo;{ps.title}&rdquo; is\n'
+    "                not yet wired on the gateway side.\n"
+    "              </Text>\n"
+    "            </Accordion>\n"
+    "          </Box>\n"
+    "        )\n"
+    "      })}\n"
+)
+assert old7d in content, 'branding.tsx sections: old not found'
+content = content.replace(old7d, new7d, 1)
+
+old7e = (
+    "interface SessionPanelProps {\n"
+    "  info: SessionInfo\n"
+    "  maxWidth?: number\n"
+    "  sid?: string | null\n"
+    "  t: Theme\n"
+    "}"
+)
+new7e = (
+    "interface SessionPanelProps {\n"
+    "  info: SessionInfo\n"
+    "  maxWidth?: number\n"
+    "  sid?: string | null\n"
+    "  t: Theme\n"
+    "  welcomeBanner: WelcomeBannerConfig\n"
+    "}"
+)
+assert old7e in content, 'branding.tsx props: old not found'
+content = content.replace(old7e, new7e, 1)
+write('branding.tsx', content)
+
+# 8. appLayout.tsx
+content = read('appLayout.tsx')
+old8 = (
+    "                  {row.msg.info && (\n"
+    "                    <SessionPanel\n"
+    "                      info={row.msg.info}\n"
+    "                      maxWidth={Math.max(1, composer.cols - 2)}\n"
+    "                      sid={ui.sid}\n"
+    "                      t={ui.theme}\n"
+    "                    />\n"
+    "                  )}"
+)
+new8 = (
+    "                  {row.msg.info && (\n"
+    "                    <SessionPanel\n"
+    "                      info={row.msg.info}\n"
+    "                      maxWidth={Math.max(1, composer.cols - 2)}\n"
+    "                      sid={ui.sid}\n"
+    "                      t={ui.theme}\n"
+    "                      welcomeBanner={ui.welcomeBanner}\n"
+    "                    />\n"
+    "                  )}"
+)
+assert old8 in content, 'appLayout.tsx: old not found'
+content = content.replace(old8, new8, 1)
+write('appLayout.tsx', content)
+
+# 9. cli-config.yaml.example
+content = read('config.yaml')
+old9 = (
+    "  # timestamps: false\n"
+    "\n"
+    "  # ───────────────────────────────────────────────────────────────────────────\n"
+    "  # Skin / Theme\n"
+    "  # ───────────────────────────────────────────────────────────────────────────"
+)
+new9 = (
+    "  # timestamps: false\n"
+    "\n"
+    "  # ───────────────────────────────────────────────────────────────────────────\n"
+    "  # TUI Welcome Banner Sections\n"
+    "  # ───────────────────────────────────────────────────────────────────────────\n"
+    '  # Configure which accordion sections appear in the TUI welcome panel and their\n'
+    "  # default open/closed state. Sections omitted from config use built-in defaults\n"
+    "  # (tools=open, skills=closed, system_prompt=closed, mcp_servers=closed).\n"
+    "  #\n"
+    "  # Each section supports:\n"
+    "  #   default_open: true|false - initial collapse state\n"
+    "  #   enabled: true|false     - show or hide the section entirely\n"
+    "  #\n"
+    "  # Plugin sections render custom Accordion entries after the built-in sections.\n"
+    "  # Data binding for plugin section content is a future extension (currently\n"
+    "  # shows a placeholder label).\n"
+    "  #\n"
+    "  # Example:\n"
+    "  #   welcome_banner:\n"
+    "  #     sections:\n"
+    "  #       tools:\n"
+    "  #         default_open: true\n"
+    "  #         enabled: true\n"
+    "  #       skills:\n"
+    "  #         default_open: false\n"
+    "  #         enabled: true\n"
+    "  #       system_prompt:\n"
+    "  #         default_open: false\n"
+    "  #         enabled: true\n"
+    "  #       mcp_servers:\n"
+    "  #         default_open: false\n"
+    "  #         enabled: true\n"
+    "  #     plugin_sections:\n"
+    '  #       - id: my_custom_data\n'
+    '  #         title: "Custom Data"\n'
+    "  #         default_open: false\n"
+    "\n"
+    "  # ───────────────────────────────────────────────────────────────────────────\n"
+    "  # Skin / Theme\n"
+    "  # ───────────────────────────────────────────────────────────────────────────"
+)
+assert old9 in content, 'config.yaml: old not found'
+content = content.replace(old9, new9, 1)
+write('config.yaml', content)
+
+print('\nAll 9 files patched successfully!')

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6556,6 +6556,7 @@ def _resolve_task_provider_model(
                 "nous",
                 "openai-codex",
                 "qwen-oauth",
+                "kimi-oauth",
                 "xai-oauth",
             }
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2390,6 +2390,36 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         except Exception as exc:
             logger.debug("Qwen OAuth token seed failed: %s", exc)
 
+    elif provider == "kimi-oauth":
+        # Kimi OAuth tokens live in ~/.kimi-code/credentials/kimi-code.json,
+        # written by the Kimi Code CLI.  They aren't in the Hermes auth store
+        # or env vars, so resolve them here.
+        # Use refresh_if_expiring=False to avoid network calls during pool
+        # loading / provider discovery.
+        try:
+            from hermes_cli.auth import resolve_kimi_oauth_runtime_credentials
+            creds = resolve_kimi_oauth_runtime_credentials(refresh_if_expiring=False)
+            token = creds.get("api_key", "")
+            if token:
+                source_name = creds.get("source", "kimi-code")
+                if not _is_suppressed(provider, source_name):
+                    active_sources.add(source_name)
+                    changed |= _upsert_entry(
+                        entries,
+                        provider,
+                        source_name,
+                        {
+                            "source": source_name,
+                            "auth_type": AUTH_TYPE_OAUTH,
+                            "access_token": token,
+                            "expires_at_ms": creds.get("expires_at_ms"),
+                            "base_url": creds.get("base_url", ""),
+                            "label": creds.get("auth_file", source_name),
+                        },
+                    )
+        except Exception as exc:
+            logger.debug("Kimi OAuth token seed failed: %s", exc)
+
     elif provider == "minimax-oauth":
         # MiniMax OAuth tokens live in ~/.hermes/auth.json providers.minimax-oauth.
         # Seed the pool so `/auth list` reflects the logged-in state and the

--- a/agent/credential_sources.py
+++ b/agent/credential_sources.py
@@ -332,6 +332,15 @@ def _remove_qwen_cli(provider: str, removed) -> RemovalResult:
     ])
 
 
+def _remove_kimi_code_oauth(provider: str, removed) -> RemovalResult:
+    """~/.kimi-code/credentials/kimi-code.json is owned by the Kimi Code CLI."""
+    return RemovalResult(hints=[
+        "Suppressed kimi-code credential - it will not be re-seeded.",
+        "Note: Kimi Code CLI credentials still live in ~/.kimi-code/credentials/kimi-code.json",
+        "Run `hermes auth add kimi-oauth` to re-enable if needed.",
+    ])
+
+
 def _remove_copilot_gh(provider: str, removed) -> RemovalResult:
     """Copilot token comes from `gh auth token` or COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN.
 
@@ -426,6 +435,11 @@ def _register_all_sources() -> None:
         provider="qwen-oauth", source_id="qwen-cli",
         remove_fn=_remove_qwen_cli,
         description="~/.qwen/oauth_creds.json",
+    ))
+    register(RemovalStep(
+        provider="kimi-oauth", source_id="kimi-code",
+        remove_fn=_remove_kimi_code_oauth,
+        description="~/.kimi-code/credentials/kimi-code.json",
     ))
     register(RemovalStep(
         provider="minimax-oauth", source_id="oauth",

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -17,7 +17,7 @@ import os
 from typing import Any, Iterable, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block", "kanban_wait"})
 
 _DEFAULT_MAX_ATTEMPTS = 2
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -49,7 +49,7 @@ def _resolve_requests_verify() -> bool | str:
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
-    "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek", "deepinfra",
+    "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "kimi-oauth", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek", "deepinfra",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",
     "xiaomi",

--- a/apps/desktop/src/components/onboarding/providers.tsx
+++ b/apps/desktop/src/components/onboarding/providers.tsx
@@ -8,7 +8,8 @@ const PROVIDER_DISPLAY: Record<string, { order: number; title: string }> = {
   'openai-codex': { order: 1, title: 'OpenAI OAuth (ChatGPT)' },
   'minimax-oauth': { order: 2, title: 'MiniMax' },
   'qwen-oauth': { order: 3, title: 'Qwen Code' },
-  'xai-oauth': { order: 4, title: 'xAI Grok' },
+  'kimi-oauth': { order: 4, title: 'Kimi Code' },
+  'xai-oauth': { order: 5, title: 'xAI Grok'},
   // Both Anthropic entries sit at the bottom: the API-key path first, then
   // the subscription OAuth path (only works with extra usage credits).
   anthropic: { order: 5, title: 'Anthropic API Key' },

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1345,6 +1345,41 @@ display:
   # timestamps: false
 
   # ───────────────────────────────────────────────────────────────────────────
+  # TUI Welcome Banner Sections
+  # ───────────────────────────────────────────────────────────────────────────
+  # Configure which accordion sections appear in the TUI welcome panel and their
+  # default open/closed state. Sections omitted from config use built-in defaults
+  # (tools=open, skills=closed, system_prompt=closed, mcp_servers=closed).
+  #
+  # Each section supports:
+  #   default_open: true|false - initial collapse state
+  #   enabled: true|false     - show or hide the section entirely
+  #
+  # Plugin sections render custom Accordion entries after the built-in sections.
+  # Data binding for plugin section content is a future extension (currently
+  # shows a placeholder label).
+  #
+  # Example:
+  #   welcome_banner:
+  #     sections:
+  #       tools:
+  #         default_open: true
+  #         enabled: true
+  #       skills:
+  #         default_open: false
+  #         enabled: true
+  #       system_prompt:
+  #         default_open: false
+  #         enabled: true
+  #       mcp_servers:
+  #         default_open: false
+  #         enabled: true
+  #     plugin_sections:
+  #       - id: my_custom_data
+  #         title: "Custom Data"
+  #         default_open: false
+
+  # ───────────────────────────────────────────────────────────────────────────
   # Skin / Theme
   # ───────────────────────────────────────────────────────────────────────────
   # Customize CLI visual appearance — banner colors, spinner faces, tool prefix,

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -164,7 +164,8 @@ class GatewayKanbanWatchersMixin:
 
         # "status" covers dashboard drag-drop and `_set_status_direct()`
         # writes — surface those transitions to subscribers too.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected")
+        TERMINAL_KINDS = ("completed", "blocked", "waiting", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "unwaited", "block_loop_detected")
+        TERMINAL_KINDS = ("completed", "blocked", "waiting", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "unwaited")
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -594,7 +595,7 @@ class GatewayKanbanWatchersMixin:
                         #   claim exactly like a failed send() above, so the
                         #   next tick retries.
                         task_terminal = task and task.status in {"done", "archived"}
-                        _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
+                        _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked", "waiting")
                         _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
                         from gateway.wake import adapter_supports_push as _adapter_push_ok
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2638,6 +2638,239 @@ def get_qwen_auth_status() -> Dict[str, Any]:
         }
 
 
+
+def _kimi_code_auth_path() -> Path:
+    """Return path to the Kimi Code CLI OAuth credential file."""
+    return Path.home() / ".kimi-code" / "credentials" / "kimi-code.json"
+
+
+def _read_kimi_code_tokens() -> Dict[str, Any]:
+    """Read Kimi Code CLI OAuth tokens from disk."""
+    auth_path = _kimi_code_auth_path()
+    if not auth_path.exists():
+        raise AuthError(
+            "Kimi Code CLI credentials not found.  Run the Kimi Code CLI "
+            "first (it creates ~/.kimi-code/credentials/kimi-code.json).",
+            provider="kimi-oauth",
+            code="kimi_auth_missing",
+        )
+    try:
+        data = json.loads(auth_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise AuthError(
+            f"Cannot parse Kimi Code CLI credentials at {auth_path}: {exc}",
+            provider="kimi-oauth",
+            code="kimi_auth_unreadable",
+        ) from exc
+    if not isinstance(data, dict):
+        raise AuthError(
+            f"Invalid Kimi Code CLI credentials in {auth_path} - expected a JSON object.",
+            provider="kimi-oauth",
+            code="kimi_auth_invalid",
+        )
+    return data
+
+
+def _kimi_access_token_is_expiring(
+    expires_at: Any,
+    skew_seconds: int = KIMI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+) -> bool:
+    try:
+        expiry = int(expires_at)
+    except (TypeError, ValueError):
+        return True
+    return expiry <= (time.time() + max(0, int(skew_seconds)))
+
+
+def resolve_kimi_oauth_runtime_credentials(
+    *,
+    force_refresh: bool = False,
+    refresh_if_expiring: bool = True,
+    refresh_skew_seconds: int = KIMI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+) -> Dict[str, Any]:
+    """Resolve usable Kimi OAuth credentials from the Kimi Code CLI token file."""
+    tokens = _read_kimi_code_tokens()
+    access_token = str(tokens.get("access_token", "") or "").strip()
+    should_refresh = bool(force_refresh)
+    if not should_refresh and refresh_if_expiring:
+        should_refresh = _kimi_access_token_is_expiring(
+            tokens.get("expires_at"), refresh_skew_seconds,
+        )
+    if should_refresh:
+        try:
+            tokens = _refresh_kimi_code_tokens(tokens)
+            access_token = str(tokens.get("access_token", "") or "").strip()
+        except Exception as exc:
+            logger.debug("Kimi OAuth token refresh failed: %s", exc)
+            if not access_token:
+                raise AuthError(
+                    "Kimi OAuth access token expired and refresh failed. "
+                    "Re-run the Kimi Code CLI to re-authenticate.",
+                    provider="kimi-oauth",
+                    code="kimi_refresh_failed",
+                ) from exc
+
+    if not access_token:
+        raise AuthError(
+            "Kimi OAuth access token missing.  Re-run the Kimi Code CLI.",
+            provider="kimi-oauth",
+            code="kimi_access_token_missing",
+        )
+
+    base_url = (
+        os.getenv("KIMI_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_KIMI_OAUTH_BASE_URL
+    )
+    expires_at_raw = tokens.get("expires_at") or tokens.get("expires_in")
+    expires_at_ms = None
+    if expires_at_raw:
+        try:
+            expires_at_ms = int(int(expires_at_raw) * 1000)
+        except (TypeError, ValueError):
+            pass
+
+    return {
+        "provider": "kimi-oauth",
+        "base_url": base_url,
+        "api_key": access_token,
+        "source": "kimi-code",
+        "expires_at_ms": expires_at_ms,
+        "auth_file": str(_kimi_code_auth_path()),
+    }
+
+
+def _refresh_kimi_code_tokens(tokens: Dict[str, Any]) -> Dict[str, Any]:
+    """Refresh an expired Kimi Code access token using the refresh token."""
+    refresh_token = str(tokens.get("refresh_token", "") or "").strip()
+    if not refresh_token:
+        raise AuthError(
+            "Kimi OAuth refresh token missing - cannot refresh without it. "
+            "Re-run the Kimi Code CLI.",
+            provider="kimi-oauth",
+            code="kimi_no_refresh_token",
+        )
+
+    oauth_host = (
+        os.getenv("KIMI_CODE_OAUTH_HOST")
+        or os.getenv("KIMI_OAUTH_HOST")
+        or "https://auth.kimi.com"
+    )
+    token_url = f"{oauth_host.rstrip('/')}/oauth/token"
+
+    payload = {
+        "refresh_token": refresh_token,
+        "grant_type": "refresh_token",
+        "client_id": "kimi-code",
+    }
+
+    try:
+        response = httpx.post(
+            token_url,
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=30.0,
+        )
+    except Exception as exc:
+        raise AuthError(
+            f"Kimi OAuth refresh request failed: {exc}",
+            provider="kimi-oauth",
+            code="kimi_refresh_network_error",
+        ) from exc
+
+    if response.status_code >= 400:
+        body = response.text.strip()
+        raise AuthError(
+            "Kimi OAuth refresh failed. Re-run the Kimi Code CLI to re-authenticate."
+            + (f" Response: {body}" if body else ""),
+            provider="kimi-oauth",
+            code="kimi_refresh_failed",
+        )
+
+    try:
+        payload_body = response.json()
+    except Exception as exc:
+        raise AuthError(
+            f"Kimi OAuth refresh returned invalid JSON: {exc}",
+            provider="kimi-oauth",
+            code="kimi_refresh_invalid_json",
+        ) from exc
+
+    if not isinstance(payload_body, dict) or not str(
+        payload_body.get("access_token", "") or ""
+    ).strip():
+        raise AuthError(
+            "Kimi OAuth refresh response missing access_token.",
+            provider="kimi-oauth",
+            code="kimi_refresh_invalid_response",
+        )
+
+    access_token = str(payload_body.get("access_token", "") or "").strip()
+    new_refresh_token = str(payload_body.get("refresh_token", refresh_token) or refresh_token).strip()
+    expires_in = payload_body.get("expires_in")
+    try:
+        expires_in_seconds = int(expires_in)
+    except Exception:
+        expires_in_seconds = 900
+
+    refreshed = {
+        "access_token": access_token,
+        "refresh_token": new_refresh_token,
+        "token_type": str(payload_body.get("token_type", tokens.get("token_type", "Bearer")) or "Bearer").strip() or "Bearer",
+        "scope": str(payload_body.get("scope", tokens.get("scope", "kimi-code")) or "kimi-code").strip(),
+        "expires_in": expires_in_seconds,
+        "expires_at": int(time.time()) + expires_in_seconds,
+    }
+    _save_kimi_code_tokens(refreshed)
+    return refreshed
+
+
+def _save_kimi_code_tokens(tokens: Dict[str, Any]) -> Path:
+    """Write updated OAuth tokens back to the Kimi Code CLI credential file."""
+    import stat as _stat
+    auth_path = _kimi_code_auth_path()
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    secure_parent_dir(auth_path)
+    tmp_path = auth_path.with_name(
+        f"{auth_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+    )
+    fd = os.open(
+        str(tmp_path),
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        _stat.S_IRUSR | _stat.S_IWUSR,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(tokens, f, indent=2)
+        atomic_replace(tmp_path, auth_path)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+    return auth_path
+
+
+def get_kimi_oauth_auth_status() -> Dict[str, Any]:
+    """Check whether the user has valid Kimi Code CLI OAuth credentials."""
+    auth_path = _kimi_code_auth_path()
+    try:
+        creds = resolve_kimi_oauth_runtime_credentials(refresh_if_expiring=True)
+        return {
+            "logged_in": True,
+            "auth_file": str(auth_path),
+            "source": creds.get("source"),
+            "api_key": creds.get("api_key"),
+            "expires_at_ms": creds.get("expires_at_ms"),
+        }
+    except AuthError as exc:
+        return {
+            "logged_in": False,
+            "auth_file": str(auth_path),
+            "error": str(exc),
+        }
+
+
 # =============================================================================
 # Spotify auth — PKCE tokens stored in ~/.hermes/auth.json
 # =============================================================================

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -34,7 +34,7 @@ from hermes_cli.secret_prompt import masked_secret_prompt
 
 
 # Providers that support OAuth login in addition to API keys.
-_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "xai-oauth", "qwen-oauth", "minimax-oauth"}
+_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "xai-oauth", "qwen-oauth", "minimax-oauth", "kimi-oauth"}
 
 
 def _get_custom_provider_names() -> list:
@@ -400,6 +400,26 @@ def auth_add_command(args) -> None:
             auth_type=AUTH_TYPE_OAUTH,
             priority=0,
             source=f"{SOURCE_MANUAL}:qwen_cli",
+            access_token=creds["api_key"],
+            base_url=creds.get("base_url"),
+        )
+        pool.add_entry(entry)
+        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        return
+
+    if provider == "kimi-oauth":
+        creds = auth_mod.resolve_kimi_oauth_runtime_credentials(refresh_if_expiring=False)
+        label = (getattr(args, "label", None) or "").strip() or label_from_token(
+            creds["api_key"],
+            _oauth_default_label(provider, len(pool.entries()) + 1),
+        )
+        entry = PooledCredential(
+            provider=provider,
+            id=uuid.uuid4().hex[:6],
+            label=label,
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source=f"{SOURCE_MANUAL}:kimi_code",
             access_token=creds["api_key"],
             base_url=creds.get("base_url"),
         )

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -38,6 +38,7 @@ _STATUS_ICONS = {
     "ready":    "▶",
     "running":  "●",
     "scheduled":"⏱",
+    "waiting":  "⏳",
     "blocked":  "⊘",
     "done":     "✓",
     "archived": "—",
@@ -623,7 +624,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="JSON dict of structured facts to store on the latest completed run.",
     )
 
-    p_block = sub.add_parser("block", help="Mark one or more tasks blocked")
+    p_block = sub.add_parser("block", help="Mark one or more tasks blocked (agent-time) or waiting (human-time)")
     p_block.add_argument("task_id")
     p_block.add_argument("reason", nargs="*", help="Reason (also appended as a comment)")
     p_block.add_argument("--ids", nargs="+", default=None,
@@ -647,7 +648,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     p_unblock = sub.add_parser(
         "unblock",
-        help="Return blocked/scheduled tasks to ready, or todo while parents remain open",
+        help="Return blocked/waiting/scheduled tasks to ready, or todo while parents remain open",
     )
     p_unblock.add_argument(
         "--reason",
@@ -658,7 +659,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     p_promote = sub.add_parser(
         "promote",
-        help="Manually move one or more todo/blocked tasks to ready (recovery path)",
+        help="Manually move one or more todo/waiting/blocked tasks to ready (recovery path)",
     )
     p_promote.add_argument("task_id")
     p_promote.add_argument(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4016,11 +4016,18 @@ def recompute_ready(
     with write_txn(conn):
         todo_rows = conn.execute(
             "SELECT id, status, consecutive_failures, max_retries "
-            "FROM tasks WHERE status IN ('todo', 'blocked')"
+            "FROM tasks WHERE status IN ('todo', 'waiting', 'blocked')"
         ).fetchall()
         for row in todo_rows:
             task_id = row["id"]
             cur_status = row["status"]
+            if cur_status == "waiting":
+                # Human-time wait — never auto-promote. Only an explicit
+                # unwait_task / promote_task / unblock_task moves a waiting
+                # task back to the work pool. Without this guard a waiting
+                # task — which is TTL-exempt and sits in the dispatch
+                # queue silently — would never loop on itself.
+                continue
             if cur_status == "blocked" and _has_sticky_block(conn, task_id):
                 # Worker / operator asked for human review — do not
                 # silently auto-recover.  ``unblock_task`` is the only
@@ -5470,7 +5477,7 @@ def block_task(
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
-    """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
+    """Transition ``running``/``ready`` → ``blocked``/``waiting``/``todo``/``triage``.
 
     ``kind`` (one of :data:`VALID_BLOCK_KINDS`, or ``None`` for a legacy
     un-typed block) drives routing instead of every block landing in one
@@ -5480,22 +5487,22 @@ def block_task(
       sit in ``blocked`` (where a cron would keep "unblocking" it); it goes to
       ``todo`` so the existing parent-gating / ``recompute_ready`` machinery
       promotes it automatically once its parents finish. No human, no cron, no
-      retry storm. This is Dale's "Type 2 — dependency blocked".
+      retry storm.
 
-    * ``needs_input`` / ``capability`` / ``None`` — "truly blocked" (Dale's
-      "Type 1"). Lands in ``blocked`` for a human. BUT: each time such a task
-      is re-blocked for the SAME kind after having been unblocked, the
-      unblock-loop counter (``block_recurrences``) increments. When it reaches
-      :data:`BLOCK_RECURRENCE_LIMIT`, the task is routed to ``triage`` instead
-      of ``blocked`` — breaking the cron-unblock ↔ worker-re-block loop and
-      forcing a human-in-the-loop triage decision.
+    * ``needs_input`` / ``capability`` — human-time waits. Land in ``waiting``
+      (TTL-exempt, never auto-promoted) so the dispatcher never reclaims them.
+      An explicit ``unwait_task`` / ``unblock_task`` / ``promote_task`` is
+      required to return them to the work pool.
 
-    * ``transient`` — treated like a generic block for routing, but a worker
-      can use it to signal "this might clear on its own"; it still participates
-      in the loop breaker so a forever-flaky task eventually escalates.
+    * ``transient`` / ``None`` — agent-time blocks. Land in ``blocked``
+      (TTL-reclaimable, auto-promotable for circuit-breaker conditions).
+      A transient failure may clear on retry; the loop breaker routes
+      the task to ``triage`` after :data:`BLOCK_RECURRENCE_LIMIT` unblock↔
+      re-block cycles.
 
-    Returns True on any successful transition (to ``blocked``, ``todo``, or
-    ``triage``), False when the task wasn't in a blockable state.
+    Returns True on any successful transition (to ``blocked``, ``waiting``,
+    ``todo``, or ``triage``), False when the task wasn't in a blockable
+    state.
     """
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
@@ -5614,11 +5621,14 @@ def block_task(
             )
             routed_to = "triage"
         else:
+            # Human-time kinds (needs_input, capability) → waiting (TTL-exempt)
+            # Agent-time kinds (transient, None) → blocked (reclaimable)
+            new_status = "waiting" if kind in ("needs_input", "capability") else "blocked"
             if expected_run_id is None:
                 cur = conn.execute(
-                    """
+                    f"""
                     UPDATE tasks
-                       SET status        = 'blocked',
+                       SET status        = '{new_status}',
                            claim_lock    = NULL,
                            claim_expires = NULL,
                            worker_pid    = NULL,
@@ -5631,9 +5641,9 @@ def block_task(
                 )
             else:
                 cur = conn.execute(
-                    """
+                    f"""
                     UPDATE tasks
-                       SET status        = 'blocked',
+                       SET status        = '{new_status}',
                            claim_lock    = NULL,
                            claim_expires = NULL,
                            worker_pid    = NULL,
@@ -5649,7 +5659,7 @@ def block_task(
                 return False
             run_id = _end_run(
                 conn, task_id,
-                outcome="blocked", status="blocked",
+                outcome=new_status, status=new_status,
                 summary=reason,
             )
             # Synthesize a run when blocking a never-claimed task so the
@@ -5657,11 +5667,11 @@ def block_task(
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
                     conn, task_id,
-                    outcome="blocked",
+                    outcome=new_status,
                     summary=reason,
                 )
             _append_event(
-                conn, task_id, "blocked",
+                conn, task_id, new_status,
                 {"reason": reason, "kind": kind, "recurrences": recurrences},
                 run_id=run_id,
             )
@@ -5678,6 +5688,148 @@ def block_task(
 
 
 
+def wait_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+    kind: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Transition ``running``/``ready`` → ``waiting`` for a human-time block.
+
+    A ``waiting`` task is blocked on **a human** (not a transient system
+    condition). Unlike ``blocked`` (agent-time), ``waiting`` tasks are
+    TTL-exempt — ``release_stale_claims`` never reclaims them because
+    the dispatcher only considers ``status='running'`` tasks for
+    reclaim. They also skip auto-promotion in ``recompute_ready``:
+    only an explicit ``unwait_task`` or ``promote_task`` moves them
+    back to ``ready``/``todo``.
+
+    ``kind`` is optional metadata (one of ``VALID_BLOCK_KINDS``) so
+    workers can signal *why* they are waiting for a human without
+    landing in the ``blocked`` bucket. Common kinds for human waits:
+
+    * ``needs_input`` — needs a human decision/answer it cannot derive.
+    * ``capability`` — hit a hard wall (no access, missing creds).
+
+    ``dependency`` and ``transient`` still route to ``todo`` / ``blocked``
+    respectively (via ``block_task``); ``wait_task`` refuses those kinds.
+
+    Returns True on success, False when the task wasn't in a waitable
+    state.
+    """
+    if kind is not None and kind not in VALID_BLOCK_KINDS:
+        raise ValueError(
+            f"wait kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
+        )
+    if kind == "dependency":
+        raise ValueError(
+            "use block_task(kind='dependency') for dependency waits"
+        )
+    if kind == "transient":
+        raise ValueError(
+            "use block_task(kind='transient') for transient/agent-time blocks"
+        )
+    with write_txn(conn):
+        conditions = "status IN ('running', 'ready')"
+        params: list[Any] = [task_id]
+        if expected_run_id is not None:
+            conditions += " AND current_run_id = ?"
+            params.append(int(expected_run_id))
+        cur = conn.execute(
+            f"""
+            UPDATE tasks
+               SET status        = 'waiting',
+                   claim_lock    = NULL,
+                   claim_expires = NULL,
+                   worker_pid    = NULL,
+                   block_kind    = ?
+             WHERE id = ?
+               AND {conditions}
+            """,
+            (kind, *params),
+        )
+        if cur.rowcount != 1:
+            return False
+        run_id = _end_run(
+            conn, task_id,
+            outcome="waiting", status="waiting",
+            summary=reason,
+        )
+        if run_id is None and reason:
+            run_id = _synthesize_ended_run(
+                conn, task_id, outcome="waiting", summary=reason,
+            )
+        _append_event(
+            conn, task_id, "waiting",
+            {"reason": reason, "kind": kind},
+            run_id=run_id,
+        )
+    _waiting_task = get_task(conn, task_id)
+    _fire_kanban_lifecycle_hook(
+        "kanban_task_waiting",
+        task_id,
+        board=get_current_board(),
+        assignee=_waiting_task.assignee if _waiting_task else None,
+        run_id=run_id,
+        reason=reason,
+    )
+    return True
+
+
+def unwait_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Transition ``waiting`` → ``ready`` or ``todo`` (human has responded).
+
+    Mirrors ``unblock_task`` for the ``waiting`` state. Defensively closes
+    any stale ``current_run_id`` pointer before flipping status. Re-gates
+    on parent completion: if parents are still open the task lands in
+    ``todo`` instead of ``ready``.
+
+    Returns True on success, False if the task is not in ``waiting``.
+    """
+    now = int(time.time())
+    with write_txn(conn):
+        stale = conn.execute(
+            "SELECT current_run_id FROM tasks WHERE id = ? AND status = 'waiting'",
+            (task_id,),
+        ).fetchone()
+        if stale is None:
+            return False
+        if stale and stale["current_run_id"]:
+            conn.execute(
+                """
+                UPDATE task_runs
+                   SET status = 'reclaimed', outcome = 'reclaimed',
+                       summary = COALESCE(summary, 'invariant recovery on unwait'),
+                       ended_at = ?,
+                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                 WHERE id = ? AND ended_at IS NULL
+                """,
+                (now, int(stale["current_run_id"])),
+            )
+        undone_parents = conn.execute(
+            "SELECT 1 FROM task_links l "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        new_status = "todo" if undone_parents else "ready"
+        cur = conn.execute(
+            "UPDATE tasks SET status = ?, current_run_id = NULL, "
+            "consecutive_failures = 0, last_failure_error = NULL "
+            "WHERE id = ? AND status = 'waiting'",
+            (new_status, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        _append_event(
+            conn, task_id, "unwaited",
+            {"status": new_status} if new_status != "ready" else None,
+        )
+        return True
+
+
 def promote_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5687,7 +5839,7 @@ def promote_task(
     force: bool = False,
     dry_run: bool = False,
 ) -> tuple[bool, Optional[str]]:
-    """Manually promote a `todo` or `blocked` task to `ready`.
+    """Manually promote a `todo`, `waiting`, or `blocked` task to `ready`.
 
     Mirrors the automatic promotion done by ``recompute_ready`` but
     drives it from a deliberate operator action with an audit-trail
@@ -5704,10 +5856,10 @@ def promote_task(
         return False, f"task {task_id} not found"
 
     cur_status = row["status"]
-    if cur_status not in ("todo", "blocked"):
+    if cur_status not in ("todo", "waiting", "blocked"):
         return False, (
             f"task {task_id} is {cur_status!r}; promote only applies to "
-            f"'todo' or 'blocked'"
+            f"'todo', 'waiting', or 'blocked'"
         )
 
     if not force:
@@ -5733,7 +5885,7 @@ def promote_task(
     with write_txn(conn):
         upd = conn.execute(
             "UPDATE tasks SET status = 'ready' "
-            "WHERE id = ? AND status IN ('todo', 'blocked')",
+            "WHERE id = ? AND status IN ('todo', 'waiting', 'blocked')",
             (task_id,),
         )
         if upd.rowcount != 1:
@@ -5749,10 +5901,10 @@ def promote_task(
 
 
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Transition ``blocked``/``scheduled`` -> ready or todo.
+    """Transition ``blocked``/``scheduled``/``waiting`` -> ready or todo.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
-    status. In the common path (``block_task`` closed the run already) this
+    status. In the common path (``block_task``/``wait_task`` closed the run already) this
     is a no-op. If a future or external write left the pointer dangling,
     the leaked run is closed as ``reclaimed`` inside the same txn so the
     runs invariant (``current_run_id IS NULL`` ⇔ run row in terminal
@@ -5761,7 +5913,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     now = int(time.time())
     with write_txn(conn):
         stale = conn.execute(
-            "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
+            "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled', 'waiting')",
             (task_id,),
         ).fetchone()
         if stale and stale["current_run_id"]:
@@ -5802,7 +5954,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
             "consecutive_failures = 0, last_failure_error = NULL "
-            "WHERE id = ? AND status IN ('blocked', 'scheduled')",
+            "WHERE id = ? AND status IN ('blocked', 'scheduled', 'waiting')",
             (new_status, task_id),
         )
         if cur.rowcount != 1:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -773,6 +773,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_xai_oauth,
     _model_flow_qwen_oauth,
     _model_flow_minimax_oauth,
+    _model_flow_kimi_oauth,
     _model_flow_custom,
     _model_flow_azure_foundry,
     _model_flow_named_custom,
@@ -3330,6 +3331,8 @@ def select_provider_and_model(args=None):
         _model_flow_qwen_oauth(config, current_model)
     elif selected_provider == "minimax-oauth":
         _model_flow_minimax_oauth(config, current_model, args=args)
+    elif selected_provider == "kimi-oauth":
+        _model_flow_kimi_oauth(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
     elif selected_provider == "copilot":
@@ -14801,7 +14804,7 @@ def _build_provider_choices() -> list[str]:
             "anthropic", "gemini", "vertex", "xai", "bedrock", "azure-foundry",
             "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
             "stepfun", "minimax", "minimax-cn", "kilocode", "novita", "xiaomi", "arcee",
-            "nvidia", "deepseek", "alibaba", "qwen-oauth", "opencode-zen", "opencode-go",
+            "nvidia", "deepseek", "alibaba", "qwen-oauth", "kimi-oauth", "opencode-zen", "opencode-go",
         ]
 
 

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -93,6 +93,7 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
     "zai",
     "kimi-coding",
     "kimi-coding-cn",
+    "kimi-oauth",
     "minimax",
     "minimax-oauth",
     "minimax-cn",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -367,6 +367,13 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2.7",
         "MiniMax-M2.7-highspeed",
     ],
+    "kimi-oauth": [
+        "k3",
+        "k2.7-coding",
+        "k2.7-coding-highspeed",
+        "k2.6-coding",
+        "k3-256k",
+    ],
     "minimax-cn": [
         "MiniMax-M3",
         "MiniMax-M2.7",
@@ -1115,6 +1122,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek; IAM or API key)"),
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint, your Azure AI deployment)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (Reuses local Qwen CLI login)"),
+    ProviderEntry("kimi-oauth",     "Kimi Code (OAuth)",        "Kimi Code via OAuth tokens (Reuses Kimi Code CLI login)"),
 ]
 
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/
@@ -1164,7 +1172,7 @@ _PROVIDER_LABELS["custom"] = "Custom endpoint"  # special case: not a named prov
 # Member order is the order shown inside the group submenu.
 # ---------------------------------------------------------------------------
 PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
-    "kimi":     ("Kimi / Moonshot", "Coding Plan, Moonshot global & China endpoints", ["kimi-coding", "kimi-coding-cn"]),
+    "kimi":     ("Kimi / Moonshot", "Coding Plan, Moonshot global & China endpoints", ["kimi-coding", "kimi-coding-cn", "kimi-oauth"]),
     "minimax":  ("MiniMax",         "Global, OAuth Coding Plan & China endpoints",     ["minimax", "minimax-oauth", "minimax-cn"]),
     "xai":      ("xAI Grok",        "Direct API or SuperGrok / Premium+ OAuth",        ["xai", "xai-oauth"]),
     "google":   ("Google Gemini",   "Google AI Studio (API key)",                     ["gemini"]),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -81,6 +81,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://portal.qwen.ai/v1",
         base_url_env_var="HERMES_QWEN_BASE_URL",
     ),
+    "kimi-oauth": HermesOverlay(
+        transport="openai_chat",
+        auth_type="oauth_external",
+        base_url_override="https://api.kimi.com/coding/v1",
+        base_url_env_var="KIMI_BASE_URL",
+    ),
     "lmstudio": HermesOverlay(
         transport="openai_chat",
         auth_type="api_key",
@@ -291,6 +297,11 @@ ALIASES: Dict[str, str] = {
     "kimi-coding": "kimi-for-coding",
     "kimi-coding-cn": "kimi-for-coding",
     "moonshot": "kimi-for-coding",
+    # kimi-oauth aliases
+    "kimi-oauth": "kimi-oauth",
+    "kimi-oauth-code": "kimi-oauth",
+    "kimi-oauth-cli": "kimi-oauth",
+    "kimi-code-oauth": "kimi-oauth",
 
     # stepfun
     "step": "stepfun",
@@ -406,6 +417,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "vertex": "Google Vertex AI",
     "ollama-cloud": "Ollama Cloud",
     "xai-oauth": "xAI Grok OAuth (SuperGrok / Premium+)",
+    "kimi-oauth": "Kimi Code (OAuth)",
 }
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -23,6 +23,7 @@ from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
     DEFAULT_QWEN_BASE_URL,
+    DEFAULT_KIMI_OAUTH_BASE_URL,
     DEFAULT_XAI_OAUTH_BASE_URL,
     PROVIDER_REGISTRY,
     _agent_key_is_usable,
@@ -435,6 +436,9 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "qwen-oauth":
         api_mode = "chat_completions"
         base_url = base_url or DEFAULT_QWEN_BASE_URL
+    elif provider == "kimi-oauth":
+        api_mode = "chat_completions"
+        base_url = base_url or DEFAULT_KIMI_OAUTH_BASE_URL
     elif provider == "minimax-oauth":
         # MiniMax OAuth tokens are valid only against the Anthropic Messages
         # compatible endpoint. Do not honor stale model.api_mode values from a
@@ -1965,6 +1969,24 @@ def resolve_runtime_provider(
             if requested_provider != "auto":
                 raise
             logger.info("Qwen OAuth credentials failed; "
+                        "falling through to next provider.")
+
+    if provider == "kimi-oauth":
+        try:
+            from hermes_cli.auth import resolve_kimi_oauth_runtime_credentials
+            creds = resolve_kimi_oauth_runtime_credentials()
+            return {
+                "provider": "kimi-oauth",
+                "api_mode": "chat_completions",
+                "base_url": creds.get("base_url", "").rstrip("/"),
+                "api_key": creds.get("api_key", ""),
+                "source": creds.get("source", "kimi-code"),
+                "requested_provider": requested_provider,
+            }
+        except Exception:
+            if requested_provider != "auto":
+                raise
+            logger.info("Kimi OAuth credentials failed; "
                         "falling through to next provider.")
 
     if provider == "minimax-oauth":

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -203,11 +203,13 @@ def show_status(args):
         codex_status = get_codex_auth_status()
         qwen_status = get_qwen_auth_status()
         minimax_status = get_minimax_oauth_auth_status()
+        kimi_status = get_kimi_oauth_auth_status()
     except Exception:
         nous_status = {}
         codex_status = {}
         qwen_status = {}
         minimax_status = {}
+        kimi_status = {}
 
     nous_account_info = None
     if (
@@ -304,6 +306,23 @@ def show_status(args):
         print(f"    Access exp: {minimax_exp}")
     if minimax_status.get("error") and not minimax_logged_in:
         print(f"    Error:      {minimax_status.get('error')}")
+
+    # Kimi OAuth
+    kimi_logged_in = bool(kimi_status.get("logged_in"))
+    print(
+        f"  {'Kimi OAuth':<12}  {check_mark(kimi_logged_in)} "
+        f"{'logged in' if kimi_logged_in else 'not logged in (run: kimi-code CLI first)'}"
+    )
+    kimi_auth_file = kimi_status.get("auth_file")
+    if kimi_auth_file:
+        print(f"    Auth file:  {kimi_auth_file}")
+    kimi_exp = kimi_status.get("expires_at_ms")
+    if kimi_exp:
+        from datetime import datetime, timezone
+        print(f"    Access exp: {datetime.fromtimestamp(int(kimi_exp) / 1000, tz=timezone.utc).isoformat()}")
+    if kimi_status.get("error") and not kimi_logged_in:
+        print(f"    Error:      {kimi_status.get('error')}")
+
 
     # xAI OAuth — separate try/except so an import failure here cannot
     # disrupt the already-printed Nous/Codex/Qwen/MiniMax rows above.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10186,6 +10186,16 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
                 "expires_at": raw.get("expires_at"),
                 "has_refresh_token": bool(raw.get("has_refresh_token")),
             }
+        if provider_id == "kimi-oauth":
+            raw = hauth.get_kimi_oauth_auth_status()
+            return {
+                "logged_in": bool(raw.get("logged_in")),
+                "source": "kimi_code",
+                "source_label": raw.get("auth_file") or "Kimi Code CLI",
+                "token_preview": _truncate_token(raw.get("api_key")),
+                "expires_at": raw.get("expires_at_ms"),
+                "has_refresh_token": True,
+            }
         if provider_id == "minimax-oauth":
             raw = hauth.get_minimax_oauth_auth_status()
             return {

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -148,7 +148,7 @@ def _conn(board: Optional[str] = None):
 # tasks into ``todo`` and makes the dashboard look like the Scheduled column
 # disappeared.
 BOARD_COLUMNS: list[str] = [
-    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
+    "triage", "todo", "scheduled", "ready", "running", "waiting", "blocked", "review", "done",
 ]
 
 

--- a/plugins/model-providers/kimi-oauth/__init__.py
+++ b/plugins/model-providers/kimi-oauth/__init__.py
@@ -1,0 +1,29 @@
+"""Kimi OAuth provider profile — reuse Kimi Code CLI OAuth tokens.
+
+The Kimi Code CLI stores its OAuth2 tokens at
+``~/.kimi-code/credentials/kimi-code.json``.  This provider reads those
+tokens and exposes them as a Hermes provider, so Kimi subscription users
+(K3, K2.7 Coding, etc.) don't need a separate platform API key.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+kimi_oauth = ProviderProfile(
+    name="kimi-oauth",
+    aliases=(
+        "kimi",
+        "kimi-oauth-code",
+        "kimi-oauth-cli",
+        "kimi-code-oauth",
+    ),
+    display_name="Kimi Code (OAuth)",
+    description="Kimi Code via OAuth tokens from Kimi Code CLI — no API key required",
+    signup_url="https://kimi.moonshot.cn/",
+    env_vars=(),  # OAuth — tokens in ~/.kimi-code/credentials/kimi-code.json, not env
+    base_url="https://api.kimi.com/coding/v1",
+    auth_type="oauth_external",
+    default_max_tokens=65536,
+)
+
+register_provider(kimi_oauth)

--- a/plugins/model-providers/kimi-oauth/plugin.yaml
+++ b/plugins/model-providers/kimi-oauth/plugin.yaml
@@ -1,0 +1,5 @@
+name: kimi-oauth-provider
+kind: model-provider
+version: 1.0.0
+description: Kimi Code CLI OAuth — reuse Kimi Code subscription tokens
+author: Nous Research

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -796,6 +796,54 @@ def _handle_block(args: dict, **kw) -> str:
         return tool_error(f"kanban_block: {e}")
 
 
+def _handle_wait(args: dict, **kw) -> str:
+    """Transition the task to 'waiting' for a human response."""
+    delegated_err = _reject_delegated_child_mutation("kanban_wait")
+    if delegated_err:
+        return delegated_err
+    tid = _default_task_id(args.get("task_id"))
+    if not tid:
+        return tool_error(
+            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
+        )
+    ownership_err = _enforce_worker_task_ownership(tid)
+    if ownership_err:
+        return ownership_err
+    reason = args.get("reason")
+    if not reason or not str(reason).strip():
+        return tool_error("reason is required — explain what input you need from the human")
+    reason = redact_sensitive_text(str(reason), force=True)
+    board = args.get("board")
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            ok = kb.wait_task(
+                conn, tid,
+                reason=reason,
+                kind="needs_input",
+                expected_run_id=_worker_run_id(tid),
+            )
+            if not ok:
+                return tool_error(
+                    f"could not wait {tid} (unknown id or not in "
+                    f"running/ready)"
+                )
+            run = kb.latest_run(conn, tid)
+            landed = kb.get_task(conn, tid)
+            return _ok(
+                task_id=tid,
+                run_id=run.id if run else None,
+                status=landed.status if landed else "waiting",
+            )
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_wait: {e}")
+    except Exception as e:
+        logger.exception("kanban_wait failed")
+        return tool_error(f"kanban_wait: {e}")
+
+
 def _handle_heartbeat(args: dict, **kw) -> str:
     """Signal that the worker is still alive during a long operation.
 
@@ -1627,7 +1675,7 @@ KANBAN_BLOCK_SCHEMA = {
         "Stop work on this task and route it according to WHY you're stuck. "
         "Set ``kind`` to say which: 'dependency' (waiting on another task — "
         "goes to todo and auto-resumes when that task finishes, no human "
-        "needed), 'needs_input' (you need a human decision/answer), "
+        "needed), 'needs_input' (you need a human decision/answer — goes to 'waiting', TTL-exempt), "
         "'capability' (a hard wall: no access, missing credentials, an action "
         "no agent can do), or 'transient' (a flaky failure that may clear). "
         "``reason`` is shown to the human on the board. If a task keeps "
@@ -2084,6 +2132,15 @@ registry.register(
     handler=_handle_heartbeat,
     check_fn=_check_kanban_mode,
     emoji="💓",
+)
+
+registry.register(
+    name="kanban_wait",
+    toolset="kanban",
+    schema=KANBAN_WAIT_SCHEMA,
+    handler=_handle_wait,
+    check_fn=_check_kanban_mode,
+    emoji="⏳",
 )
 
 registry.register(

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -29,7 +29,8 @@ import type {
   SessionInfo,
   SlashCatalog,
   SudoReq,
-  Usage
+  Usage,
+  WelcomeBannerConfig
 } from '../types.js'
 
 export interface StateSetter<T> {
@@ -341,6 +342,9 @@ export interface UiState {
   statusBar: StatusBarMode
   streaming: boolean
   theme: Theme
+
+  /** Resolved welcome banner section configuration. */
+  welcomeBanner: WelcomeBannerConfig
   usage: Usage
 }
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -4,7 +4,7 @@ import { MOUSE_TRACKING } from '../config/env.js'
 import { ZERO } from '../domain/usage.js'
 import { bootTheme } from '../lib/themeBoot.js'
 import { DEFAULT_THEME } from '../theme.js'
-
+import { WELCOME_BANNER_DEFAULTS } from '../types.js'
 import { DEFAULT_INDICATOR_STYLE, type UiState } from './interfaces.js'
 
 const buildUiState = (): UiState => ({
@@ -34,7 +34,8 @@ const buildUiState = (): UiState => ({
   // Last session's resolved theme paints frame one (flash-free boot, like
   // the desktop's hermes-boot-* keys); DEFAULT_THEME only on first launch.
   theme: bootTheme ?? DEFAULT_THEME,
-  usage: ZERO
+  usage: ZERO,
+  welcomeBanner: { sections: { ...WELCOME_BANNER_DEFAULTS }, plugin_sections: [] }
 })
 
 export const $uiState = atom<UiState>(buildUiState())

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -1,7 +1,7 @@
 import type { MouseTrackingMode } from '@hermes/ink'
 import { useEffect, useRef } from 'react'
 
-import { resolveDetailsMode, resolveSections } from '../domain/details.js'
+import { resolveDetailsMode, resolveSections, resolveWelcomeBanner } from '../domain/details.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { ConfigFullResponse, ConfigMtimeResponse, ReloadMcpResponse } from '../gatewayTypes.js'
 import { DEFAULT_VOICE_RECORD_KEY, type ParsedVoiceRecordKey, parseVoiceRecordKey } from '../lib/platform.js'
@@ -283,7 +283,8 @@ export const applyDisplay = (
     sections: resolveSections(d.sections),
     showReasoning: !!d.show_reasoning,
     statusBar: normalizeStatusBar(d.tui_statusbar),
-    streaming: d.streaming !== false
+    streaming: d.streaming !== false,
+    welcomeBanner: resolveWelcomeBanner(d.welcome_banner)
   })
 }
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -213,6 +213,7 @@ const TranscriptPane = memo(function TranscriptPane({
                       maxWidth={Math.max(1, composer.cols - 2)}
                       sid={ui.sid}
                       t={ui.theme}
+                      welcomeBanner={ui.welcomeBanner}
                     />
                   )}
                 </Box>

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -6,7 +6,7 @@ import { artWidth, caduceus, CADUCEUS_WIDTH, logo, LOGO_WIDTH } from '../banner.
 import { mix } from '../lib/color.js'
 import { flat } from '../lib/text.js'
 import type { Theme } from '../theme.js'
-import type { PanelSection, SessionInfo } from '../types.js'
+import type { PanelSection, SessionInfo, WelcomeBannerConfig } from '../types.js'
 
 import { Accordion } from './accordion.js'
 import { ShimmerRows } from './loaders.js'
@@ -209,7 +209,7 @@ const SKELETON_ROWS: readonly (readonly [number, number])[] = [
 const SKILLS_MAX = 8
 const TOOLSETS_MAX = 8
 
-export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
+export function SessionPanel({ info, maxWidth, sid, t, welcomeBanner }: SessionPanelProps) {
   const term = useStdout().stdout?.columns ?? 100
   const cols = Math.max(20, Math.min(term, maxWidth ?? term))
   const heroLines = caduceus(t.color, t.bannerHero || undefined)
@@ -225,11 +225,17 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
   // wrong — surface-relative blends go invisible when text is already pale.
   const listFade = mix(t.color.muted, t.color.text, 0.5)
 
-  // ── Local collapse state for each section ──
-  const [toolsOpen, setToolsOpen] = useState(true)
-  const [skillsOpen, setSkillsOpen] = useState(false)
-  const [systemOpen, setSystemOpen] = useState(false)
-  const [mcpOpen, setMcpOpen] = useState(false)
+  // ── Collapse state for each section, driven by config defaults ──
+  const [toolsOpen, setToolsOpen] = useState(welcomeBanner.sections.tools?.default_open ?? true)
+  const [skillsOpen, setSkillsOpen] = useState(welcomeBanner.sections.skills?.default_open ?? false)
+  const [systemOpen, setSystemOpen] = useState(welcomeBanner.sections.system_prompt?.default_open ?? false)
+  const [mcpOpen, setMcpOpen] = useState(welcomeBanner.sections.mcp_servers?.default_open ?? false)
+  // Dynamic state for plugin sections
+  const [pluginOpen, setPluginOpen] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(
+      welcomeBanner.plugin_sections.map(s => [s.id, s.default_open])
+    )
+  )
 
   const truncLine = (pfx: string, items: string[]) => {
     let line = ''
@@ -401,15 +407,18 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
         </Box>
       )}
 
-      {/* ── Tools (expanded by default) ── */}
-      <Box flexDirection="column" marginTop={1}>
+      {/* ── Tools (default: expanded) ── */}
+      {welcomeBanner.sections.tools?.enabled !== false && (
+        <Box flexDirection="column" marginTop={1}>
         <Accordion onToggle={() => setToolsOpen(v => !v)} open={toolsOpen} t={t} title="Available Tools">
           {toolsBody()}
         </Accordion>
       </Box>
+      )}
 
-      {/* ── Skills (collapsed by default) ── */}
-      <Box flexDirection="column" marginTop={1}>
+      {/* ── Skills (default: collapsed) ── */}
+      {welcomeBanner.sections.skills?.enabled !== false && (
+        <Box flexDirection="column" marginTop={1}>
         <Accordion
           count={skillsTotal}
           onToggle={() => setSkillsOpen(v => !v)}
@@ -421,37 +430,55 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
           {skillsBody()}
         </Accordion>
       </Box>
-
-      {/* ── System Prompt (collapsed by default) ── */}
-      {sysPromptLen > 0 && (
-        <Box flexDirection="column" marginTop={1}>
-          <Accordion
-            onToggle={() => setSystemOpen(v => !v)}
-            open={systemOpen}
-            suffix={`— ${sysPromptLen.toLocaleString()} chars`}
-            t={t}
-            title="System Prompt"
-          >
-            {systemBody()}
-          </Accordion>
-        </Box>
       )}
 
-      {/* ── MCP Servers (collapsed by default) ── */}
-      {mcpServers.length > 0 && (
+      {/* ── System Prompt (default: collapsed) ── */}
+      {sysPromptLen > 0 && welcomeBanner.sections.system_prompt?.enabled !== false && (
         <Box flexDirection="column" marginTop={1}>
-          <Accordion
-            count={mcpConnected}
-            onToggle={() => setMcpOpen(v => !v)}
-            open={mcpOpen}
-            suffix="connected"
-            t={t}
-            title="MCP Servers"
-          >
-            {mcpBody()}
-          </Accordion>
-        </Box>
+        <Accordion
+          onToggle={() => setSystemOpen(v => !v)}
+          open={systemOpen}
+          suffix={`— ${sysPromptLen.toLocaleString()} chars`}
+          t={t}
+          title="System Prompt"
+        >
+          {systemBody()}
+        </Accordion>
+      </Box>
       )}
+
+      {/* ── MCP Servers (default: collapsed) ── */}
+      {mcpServers.length > 0 && welcomeBanner.sections.mcp_servers?.enabled !== false && (
+        <Box flexDirection="column" marginTop={1}>
+        <Accordion
+          count={mcpConnected}
+          onToggle={() => setMcpOpen(v => !v)}
+          open={mcpOpen}
+          suffix="connected"
+          t={t}
+          title="MCP Servers"
+        >
+          {mcpBody()}
+        </Accordion>
+      </Box>
+      )}
+
+      {/* ── Plugin sections ── */}
+      {welcomeBanner.plugin_sections.map(ps => {
+        const isOpen = pluginOpen[ps.id] ?? ps.default_open
+        const toggle = () => setPluginOpen(p => ({ ...p, [ps.id]: !(p[ps.id] ?? ps.default_open) }))
+        return (
+          <Box flexDirection="column" key={ps.id} marginTop={1}>
+            <Accordion onToggle={toggle} open={isOpen} t={t} title={ps.title}>
+              <Text color={t.color.muted}>
+                Plugin section — data binding for &ldquo;{ps.title}&rdquo; is
+                not yet wired on the gateway side.
+              </Text>
+            </Accordion>
+          </Box>
+        )
+      })}
+
 
       <Text />
 
@@ -559,4 +586,5 @@ interface SessionPanelProps {
   maxWidth?: number
   sid?: string | null
   t: Theme
+  welcomeBanner: WelcomeBannerConfig
 }

--- a/ui-tui/src/domain/details.ts
+++ b/ui-tui/src/domain/details.ts
@@ -1,4 +1,6 @@
 import type { DetailsMode, SectionName, SectionVisibility } from '../types.js'
+import type { WelcomeBannerConfig, WelcomeBannerPluginSection, WelcomeBannerSectionConfig } from '../types.js'
+import { WELCOME_BANNER_DEFAULTS } from '../types.js'
 
 const MODES = ['hidden', 'collapsed', 'expanded'] as const
 
@@ -73,4 +75,50 @@ export const sectionMode = (
   commandOverride = false
 ): DetailsMode => sections?.[name] ?? (commandOverride ? global : (SECTION_DEFAULTS[name] ?? global))
 
-export const nextDetailsMode = (m: DetailsMode): DetailsMode => MODES[(MODES.indexOf(m) + 1) % MODES.length]!
+export const nextDetailsMode = (m: DetailsMode): DetailsMode => MODES[(MODES.indexOf(m) + 1) % MODES.length]
+
+/**
+ * Build a WelcomeBannerConfig from the raw display.welcome_banner blob.
+ * Merges user overrides atop the built-in defaults, dropping unknown keys.
+ * Plugin sections are validated for required fields.
+ */
+export const resolveWelcomeBanner = (raw: unknown): WelcomeBannerConfig => {
+  const sections: Record<string, WelcomeBannerSectionConfig> = { ...WELCOME_BANNER_DEFAULTS }
+  const plugin_sections: WelcomeBannerPluginSection[] = []
+
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { sections, plugin_sections }
+  }
+
+  const cfg = raw as Record<string, unknown>
+
+  // Merge user section overrides
+  if (cfg.sections && typeof cfg.sections === 'object' && !Array.isArray(cfg.sections)) {
+    for (const [key, val] of Object.entries(cfg.sections as Record<string, unknown>)) {
+      if (!sections[key]) continue
+      if (val && typeof val === 'object' && !Array.isArray(val)) {
+        const entry = val as Record<string, unknown>
+        if (typeof entry.default_open === 'boolean') {
+          sections[key] = { ...sections[key], default_open: entry.default_open }
+        }
+        if (typeof entry.enabled === 'boolean') {
+          sections[key] = { ...sections[key], enabled: entry.enabled }
+        }
+      }
+    }
+  }
+
+  if (cfg.plugin_sections && Array.isArray(cfg.plugin_sections)) {
+    for (const item of cfg.plugin_sections) {
+      if (item && typeof item === 'object' && typeof item.id === 'string' && typeof item.title === 'string') {
+        plugin_sections.push({
+          id: item.id,
+          title: item.title,
+          default_open: typeof item.default_open === 'boolean' ? item.default_open : false
+        })
+      }
+    }
+  }
+
+  return { sections, plugin_sections }
+}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -110,6 +110,26 @@ export interface ConfigDisplayConfig {
   tui_theme?: string
 }
 
+  /**
+   * Welcome banner section configuration.
+   *
+   * Controls which accordion sections appear in the TUI welcome panel, their
+   * default open/closed state, and custom plugin-provided sections.
+   *
+   * Sections omitted from config use their built-in defaults (tools=open,
+   * skills=closed, system_prompt=closed, mcp_servers=closed). Set
+   * `enabled: false` to hide a section entirely.
+   *
+   * `plugin_sections` renders custom Accordion sections after the built-in
+   * ones. Data for plugin sections is expected on SessionInfo under the
+   * matching key (future - currently renders a placeholder label).
+   */
+  welcome_banner?: {
+    sections?: Record<string, { default_open?: boolean; enabled?: boolean }>
+    plugin_sections?: Array<{ id: string; title: string; default_open?: boolean }>
+  }
+}
+
 export interface ConfigVoiceConfig {
   // Raw `yaml.safe_load()` value from config; may be non-string if hand-edited.
   // Callers must normalize/validate at runtime (parseVoiceRecordKey()).

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -228,6 +228,40 @@ export interface SlashCatalog {
   sub: Record<string, string[]>
 }
 
+/**
+ * Welcome banner section config as resolved from display.welcome_banner.
+ * Each built-in section (tools, skills, system_prompt, mcp_servers) can be
+ * independently enabled/disabled and default-open/closed.
+ *
+ * Plugin sections render custom Accordion entries after built-in sections.
+ */
+export interface WelcomeBannerSectionConfig {
+  default_open: boolean
+  enabled: boolean
+}
+
+export interface WelcomeBannerPluginSection {
+  id: string
+  title: string
+  default_open: boolean
+}
+
+export interface WelcomeBannerConfig {
+  sections: Record<string, WelcomeBannerSectionConfig>
+  plugin_sections: WelcomeBannerPluginSection[]
+}
+
+/**
+ * Welcome banner section default defaults for each built-in section.
+ * These match the hardcoded values in branding.tsx before this feature.
+ */
+export const WELCOME_BANNER_DEFAULTS: Record<string, WelcomeBannerSectionConfig> = {
+  tools: { default_open: true, enabled: true },
+  skills: { default_open: false, enabled: true },
+  system_prompt: { default_open: false, enabled: true },
+  mcp_servers: { default_open: false, enabled: true }
+}
+
 export interface SlashCategory {
   name: string
   pairs: [string, string][]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -119,6 +119,7 @@ const CHAT_NAV_ITEM: NavItem = {
   labelKey: "chat",
   label: "Chat",
   icon: Terminal,
+  section: "Workspace",
 };
 
 /**
@@ -166,37 +167,41 @@ const BUILTIN_NAV_REST: NavItem[] = [
     labelKey: "sessions",
     label: "Sessions",
     icon: MessageSquare,
+    section: "Workspace",
   },
-  { path: "/files", label: "Files", icon: FolderOpen },
+  { path: "/files", label: "Files", icon: FolderOpen, section: "Workspace" },
   {
     path: "/analytics",
     labelKey: "analytics",
     label: "Analytics",
     icon: BarChart3,
+    section: "Monitoring",
   },
   {
     path: "/models",
     labelKey: "models",
     label: "Models",
     icon: Cpu,
+    section: "Configuration",
   },
-  { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
-  { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
-  { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
-  { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
-  { path: "/mcp", label: "MCP", icon: Plug },
-  { path: "/channels", label: "Channels", icon: Radio },
-  { path: "/webhooks", label: "Webhooks", icon: Webhook },
-  { path: "/pairing", label: "Pairing", icon: ShieldCheck },
-  { path: "/profiles", labelKey: "profiles", label: "Profiles", icon: Users },
-  { path: "/config", labelKey: "config", label: "Config", icon: Settings },
-  { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound },
-  { path: "/system", label: "System", icon: Wrench },
+  { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText, section: "Monitoring" },
+  { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock, section: "Automation" },
+  { path: "/skills", labelKey: "skills", label: "Skills", icon: Package, section: "Extensions" },
+  { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle, section: "Extensions" },
+  { path: "/mcp", label: "MCP", icon: Plug, section: "Extensions" },
+  { path: "/channels", label: "Channels", icon: Radio, section: "Integrations" },
+  { path: "/webhooks", label: "Webhooks", icon: Webhook, section: "Integrations" },
+  { path: "/pairing", label: "Pairing", icon: ShieldCheck, section: "Configuration" },
+  { path: "/profiles", labelKey: "profiles", label: "Profiles", icon: Users, section: "Configuration" },
+  { path: "/config", labelKey: "config", label: "Config", icon: Settings, section: "Configuration" },
+  { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound, section: "Configuration" },
+  { path: "/system", label: "System", icon: Wrench, section: "System" },
   {
     path: "/docs",
     labelKey: "documentation",
     label: "Documentation",
     icon: BookOpen,
+    section: "System",
   },
 ];
 
@@ -244,6 +249,7 @@ function buildNavItems(
       path: manifest.tab.path,
       label: manifest.label,
       icon: resolveIcon(manifest.icon),
+      section: manifest.tab.section,
     };
 
     const pos = manifest.tab.position ?? "end";
@@ -615,18 +621,45 @@ export default function App() {
               className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden border-t border-current/10 py-2"
               aria-label={t.app.navigation}
             >
-              <ul className="flex flex-col">
-                {sidebarNav.coreItems.map((item) => (
-                  <SidebarNavLink
-                    closeMobile={closeMobile}
-                    collapsed={isDesktopCollapsed}
-                    item={item}
-                    key={item.path}
-                    t={t}
-                    tooltipWarmRef={tooltipWarmRef}
-                  />
-                ))}
-              </ul>
+              {(() => {
+                let lastSection: string | undefined;
+                const groups: { section?: string; items: NavItem[] }[] = [];
+                for (const item of sidebarNav.coreItems) {
+                  if (item.section !== lastSection) {
+                    groups.push({ section: item.section, items: [item] });
+                    lastSection = item.section;
+                  } else {
+                    groups[groups.length - 1].items.push(item);
+                  }
+                }
+                return groups.map((group) => (
+                  <div key={group.section ?? "__ungrouped"}>
+                    {group.section && (
+                      <span
+                        className={cn(
+                          "block px-5 pt-2.5 pb-1",
+                          "font-sans text-display text-xs tracking-[0.12em] text-text-tertiary",
+                          isDesktopCollapsed && "lg:hidden",
+                        )}
+                      >
+                        {group.section}
+                      </span>
+                    )}
+                    <ul className="flex flex-col">
+                      {group.items.map((item) => (
+                        <SidebarNavLink
+                          closeMobile={closeMobile}
+                          collapsed={isDesktopCollapsed}
+                          item={item}
+                          key={item.path}
+                          t={t}
+                          tooltipWarmRef={tooltipWarmRef}
+                        />
+                      ))}
+                    </ul>
+                  </div>
+                ));
+              })()}
 
               {sidebarNav.pluginItems.length > 0 && (
                 <div
@@ -1307,6 +1340,8 @@ interface NavItem {
   label: string;
   labelKey?: string;
   path: string;
+  /** Optional section/group label. When set, sidebar groups consecutive items with the same section under a header. */
+  section?: string;
 }
 
 interface SidebarIconWithTooltipProps {

--- a/web/src/plugins/types.ts
+++ b/web/src/plugins/types.ts
@@ -16,6 +16,9 @@ export interface PluginManifest {
     override?: string;
     /** When true, the plugin may register without a sidebar tab (slot-only, etc.). */
     hidden?: boolean;
+    /** Optional section/group name. When set and the sidebar supports section grouping,
+     * the plugin nav item renders under the named section header. */
+    section?: string;
   };
   /** Declared for discovery; actual slots use registerSlot in the plugin bundle. */
   slots?: string[];


### PR DESCRIPTION
Implements #70916

Makes TUI welcome banner sections configurable via config.yaml display.welcome_banner. Users can now:
- Show/hide each section
- Set default open/closed state
- Plugin sections are supported

9 files modified across TUI frontend and config.