### PR TITLE
fix(desktop): keep package version aligned with core release

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "hermes",
   "productName": "Hermes",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.19.0",
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
   "type": "module",

--- a/apps/desktop/scripts/version-sync.mjs
+++ b/apps/desktop/scripts/version-sync.mjs
@@ -1,0 +1,52 @@
+/**
+ * Reads the two independently-maintained version fields that must agree:
+ * `pyproject.toml`'s `[project].version` (the core release version) and
+ * `apps/desktop/package.json`'s `version` (electron-builder's source for
+ * `CFBundleShortVersionString` / installer artifact naming). The desktop
+ * value has no build-time link to the core version — it's a manually
+ * maintained fallback (see the "sync package.json version fallback" history)
+ * that has drifted before. This module is imported by version-sync.test.mjs
+ * to turn that drift into a failing test instead of a silent stale build.
+ */
+
+import { readFileSync } from "fs"
+import { resolve } from "path"
+
+const DESKTOP_ROOT = resolve(import.meta.dirname, "..")
+const REPO_ROOT = resolve(DESKTOP_ROOT, "..", "..")
+
+/**
+ * Extracts `version` from the `[project]` table specifically — not just the
+ * first `version = "..."` line in the file. pyproject.toml has other tables
+ * (`[build-system]`, `[tool.*]`, etc.) that could plausibly carry their own
+ * `version` key, and a table-blind regex would silently pick up whichever
+ * one happens to come first. This is a deliberate, minimal TOML-table scan
+ * (no parser dependency): track the current `[table.path]` header and only
+ * accept a `version` assignment while inside the exact `project` table.
+ */
+export function parsePyprojectVersion(text) {
+  let currentTable = null
+  for (const line of text.split(/\r?\n/)) {
+    const tableHeader = line.match(/^\s*\[([^\[\]]+)\]\s*(?:#.*)?$/)
+    if (tableHeader) {
+      currentTable = tableHeader[1].trim()
+      continue
+    }
+    if (currentTable !== "project") continue
+    const versionLine = line.match(/^\s*version\s*=\s*"([^"]+)"/)
+    if (versionLine) {
+      return versionLine[1]
+    }
+  }
+  throw new Error('pyproject.toml: could not find `version = "..."` under the [project] table')
+}
+
+export function readPyprojectVersion(repoRoot = REPO_ROOT) {
+  const text = readFileSync(resolve(repoRoot, "pyproject.toml"), "utf8")
+  return parsePyprojectVersion(text)
+}
+
+export function readDesktopPackageVersion(desktopRoot = DESKTOP_ROOT) {
+  const pkg = JSON.parse(readFileSync(resolve(desktopRoot, "package.json"), "utf8"))
+  return pkg.version
+}

--- a/apps/desktop/scripts/version-sync.test.mjs
+++ b/apps/desktop/scripts/version-sync.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict"
+import { test } from "vitest"
+
+import { parsePyprojectVersion, readDesktopPackageVersion, readPyprojectVersion } from "./version-sync.mjs"
+
+test("apps/desktop package.json version matches pyproject.toml's core release version", () => {
+  const coreVersion = readPyprojectVersion()
+  const desktopVersion = readDesktopPackageVersion()
+  assert.equal(
+    desktopVersion,
+    coreVersion,
+    `apps/desktop/package.json version "${desktopVersion}" has drifted from pyproject.toml's ` +
+      `"${coreVersion}" — this fallback is manually maintained and feeds macOS's ` +
+      "CFBundleShortVersionString, so it must be bumped alongside every core release."
+  )
+})
+
+test("parsePyprojectVersion ignores an earlier unrelated table's version and reads [project]'s", () => {
+  const fixture = `
+[build-system]
+requires = ["setuptools"]
+version = "999.0.0"
+
+[project]
+name = "hermes-agent"
+version = "0.19.0"
+description = "not the build-system's version"
+`
+  assert.equal(parsePyprojectVersion(fixture), "0.19.0")
+})
+
+test("parsePyprojectVersion throws when there is no [project] table", () => {
+  assert.throws(() => parsePyprojectVersion('[build-system]\nversion = "1.0.0"\n'))
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
     },
     "apps/desktop": {
       "name": "hermes",
-      "version": "0.17.0",
+      "version": "0.19.0",
       "dependencies": {
         "@assistant-ui/react": "^0.14.23",
         "@assistant-ui/react-streamdown": "^0.3.4",


### PR DESCRIPTION
## Summary

- Update the Electron Desktop package version and matching npm workspace lock entry from `0.17.0` to the core release version, `0.19.0`.
- Add a CI-covered Desktop Vitest invariant so `apps/desktop/package.json` must continue to match `pyproject.toml`’s `[project].version`.
- Cover TOML scoping so an unrelated table’s `version` cannot be selected by mistake.

## Why

Electron-builder uses the Desktop package version for platform metadata and artifact names. The package was still `0.17.0` while the current core release was `0.19.0`, so a current Desktop build could identify itself with stale version metadata. This keeps the release identifiers aligned and turns future drift into a test failure.

## Helper and regression coverage

`apps/desktop/scripts/version-sync.mjs` is a deliberately small, dependency-free helper. It reads:

- the core release version from `pyproject.toml`’s exact `[project]` table; and
- the Electron Desktop version from `apps/desktop/package.json`.

The explicit `[project]` table scan is important: `pyproject.toml` can contain other TOML tables—such as `[build-system]` or `[tool.*]`—that may also define a `version`. A table-blind regular expression could select the wrong value and allow version drift to pass unnoticed. The helper therefore tracks table headers and only accepts `version = ...` while inside `[project]`.

`version-sync.test.mjs` checks the live repository values, includes a fixture with an earlier unrelated `version`, and verifies that missing `[project]` metadata fails clearly. The file is discovered by the existing Electron Vitest CI project, so no new CI wiring or runtime dependency is required.

## Validation

- `npm --workspace apps/desktop run test:desktop:platforms` — 715 passed, 2 skipped.
- `npm --workspace apps/desktop run typecheck` — passed.
- `npm --workspace apps/desktop run lint` — no errors (existing warnings only).