### PR TITLE
fix(desktop): restore webhook subscription status pill with labels

### DIFF
--- a/apps/desktop/src/app/webhooks/index.test.tsx
+++ b/apps/desktop/src/app/webhooks/index.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as HermesApi from '@/hermes'
+import type { WebhookRoute, WebhooksResponse } from '@/types/hermes'
+
+const getWebhooks = vi.fn()
+
+// Partial mock: keep the real module (WebhooksView pulls in @/store/profile,
+// whose import-time subscription calls setApiRequestProfile) and stub only the
+// webhook reads we assert on.
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<typeof HermesApi>()),
+  getWebhooks: () => getWebhooks()
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/store/system-actions', () => ({
+  runGatewayRestart: vi.fn()
+}))
+
+vi.mock('../hooks/use-refresh-hotkey', () => ({
+  useRefreshHotkey: () => undefined
+}))
+
+function subscription(patch: Partial<WebhookRoute> = {}): WebhookRoute {
+  return {
+    created_at: null,
+    deliver: 'log',
+    deliver_only: false,
+    description: '',
+    enabled: true,
+    events: [],
+    name: 'github-push',
+    prompt: '',
+    secret_set: true,
+    skills: [],
+    url: 'http://127.0.0.1:8642/webhooks/github-push',
+    ...patch
+  }
+}
+
+function payload(subs: WebhookRoute[]): WebhooksResponse {
+  return {
+    base_url: 'http://127.0.0.1:8642',
+    enabled: true,
+    subscriptions: subs
+  }
+}
+
+async function renderWebhooks(data: WebhooksResponse) {
+  getWebhooks.mockResolvedValue(data)
+  const { WebhooksView } = await import('./index')
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  })
+
+  let result: ReturnType<typeof render>
+  await act(async () => {
+    result = render(
+      <QueryClientProvider client={client}>
+        <WebhooksView onClose={() => undefined} />
+      </QueryClientProvider>
+    )
+  })
+
+  return result!
+}
+
+async function detailHeader(name: string): Promise<HTMLElement> {
+  // Master/detail falls back to the first visible subscription, so the detail
+  // heading is present as soon as the list loads.
+  const heading = await screen.findByRole('heading', { name })
+  const header = heading.parentElement
+  expect(header).not.toBeNull()
+  return header!
+}
+
+describe('WebhooksView subscription status pill', () => {
+  beforeEach(() => {
+    Element.prototype.hasPointerCapture ??= () => false
+    Element.prototype.releasePointerCapture ??= () => undefined
+    Element.prototype.setPointerCapture ??= () => undefined
+    HTMLElement.prototype.scrollIntoView ??= () => undefined
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('shows an Enabled status pill for an enabled subscription detail', async () => {
+    await renderWebhooks(payload([subscription({ enabled: true, name: 'github-push' })]))
+
+    expect(within(await detailHeader('github-push')).getByText('Enabled')).toBeTruthy()
+  })
+
+  it('shows a Disabled status pill for a disabled subscription detail', async () => {
+    await renderWebhooks(payload([subscription({ enabled: false, name: 'nightly-hook' })]))
+
+    expect(within(await detailHeader('nightly-hook')).getByText('Disabled')).toBeTruthy()
+  })
+
+  it('keeps the deliver-only pill beside the status pill when both apply', async () => {
+    await renderWebhooks(payload([subscription({ deliver_only: true, enabled: true, name: 'payload-only' })]))
+
+    const header = await detailHeader('payload-only')
+    expect(within(header).getByText('Enabled')).toBeTruthy()
+    expect(within(header).getByText('deliver only')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/webhooks/index.test.tsx
+++ b/apps/desktop/src/app/webhooks/index.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, render, screen, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as HermesApi from '@/hermes'
+import { TRANSLATIONS } from '@/i18n/catalog'
 import type { WebhookRoute, WebhooksResponse } from '@/types/hermes'
 
 const getWebhooks = vi.fn()
@@ -113,5 +114,27 @@ describe('WebhooksView subscription status pill', () => {
     const header = await detailHeader('payload-only')
     expect(within(header).getByText('Enabled')).toBeTruthy()
     expect(within(header).getByText('deliver only')).toBeTruthy()
+  })
+})
+
+describe('webhook status labels across locale catalogs', () => {
+  it('keeps distinct non-empty status labels in every desktop locale', () => {
+    const expected: Record<string, { disabled: string; enabled: string }> = {
+      ar: { disabled: 'معطّل', enabled: 'مفعّل' },
+      en: { disabled: 'Disabled', enabled: 'Enabled' },
+      ja: { disabled: '無効', enabled: '有効' },
+      zh: { disabled: '已禁用', enabled: '已启用' },
+      'zh-hant': { disabled: '已停用', enabled: '已啟用' }
+    }
+
+    for (const [locale, t] of Object.entries(TRANSLATIONS)) {
+      const labels = expected[locale]
+      expect(labels, `missing expectation for ${locale}`).toBeTruthy()
+      expect(t.webhooks.statusEnabled).toBe(labels.enabled)
+      expect(t.webhooks.statusDisabled).toBe(labels.disabled)
+      // Keep the old dead-key trap closed: messaging platform states must not
+      // grow an `enabled` entry that webhooks no longer consume.
+      expect(Object.hasOwn(t.messaging.states, 'enabled')).toBe(false)
+    }
   })
 })

--- a/apps/desktop/src/app/webhooks/index.tsx
+++ b/apps/desktop/src/app/webhooks/index.tsx
@@ -552,6 +552,9 @@ function WebhookDetail({ sub }: { sub: WebhookRoute }) {
       <header className="space-y-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <h3 className="text-[0.95rem] font-semibold tracking-tight text-foreground">{sub.name}</h3>
+          <PanelPill tone={sub.enabled ? 'good' : 'muted'}>
+            {sub.enabled ? w.statusEnabled : w.statusDisabled}
+          </PanelPill>
           {sub.deliver_only && <PanelPill tone="warn">{w.deliverOnly}</PanelPill>}
         </div>
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1360,6 +1360,12 @@ export const ar = defineLocale({
     failedCreate: 'فشل الإنشاء',
     failedRename: 'فشل إعادة التسمية'
   },
+
+  webhooks: {
+    statusEnabled: 'مفعّل',
+    statusDisabled: 'معطّل'
+  },
+
   cron: {
     close: 'إغلاق',
     search: 'بحث',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1509,6 +1509,8 @@ export const en: Translations = {
     enabledRestarting: 'Webhooks enabled; gateway restarting...',
     all: '(all)',
     deliverOnly: 'deliver only',
+    statusEnabled: 'Enabled',
+    statusDisabled: 'Disabled',
     createdTitle: 'Subscription created',
     createdSecretHint: 'Copy the secret now — it is only shown once.',
     webhookUrl: 'Webhook URL',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1379,6 +1379,11 @@ export const ja = defineLocale({
     platformIntro: {}
   },
 
+  webhooks: {
+    statusEnabled: '有効',
+    statusDisabled: '無効'
+  },
+
   profiles: {
     close: 'プロファイルを閉じる',
     nameHint: '小文字、数字、ハイフン、アンダースコア。文字または数字で始める必要があります。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1263,6 +1263,8 @@ export interface Translations {
     enabledRestarting: string
     all: string
     deliverOnly: string
+    statusEnabled: string
+    statusDisabled: string
     createdTitle: string
     createdSecretHint: string
     webhookUrl: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1328,6 +1328,11 @@ export const zhHant = defineLocale({
     platformIntro: {}
   },
 
+  webhooks: {
+    statusEnabled: '已啟用',
+    statusDisabled: '已停用'
+  },
+
   profiles: {
     close: '關閉設定檔',
     nameHint: '小寫字母、數字、連字號和底線。必須以字母或數字開頭。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1703,6 +1703,8 @@ export const zh: Translations = {
     enabledRestarting: 'Webhook 已启用；网关正在重启…',
     all: '（全部）',
     deliverOnly: '仅投递',
+    statusEnabled: '已启用',
+    statusDisabled: '已禁用',
     createdTitle: '订阅已创建',
     createdSecretHint: '请立即复制密钥 —— 它只显示一次。',
     webhookUrl: 'Webhook URL',


### PR DESCRIPTION
## Summary
- Restore the Webhooks detail-header status pill that main removed when it rendered as a stray dash (the pill read a missing `messaging.states.enabled` key).
- Scope this as an intentional Webhooks UI change: the pill now uses typed `webhooks.statusEnabled` / `webhooks.statusDisabled` labels in `en`, `ja`, `zh`, `zh-hant`, and `ar` — not a dead `messaging.states` catalog entry.
- Cover enabled, disabled, and deliver-only+enabled detail headers with UI tests, plus catalog assertions for every desktop locale.

## Context
hermes-sweeper correctly rejected the earlier catalog-only patch: current main no longer consumed `t.messaging.states.enabled` after `0d865dd`. This replaces that approach.

## Test plan
- [x] `cd apps/desktop && npm run test -- src/app/webhooks/index.test.tsx` (4/4)
- [x] `cd apps/desktop && npx tsc -p . --noEmit`
- [x] Confirm UI binds `w.statusEnabled` / `w.statusDisabled` and does not reference `messaging.states.enabled`
- [x] Confirm every locale catalog has distinct non-empty status labels and `messaging.states` has no `enabled` key