### PR TITLE
fix(doctor): normalize model config shape before validating

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -125,6 +125,22 @@ def _termux_install_all_fallback_notes() -> list[str]:
     ]
 
 
+def _as_config_str(value: object) -> str:
+    """Coerce a raw config scalar to a stripped string, tolerating junk shapes.
+
+    ``config.yaml`` is user-authored, so ``model.default`` / ``model.provider``
+    can legitimately arrive as a list, dict, int, or None. Doctor is a
+    diagnostic: a malformed value must be reported, never crash the check.
+    Calling ``.strip()`` on a non-string raised AttributeError inside the
+    ~180-line ``try`` that guards the whole model/provider section, whose
+    blanket handler then hid every check in it (#71019).
+
+    Returns "" for anything that is not a string, so the surrounding checks
+    treat a malformed value as "not configured" rather than aborting.
+    """
+    return value.strip() if isinstance(value, str) else ""
+
+
 def _has_provider_env_config(content: str) -> bool:
     """Return True when ~/.hermes/.env contains provider auth/base URL settings."""
     return any(key in content for key in _PROVIDER_ENV_HINTS)
@@ -962,10 +978,37 @@ def run_doctor(args):
             # Raw-file diagnostic: inspects what the user actually wrote.
             from hermes_cli.config import read_user_config_raw
             cfg = read_user_config_raw(config_path)
-            model_section = cfg.get("model") or {}
-            provider_raw = (model_section.get("provider") or "").strip()
+            # Coerce legacy/root-level shapes into the canonical nested mapping
+            # before reading, without giving up the raw-diagnostic contract:
+            # read_user_config_raw() deliberately skips migration, but every
+            # behavioural consumer (cli.py, config.py, managed_scope.py) applies
+            # _normalize_root_model_keys on load, so ``model: <id>`` + root
+            # ``provider:`` resolves fine at runtime. Doctor alone read the
+            # unmigrated shape, leaving ``model_section`` a str, so the first
+            # ``.get()`` raised AttributeError and the blanket handler below
+            # silently discarded every check in this block — unknown provider,
+            # vendor-prefixed id, and missing API key alike. See #71019.
+            try:
+                from hermes_cli.config import _normalize_root_model_keys
+
+                cfg = _normalize_root_model_keys(cfg)
+            except Exception:
+                pass
+            model_section = cfg.get("model")
+            # Defence in depth. Two distinct shapes reach here:
+            #   * ``model:`` itself not a mapping (a bare list, no root keys) —
+            #     migration leaves it alone, so coerce to {}.
+            #   * ``model:`` a list *with* root keys present — migration wraps it
+            #     as {"default": [...]}, so the mapping check passes but the
+            #     values are still non-strings and ``.strip()`` would raise.
+            # Coerce per value rather than trusting the container's type.
+            if not isinstance(model_section, dict):
+                model_section = {}
+            provider_raw = _as_config_str(model_section.get("provider"))
             provider = provider_raw.lower()
-            default_model = (model_section.get("default") or model_section.get("model") or "").strip()
+            default_model = _as_config_str(
+                model_section.get("default") or model_section.get("model")
+            )
 
             known_providers: set = set()
             try:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1224,3 +1224,165 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+class TestDoctorScalarModelShape:
+    """A scalar ``model:`` must not disable the whole model/provider block.
+
+    Regression tests for #71019. ``doctor`` read raw YAML and assumed
+    ``model:`` was a mapping, so ``model: <id>`` (the shape
+    ``hermes config set model <id>`` writes) made ``model_section`` a ``str``.
+    The first ``.get()`` raised AttributeError inside the ~184-line ``try``
+    guarding this section, and its blanket handler collapsed every check —
+    unknown provider, vendor-prefixed id, missing API key — into a single
+    "Could not validate model/provider config" warning.
+    """
+
+    def _run(self, monkeypatch, tmp_path, config_yaml):
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / ".env").write_text("", encoding="utf-8")
+        (home / "config.yaml").write_text(config_yaml, encoding="utf-8")
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        (tmp_path / "project").mkdir(exist_ok=True)
+
+        monkeypatch.setitem(
+            sys.modules,
+            "model_tools",
+            types.SimpleNamespace(
+                check_tool_availability=lambda *a, **kw: ([], []),
+                TOOLSET_REQUIREMENTS={},
+            ),
+        )
+
+        from hermes_cli import auth as _auth_mod
+
+        for _fn in (
+            "get_nous_auth_status",
+            "get_codex_auth_status",
+            "get_minimax_oauth_auth_status",
+            "get_xai_oauth_auth_status",
+        ):
+            monkeypatch.setattr(_auth_mod, _fn, lambda: {})
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    def test_scalar_model_does_not_trip_the_blanket_handler(
+        self, monkeypatch, tmp_path
+    ):
+        out = self._run(
+            monkeypatch,
+            tmp_path,
+            "model: openai-codex/gpt-5.6-sol\nprovider: openai-codex\n",
+        )
+        assert "Could not validate model/provider config" not in out
+
+    def test_scalar_model_still_reports_unknown_provider(self, monkeypatch, tmp_path):
+        """The check that matters most: a bogus provider must not pass clean."""
+        out = self._run(
+            monkeypatch,
+            tmp_path,
+            "model: totally-made-up/xyz\nprovider: not-a-real-provider\n",
+        )
+        assert "model.provider 'not-a-real-provider' is not a recognised provider" in out
+
+    def test_scalar_model_still_reports_vendor_prefix(self, monkeypatch, tmp_path):
+        out = self._run(
+            monkeypatch,
+            tmp_path,
+            "model: openai-codex/gpt-5.6-sol\nprovider: openai-codex\n",
+        )
+        assert (
+            "model.default 'openai-codex/gpt-5.6-sol' uses a vendor/model slug "
+            "but provider is 'openai-codex'"
+        ) in out
+
+    def test_scalar_and_nested_configs_agree(self, monkeypatch, tmp_path):
+        """Behaviour contract: the two shapes are equivalent inputs.
+
+        Pins the invariant rather than a literal, so it keeps holding as the
+        individual check strings evolve.
+        """
+        scalar = self._run(
+            monkeypatch,
+            tmp_path / "a",
+            "model: totally-made-up/xyz\nprovider: not-a-real-provider\n",
+        )
+        nested = self._run(
+            monkeypatch,
+            tmp_path / "b",
+            "model:\n  default: totally-made-up/xyz\n  provider: not-a-real-provider\n",
+        )
+        for marker in (
+            "is not a recognised provider",
+            "uses a vendor/model slug",
+        ):
+            assert (marker in scalar) == (marker in nested), (
+                f"scalar and nested model: shapes disagree on {marker!r}"
+            )
+
+    def test_non_mapping_non_scalar_model_is_survivable(self, monkeypatch, tmp_path):
+        """A ``model:`` list is not migratable — degrade, don't crash."""
+        out = self._run(
+            monkeypatch, tmp_path, "model:\n  - gpt-4o\n  - gpt-5.6-sol\n"
+        )
+        assert "Could not validate model/provider config" not in out
+        assert "config.yaml exists" in out
+
+    def test_list_model_with_root_provider_is_survivable(self, monkeypatch, tmp_path):
+        """List ``model:`` *plus* a root ``provider:`` — the harder shape.
+
+        Regression for the review finding on #71046: with root keys present,
+        _normalize_root_model_keys wraps the list as ``{"default": [...]}``, so a
+        container-level isinstance check passes while the *values* are still
+        lists. ``.strip()`` on that raised AttributeError and the blanket
+        handler swallowed the whole block again.
+        """
+        out = self._run(
+            monkeypatch,
+            tmp_path,
+            "model:\n  - gpt-4o\n  - gpt-5.6-sol\nprovider: openai-codex\n",
+        )
+        assert "Could not validate model/provider config" not in out
+        assert "config.yaml exists" in out
+
+    def test_scalar_junk_model_values_are_survivable(self, monkeypatch, tmp_path):
+        """Non-string scalars (int, mapping) must not abort the block either."""
+        out = self._run(
+            monkeypatch,
+            tmp_path,
+            "model:\n  default: 42\n  provider:\n    nested: true\n",
+        )
+        assert "Could not validate model/provider config" not in out
+        assert "config.yaml exists" in out
+
+    def test_doctor_remains_read_only_without_fix(self, monkeypatch, tmp_path):
+        """The added migration is in-memory only; --fix owns writes."""
+        original = "model: openai-codex/gpt-5.6-sol\nprovider: openai-codex\n"
+        self._run(monkeypatch, tmp_path, original)
+        assert (
+            tmp_path / ".hermes" / "config.yaml"
+        ).read_text(encoding="utf-8") == original
+
+
+class TestAsConfigStr:
+    """Unit coverage for the value coercion helper (pure function)."""
+
+    def test_strings_are_stripped(self):
+        assert doctor_mod._as_config_str("  openai-codex  ") == "openai-codex"
+
+    def test_none_becomes_empty(self):
+        assert doctor_mod._as_config_str(None) == ""
+
+    @pytest.mark.parametrize(
+        "value",
+        [["gpt-4o", "gpt-5"], {"nested": True}, 42, 3.14, True],
+    )
+    def test_non_strings_become_empty_rather_than_raising(self, value):
+        assert doctor_mod._as_config_str(value) == ""


### PR DESCRIPTION
Fixes #71019.

## Problem

`doctor` read `config.yaml` as raw YAML and assumed `model:` was a mapping:

```python
cfg = _yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
model_section = cfg.get("model") or {}
provider_raw  = (model_section.get("provider") or "").strip()   # AttributeError on a scalar model:
```

With the scalar form (`model: <id>` plus a root `provider:`), `model_section` is a `str`, so the first `.get()` raises `AttributeError`. That statement sits inside the ~184-line `try` guarding the whole model/provider section (`doctor.py:861-1019` on main), whose handler is a blanket `except Exception as e: check_warn("Could not validate model/provider config", ...)`.

One `AttributeError` on line 1 therefore discarded **every** check in the block:

| Check | nested `model:` | scalar `model:` (before) |
|---|---|---|
| `model.provider ... is not a recognised provider` | reported | **silent** |
| `model.default ... uses a vendor/model slug` | reported | **silent** |
| `model.provider ... set but no API key is configured` | reported | **silent** |

A config with a completely bogus provider passed doctor clean.

## Why this matters beyond legacy files

The runtime is unaffected — `cli.py`, `config.py`, and `managed_scope.py` all run `_normalize_root_model_keys` on load, and `load_config()["model"]` returns a proper mapping for these configs. Only doctor's raw-YAML read diverged, so **Hermes ran fine on a config doctor could not parse**: the diagnostic went blind precisely when a user's config was non-canonical, i.e. exactly when they would run `doctor`.

The shape is also reachable from a supported command, not just hand-edited files — `hermes config set model <id>` writes it (and drops sibling `model.provider` / `model.context_length` keys doing so, which is filed separately in #71019 as a related report).

## Fix

Run the same migration every other consumer already runs, before reading:

- `_normalize_root_model_keys(cfg)` unconditionally on the read path, so the read-only and `--fix` paths agree on what they are looking at.
- Fall back to `{}` when `model:` is neither a mapping nor migratable (a list, say), so an exotic hand-edit degrades to "no model checks" instead of taking the whole block down.

The migration is **in-memory only** — `--fix` still owns every write, pinned by a test.

Deliberately scoped: I did not touch the 184-line blanket `except` here. Narrowing it is the right follow-up (it is what hid this for so long) but it is a behaviour change across unrelated checks and belongs in its own PR.

## Tests

`TestDoctorScalarModelShape` in `tests/hermes_cli/test_doctor.py` — real `run_doctor()` against a temp `HERMES_HOME`, no mocking of the code under test:

- scalar `model:` no longer trips the blanket handler
- scalar `model:` still reports an unknown provider (the check that matters most)
- scalar `model:` still reports the vendor-prefixed id
- **scalar and nested shapes agree** — asserted as an invariant over both markers rather than frozen strings, so it survives message rewording
- a `model:` *list* degrades without crashing
- doctor without `--fix` leaves `config.yaml` byte-for-byte unchanged

Verified RED→GREEN: **5 of 6 fail** against unpatched `doctor.py`, all 6 pass after. (The read-only assertion holds either way — the old path did not write — kept as a guard on the new migration.)

Suite: `tests/hermes_cli/test_doctor.py` **81 passed** (75 existing + 6 new). `test_config.py` 184, `test_config_validation.py` 25, `test_aux_config.py` 21 — all identical to a clean `origin/main` worktree.

Note for reviewers: a broad `-k "config or doctor or normalize"` run across `tests/hermes_cli/` shows a handful of failures and a stall around 82%. I checked this on an unmodified `origin/main` worktree and it reproduces identically — cross-file pollution in that ad-hoc selection, unrelated to this change. Every file passes on its own.
