### PR TITLE
feat(skills): add ShieldNode optional skill for proxied API credentials

### DIFF
--- a/optional-skills/security/shieldnode/SKILL.md
+++ b/optional-skills/security/shieldnode/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: shieldnode
-description: Call APIs through a proxy that holds the real keys, with push approval on your phone.
+description: Call APIs without the real keys, approved by phone push.
 version: 1.0.0
-author: RP0-undefined
+author: Ray Pendragon (RP0-undefined)
 license: MIT
 platforms: [macos, linux, windows]
 metadata:
@@ -11,17 +11,15 @@ metadata:
     category: security
 ---
 
-# ShieldNode
+# ShieldNode Skill
 
-ShieldNode keeps the user's real API keys in an encrypted vault and gives this agent a **virtual key** instead. You call the proxy, it injects the real credential, the upstream API answers. The real key never reaches you, so a leaked virtual key is worthless on its own.
+Call a user's third-party APIs through the ShieldNode proxy, which holds their real credentials and hands the agent a **virtual key** instead, so the real key never enters the conversation. When a key is disabled, the call returns a structured `403` and the user approves it by push for a bounded window. It does not store or read the user's data, does not manage non-HTTP credentials, and cannot revoke keys: revocation happens in the ShieldNode app.
 
 ```
 Hermes --X-Api-Key: shieldnode_...--> proxy.shieldnode.app/{path} --real key--> api.upstream.com/{path}
 ```
 
-The user can leave a key **disabled** by default. Your call then triggers a push notification on their phone, they approve it for a bounded window, and the call goes through.
-
-**The key format is the signal.** Any value starting with `shieldnode_` is not a provider key and must not be sent to a provider. It goes in the `X-Api-Key` header against `proxy.shieldnode.app`, and this skill applies. The user pasting one into the chat is all the setup you need to get started.
+**The key format is the signal.** Any value starting with `shieldnode_` is not a provider key and must not be sent to a provider. It goes in the `X-Api-Key` header against `proxy.shieldnode.app`, and this skill applies. The user pasting one into the chat is all the setup needed to get started.
 
 ## When to Use
 
@@ -79,7 +77,7 @@ curl -sS -H "X-Api-Key: $SHIELDNODE_KEY" \
 
 That gives you the upstream, the configured `base_url` (which fixes your path convention) and whether the next call goes straight through (`active: true`) or triggers an approval push. `alias` is the label the user put on the key, usually the name of the agent it was issued to. Name a key by its **service** when you talk about it, and use `alias` only to disambiguate when several keys exist on the same service. Never quote any part of the key value. whoami never returns credentials, is never forwarded upstream, and fires no push.
 
-**Then write the service doc, without being asked.** If there is no `services/<slug>.md` for the service whoami just named, create one from the template in `references/service-docs.md`. No command and no question to the user: whoami already gave you the service, the base URL and the auth shape. Later sessions read that file instead of deriving it again.
+**Then write the service doc, without being asked.** The one location, used everywhere in this skill, is `~/.hermes/shieldnode/services/<slug>.md`, named with the service slug in lowercase kebab. If no file exists there for the service whoami just named, create one from the template in `references/service-docs.md`. No command and no question to the user: whoami already gave you the service, the base URL and the auth shape. Later sessions read that file instead of deriving it again, and it sits outside `~/.hermes/skills/` so reinstalling this skill never deletes it.
 
 Then call the API, always identifying yourself:
 
@@ -159,7 +157,7 @@ curl -sS -X POST "https://proxy.shieldnode.app/_shieldnode/config-request" \
           "agent_name":"Hermes","reason":"creating invoices for the user"}'
 ```
 
-Fill `base_url` and `detected_auth_method` from what you know about the API, or from its docs. Poll `/_shieldnode/config-request/<request_id>` until `approved`, then ask the user for a virtual key on the new service and **write its `services/<slug>.md` at that point** (`references/service-docs.md`): you already know the name, base URL and auth method, since you proposed them.
+Fill `base_url` and `detected_auth_method` from what you know about the API, or from its docs. Poll `/_shieldnode/config-request/<request_id>` until `approved`, then ask the user for a virtual key on the new service and **write its `~/.hermes/shieldnode/services/<slug>.md` at that point** (`references/service-docs.md`): you already know the name, base URL and auth method, since you proposed them.
 
 **Never put the user's upstream API key in this request.** You propose the non-secret shape only.
 

--- a/optional-skills/security/shieldnode/SKILL.md
+++ b/optional-skills/security/shieldnode/SKILL.md
@@ -21,6 +21,8 @@ Hermes --X-Api-Key: shieldnode_...--> proxy.shieldnode.app/{path} --real key--> 
 
 The user can leave a key **disabled** by default. Your call then triggers a push notification on their phone, they approve it for a bounded window, and the call goes through.
 
+**The key format is the signal.** Any value starting with `shieldnode_` is not a provider key and must not be sent to a provider. It goes in the `X-Api-Key` header against `proxy.shieldnode.app`, and this skill applies. The user pasting one into the chat is all the setup you need to get started.
+
 ## When to Use
 
 - The user hands you a value starting with `shieldnode_`
@@ -74,6 +76,8 @@ curl -sS -H "X-Api-Key: $SHIELDNODE_KEY" \
 ```
 
 That gives you the upstream, the configured `base_url` (which fixes your path convention) and whether the next call goes straight through (`active: true`) or triggers an approval push. whoami never returns credentials, is never forwarded upstream, and fires no push.
+
+**Then write the service doc, without being asked.** If there is no `services/<slug>.md` for the service whoami just named, create one from the template in `references/service-docs.md`. No command and no question to the user: whoami already gave you the service, the base URL and the auth shape. Later sessions read that file instead of deriving it again.
 
 Then call the API, always identifying yourself:
 
@@ -153,7 +157,7 @@ curl -sS -X POST "https://proxy.shieldnode.app/_shieldnode/config-request" \
           "agent_name":"Hermes","reason":"creating invoices for the user"}'
 ```
 
-Fill `base_url` and `detected_auth_method` from what you know about the API, or from its docs. Poll `/_shieldnode/config-request/<request_id>` until `approved`, then ask the user for a virtual key on the new service.
+Fill `base_url` and `detected_auth_method` from what you know about the API, or from its docs. Poll `/_shieldnode/config-request/<request_id>` until `approved`, then ask the user for a virtual key on the new service and **write its `services/<slug>.md` at that point** (`references/service-docs.md`): you already know the name, base URL and auth method, since you proposed them.
 
 **Never put the user's upstream API key in this request.** You propose the non-secret shape only.
 
@@ -179,7 +183,7 @@ More in `references/troubleshooting.md`.
 
 ### Behaviour rules
 
-- Never print a virtual key back to the user, and never ask them to paste one into the chat. They put it in `~/.hermes/.env` themselves.
+- Never print a virtual key back to the user. Them pasting one to you is fine and expected: a virtual key is not a real credential, it is revocable in one tap and often disabled until approved. Take it, resolve it with whoami, and carry on. Suggest `~/.hermes/.env` when the work is recurring, not as a precondition to helping them.
 - Tell the user **once** that an approval is pending, then poll silently. A message every 30 seconds feels like spyware.
 - Never retry after an explicit decline, and never retry past the timeout. Ask the user instead.
 - Do not fire parallel calls to force an approval. Pushes are debounced to one per 30s per key, and parallel calls wait on the same approval anyway.

--- a/optional-skills/security/shieldnode/SKILL.md
+++ b/optional-skills/security/shieldnode/SKILL.md
@@ -77,7 +77,7 @@ curl -sS -H "X-Api-Key: $SHIELDNODE_KEY" \
 }
 ```
 
-That gives you the upstream, the configured `base_url` (which fixes your path convention) and whether the next call goes straight through (`active: true`) or triggers an approval push. `alias` is the name the user gave the key, so refer to it by that rather than showing any part of its value. whoami never returns credentials, is never forwarded upstream, and fires no push.
+That gives you the upstream, the configured `base_url` (which fixes your path convention) and whether the next call goes straight through (`active: true`) or triggers an approval push. `alias` is the label the user put on the key, usually the name of the agent it was issued to. Name a key by its **service** when you talk about it, and use `alias` only to disambiguate when several keys exist on the same service. Never quote any part of the key value. whoami never returns credentials, is never forwarded upstream, and fires no push.
 
 **Then write the service doc, without being asked.** If there is no `services/<slug>.md` for the service whoami just named, create one from the template in `references/service-docs.md`. No command and no question to the user: whoami already gave you the service, the base URL and the auth shape. Later sessions read that file instead of deriving it again.
 

--- a/optional-skills/security/shieldnode/SKILL.md
+++ b/optional-skills/security/shieldnode/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: shieldnode
+description: Call APIs through a proxy that holds the real keys, with push approval on your phone.
+version: 1.0.0
+author: RP0-undefined
+license: MIT
+platforms: [macos, linux, windows]
+metadata:
+  hermes:
+    tags: [Security, Secrets, API Keys, Proxy, Approval]
+    category: security
+---
+
+# ShieldNode
+
+ShieldNode keeps the user's real API keys in an encrypted vault and gives this agent a **virtual key** instead. You call the proxy, it injects the real credential, the upstream API answers. The real key never reaches you, so a leaked virtual key is worthless on its own.
+
+```
+Hermes --X-Api-Key: shieldnode_...--> proxy.shieldnode.app/{path} --real key--> api.upstream.com/{path}
+```
+
+The user can leave a key **disabled** by default. Your call then triggers a push notification on their phone, they approve it for a bounded window, and the call goes through.
+
+## When to Use
+
+- The user hands you a value starting with `shieldnode_`
+- Calling any API the user has put behind ShieldNode
+- A call returns `403 approval_required`
+- Setting up recurring access for a cron job or scheduled task
+- The user wants to use an API they have not configured yet
+- Debugging proxy errors, especially unexpected 404s
+
+## Prerequisites
+
+A ShieldNode account. The free tier is **2 services, 3 virtual keys per service, and 500 requests a month**, no card required.
+
+**Get the app first: https://shieldnode.app/get-app** (iOS and Android). The account is created there, and the app is what makes the product work end to end: it delivers the approval notifications, and it is where the user approves the services this agent proposes. Without it, a disabled key simply fails instead of asking them.
+
+There is a web dashboard at https://shieldnode.app for anyone who prefers a browser, but push approval and agent-driven service setup both need the app.
+
+Keys live in `~/.hermes/.env`, one per service, and nothing else needs installing:
+
+```env
+SHIELDNODE_STRIPE_KEY=shieldnode_...
+SHIELDNODE_OPENAI_KEY=shieldnode_...
+SHIELDNODE_CONFIG_KEY=shieldnode_config_...
+```
+
+One virtual key maps to one service, hence `SHIELDNODE_<SERVICE>_KEY`. The optional `SHIELDNODE_CONFIG_KEY` unlocks proposing new services. Values can also be mapped in from Bitwarden or 1Password. Examples below write `$SHIELDNODE_KEY` as shorthand for whichever service variable applies.
+
+New accounts come with a keyless demo service, so the whole flow including approvals can be tested before wiring up a real API.
+
+## How to Run
+
+Everything is a plain HTTPS call through the `terminal` tool. There is no CLI to install.
+
+Resolve an unknown key **first**, in one call. Do not ask the user which service it belongs to:
+
+```bash
+curl -sS -H "X-Api-Key: $SHIELDNODE_KEY" \
+  "https://proxy.shieldnode.app/_shieldnode/whoami"
+```
+
+```json
+{
+  "service": "OpenAI",
+  "base_url": "https://api.openai.com/v1",
+  "allowed_methods": ["GET", "POST"],
+  "rate_limit_per_min": 60,
+  "active": false,
+  "requires_approval": true,
+  "default_approval_duration_minutes": 30
+}
+```
+
+That gives you the upstream, the configured `base_url` (which fixes your path convention) and whether the next call goes straight through (`active: true`) or triggers an approval push. whoami never returns credentials, is never forwarded upstream, and fires no push.
+
+Then call the API, always identifying yourself:
+
+```bash
+curl -sS -H "X-Api-Key: $SHIELDNODE_KEY" \
+     -H "X-Agent-Name: Hermes" \
+     "https://proxy.shieldnode.app/<API_PATH>"
+```
+
+## Quick Reference
+
+| Header | Purpose |
+|---|---|
+| `X-Api-Key` | The virtual key. Required on every call. |
+| `X-Agent-Name: Hermes` | Makes the push read "Hermes is requesting access" instead of "An external agent". Send it always. |
+| `X-Approval-Duration` | How long you need. Clamped to [1, 1440] minutes. Accepts `30`, `15m`, `2h`. |
+| `X-Approval-Reason` | Short honest phrase shown to the user. Never put secrets in it. |
+
+| Code | Meaning | Action |
+|---|---|---|
+| 401 | Key invalid or expired | Check it in the app |
+| 403 | Disabled, over quota, or path not allowlisted | See Procedure below |
+| 404 | Path missing upstream | Check the base URL pitfall first |
+| 429 | Rate limited | Wait, or raise the key's limit |
+| 413 | Body over the 90 MB cap | Use a signed-URL upload |
+| 502 / 504 | Cold start or slow upstream | Wait 30s, then test the upstream directly |
+
+## Procedure
+
+### Push approval
+
+A disabled key whose owner has the app returns a structured 403 rather than a plain failure.
+
+| `error` in the body | What to do |
+|---|---|
+| `approval_required` | The user got a push. Wait `poll_interval_seconds` (default 30s), retry, up to `timeout_seconds` (default 5 min). |
+| `approval_denied` | Stop. Report "User declined access on ShieldNode mobile." Do not retry on your own. |
+| `key_disabled` | No app registered. Surface and stop. |
+
+```bash
+curl -sS -H "X-Api-Key: $SHIELDNODE_KEY" \
+     -H "X-Agent-Name: Hermes" \
+     -H "X-Approval-Duration: 15m" \
+     -H "X-Approval-Reason: sending the weekly report" \
+     "https://proxy.shieldnode.app/emails"
+```
+
+Full polling loop in code: `references/approval-recipe.md`.
+
+### Scheduled windows for recurring jobs
+
+For a cron or nightly batch, ask **once** for a recurring window instead of firing a push every run. Inside the window, calls return 200 with no push and no polling.
+
+```bash
+curl -sS -X POST "https://proxy.shieldnode.app/_shieldnode/schedule-request" \
+     -H "X-Api-Key: $SHIELDNODE_KEY" -H "Content-Type: application/json" \
+     -d '{"time":"03:00","timezone":"Europe/Paris","days":["mon","tue","wed","thu","fri"],
+          "duration_minutes":30,"agent_name":"Hermes","reason":"nightly analytics sync"}'
+```
+
+`time` and `timezone` are required. Use the zone **your scheduler** runs in, not the user's. `duration_minutes` defaults to 10, clamped to [5, 1440], and the window opens 5 minutes early as a lead. Returns `202` with a `request_id`, pollable at `/_shieldnode/schedule-request/<request_id>`.
+
+The server never reveals the next open time, by design: that would tell anyone holding a leaked key exactly when to use it. You set the schedule, so you already know it.
+
+### Proposing a new service
+
+When the user wants an API that is not in their account yet, propose it rather than walking them through a form. They get a push, open a prefilled screen, type only their own credential, and approve. **You never see that credential.**
+
+Needs a config key (prefix `shieldnode_config_`), created on the built-in ShieldNode service at the top of their service list.
+
+```bash
+curl -sS -X POST "https://proxy.shieldnode.app/_shieldnode/config-request" \
+     -H "X-Api-Key: $SHIELDNODE_CONFIG_KEY" -H "Content-Type: application/json" \
+     -d '{"name":"Stripe","base_url":"https://api.stripe.com",
+          "detected_auth_method":{"method":"header_bearer"},
+          "credential_labels":["API key"],
+          "agent_name":"Hermes","reason":"creating invoices for the user"}'
+```
+
+Fill `base_url` and `detected_auth_method` from what you know about the API, or from its docs. Poll `/_shieldnode/config-request/<request_id>` until `approved`, then ask the user for a virtual key on the new service.
+
+**Never put the user's upstream API key in this request.** You propose the non-secret shape only.
+
+## Pitfalls
+
+**The base URL trap causes nearly every unexpected 404.** The proxy appends your path verbatim to the configured base URL, so a version prefix already in the base URL must not be repeated. For an upstream `https://api.example.com/v1/users`:
+
+| Base URL on the service | Correct proxy call |
+|---|---|
+| `https://api.example.com/v1` | `https://proxy.shieldnode.app/users` |
+| `https://api.example.com` | `https://proxy.shieldnode.app/v1/users` |
+
+Take `base_url` from whoami, subtract it from the full upstream URL, and what remains goes after `proxy.shieldnode.app/`.
+
+Other things that bite:
+
+- **One service maps to one base URL.** APIs spanning subdomains (Twilio, Shopify Admin plus Storefront) need one service each, with their own key.
+- **Absolute next-page URLs break pagination.** Following a `Link` header verbatim sends the request to the upstream with a virtual key it cannot read, giving a 401 that never appears in ShieldNode logs. Reuse the proxy base with the cursor parameter instead.
+- **A 403 with `error code: 1010` in the body is a Cloudflare client-fingerprint block on the upstream, not an IP ban.** Routing through ShieldNode is the fix, since the proxy makes the outbound call.
+- Every proxy response carries `cf-ray` and `server: cloudflare` headers because the proxy sits behind Cloudflare. That is normal and does not mean you were blocked.
+
+More in `references/troubleshooting.md`.
+
+### Behaviour rules
+
+- Never print a virtual key back to the user, and never ask them to paste one into the chat. They put it in `~/.hermes/.env` themselves.
+- Tell the user **once** that an approval is pending, then poll silently. A message every 30 seconds feels like spyware.
+- Never retry after an explicit decline, and never retry past the timeout. Ask the user instead.
+- Do not fire parallel calls to force an approval. Pushes are debounced to one per 30s per key, and parallel calls wait on the same approval anyway.
+- Distinguish a decline from a timeout when reporting back. They mean different things to the user.
+- Keep `X-Approval-Reason` truthful. It is how the user decides, and a misleading one gets every future request declined.
+
+## Verification
+
+Confirm the setup end to end without touching a real API, using the keyless demo service seeded on every account:
+
+```bash
+curl -sS -H "X-Api-Key: $SHIELDNODE_KEY" \
+  "https://proxy.shieldnode.app/_shieldnode/whoami"
+```
+
+A `200` with a `service` field means the key resolves. If `active` is `true`, a normal proxied call should return `200`. If `requires_approval` is `true`, the same call returns `403 approval_required` and a push lands on the user's phone, which confirms the whole chain.
+
+An invalid key returns `401 invalid_key`.
+
+## References
+
+- `references/approval-recipe.md` for the full polling loop in code
+- `references/troubleshooting.md` for compression, pagination, Cloudflare 1010 and upload limits
+- `references/service-docs.md` for writing a per-service reference document
+- `references/dashboard-setup.md` for configuring a service by hand
+- Canonical skill repository, kept up to date: https://github.com/Dorunaitsu/ShieldNode
+- https://shieldnode.app

--- a/optional-skills/security/shieldnode/SKILL.md
+++ b/optional-skills/security/shieldnode/SKILL.md
@@ -50,7 +50,7 @@ SHIELDNODE_CONFIG_KEY=shieldnode_config_...
 
 One virtual key maps to one service, hence `SHIELDNODE_<SERVICE>_KEY`. The optional `SHIELDNODE_CONFIG_KEY` unlocks proposing new services. Values can also be mapped in from Bitwarden or 1Password. Examples below write `$SHIELDNODE_KEY` as shorthand for whichever service variable applies.
 
-New accounts come with a keyless demo service, so the whole flow including approvals can be tested before wiring up a real API.
+New accounts come with a keyless demo service, so the whole flow including approvals can be tested before wiring up a real API. Ask the user for a key on it, resolve it with whoami like any other, and you have everything you need: no configuration, and no credential involved anywhere.
 
 ## How to Run
 
@@ -66,16 +66,18 @@ curl -sS -H "X-Api-Key: $SHIELDNODE_KEY" \
 ```json
 {
   "service": "OpenAI",
+  "alias": "production",
   "base_url": "https://api.openai.com/v1",
   "allowed_methods": ["GET", "POST"],
   "rate_limit_per_min": 60,
   "active": false,
+  "expired": false,
   "requires_approval": true,
   "default_approval_duration_minutes": 30
 }
 ```
 
-That gives you the upstream, the configured `base_url` (which fixes your path convention) and whether the next call goes straight through (`active: true`) or triggers an approval push. whoami never returns credentials, is never forwarded upstream, and fires no push.
+That gives you the upstream, the configured `base_url` (which fixes your path convention) and whether the next call goes straight through (`active: true`) or triggers an approval push. `alias` is the name the user gave the key, so refer to it by that rather than showing any part of its value. whoami never returns credentials, is never forwarded upstream, and fires no push.
 
 **Then write the service doc, without being asked.** If there is no `services/<slug>.md` for the service whoami just named, create one from the template in `references/service-docs.md`. No command and no question to the user: whoami already gave you the service, the base URL and the auth shape. Later sessions read that file instead of deriving it again.
 
@@ -192,7 +194,7 @@ More in `references/troubleshooting.md`.
 
 ## Verification
 
-Confirm the setup end to end without touching a real API, using the keyless demo service seeded on every account:
+Confirm the setup end to end without touching a real API, using a key on the keyless demo service seeded on every account:
 
 ```bash
 curl -sS -H "X-Api-Key: $SHIELDNODE_KEY" \

--- a/optional-skills/security/shieldnode/references/approval-recipe.md
+++ b/optional-skills/security/shieldnode/references/approval-recipe.md
@@ -9,7 +9,7 @@ import requests
 PROXY = "https://proxy.shieldnode.app"
 KEY = "shieldnode_..."  # virtual key, load from $SHIELDNODE_<SERVICE>_KEY
 
-def call_with_approval(path, *, method="GET", json=None, agent="Claude",
+def call_with_approval(path, *, method="GET", json=None, agent="Hermes",
                        minutes=15, max_wait_s=300, poll_s=30):
     """
     Call the proxy. If the key is disabled and the user has the mobile app,
@@ -57,10 +57,20 @@ def call_with_approval(path, *, method="GET", json=None, agent="Claude",
         r.raise_for_status()
 
 
-data = call_with_approval("/chat/completions",
-                          method="POST",
-                          json={"model": "gpt-4o", "messages": [...]},
-                          agent="Claude", minutes=30).json()
+# A consequential action on a classic API, which is what this flow is for:
+# the user gets a push, approves once, and the send goes through.
+data = call_with_approval(
+    "/emails",
+    method="POST",
+    json={
+        "from": "reports@example.com",
+        "to": ["owner@example.com"],
+        "subject": "Weekly report",
+        "html": "<p>Numbers attached.</p>",
+    },
+    agent="Hermes",
+    minutes=5,
+).json()
 ```
 
 ## Why each part matters

--- a/optional-skills/security/shieldnode/references/approval-recipe.md
+++ b/optional-skills/security/shieldnode/references/approval-recipe.md
@@ -1,0 +1,82 @@
+# Approval polling recipe
+
+Full implementation of the push-approval loop described in the push approval section of SKILL.md. Use it when you are writing code that must survive a disabled key, not when you are making a one-off call.
+
+```python
+import time
+import requests
+
+PROXY = "https://proxy.shieldnode.app"
+KEY = "shieldnode_..."  # virtual key, load from $SHIELDNODE_<SERVICE>_KEY
+
+def call_with_approval(path, *, method="GET", json=None, agent="Claude",
+                       minutes=15, max_wait_s=300, poll_s=30):
+    """
+    Call the proxy. If the key is disabled and the user has the mobile app,
+    notify them and poll until they approve, decline, or time out.
+    """
+    headers = {
+        "X-Api-Key": KEY,
+        "X-Agent-Name": agent,                  # appears in the user's notification
+        "X-Approval-Duration": f"{minutes}m",   # honored on 403, ignored on 200
+    }
+
+    elapsed = 0
+    while True:
+        r = requests.request(method, f"{PROXY}{path}", headers=headers, json=json)
+
+        if r.status_code < 400:
+            return r  # proxy let it through
+
+        if r.status_code == 403:
+            body = r.json()
+            err = body.get("error")
+
+            if err == "approval_required":
+                # Tell the user once, then poll silently.
+                if elapsed == 0:
+                    print(f"[ShieldNode] Approval pending on your phone "
+                          f"({body['requested_minutes']} min requested).")
+                if elapsed >= min(max_wait_s, body.get("timeout_seconds", 300)):
+                    raise TimeoutError("ShieldNode approval timed out.")
+                wait = body.get("poll_interval_seconds", poll_s)
+                time.sleep(wait)
+                elapsed += wait
+                continue
+
+            if err == "approval_denied":
+                raise PermissionError("User declined access on ShieldNode mobile.")
+
+            if err == "key_disabled":
+                raise PermissionError(
+                    "Key is disabled and no mobile device is registered. "
+                    "The user needs to re-enable it in the dashboard."
+                )
+
+        # Anything else (401, 429, 5xx, path/method restrictions) surfaces as-is.
+        r.raise_for_status()
+
+
+data = call_with_approval("/chat/completions",
+                          method="POST",
+                          json={"model": "gpt-4o", "messages": [...]},
+                          agent="Claude", minutes=30).json()
+```
+
+## Why each part matters
+
+- **Read `poll_interval_seconds` and `timeout_seconds` from the body**, do not hardcode. The server tunes them.
+- **Print once, at `elapsed == 0`.** Repeating the message every poll is the single most annoying agent behaviour in this flow.
+- **Separate the three 403 errors.** `approval_denied` is a decision, `key_disabled` is a missing app, a timeout is silence. Reporting all three as "access denied" hides what the user needs to do.
+- **Let non-403 errors raise.** A 429 or a 500 is not an approval problem, and looping on it wastes the user's quota.
+
+## Choosing a duration
+
+| Workload | Suggested |
+|---|---|
+| Chat, completion, inference (OpenAI, Anthropic, Mistral) | 30 min |
+| Long batch, training, video or audio generation | 2 h |
+| One-shot lookups (geocoding, currency, weather, CMS reads) | 15 min |
+| Unattended 24/7 cron | Use a scheduled window instead (see the scheduled windows section of SKILL.md), or tell the user to leave the key always-on |
+
+If the user gives you a standing instruction ("for OpenAI ask 30 min by default"), encode it as the header on your first call to that service rather than asking again each time.

--- a/optional-skills/security/shieldnode/references/dashboard-setup.md
+++ b/optional-skills/security/shieldnode/references/dashboard-setup.md
@@ -1,0 +1,58 @@
+# Manual setup in the dashboard
+
+The agent path for adding a service is the config request documented in SKILL.md: propose it, the user approves on their phone and types only the credential. Use this file when the user wants to do it by hand instead, or asks how the dashboard works.
+
+## Auto tab (default, fastest)
+
+For APIs with a common auth scheme (Bearer, `x-api-key`, Basic, query param) and straightforward docs.
+
+1. Dashboard, **Add service**
+2. Tab **Auto**
+3. Fill service name, base URL, credentials (label + value)
+4. **Test connection**: the proxy probes the API and detects the auth method
+5. On `Connected successfully (HTTP xxx)`, click **Create service**
+
+HTTP 200, 201 or 404 on the test all mean auth is fine (the server is reachable and accepted the credential). 401 or 403 mean the credential is wrong.
+
+## Manual tab
+
+When Auto fails, or to force a specific method.
+
+1. Tab **Manual**
+2. Pick the method:
+   - **Bearer Token**: `Authorization: Bearer <key>`
+   - **API Key Header**: a custom header such as `x-api-key`. Leave the name empty to let the proxy try common ones.
+   - **Basic Auth**: `Authorization: Basic base64(user:pass)`
+   - **Query Param**: `?api_key=<value>`. Leave the name empty to let the proxy try common ones.
+3. Test, then save.
+
+## Multi-header auth
+
+Two headers required at once (`Client-Id` + `Client-Secret`), common with banking, shipping carriers (DHL, FedEx) and enterprise B2B SaaS. Supported in both tabs.
+
+1. Tab **Auto** to let the proxy detect it, or **Manual, Multi-header** to force it.
+2. Use **+ Add credential** to add one row per header.
+3. The left field is the exact header name the upstream expects (`Client-Id`, `X-Client-Secret`, case-insensitive), the right field is the value.
+4. **Test connection**: the proxy sends all rows as simultaneous headers and confirms when the upstream returns anything other than 401/403.
+5. Save. The forwarder injects all of them on every proxied request.
+
+## Creating a virtual key
+
+1. Dashboard, pick the service, **New key**
+2. Set alias, rate limit (req/min), max requests (total), allowed paths, expiration
+3. The `shieldnode_...` key is **shown once only**. Copy it straight into the user's secure store.
+
+## Common base URLs
+
+| Service | Base URL |
+|---|---|
+| OpenAI | `https://api.openai.com/v1` |
+| Anthropic | `https://api.anthropic.com/v1` |
+| Airtable | `https://api.airtable.com/v0` |
+| Resend | `https://api.resend.com` |
+| Stripe | `https://api.stripe.com/v1` |
+| GitHub | `https://api.github.com` |
+| Shopify Admin | `https://<SHOP>.myshopify.com/admin/api/2024-01` |
+| Cool Dogs — Playground (auto-seeded, keyless) | `https://dog.ceo/api` |
+
+Remember that the prefix present in the base URL (`/v1`, `/v0`) is the one you must **not** repeat in the proxied path. See the base URL trap in SKILL.md.

--- a/optional-skills/security/shieldnode/references/service-docs.md
+++ b/optional-skills/security/shieldnode/references/service-docs.md
@@ -1,6 +1,6 @@
 # Per-service reference docs and key storage
 
-After a service is configured, write a markdown reference at `skills/shieldnode/services/<service-slug>.md` (lowercase kebab: `openai`, `airtable`, `stripe`). It becomes the single source of truth for that service in the project, so future agents read it instead of re-fetching the docs.
+After a service is configured, write a markdown reference for it. **SKILL.md gives the one path to write to**, so it is stated in a single place and never drifts; the file name is the service slug in lowercase kebab (`openai`, `airtable`, `stripe`). It becomes the single source of truth for that service, so future agents read it instead of re-fetching the docs.
 
 ## Template
 

--- a/optional-skills/security/shieldnode/references/service-docs.md
+++ b/optional-skills/security/shieldnode/references/service-docs.md
@@ -1,0 +1,98 @@
+# Per-service reference docs and key storage
+
+After a service is configured, write a markdown reference at `skills/shieldnode/services/<service-slug>.md` (lowercase kebab: `openai`, `airtable`, `stripe`). It becomes the single source of truth for that service in the project, so future agents read it instead of re-fetching the docs.
+
+## Template
+
+```markdown
+# <Service Name> — ShieldNode integration
+
+## Routing
+- **ShieldNode base URL**: https://proxy.shieldnode.app
+- **Original API base URL** (set in the service config): https://api.example.com/v1
+- **Auth header for proxy calls**: `X-Api-Key: $SHIELDNODE_<SERVICE>_KEY`
+  > Never write the actual key value here. Reference the env variable only.
+- **Effective call pattern**: `https://proxy.shieldnode.app/<endpoint-path>`
+  > The configured base URL already includes `/v1`, so the proxied path omits it.
+
+## Documentation
+- Official docs: https://docs.example.com
+- Reference page used to populate this file: https://docs.example.com/api/v1
+
+## Auth method
+Bearer token in the `Authorization` header, handled by ShieldNode. The client only sends `X-Api-Key`.
+
+## Endpoints
+| Method | Path | Description |
+|--------|------|-------------|
+| GET    | /users      | List users |
+| GET    | /users/{id} | Retrieve a user |
+| POST   | /users      | Create a user |
+| PATCH  | /users/{id} | Update a user |
+| DELETE | /users/{id} | Delete a user |
+
+## Push approval
+- **Default window**: 30 min (override per call with `X-Approval-Duration`).
+- **When triggered**: only when the key is disabled AND the user has the mobile app. Otherwise the key is always-on.
+- **On `403 approval_required`**: wait `poll_interval_seconds` (default 30s), retry up to `timeout_seconds` (default 5 min). Tell the user once.
+- **On `403 approval_denied`**: stop, surface "User declined access on ShieldNode mobile."
+- **Suggested duration for this service**: <fill in, see the table below>
+
+## Notes
+- Upstream rate limit: 60 req/min per API key.
+- Pagination: cursor-based via `?cursor=<token>`.
+```
+
+## Filling the Endpoints section
+
+1. Ask for the docs URL: *"Could you give me the URL of the API documentation page that lists the endpoints? I'll extract them and save a reference file."*
+2. Fetch it with whatever web tool you have.
+3. Extract method, path, one-line description into the table.
+4. Save the file and confirm with a clickable link.
+
+If the user pastes raw doc content instead of a URL, parse that directly. If the docs are auth-walled and the fetch fails, ask them to paste the page.
+
+**Many API doc sites are JavaScript-rendered SPAs.** A plain fetch returns an empty shell: only a `<noscript>` tag, a suspiciously short document (< 500 chars), or no endpoint paths anywhere. When you detect that, try in order:
+
+1. **The machine-readable spec.** Try `<base-url>/openapi.json`, `/swagger.json`, `/.well-known/openapi.json`, or look in the docs page `<head>` for a `link rel="alternate" type="application/json"`.
+2. **The project's public source.** If it is open source, the GitHub README usually lists endpoints and the repo often holds the OpenAPI file.
+3. **Ask the user to paste the rendered content** from their browser. They have a real browser, you often do not.
+4. **A headless browser** (Puppeteer, Playwright) if your runtime has one. Last resort: slow, fragile, not always available.
+
+If all four fail, save the partial doc with `> _Endpoints to be populated, documentation site rendered client-side._` and ask the user to point you at another page.
+
+## Suggested approval durations
+
+| Workload | Value |
+|---|---|
+| Chat, completion, inference | 30 min |
+| Long batch, training, video or audio generation | 2 h |
+| One-shot lookups (geocoding, currency, weather, CMS reads) | 15 min |
+| Unattended 24/7 cron | Use a scheduled window (see the scheduled windows section of SKILL.md), or note that the key should stay always-on |
+
+If the user already set a per-key default in the dashboard, write that exact value and add *"(matches the dashboard default, agent does not need to send the header)"*. If they are clearly web-only with no mobile app, note that push approval falls back to a plain `403 key_disabled`.
+
+## Storing the virtual key
+
+The reference doc is designed to be committable, so the key value never goes in it, only the env variable name.
+
+Convention: `SHIELDNODE_<SERVICE>_KEY` in uppercase, e.g. `SHIELDNODE_STRIPE_KEY`.
+
+**Multiple environments of the same API** (Stripe test and live, staging and prod) expand to `SHIELDNODE_<SERVICE>_<ENV>_KEY`: `SHIELDNODE_STRIPE_TEST_KEY`, `SHIELDNODE_OPENAI_PROD_KEY`. Detect this by checking whether `SHIELDNODE_<SERVICE>_KEY` already exists in `.env`; if it does, propose the suffixed form and ask which environment this key is.
+
+Steps:
+
+1. **Check for `.env` at the project root.** Append the variable if it exists (never overwrite entries), otherwise create it:
+   ```env
+   # ShieldNode virtual keys, never commit this file.
+   SHIELDNODE_STRIPE_KEY=shieldnode_...
+   ```
+2. **Update `.env.example`** (create if missing) with the value blanked. That file is committable and documents what collaborators need:
+   ```env
+   SHIELDNODE_STRIPE_KEY=
+   ```
+3. **Verify `.gitignore` excludes `.env`.** If not, append `.env` and `.env.local`. Do not touch other entries.
+4. **Reference it by name only** in the per-service doc: `X-Api-Key: $SHIELDNODE_STRIPE_KEY`.
+5. **Confirm to the user** what changed, and remind them the key is shown once at creation so they must paste it into `.env` immediately.
+
+**Never ask the user to paste a key into the chat.** They paste it into `.env` on their machine. If they paste one anyway, redact it in later turns and tell them to rotate it in the dashboard if it may have hit any logs.

--- a/optional-skills/security/shieldnode/references/troubleshooting.md
+++ b/optional-skills/security/shieldnode/references/troubleshooting.md
@@ -1,0 +1,88 @@
+# Troubleshooting
+
+Deeper diagnosis for calls that fail after the status-code table in SKILL.md. Check the base URL trap first, it explains most unexpected 404s.
+
+## Diagnostic checklist
+
+1. **Check the dashboard logs.** Service, then the Logs tab. If the request is not there it never reached the proxy, so the problem is client-side: bad key, bad URL, network.
+2. **Bypass the proxy.** Call the upstream directly with the real credential. If that fails too, the problem is not ShieldNode.
+   ```bash
+   curl -H "Authorization: Bearer <REAL_KEY>" "https://api.example.com/v1/<endpoint>"
+   ```
+3. **Verbose curl through the proxy**, to see headers and timing:
+   ```bash
+   curl -sv -H "X-Api-Key: shieldnode_..." \
+     "https://proxy.shieldnode.app/<endpoint>" 2>&1 | grep -E "< HTTP|< content"
+   ```
+
+## Common gotchas
+
+- **`Connected successfully (HTTP 404)` on the Auto test.** Normal. Auth was accepted, the bare base URL just is not a resource. Save the service.
+- **401 through the proxy but the credentials are correct.** The auto-detected auth method is probably wrong. Reconfigure with Manual and pick it explicitly.
+- **Repeated 502 (not a single cold start).** Check the backend logs.
+- **`502 Upstream unreachable`.** The upstream itself is down or the domain is dead. Test it directly with `curl -v` before blaming the proxy. A parked or expired domain serving ad HTML is a common cause.
+- **Truncated or empty response.** Possibly the 30s proxy timeout. SSE and WebSocket streams are not supported by the HTTP proxy.
+- **Upstream 429 despite low traffic.** ShieldNode does not aggregate rate limits across virtual keys hitting the same service. Multiple keys mean multiple traffic sources upstream.
+- **A virtual key suddenly stops working.** Check expiration, total request cap, manual disable. Dashboard, key, status.
+
+## Uploads: 413 and 504
+
+The proxy enforces a **90 MB** request-body limit, set just below the Cloudflare edge's hard cap (past that the edge returns a fast 503 anyway, so 413 is the friendlier explicit version).
+
+For anything larger (audio transcription, fine-tuning datasets, video, large image batches) do not stream it through the proxy. Use a signed-URL pattern: get a presigned upload URL from the upstream API through the proxy, then upload the file from the client straight to that URL. The bytes never touch ShieldNode.
+
+The total proxy timeout scales with body size (30s baseline, +1s per MB above 5 MB) so a large upload over a slow link does not fail. If you still hit 504, the upstream is probably slow processing the upload. Test it directly with the same payload size to confirm.
+
+## Pagination breaks with 401 after the first page
+
+Affects Stripe, GitHub, Shopify, Notion, Algolia and any API returning **absolute** next-page URLs in a `Link` header or in JSON fields (`next_url`, `next`, `cursor.next_url`). Those URLs point at the upstream domain. Followed verbatim, the request bypasses ShieldNode and lands upstream carrying a `shieldnode_...` key it cannot understand, so it 401s.
+
+Two correct patterns:
+
+1. **Extract just the cursor parameter** and reuse the proxy base: `https://proxy.shieldnode.app/customers?starting_after=xyz`. Cleanest, and what most SDKs do internally if you set their `base_url` to the proxy.
+2. **Rewrite the host** in the absolute URL, replacing `https://api.stripe.com/v1` with `https://proxy.shieldnode.app` (keeping or dropping the path prefix per the base URL trap).
+
+Hard rule: **never let a next-page request leave for the upstream domain directly.** It fails, and the failure does not appear in ShieldNode logs.
+
+## Body looks like binary garbage
+
+Symptoms: unparseable JSON, "Invalid numeric literal at EOF". The response is compressed (Brotli, gzip, zstd) and your HTTP client is not decompressing. Common through a proxy because compression is negotiated between three parties and `Content-Encoding` can get out of sync.
+
+| Client | Fix |
+|---|---|
+| `curl` | Add `--compressed` (gzip, deflate, brotli, zstd) |
+| Python `requests` | Automatic for gzip, deflate, brotli |
+| Python `httpx` | Install as `httpx[brotli]` for brotli support |
+| Node built-in `fetch` | gzip and deflate only, **not brotli**. Use `undici`, or pipe through `zlib.brotliDecompress` |
+| Browser `fetch` | Automatic for all three |
+| Go `net/http` | gzip built in; add `github.com/andybalholm/brotli` for brotli |
+
+## Cloudflare Error 1010 (TLS fingerprint block)
+
+A `403` whose body contains `error code: 1010` from a Cloudflare-fronted upstream is **not an IP block and not an ASN block**, despite many assistants diagnosing it that way. It is a documented *client signature* block, triggered by:
+
+- the TLS handshake fingerprint (JA3/JA4): Python `requests`, `httpx`, `aiohttp`, Go `net/http`, OkHttp each have a recognisable signature some zones flag as automated;
+- HTTP/2 frame ordering and header casing;
+- the `User-Agent`.
+
+It does not trigger on caller IP or ASN. Two clients behind the same NAT get different results depending on the library.
+
+**Verify before claiming an IP block:**
+
+1. Get the egress IP: `curl -s https://api.ipify.org` (the real curl binary).
+2. From the same machine, hit the upstream with real curl:
+   ```bash
+   curl -sw "HTTP %{http_code}\n" --max-time 8 https://upstream.example.com/endpoint -o /dev/null
+   ```
+   - 200 from curl but `403 1010` from your library: fingerprint block.
+   - `403 1010` from both: the IP itself may genuinely be flagged (rare on residential, common on datacenter).
+
+**The fix is to route through ShieldNode.** The outbound request is made by ShieldNode's backend, which forces a browser-like User-Agent on every forwarded request specifically to clear these rules. Your client only has to reach `proxy.shieldnode.app`.
+
+If you genuinely need a specific UA forwarded upstream (analytics tagging, partner requirement), send `X-ShieldNode-User-Agent`. The proxy consumes that header and uses its value as the outbound UA.
+
+**When reproducing from a shell, prefer the real curl binary** over Python wrappers. Asked to "run curl", many agents silently translate it into a `requests`/`httpx` call, and the fingerprint difference produces confusing diagnostics.
+
+**Reading the headers correctly:** every response from `proxy.shieldnode.app` carries `cf-ray` and `server: cloudflare` because the proxy's own CDN edge is Cloudflare. **That does not mean Cloudflare blocked you.** Judge by the status code and the body. A 1010 block always contains the literal string `error code: 1010`. If the body is the upstream's normal JSON, you were not blocked.
+
+**Anti-pattern:** concluding "Cloudflare blocked us by ASN" from seeing `cf-ray`, running on a server, and getting a 403. Run the verification above before reporting that.

--- a/tests/skills/test_shieldnode_skill.py
+++ b/tests/skills/test_shieldnode_skill.py
@@ -1,0 +1,216 @@
+"""Hermetic tests for the shieldnode skill.
+
+The skill ships no scripts: it is a document contract telling the agent which
+endpoints to call and how to behave. These tests enforce that contract, so a
+future edit cannot silently break the parts a reader copies and pastes.
+
+Stdlib + pytest only. No network, no API keys, no filesystem writes.
+
+    scripts/run_tests.sh tests/skills/test_shieldnode_skill.py -q
+"""
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_REL = ("optional-skills", "security", "shieldnode")
+_CANDIDATES = [
+    _HERE.parent.parent.parent.joinpath(*_REL),  # hermes-agent (tests/skills/)
+    _HERE.parent.parent.joinpath(*_REL),         # standalone layout
+]
+SKILL_DIR = next((c for c in _CANDIDATES if (c / "SKILL.md").exists()), _CANDIDATES[0])
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+# The one place the skill is allowed to tell the agent to persist service docs.
+# Duplicating this path in a second file is what drifted before, so the test
+# asserts exactly one file states it.
+SERVICE_DOC_PATH = "~/.hermes/shieldnode/services/<slug>.md"
+
+MANDATED_SECTIONS = [
+    "When to Use",
+    "Prerequisites",
+    "How to Run",
+    "Quick Reference",
+    "Procedure",
+    "Pitfalls",
+    "Verification",
+]
+
+MARKETING_WORDS = ("powerful", "comprehensive", "seamless", "advanced", "revolutionary")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    """Parse the top-level scalar keys of the frontmatter without PyYAML."""
+    assert text.startswith("---\n"), "SKILL.md must open with a frontmatter block"
+    end = text.index("\n---\n", 3)
+    out: dict[str, str] = {}
+    for line in text[4:end].splitlines():
+        if not line or line.startswith((" ", "\t", "#")):
+            continue  # nested mapping (metadata:) or comment
+        key, _, value = line.partition(":")
+        out[key.strip()] = value.strip()
+    return out
+
+
+def _fenced_blocks(text: str, lang: str) -> list[str]:
+    return re.findall(rf"^```{lang}\n(.*?)^```", text, re.MULTILINE | re.DOTALL)
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return _read(SKILL_MD)
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_text: str) -> dict[str, str]:
+    return _frontmatter(skill_text)
+
+
+def test_skill_directory_layout():
+    assert SKILL_MD.exists(), f"SKILL.md not found under {SKILL_DIR}"
+    assert (SKILL_DIR / "references").is_dir()
+    # Scripts belong in scripts/; this skill intentionally ships none.
+    assert not (SKILL_DIR / "scripts").exists()
+
+
+def test_frontmatter_has_required_keys(frontmatter):
+    for key in ("name", "description", "version", "author", "license"):
+        assert key in frontmatter, f"missing frontmatter key: {key}"
+    assert frontmatter["name"] == "shieldnode"
+
+
+def test_description_meets_authoring_standard(frontmatter):
+    description = frontmatter["description"]
+    assert len(description) <= 60, f"description is {len(description)} chars, max 60"
+    assert description.endswith("."), "description must end with a period"
+    assert description.count(".") == 1, "description must be a single sentence"
+    lowered = description.lower()
+    for word in MARKETING_WORDS:
+        assert word not in lowered, f"marketing word in description: {word}"
+    assert "shieldnode" not in lowered, "description must not repeat the skill name"
+
+
+def test_author_credits_a_human_with_handle(frontmatter):
+    # "Real Name (github-handle)", human first per the authoring standards.
+    assert re.match(r"^[^(]+\([\w-]+\)", frontmatter["author"]), frontmatter["author"]
+
+
+def test_title_and_section_order(skill_text):
+    headings = re.findall(r"^#{1,2} (.+)$", skill_text, re.MULTILINE)
+    assert headings[0] == "ShieldNode Skill"
+    found = [h for h in headings if h in MANDATED_SECTIONS]
+    assert found == MANDATED_SECTIONS, f"section order is {found}"
+
+
+def test_every_referenced_file_exists(skill_text):
+    referenced = set(re.findall(r"references/([\w-]+\.md)", skill_text))
+    assert referenced, "SKILL.md should point at its references"
+    for name in sorted(referenced):
+        assert (SKILL_DIR / "references" / name).exists(), f"missing references/{name}"
+
+
+def test_service_doc_path_is_stated_exactly_once(skill_text):
+    """Regression guard: the path used to be duplicated and the copies drifted."""
+    assert SERVICE_DOC_PATH in skill_text, "SKILL.md must state the service-doc path"
+
+    others = [
+        p for p in sorted((SKILL_DIR / "references").glob("*.md"))
+        if re.search(r"services/<[\w-]*slug>\.md", _read(p))
+    ]
+    assert not others, (
+        "the service-doc path must live only in SKILL.md, found a second copy in: "
+        + ", ".join(p.name for p in others)
+    )
+
+
+def test_no_conflicting_service_doc_path(skill_text):
+    variants = set(re.findall(r"[\w~./]*services/<[\w-]*slug>\.md", skill_text))
+    assert variants == {SERVICE_DOC_PATH}, f"conflicting paths in SKILL.md: {variants}"
+
+
+def test_json_examples_parse(skill_text):
+    blocks = _fenced_blocks(skill_text, "json")
+    assert blocks, "SKILL.md should document at least one response shape"
+    for block in blocks:
+        json.loads(block)  # raises on a malformed example
+
+
+def _unsendable_json_payloads(source: str) -> list[str]:
+    """Return a description of every literal `json=` payload that cannot be sent.
+
+    Payloads referencing variables are skipped: nothing can be verified about
+    them statically. Literal ones must survive json.dumps, which is what
+    catches `[...]` (Ellipsis) and other non-serialisable values.
+    """
+    problems: list[str] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg != "json":
+                continue
+            try:
+                payload = ast.literal_eval(kw.value)
+            except ValueError:
+                continue  # references a variable, not a literal
+            try:
+                json.dumps(payload)
+            except TypeError as exc:
+                problems.append(f"line {kw.value.lineno}: {exc}")
+    return problems
+
+
+def test_python_recipe_is_valid_and_serialisable():
+    """Regression guard: the recipe once passed `messages: [...]`, i.e. Ellipsis,
+    which is not JSON-serialisable, so the snippet failed before reaching the
+    proxy. Parse it and prove every literal json= payload can actually be sent."""
+    recipe = SKILL_DIR / "references" / "approval-recipe.md"
+    blocks = _fenced_blocks(_read(recipe), "python")
+    assert blocks, "approval-recipe.md must contain the implementation"
+
+    for block in blocks:
+        ast.parse(block)  # raises SyntaxError on broken code
+        assert not _unsendable_json_payloads(block), _unsendable_json_payloads(block)
+
+
+def test_the_serialisability_guard_actually_catches_the_old_bug():
+    """Prove the guard above is not vacuous by running it on the original bug."""
+    bad = 'requests.post(url, json={"model": "x", "messages": [...]})'
+    assert _unsendable_json_payloads(bad), "the guard would not catch Ellipsis"
+
+    good = 'requests.post(url, json={"model": "x", "messages": [{"role": "user"}]})'
+    assert not _unsendable_json_payloads(good)
+
+
+def test_no_stale_or_literal_credentials():
+    """No obsolete key prefix, and no value that looks like a usable key."""
+    for path in [SKILL_MD, *sorted((SKILL_DIR / "references").glob("*.md"))]:
+        text = _read(path)
+        assert "sk_live_" not in text, f"obsolete key prefix in {path.name}"
+        for match in re.findall(r"shieldnode_(?:config_)?([A-Za-z0-9_-]*)", text):
+            assert len(match) < 20, f"{path.name} may embed a real key value"
+
+
+def test_reserved_namespace_endpoints_are_documented(skill_text):
+    """The endpoints the skill drives must stay under the reserved namespace,
+    which the proxy answers itself and never forwards upstream."""
+    for endpoint in ("whoami", "schedule-request", "config-request"):
+        assert f"/_shieldnode/{endpoint}" in skill_text, f"undocumented: {endpoint}"
+
+    stray = re.findall(r"proxy\.shieldnode\.app/_(?!shieldnode/)[\w-]+", skill_text)
+    assert not stray, f"endpoints outside the reserved namespace: {stray}"
+
+
+def test_agent_identifies_itself_in_examples(skill_text):
+    """X-Agent-Name is what makes an approval prompt name the requester, so the
+    examples must model sending it."""
+    assert "X-Agent-Name: Hermes" in skill_text


### PR DESCRIPTION
## What does this PR do?

Adds an optional skill for [ShieldNode](https://shieldnode.app), a credential proxy for AI agents. The user's real API keys stay in an encrypted vault and the agent gets a virtual key instead, so a key that leaks into a log, a screenshot or a context window is worthless on its own. When a key is left disabled, the call returns a structured `403` and the user gets a push notification they approve for a bounded window.

It is instructions plus `curl` through the `terminal` tool: no Python, no new dependencies, no core changes. The free tier (2 services, 500 requests a month, no card) makes it usable without paying, and every account is seeded with a keyless demo service so the whole flow, approvals included, can be tested without a real API key.

Placed in `optional-skills/security/` alongside `1password`, since it is credential handling, and because the contributing guide names "a paid service integration" as the case for `optional-skills/` rather than bundled.

## Related Issue

No existing issue. New optional skill.

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/security/shieldnode/SKILL.md`
- `optional-skills/security/shieldnode/references/approval-recipe.md`
- `optional-skills/security/shieldnode/references/troubleshooting.md`
- `optional-skills/security/shieldnode/references/service-docs.md`
- `optional-skills/security/shieldnode/references/dashboard-setup.md`

Nothing outside that directory is touched.

## How to Test

Setup is a copy and paste. There is no config file to edit and no command to memorise.

1. Create a free account in the ShieldNode app and make a virtual key on the demo service every account starts with. No real API key needed at any point.
2. Paste it into the chat: *"here is my ShieldNode key shieldnode_..., what service is it for?"* The `shieldnode_` prefix is the trigger. The agent resolves the key through `/_shieldnode/whoami`, answers without asking which service it is, and writes a `services/<slug>.md` reference for it so later sessions skip that step.
3. Ask it to call the API. It goes through the proxy, and the request shows up in the ShieldNode logs.
4. Disable the key in the app and ask again. The call returns `403 approval_required`, a push lands on the phone, and approving it unblocks the next call. Declining stops the agent cleanly instead of making it retry.

The one-shot equivalent, per the checklist: `hermes --toolsets skills -q "Use the shieldnode skill to check what service my key belongs to"`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] N/A: no code changed, this adds markdown only
- [x] N/A: skills without a `scripts/` directory have no test module in `tests/skills/` (same as `security/1password`)
- [x] I've tested on my platform: macOS and Debian

### Documentation & Housekeeping

- [x] Documentation is the change itself
- [x] N/A: no config keys added
- [x] N/A: no architecture or workflow change
- [x] Cross-platform: plain HTTPS via `curl`, no platform-specific paths
- [x] N/A: no tool behavior changed

## For New Skills

- [x] Correctly scoped to `optional-skills/` rather than bundled
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format): frontmatter, When to Use, Prerequisites, How to Run, Quick Reference, Procedure, Pitfalls, Verification
- [x] No external dependencies beyond `curl`
- [x] Tested end to end on a live Hermes agent running several ShieldNode services

## Notes

The skill has been running unmodified on a live Hermes agent with several ShieldNode services, keys in `~/.hermes/.env`, before this PR. The canonical source is [Dorunaitsu/ShieldNode](https://github.com/Dorunaitsu/ShieldNode) (MIT), and I will keep this copy in sync and bump `version` on each release.
