### PR TITLE
fix(auth): protect Windows auth store during tests

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -11,7 +11,6 @@ import uuid
 import re
 from dataclasses import dataclass, fields, replace
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
@@ -551,19 +550,15 @@ def _write_through_provider_state_to_global_root(
     if global_path is None:
         # Classic mode (profile == root); the profile save already hit root.
         return
-    # Seat belt: under pytest, refuse to write the real user's
-    # ~/.hermes/auth.json even when HERMES_HOME points at a profile path
-    # (mirrors the read-side guard in _load_global_auth_store). Uses the
-    # unmodified HOME env, not Path.home() which fixtures may monkeypatch.
+    # Seat belt: under pytest, refuse to write the platform-native user's
+    # auth store even when HERMES_HOME points at a profile path.
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_env = os.environ.get("HOME", "")
-        if real_home_env:
-            real_root = Path(real_home_env) / ".hermes" / "auth.json"
-            try:
-                if global_path.resolve(strict=False) == real_root.resolve(strict=False):
-                    return
-            except Exception:
+        real_root = auth_mod._platform_default_auth_file_path()
+        try:
+            if global_path.resolve(strict=False) == real_root.resolve(strict=False):
                 return
+        except Exception:
+            return
     try:
         auth_mod._persist_provider_state_to_store(
             provider_id,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -902,6 +902,13 @@ def _oauth_trace(event: str, *, sequence_id: Optional[str] = None, **fields: Any
 # Auth Store — persistence layer for ~/.hermes/auth.json
 # =============================================================================
 
+def _platform_default_auth_file_path() -> Path:
+    """Return the native user's auth path without following HERMES_HOME."""
+    from hermes_constants import _get_platform_default_hermes_home
+
+    return _get_platform_default_hermes_home() / "auth.json"
+
+
 def _auth_file_path() -> Path:
     path = get_hermes_home() / "auth.json"
     # Seat belt: if pytest is running and HERMES_HOME resolves to the real
@@ -910,11 +917,15 @@ def _auth_file_path() -> Path:
     # hermetic conftest, or sandbox escapes via threads/subprocesses. In
     # production (no PYTEST_CURRENT_TEST) this is a single dict lookup.
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_auth = (Path.home() / ".hermes" / "auth.json").resolve(strict=False)
+        real_home_auth = _platform_default_auth_file_path().resolve(strict=False)
         try:
             resolved = path.resolve(strict=False)
-        except Exception:
-            resolved = path
+        except Exception as exc:
+            raise RuntimeError(
+                f"Refusing to touch real user auth store during test run: {path}. "
+                "Could not safely resolve the target path; set HERMES_HOME to "
+                "a tmp_path in your test fixture."
+            ) from exc
         if resolved == real_home_auth:
             raise RuntimeError(
                 f"Refusing to touch real user auth store during test run: {path}. "
@@ -961,28 +972,22 @@ def _load_global_auth_store() -> Dict[str, Any]:
     Returns an empty dict when no global fallback exists (classic mode,
     or the global auth.json is absent). Never raises on missing file.
 
-    Seat belt: under pytest, refuses to read the real user's
-    ``~/.hermes/auth.json`` even when HERMES_HOME is set to a profile
-    path. The hermetic conftest does not redirect ``HOME``, so
-    ``get_default_hermes_root()`` for a profile-shaped HERMES_HOME can
-    still resolve to the real user's home on a dev machine. That would
-    leak real credentials into tests. This guard uses the unmodified
-    ``HOME`` env var (what ``os.path.expanduser('~')`` would resolve to),
-    not ``Path.home()``, because ``Path.home`` is sometimes monkeypatched
-    by fixtures that want to relocate the global root to a tmp path.
+    Seat belt: under pytest, refuses to read the platform-native user's
+    auth store even when HERMES_HOME is set to a profile path. This uses
+    the same platform-aware path as the write guard, so native Windows
+    resolves to ``%LOCALAPPDATA%\\hermes\\auth.json`` rather than
+    ``~/.hermes/auth.json``.
     """
     global_path = _global_auth_file_path()
     if global_path is None or not global_path.exists():
         return {}
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_env = os.environ.get("HOME", "")
-        if real_home_env:
-            real_root = Path(real_home_env) / ".hermes" / "auth.json"
-            try:
-                if global_path.resolve(strict=False) == real_root.resolve(strict=False):
-                    return {}
-            except Exception:
-                pass
+        real_root = _platform_default_auth_file_path()
+        try:
+            if global_path.resolve(strict=False) == real_root.resolve(strict=False):
+                return {}
+        except Exception:
+            return {}
     try:
         return _load_auth_store(global_path)
     except Exception:
@@ -1123,8 +1128,8 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
     try:
-        raw = json.loads(auth_file.read_text())
-    except Exception as exc:
+        raw = json.loads(auth_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         corrupt_path = auth_file.with_suffix(".json.corrupt")
         try:
             import shutil
@@ -4421,19 +4426,16 @@ def _write_through_xai_oauth_to_global_root(state: Dict[str, Any]) -> None:
     if global_path is None:
         # Classic mode (profile == root); the profile save already hit root.
         return
-    # Seat belt: under pytest, refuse to write the real user's
-    # ~/.hermes/auth.json even when HERMES_HOME points at a profile path
-    # (mirrors the read-side guard in _load_global_auth_store). Uses the
-    # unmodified HOME env, not Path.home() which fixtures may monkeypatch.
+    # Seat belt: under pytest, refuse to write the platform-native user's
+    # auth store even when HERMES_HOME points at a profile path (mirrors the
+    # read-side guard in _load_global_auth_store).
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_env = os.environ.get("HOME", "")
-        if real_home_env:
-            real_root = Path(real_home_env) / ".hermes" / "auth.json"
-            try:
-                if global_path.resolve(strict=False) == real_root.resolve(strict=False):
-                    return
-            except Exception:
+        real_root = _platform_default_auth_file_path()
+        try:
+            if global_path.resolve(strict=False) == real_root.resolve(strict=False):
                 return
+        except Exception:
+            return
     try:
         _persist_provider_state_to_store(
             "xai-oauth",

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -57,9 +57,9 @@ def profile_and_root(tmp_path, monkeypatch):
     """Wire a profile auth store + a distinct global-root auth store on disk.
 
     The pytest seat belt in ``_write_through_provider_state_to_global_root``
-    only refuses the *real* user's ``$HOME/.hermes/auth.json``; a tmp_path
-    root is allowed, so point HOME away from the tmp root to keep the guard
-    from tripping on these fixtures.
+    refuses only the platform-native user auth store; this tmp_path root is
+    allowed. Point HOME away as an additional assertion that legacy HOME-based
+    matching is not what grants access.
     """
     profile_path = tmp_path / "profiles" / "work" / "auth.json"
     root_path = tmp_path / "root" / "auth.json"
@@ -189,6 +189,29 @@ def test_write_through_helper_is_noop_in_classic_mode(monkeypatch, tmp_path):
     CP._write_through_provider_state_to_global_root(
         "openai-codex", {"tokens": {"access_token": "a", "refresh_token": "r"}}
     )
+
+
+def test_write_through_helper_refuses_platform_store_under_pytest(
+    monkeypatch, tmp_path
+):
+    """Pool refresh tests must not write OAuth state into the native root."""
+    global_path = tmp_path / "AppData" / "Local" / "hermes" / "auth.json"
+    persist_calls = []
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "pool global write seat belt")
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: global_path)
+    monkeypatch.setattr(A, "_platform_default_auth_file_path", lambda: global_path)
+    monkeypatch.setattr(
+        A,
+        "_persist_provider_state_to_store",
+        lambda *args, **kwargs: persist_calls.append((args, kwargs)),
+    )
+
+    CP._write_through_provider_state_to_global_root(
+        "openai-codex", {"tokens": {"access_token": "fake"}}
+    )
+
+    assert persist_calls == []
 
 
 def test_global_write_through_preserves_concurrent_root_update(

--- a/tests/hermes_cli/test_auth_store_safety.py
+++ b/tests/hermes_cli/test_auth_store_safety.py
@@ -1,0 +1,192 @@
+"""Regression tests for auth-store path and transient-read safety."""
+
+from pathlib import Path
+
+import pytest
+
+
+def test_auth_file_seat_belt_uses_platform_default_root(tmp_path, monkeypatch):
+    """Pytest must reject the real Windows-native auth path, not only ~/.hermes."""
+    from hermes_cli import auth
+    import hermes_constants
+
+    default_root = tmp_path / "AppData" / "Local" / "hermes"
+    fake_user_home = tmp_path / "Users" / "Luke"
+    default_root.mkdir(parents=True)
+    fake_user_home.mkdir(parents=True)
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "auth seat belt")
+    monkeypatch.setattr(auth, "get_hermes_home", lambda: default_root)
+    monkeypatch.setattr(
+        hermes_constants,
+        "_get_platform_default_hermes_home",
+        lambda: default_root,
+    )
+    monkeypatch.setattr(Path, "home", lambda: fake_user_home)
+
+    with pytest.raises(RuntimeError, match="real user auth store"):
+        auth._auth_file_path()
+
+
+def test_auth_file_seat_belt_fails_closed_when_target_resolution_fails(
+    tmp_path, monkeypatch
+):
+    """An unresolved alias must not bypass the active-store write guard."""
+    from hermes_cli import auth
+    import hermes_constants
+
+    default_root = tmp_path / "AppData" / "Local" / "hermes"
+    aliased_root = default_root.parent / "alias" / ".." / "hermes"
+    target = aliased_root / "auth.json"
+    real_resolve = Path.resolve
+
+    def deny_target(self, *args, **kwargs):
+        if self == target:
+            raise PermissionError("cannot canonicalize active auth path")
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "active auth resolve seat belt")
+    monkeypatch.setattr(auth, "get_hermes_home", lambda: aliased_root)
+    monkeypatch.setattr(
+        hermes_constants,
+        "_get_platform_default_hermes_home",
+        lambda: default_root,
+    )
+    monkeypatch.setattr(Path, "resolve", deny_target)
+
+    with pytest.raises(RuntimeError, match="real user auth store"):
+        auth._auth_file_path()
+
+
+def test_global_auth_fallback_does_not_read_platform_store_under_pytest(
+    tmp_path, monkeypatch
+):
+    """Profile tests must not import credentials from the Windows-native root."""
+    from hermes_cli import auth
+    import hermes_constants
+
+    default_root = tmp_path / "AppData" / "Local" / "hermes"
+    default_root.mkdir(parents=True)
+    global_auth = default_root / "auth.json"
+    global_auth.write_text(
+        '{"version": 1, "providers": {"openai-codex": {"access_token": "fake"}}}',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "global auth seat belt")
+    monkeypatch.setenv("HOME", str(tmp_path / "Users" / "Luke"))
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: global_auth)
+    monkeypatch.setattr(
+        hermes_constants,
+        "_get_platform_default_hermes_home",
+        lambda: default_root,
+    )
+
+    assert auth._load_global_auth_store() == {}
+
+
+def test_global_auth_fallback_fails_closed_when_path_resolution_fails(
+    tmp_path, monkeypatch
+):
+    """A canonicalization failure must not fall through to credential loading."""
+    from hermes_cli import auth
+
+    global_auth = tmp_path / "auth.json"
+    global_auth.write_text('{"version": 1, "providers": {}}', encoding="utf-8")
+    real_resolve = Path.resolve
+
+    def deny_target(self, *args, **kwargs):
+        if self == global_auth:
+            raise PermissionError("cannot canonicalize auth path")
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "global auth resolve seat belt")
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: global_auth)
+    monkeypatch.setattr(auth, "_platform_default_auth_file_path", lambda: global_auth)
+    monkeypatch.setattr(Path, "resolve", deny_target)
+    monkeypatch.setattr(
+        auth,
+        "_load_auth_store",
+        lambda *_args, **_kwargs: pytest.fail("real global auth store was read"),
+    )
+
+    assert auth._load_global_auth_store() == {}
+
+
+def test_xai_write_through_refuses_platform_store_under_pytest(tmp_path, monkeypatch):
+    """Profile refresh tests must not write xAI tokens into the native root."""
+    from hermes_cli import auth
+
+    global_auth = tmp_path / "AppData" / "Local" / "hermes" / "auth.json"
+    global_auth.parent.mkdir(parents=True)
+    persist_calls = []
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "xai global write seat belt")
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: global_auth)
+    monkeypatch.setattr(auth, "_platform_default_auth_file_path", lambda: global_auth)
+    monkeypatch.setattr(
+        auth,
+        "_persist_provider_state_to_store",
+        lambda *args, **kwargs: persist_calls.append((args, kwargs)),
+    )
+
+    auth._write_through_xai_oauth_to_global_root({"tokens": {"access_token": "fake"}})
+
+    assert persist_calls == []
+
+
+def test_auth_store_permission_error_is_not_treated_as_corruption(tmp_path, monkeypatch):
+    """A transient read denial must fail closed without creating an empty store."""
+    from hermes_cli import auth
+
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text('{"version": 1, "providers": {}}', encoding="utf-8")
+    real_read_text = Path.read_text
+
+    def deny_target(self, *args, **kwargs):
+        if self == auth_file:
+            raise PermissionError("temporarily locked")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", deny_target)
+
+    with pytest.raises(PermissionError, match="temporarily locked"):
+        auth._load_auth_store(auth_file)
+
+    assert not auth_file.with_suffix(".json.corrupt").exists()
+
+
+def test_auth_store_invalid_utf8_is_quarantined_on_legacy_locale(tmp_path, monkeypatch):
+    """Auth JSON is always UTF-8, even when the platform default is cp1252."""
+    from hermes_cli import auth
+
+    auth_file = tmp_path / "auth.json"
+    malformed = b'{"version": 1, "providers": {"example": "\x80"}}'
+    auth_file.write_bytes(malformed)
+    real_read_text = Path.read_text
+
+    def emulate_legacy_default(self, *args, **kwargs):
+        if kwargs.get("encoding") is None:
+            kwargs["encoding"] = "cp1252"
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", emulate_legacy_default)
+
+    store = auth._load_auth_store(auth_file)
+
+    assert store == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
+    assert auth_file.with_suffix(".json.corrupt").read_bytes() == malformed
+
+
+def test_auth_store_malformed_json_is_preserved_and_reset(tmp_path):
+    """Actual malformed JSON keeps the existing quarantine-and-reset behavior."""
+    from hermes_cli import auth
+
+    auth_file = tmp_path / "auth.json"
+    malformed = "{ not-json"
+    auth_file.write_text(malformed, encoding="utf-8")
+
+    store = auth._load_auth_store(auth_file)
+
+    assert store == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
+    assert auth_file.with_suffix(".json.corrupt").read_text(encoding="utf-8") == malformed

--- a/tests/hermes_cli/test_xai_oauth_writethrough.py
+++ b/tests/hermes_cli/test_xai_oauth_writethrough.py
@@ -34,9 +34,9 @@ def profile_and_root(tmp_path, monkeypatch):
     """Wire a profile auth store + a distinct global-root auth store on disk.
 
     Returns (profile_path, root_path). The pytest seat belt in
-    ``_write_through_xai_oauth_to_global_root`` only refuses the *real* user's
-    ``$HOME/.hermes/auth.json``; a tmp_path root is allowed, so we point HOME
-    away from the tmp root to keep the guard from tripping on these fixtures.
+    ``_write_through_xai_oauth_to_global_root`` refuses only the platform-native
+    user auth store; this tmp_path root is allowed. HOME is pointed elsewhere
+    to prove legacy HOME-based matching does not control the decision.
     """
     profile_path = tmp_path / "profiles" / "work" / "auth.json"
     root_path = tmp_path / "root" / "auth.json"


### PR DESCRIPTION
## Summary

- protect the platform-native Hermes auth store during pytest on Windows and POSIX
- fail closed when protected auth-store paths cannot be canonicalized
- use the same native-path guard for profile fallback reads, direct xAI OAuth write-through, and credential-pool write-through for Nous, OpenAI Codex, and xAI
- decode `auth.json` explicitly as UTF-8, quarantining malformed JSON/encoding while allowing transient I/O errors to propagate

## Problem

The pytest seat belts derived the protected store as `HOME/.hermes/auth.json`. Native Windows stores Hermes state at `%LOCALAPPDATA%\hermes`, so a test or escaped subprocess could read or overwrite the real `auth.json`. A broad load exception handler could then misclassify a transient Windows read failure as corruption and return an empty store.

## Verification

- regression tests were written first and observed failing for each repaired boundary
- `381 passed, 4 skipped, 2 deselected` across relevant auth and OAuth suites on Windows
- the two deselected permission-mode assertions fail identically on the untouched Windows baseline
- live auth-store metadata remained unchanged during isolated test runs
- `git diff --check` and Python compilation passed
- independent final review reported PASS with no blockers

## Safety

All test runs used a disposable process-level `HERMES_HOME`. No credential values are included in this change.
