### PR TITLE
Fix authoritative delegation receipt handoff

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2865,6 +2865,12 @@ def record_delegation_receipt(
     terminal_status: str,
     result: dict[str, Any],
     task_id: str,
+    expected_run_id: Optional[int] = None,
+    expected_claim_token: Optional[str] = None,
+    expected_workflow_id: Optional[str] = None,
+    expected_step_key: Optional[str] = None,
+    expected_lane: Optional[str] = None,
+    allow_legacy_running_task: bool = False,
 ) -> dict[str, Any]:
     """Create or validate one receipt/event/continuation atomic unit."""
     key_bytes = logical_key.encode("utf-8")
@@ -2876,8 +2882,36 @@ def record_delegation_receipt(
         result_digest, terminal_status, result_json, task_id, continuation_id,
     )
     with write_txn(conn):
-        if conn.execute("SELECT 1 FROM tasks WHERE id=?", (task_id,)).fetchone() is None:
-            return {"status": "conflict", "reason": "target task does not exist"}
+        if allow_legacy_running_task:
+            authority = conn.execute(
+                "SELECT id FROM tasks WHERE id=? AND status IN ('ready','running')",
+                (task_id,),
+            ).fetchone()
+        elif expected_run_id is None or not expected_claim_token:
+            return {"status": "conflict", "reason": "worker authority is required"}
+        else:
+            authority = conn.execute(
+                """SELECT t.id
+                     FROM tasks AS t
+                     JOIN task_runs AS r
+                       ON r.id=t.current_run_id AND r.task_id=t.id
+                    WHERE t.id=? AND t.status='running'
+                      AND t.current_run_id=? AND t.claim_lock=?
+                      AND r.status='running' AND r.ended_at IS NULL
+                      AND r.claim_lock=?
+                      AND (? IS NULL OR t.workflow_template_id=?)
+                      AND (? IS NULL OR t.current_step_key=?)
+                      AND (? IS NULL OR t.assignee=?)""",
+                (
+                    task_id, int(expected_run_id), expected_claim_token,
+                    expected_claim_token,
+                    expected_workflow_id, expected_workflow_id,
+                    expected_step_key, expected_step_key,
+                    expected_lane, expected_lane,
+                ),
+            ).fetchone()
+        if authority is None:
+            return {"status": "conflict", "reason": "worker authority is stale or mismatched"}
         row = conn.execute(
             """SELECT receipt_id, logical_key, input_digest, delegation_id,
                       execution_id, result_digest, terminal_status, result_json,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -86,6 +86,7 @@ import logging
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
@@ -4596,6 +4597,14 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+class CompletionAuthority(str, Enum):
+    """Explicit authority used for a terminal task completion."""
+
+    WORKER = "worker"
+    ORCHESTRATOR = "orchestrator"
+    LEGACY = "legacy"
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4605,6 +4614,8 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    expected_claim_token: Optional[str] = None,
+    authority_mode: CompletionAuthority = CompletionAuthority.LEGACY,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -4628,6 +4639,11 @@ def complete_task(
     attempt is auditable. When all ids verify, they are recorded on the
     ``completed`` event payload.
 
+    ``authority_mode`` explicitly distinguishes worker, orchestrator, and
+    backwards-compatible direct-kernel completion. Worker authority requires
+    the exact current run and claim on both the task and active run row. Legacy
+    callers that pass ``expected_claim_token`` retain the worker-style guard.
+
     After a successful completion, ``summary`` and ``result`` are scanned
     for prose references like ``t_deadbeefcafe`` that do not resolve.
     Any suspected phantom references are recorded as a
@@ -4635,31 +4651,89 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
-
-    # Gate: verify created_cards BEFORE the main write txn. A rejected
-    # completion still needs an auditable event, so we emit it in a
-    # tiny dedicated txn, then raise. The caller is responsible for
-    # surfacing HallucinatedCardsError to the worker; this function
-    # never mutates task state on a phantom-card rejection.
-    if created_cards:
-        verified_cards, phantom_cards = _verify_created_cards(
-            conn, task_id, created_cards
+    authority_mode = CompletionAuthority(authority_mode)
+    worker_authority = (
+        authority_mode is CompletionAuthority.WORKER
+        or (
+            authority_mode is CompletionAuthority.LEGACY
+            and expected_claim_token is not None
         )
-        if phantom_cards:
+    )
+
+    # A worker must prove exact task/run/task-claim/run-row-claim authority
+    # under BEGIN IMMEDIATE before its phantom-card rejection audit can write.
+    # The later terminal UPDATE retains the same predicate as a final CAS.
+    if created_cards:
+        hallucination_error: Optional[HallucinatedCardsError] = None
+        if worker_authority:
             with write_txn(conn):
-                _append_event(
-                    conn, task_id, "completion_blocked_hallucination",
-                    {
-                        "phantom_cards": phantom_cards,
-                        "verified_cards": verified_cards,
-                        "summary_preview": (
-                            (summary or result or "").strip().splitlines()[0][:200]
-                            if (summary or result)
-                            else None
-                        ),
-                    },
+                if expected_run_id is None or int(expected_run_id) <= 0:
+                    return False
+                current_authority = conn.execute(
+                    """
+                    SELECT 1
+                      FROM tasks
+                     WHERE id = ?
+                       AND status = 'running'
+                       AND current_run_id = ?
+                       AND claim_lock = ?
+                       AND EXISTS (
+                           SELECT 1
+                             FROM task_runs AS active_run
+                            WHERE active_run.id = tasks.current_run_id
+                              AND active_run.task_id = tasks.id
+                              AND active_run.status = 'running'
+                              AND active_run.ended_at IS NULL
+                              AND active_run.claim_lock = ?
+                       )
+                    """,
+                    (
+                        task_id, int(expected_run_id),
+                        expected_claim_token, expected_claim_token,
+                    ),
+                ).fetchone()
+                if current_authority is None:
+                    return False
+                verified_cards, phantom_cards = _verify_created_cards(
+                    conn, task_id, created_cards
                 )
-            raise HallucinatedCardsError(phantom_cards, task_id)
+                if phantom_cards:
+                    _append_event(
+                        conn, task_id, "completion_blocked_hallucination",
+                        {
+                            "phantom_cards": phantom_cards,
+                            "verified_cards": verified_cards,
+                            "summary_preview": (
+                                (summary or result or "").strip().splitlines()[0][:200]
+                                if (summary or result)
+                                else None
+                            ),
+                        },
+                    )
+                    hallucination_error = HallucinatedCardsError(
+                        phantom_cards, task_id
+                    )
+            if hallucination_error is not None:
+                raise hallucination_error
+        else:
+            verified_cards, phantom_cards = _verify_created_cards(
+                conn, task_id, created_cards
+            )
+            if phantom_cards:
+                with write_txn(conn):
+                    _append_event(
+                        conn, task_id, "completion_blocked_hallucination",
+                        {
+                            "phantom_cards": phantom_cards,
+                            "verified_cards": verified_cards,
+                            "summary_preview": (
+                                (summary or result or "").strip().splitlines()[0][:200]
+                                if (summary or result)
+                                else None
+                            ),
+                        },
+                    )
+                raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
 
@@ -4667,7 +4741,40 @@ def complete_task(
         conn, task_id, metadata, summary=summary, result=result,
     )
     with write_txn(conn):
-        if expected_run_id is None:
+        if worker_authority:
+            if expected_run_id is None or int(expected_run_id) <= 0:
+                return False
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'done',
+                       result       = ?,
+                       completed_at = ?,
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL,
+                       block_kind   = NULL,
+                       block_recurrences = 0
+                 WHERE id = ?
+                   AND status = 'running'
+                   AND current_run_id = ?
+                   AND claim_lock = ?
+                   AND EXISTS (
+                       SELECT 1
+                         FROM task_runs AS active_run
+                        WHERE active_run.id = tasks.current_run_id
+                          AND active_run.task_id = tasks.id
+                          AND active_run.status = 'running'
+                          AND active_run.ended_at IS NULL
+                          AND active_run.claim_lock = ?
+                   )
+                """,
+                (
+                    result, now, task_id, int(expected_run_id),
+                    expected_claim_token, expected_claim_token,
+                ),
+            )
+        elif expected_run_id is None:
             cur = conn.execute(
                 """
                 UPDATE tasks
@@ -4742,6 +4849,7 @@ def complete_task(
         completed_payload: dict = {
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
+            "authority_mode": authority_mode.value,
         }
         if verified_cards:
             completed_payload["verified_cards"] = verified_cards

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2883,33 +2883,40 @@ def record_delegation_receipt(
     )
     with write_txn(conn):
         if allow_legacy_running_task:
-            authority = conn.execute(
-                "SELECT id FROM tasks WHERE id=? AND status IN ('ready','running')",
-                (task_id,),
-            ).fetchone()
-        elif expected_run_id is None or not expected_claim_token:
-            return {"status": "conflict", "reason": "worker authority is required"}
-        else:
-            authority = conn.execute(
-                """SELECT t.id
-                     FROM tasks AS t
-                     JOIN task_runs AS r
-                       ON r.id=t.current_run_id AND r.task_id=t.id
-                    WHERE t.id=? AND t.status='running'
-                      AND t.current_run_id=? AND t.claim_lock=?
-                      AND r.status='running' AND r.ended_at IS NULL
-                      AND r.claim_lock=?
-                      AND (? IS NULL OR t.workflow_template_id=?)
-                      AND (? IS NULL OR t.current_step_key=?)
-                      AND (? IS NULL OR t.assignee=?)""",
-                (
-                    task_id, int(expected_run_id), expected_claim_token,
-                    expected_claim_token,
-                    expected_workflow_id, expected_workflow_id,
-                    expected_step_key, expected_step_key,
-                    expected_lane, expected_lane,
-                ),
-            ).fetchone()
+            return {
+                "status": "conflict",
+                "reason": "legacy task state is not receipt authority",
+            }
+        if (
+            expected_run_id is None
+            or not expected_claim_token
+            or not expected_workflow_id
+            or not expected_step_key
+            or not expected_lane
+        ):
+            return {"status": "conflict", "reason": "complete worker authority is required"}
+        authority = conn.execute(
+            """SELECT t.id
+                 FROM tasks AS t
+                 JOIN task_runs AS r
+                   ON r.id=t.current_run_id AND r.task_id=t.id
+                WHERE t.id=? AND t.status='running'
+                  AND t.current_run_id=? AND t.claim_lock=?
+                  AND r.status='running' AND r.ended_at IS NULL
+                  AND r.claim_lock=?
+                  AND t.workflow_template_id=?
+                  AND t.current_step_key=?
+                  AND t.assignee=?""",
+            (
+                task_id,
+                int(expected_run_id),
+                expected_claim_token,
+                expected_claim_token,
+                expected_workflow_id,
+                expected_step_key,
+                expected_lane,
+            ),
+        ).fetchone()
         if authority is None:
             return {"status": "conflict", "reason": "worker authority is stale or mismatched"}
         row = conn.execute(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1309,6 +1309,84 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Task-2 workflow acceptance state.  These records are additive and immutable:
+-- ordinary task status/result fields remain backwards compatible, while a
+-- workflow verifier edge consults only these kernel-created records.
+CREATE TABLE IF NOT EXISTS accepted_handoffs (
+    id                         TEXT PRIMARY KEY,
+    workflow_step_attempt_id   TEXT NOT NULL UNIQUE,
+    implementation_task_id     TEXT NOT NULL,
+    implementation_run_id      INTEGER NOT NULL,
+    implementation_event_id    INTEGER NOT NULL,
+    verifier_task_id            TEXT NOT NULL UNIQUE,
+    verifier_role               TEXT NOT NULL,
+    artifact_manifest_json      TEXT NOT NULL,
+    artifact_manifest_digest    TEXT NOT NULL,
+    source_revision             TEXT NOT NULL,
+    baseline_manifest_digest    TEXT,
+    acceptance_contract_hash    TEXT NOT NULL,
+    route_gate_json             TEXT,
+    created_at                  INTEGER NOT NULL,
+    UNIQUE (implementation_task_id, implementation_run_id, implementation_event_id)
+);
+
+CREATE TABLE IF NOT EXISTS verifier_pass_receipts (
+    id                          TEXT PRIMARY KEY,
+    verifier_task_id            TEXT NOT NULL UNIQUE,
+    verifier_run_id             INTEGER NOT NULL UNIQUE,
+    verifier_role               TEXT NOT NULL,
+    accepted_handoff_id         TEXT NOT NULL UNIQUE,
+    workflow_step_attempt_id    TEXT NOT NULL,
+    parent_run_id               INTEGER NOT NULL,
+    parent_event_id             INTEGER NOT NULL,
+    artifact_manifest_digest    TEXT NOT NULL,
+    recomputed_manifest_digest  TEXT NOT NULL,
+    source_revision             TEXT NOT NULL,
+    baseline_manifest_digest    TEXT,
+    acceptance_contract_hash    TEXT NOT NULL,
+    predecessor_versions_json   TEXT NOT NULL,
+    route_telemetry_json        TEXT,
+    outcome                     TEXT NOT NULL CHECK (outcome = 'PASS'),
+    receipt_version             INTEGER NOT NULL CHECK (receipt_version > 0),
+    created_at                  INTEGER NOT NULL
+);
+
+-- Exact parent/link/status/result/receipt state captured atomically with claim.
+-- The JSON is canonical and content-addressed so direct SQL changes are caught
+-- even when they bypass a version-incrementing application path.
+CREATE TABLE IF NOT EXISTS task_run_prerequisite_sets (
+    run_id          INTEGER PRIMARY KEY,
+    task_id         TEXT NOT NULL,
+    snapshot_json   TEXT NOT NULL,
+    snapshot_digest TEXT NOT NULL,
+    created_at      INTEGER NOT NULL
+);
+
+CREATE TRIGGER IF NOT EXISTS accepted_handoffs_immutable_update
+BEFORE UPDATE ON accepted_handoffs BEGIN
+    SELECT RAISE(ABORT, 'accepted handoff is immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS accepted_handoffs_immutable_delete
+BEFORE DELETE ON accepted_handoffs BEGIN
+    SELECT RAISE(ABORT, 'accepted handoff is immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS verifier_pass_receipts_immutable_update
+BEFORE UPDATE ON verifier_pass_receipts BEGIN
+    SELECT RAISE(ABORT, 'verifier PASS receipt is immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS verifier_pass_receipts_immutable_delete
+BEFORE DELETE ON verifier_pass_receipts BEGIN
+    SELECT RAISE(ABORT, 'verifier PASS receipt is immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS task_run_prerequisite_sets_immutable_update
+BEFORE UPDATE ON task_run_prerequisite_sets BEGIN
+    SELECT RAISE(ABORT, 'prerequisite snapshot is immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS task_run_prerequisite_sets_immutable_delete
+BEFORE DELETE ON task_run_prerequisite_sets BEGIN
+    SELECT RAISE(ABORT, 'prerequisite snapshot is immutable');
+END;
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -1319,6 +1397,9 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_handoffs_verifier     ON accepted_handoffs(verifier_task_id);
+CREATE INDEX IF NOT EXISTS idx_verifier_receipts_task ON verifier_pass_receipts(verifier_task_id, receipt_version);
+CREATE INDEX IF NOT EXISTS idx_prerequisite_task      ON task_run_prerequisite_sets(task_id, run_id);
 """
 
 
@@ -2795,6 +2876,8 @@ def create_task(
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
+    workflow_template_id: Optional[str] = None,
+    current_step_key: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
@@ -3090,8 +3173,9 @@ def create_task(
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id,
+                        workflow_template_id, current_step_key
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3116,12 +3200,23 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        workflow_template_id,
+                        current_step_key,
                     ),
                 )
                 for pid in parents:
                     conn.execute(
                         "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
                         (pid, task_id),
+                    )
+                if (
+                    task_status not in {"blocked", "triage"}
+                    and not _prerequisites_satisfied(conn, task_id)
+                ):
+                    task_status = "todo"
+                    conn.execute(
+                        "UPDATE tasks SET status = 'todo' WHERE id = ?",
+                        (task_id,),
                     )
                 _append_event(
                     conn,
@@ -3333,10 +3428,7 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             (parent_id, child_id),
         )
         # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
+        if not _prerequisites_satisfied(conn, child_id):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
@@ -3858,6 +3950,157 @@ def _synthesize_ended_run(
 # Dependency resolution (todo -> ready)
 # ---------------------------------------------------------------------------
 
+def _canonical_json(value: Any) -> str:
+    """Serialize a kernel record deterministically for hashing/comparison."""
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _workflow_verifier_edge(
+    conn: sqlite3.Connection, parent_id: str, child_id: str,
+) -> bool:
+    """Return whether ``parent -> child`` is a workflow verification edge."""
+    row = conn.execute(
+        """
+        SELECT p.workflow_template_id AS parent_workflow,
+               p.current_step_key AS parent_step,
+               c.workflow_template_id AS child_workflow
+          FROM tasks AS p
+          JOIN tasks AS c ON c.id = ?
+         WHERE p.id = ?
+        """,
+        (child_id, parent_id),
+    ).fetchone()
+    return bool(
+        row
+        and row["parent_workflow"]
+        and row["parent_workflow"] == row["child_workflow"]
+        and row["parent_step"] == "verify"
+    )
+
+
+def _valid_verifier_receipt(
+    conn: sqlite3.Connection, verifier_task_id: str,
+) -> Optional[sqlite3.Row]:
+    """Return the immutable, internally consistent current PASS receipt."""
+    return conn.execute(
+        """
+        SELECT r.*
+          FROM verifier_pass_receipts AS r
+          JOIN accepted_handoffs AS h ON h.id = r.accepted_handoff_id
+          JOIN tasks AS verifier ON verifier.id = r.verifier_task_id
+         WHERE r.verifier_task_id = ?
+           AND r.outcome = 'PASS'
+           AND verifier.status IN ('done', 'archived')
+           AND verifier.current_step_key = 'verify'
+           AND h.verifier_task_id = r.verifier_task_id
+           AND h.workflow_step_attempt_id = r.workflow_step_attempt_id
+           AND h.implementation_run_id = r.parent_run_id
+           AND h.implementation_event_id = r.parent_event_id
+           AND h.artifact_manifest_digest = r.artifact_manifest_digest
+           AND r.artifact_manifest_digest = r.recomputed_manifest_digest
+           AND h.source_revision = r.source_revision
+           AND h.acceptance_contract_hash = r.acceptance_contract_hash
+           AND COALESCE(h.baseline_manifest_digest, '') =
+               COALESCE(r.baseline_manifest_digest, '')
+         LIMIT 1
+        """,
+        (verifier_task_id,),
+    ).fetchone()
+
+
+def _prerequisites_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Kernel eligibility predicate for ordinary and verifier dependencies."""
+    parents = conn.execute(
+        """
+        SELECT p.id, p.status
+          FROM task_links AS l
+          JOIN tasks AS p ON p.id = l.parent_id
+         WHERE l.child_id = ?
+         ORDER BY p.id
+        """,
+        (task_id,),
+    ).fetchall()
+    for parent in parents:
+        if parent["status"] not in ("done", "archived"):
+            return False
+        if _workflow_verifier_edge(conn, parent["id"], task_id):
+            if _valid_verifier_receipt(conn, parent["id"]) is None:
+                return False
+    return True
+
+
+def _prerequisite_snapshot(conn: sqlite3.Connection, task_id: str) -> list[dict]:
+    """Return exact current graph/state/receipt versions for ``task_id``."""
+    rows = conn.execute(
+        """
+        SELECT p.id, p.status, p.result, p.workflow_template_id, p.current_step_key
+          FROM task_links AS l
+          JOIN tasks AS p ON p.id = l.parent_id
+         WHERE l.child_id = ?
+         ORDER BY p.id
+        """,
+        (task_id,),
+    ).fetchall()
+    snapshot: list[dict] = []
+    for parent in rows:
+        is_verifier = _workflow_verifier_edge(conn, parent["id"], task_id)
+        receipt = _valid_verifier_receipt(conn, parent["id"]) if is_verifier else None
+        result_value = parent["result"]
+        snapshot.append(
+            {
+                "parent_id": parent["id"],
+                "status": parent["status"],
+                "result_digest": (
+                    _sha256_text(str(result_value)) if result_value is not None else None
+                ),
+                "workflow_template_id": parent["workflow_template_id"],
+                "step_key": parent["current_step_key"],
+                "verification_dependency": is_verifier,
+                "receipt_id": receipt["id"] if receipt else None,
+                "receipt_version": int(receipt["receipt_version"]) if receipt else None,
+                "accepted_handoff_id": receipt["accepted_handoff_id"] if receipt else None,
+            }
+        )
+    return snapshot
+
+
+def _capture_prerequisite_snapshot(
+    conn: sqlite3.Connection, task_id: str, run_id: int, *, created_at: int,
+) -> None:
+    snapshot_json = _canonical_json(_prerequisite_snapshot(conn, task_id))
+    conn.execute(
+        """
+        INSERT INTO task_run_prerequisite_sets
+            (run_id, task_id, snapshot_json, snapshot_digest, created_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (run_id, task_id, snapshot_json, _sha256_text(snapshot_json), created_at),
+    )
+
+
+def _captured_prerequisites_are_current(
+    conn: sqlite3.Connection, task_id: str, run_id: int,
+) -> bool:
+    captured = conn.execute(
+        "SELECT snapshot_json, snapshot_digest FROM task_run_prerequisite_sets "
+        "WHERE run_id = ? AND task_id = ?",
+        (run_id, task_id),
+    ).fetchone()
+    # Compatibility for attempts that predate the additive migration. New
+    # claims always capture a row; old in-flight attempts keep their old rules.
+    if captured is None:
+        return True
+    current_json = _canonical_json(_prerequisite_snapshot(conn, task_id))
+    return (
+        captured["snapshot_json"] == current_json
+        and captured["snapshot_digest"] == _sha256_text(current_json)
+        and _prerequisites_satisfied(conn, task_id)
+    )
+
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return True when ``task_id`` is sticky-blocked by an explicit
     worker/operator ``kanban_block`` call (#28712).
@@ -3944,13 +4187,7 @@ def recompute_ready(
                 # legitimate exit (it emits ``"unblocked"`` which flips
                 # this predicate back).
                 continue
-            parents = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            if _prerequisites_satisfied(conn, task_id):
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
                     # circuit-breaker failure limit.  Without this
@@ -4011,13 +4248,7 @@ def claim_task(
         # 'todo' here — recompute_ready will re-promote when the parents
         # actually finish. See RCA at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone = conn.execute(
-            "SELECT 1 FROM task_links l "
-            "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
-            (task_id,),
-        ).fetchone()
-        if undone:
+        if not _prerequisites_satisfied(conn, task_id):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "
                 "WHERE id = ? AND status = 'ready'",
@@ -4025,7 +4256,7 @@ def claim_task(
             )
             _append_event(
                 conn, task_id, "claim_rejected",
-                {"reason": "parents_not_done"},
+                {"reason": "prerequisites_not_current"},
             )
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
@@ -4088,10 +4319,15 @@ def claim_task(
                 now,
             ),
         )
-        run_id = run_cur.lastrowid
+        run_id = int(run_cur.lastrowid or 0)
+        if run_id <= 0:
+            raise RuntimeError("failed to create task run")
         conn.execute(
             "UPDATE tasks SET current_run_id = ? WHERE id = ?",
             (run_id, task_id),
+        )
+        _capture_prerequisite_snapshot(
+            conn, task_id, int(run_id), created_at=now,
         )
         _append_event(
             conn, task_id, "claimed",
@@ -4121,9 +4357,8 @@ def claim_review_task(
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``review`` status).
 
-    Unlike ``claim_task`` (which handles ``ready -> running``), this
-    does NOT check parent dependencies — the task already passed that
-    gate on its original ``todo -> ready -> running`` transition.
+    Parent state is revalidated because a workflow prerequisite may have been
+    reopened or superseded while the task waited in review.
 
     Creates a new run entry so the review agent's lifecycle is tracked
     independently from the original worker run.
@@ -4132,6 +4367,12 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        if not _prerequisites_satisfied(conn, task_id):
+            _append_event(
+                conn, task_id, "claim_rejected",
+                {"reason": "prerequisites_not_current", "source_status": "review"},
+            )
+            return None
         cur = conn.execute(
             """
             UPDATE tasks
@@ -4170,10 +4411,15 @@ def claim_review_task(
                 now,
             ),
         )
-        run_id = run_cur.lastrowid
+        run_id = int(run_cur.lastrowid or 0)
+        if run_id <= 0:
+            raise RuntimeError("failed to create review run")
         conn.execute(
             "UPDATE tasks SET current_run_id = ? WHERE id = ?",
             (run_id, task_id),
+        )
+        _capture_prerequisite_snapshot(
+            conn, task_id, run_id, created_at=now,
         )
         _append_event(
             conn, task_id, "claimed",
@@ -4597,6 +4843,364 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+def _canonical_artifact_manifest(manifest: Iterable[dict]) -> tuple[str, str]:
+    """Validate and content-address a frozen-workspace-relative manifest."""
+    normalized: list[dict] = []
+    seen: set[str] = set()
+    for raw in manifest:
+        if not isinstance(raw, dict):
+            raise ValueError("artifact manifest entries must be objects")
+        path = str(raw.get("path") or "").strip().replace("\\", "/")
+        parts = tuple(part for part in path.split("/") if part not in ("", "."))
+        if (
+            not path
+            or path.startswith("/")
+            or any(part == ".." for part in parts)
+            or ":" in parts[0]
+        ):
+            raise ValueError("artifact paths must be frozen-workspace-relative")
+        canonical_path = "/".join(parts)
+        if canonical_path in seen:
+            raise ValueError(f"duplicate artifact path: {canonical_path}")
+        seen.add(canonical_path)
+        kind = str(raw.get("type") or "").strip().lower()
+        if kind not in {"file", "symlink", "missing"}:
+            raise ValueError(f"unsupported artifact type for {canonical_path}: {kind!r}")
+        size = raw.get("size")
+        digest = raw.get("sha256")
+        target = raw.get("target")
+        if kind == "file":
+            if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+                raise ValueError(f"invalid artifact size for {canonical_path}")
+            if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+                raise ValueError(f"invalid artifact SHA-256 for {canonical_path}")
+            entry = {"path": canonical_path, "type": kind, "size": size, "sha256": digest}
+        elif kind == "symlink":
+            if not isinstance(target, str) or not target:
+                raise ValueError(f"symlink target required for {canonical_path}")
+            entry = {"path": canonical_path, "type": kind, "target": target}
+        else:
+            entry = {"path": canonical_path, "type": kind}
+        normalized.append(entry)
+    if not normalized:
+        raise ValueError("artifact manifest must contain at least one entry")
+    normalized.sort(key=lambda entry: entry["path"])
+    canonical = _canonical_json(normalized)
+    return canonical, _sha256_text(canonical)
+
+
+def record_accepted_handoff(
+    conn: sqlite3.Connection,
+    *,
+    workflow_step_attempt_id: str,
+    implementation_task_id: str,
+    implementation_run_id: int,
+    implementation_event_id: int,
+    verifier_task_id: str,
+    verifier_role: str,
+    artifact_manifest: Iterable[dict],
+    source_revision: str,
+    baseline_manifest_digest: Optional[str],
+    acceptance_contract_hash: str,
+    route_gate: Optional[dict] = None,
+) -> str:
+    """Persist one immutable implementation handoff for one step attempt.
+
+    This is acceptance state, not the cross-database delivery bridge from Task
+    3. The caller supplies already-durable source identities; the kernel binds
+    them once to the predeclared verifier and canonical evidence contract.
+    """
+    step_attempt = str(workflow_step_attempt_id).strip()
+    role = str(verifier_role).strip()
+    if not step_attempt or not role or not source_revision or not acceptance_contract_hash:
+        raise ValueError("step attempt, verifier role, revision, and contract are required")
+    manifest_json, manifest_digest = _canonical_artifact_manifest(artifact_manifest)
+    route_gate_json = _canonical_json(route_gate) if route_gate is not None else None
+    now = int(time.time())
+    handoff_id = "ah_" + secrets.token_hex(16)
+    with write_txn(conn):
+        if conn.execute(
+            "SELECT 1 FROM accepted_handoffs WHERE workflow_step_attempt_id = ?",
+            (step_attempt,),
+        ).fetchone():
+            raise sqlite3.IntegrityError(
+                "one accepted handoff is allowed per workflow step attempt"
+            )
+        evidence = conn.execute(
+            """
+            SELECT t.status AS task_status, r.task_id AS run_task,
+                   r.outcome AS run_outcome, e.task_id AS event_task,
+                   e.run_id AS event_run, e.kind AS event_kind
+              FROM tasks AS t
+              JOIN task_runs AS r ON r.id = ?
+              JOIN task_events AS e ON e.id = ?
+             WHERE t.id = ?
+            """,
+            (int(implementation_run_id), int(implementation_event_id), implementation_task_id),
+        ).fetchone()
+        verifier = conn.execute(
+            "SELECT assignee, current_step_key, workflow_template_id FROM tasks WHERE id = ?",
+            (verifier_task_id,),
+        ).fetchone()
+        implementation = conn.execute(
+            "SELECT workflow_template_id FROM tasks WHERE id = ?",
+            (implementation_task_id,),
+        ).fetchone()
+        if not evidence or not verifier or not implementation:
+            raise ValueError("handoff source or verifier task does not exist")
+        if not (
+            evidence["task_status"] in ("done", "archived")
+            and evidence["run_task"] == implementation_task_id
+            and evidence["run_outcome"] == "completed"
+            and evidence["event_task"] == implementation_task_id
+            and int(evidence["event_run"] or 0) == int(implementation_run_id)
+            and evidence["event_kind"] == "completed"
+            and verifier["current_step_key"] == "verify"
+            and verifier["assignee"] == role
+            and verifier["workflow_template_id"]
+            and verifier["workflow_template_id"] == implementation["workflow_template_id"]
+        ):
+            raise ValueError("handoff source/run/event or verifier authority is not exact")
+        conn.execute(
+            """
+            INSERT INTO accepted_handoffs (
+                id, workflow_step_attempt_id, implementation_task_id,
+                implementation_run_id, implementation_event_id,
+                verifier_task_id, verifier_role, artifact_manifest_json,
+                artifact_manifest_digest, source_revision,
+                baseline_manifest_digest, acceptance_contract_hash,
+                route_gate_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                handoff_id, step_attempt, implementation_task_id,
+                int(implementation_run_id), int(implementation_event_id),
+                verifier_task_id, role, manifest_json, manifest_digest,
+                str(source_revision), baseline_manifest_digest,
+                str(acceptance_contract_hash), route_gate_json, now,
+            ),
+        )
+        _append_event(
+            conn,
+            verifier_task_id,
+            "accepted_handoff",
+            {
+                "accepted_handoff_id": handoff_id,
+                "workflow_step_attempt_id": step_attempt,
+                "artifact_manifest_digest": manifest_digest,
+            },
+        )
+    return handoff_id
+
+
+def _record_verifier_rework_in_txn(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: str,
+    now: int,
+) -> None:
+    """Deterministically persist a failed verifier gate as REWORK."""
+    row = conn.execute(
+        "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    run_id = int(row["current_run_id"]) if row and row["current_run_id"] else None
+    conn.execute(
+        """
+        UPDATE tasks
+           SET status = 'blocked', result = ?, completed_at = NULL,
+               claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+         WHERE id = ? AND status IN ('ready', 'running', 'blocked')
+        """,
+        (f"REWORK: {reason}", task_id),
+    )
+    if run_id is not None:
+        conn.execute(
+            """
+            UPDATE task_runs
+               SET status = 'blocked', outcome = 'rework', ended_at = ?,
+                   summary = ?, claim_lock = NULL, claim_expires = NULL,
+                   worker_pid = NULL
+             WHERE id = ? AND task_id = ? AND ended_at IS NULL
+            """,
+            (now, reason, run_id, task_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,),
+        )
+    _append_event(
+        conn, task_id, "verifier_rework", {"reason": reason}, run_id=run_id,
+    )
+
+
+def _route_telemetry_matches(route_gate_json: Optional[str], telemetry: Optional[dict]) -> bool:
+    if route_gate_json is None:
+        return True
+    if not isinstance(telemetry, dict):
+        return False
+    try:
+        gate = json.loads(route_gate_json)
+    except (TypeError, ValueError):
+        return False
+    requested_provider = gate.get("requested_provider")
+    requested_model = gate.get("requested_model")
+    return bool(
+        requested_provider
+        and requested_model
+        and telemetry.get("requested_provider") == requested_provider
+        and telemetry.get("requested_model") == requested_model
+        and telemetry.get("actual_provider") == requested_provider
+        and telemetry.get("actual_model") == requested_model
+        and telemetry.get("fallback_index") == 0
+        and telemetry.get("fallback_reason") in (None, "")
+    )
+
+
+def record_verifier_pass(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: int,
+    expected_claim_token: str,
+    verifier_role: str,
+    accepted_handoff_id: str,
+    artifact_manifest: Iterable[dict],
+    source_revision: str,
+    baseline_manifest_digest: Optional[str],
+    acceptance_contract_hash: str,
+    route_telemetry: Optional[dict] = None,
+) -> Optional[str]:
+    """Validate the full verifier predicate and atomically mint one PASS receipt."""
+    manifest_json, recomputed_digest = _canonical_artifact_manifest(artifact_manifest)
+    del manifest_json  # digest is the independently recomputed comparison value
+    now = int(time.time())
+    receipt_id = "vpr_" + secrets.token_hex(16)
+    mismatch_reason: Optional[str] = None
+    run_id = int(expected_run_id)
+    with write_txn(conn):
+        task = conn.execute(
+            """
+            SELECT assignee, current_step_key, workflow_template_id
+              FROM tasks
+             WHERE id = ? AND status = 'running' AND current_run_id = ?
+               AND claim_lock = ?
+               AND EXISTS (
+                   SELECT 1 FROM task_runs AS r
+                    WHERE r.id = tasks.current_run_id AND r.task_id = tasks.id
+                      AND r.status = 'running' AND r.ended_at IS NULL
+                      AND r.claim_lock = ?
+               )
+            """,
+            (task_id, run_id, expected_claim_token, expected_claim_token),
+        ).fetchone()
+        handoff = conn.execute(
+            "SELECT * FROM accepted_handoffs WHERE id = ? AND verifier_task_id = ?",
+            (accepted_handoff_id, task_id),
+        ).fetchone()
+        if task is None:
+            return None
+        if handoff is None:
+            mismatch_reason = "accepted_handoff_mismatch"
+        elif task["current_step_key"] != "verify":
+            mismatch_reason = "verifier_step_mismatch"
+        elif task["assignee"] != verifier_role or handoff["verifier_role"] != verifier_role:
+            mismatch_reason = "verifier_role_mismatch"
+        elif handoff["artifact_manifest_digest"] != recomputed_digest:
+            mismatch_reason = "artifact_manifest_mismatch"
+        elif handoff["source_revision"] != source_revision:
+            mismatch_reason = "source_revision_mismatch"
+        elif (handoff["baseline_manifest_digest"] or None) != (baseline_manifest_digest or None):
+            mismatch_reason = "baseline_manifest_mismatch"
+        elif handoff["acceptance_contract_hash"] != acceptance_contract_hash:
+            mismatch_reason = "acceptance_contract_mismatch"
+        elif not _captured_prerequisites_are_current(conn, task_id, run_id):
+            mismatch_reason = "predecessor_versions_stale"
+        elif not _route_telemetry_matches(handoff["route_gate_json"], route_telemetry):
+            mismatch_reason = "route_telemetry_mismatch"
+        if mismatch_reason is not None:
+            _record_verifier_rework_in_txn(
+                conn, task_id, reason=mismatch_reason, now=now,
+            )
+            return None
+        assert handoff is not None
+
+        captured = conn.execute(
+            "SELECT snapshot_json FROM task_run_prerequisite_sets WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        predecessor_versions_json = captured["snapshot_json"] if captured else "[]"
+        conn.execute(
+            """
+            INSERT INTO verifier_pass_receipts (
+                id, verifier_task_id, verifier_run_id, verifier_role,
+                accepted_handoff_id, workflow_step_attempt_id,
+                parent_run_id, parent_event_id, artifact_manifest_digest,
+                recomputed_manifest_digest, source_revision,
+                baseline_manifest_digest, acceptance_contract_hash,
+                predecessor_versions_json, route_telemetry_json,
+                outcome, receipt_version, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'PASS', 1, ?)
+            """,
+            (
+                receipt_id, task_id, run_id, verifier_role,
+                accepted_handoff_id, handoff["workflow_step_attempt_id"],
+                int(handoff["implementation_run_id"]),
+                int(handoff["implementation_event_id"]),
+                handoff["artifact_manifest_digest"], recomputed_digest,
+                source_revision, baseline_manifest_digest,
+                acceptance_contract_hash, predecessor_versions_json,
+                _canonical_json(route_telemetry) if route_telemetry is not None else None,
+                now,
+            ),
+        )
+        updated = conn.execute(
+            """
+            UPDATE tasks
+               SET status = 'done', result = 'PASS', completed_at = ?,
+                   claim_lock = NULL, claim_expires = NULL, worker_pid = NULL,
+                   block_kind = NULL, block_recurrences = 0
+             WHERE id = ? AND status = 'running' AND current_run_id = ?
+            """,
+            (now, task_id, run_id),
+        )
+        if updated.rowcount != 1:
+            raise RuntimeError("verifier terminal CAS lost after authority validation")
+        conn.execute(
+            """
+            UPDATE task_runs
+               SET status = 'done', outcome = 'completed', ended_at = ?,
+                   summary = 'PASS', claim_lock = NULL, claim_expires = NULL,
+                   worker_pid = NULL
+             WHERE id = ? AND task_id = ? AND status = 'running' AND ended_at IS NULL
+            """,
+            (now, run_id, task_id),
+        )
+        conn.execute("UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,))
+        _append_event(
+            conn,
+            task_id,
+            "verifier_pass",
+            {
+                "receipt_id": receipt_id,
+                "accepted_handoff_id": accepted_handoff_id,
+                "receipt_version": 1,
+                "artifact_manifest_digest": recomputed_digest,
+            },
+            run_id=run_id,
+        )
+        _append_event(
+            conn,
+            task_id,
+            "completed",
+            {"result_len": 4, "summary": "PASS", "authority_mode": "kernel_verifier"},
+            run_id=run_id,
+        )
+    recompute_ready(conn)
+    _clear_failure_counter(conn, task_id)
+    _cleanup_workspace(conn, task_id)
+    return receipt_id
+
+
 class CompletionAuthority(str, Enum):
     """Explicit authority used for a terminal task completion."""
 
@@ -4659,6 +5263,29 @@ def complete_task(
             and expected_claim_token is not None
         )
     )
+
+    # PASS-looking prose/metadata is never receipt authority. For an opted-in
+    # verifier task, process the attempted terminal action as deterministic
+    # REWORK while preserving ``True`` as the legacy command's "handled"
+    # signal. Only ``record_verifier_pass`` can mint the immutable receipt.
+    if isinstance(metadata, dict) and metadata.get("verifier_outcome") == "PASS":
+        verifier_row = conn.execute(
+            "SELECT workflow_template_id, current_step_key FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if (
+            verifier_row
+            and verifier_row["workflow_template_id"]
+            and verifier_row["current_step_key"] == "verify"
+        ):
+            with write_txn(conn):
+                _record_verifier_rework_in_txn(
+                    conn,
+                    task_id,
+                    reason="kernel_verifier_receipt_required",
+                    now=now,
+                )
+            return True
 
     # A worker must prove exact task/run/task-claim/run-row-claim authority
     # under BEGIN IMMEDIATE before its phantom-card rejection audit can write.
@@ -4743,6 +5370,37 @@ def complete_task(
     with write_txn(conn):
         if worker_authority:
             if expected_run_id is None or int(expected_run_id) <= 0:
+                return False
+            current_authority = conn.execute(
+                """
+                SELECT 1 FROM tasks
+                 WHERE id = ? AND status = 'running' AND current_run_id = ?
+                   AND claim_lock = ?
+                   AND EXISTS (
+                       SELECT 1 FROM task_runs AS active_run
+                        WHERE active_run.id = tasks.current_run_id
+                          AND active_run.task_id = tasks.id
+                          AND active_run.status = 'running'
+                          AND active_run.ended_at IS NULL
+                          AND active_run.claim_lock = ?
+                   )
+                """,
+                (
+                    task_id, int(expected_run_id), expected_claim_token,
+                    expected_claim_token,
+                ),
+            ).fetchone()
+            if current_authority is None:
+                return False
+            if not _captured_prerequisites_are_current(
+                conn, task_id, int(expected_run_id),
+            ):
+                _record_verifier_rework_in_txn(
+                    conn,
+                    task_id,
+                    reason="predecessor_versions_stale",
+                    now=now,
+                )
                 return False
             cur = conn.execute(
                 """

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1247,6 +1247,48 @@ CREATE TABLE IF NOT EXISTS task_events (
     created_at INTEGER NOT NULL
 );
 
+-- Generic immutable acceptance evidence for any durable delegation terminal
+-- outcome.  Kept separate from PASS/workflow-specific receipt tables.
+CREATE TABLE IF NOT EXISTS delegation_receipts (
+    receipt_id       TEXT PRIMARY KEY,
+    logical_key      TEXT NOT NULL UNIQUE,
+    input_digest     TEXT NOT NULL,
+    delegation_id    TEXT NOT NULL,
+    execution_id     TEXT NOT NULL,
+    result_digest    TEXT NOT NULL,
+    terminal_status  TEXT NOT NULL,
+    result_json      TEXT NOT NULL,
+    task_id          TEXT NOT NULL,
+    continuation_id  TEXT NOT NULL UNIQUE,
+    created_at       INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS delegation_continuations (
+    continuation_id  TEXT PRIMARY KEY,
+    logical_key      TEXT NOT NULL UNIQUE,
+    receipt_id       TEXT NOT NULL UNIQUE,
+    task_id          TEXT NOT NULL,
+    state            TEXT NOT NULL CHECK (state = 'accepted'),
+    created_at       INTEGER NOT NULL
+);
+
+CREATE TRIGGER IF NOT EXISTS delegation_receipts_immutable_update
+BEFORE UPDATE ON delegation_receipts BEGIN
+    SELECT RAISE(ABORT, 'delegation receipt is immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS delegation_receipts_immutable_delete
+BEFORE DELETE ON delegation_receipts BEGIN
+    SELECT RAISE(ABORT, 'delegation receipt is immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS delegation_continuations_immutable_update
+BEFORE UPDATE ON delegation_continuations BEGIN
+    SELECT RAISE(ABORT, 'delegation continuation is immutable');
+END;
+CREATE TRIGGER IF NOT EXISTS delegation_continuations_immutable_delete
+BEFORE DELETE ON delegation_continuations BEGIN
+    SELECT RAISE(ABORT, 'delegation continuation is immutable');
+END;
+
 -- Historical attempt record. Each time the dispatcher claims a task, a
 -- new row is created here; claim state, PID, heartbeat, runtime cap,
 -- and structured summary all live on the run, not the task. Multiple
@@ -2812,6 +2854,96 @@ def write_txn(conn: sqlite3.Connection):
         _check_file_length_invariant(conn)
 
 
+def record_delegation_receipt(
+    conn: sqlite3.Connection,
+    *,
+    logical_key: str,
+    input_digest: str,
+    delegation_id: str,
+    execution_id: str,
+    result_digest: str,
+    terminal_status: str,
+    result: dict[str, Any],
+    task_id: str,
+) -> dict[str, Any]:
+    """Create or validate one receipt/event/continuation atomic unit."""
+    key_bytes = logical_key.encode("utf-8")
+    receipt_id = "dr_" + hashlib.sha256(b"receipt\0" + key_bytes).hexdigest()[:24]
+    continuation_id = "dc_" + hashlib.sha256(b"continuation\0" + key_bytes).hexdigest()[:24]
+    result_json = json.dumps(result, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    expected = (
+        receipt_id, logical_key, input_digest, delegation_id, execution_id,
+        result_digest, terminal_status, result_json, task_id, continuation_id,
+    )
+    with write_txn(conn):
+        if conn.execute("SELECT 1 FROM tasks WHERE id=?", (task_id,)).fetchone() is None:
+            return {"status": "conflict", "reason": "target task does not exist"}
+        row = conn.execute(
+            """SELECT receipt_id, logical_key, input_digest, delegation_id,
+                      execution_id, result_digest, terminal_status, result_json,
+                      task_id, continuation_id
+               FROM delegation_receipts WHERE logical_key=?""",
+            (logical_key,),
+        ).fetchone()
+        if row is not None:
+            if tuple(row) != expected:
+                return {"status": "conflict", "reason": "immutable receipt identity mismatch"}
+            continuation = conn.execute(
+                """SELECT continuation_id, logical_key, receipt_id, task_id, state
+                   FROM delegation_continuations WHERE logical_key=?""",
+                (logical_key,),
+            ).fetchone()
+            events = conn.execute(
+                "SELECT payload FROM task_events WHERE task_id=? AND kind='delegation_receipted'",
+                (task_id,),
+            ).fetchall()
+            matching_events = sum(
+                json.loads(payload or "{}").get("logical_key") == logical_key
+                for (payload,) in events
+            )
+            if tuple(continuation or ()) != (
+                continuation_id, logical_key, receipt_id, task_id, "accepted"
+            ) or matching_events != 1:
+                return {"status": "conflict", "reason": "partial receipt atomic unit"}
+            return {
+                "status": "replayed", "receipt_id": receipt_id,
+                "continuation_id": continuation_id,
+            }
+
+        now = int(time.time())
+        conn.execute(
+            """INSERT INTO delegation_receipts
+               (receipt_id, logical_key, input_digest, delegation_id,
+                execution_id, result_digest, terminal_status, result_json,
+                task_id, continuation_id, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (*expected, now),
+        )
+        payload = json.dumps(
+            {
+                "logical_key": logical_key, "receipt_id": receipt_id,
+                "delegation_id": delegation_id, "execution_id": execution_id,
+                "result_digest": result_digest, "continuation_id": continuation_id,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) VALUES (?, 'delegation_receipted', ?, ?)",
+            (task_id, payload, now),
+        )
+        conn.execute(
+            """INSERT INTO delegation_continuations
+               (continuation_id, logical_key, receipt_id, task_id, state, created_at)
+               VALUES (?, ?, ?, ?, 'accepted', ?)""",
+            (continuation_id, logical_key, receipt_id, task_id, now),
+        )
+        return {
+            "status": "committed", "receipt_id": receipt_id,
+            "continuation_id": continuation_id,
+        }
+
+
 # ---------------------------------------------------------------------------
 # ID generation
 # ---------------------------------------------------------------------------
@@ -4090,10 +4222,19 @@ def _captured_prerequisites_are_current(
         "WHERE run_id = ? AND task_id = ?",
         (run_id, task_id),
     ).fetchone()
-    # Compatibility for attempts that predate the additive migration. New
-    # claims always capture a row; old in-flight attempts keep their old rules.
     if captured is None:
-        return True
+        # Additive rollout compatibility is safe only for ordinary legacy DAG
+        # runs. A pre-existing workflow run with predecessors has no frozen
+        # version baseline and therefore must fail closed at terminal time.
+        workflow = conn.execute(
+            "SELECT workflow_template_id FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        has_parents = conn.execute(
+            "SELECT 1 FROM task_links WHERE child_id = ? LIMIT 1", (task_id,),
+        ).fetchone()
+        return not bool(
+            workflow and workflow["workflow_template_id"] and has_parents
+        )
     current_json = _canonical_json(_prerequisite_snapshot(conn, task_id))
     return (
         captured["snapshot_json"] == current_json

--- a/run_agent.py
+++ b/run_agent.py
@@ -6498,6 +6498,7 @@ class AIAgent:
         invocation paths (concurrent, sequential, inline).
         """
         from tools.delegate_tool import (
+            _kernel_bridge_authority_context,
             _strip_model_hidden_task_fields,
             delegate_task as _delegate_task,
         )
@@ -6520,6 +6521,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            bridge_authority_context=_kernel_bridge_authority_context(self),
             parent_agent=self,
         )
 

--- a/tests/hermes_cli/test_kanban_verifier_gate.py
+++ b/tests/hermes_cli/test_kanban_verifier_gate.py
@@ -1,0 +1,248 @@
+"""Task 2 RED contract: kernel verifier PASS and prerequisite versions.
+
+These tests deliberately exercise only disposable SQLite databases.  They
+freeze the security boundary before production code exists: a verification
+edge is not satisfied by a task status, completion metadata, or another
+mutation surface.  Every failing assertion on the Task-1 baseline identifies
+an unsafe eligibility/completion path, rather than an import or fixture error.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+WORKFLOW = "task2-verifier-gate-v1"
+ACCEPTANCE_CONTRACT_HASH = "sha256:acceptance-v1"
+SOURCE_REVISION = "4b399c477c8b78a34b08456618a8580653c41003"
+MANIFEST_HASH = "sha256:canonical-manifest-v1"
+HANDOFF_ID = "handoff-immutable-1"
+PREDECESSOR_RECEIPT_VERSION = 7
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db_path = tmp_path / "task2-red.db"
+    connection = kb.connect(db_path)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _verification_graph(conn):
+    """Create a v2-tagged verifier -> successor edge using existing kernel fields."""
+    verifier = kb.create_task(conn, title="independent verifier", assignee="gauge")
+    successor = kb.create_task(
+        conn,
+        title="integration successor",
+        assignee="circuit",
+        parents=[verifier],
+    )
+    conn.execute(
+        "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+        (WORKFLOW, "verify", verifier),
+    )
+    conn.execute(
+        "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+        (WORKFLOW, "integrate", successor),
+    )
+    conn.commit()
+    assert kb.get_task(conn, verifier).status == "ready"
+    assert kb.get_task(conn, successor).status == "todo"
+    return verifier, successor
+
+
+def _generic_complete(conn, verifier):
+    assert kb.complete_task(conn, verifier, result="PASS")
+
+
+def _manual_complete(conn, verifier):
+    assert kb.complete_task(
+        conn, verifier, result="PASS", authority_mode=kb.CompletionAuthority.LEGACY
+    )
+
+
+def _orchestrator_complete(conn, verifier):
+    assert kb.complete_task(
+        conn,
+        verifier,
+        result="PASS",
+        authority_mode=kb.CompletionAuthority.ORCHESTRATOR,
+    )
+
+
+def _metadata_pass(conn, verifier):
+    """Models API/dashboard/AgentOS/bulk callers forwarding claimed PASS metadata."""
+    assert kb.complete_task(
+        conn,
+        verifier,
+        result="PASS",
+        metadata={
+            "verifier_outcome": "PASS",
+            "verifier_role": "gauge",
+            "handoff_id": HANDOFF_ID,
+            "manifest_hash": MANIFEST_HASH,
+            "source_revision": SOURCE_REVISION,
+            "acceptance_contract_hash": ACCEPTANCE_CONTRACT_HASH,
+            "predecessor_receipt_versions": [PREDECESSOR_RECEIPT_VERSION],
+        },
+        authority_mode=kb.CompletionAuthority.ORCHESTRATOR,
+    )
+
+
+def _archive(conn, verifier):
+    assert kb.archive_task(conn, verifier)
+
+
+def _direct_sql(conn, verifier):
+    conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (verifier,))
+    conn.commit()
+    kb.recompute_ready(conn)
+
+
+BYPASS_ACTIONS: dict[str, Callable] = {
+    "generic-complete": _generic_complete,
+    "manual-cli-complete": _manual_complete,
+    "api-complete": _metadata_pass,
+    "dashboard-agentos-complete": _metadata_pass,
+    "bulk-complete": _orchestrator_complete,
+    "direct-orchestrator-complete": _orchestrator_complete,
+    "archive": _archive,
+    "direct-sql-status-repair": _direct_sql,
+}
+
+
+@pytest.mark.parametrize("surface", BYPASS_ACTIONS, ids=BYPASS_ACTIONS)
+def test_generic_mutation_surface_cannot_unlock_verification_dependency(conn, surface):
+    verifier, successor = _verification_graph(conn)
+
+    BYPASS_ACTIONS[surface](conn, verifier)
+
+    assert kb.get_task(conn, successor).status == "todo", (
+        f"{surface} bypassed the kernel verifier-PASS receipt predicate"
+    )
+    assert kb.claim_task(conn, successor, claimer="must-not-claim") is None
+
+
+@pytest.mark.parametrize(
+    "mismatch,wrong_value",
+    [
+        ("source_revision", "wrong-revision"),
+        ("manifest_hash", "sha256:wrong-manifest"),
+        ("acceptance_contract_hash", "sha256:wrong-contract"),
+        ("predecessor_receipt_versions", [PREDECESSOR_RECEIPT_VERSION - 1]),
+    ],
+)
+def test_purported_pass_mismatch_deterministically_enters_rework(
+    conn, mismatch, wrong_value
+):
+    verifier, successor = _verification_graph(conn)
+    metadata = {
+        "verifier_outcome": "PASS",
+        "verifier_role": "gauge",
+        "verifier_run_id": "verifier-run-1",
+        "handoff_id": HANDOFF_ID,
+        "manifest_hash": MANIFEST_HASH,
+        "source_revision": SOURCE_REVISION,
+        "acceptance_contract_hash": ACCEPTANCE_CONTRACT_HASH,
+        "predecessor_receipt_versions": [PREDECESSOR_RECEIPT_VERSION],
+    }
+    metadata[mismatch] = wrong_value
+
+    kb.complete_task(
+        conn,
+        verifier,
+        result="PASS",
+        metadata=metadata,
+        authority_mode=kb.CompletionAuthority.ORCHESTRATOR,
+    )
+
+    assert kb.get_task(conn, verifier).status != "done", (
+        f"{mismatch} mismatch was accepted instead of entering REWORK"
+    )
+    assert kb.get_task(conn, successor).status == "todo"
+    assert any(event.kind == "verifier_rework" for event in kb.list_events(conn, verifier))
+
+
+def _claimed_running_descendant(conn):
+    """Claim under ordinary dependency rules, then opt into verifier identity.
+
+    The setup must remain reachable after the generic verifier-bypass defect is
+    fixed.  Therefore the predecessor is completed while it is still an
+    ordinary legacy dependency; only after its descendant is running do we tag
+    the graph as the workflow verifier edge whose stability is under test.
+    """
+    predecessor = kb.create_task(conn, title="ordinary predecessor")
+    descendant = kb.create_task(
+        conn,
+        title="running integration descendant",
+        assignee="circuit",
+        parents=[predecessor],
+    )
+    assert kb.get_task(conn, predecessor).status == "ready"
+    assert kb.get_task(conn, descendant).status == "todo"
+    assert kb.complete_task(
+        conn,
+        predecessor,
+        result="ordinary legacy completion",
+        authority_mode=kb.CompletionAuthority.LEGACY,
+    )
+    running = kb.claim_task(conn, descendant, claimer="descendant-claim")
+    assert running is not None
+    run_id = kb.get_task(conn, descendant).current_run_id
+    assert run_id is not None
+
+    conn.execute(
+        "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+        (WORKFLOW, "verify", predecessor),
+    )
+    conn.execute(
+        "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+        (WORKFLOW, "integrate", descendant),
+    )
+    conn.commit()
+    return predecessor, descendant, run_id
+
+
+@pytest.mark.parametrize("mutation", ["reopened", "relinked", "receipt-version-changed"])
+def test_running_descendant_cannot_complete_after_predecessor_mutation(conn, mutation):
+    predecessor, descendant, run_id = _claimed_running_descendant(conn)
+
+    if mutation == "reopened":
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (predecessor,))
+    elif mutation == "relinked":
+        replacement = kb.create_task(conn, title="replacement predecessor")
+        conn.execute(
+            "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (predecessor, descendant),
+        )
+        conn.execute(
+            "INSERT INTO task_links(parent_id, child_id) VALUES (?, ?)",
+            (replacement, descendant),
+        )
+    else:
+        conn.execute(
+            "UPDATE tasks SET result = ? WHERE id = ?",
+            ("receipt-version-8", predecessor),
+        )
+    conn.commit()
+
+    completed = kb.complete_task(
+        conn,
+        descendant,
+        result="must be invalidated",
+        expected_run_id=run_id,
+        expected_claim_token="descendant-claim",
+        authority_mode=kb.CompletionAuthority.WORKER,
+    )
+
+    assert completed is False, (
+        f"running descendant completed after predecessor was {mutation}"
+    )
+    assert kb.get_task(conn, descendant).status != "done"

--- a/tests/hermes_cli/test_kanban_verifier_gate_positive.py
+++ b/tests/hermes_cli/test_kanban_verifier_gate_positive.py
@@ -1,0 +1,377 @@
+"""Implementer-owned positive and schema tests for the Task 2 verifier gate.
+
+All databases are disposable ``tmp_path`` fixtures.  The independently frozen
+negative contract remains in ``test_kanban_verifier_gate.py`` and is not edited
+here.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+WORKFLOW = "task2-positive-v1"
+STEP_ATTEMPT = "task2-positive-v1/implement/1"
+REVISION = "4b399c477c8b78a34b08456618a8580653c41003"
+BASELINE = "sha256:" + "b" * 64
+CONTRACT = "sha256:" + "c" * 64
+MANIFEST = [
+    {
+        "path": "src/example.py",
+        "type": "file",
+        "size": 12,
+        "sha256": "a" * 64,
+    }
+]
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    connection = kb.connect(tmp_path / "task2-positive.db")
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _positive_graph(conn):
+    implementation = kb.create_task(conn, title="implementation", assignee="circuit")
+    claimed_impl = kb.claim_task(conn, implementation, claimer="implementation-claim")
+    assert claimed_impl is not None
+    implementation_run_id = kb.get_task(conn, implementation).current_run_id
+    assert implementation_run_id is not None
+    assert kb.complete_task(
+        conn,
+        implementation,
+        result="implementation complete",
+        expected_run_id=implementation_run_id,
+        expected_claim_token="implementation-claim",
+        authority_mode=kb.CompletionAuthority.WORKER,
+    )
+    implementation_event_id = next(
+        event.id
+        for event in reversed(kb.list_events(conn, implementation))
+        if event.kind == "completed"
+    )
+
+    verifier = kb.create_task(
+        conn,
+        title="independent verifier",
+        assignee="gauge",
+        parents=[implementation],
+    )
+    successor = kb.create_task(
+        conn,
+        title="integration successor",
+        assignee="circuit",
+        parents=[verifier],
+    )
+    conn.execute(
+        "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+        (WORKFLOW, "implement", implementation),
+    )
+    conn.execute(
+        "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+        (WORKFLOW, "verify", verifier),
+    )
+    conn.execute(
+        "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+        (WORKFLOW, "integrate", successor),
+    )
+    conn.commit()
+
+    handoff_id = kb.record_accepted_handoff(
+        conn,
+        workflow_step_attempt_id=STEP_ATTEMPT,
+        implementation_task_id=implementation,
+        implementation_run_id=implementation_run_id,
+        implementation_event_id=implementation_event_id,
+        verifier_task_id=verifier,
+        verifier_role="gauge",
+        artifact_manifest=MANIFEST,
+        source_revision=REVISION,
+        baseline_manifest_digest=BASELINE,
+        acceptance_contract_hash=CONTRACT,
+    )
+    claimed_verifier = kb.claim_task(conn, verifier, claimer="verifier-claim")
+    assert claimed_verifier is not None
+    verifier_run_id = kb.get_task(conn, verifier).current_run_id
+    assert verifier_run_id is not None
+    return verifier, successor, verifier_run_id, handoff_id
+
+
+def _record_pass(conn, verifier, verifier_run_id, handoff_id, **overrides):
+    payload = {
+        "verifier_role": "gauge",
+        "accepted_handoff_id": handoff_id,
+        "artifact_manifest": MANIFEST,
+        "source_revision": REVISION,
+        "baseline_manifest_digest": BASELINE,
+        "acceptance_contract_hash": CONTRACT,
+    }
+    payload.update(overrides)
+    return kb.record_verifier_pass(
+        conn,
+        verifier,
+        expected_run_id=verifier_run_id,
+        expected_claim_token="verifier-claim",
+        **payload,
+    )
+
+
+def test_additive_schema_has_immutable_receipts_and_prerequisite_snapshots(conn):
+    tables = {
+        row["name"]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+    assert {
+        "accepted_handoffs",
+        "verifier_pass_receipts",
+        "task_run_prerequisite_sets",
+    } <= tables
+
+    triggers = {
+        row["name"]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'trigger'")
+    }
+    assert {
+        "accepted_handoffs_immutable_update",
+        "accepted_handoffs_immutable_delete",
+        "verifier_pass_receipts_immutable_update",
+        "verifier_pass_receipts_immutable_delete",
+        "task_run_prerequisite_sets_immutable_update",
+        "task_run_prerequisite_sets_immutable_delete",
+    } <= triggers
+
+
+def test_task2_schema_migration_is_idempotent_and_preserves_existing_rows(tmp_path: Path):
+    db_path = tmp_path / "pre-task2.db"
+    connection = kb.connect(db_path)
+    legacy_task = kb.create_task(connection, title="preserve me", assignee="circuit")
+    connection.executescript(
+        """
+        DROP TRIGGER task_run_prerequisite_sets_immutable_delete;
+        DROP TRIGGER task_run_prerequisite_sets_immutable_update;
+        DROP TRIGGER verifier_pass_receipts_immutable_delete;
+        DROP TRIGGER verifier_pass_receipts_immutable_update;
+        DROP TRIGGER accepted_handoffs_immutable_delete;
+        DROP TRIGGER accepted_handoffs_immutable_update;
+        DROP TABLE task_run_prerequisite_sets;
+        DROP TABLE verifier_pass_receipts;
+        DROP TABLE accepted_handoffs;
+        """
+    )
+    connection.close()
+    with kb._INIT_LOCK:
+        kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    kb.init_db(db_path)
+    kb.init_db(db_path)
+
+    migrated = kb.connect(db_path)
+    try:
+        preserved = kb.get_task(migrated, legacy_task)
+        assert preserved is not None
+        assert preserved.title == "preserve me"
+        tables = {
+            row["name"]
+            for row in migrated.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        assert {
+            "accepted_handoffs",
+            "verifier_pass_receipts",
+            "task_run_prerequisite_sets",
+        } <= tables
+        assert migrated.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert migrated.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        migrated.close()
+
+
+def test_accepted_handoff_is_unique_per_step_attempt_and_database_immutable(conn):
+    verifier, _, _, handoff_id = _positive_graph(conn)
+    row = conn.execute(
+        "SELECT * FROM accepted_handoffs WHERE id = ?", (handoff_id,)
+    ).fetchone()
+    assert row["workflow_step_attempt_id"] == STEP_ATTEMPT
+    assert json.loads(row["artifact_manifest_json"]) == MANIFEST
+
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        conn.execute(
+            "UPDATE accepted_handoffs SET verifier_task_id = ? WHERE id = ?",
+            ("different", handoff_id),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        conn.execute("DELETE FROM accepted_handoffs WHERE id = ?", (handoff_id,))
+
+    with pytest.raises(sqlite3.IntegrityError):
+        kb.record_accepted_handoff(
+            conn,
+            workflow_step_attempt_id=STEP_ATTEMPT,
+            implementation_task_id=verifier,
+            implementation_run_id=999,
+            implementation_event_id=999,
+            verifier_task_id=verifier,
+            verifier_role="gauge",
+            artifact_manifest=MANIFEST,
+            source_revision=REVISION,
+            baseline_manifest_digest=BASELINE,
+            acceptance_contract_hash=CONTRACT,
+        )
+
+
+def test_kernel_created_exact_verifier_pass_unlocks_only_predeclared_successor(conn):
+    verifier, successor, verifier_run_id, handoff_id = _positive_graph(conn)
+
+    receipt_id = _record_pass(conn, verifier, verifier_run_id, handoff_id)
+
+    assert receipt_id.startswith("vpr_")
+    assert kb.get_task(conn, verifier).status == "done"
+    assert kb.get_task(conn, successor).status == "ready"
+    receipt = conn.execute(
+        "SELECT * FROM verifier_pass_receipts WHERE id = ?", (receipt_id,)
+    ).fetchone()
+    assert receipt["accepted_handoff_id"] == handoff_id
+    assert receipt["outcome"] == "PASS"
+    assert receipt["receipt_version"] == 1
+    assert kb.claim_task(conn, successor, claimer="successor-claim") is not None
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("verifier_role", "circuit"),
+        ("source_revision", "wrong-revision"),
+        ("baseline_manifest_digest", "sha256:" + "0" * 64),
+        ("acceptance_contract_hash", "sha256:" + "1" * 64),
+        (
+            "artifact_manifest",
+            [{"path": "src/example.py", "type": "file", "size": 12, "sha256": "d" * 64}],
+        ),
+    ],
+)
+def test_kernel_pass_mismatch_records_rework_and_no_receipt(conn, field, value):
+    verifier, successor, verifier_run_id, handoff_id = _positive_graph(conn)
+
+    receipt_id = _record_pass(
+        conn, verifier, verifier_run_id, handoff_id, **{field: value}
+    )
+
+    assert receipt_id is None
+    assert kb.get_task(conn, verifier).status == "blocked"
+    assert kb.get_task(conn, successor).status == "todo"
+    assert conn.execute("SELECT count(*) FROM verifier_pass_receipts").fetchone()[0] == 0
+    assert any(event.kind == "verifier_rework" for event in kb.list_events(conn, verifier))
+
+
+def test_route_gated_handoff_requires_exact_runtime_telemetry(conn):
+    implementation = kb.create_task(conn, title="route implementation", assignee="circuit")
+    run = kb.claim_task(conn, implementation, claimer="route-impl")
+    assert run is not None
+    implementation_run_id = kb.get_task(conn, implementation).current_run_id
+    assert kb.complete_task(
+        conn,
+        implementation,
+        result="done",
+        expected_run_id=implementation_run_id,
+        expected_claim_token="route-impl",
+        authority_mode=kb.CompletionAuthority.WORKER,
+    )
+    implementation_event_id = next(
+        event.id
+        for event in reversed(kb.list_events(conn, implementation))
+        if event.kind == "completed"
+    )
+    verifier = kb.create_task(conn, title="route verifier", assignee="gauge", parents=[implementation])
+    successor = kb.create_task(conn, title="route successor", parents=[verifier])
+    for task, step in ((implementation, "implement"), (verifier, "verify"), (successor, "integrate")):
+        conn.execute(
+            "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+            (WORKFLOW + "-route", step, task),
+        )
+    conn.commit()
+    handoff_id = kb.record_accepted_handoff(
+        conn,
+        workflow_step_attempt_id=STEP_ATTEMPT + "-route",
+        implementation_task_id=implementation,
+        implementation_run_id=implementation_run_id,
+        implementation_event_id=implementation_event_id,
+        verifier_task_id=verifier,
+        verifier_role="gauge",
+        artifact_manifest=MANIFEST,
+        source_revision=REVISION,
+        baseline_manifest_digest=BASELINE,
+        acceptance_contract_hash=CONTRACT,
+        route_gate={"requested_provider": "openai-codex", "requested_model": "gpt-5.6-sol"},
+    )
+    assert kb.claim_task(conn, verifier, claimer="route-verifier") is not None
+    verifier_run_id = kb.get_task(conn, verifier).current_run_id
+
+    receipt = kb.record_verifier_pass(
+        conn,
+        verifier,
+        expected_run_id=verifier_run_id,
+        expected_claim_token="route-verifier",
+        verifier_role="gauge",
+        accepted_handoff_id=handoff_id,
+        artifact_manifest=MANIFEST,
+        source_revision=REVISION,
+        baseline_manifest_digest=BASELINE,
+        acceptance_contract_hash=CONTRACT,
+        route_telemetry={
+            "requested_provider": "openai-codex",
+            "requested_model": "gpt-5.6-sol",
+            "actual_provider": "other",
+            "actual_model": "gpt-5.6-sol",
+            "fallback_index": 0,
+        },
+    )
+
+    assert receipt is None
+    assert kb.get_task(conn, successor).status == "todo"
+
+
+def test_direct_sql_done_verifier_without_receipt_stays_unclaimable(conn):
+    verifier = kb.create_task(conn, title="sql verifier", assignee="gauge")
+    successor = kb.create_task(conn, title="sql successor", parents=[verifier])
+    for task, step in ((verifier, "verify"), (successor, "integrate")):
+        conn.execute(
+            "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+            (WORKFLOW + "-sql", step, task),
+        )
+    conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (verifier,))
+    conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (successor,))
+    conn.commit()
+
+    assert kb.claim_task(conn, successor, claimer="sql-bypass") is None
+    assert kb.get_task(conn, successor).status == "todo"
+
+
+def test_successor_completion_revalidates_captured_verifier_receipt_version(conn):
+    verifier, successor, verifier_run_id, handoff_id = _positive_graph(conn)
+    assert _record_pass(conn, verifier, verifier_run_id, handoff_id)
+    assert kb.claim_task(conn, successor, claimer="successor") is not None
+    successor_run_id = kb.get_task(conn, successor).current_run_id
+
+    # Direct status repair cannot delete the immutable receipt, but reopening the
+    # verifier makes the captured prerequisite set stale and must fail closed.
+    conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (verifier,))
+    conn.commit()
+
+    assert not kb.complete_task(
+        conn,
+        successor,
+        result="must not complete",
+        expected_run_id=successor_run_id,
+        expected_claim_token="successor",
+        authority_mode=kb.CompletionAuthority.WORKER,
+    )
+    assert kb.get_task(conn, successor).status != "done"

--- a/tests/hermes_cli/test_kanban_verifier_gate_positive.py
+++ b/tests/hermes_cli/test_kanban_verifier_gate_positive.py
@@ -374,4 +374,54 @@ def test_successor_completion_revalidates_captured_verifier_receipt_version(conn
         expected_claim_token="successor",
         authority_mode=kb.CompletionAuthority.WORKER,
     )
-    assert kb.get_task(conn, successor).status != "done"
+    final_successor = kb.get_task(conn, successor)
+    assert final_successor is not None
+    assert final_successor.status != "done"
+
+
+def test_predeployment_workflow_run_without_snapshot_fails_closed(conn):
+    verifier = kb.create_task(conn, title="legacy verifier", assignee="gauge")
+    conn.execute("UPDATE tasks SET status = 'done', result = 'PASS' WHERE id = ?", (verifier,))
+    successor = kb.create_task(conn, title="legacy successor", parents=[verifier])
+    for task, step in ((verifier, "verify"), (successor, "integrate")):
+        conn.execute(
+            "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+            (WORKFLOW + "-legacy", step, task),
+        )
+    # Simulate a run that was already active when the additive table appeared.
+    conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (successor,))
+    conn.commit()
+    assert kb.claim_task(conn, successor, claimer="legacy-successor") is None
+
+    # A pre-deployment run can exist with no snapshot row. Construct that exact
+    # legacy state and prove terminal completion does not receive compatibility
+    # authority merely because the additive row is absent.
+    now = 1_700_000_000
+    conn.execute(
+        """
+        INSERT INTO task_runs (task_id, profile, status, claim_lock, started_at)
+        VALUES (?, 'circuit', 'running', 'legacy-claim', ?)
+        """,
+        (successor, now),
+    )
+    run_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.execute(
+        """
+        UPDATE tasks SET status = 'running', current_run_id = ?, claim_lock = 'legacy-claim'
+        WHERE id = ?
+        """,
+        (run_id, successor),
+    )
+    conn.commit()
+
+    assert not kb.complete_task(
+        conn,
+        successor,
+        result="must fail closed",
+        expected_run_id=run_id,
+        expected_claim_token="legacy-claim",
+        authority_mode=kb.CompletionAuthority.WORKER,
+    )
+    final_successor = kb.get_task(conn, successor)
+    assert final_successor is not None
+    assert final_successor.status != "done"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -168,9 +168,15 @@ def worker_env(monkeypatch, tmp_path):
     try:
         tid = kb.create_task(conn, title="worker-test", assignee="test-worker")
         kb.claim_task(conn, tid)
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.current_run_id is not None
+        assert task.claim_lock is not None
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(task.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", task.claim_lock)
     return tid
 
 
@@ -642,9 +648,15 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
             body="Must achieve X with verified evidence.", goal_mode=True
         )
         kb.claim_task(conn, goal_task_id)
+        goal_task = kb.get_task(conn, goal_task_id)
+        assert goal_task is not None
+        assert goal_task.current_run_id is not None
+        assert goal_task.claim_lock is not None
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(goal_task.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", goal_task.claim_lock)
 
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
@@ -700,9 +712,15 @@ def test_complete_goal_mode_allows_when_judge_unavailable(monkeypatch, tmp_path)
             body="Must achieve X with verified evidence.", goal_mode=True
         )
         kb.claim_task(conn, goal_task_id)
+        goal_task = kb.get_task(conn, goal_task_id)
+        assert goal_task is not None
+        assert goal_task.current_run_id is not None
+        assert goal_task.claim_lock is not None
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(goal_task.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", goal_task.claim_lock)
 
     # No judge reachable. judge_goal must not even be consulted; if it were,
     # this stub would reject — so reaching "done" proves the probe short-circuit.
@@ -1959,6 +1977,394 @@ def test_worker_complete_own_task_still_works(worker_env):
     assert d.get("ok") is True and d.get("task_id") == worker_env
 
 
+CLAIM_TOKEN_MAX_BYTES = 512
+
+
+def _completion_authority_state(kb, task_id):
+    """Snapshot every task, run, claim-bearing, and event field for a task."""
+    with kb.connect() as conn:
+        task = dict(conn.execute(
+            "SELECT * FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone())
+        runs = [
+            dict(row) for row in conn.execute(
+                "SELECT * FROM task_runs WHERE task_id = ? ORDER BY id", (task_id,)
+            )
+        ]
+        events = [
+            dict(row) for row in conn.execute(
+                "SELECT * FROM task_events WHERE task_id = ? ORDER BY id", (task_id,)
+            )
+        ]
+    return {"task": task, "runs": runs, "events": events}
+
+
+def _assert_completion_rejected_without_mutation(response, before, after):
+    violations = []
+    if response.get("ok") is True:
+        violations.append(f"completion succeeded: {response}")
+    if after != before:
+        violations.append(
+            "task/run/claim/event state changed: "
+            f"before={before!r}, after={after!r}"
+        )
+    assert not violations, "; ".join(violations)
+
+
+def test_canonical_worker_marker_without_nonempty_task_scope_cannot_complete_explicit_task(
+    monkeypatch, worker_env
+):
+    """A declared canonical worker cannot downgrade to orchestrator authority."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, worker_env)
+    assert task is not None
+    assert task.current_run_id is not None
+    assert task.claim_lock is not None
+
+    monkeypatch.setenv("KANBAN_WORKER", "1")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("KANBAN_TASK_RUN_ID", str(task.current_run_id))
+    monkeypatch.setenv("KANBAN_CLAIM_TOKEN", task.claim_lock)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+
+    before = _completion_authority_state(kb, worker_env)
+    response = json.loads(kt._handle_complete({
+        "task_id": worker_env,
+        "summary": "must not become orchestrator",
+    }))
+    after = _completion_authority_state(kb, worker_env)
+
+    _assert_completion_rejected_without_mutation(response, before, after)
+
+
+def test_empty_legacy_task_scope_cannot_complete_explicit_task(
+    monkeypatch, worker_env
+):
+    """An empty compatibility task marker is invalid worker scope, not manual."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("KANBAN_WORKER", raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "")
+    monkeypatch.delenv("KANBAN_TASK_RUN_ID", raising=False)
+    monkeypatch.delenv("KANBAN_CLAIM_TOKEN", raising=False)
+
+    before = _completion_authority_state(kb, worker_env)
+    response = json.loads(kt._handle_complete({
+        "task_id": worker_env,
+        "summary": "empty scope must fail closed",
+    }))
+    after = _completion_authority_state(kb, worker_env)
+
+    _assert_completion_rejected_without_mutation(response, before, after)
+
+
+def test_worker_complete_accepts_canonical_run_and_claim_aliases(
+    monkeypatch, worker_env
+):
+    """Canonical run/claim names identify a valid task-scoped worker."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, worker_env)
+    assert task is not None
+    assert task.current_run_id is not None
+    assert task.claim_lock is not None
+
+    monkeypatch.setenv("KANBAN_WORKER", "1")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", worker_env)
+    monkeypatch.setenv("KANBAN_TASK_RUN_ID", str(task.current_run_id))
+    monkeypatch.setenv("KANBAN_CLAIM_TOKEN", task.claim_lock)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+
+    response = json.loads(kt._handle_complete({
+        "task_id": worker_env,
+        "summary": "canonical worker completion",
+    }))
+
+    assert response.get("ok") is True, response
+    with kb.connect() as conn:
+        completed = [
+            event for event in kb.list_events(conn, worker_env)
+            if event.kind == "completed"
+        ]
+    assert len(completed) == 1
+    assert (completed[0].payload or {})["authority_mode"] == "worker"
+
+
+@pytest.mark.parametrize(
+    "conflicting_identity",
+    [
+        pytest.param("run-id", id="run-id"),
+        pytest.param("claim-token", id="claim-token"),
+    ],
+)
+def test_worker_complete_rejects_conflicting_canonical_and_legacy_identity_without_mutation(
+    monkeypatch, worker_env, conflicting_identity
+):
+    """Compatibility aliases must agree; conflicts cannot select one silently."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, worker_env)
+    assert task is not None
+    assert task.current_run_id is not None
+    assert task.claim_lock is not None
+
+    monkeypatch.setenv("KANBAN_WORKER", "1")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", worker_env)
+    monkeypatch.setenv("KANBAN_TASK_RUN_ID", str(task.current_run_id))
+    monkeypatch.setenv("KANBAN_CLAIM_TOKEN", task.claim_lock)
+    if conflicting_identity == "run-id":
+        monkeypatch.setenv("KANBAN_TASK_RUN_ID", str(task.current_run_id + 1))
+    else:
+        monkeypatch.setenv(
+            "KANBAN_CLAIM_TOKEN", "syntactically-valid-conflicting-claim"
+        )
+
+    before = _completion_authority_state(kb, worker_env)
+    response = json.loads(kt._handle_complete({
+        "task_id": worker_env,
+        "summary": "conflicting identity must fail closed",
+    }))
+    after = _completion_authority_state(kb, worker_env)
+
+    _assert_completion_rejected_without_mutation(response, before, after)
+
+
+@pytest.mark.parametrize(
+    ("run_authority", "claim_authority"),
+    [
+        pytest.param("stale", "current", id="stale-run-current-claim"),
+        pytest.param("current", "wrong", id="current-run-wrong-claim"),
+        pytest.param("stale", "stale", id="stale-run-stale-claim"),
+    ],
+)
+def test_worker_complete_with_phantom_card_rejects_stale_authority_without_mutation(
+    monkeypatch, worker_env, run_authority, claim_authority
+):
+    """Unauthorized phantom-card attempts cannot write before authority CAS."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    with kb.connect() as conn:
+        stale_task = kb.get_task(conn, worker_env)
+        stale_run = kb.latest_run(conn, worker_env)
+        assert stale_task is not None and stale_task.claim_lock is not None
+        assert stale_run is not None
+        kb._set_worker_pid(conn, worker_env, 98765)
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+        assert kb.detect_crashed_workers(conn) == [worker_env]
+        current_task = kb.claim_task(
+            conn, worker_env, claimer="deterministic-current-claim"
+        )
+        current_run = kb.latest_run(conn, worker_env)
+        assert current_task is not None and current_task.claim_lock is not None
+        assert current_run is not None
+        assert current_run.id != stale_run.id
+        assert current_task.claim_lock != stale_task.claim_lock
+
+    run_id = stale_run.id if run_authority == "stale" else current_run.id
+    if claim_authority == "current":
+        claim_token = current_task.claim_lock
+    elif claim_authority == "stale":
+        claim_token = stale_task.claim_lock
+    else:
+        claim_token = "syntactically-valid-wrong-claim"
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claim_token)
+
+    before = _completion_authority_state(kb, worker_env)
+    response = json.loads(kt._handle_complete({
+        "summary": "obsolete worker completion",
+        "created_cards": ["t_deadbeefcafe"],
+    }))
+    after = _completion_authority_state(kb, worker_env)
+
+    assert response.get("ok") is not True
+    assert after == before, (
+        "stale or mixed worker authority mutated task/run/claim/events; "
+        f"event kinds changed from {[e['kind'] for e in before['events']]} "
+        f"to {[e['kind'] for e in after['events']]}"
+    )
+
+
+def test_worker_completion_event_records_worker_authority(worker_env):
+    """Successful tool-path worker completion is durably attributable."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    response = json.loads(kt._handle_complete({"summary": "worker complete"}))
+    assert response.get("ok") is True
+    with kb.connect() as conn:
+        completed = [
+            event for event in kb.list_events(conn, worker_env)
+            if event.kind == "completed"
+        ]
+    assert len(completed) == 1
+    payload = completed[0].payload or {}
+    assert payload["authority_mode"] == "worker"
+
+
+def test_orchestrator_completion_event_records_orchestrator_authority(
+    monkeypatch, tmp_path
+):
+    """Explicit orchestrator completion is durably distinct from a worker."""
+    monkeypatch.delenv("KANBAN_WORKER", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("KANBAN_TASK_RUN_ID", raising=False)
+    monkeypatch.delenv("KANBAN_CLAIM_TOKEN", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="explicit orchestrator completion")
+
+    response = json.loads(kt._handle_complete({
+        "task_id": task_id,
+        "summary": "orchestrator complete",
+    }))
+    assert response.get("ok") is True
+    with kb.connect() as conn:
+        completed = [
+            event for event in kb.list_events(conn, task_id)
+            if event.kind == "completed"
+        ]
+    assert len(completed) == 1
+    payload = completed[0].payload or {}
+    assert payload["authority_mode"] == "orchestrator"
+
+
+@pytest.mark.parametrize(
+    "malformed_claim",
+    [
+        pytest.param("padded", id="padded"),
+        pytest.param("control-character", id="control-character"),
+        pytest.param("over-limit", id="over-512-byte-limit"),
+    ],
+)
+def test_worker_complete_rejects_malformed_claim_token_without_mutation(
+    monkeypatch, worker_env, malformed_claim
+):
+    """Malformed claims are parse rejections, never orchestrator authority."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, worker_env)
+    assert task is not None and task.claim_lock is not None
+    if malformed_claim == "padded":
+        claim_token = f" {task.claim_lock} "
+    elif malformed_claim == "control-character":
+        claim_token = f"{task.claim_lock}\x1fblocked"
+    else:
+        claim_token = "x" * (CLAIM_TOKEN_MAX_BYTES + 1)
+        assert len(claim_token.encode("utf-8")) == 513
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claim_token)
+
+    before = _completion_authority_state(kb, worker_env)
+    response = json.loads(kt._handle_complete({"summary": "must be rejected"}))
+    after = _completion_authority_state(kb, worker_env)
+
+    assert response.get("ok") is not True
+    assert after == before
+    assert "claim token" in response.get("error", ""), response
+
+
+@pytest.mark.parametrize(
+    ("run_identity", "claim_identity"),
+    [
+        pytest.param(None, "current", id="missing-run-id"),
+        pytest.param("not-an-integer", "current", id="malformed-run-id"),
+        pytest.param("current", None, id="missing-claim-token"),
+        pytest.param("current", "other-host:999999", id="invalid-claim-token"),
+    ],
+)
+def test_worker_complete_fails_closed_without_current_run_and_claim_identity(
+    monkeypatch, worker_env, run_identity, claim_identity
+):
+    """Worker completion requires both identities and leaves no terminal trace."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    with kb.connect() as conn:
+        before = kb.get_task(conn, worker_env)
+        before_events = [event.id for event in kb.list_events(conn, worker_env)]
+        before_run = kb.latest_run(conn, worker_env)
+    assert before is not None
+    assert before.current_run_id is not None
+    assert before.claim_lock is not None
+    assert before_run is not None
+
+    # HERMES_KANBAN_TASK is the existing worker-context marker. The two
+    # dispatcher-provided values below are the current source names for the
+    # contract's KANBAN_TASK_RUN_ID and KANBAN_CLAIM_TOKEN identities.
+    monkeypatch.setenv("KANBAN_WORKER", "1")
+    if run_identity is None:
+        monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    else:
+        monkeypatch.setenv(
+            "HERMES_KANBAN_RUN_ID",
+            str(before.current_run_id) if run_identity == "current" else run_identity,
+        )
+    if claim_identity is None:
+        monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    else:
+        monkeypatch.setenv(
+            "HERMES_KANBAN_CLAIM_LOCK",
+            before.claim_lock if claim_identity == "current" else claim_identity,
+        )
+
+    response = json.loads(kt._handle_complete({"summary": "must be rejected"}))
+
+    with kb.connect() as conn:
+        after = kb.get_task(conn, worker_env)
+        after_events = [event.id for event in kb.list_events(conn, worker_env)]
+        after_run = kb.latest_run(conn, worker_env)
+    assert after is not None
+    assert after_run is not None
+
+    violations = []
+    if response.get("ok") is True:
+        violations.append(f"completion succeeded: {response}")
+    if after.status != "running":
+        violations.append(f"task status changed: running -> {after.status}")
+    if after.current_run_id != before.current_run_id:
+        violations.append(
+            f"current run changed: {before.current_run_id} -> {after.current_run_id}"
+        )
+    if after.claim_lock != before.claim_lock:
+        violations.append(f"claim changed: {before.claim_lock!r} -> {after.claim_lock!r}")
+    if after_events != before_events:
+        violations.append(f"events changed: {before_events} -> {after_events}")
+    if after_run.status != before_run.status or after_run.outcome != before_run.outcome:
+        violations.append(
+            "run became terminal: "
+            f"status {before_run.status!r} -> {after_run.status!r}, "
+            f"outcome {before_run.outcome!r} -> {after_run.outcome!r}"
+        )
+
+    assert not violations, "; ".join(violations)
+
+
 def test_worker_complete_rejects_stale_run_id(worker_env, monkeypatch):
     """A retried worker cannot complete the task using an old run token."""
     from hermes_cli import kanban_db as kb
@@ -1982,7 +2388,10 @@ def test_worker_complete_rejects_stale_run_id(worker_env, monkeypatch):
 
         kb.claim_task(conn, worker_env)
         run2 = kb.latest_run(conn, worker_env)
+        task2 = kb.get_task(conn, worker_env)
         assert run2.id != run1.id
+        assert task2 is not None
+        assert task2.claim_lock is not None
     finally:
         conn.close()
 
@@ -2001,6 +2410,7 @@ def test_worker_complete_rejects_stale_run_id(worker_env, monkeypatch):
         conn.close()
 
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run2.id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", task2.claim_lock)
     out = kt._handle_complete({"summary": "current completion"})
     d = json.loads(out)
     assert d.get("ok") is True

--- a/tests/tools/test_logical_dispatch_correction.py
+++ b/tests/tools/test_logical_dispatch_correction.py
@@ -1,0 +1,505 @@
+"""Focused regressions for the single Task-3 correction cycle."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from tools import async_delegation as ad
+
+
+@pytest.fixture(autouse=True)
+def isolated_stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    ad._reset_for_tests()
+    yield
+    ad._reset_for_tests()
+
+
+def _claimed_authority(board: Path, *, title: str = "bridge target"):
+    kb.init_db(board)
+    with kb.connect_closing(board) as conn:
+        task_id = kb.create_task(
+            conn,
+            title=title,
+            assignee="forge",
+            created_by="correction-test",
+            initial_status="running",
+        )
+        assert kb.claim_task(conn, task_id, claimer="bridge-claim") is not None
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.current_run_id is not None
+        conn.execute(
+            "UPDATE tasks SET workflow_template_id='workflow-v1', current_step_key='implement' WHERE id=?",
+            (task_id,),
+        )
+        conn.commit()
+    return ad.BridgeAuthorityContext(
+        kanban_db_path=str(board.resolve()),
+        workflow_id="workflow-v1",
+        step_key="implement",
+        step_attempt_id=f"workflow-v1/implement/{task.current_run_id}",
+        task_id=task_id,
+        run_id=task.current_run_id,
+        claim_token="bridge-claim",
+        lane="forge",
+        route="openai-codex/gpt-5.6-sol",
+        owner_id="parent-session",
+    )
+
+
+def _reserve_terminal(authority, result):
+    key = ad.canonical_logical_key(authority)
+    digest = ad.canonical_json_digest({"goal": "bounded receipt"})
+    reserved = ad.reserve_logical_delegation(
+        logical_key=key,
+        input_digest=digest,
+        goal="bounded receipt",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="gpt-5.6-sol",
+        authority_context=authority,
+    )
+    assert reserved["status"] == "reserved"
+    assert ad.claim_logical_delegation_launch(key, digest)
+    committed = ad.commit_logical_delegation_result(key, digest, result)
+    assert committed["state"] == "terminal_unattached"
+    return key, digest
+
+
+def test_receipt_requires_current_claim_and_stores_only_bounded_redacted_projection(tmp_path: Path):
+    board = tmp_path / "board.db"
+    authority = _claimed_authority(board)
+    secret = "OPENAI_API_KEY=" + "sk-" + ("x" * 300_000)
+    key, digest = _reserve_terminal(
+        authority,
+        {"status": "PASS", "summary": secret, "private": {"raw": secret}},
+    )
+
+    attached = ad.attach_logical_dispatch_receipt(
+        logical_key=key,
+        kanban_db_path=board,
+        task_id=authority.task_id,
+        acknowledge_source=False,
+    )
+
+    assert attached["status"] == "committed"
+    with sqlite3.connect(board) as conn:
+        row = conn.execute(
+            "SELECT input_digest, result_digest, result_json FROM delegation_receipts WHERE logical_key=?",
+            (key,),
+        ).fetchone()
+    assert row is not None
+    assert row[0] == digest
+    assert row[1].startswith("sha256:") and len(row[1]) == 71
+    assert len(row[2].encode("utf-8")) <= 8192
+    assert secret not in row[2]
+    projection = json.loads(row[2])
+    assert projection["source_pointer"].startswith("state.db:logical_delegations/")
+    assert projection["result_digest"] == row[1]
+
+    stale_board = tmp_path / "stale.db"
+    stale_authority = _claimed_authority(stale_board, title="stale target")
+    stale_key, _ = _reserve_terminal(stale_authority, {"status": "PASS", "summary": "ok"})
+    with kb.connect_closing(stale_board) as conn:
+        conn.execute(
+            "UPDATE tasks SET claim_lock='replacement-claim' WHERE id=?",
+            (stale_authority.task_id,),
+        )
+        conn.commit()
+    rejected = ad.attach_logical_dispatch_receipt(
+        logical_key=stale_key,
+        kanban_db_path=stale_board,
+        task_id=stale_authority.task_id,
+        acknowledge_source=False,
+    )
+    assert rejected["status"] == "conflict"
+    with sqlite3.connect(stale_board) as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM delegation_receipts WHERE logical_key=?", (stale_key,)
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM delegation_continuations WHERE logical_key=?", (stale_key,)
+        ).fetchone()[0] == 0
+
+
+def test_conflict_before_launch_executes_zero_runners():
+    original_lock = ad._records_lock
+    reached_launch = threading.Event()
+    release_launch = threading.Event()
+    runner_called = threading.Event()
+
+    class _FirstEntryGate:
+        def __init__(self, wrapped):
+            self.wrapped = wrapped
+            self.first = True
+
+        def __enter__(self):
+            if self.first:
+                self.first = False
+                reached_launch.set()
+                assert release_launch.wait(timeout=5)
+            self.wrapped.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            self.wrapped.release()
+            return False
+
+    ad._records_lock = _FirstEntryGate(original_lock)
+    dispatch_result = {}
+
+    def _runner():
+        runner_called.set()
+        return {"status": "PASS", "summary": "must not run"}
+
+    def _dispatch():
+        dispatch_result.update(
+            ad.dispatch_logical_delegation(
+                logical_key="race/key",
+                input_digest="sha256:original",
+                goal="race",
+                context=None,
+                toolsets=None,
+                role="leaf",
+                model="local",
+                session_key="forge",
+                parent_session_id="parent",
+                runner=_runner,
+                max_async_children=2,
+            )
+        )
+
+    thread = threading.Thread(target=_dispatch)
+    try:
+        thread.start()
+        assert reached_launch.wait(timeout=5)
+        conflict = ad.reserve_logical_delegation(
+            logical_key="race/key",
+            input_digest="sha256:conflict",
+            goal="conflict",
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model="local",
+        )
+        assert conflict["status"] == "quarantined"
+        release_launch.set()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+        time.sleep(0.05)
+        assert dispatch_result["status"] != "dispatched"
+        assert not runner_called.is_set()
+    finally:
+        release_launch.set()
+        thread.join(timeout=5)
+        ad._records_lock = original_lock
+
+
+def test_cross_board_attach_cas_mutates_exactly_one_target(tmp_path: Path):
+    key = "attach/race"
+    digest = "sha256:attach-race"
+    dispatched = ad.dispatch_logical_delegation(
+        logical_key=key,
+        input_digest=digest,
+        goal="attach once",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="local",
+        session_key="forge",
+        parent_session_id="parent",
+        runner=lambda: {"status": "PASS", "summary": "one execution"},
+    )
+    assert dispatched["status"] == "dispatched"
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        row = ad.get_logical_delegation(key)
+        if row and row["state"] == "terminal_unattached":
+            break
+        time.sleep(0.01)
+    else:
+        pytest.fail("logical dispatch did not become terminal")
+
+    targets = []
+    for label in ("a", "b"):
+        board = tmp_path / f"board-{label}.db"
+        kb.init_db(board)
+        with kb.connect_closing(board) as conn:
+            task_id = kb.create_task(conn, title=label, created_by="forge")
+        targets.append((label, board, task_id))
+
+    original_get = ad.get_logical_delegation
+    barrier = threading.Barrier(2)
+    first_reads = set()
+    first_reads_lock = threading.Lock()
+
+    def _synchronized_get(logical_key):
+        record = original_get(logical_key)
+        if threading.current_thread().name.startswith("attach-"):
+            ident = threading.get_ident()
+            with first_reads_lock:
+                first = ident not in first_reads
+                first_reads.add(ident)
+            if first:
+                barrier.wait(timeout=5)
+        return record
+
+    ad.get_logical_delegation = _synchronized_get
+    results = {}
+
+    def _attach(label, board, task_id):
+        results[label] = ad.attach_logical_dispatch_receipt(
+            logical_key=key,
+            kanban_db_path=board,
+            task_id=task_id,
+            acknowledge_source=False,
+        )
+
+    threads = [
+        threading.Thread(target=_attach, args=target, name=f"attach-{target[0]}")
+        for target in targets
+    ]
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+            assert not thread.is_alive()
+    finally:
+        ad.get_logical_delegation = original_get
+
+    counts = []
+    for _, board, task_id in targets:
+        with sqlite3.connect(board) as conn:
+            counts.append(
+                conn.execute(
+                    "SELECT COUNT(*) FROM delegation_receipts WHERE logical_key=?",
+                    (key,),
+                ).fetchone()[0]
+            )
+            assert conn.execute(
+                "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='delegation_receipted'",
+                (task_id,),
+            ).fetchone()[0] == counts[-1]
+    assert sorted(counts) == [0, 1]
+    assert sorted(result["status"] for result in results.values()) == ["committed", "conflict"]
+
+
+def test_prune_health_matches_reservation_capacity_at_boundaries():
+    limit = 2
+    for protected, expected in ((limit - 1, "ok"), (limit, "backpressure"), (limit + 1, "backpressure")):
+        with ad._DB_LOCK, ad._connect() as conn:
+            conn.execute("DELETE FROM logical_delegations")
+        for index in range(protected):
+            result = ad.reserve_logical_delegation(
+                logical_key=f"threshold/{protected}/{index}",
+                input_digest=f"sha256:{protected}-{index}",
+                goal="threshold",
+                context=None,
+                toolsets=None,
+                role="leaf",
+                model="local",
+                max_pending_records=limit + 2,
+            )
+            assert result["status"] == "reserved"
+
+        health = ad.prune_logical_delegations(
+            retention_seconds=0,
+            max_records=100,
+            max_pending_records=limit,
+        )
+        reservation = ad.reserve_logical_delegation(
+            logical_key=f"threshold/{protected}/next",
+            input_digest=f"sha256:{protected}-next",
+            goal="next",
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model="local",
+            max_pending_records=limit,
+        )
+        assert health["status"] == expected
+        assert reservation["status"] == ("reserved" if expected == "ok" else expected)
+
+
+def test_predecessor_prune_fails_closed_before_deleting_pending_evidence():
+    with ad._DB_LOCK, ad._connect() as conn:
+        for index in range(60):
+            conn.execute(
+                """INSERT INTO async_delegations
+                   (delegation_id, origin_session, state, dispatched_at,
+                    completed_at, updated_at, event_json, result_json,
+                    delivery_state, delivery_attempts)
+                   VALUES (?, 'b6-rollback', 'completed', ?, ?, ?, '{}', '{}',
+                           'pending', 0)""",
+                (f"deleg-b6-{index:03d}", index + 1, index + 1, index + 1),
+            )
+
+    with pytest.raises(
+        sqlite3.IntegrityError,
+        match="pending delegation evidence requires a compatible Hermes writer",
+    ):
+        with sqlite3.connect(ad._db_path()) as conn:
+            terminal_count = conn.execute(
+                """SELECT COUNT(*) FROM async_delegations
+                   WHERE state NOT IN ('running','finalizing')"""
+            ).fetchone()[0]
+            excess = max(0, terminal_count - 50)
+            conn.execute(
+                """DELETE FROM async_delegations WHERE delegation_id IN (
+                     SELECT delegation_id FROM async_delegations
+                     WHERE state NOT IN ('running','finalizing')
+                     ORDER BY CASE delivery_state WHEN 'delivered' THEN 0 ELSE 1 END,
+                              updated_at ASC LIMIT ?
+                   )""",
+                (excess,),
+            )
+
+    with sqlite3.connect(ad._db_path()) as conn:
+        remaining = conn.execute(
+            """SELECT COUNT(*) FROM async_delegations
+               WHERE delivery_state='pending'"""
+        ).fetchone()[0]
+    assert remaining == 60
+
+
+def _real_delegate_aggregate(monkeypatch: pytest.MonkeyPatch, statuses: list[str]):
+    from tools import delegate_tool as dt
+    from tools import delegation_live_log as live_log
+
+    credentials = {
+        "model": "local",
+        "provider": None,
+        "base_url": None,
+        "api_key": None,
+        "api_mode": None,
+        "request_overrides": None,
+        "max_output_tokens": None,
+        "command": None,
+        "args": None,
+    }
+    parent = SimpleNamespace(
+        _delegate_depth=0,
+        _interrupt_requested=False,
+        _memory_manager=None,
+        _active_children=[],
+        session_id="parent-session",
+        session_estimated_cost_usd=0.0,
+        session_cost_source="none",
+        session_cost_status="unknown",
+    )
+    children = [SimpleNamespace(_delegate_role="leaf") for _ in statuses]
+    monkeypatch.setattr(dt, "_load_config", lambda: {"workflow_bridge_enabled": False})
+    monkeypatch.setattr(dt, "_get_max_concurrent_children", lambda: len(statuses))
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *_a, **_k: credentials)
+    monkeypatch.setattr(dt, "_build_child_agent", lambda task_index, **_k: children[task_index])
+    monkeypatch.setattr(
+        dt,
+        "_run_single_child",
+        lambda task_index, *_a, **_k: {
+            "task_index": task_index,
+            "status": statuses[task_index],
+            "summary": "result",
+            "api_calls": 1,
+            "duration_seconds": 0,
+            "_child_role": "leaf",
+        },
+    )
+    monkeypatch.setattr(
+        live_log,
+        "create_live_transcripts",
+        lambda *_a, **_k: ("deleg-b5", [], []),
+    )
+    monkeypatch.setattr(live_log, "update_manifest_statuses", lambda *_a, **_k: None)
+
+    return json.loads(
+        dt.delegate_task(
+            tasks=[{"goal": f"task-{index}"} for index in range(len(statuses))],
+            background=False,
+            parent_agent=parent,
+        )
+    )
+
+
+def test_real_delegate_aggregate_maps_all_success_to_pass(monkeypatch: pytest.MonkeyPatch):
+    aggregate = _real_delegate_aggregate(monkeypatch, ["completed", "completed"])
+
+    assert aggregate["status"] == "PASS"
+
+
+@pytest.mark.parametrize(
+    "statuses",
+    [
+        ["completed", "failed"],
+        ["failed"],
+        ["interrupted"],
+        ["unknown"],
+    ],
+    ids=["partial", "failed", "interrupted", "unknown"],
+)
+def test_real_delegate_aggregate_never_false_passes(
+    monkeypatch: pytest.MonkeyPatch, statuses: list[str]
+):
+    aggregate = _real_delegate_aggregate(monkeypatch, statuses)
+
+    assert aggregate["status"] == "FAILED"
+
+
+@pytest.mark.parametrize("boundary", ["ai-agent", "registered-tool"])
+def test_model_cannot_select_hidden_bridge_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+):
+    import run_agent
+    from tools import delegate_tool as dt
+
+    board = tmp_path / "bridge-boundary.db"
+    expected = _claimed_authority(board)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(board))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", expected.task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(expected.run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", expected.claim_token)
+    monkeypatch.setenv("HERMES_PROFILE", expected.lane)
+
+    parent = SimpleNamespace(
+        _delegate_depth=0,
+        session_id=expected.owner_id,
+        model=expected.route,
+    )
+    captured = {}
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+        return "{}"
+
+    monkeypatch.setattr(dt, "delegate_task", _capture)
+    model_args = {
+        "goal": "bounded bridge",
+        "logical_dispatch_key": "model-selected-key",
+        "logical_input_digest": "sha256:model-selected-digest",
+        "bridge_authority_context": {"task_id": "model-selected-task"},
+        "authority_context": {"claim_token": "model-selected-claim"},
+    }
+
+    if boundary == "ai-agent":
+        run_agent.AIAgent._dispatch_delegate_task(parent, model_args)  # type: ignore[arg-type]
+    else:
+        dt.registry._tools["delegate_task"].handler(model_args, parent_agent=parent)
+
+    assert captured["bridge_authority_context"] == expected
+    assert "logical_dispatch_key" not in captured
+    assert "logical_input_digest" not in captured
+    assert "bridge_authority_context" not in dt.DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+    assert "authority_context" not in dt.DELEGATE_TASK_SCHEMA["parameters"]["properties"]

--- a/tests/tools/test_logical_dispatch_correction.py
+++ b/tests/tools/test_logical_dispatch_correction.py
@@ -59,7 +59,9 @@ def _claimed_authority(board: Path, *, title: str = "bridge target"):
 
 def _reserve_terminal(authority, result):
     key = ad.canonical_logical_key(authority)
-    digest = ad.canonical_json_digest({"goal": "bounded receipt"})
+    digest = ad.canonical_json_digest(
+        ad.canonical_dispatch_input("bounded receipt", None, "leaf")
+    )
     reserved = ad.reserve_logical_delegation(
         logical_key=key,
         input_digest=digest,
@@ -75,6 +77,203 @@ def _reserve_terminal(authority, result):
     committed = ad.commit_logical_delegation_result(key, digest, result)
     assert committed["state"] == "terminal_unattached"
     return key, digest
+
+
+def _bridge_counts(board: Path, task_id: str, logical_key: str):
+    with sqlite3.connect(board) as conn:
+        receipt = conn.execute(
+            "SELECT COUNT(*) FROM delegation_receipts WHERE logical_key=?",
+            (logical_key,),
+        ).fetchone()[0]
+        continuation = conn.execute(
+            "SELECT COUNT(*) FROM delegation_continuations WHERE logical_key=?",
+            (logical_key,),
+        ).fetchone()[0]
+        events = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id=? AND kind='delegation_receipted'",
+            (task_id,),
+        ).fetchall()
+    event = sum(json.loads(payload)["logical_key"] == logical_key for (payload,) in events)
+    return {"receipt": receipt, "event": event, "continuation": continuation}
+
+
+def test_direct_dispatch_without_current_run_claim_emits_no_authoritative_bridge_state(
+    tmp_path: Path,
+):
+    board = tmp_path / "unclaimed.db"
+    kb.init_db(board)
+    with kb.connect_closing(board) as conn:
+        task_id = kb.create_task(
+            conn,
+            title="unclaimed compatibility target",
+            created_by="correction-test",
+            initial_status="running",
+        )
+
+    goal = "unclaimed direct dispatch"
+    logical_key = "compatibility/unclaimed"
+    input_digest = ad.canonical_json_digest(
+        {"tasks": [{"goal": goal, "context": None, "role": "leaf"}]}
+    )
+    dispatched = ad.dispatch_logical_delegation(
+        logical_key=logical_key,
+        input_digest=input_digest,
+        goal=goal,
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="local",
+        session_key="forge",
+        parent_session_id="parent",
+        runner=lambda: {"status": "PASS", "summary": "compatibility evidence"},
+    )
+    assert dispatched["status"] == "dispatched"
+
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        record = ad.get_logical_delegation(logical_key)
+        if record and record["state"] == "terminal_unattached":
+            break
+        time.sleep(0.01)
+    else:
+        pytest.fail("direct logical dispatch did not become terminal")
+
+    attached = ad.attach_logical_dispatch_receipt(
+        logical_key=logical_key,
+        kanban_db_path=board,
+        task_id=task_id,
+        acknowledge_source=False,
+    )
+
+    assert attached["status"] == "non_authoritative"
+    with sqlite3.connect(board) as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM delegation_receipts WHERE logical_key=?",
+            (logical_key,),
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM delegation_continuations WHERE logical_key=?",
+            (logical_key,),
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='delegation_receipted'",
+            (task_id,),
+        ).fetchone()[0] == 0
+
+
+def test_authoritative_reservation_rejects_sha256_prefixed_non_hex_digest(tmp_path: Path):
+    authority = _claimed_authority(tmp_path / "malformed-digest.db")
+    logical_key = ad.canonical_logical_key(authority)
+
+    rejected = ad.reserve_logical_delegation(
+        logical_key=logical_key,
+        input_digest="sha256:not-a-canonical-hex-digest",
+        goal="malformed digest",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="local",
+        authority_context=authority,
+    )
+
+    assert rejected["status"] == "rejected"
+    assert ad.get_logical_delegation(logical_key) is None
+
+
+def test_compatibility_evidence_is_explicitly_non_authoritative_and_cannot_attach(
+    tmp_path: Path,
+):
+    board = tmp_path / "claimed-compatibility.db"
+    authority = _claimed_authority(board)
+    goal = "retain non-authoritative compatibility evidence"
+    logical_key = "compatibility/claimed"
+    input_digest = ad.canonical_json_digest(
+        {"tasks": [{"goal": goal, "context": None, "role": "leaf"}]}
+    )
+    dispatched = ad.dispatch_logical_delegation(
+        logical_key=logical_key,
+        input_digest=input_digest,
+        goal=goal,
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="local",
+        session_key="forge",
+        parent_session_id="parent",
+        runner=lambda: {"status": "PASS", "summary": "compatibility evidence"},
+    )
+    assert dispatched["status"] == "dispatched"
+
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        record = ad.get_logical_delegation(logical_key)
+        if record and record["state"] == "terminal_unattached":
+            break
+        time.sleep(0.01)
+    else:
+        pytest.fail("compatibility dispatch did not become terminal")
+
+    attached = ad.attach_logical_dispatch_receipt(
+        logical_key=logical_key,
+        kanban_db_path=board,
+        task_id=authority.task_id,
+        acknowledge_source=False,
+    )
+    record = ad.get_logical_delegation(logical_key)
+
+    assert record is not None
+    assert attached["status"] == "non_authoritative"
+    assert attached["status"] != "committed"
+    assert record["authority"] == {
+        "authoritative": False,
+        "compatibility_mode": "direct_dispatch",
+    }
+    assert record["state"] == "terminal_unattached"
+    assert record["receipt_id"] is None
+    assert record["continuation_id"] is None
+    assert _bridge_counts(board, authority.task_id, logical_key) == {
+        "receipt": 0,
+        "event": 0,
+        "continuation": 0,
+    }
+
+
+def test_kanban_receipt_authorization_rejects_task_state_without_current_authority(
+    tmp_path: Path,
+):
+    board = tmp_path / "task-state-only.db"
+    kb.init_db(board)
+    with kb.connect_closing(board) as conn:
+        task_id = kb.create_task(
+            conn,
+            title="task state is not authority",
+            created_by="correction-test",
+            initial_status="running",
+        )
+        result = kb.record_delegation_receipt(
+            conn,
+            logical_key="task-state-only",
+            input_digest="sha256:" + "a" * 64,
+            delegation_id="deleg_task_state_only",
+            execution_id="exec_task_state_only",
+            result_digest="sha256:" + "b" * 64,
+            terminal_status="PASS",
+            result={"status": "PASS", "summary": "must not authorize"},
+            task_id=task_id,
+            allow_legacy_running_task=True,
+        )
+
+        assert result["status"] == "conflict"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM delegation_receipts WHERE logical_key='task-state-only'"
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM delegation_continuations WHERE logical_key='task-state-only'"
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='delegation_receipted'",
+            (task_id,),
+        ).fetchone()[0] == 0
 
 
 def test_receipt_requires_current_claim_and_stores_only_bounded_redacted_projection(tmp_path: Path):
@@ -207,12 +406,22 @@ def test_conflict_before_launch_executes_zero_runners():
 
 
 def test_cross_board_attach_cas_mutates_exactly_one_target(tmp_path: Path):
-    key = "attach/race"
-    digest = "sha256:attach-race"
+    targets = []
+    for label in ("a", "b"):
+        board = tmp_path / f"board-{label}.db"
+        authority = _claimed_authority(board, title=label)
+        targets.append((label, board, authority))
+
+    source_authority = targets[0][2]
+    key = ad.canonical_logical_key(source_authority)
+    goal = "attach once"
+    digest = ad.canonical_json_digest(
+        ad.canonical_dispatch_input(goal, None, "leaf")
+    )
     dispatched = ad.dispatch_logical_delegation(
         logical_key=key,
         input_digest=digest,
-        goal="attach once",
+        goal=goal,
         context=None,
         toolsets=None,
         role="leaf",
@@ -220,6 +429,7 @@ def test_cross_board_attach_cas_mutates_exactly_one_target(tmp_path: Path):
         session_key="forge",
         parent_session_id="parent",
         runner=lambda: {"status": "PASS", "summary": "one execution"},
+        authority_context=source_authority,
     )
     assert dispatched["status"] == "dispatched"
     deadline = time.time() + 5
@@ -230,14 +440,6 @@ def test_cross_board_attach_cas_mutates_exactly_one_target(tmp_path: Path):
         time.sleep(0.01)
     else:
         pytest.fail("logical dispatch did not become terminal")
-
-    targets = []
-    for label in ("a", "b"):
-        board = tmp_path / f"board-{label}.db"
-        kb.init_db(board)
-        with kb.connect_closing(board) as conn:
-            task_id = kb.create_task(conn, title=label, created_by="forge")
-        targets.append((label, board, task_id))
 
     original_get = ad.get_logical_delegation
     barrier = threading.Barrier(2)
@@ -258,11 +460,11 @@ def test_cross_board_attach_cas_mutates_exactly_one_target(tmp_path: Path):
     ad.get_logical_delegation = _synchronized_get
     results = {}
 
-    def _attach(label, board, task_id):
+    def _attach(label, board, authority):
         results[label] = ad.attach_logical_dispatch_receipt(
             logical_key=key,
             kanban_db_path=board,
-            task_id=task_id,
+            task_id=authority.task_id,
             acknowledge_source=False,
         )
 
@@ -279,21 +481,144 @@ def test_cross_board_attach_cas_mutates_exactly_one_target(tmp_path: Path):
     finally:
         ad.get_logical_delegation = original_get
 
-    counts = []
-    for _, board, task_id in targets:
+    outcomes = []
+    for label, board, authority in targets:
         with sqlite3.connect(board) as conn:
-            counts.append(
-                conn.execute(
-                    "SELECT COUNT(*) FROM delegation_receipts WHERE logical_key=?",
-                    (key,),
-                ).fetchone()[0]
-            )
-            assert conn.execute(
+            receipt_count = conn.execute(
+                "SELECT COUNT(*) FROM delegation_receipts WHERE logical_key=?",
+                (key,),
+            ).fetchone()[0]
+            event_count = conn.execute(
                 "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='delegation_receipted'",
-                (task_id,),
-            ).fetchone()[0] == counts[-1]
-    assert sorted(counts) == [0, 1]
-    assert sorted(result["status"] for result in results.values()) == ["committed", "conflict"]
+                (authority.task_id,),
+            ).fetchone()[0]
+            continuation_count = conn.execute(
+                "SELECT COUNT(*) FROM delegation_continuations WHERE logical_key=?",
+                (key,),
+            ).fetchone()[0]
+        outcomes.append(
+            (
+                receipt_count,
+                event_count,
+                continuation_count,
+                results[label]["status"],
+            )
+        )
+    assert sorted(outcomes) == [
+        (0, 0, 0, "conflict"),
+        (1, 1, 1, "committed"),
+    ]
+
+
+def test_concurrent_attach_refuses_missing_run_claim_before_cas_and_commits_authorized(
+    tmp_path: Path,
+):
+    authorized_board = tmp_path / "authorized.db"
+    authorized = _claimed_authority(authorized_board, title="authorized target")
+    authorized_key, authorized_digest = _reserve_terminal(
+        authorized,
+        {"status": "PASS", "summary": "authorized execution"},
+    )
+
+    refused_board = tmp_path / "missing-authority.db"
+    kb.init_db(refused_board)
+    with kb.connect_closing(refused_board) as conn:
+        refused_task_id = kb.create_task(
+            conn,
+            title="missing run and claim",
+            assignee="forge",
+            created_by="correction-test",
+            initial_status="running",
+        )
+        refused_task = kb.get_task(conn, refused_task_id)
+        assert refused_task is not None
+        assert refused_task.current_run_id is None
+        assert refused_task.claim_lock is None
+
+    refused_key = "compatibility/b3-missing-run-claim"
+    refused_goal = "refuse incomplete authority"
+    refused_digest = ad.canonical_json_digest(
+        ad.canonical_dispatch_input(refused_goal, None, "leaf")
+    )
+    refused_dispatch = ad.dispatch_logical_delegation(
+        logical_key=refused_key,
+        input_digest=refused_digest,
+        goal=refused_goal,
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="local",
+        session_key="forge",
+        parent_session_id="parent",
+        runner=lambda: {"status": "PASS", "summary": "non-authoritative evidence"},
+    )
+    assert refused_dispatch["status"] == "dispatched"
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        refused_source = ad.get_logical_delegation(refused_key)
+        if refused_source and refused_source["state"] == "terminal_unattached":
+            break
+        time.sleep(0.01)
+    else:
+        pytest.fail("incomplete-authority logical dispatch did not become terminal")
+
+    assert authorized_digest == ad.canonical_json_digest(
+        ad.canonical_dispatch_input("bounded receipt", None, "leaf")
+    )
+    assert refused_digest == ad.canonical_json_digest(
+        ad.canonical_dispatch_input(refused_goal, None, "leaf")
+    )
+
+    barrier = threading.Barrier(2)
+    results = {}
+
+    def _attach(label, logical_key, board, task_id):
+        barrier.wait(timeout=5)
+        results[label] = ad.attach_logical_dispatch_receipt(
+            logical_key=logical_key,
+            kanban_db_path=board,
+            task_id=task_id,
+            acknowledge_source=False,
+        )
+
+    threads = [
+        threading.Thread(
+            target=_attach,
+            args=("authorized", authorized_key, authorized_board, authorized.task_id),
+            name="b3-authorized-attach",
+        ),
+        threading.Thread(
+            target=_attach,
+            args=("refused", refused_key, refused_board, refused_task_id),
+            name="b3-refused-attach",
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+    assert results["authorized"]["status"] == "committed"
+    assert results["refused"]["status"] == "non_authoritative"
+    assert sum(result["status"] == "committed" for result in results.values()) == 1
+    assert _bridge_counts(authorized_board, authorized.task_id, authorized_key) == {
+        "receipt": 1,
+        "event": 1,
+        "continuation": 1,
+    }
+    assert _bridge_counts(refused_board, refused_task_id, refused_key) == {
+        "receipt": 0,
+        "event": 0,
+        "continuation": 0,
+    }
+    refused_source = ad.get_logical_delegation(refused_key)
+    assert refused_source is not None
+    assert refused_source["state"] == "terminal_unattached"
+    assert refused_source["kanban_db_path"] is None
+    assert refused_source["task_id"] is None
+    assert refused_source["receipt_id"] is None
+    assert refused_source["continuation_id"] is None
 
 
 def test_prune_health_matches_reservation_capacity_at_boundaries():

--- a/tests/tools/test_logical_dispatch_receipt_bridge.py
+++ b/tests/tools/test_logical_dispatch_receipt_bridge.py
@@ -51,10 +51,31 @@ def board_task(isolated_bridge):
         task_id = kb.create_task(
             conn,
             title="Task 3 receipt destination",
+            assignee="forge",
             created_by="gauge",
             initial_status="running",
         )
-    return task_id
+        assert kb.claim_task(conn, task_id, claimer="bridge-claim") is not None
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.current_run_id is not None
+        conn.execute(
+            "UPDATE tasks SET workflow_template_id='workflow-v1', current_step_key='implement' WHERE id=?",
+            (task_id,),
+        )
+        conn.commit()
+    return ad.BridgeAuthorityContext(
+        kanban_db_path=str(isolated_bridge["kanban_path"].resolve()),
+        workflow_id="workflow-v1",
+        step_key="implement",
+        step_attempt_id=f"workflow-v1/implement/{task.current_run_id}",
+        task_id=task_id,
+        run_id=task.current_run_id,
+        claim_token="bridge-claim",
+        lane="forge",
+        route="test-model",
+        owner_id="parent-session",
+    )
 
 
 def _public(name: str) -> Callable:
@@ -63,19 +84,32 @@ def _public(name: str) -> Callable:
     return value
 
 
-def _dispatch(logical_key: str, digest: str, runner: Callable, **extra):
+def _dispatch(
+    logical_key: str,
+    runner: Callable,
+    authority_context: ad.BridgeAuthorityContext,
+    *,
+    goal: str = "verify logical receipt",
+    context: str = "Task 3 RED",
+    role: str = "leaf",
+    **extra,
+):
+    digest = ad.canonical_json_digest(
+        ad.canonical_dispatch_input(goal, context, role)
+    )
     return _public("dispatch_logical_delegation")(
         logical_key=logical_key,
         input_digest=digest,
-        goal="verify logical receipt",
-        context="Task 3 RED",
+        goal=goal,
+        context=context,
         toolsets=None,
-        role="leaf",
+        role=role,
         model="test-model",
         session_key="source-session",
         parent_session_id="parent-session",
         runner=runner,
         max_async_children=8,
+        authority_context=authority_context,
         **extra,
     )
 
@@ -102,11 +136,16 @@ def _terminal_runner(summary: str = "done"):
     }
 
 
-def _attach(logical_key: str, isolated_bridge, board_task: str, **extra):
+def _attach(
+    logical_key: str,
+    isolated_bridge,
+    board_task: ad.BridgeAuthorityContext,
+    **extra,
+):
     return _public("attach_logical_dispatch_receipt")(
         logical_key=logical_key,
         kanban_db_path=isolated_bridge["kanban_path"],
-        task_id=board_task,
+        task_id=board_task.task_id,
         **extra,
     )
 
@@ -127,7 +166,7 @@ def _bridge_counts(kanban_path: Path, task_id: str, logical_key: str) -> dict[st
     return {"receipt": receipt, "event": event, "continuation": continuation}
 
 
-def test_stable_logical_key_reserves_before_launch_and_reuses_one_execution():
+def test_stable_logical_key_reserves_before_launch_and_reuses_one_execution(board_task):
     gate = threading.Event()
     entered = threading.Event()
     calls = {"count": 0}
@@ -140,10 +179,10 @@ def test_stable_logical_key_reserves_before_launch_and_reuses_one_execution():
         gate.wait(timeout=5)
         return _terminal_runner()
 
-    first = _dispatch("workflow/step/attempt", "sha256:input-a", runner)
+    first = _dispatch("workflow/step/attempt", runner, board_task)
     assert first["state"] in {"reserved", "running"}
     assert entered.wait(timeout=2)
-    second = _dispatch("workflow/step/attempt", "sha256:input-a", runner)
+    second = _dispatch("workflow/step/attempt", runner, board_task)
 
     assert second["delegation_id"] == first["delegation_id"]
     assert second["execution_id"] == first["execution_id"]
@@ -159,7 +198,7 @@ def test_stable_logical_key_reserves_before_launch_and_reuses_one_execution():
 def test_terminal_source_evidence_is_durable_before_kanban_attachment(
     isolated_bridge, board_task
 ):
-    dispatched = _dispatch("durable/source", "sha256:input", _terminal_runner)
+    dispatched = _dispatch("durable/source", _terminal_runner, board_task)
     terminal = _wait_state("durable/source", {"terminal_unattached"})
     ad._reset_for_tests()  # discard process memory; the next read must come from SQLite
     terminal = _get("durable/source")
@@ -170,7 +209,9 @@ def test_terminal_source_evidence_is_durable_before_kanban_attachment(
     assert terminal["receipt_id"] is None
     assert terminal["source_acknowledged_at"] is None
     assert isolated_bridge["kanban_path"].exists()
-    assert _bridge_counts(isolated_bridge["kanban_path"], board_task, "durable/source") == {
+    assert _bridge_counts(
+        isolated_bridge["kanban_path"], board_task.task_id, "durable/source"
+    ) == {
         "receipt": 0,
         "event": 0,
         "continuation": 0,
@@ -185,7 +226,7 @@ def test_replay_at_attach_and_source_ack_boundaries_is_exactly_once(
     boundary, isolated_bridge, board_task
 ):
     logical_key = f"replay/{boundary}"
-    _dispatch(logical_key, "sha256:stable", _terminal_runner)
+    _dispatch(logical_key, _terminal_runner, board_task)
     _wait_state(logical_key, {"terminal_unattached"})
 
     if boundary == "before_attach":
@@ -213,7 +254,7 @@ def test_replay_at_attach_and_source_ack_boundaries_is_exactly_once(
     _public("acknowledge_logical_dispatch")(logical_key=logical_key)
     _public("acknowledge_logical_dispatch")(logical_key=logical_key)
 
-    assert _bridge_counts(isolated_bridge["kanban_path"], board_task, logical_key) == {
+    assert _bridge_counts(isolated_bridge["kanban_path"], board_task.task_id, logical_key) == {
         "receipt": 1,
         "event": 1,
         "continuation": 1,
@@ -232,18 +273,31 @@ def test_conflicting_digest_quarantines_logical_key_and_cannot_continue(
         calls["count"] += 1
         return _terminal_runner()
 
-    first = _dispatch("conflict/key", "sha256:a", runner)
-    conflict = _dispatch("conflict/key", "sha256:b", runner)
+    first = _dispatch("conflict/key", runner, board_task)
+    conflict = _dispatch(
+        "conflict/key",
+        runner,
+        board_task,
+        context="Task 3 RED changed input",
+    )
 
     assert conflict["status"] == "quarantined"
     assert conflict["delegation_id"] == first["delegation_id"]
-    assert conflict["expected_digest"] == "sha256:a"
-    assert conflict["observed_digest"] == "sha256:b"
+    assert conflict["expected_digest"] == ad.canonical_json_digest(
+        ad.canonical_dispatch_input("verify logical receipt", "Task 3 RED", "leaf")
+    )
+    assert conflict["observed_digest"] == ad.canonical_json_digest(
+        ad.canonical_dispatch_input(
+            "verify logical receipt", "Task 3 RED changed input", "leaf"
+        )
+    )
     assert calls["count"] == 1
     replay = _attach("conflict/key", isolated_bridge, board_task)
     assert replay["status"] == "quarantined"
     assert _get("conflict/key")["state"] == "quarantined"
-    assert _bridge_counts(isolated_bridge["kanban_path"], board_task, "conflict/key") == {
+    assert _bridge_counts(
+        isolated_bridge["kanban_path"], board_task.task_id, "conflict/key"
+    ) == {
         "receipt": 0,
         "event": 0,
         "continuation": 0,
@@ -255,7 +309,7 @@ def test_retention_protects_unfinished_bridge_evidence_and_overflow_backpressure
 ):
     keys = ["retain/unattached", "retain/pending-receipt", "retain/unacknowledged"]
     for key in keys:
-        _dispatch(key, f"sha256:{key}", _terminal_runner)
+        _dispatch(key, _terminal_runner, board_task)
         _wait_state(key, {"terminal_unattached"})
 
     pending = _attach(
@@ -285,8 +339,8 @@ def test_retention_protects_unfinished_bridge_evidence_and_overflow_backpressure
 
     rejected = _dispatch(
         "retain/overflow",
-        "sha256:overflow",
         _terminal_runner,
+        board_task,
         max_pending_records=1,
     )
     assert rejected["status"] == "backpressure"

--- a/tests/tools/test_logical_dispatch_receipt_bridge.py
+++ b/tests/tools/test_logical_dispatch_receipt_bridge.py
@@ -1,0 +1,293 @@
+"""Task 3 RED contract: logical dispatch -> durable Kanban receipt bridge.
+
+These tests intentionally describe the public API Task 3 must add.  They use
+only disposable ``HERMES_HOME`` / Kanban SQLite files and inspect committed
+state rather than mocking either persistence layer.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from tools import async_delegation as ad
+from tools.process_registry import process_registry
+
+
+TERMINAL = {"PASS", "REWORK", "REPLAN", "BLOCKED", "FALLBACK_REQUIRED", "FAILED"}
+
+
+@pytest.fixture(autouse=True)
+def isolated_bridge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    hermes_home = tmp_path / "hermes"
+    kanban_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(kanban_path))
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    kb.init_db(kanban_path)
+    yield {"hermes_home": hermes_home, "kanban_path": kanban_path}
+    deadline = time.monotonic() + 2
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+@pytest.fixture
+def board_task(isolated_bridge):
+    with kb.connect_closing(isolated_bridge["kanban_path"]) as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Task 3 receipt destination",
+            created_by="gauge",
+            initial_status="running",
+        )
+    return task_id
+
+
+def _public(name: str) -> Callable:
+    value = getattr(ad, name, None)
+    assert callable(value), f"Task 3 public API tools.async_delegation.{name} is missing"
+    return value
+
+
+def _dispatch(logical_key: str, digest: str, runner: Callable, **extra):
+    return _public("dispatch_logical_delegation")(
+        logical_key=logical_key,
+        input_digest=digest,
+        goal="verify logical receipt",
+        context="Task 3 RED",
+        toolsets=None,
+        role="leaf",
+        model="test-model",
+        session_key="source-session",
+        parent_session_id="parent-session",
+        runner=runner,
+        max_async_children=8,
+        **extra,
+    )
+
+
+def _get(logical_key: str):
+    return _public("get_logical_delegation")(logical_key)
+
+
+def _wait_state(logical_key: str, expected: set[str], timeout: float = 5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        record = _get(logical_key)
+        if record and record["state"] in expected:
+            return record
+        time.sleep(0.01)
+    pytest.fail(f"logical dispatch {logical_key!r} did not reach {sorted(expected)}")
+
+
+def _terminal_runner(summary: str = "done"):
+    return {
+        "status": "PASS",
+        "summary": summary,
+        "artifact_digest": "sha256:terminal-evidence",
+    }
+
+
+def _attach(logical_key: str, isolated_bridge, board_task: str, **extra):
+    return _public("attach_logical_dispatch_receipt")(
+        logical_key=logical_key,
+        kanban_db_path=isolated_bridge["kanban_path"],
+        task_id=board_task,
+        **extra,
+    )
+
+
+def _bridge_counts(kanban_path: Path, task_id: str, logical_key: str) -> dict[str, int]:
+    with sqlite3.connect(kanban_path) as conn:
+        receipt = conn.execute(
+            "SELECT COUNT(*) FROM delegation_receipts WHERE logical_key=?", (logical_key,)
+        ).fetchone()[0]
+        continuation = conn.execute(
+            "SELECT COUNT(*) FROM delegation_continuations WHERE logical_key=?", (logical_key,)
+        ).fetchone()[0]
+        events = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id=? AND kind='delegation_receipted'",
+            (task_id,),
+        ).fetchall()
+    event = sum(json.loads(payload)["logical_key"] == logical_key for (payload,) in events)
+    return {"receipt": receipt, "event": event, "continuation": continuation}
+
+
+def test_stable_logical_key_reserves_before_launch_and_reuses_one_execution():
+    gate = threading.Event()
+    entered = threading.Event()
+    calls = {"count": 0}
+    observed = {}
+
+    def runner():
+        calls["count"] += 1
+        observed["reservation"] = _get("workflow/step/attempt")
+        entered.set()
+        gate.wait(timeout=5)
+        return _terminal_runner()
+
+    first = _dispatch("workflow/step/attempt", "sha256:input-a", runner)
+    assert first["state"] in {"reserved", "running"}
+    assert entered.wait(timeout=2)
+    second = _dispatch("workflow/step/attempt", "sha256:input-a", runner)
+
+    assert second["delegation_id"] == first["delegation_id"]
+    assert second["execution_id"] == first["execution_id"]
+    assert calls["count"] == 1
+    assert observed["reservation"]["delegation_id"] == first["delegation_id"]
+    assert observed["reservation"]["execution_id"] == first["execution_id"]
+    assert observed["reservation"]["state"] in {"reserved", "running"}
+    gate.set()
+    terminal = _wait_state("workflow/step/attempt", {"terminal_unattached"})
+    assert terminal["terminal_status"] in TERMINAL
+
+
+def test_terminal_source_evidence_is_durable_before_kanban_attachment(
+    isolated_bridge, board_task
+):
+    dispatched = _dispatch("durable/source", "sha256:input", _terminal_runner)
+    terminal = _wait_state("durable/source", {"terminal_unattached"})
+    ad._reset_for_tests()  # discard process memory; the next read must come from SQLite
+    terminal = _get("durable/source")
+
+    assert terminal["delegation_id"] == dispatched["delegation_id"]
+    assert terminal["terminal_status"] == "PASS"
+    assert terminal["result"]["summary"] == "done"
+    assert terminal["receipt_id"] is None
+    assert terminal["source_acknowledged_at"] is None
+    assert isolated_bridge["kanban_path"].exists()
+    assert _bridge_counts(isolated_bridge["kanban_path"], board_task, "durable/source") == {
+        "receipt": 0,
+        "event": 0,
+        "continuation": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    ["before_attach", "after_kanban_commit", "before_source_ack", "after_source_ack_commit"],
+)
+def test_replay_at_attach_and_source_ack_boundaries_is_exactly_once(
+    boundary, isolated_bridge, board_task
+):
+    logical_key = f"replay/{boundary}"
+    _dispatch(logical_key, "sha256:stable", _terminal_runner)
+    _wait_state(logical_key, {"terminal_unattached"})
+
+    if boundary == "before_attach":
+        _attach(logical_key, isolated_bridge, board_task, acknowledge_source=False)
+    elif boundary == "after_kanban_commit":
+        with pytest.raises(ad.LogicalDispatchBridgeFault, match="kanban_commit"):
+            _attach(
+                logical_key,
+                isolated_bridge,
+                board_task,
+                acknowledge_source=False,
+                fault_after="kanban_commit",
+            )
+    elif boundary == "before_source_ack":
+        _attach(logical_key, isolated_bridge, board_task, acknowledge_source=False)
+    else:
+        _attach(logical_key, isolated_bridge, board_task, acknowledge_source=False)
+        with pytest.raises(ad.LogicalDispatchBridgeFault, match="source_ack_commit"):
+            _public("acknowledge_logical_dispatch")(
+                logical_key=logical_key, fault_after="source_ack_commit"
+            )
+
+    # Replay attach and acknowledgement after every boundary. Both are idempotent.
+    _attach(logical_key, isolated_bridge, board_task, acknowledge_source=False)
+    _public("acknowledge_logical_dispatch")(logical_key=logical_key)
+    _public("acknowledge_logical_dispatch")(logical_key=logical_key)
+
+    assert _bridge_counts(isolated_bridge["kanban_path"], board_task, logical_key) == {
+        "receipt": 1,
+        "event": 1,
+        "continuation": 1,
+    }
+    record = _get(logical_key)
+    assert record["state"] == "acknowledged"
+    assert record["source_ack_count"] == 1
+
+
+def test_conflicting_digest_quarantines_logical_key_and_cannot_continue(
+    isolated_bridge, board_task
+):
+    calls = {"count": 0}
+
+    def runner():
+        calls["count"] += 1
+        return _terminal_runner()
+
+    first = _dispatch("conflict/key", "sha256:a", runner)
+    conflict = _dispatch("conflict/key", "sha256:b", runner)
+
+    assert conflict["status"] == "quarantined"
+    assert conflict["delegation_id"] == first["delegation_id"]
+    assert conflict["expected_digest"] == "sha256:a"
+    assert conflict["observed_digest"] == "sha256:b"
+    assert calls["count"] == 1
+    replay = _attach("conflict/key", isolated_bridge, board_task)
+    assert replay["status"] == "quarantined"
+    assert _get("conflict/key")["state"] == "quarantined"
+    assert _bridge_counts(isolated_bridge["kanban_path"], board_task, "conflict/key") == {
+        "receipt": 0,
+        "event": 0,
+        "continuation": 0,
+    }
+
+
+def test_retention_protects_unfinished_bridge_evidence_and_overflow_backpressures(
+    isolated_bridge, board_task
+):
+    keys = ["retain/unattached", "retain/pending-receipt", "retain/unacknowledged"]
+    for key in keys:
+        _dispatch(key, f"sha256:{key}", _terminal_runner)
+        _wait_state(key, {"terminal_unattached"})
+
+    pending = _attach(
+        keys[1],
+        isolated_bridge,
+        board_task,
+        acknowledge_source=False,
+        prepare_only=True,
+    )
+    assert pending["state"] == "terminal_pending_receipt"
+    _attach(keys[2], isolated_bridge, board_task, acknowledge_source=False)
+    assert _get(keys[2])["state"] == "receipted_unacknowledged"
+
+    result = _public("prune_logical_delegations")(
+        retention_seconds=0,
+        max_records=1,
+        max_pending_records=1,
+    )
+    assert result["status"] == "backpressure"
+    assert result["deleted"] == 0
+    assert result["protected"] >= 3
+    assert {key: _get(key)["state"] for key in keys} == {
+        keys[0]: "terminal_unattached",
+        keys[1]: "terminal_pending_receipt",
+        keys[2]: "receipted_unacknowledged",
+    }
+
+    rejected = _dispatch(
+        "retain/overflow",
+        "sha256:overflow",
+        _terminal_runner,
+        max_pending_records=1,
+    )
+    assert rejected["status"] == "backpressure"
+    assert _get("retain/overflow") is None

--- a/tests/tools/test_logical_dispatch_receipt_bridge_positive.py
+++ b/tests/tools/test_logical_dispatch_receipt_bridge_positive.py
@@ -34,6 +34,31 @@ def _wait(key: str):
     pytest.fail("logical delegation did not finish")
 
 
+def _claimed_authority(board: Path, task_id: str):
+    with kb.connect_closing(board) as conn:
+        assert kb.claim_task(conn, task_id, claimer="bridge-claim") is not None
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.current_run_id is not None
+        conn.execute(
+            "UPDATE tasks SET workflow_template_id='workflow-v1', current_step_key='implement' WHERE id=?",
+            (task_id,),
+        )
+        conn.commit()
+    return ad.BridgeAuthorityContext(
+        kanban_db_path=str(board.resolve()),
+        workflow_id="workflow-v1",
+        step_key="implement",
+        step_attempt_id=f"workflow-v1/implement/{task.current_run_id}",
+        task_id=task_id,
+        run_id=task.current_run_id,
+        claim_token="bridge-claim",
+        lane="forge",
+        route="openai-codex/gpt-5.6-sol",
+        owner_id="parent-session",
+    )
+
+
 def test_terminal_digest_is_canonical_and_source_schema_migrates_idempotently(stores):
     result = {"status": "PASS", "summary": "ok", "nested": {"b": 2, "a": 1}}
     ad.dispatch_logical_delegation(
@@ -60,26 +85,59 @@ def test_kanban_receipt_schema_is_additive_and_idempotent(stores):
     assert {"delegation_receipts", "delegation_continuations"} <= tables
 
 
-def test_receipt_target_conflict_quarantines_source(stores):
+def test_receipt_target_conflict_preserves_authoritative_source(stores):
     with kb.connect_closing(stores) as conn:
-        first_task = kb.create_task(conn, title="one", created_by="loom", initial_status="running")
+        first_task = kb.create_task(
+            conn,
+            title="one",
+            assignee="forge",
+            created_by="loom",
+            initial_status="running",
+        )
         second_task = kb.create_task(conn, title="two", created_by="loom", initial_status="running")
+    authority = _claimed_authority(stores, first_task)
+    logical_key = ad.canonical_logical_key(authority)
+    goal = "g"
+    input_digest = ad.canonical_json_digest(
+        ad.canonical_dispatch_input(goal, None, "leaf")
+    )
     ad.dispatch_logical_delegation(
-        logical_key="target/conflict", input_digest="sha256:request", goal="g",
+        logical_key=logical_key, input_digest=input_digest, goal=goal,
         context=None, toolsets=None, role="leaf", model="m", session_key="s",
         parent_session_id="p", runner=lambda: {"status": "PASS", "summary": "ok"},
+        authority_context=authority,
     )
-    _wait("target/conflict")
-    ad.attach_logical_dispatch_receipt(
-        logical_key="target/conflict", kanban_db_path=stores, task_id=first_task,
+    _wait(logical_key)
+    attached = ad.attach_logical_dispatch_receipt(
+        logical_key=logical_key, kanban_db_path=stores, task_id=first_task,
         acknowledge_source=False,
     )
     conflict = ad.attach_logical_dispatch_receipt(
-        logical_key="target/conflict", kanban_db_path=stores, task_id=second_task,
+        logical_key=logical_key, kanban_db_path=stores, task_id=second_task,
         acknowledge_source=False,
     )
-    assert conflict["status"] == "quarantined"
-    assert ad.get_logical_delegation("target/conflict")["state"] == "quarantined"
+    assert attached["status"] == "committed"
+    assert conflict["status"] == "conflict"
+    source = ad.get_logical_delegation(logical_key)
+    assert source["state"] == "receipted_unacknowledged"
+    assert source["receipt_id"] == attached["receipt_id"]
+    with sqlite3.connect(stores) as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM delegation_receipts WHERE logical_key=?",
+            (logical_key,),
+        ).fetchone()[0] == 1
+        assert conn.execute(
+            "SELECT COUNT(*) FROM delegation_continuations WHERE logical_key=?",
+            (logical_key,),
+        ).fetchone()[0] == 1
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='delegation_receipted'",
+            (first_task,),
+        ).fetchone()[0] == 1
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='delegation_receipted'",
+            (second_task,),
+        ).fetchone()[0] == 0
 
 
 def test_enabled_delegate_bridge_replay_returns_before_transcript_or_child(stores, monkeypatch):

--- a/tests/tools/test_logical_dispatch_receipt_bridge_positive.py
+++ b/tests/tools/test_logical_dispatch_receipt_bridge_positive.py
@@ -1,0 +1,120 @@
+"""Implementer-owned Task 3 bridge compatibility and migration checks."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+from unittest.mock import MagicMock
+
+from hermes_cli import kanban_db as kb
+from tools import async_delegation as ad
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    board = tmp_path / "kanban.db"
+    kb.init_db(board)
+    ad._reset_for_tests()
+    yield board
+    ad._reset_for_tests()
+
+
+def _wait(key: str):
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        row = ad.get_logical_delegation(key)
+        if row and row["state"] == "terminal_unattached":
+            return row
+        time.sleep(0.01)
+    pytest.fail("logical delegation did not finish")
+
+
+def test_terminal_digest_is_canonical_and_source_schema_migrates_idempotently(stores):
+    result = {"status": "PASS", "summary": "ok", "nested": {"b": 2, "a": 1}}
+    ad.dispatch_logical_delegation(
+        logical_key="canonical/result", input_digest="sha256:request", goal="g",
+        context=None, toolsets=None, role="leaf", model="m", session_key="s",
+        parent_session_id="p", runner=lambda: result,
+    )
+    first = _wait("canonical/result")
+    assert first["result_digest"] == ad.canonical_json_digest(
+        {"nested": {"a": 1, "b": 2}, "summary": "ok", "status": "PASS"}
+    )
+    with ad._connect() as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(logical_delegations)")}
+    with ad._connect():
+        pass
+    assert {"logical_key", "input_digest", "result_digest", "source_ack_count"} <= columns
+
+
+def test_kanban_receipt_schema_is_additive_and_idempotent(stores):
+    kb.init_db(stores)
+    kb.init_db(stores)
+    with sqlite3.connect(stores) as conn:
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {"delegation_receipts", "delegation_continuations"} <= tables
+
+
+def test_receipt_target_conflict_quarantines_source(stores):
+    with kb.connect_closing(stores) as conn:
+        first_task = kb.create_task(conn, title="one", created_by="loom", initial_status="running")
+        second_task = kb.create_task(conn, title="two", created_by="loom", initial_status="running")
+    ad.dispatch_logical_delegation(
+        logical_key="target/conflict", input_digest="sha256:request", goal="g",
+        context=None, toolsets=None, role="leaf", model="m", session_key="s",
+        parent_session_id="p", runner=lambda: {"status": "PASS", "summary": "ok"},
+    )
+    _wait("target/conflict")
+    ad.attach_logical_dispatch_receipt(
+        logical_key="target/conflict", kanban_db_path=stores, task_id=first_task,
+        acknowledge_source=False,
+    )
+    conflict = ad.attach_logical_dispatch_receipt(
+        logical_key="target/conflict", kanban_db_path=stores, task_id=second_task,
+        acknowledge_source=False,
+    )
+    assert conflict["status"] == "quarantined"
+    assert ad.get_logical_delegation("target/conflict")["state"] == "quarantined"
+
+
+def test_enabled_delegate_bridge_replay_returns_before_transcript_or_child(stores, monkeypatch):
+    import tools.delegate_tool as dt
+    import tools.delegation_live_log as live_log
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "parent"
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    monkeypatch.setattr(dt, "_load_config", lambda: {"workflow_bridge_enabled": True})
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *_a, **_k: creds)
+    called = {"transcript": 0, "child": 0}
+    monkeypatch.setattr(
+        live_log, "create_live_transcripts",
+        lambda *_a, **_k: called.__setitem__("transcript", called["transcript"] + 1),
+    )
+    monkeypatch.setattr(
+        dt, "_build_child_agent",
+        lambda **_k: called.__setitem__("child", called["child"] + 1),
+    )
+    reserved = ad.reserve_logical_delegation(
+        logical_key="kanban/step/attempt", input_digest="sha256:stable", goal="g",
+        context=None, toolsets=None, role="leaf", model="m",
+    )
+    assert reserved["status"] == "reserved"
+
+    replay = json.loads(dt.delegate_task(
+        goal="g", background=True, parent_agent=parent,
+        logical_dispatch_key="kanban/step/attempt",
+        logical_input_digest="sha256:stable",
+    ))
+    assert replay["status"] == "replayed"
+    assert replay["delegation_id"] == reserved["delegation_id"]
+    assert called == {"transcript": 0, "child": 0}

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -45,6 +45,8 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
@@ -57,6 +59,45 @@ logger = logging.getLogger(__name__)
 # other subsystems (tool_executor, memory_manager, delegate_tool, skills_hub)
 # can share it. Existing imports of ``_DaemonThreadPoolExecutor`` keep working.
 _DaemonThreadPoolExecutor = DaemonThreadPoolExecutor
+
+
+@dataclass(frozen=True)
+class BridgeAuthorityContext:
+    """Immutable worker authority captured before a logical dispatch starts."""
+
+    kanban_db_path: str
+    workflow_id: str
+    step_key: str
+    step_attempt_id: str
+    task_id: str
+    run_id: int
+    claim_token: str
+    lane: str
+    route: str
+    owner_id: str
+
+    def __post_init__(self) -> None:
+        if not self.task_id or not self.claim_token or int(self.run_id) <= 0:
+            raise ValueError("bridge authority requires task, run, and claim identity")
+        object.__setattr__(
+            self,
+            "kanban_db_path",
+            str(Path(self.kanban_db_path).expanduser().resolve()),
+        )
+
+
+def canonical_logical_key(authority: BridgeAuthorityContext) -> str:
+    identity = {
+        "workflow_id": authority.workflow_id,
+        "step_key": authority.step_key,
+        "step_attempt_id": authority.step_attempt_id,
+        "task_id": authority.task_id,
+        "run_id": int(authority.run_id),
+        "lane": authority.lane,
+        "route": authority.route,
+        "owner_id": authority.owner_id,
+    }
+    return "kanban:v1:" + canonical_json_digest(identity).removeprefix("sha256:")
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +201,8 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             source_acknowledged_at REAL,
             source_ack_count INTEGER NOT NULL DEFAULT 0,
             quarantine_reason TEXT,
-            observed_digest TEXT
+            observed_digest TEXT,
+            authority_json TEXT
         )"""
     )
     columns = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
@@ -178,6 +220,23 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
     ):
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
+    conn.execute(
+        """CREATE TRIGGER IF NOT EXISTS protect_pending_async_delegation_evidence
+           BEFORE DELETE ON async_delegations
+           WHEN OLD.delivery_state='pending'
+             AND OLD.state NOT IN ('running','finalizing')
+           BEGIN
+             SELECT RAISE(
+               ABORT,
+               'pending delegation evidence requires a compatible Hermes writer'
+             );
+           END"""
+    )
+    logical_columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(logical_delegations)")
+    }
+    if "authority_json" not in logical_columns:
+        conn.execute("ALTER TABLE logical_delegations ADD COLUMN authority_json TEXT")
 
 
 @contextmanager
@@ -567,7 +626,7 @@ _LOGICAL_COLUMNS = (
     "updated_at", "terminal_status", "result_json", "result_digest",
     "receipt_id", "kanban_db_path", "task_id", "continuation_id",
     "source_acknowledged_at", "source_ack_count", "quarantine_reason",
-    "observed_digest",
+    "observed_digest", "authority_json",
 )
 
 
@@ -578,9 +637,11 @@ def _logical_record(row) -> Optional[Dict[str, Any]]:
     context_json = record.pop("context_json")
     toolsets_json = record.pop("toolsets_json")
     result_json = record.pop("result_json")
+    authority_json = record.pop("authority_json")
     record["context"] = json.loads(context_json) if context_json else None
     record["toolsets"] = json.loads(toolsets_json) if toolsets_json else None
     record["result"] = json.loads(result_json) if result_json else None
+    record["authority"] = json.loads(authority_json) if authority_json else None
     return record
 
 
@@ -595,6 +656,10 @@ def get_logical_delegation(logical_key: str) -> Optional[Dict[str, Any]]:
     """Read committed logical-dispatch evidence from source state.db."""
     with _DB_LOCK, _connect() as conn:
         return _logical_record(_select_logical(conn, logical_key))
+
+
+def _logical_capacity_reached(protected: int, limit: int) -> bool:
+    return protected >= max(0, int(limit))
 
 
 def _quarantine_logical(
@@ -626,12 +691,13 @@ def _quarantine_logical_in_conn(
     }
 
 
-def reserve_logical_delegation(
+def _reserve_logical_delegation_legacy(
     *, logical_key: str, input_digest: str, goal: str,
     context: Optional[str], toolsets: Optional[List[str]], role: str,
     model: Optional[str], session_key: str = "",
     parent_session_id: Optional[str] = None,
     max_pending_records: int = _MAX_DURABLE_PENDING,
+    authority_json: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Reserve K→D identity without launching; used at delegate_task's seam."""
     logical_key = str(logical_key or "").strip()
@@ -659,7 +725,7 @@ def reserve_logical_delegation(
         protected = conn.execute(
             "SELECT COUNT(*) FROM logical_delegations WHERE state != 'acknowledged'"
         ).fetchone()[0]
-        if protected >= max_pending_records:
+        if _logical_capacity_reached(protected, max_pending_records):
             return {"status": "backpressure", "state": "backpressure", "protected": protected}
         delegation_id = _new_delegation_id()
         execution_id = "exec_" + uuid.uuid4().hex
@@ -667,13 +733,14 @@ def reserve_logical_delegation(
             """INSERT INTO logical_delegations
                (logical_key, input_digest, delegation_id, execution_id, state,
                 goal, context_json, toolsets_json, role, model, session_key,
-                parent_session_id, reserved_at, updated_at)
-               VALUES (?, ?, ?, ?, 'reserved', ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                parent_session_id, reserved_at, updated_at, authority_json)
+               VALUES (?, ?, ?, ?, 'reserved', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 logical_key, input_digest, delegation_id, execution_id, goal,
                 json.dumps(context) if context is not None else None,
                 json.dumps(list(toolsets)) if toolsets else None,
                 role, model, session_key, parent_session_id, now, now,
+                authority_json,
             ),
         )
         return {
@@ -681,6 +748,39 @@ def reserve_logical_delegation(
             "input_digest": input_digest, "delegation_id": delegation_id,
             "execution_id": execution_id,
         }
+
+
+def reserve_logical_delegation(
+    *, logical_key: str, input_digest: str, goal: str,
+    context: Optional[str], toolsets: Optional[List[str]], role: str,
+    model: Optional[str], session_key: str = "",
+    parent_session_id: Optional[str] = None,
+    max_pending_records: int = _MAX_DURABLE_PENDING,
+    authority_context: Optional[BridgeAuthorityContext] = None,
+) -> Dict[str, Any]:
+    """Reserve a logical dispatch and bind immutable worker authority to it."""
+    authority_json = None
+    if authority_context is not None:
+        if logical_key != canonical_logical_key(authority_context):
+            return {"status": "rejected", "error": "logical_key is not canonical for authority"}
+        if not str(input_digest).startswith("sha256:"):
+            return {"status": "rejected", "error": "input_digest must use sha256"}
+        authority_json = json.dumps(
+            asdict(authority_context), sort_keys=True, separators=(",", ":")
+        )
+    return _reserve_logical_delegation_legacy(
+        logical_key=logical_key,
+        input_digest=input_digest,
+        goal=goal,
+        context=context,
+        toolsets=toolsets,
+        role=role,
+        model=model,
+        session_key=session_key,
+        parent_session_id=parent_session_id,
+        max_pending_records=max_pending_records,
+        authority_json=authority_json,
+    )
 
 
 def claim_logical_delegation_launch(logical_key: str, input_digest: str) -> bool:
@@ -768,7 +868,7 @@ def dispatch_logical_delegation(
         protected = conn.execute(
             "SELECT COUNT(*) FROM logical_delegations WHERE state != 'acknowledged'"
         ).fetchone()[0]
-        if protected >= max_pending_records:
+        if _logical_capacity_reached(protected, max_pending_records):
             return {
                 "status": "backpressure", "state": "backpressure",
                 "protected": protected,
@@ -780,13 +880,14 @@ def dispatch_logical_delegation(
             """INSERT INTO logical_delegations
                (logical_key, input_digest, delegation_id, execution_id, state,
                 goal, context_json, toolsets_json, role, model, session_key,
-                parent_session_id, reserved_at, updated_at)
-               VALUES (?, ?, ?, ?, 'reserved', ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                parent_session_id, reserved_at, updated_at, authority_json)
+               VALUES (?, ?, ?, ?, 'reserved', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 logical_key, input_digest, delegation_id, execution_id, goal,
                 json.dumps(context) if context is not None else None,
                 json.dumps(list(toolsets)) if toolsets else None,
                 role, model, session_key, parent_session_id, now, now,
+                '{"compatibility_mode":"direct_dispatch"}',
             ),
         )
 
@@ -809,13 +910,11 @@ def dispatch_logical_delegation(
                 logical_key, "async execution capacity changed after reservation"
             )
         _records[delegation_id] = record
-    started = time.time()
-    with _DB_LOCK, _connect() as conn:
-        conn.execute(
-            """UPDATE logical_delegations SET state='running', started_at=?, updated_at=?
-               WHERE logical_key=? AND state='reserved'""",
-            (started, started, logical_key),
-        )
+    if not claim_logical_delegation_launch(logical_key, input_digest):
+        with _records_lock:
+            _records.pop(delegation_id, None)
+        current = get_logical_delegation(logical_key) or {}
+        return {**current, "status": current.get("state", "quarantined")}
 
     def _worker() -> None:
         try:
@@ -931,10 +1030,34 @@ def attach_logical_dispatch_receipt(
         return {"status": "missing", "logical_key": logical_key}
     if record["state"] == "quarantined":
         return {**record, "status": "quarantined"}
+    authority = record.get("authority")
+    compatibility_mode = (authority or {}).get("compatibility_mode")
+    if not authority:
+        quarantined = _quarantine_logical(
+            logical_key, "logical dispatch lacks kernel worker authority"
+        )
+        return {**quarantined, "status": "conflict"}
+    canonical_board_path = str(Path(kanban_db_path).expanduser().resolve())
+    if not compatibility_mode and (
+        authority.get("kanban_db_path") != canonical_board_path
+        or authority.get("task_id") != task_id
+    ):
+        quarantined = _quarantine_logical(
+            logical_key, "Kanban target conflicts with immutable worker authority"
+        )
+        return {**quarantined, "status": "conflict"}
     if record.get("task_id") and record["task_id"] != task_id:
         return _quarantine_logical(logical_key, "Kanban target task conflict")
     if not record.get("result") or not record.get("result_digest"):
         return _quarantine_logical(logical_key, "source terminal result is not committed")
+    computed_result_digest = canonical_json_digest(record["result"])
+    if computed_result_digest != record["result_digest"]:
+        quarantined = _quarantine_logical(
+            logical_key,
+            "source result digest does not match committed result",
+            computed_result_digest,
+        )
+        return {**quarantined, "status": "conflict"}
     allowed = {
         "terminal_unattached", "terminal_pending_receipt",
         "receipted_unacknowledged", "acknowledged",
@@ -944,35 +1067,57 @@ def attach_logical_dispatch_receipt(
             **record, "status": "not_terminal",
             "error": f"logical dispatch is in {record['state']}",
         }
-    if prepare_only:
-        if record["state"] == "terminal_unattached":
-            now = time.time()
-            with _DB_LOCK, _connect() as conn:
-                conn.execute(
-                    """UPDATE logical_delegations
-                       SET state='terminal_pending_receipt', kanban_db_path=?,
-                           task_id=?, updated_at=?
-                       WHERE logical_key=? AND state='terminal_unattached'""",
-                    (str(kanban_db_path), task_id, now, logical_key),
+    now = time.time()
+    with _DB_LOCK, _connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        pinned = _logical_record(_select_logical(conn, logical_key)) or {}
+        if pinned.get("state") == "terminal_unattached":
+            cur = conn.execute(
+                """UPDATE logical_delegations
+                   SET state='terminal_pending_receipt', kanban_db_path=?,
+                       task_id=?, updated_at=?
+                   WHERE logical_key=? AND state='terminal_unattached'
+                     AND kanban_db_path IS NULL AND task_id IS NULL
+                     AND delegation_id=? AND execution_id=? AND result_digest=?""",
+                (
+                    canonical_board_path, task_id, now, logical_key,
+                    record["delegation_id"], record["execution_id"],
+                    record["result_digest"],
+                ),
+            )
+            if cur.rowcount != 1:
+                return _quarantine_logical_in_conn(
+                    conn, logical_key, "Kanban target pin CAS failed"
                 )
+        elif (
+            pinned.get("kanban_db_path") != canonical_board_path
+            or pinned.get("task_id") != task_id
+        ):
+            quarantined = _quarantine_logical_in_conn(
+                conn, logical_key, "Kanban target conflicts with pinned target"
+            )
+            return {**quarantined, "status": "conflict"}
+
+    if prepare_only:
         return {
             **(get_logical_delegation(logical_key) or record),
             "status": "prepared",
         }
 
-    if record["state"] in {"terminal_unattached", "terminal_pending_receipt"}:
-        now = time.time()
-        with _DB_LOCK, _connect() as conn:
-            conn.execute(
-                """UPDATE logical_delegations
-                   SET state='terminal_pending_receipt', kanban_db_path=?,
-                       task_id=?, updated_at=?
-                   WHERE logical_key=? AND state IN
-                       ('terminal_unattached','terminal_pending_receipt')""",
-                (str(kanban_db_path), task_id, now, logical_key),
-            )
-
+    from agent.redact import redact_sensitive_text
     from hermes_cli import kanban_db as kb
+    raw_summary = record["result"].get("summary")
+    if raw_summary is None:
+        raw_summary = record["result"].get("error") or record["terminal_status"]
+    summary = redact_sensitive_text(
+        str(raw_summary), force=True, file_read=True, redact_url_credentials=True
+    )[:4096]
+    receipt_projection = {
+        "terminal_status": record["terminal_status"],
+        "summary": summary,
+        "source_pointer": f"state.db:logical_delegations/{logical_key}",
+        "result_digest": record["result_digest"],
+    }
     with kb.connect_closing(kanban_db_path) as conn:
         receipt = kb.record_delegation_receipt(
             conn,
@@ -982,13 +1127,24 @@ def attach_logical_dispatch_receipt(
             execution_id=record["execution_id"],
             result_digest=record["result_digest"],
             terminal_status=record["terminal_status"],
-            result=record["result"],
+            result=receipt_projection,
             task_id=task_id,
+            expected_run_id=(
+                int(authority["run_id"]) if not compatibility_mode else None
+            ),
+            expected_claim_token=(
+                authority["claim_token"] if not compatibility_mode else None
+            ),
+            expected_workflow_id=authority.get("workflow_id"),
+            expected_step_key=authority.get("step_key"),
+            expected_lane=authority.get("lane"),
+            allow_legacy_running_task=bool(compatibility_mode),
         )
     if receipt["status"] == "conflict":
-        return _quarantine_logical(
+        quarantined = _quarantine_logical(
             logical_key, f"Kanban receipt conflict: {receipt.get('reason', 'unknown')}"
         )
+        return {**quarantined, "status": "conflict"}
     if fault_after == "kanban_commit":
         raise LogicalDispatchBridgeFault("fault after kanban_commit")
 
@@ -1043,7 +1199,8 @@ def prune_logical_delegations(
             )
         status = (
             "backpressure"
-            if protected > max_pending_records or protected > max_records
+            if _logical_capacity_reached(protected, max_pending_records)
+            or _logical_capacity_reached(protected, max_records)
             else "ok"
         )
         return {

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -37,6 +37,7 @@ logic stays in one place.
 from __future__ import annotations
 
 import json
+import hashlib
 import logging
 import sqlite3
 import threading
@@ -131,6 +132,37 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             origin_session_id TEXT NOT NULL DEFAULT ''
         )"""
     )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS logical_delegations (
+            logical_key TEXT PRIMARY KEY,
+            input_digest TEXT NOT NULL,
+            delegation_id TEXT NOT NULL UNIQUE,
+            execution_id TEXT NOT NULL UNIQUE,
+            state TEXT NOT NULL,
+            goal TEXT NOT NULL,
+            context_json TEXT,
+            toolsets_json TEXT,
+            role TEXT NOT NULL,
+            model TEXT,
+            session_key TEXT NOT NULL,
+            parent_session_id TEXT,
+            reserved_at REAL NOT NULL,
+            started_at REAL,
+            completed_at REAL,
+            updated_at REAL NOT NULL,
+            terminal_status TEXT,
+            result_json TEXT,
+            result_digest TEXT,
+            receipt_id TEXT,
+            kanban_db_path TEXT,
+            task_id TEXT,
+            continuation_id TEXT,
+            source_acknowledged_at REAL,
+            source_ack_count INTEGER NOT NULL DEFAULT 0,
+            quarantine_reason TEXT,
+            observed_digest TEXT
+        )"""
+    )
     columns = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
     for name, sql_type in (
         ("owner_pid", "INTEGER"),
@@ -207,36 +239,31 @@ def _prune_durable_records() -> None:
     cutoff = now - _DURABLE_RETENTION_SECONDS
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
-            "DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ?",
+            """DELETE FROM async_delegations
+               WHERE delivery_state='delivered'
+                 AND state NOT IN ('running','finalizing','unknown')
+                 AND updated_at < ?""",
             (cutoff,),
         )
-        terminal_count = conn.execute(
+        # Count caps may retire only positively delivered ordinary records.
+        # Pending/unknown records are evidence, not cache: pressure must be
+        # handled by logical-dispatch backpressure rather than deletion.
+        total_terminal_count = conn.execute(
             "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing')"
         ).fetchone()[0]
-        excess = max(0, terminal_count - _MAX_RETAINED_COMPLETED)
+        # The total history cap may retire delivered rows to make room, but it
+        # never spills over into pending/unknown evidence when delivered rows
+        # are insufficient.
+        excess = max(0, total_terminal_count - _MAX_RETAINED_COMPLETED)
         if excess:
             conn.execute(
                 """DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
                      WHERE state NOT IN ('running','finalizing')
-                     ORDER BY CASE delivery_state WHEN 'delivered' THEN 0 ELSE 1 END,
-                              updated_at ASC LIMIT ?
-                   )""",
-                (excess,),
-            )
-        pending_count = conn.execute(
-            """SELECT COUNT(*) FROM async_delegations
-               WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'"""
-        ).fetchone()[0]
-        overflow = max(0, pending_count - _MAX_DURABLE_PENDING)
-        if overflow:
-            conn.execute(
-                """DELETE FROM async_delegations WHERE delegation_id IN (
-                     SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'
+                       AND delivery_state='delivered'
                      ORDER BY updated_at ASC LIMIT ?
                    )""",
-                (overflow,),
+                (excess,),
             )
 
 
@@ -510,6 +537,519 @@ def active_count() -> int:
 
 def _new_delegation_id() -> str:
     return f"deleg_{uuid.uuid4().hex[:8]}"
+
+
+_LOGICAL_TERMINAL_STATUSES = {
+    "PASS", "REWORK", "REPLAN", "BLOCKED", "FALLBACK_REQUIRED", "FAILED"
+}
+_LOGICAL_PROTECTED_STATES = {
+    "reserved", "running", "terminal_unattached", "terminal_pending_receipt",
+    "receipted_unacknowledged", "quarantined", "unknown",
+}
+
+
+class LogicalDispatchBridgeFault(RuntimeError):
+    """Deterministic test seam raised only after a named durable boundary."""
+
+
+def canonical_json_digest(value: Any) -> str:
+    payload = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+_LOGICAL_COLUMNS = (
+    "logical_key", "input_digest", "delegation_id", "execution_id", "state",
+    "goal", "context_json", "toolsets_json", "role", "model", "session_key",
+    "parent_session_id", "reserved_at", "started_at", "completed_at",
+    "updated_at", "terminal_status", "result_json", "result_digest",
+    "receipt_id", "kanban_db_path", "task_id", "continuation_id",
+    "source_acknowledged_at", "source_ack_count", "quarantine_reason",
+    "observed_digest",
+)
+
+
+def _logical_record(row) -> Optional[Dict[str, Any]]:
+    if row is None:
+        return None
+    record: Dict[str, Any] = dict(zip(_LOGICAL_COLUMNS, row))
+    context_json = record.pop("context_json")
+    toolsets_json = record.pop("toolsets_json")
+    result_json = record.pop("result_json")
+    record["context"] = json.loads(context_json) if context_json else None
+    record["toolsets"] = json.loads(toolsets_json) if toolsets_json else None
+    record["result"] = json.loads(result_json) if result_json else None
+    return record
+
+
+def _select_logical(conn: sqlite3.Connection, logical_key: str):
+    return conn.execute(
+        f"SELECT {', '.join(_LOGICAL_COLUMNS)} FROM logical_delegations WHERE logical_key=?",
+        (logical_key,),
+    ).fetchone()
+
+
+def get_logical_delegation(logical_key: str) -> Optional[Dict[str, Any]]:
+    """Read committed logical-dispatch evidence from source state.db."""
+    with _DB_LOCK, _connect() as conn:
+        return _logical_record(_select_logical(conn, logical_key))
+
+
+def _quarantine_logical(
+    logical_key: str, reason: str, observed_digest: Optional[str] = None
+) -> Dict[str, Any]:
+    with _DB_LOCK, _connect() as conn:
+        return _quarantine_logical_in_conn(
+            conn, logical_key, reason, observed_digest
+        )
+
+
+def _quarantine_logical_in_conn(
+    conn: sqlite3.Connection,
+    logical_key: str,
+    reason: str,
+    observed_digest: Optional[str] = None,
+) -> Dict[str, Any]:
+    conn.execute(
+        """UPDATE logical_delegations
+           SET state='quarantined', quarantine_reason=?, observed_digest=?, updated_at=?
+           WHERE logical_key=?""",
+        (reason, observed_digest, time.time(), logical_key),
+    )
+    record = _logical_record(_select_logical(conn, logical_key)) or {}
+    return {
+        **record, "status": "quarantined", "reason": reason,
+        "expected_digest": record.get("input_digest"),
+        "observed_digest": observed_digest,
+    }
+
+
+def reserve_logical_delegation(
+    *, logical_key: str, input_digest: str, goal: str,
+    context: Optional[str], toolsets: Optional[List[str]], role: str,
+    model: Optional[str], session_key: str = "",
+    parent_session_id: Optional[str] = None,
+    max_pending_records: int = _MAX_DURABLE_PENDING,
+) -> Dict[str, Any]:
+    """Reserve K→D identity without launching; used at delegate_task's seam."""
+    logical_key = str(logical_key or "").strip()
+    input_digest = str(input_digest or "").strip()
+    if not logical_key or not input_digest:
+        return {"status": "rejected", "error": "logical_key and input_digest are required"}
+    now = time.time()
+    with _DB_LOCK, _connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        existing = _logical_record(_select_logical(conn, logical_key))
+        if existing is not None:
+            if existing["input_digest"] != input_digest:
+                conn.execute(
+                    """UPDATE logical_delegations SET state='quarantined',
+                       quarantine_reason='input digest conflict', observed_digest=?, updated_at=?
+                       WHERE logical_key=?""",
+                    (input_digest, now, logical_key),
+                )
+                return {
+                    **existing, "state": "quarantined", "status": "quarantined",
+                    "expected_digest": existing["input_digest"],
+                    "observed_digest": input_digest,
+                }
+            return {**existing, "status": "replayed"}
+        protected = conn.execute(
+            "SELECT COUNT(*) FROM logical_delegations WHERE state != 'acknowledged'"
+        ).fetchone()[0]
+        if protected >= max_pending_records:
+            return {"status": "backpressure", "state": "backpressure", "protected": protected}
+        delegation_id = _new_delegation_id()
+        execution_id = "exec_" + uuid.uuid4().hex
+        conn.execute(
+            """INSERT INTO logical_delegations
+               (logical_key, input_digest, delegation_id, execution_id, state,
+                goal, context_json, toolsets_json, role, model, session_key,
+                parent_session_id, reserved_at, updated_at)
+               VALUES (?, ?, ?, ?, 'reserved', ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                logical_key, input_digest, delegation_id, execution_id, goal,
+                json.dumps(context) if context is not None else None,
+                json.dumps(list(toolsets)) if toolsets else None,
+                role, model, session_key, parent_session_id, now, now,
+            ),
+        )
+        return {
+            "status": "reserved", "state": "reserved", "logical_key": logical_key,
+            "input_digest": input_digest, "delegation_id": delegation_id,
+            "execution_id": execution_id,
+        }
+
+
+def claim_logical_delegation_launch(logical_key: str, input_digest: str) -> bool:
+    """CAS a pre-transcript reservation immediately before executor launch."""
+    now = time.time()
+    with _DB_LOCK, _connect() as conn:
+        cur = conn.execute(
+            """UPDATE logical_delegations SET state='running', started_at=?, updated_at=?
+               WHERE logical_key=? AND input_digest=? AND state='reserved'""",
+            (now, now, logical_key, input_digest),
+        )
+        return cur.rowcount == 1
+
+
+def commit_logical_delegation_result(
+    logical_key: str, input_digest: str, result: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Commit canonical terminal evidence for an integrated delegate runner."""
+    terminal_status = str(result.get("status") or "FAILED").upper()
+    if terminal_status == "COMPLETED":
+        terminal_status = "PASS"
+    if terminal_status not in _LOGICAL_TERMINAL_STATUSES:
+        terminal_status = "FAILED"
+    digest = canonical_json_digest(result)
+    payload = json.dumps(result, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    now = time.time()
+    with _DB_LOCK, _connect() as conn:
+        cur = conn.execute(
+            """UPDATE logical_delegations SET state='terminal_unattached',
+               terminal_status=?, result_json=?, result_digest=?, completed_at=?, updated_at=?
+               WHERE logical_key=? AND input_digest=? AND state='running'""",
+            (terminal_status, payload, digest, now, now, logical_key, input_digest),
+        )
+        if cur.rowcount != 1:
+            return _quarantine_logical_in_conn(
+                conn, logical_key, "terminal commit identity/state mismatch"
+            )
+    return get_logical_delegation(logical_key) or {}
+
+
+def dispatch_logical_delegation(
+    *,
+    logical_key: str,
+    input_digest: str,
+    goal: str,
+    context: Optional[str],
+    toolsets: Optional[List[str]],
+    role: str,
+    model: Optional[str],
+    session_key: str,
+    parent_session_id: Optional[str],
+    runner: Callable[[], Dict[str, Any]],
+    origin_ui_session_id: str = "",
+    interrupt_fn: Optional[Callable[[], None]] = None,
+    max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
+    max_pending_records: int = _MAX_DURABLE_PENDING,
+) -> Dict[str, Any]:
+    """Reserve one logical identity durably, then launch exactly one runner."""
+    logical_key = str(logical_key or "").strip()
+    input_digest = str(input_digest or "").strip()
+    if not logical_key or not input_digest:
+        return {"status": "rejected", "error": "logical_key and input_digest are required"}
+    now = time.time()
+    with _DB_LOCK, _connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        existing = _logical_record(_select_logical(conn, logical_key))
+        if existing is not None:
+            if existing["input_digest"] != input_digest:
+                conn.execute(
+                    """UPDATE logical_delegations SET state='quarantined',
+                       quarantine_reason='input digest conflict', observed_digest=?, updated_at=?
+                       WHERE logical_key=?""",
+                    (input_digest, now, logical_key),
+                )
+                existing.update(
+                    state="quarantined", observed_digest=input_digest,
+                    quarantine_reason="input digest conflict",
+                )
+                return {
+                    **existing, "status": "quarantined",
+                    "expected_digest": existing["input_digest"],
+                    "observed_digest": input_digest,
+                }
+            return {**existing, "status": "replayed"}
+        protected = conn.execute(
+            "SELECT COUNT(*) FROM logical_delegations WHERE state != 'acknowledged'"
+        ).fetchone()[0]
+        if protected >= max_pending_records:
+            return {
+                "status": "backpressure", "state": "backpressure",
+                "protected": protected,
+                "error": "logical delegation protected-state capacity reached",
+            }
+        delegation_id = _new_delegation_id()
+        execution_id = "exec_" + uuid.uuid4().hex
+        conn.execute(
+            """INSERT INTO logical_delegations
+               (logical_key, input_digest, delegation_id, execution_id, state,
+                goal, context_json, toolsets_json, role, model, session_key,
+                parent_session_id, reserved_at, updated_at)
+               VALUES (?, ?, ?, ?, 'reserved', ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                logical_key, input_digest, delegation_id, execution_id, goal,
+                json.dumps(context) if context is not None else None,
+                json.dumps(list(toolsets)) if toolsets else None,
+                role, model, session_key, parent_session_id, now, now,
+            ),
+        )
+
+    record: Dict[str, Any] = {
+        "delegation_id": delegation_id, "execution_id": execution_id,
+        "logical_key": logical_key, "goal": goal, "context": context,
+        "toolsets": list(toolsets) if toolsets else None, "role": role,
+        "model": model, "session_key": session_key,
+        "origin_ui_session_id": origin_ui_session_id,
+        "parent_session_id": parent_session_id, "status": "running",
+        "dispatched_at": now, "completed_at": None, "interrupt_fn": interrupt_fn,
+    }
+    with _records_lock:
+        running = sum(
+            1 for r in _records.values()
+            if r.get("status") in {"running", "finalizing"}
+        )
+        if running >= max_async_children:
+            return _quarantine_logical(
+                logical_key, "async execution capacity changed after reservation"
+            )
+        _records[delegation_id] = record
+    started = time.time()
+    with _DB_LOCK, _connect() as conn:
+        conn.execute(
+            """UPDATE logical_delegations SET state='running', started_at=?, updated_at=?
+               WHERE logical_key=? AND state='reserved'""",
+            (started, started, logical_key),
+        )
+
+    def _worker() -> None:
+        try:
+            result = runner() or {}
+            if not isinstance(result, dict):
+                raise TypeError("logical delegation runner must return a dict")
+            terminal_status = str(result.get("status") or "FAILED").upper()
+            if terminal_status not in _LOGICAL_TERMINAL_STATUSES:
+                terminal_status = "FAILED"
+        except Exception as exc:  # noqa: BLE001
+            result = {
+                "status": "FAILED", "summary": None,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+            terminal_status = "FAILED"
+        completed = time.time()
+        try:
+            result_digest = canonical_json_digest(result)
+        except (TypeError, ValueError) as exc:
+            result = {
+                "status": "FAILED", "summary": None,
+                "error": f"uncanonicalizable result: {exc}",
+            }
+            terminal_status = "FAILED"
+            result_digest = canonical_json_digest(result)
+        result_json = json.dumps(
+            result, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        )
+        with _DB_LOCK, _connect() as conn:
+            conn.execute(
+                """UPDATE logical_delegations SET state='terminal_unattached',
+                   terminal_status=?, result_json=?, result_digest=?, completed_at=?, updated_at=?
+                   WHERE logical_key=? AND state != 'quarantined'""",
+                (
+                    terminal_status, result_json, result_digest,
+                    completed, completed, logical_key,
+                ),
+            )
+        with _records_lock:
+            current = _records.get(delegation_id)
+            if current is not None:
+                current["status"] = terminal_status
+                current["completed_at"] = completed
+            _prune_completed_locked()
+
+    try:
+        _get_executor(max_async_children).submit(propagate_context_to_thread(_worker))
+    except Exception as exc:  # pragma: no cover
+        with _records_lock:
+            _records.pop(delegation_id, None)
+        return _quarantine_logical(
+            logical_key, f"executor submission outcome unknown: {exc}"
+        )
+    return {
+        "status": "dispatched", "state": "reserved",
+        "logical_key": logical_key, "delegation_id": delegation_id,
+        "execution_id": execution_id,
+    }
+
+
+def acknowledge_logical_dispatch(
+    *, logical_key: str, fault_after: Optional[str] = None
+) -> Dict[str, Any]:
+    """Commit exactly one source acknowledgement after a proven receipt."""
+    now = time.time()
+    with _DB_LOCK, _connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        record = _logical_record(_select_logical(conn, logical_key))
+        if record is None:
+            return {"status": "missing", "logical_key": logical_key}
+        if record["state"] == "quarantined":
+            return {**record, "status": "quarantined"}
+        if not record["receipt_id"] or not record["result_digest"]:
+            return _quarantine_logical_in_conn(
+                conn, logical_key,
+                "source acknowledgement lacks committed receipt proof",
+            )
+        if record["state"] == "acknowledged":
+            return {**record, "status": "replayed"}
+        if record["state"] != "receipted_unacknowledged":
+            return _quarantine_logical_in_conn(
+                conn, logical_key,
+                f"invalid acknowledgement state {record['state']}",
+            )
+        conn.execute(
+            """UPDATE logical_delegations
+               SET state='acknowledged', source_acknowledged_at=?,
+                   source_ack_count=1, updated_at=?
+               WHERE logical_key=? AND state='receipted_unacknowledged'
+                 AND source_ack_count=0 AND receipt_id=? AND result_digest=?""",
+            (
+                now, now, logical_key, record["receipt_id"],
+                record["result_digest"],
+            ),
+        )
+    if fault_after == "source_ack_commit":
+        raise LogicalDispatchBridgeFault("fault after source_ack_commit")
+    return {**(get_logical_delegation(logical_key) or {}), "status": "acknowledged"}
+
+
+def attach_logical_dispatch_receipt(
+    *,
+    logical_key: str,
+    kanban_db_path,
+    task_id: str,
+    acknowledge_source: bool = True,
+    prepare_only: bool = False,
+    fault_after: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Bridge committed source evidence to one atomic Kanban receipt unit."""
+    record = get_logical_delegation(logical_key)
+    if record is None:
+        return {"status": "missing", "logical_key": logical_key}
+    if record["state"] == "quarantined":
+        return {**record, "status": "quarantined"}
+    if record.get("task_id") and record["task_id"] != task_id:
+        return _quarantine_logical(logical_key, "Kanban target task conflict")
+    if not record.get("result") or not record.get("result_digest"):
+        return _quarantine_logical(logical_key, "source terminal result is not committed")
+    allowed = {
+        "terminal_unattached", "terminal_pending_receipt",
+        "receipted_unacknowledged", "acknowledged",
+    }
+    if record["state"] not in allowed:
+        return {
+            **record, "status": "not_terminal",
+            "error": f"logical dispatch is in {record['state']}",
+        }
+    if prepare_only:
+        if record["state"] == "terminal_unattached":
+            now = time.time()
+            with _DB_LOCK, _connect() as conn:
+                conn.execute(
+                    """UPDATE logical_delegations
+                       SET state='terminal_pending_receipt', kanban_db_path=?,
+                           task_id=?, updated_at=?
+                       WHERE logical_key=? AND state='terminal_unattached'""",
+                    (str(kanban_db_path), task_id, now, logical_key),
+                )
+        return {
+            **(get_logical_delegation(logical_key) or record),
+            "status": "prepared",
+        }
+
+    if record["state"] in {"terminal_unattached", "terminal_pending_receipt"}:
+        now = time.time()
+        with _DB_LOCK, _connect() as conn:
+            conn.execute(
+                """UPDATE logical_delegations
+                   SET state='terminal_pending_receipt', kanban_db_path=?,
+                       task_id=?, updated_at=?
+                   WHERE logical_key=? AND state IN
+                       ('terminal_unattached','terminal_pending_receipt')""",
+                (str(kanban_db_path), task_id, now, logical_key),
+            )
+
+    from hermes_cli import kanban_db as kb
+    with kb.connect_closing(kanban_db_path) as conn:
+        receipt = kb.record_delegation_receipt(
+            conn,
+            logical_key=logical_key,
+            input_digest=record["input_digest"],
+            delegation_id=record["delegation_id"],
+            execution_id=record["execution_id"],
+            result_digest=record["result_digest"],
+            terminal_status=record["terminal_status"],
+            result=record["result"],
+            task_id=task_id,
+        )
+    if receipt["status"] == "conflict":
+        return _quarantine_logical(
+            logical_key, f"Kanban receipt conflict: {receipt.get('reason', 'unknown')}"
+        )
+    if fault_after == "kanban_commit":
+        raise LogicalDispatchBridgeFault("fault after kanban_commit")
+
+    now = time.time()
+    with _DB_LOCK, _connect() as conn:
+        conn.execute(
+            """UPDATE logical_delegations
+               SET state=CASE WHEN state='acknowledged' THEN state
+                              ELSE 'receipted_unacknowledged' END,
+                   receipt_id=?, continuation_id=?, kanban_db_path=?, task_id=?,
+                   updated_at=?
+               WHERE logical_key=? AND delegation_id=? AND execution_id=?
+                 AND result_digest=? AND state != 'quarantined'""",
+            (
+                receipt["receipt_id"], receipt["continuation_id"],
+                str(kanban_db_path), task_id, now, logical_key,
+                record["delegation_id"], record["execution_id"],
+                record["result_digest"],
+            ),
+        )
+    if acknowledge_source:
+        return acknowledge_logical_dispatch(logical_key=logical_key)
+    return {
+        **(get_logical_delegation(logical_key) or {}),
+        "status": receipt["status"],
+    }
+
+
+def prune_logical_delegations(
+    *, retention_seconds: float, max_records: int, max_pending_records: int
+) -> Dict[str, Any]:
+    """Delete only old acknowledged rows; protected evidence backpressures."""
+    cutoff = time.time() - max(0.0, float(retention_seconds))
+    with _DB_LOCK, _connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        protected = conn.execute(
+            "SELECT COUNT(*) FROM logical_delegations WHERE state != 'acknowledged'"
+        ).fetchone()[0]
+        total = conn.execute("SELECT COUNT(*) FROM logical_delegations").fetchone()[0]
+        eligible = conn.execute(
+            """SELECT logical_key FROM logical_delegations
+               WHERE state='acknowledged' AND source_acknowledged_at <= ?
+               ORDER BY source_acknowledged_at ASC""",
+            (cutoff,),
+        ).fetchall()
+        excess = max(0, total - max(0, int(max_records)))
+        delete_keys = [row[0] for row in eligible[:excess]]
+        if delete_keys:
+            conn.executemany(
+                "DELETE FROM logical_delegations WHERE logical_key=? AND state='acknowledged'",
+                [(key,) for key in delete_keys],
+            )
+        status = (
+            "backpressure"
+            if protected > max_pending_records or protected > max_records
+            else "ok"
+        )
+        return {
+            "status": status, "deleted": len(delete_keys),
+            "protected": protected, "total": total - len(delete_keys),
+        }
 
 
 def _prune_completed_locked() -> None:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -77,8 +77,20 @@ class BridgeAuthorityContext:
     owner_id: str
 
     def __post_init__(self) -> None:
-        if not self.task_id or not self.claim_token or int(self.run_id) <= 0:
-            raise ValueError("bridge authority requires task, run, and claim identity")
+        if (
+            not self.task_id
+            or not self.claim_token
+            or int(self.run_id) <= 0
+            or not self.workflow_id
+            or not self.step_key
+            or not self.step_attempt_id
+            or not self.lane
+        ):
+            raise ValueError(
+                "bridge authority requires task, run, claim, workflow, step, and lane identity"
+            )
+        if self.step_attempt_id != f"{self.workflow_id}/{self.step_key}/{int(self.run_id)}":
+            raise ValueError("bridge authority step attempt does not match current run")
         object.__setattr__(
             self,
             "kanban_db_path",
@@ -619,6 +631,29 @@ def canonical_json_digest(value: Any) -> str:
     return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 
+def canonical_dispatch_input(goal: str, context: Optional[str], role: str) -> Dict[str, Any]:
+    """Return the model-facing dispatch object bound by ``input_digest``."""
+    return {"tasks": [{"goal": goal, "context": context, "role": role}]}
+
+
+def _canonical_dispatch_digest(goal: str, context: Optional[str], role: str) -> str:
+    return canonical_json_digest(canonical_dispatch_input(goal, context, role))
+
+
+def _is_canonical_sha256_digest(value: Any) -> bool:
+    if not isinstance(value, str) or len(value) != 71 or not value.startswith("sha256:"):
+        return False
+    return all(character in "0123456789abcdef" for character in value[7:])
+
+
+def _authority_json(authority: BridgeAuthorityContext) -> str:
+    return json.dumps(
+        {**asdict(authority), "authoritative": True},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
 _LOGICAL_COLUMNS = (
     "logical_key", "input_digest", "delegation_id", "execution_id", "state",
     "goal", "context_json", "toolsets_json", "role", "model", "session_key",
@@ -763,11 +798,15 @@ def reserve_logical_delegation(
     if authority_context is not None:
         if logical_key != canonical_logical_key(authority_context):
             return {"status": "rejected", "error": "logical_key is not canonical for authority"}
-        if not str(input_digest).startswith("sha256:"):
-            return {"status": "rejected", "error": "input_digest must use sha256"}
-        authority_json = json.dumps(
-            asdict(authority_context), sort_keys=True, separators=(",", ":")
-        )
+        expected_digest = _canonical_dispatch_digest(goal, context, role)
+        if not _is_canonical_sha256_digest(input_digest):
+            return {"status": "rejected", "error": "input_digest must be canonical sha256"}
+        if input_digest != expected_digest:
+            return {
+                "status": "rejected",
+                "error": "input_digest does not match canonical dispatch input",
+            }
+        authority_json = _authority_json(authority_context)
     return _reserve_logical_delegation_legacy(
         logical_key=logical_key,
         input_digest=input_digest,
@@ -837,12 +876,29 @@ def dispatch_logical_delegation(
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     max_pending_records: int = _MAX_DURABLE_PENDING,
+    authority_context: Optional[BridgeAuthorityContext] = None,
 ) -> Dict[str, Any]:
     """Reserve one logical identity durably, then launch exactly one runner."""
     logical_key = str(logical_key or "").strip()
     input_digest = str(input_digest or "").strip()
     if not logical_key or not input_digest:
         return {"status": "rejected", "error": "logical_key and input_digest are required"}
+    if authority_context is not None:
+        expected_digest = _canonical_dispatch_digest(goal, context, role)
+        if not _is_canonical_sha256_digest(input_digest):
+            return {"status": "rejected", "error": "input_digest must be canonical sha256"}
+        if input_digest != expected_digest:
+            return {
+                "status": "rejected",
+                "error": "input_digest does not match canonical dispatch input",
+            }
+        authority_json = _authority_json(authority_context)
+    else:
+        authority_json = json.dumps(
+            {"authoritative": False, "compatibility_mode": "direct_dispatch"},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
     now = time.time()
     with _DB_LOCK, _connect() as conn:
         conn.execute("BEGIN IMMEDIATE")
@@ -887,7 +943,7 @@ def dispatch_logical_delegation(
                 json.dumps(context) if context is not None else None,
                 json.dumps(list(toolsets)) if toolsets else None,
                 role, model, session_key, parent_session_id, now, now,
-                '{"compatibility_mode":"direct_dispatch"}',
+                authority_json,
             ),
         )
 
@@ -1031,19 +1087,39 @@ def attach_logical_dispatch_receipt(
     if record["state"] == "quarantined":
         return {**record, "status": "quarantined"}
     authority = record.get("authority")
-    compatibility_mode = (authority or {}).get("compatibility_mode")
     if not authority:
         quarantined = _quarantine_logical(
             logical_key, "logical dispatch lacks kernel worker authority"
         )
         return {**quarantined, "status": "conflict"}
+    if authority.get("authoritative") is not True:
+        return {
+            **record,
+            "status": "non_authoritative",
+            "authoritative": False,
+            "error": "compatibility evidence cannot create a Kanban receipt",
+        }
     canonical_board_path = str(Path(kanban_db_path).expanduser().resolve())
-    if not compatibility_mode and (
+    if (
         authority.get("kanban_db_path") != canonical_board_path
         or authority.get("task_id") != task_id
     ):
+        return {
+            **record,
+            "status": "conflict",
+            "error": "Kanban target conflicts with immutable worker authority",
+        }
+    expected_input_digest = _canonical_dispatch_digest(
+        record["goal"], record.get("context"), record["role"]
+    )
+    if (
+        not _is_canonical_sha256_digest(record["input_digest"])
+        or record["input_digest"] != expected_input_digest
+    ):
         quarantined = _quarantine_logical(
-            logical_key, "Kanban target conflicts with immutable worker authority"
+            logical_key,
+            "source input digest does not match canonical dispatch input",
+            expected_input_digest,
         )
         return {**quarantined, "status": "conflict"}
     if record.get("task_id") and record["task_id"] != task_id:
@@ -1129,16 +1205,11 @@ def attach_logical_dispatch_receipt(
             terminal_status=record["terminal_status"],
             result=receipt_projection,
             task_id=task_id,
-            expected_run_id=(
-                int(authority["run_id"]) if not compatibility_mode else None
-            ),
-            expected_claim_token=(
-                authority["claim_token"] if not compatibility_mode else None
-            ),
-            expected_workflow_id=authority.get("workflow_id"),
-            expected_step_key=authority.get("step_key"),
-            expected_lane=authority.get("lane"),
-            allow_legacy_running_task=bool(compatibility_mode),
+            expected_run_id=int(authority["run_id"]),
+            expected_claim_token=authority["claim_token"],
+            expected_workflow_id=authority["workflow_id"],
+            expected_step_key=authority["step_key"],
+            expected_lane=authority["lane"],
         )
     if receipt["status"] == "conflict":
         quarantined = _quarantine_logical(

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2436,6 +2436,8 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    logical_dispatch_key: Optional[str] = None,
+    logical_input_digest: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2553,6 +2555,35 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    # Optional Kanban→delegation logical identity.  The bridge is deliberately
+    # disabled by default and the direct source APIs remain available for
+    # disposable-store workflows.  When enabled, reserve after all validation
+    # but before transcript IDs, child sessions, or execution identities exist.
+    _logical_bridge = None
+    if is_truthy_value(cfg.get("workflow_bridge_enabled", False)):
+        if bool(logical_dispatch_key) != bool(logical_input_digest):
+            return tool_error(
+                "logical_dispatch_key and logical_input_digest must be provided together."
+            )
+        if logical_dispatch_key and logical_input_digest:
+            from tools.async_delegation import reserve_logical_delegation
+
+            _logical_bridge = reserve_logical_delegation(
+                logical_key=logical_dispatch_key,
+                input_digest=logical_input_digest,
+                goal=task_list[0]["goal"] if len(task_list) == 1 else json.dumps(
+                    [task["goal"] for task in task_list], ensure_ascii=False
+                ),
+                context=context,
+                toolsets=None,
+                role=top_role,
+                model=creds["model"],
+                session_key="",
+                parent_session_id=getattr(parent_agent, "session_id", None),
+            )
+            if _logical_bridge.get("status") != "reserved":
+                return json.dumps(_logical_bridge, ensure_ascii=False)
 
     overall_start = time.monotonic()
     results = []
@@ -2962,7 +2993,22 @@ def delegate_task(
                 "delegate_task: async delivery unsupported on this session "
                 "runtime; running the batch synchronously instead."
             )
+            if _logical_bridge:
+                from tools.async_delegation import (
+                    claim_logical_delegation_launch,
+                    commit_logical_delegation_result,
+                )
+                if not claim_logical_delegation_launch(
+                    logical_dispatch_key, logical_input_digest
+                ):
+                    return json.dumps(
+                        {"status": "quarantined", "error": "logical launch claim failed"}
+                    )
             _sync_result = _execute_and_aggregate()
+            if _logical_bridge:
+                commit_logical_delegation_result(
+                    logical_dispatch_key, logical_input_digest, _sync_result
+                )
             if isinstance(_sync_result, dict):
                 _sync_result["note"] = (
                     "background=true is not available in this session — it cannot "
@@ -3026,7 +3072,13 @@ def delegate_task(
                     pass
 
         def _batch_runner():
-            return _execute_and_aggregate()
+            combined = _execute_and_aggregate()
+            if _logical_bridge:
+                from tools.async_delegation import commit_logical_delegation_result
+                commit_logical_delegation_result(
+                    logical_dispatch_key, logical_input_digest, combined
+                )
+            return combined
 
         def _batch_interrupt():
             for _c in _child_agents:
@@ -3039,6 +3091,14 @@ def delegate_task(
                     pass
 
         _goals = [t["goal"] for t in task_list]
+        if _logical_bridge:
+            from tools.async_delegation import claim_logical_delegation_launch
+            if not claim_logical_delegation_launch(
+                logical_dispatch_key, logical_input_digest
+            ):
+                return json.dumps(
+                    {"status": "quarantined", "error": "logical launch claim failed"}
+                )
         dispatch = dispatch_async_delegation_batch(
             goals=_goals,
             context=context,
@@ -3056,7 +3116,9 @@ def delegate_task(
             max_async_children=_get_max_async_children(),
             # Reuse the live-transcript directory's id (when created) so the
             # returned delegation_id matches cache/delegation/live/<id>/.
-            delegation_id=live_deleg_id,
+            delegation_id=(
+                _logical_bridge["delegation_id"] if _logical_bridge else live_deleg_id
+            ),
         )
 
         if dispatch.get("status") == "dispatched":
@@ -3099,6 +3161,15 @@ def delegate_task(
             "batch synchronously instead.",
             dispatch.get("error", "rejected"),
         )
+        if _logical_bridge:
+            from tools.async_delegation import _quarantine_logical
+            return json.dumps(
+                _quarantine_logical(
+                    logical_dispatch_key,
+                    "async submit rejected after logical launch claim",
+                ),
+                ensure_ascii=False,
+            )
         _cap_result = _execute_and_aggregate()
         if isinstance(_cap_result, dict):
             _cap_result["note"] = (
@@ -3111,6 +3182,22 @@ def delegate_task(
         return json.dumps(_cap_result, ensure_ascii=False)
 
     # ----- Synchronous path -----
+    if _logical_bridge:
+        from tools.async_delegation import (
+            claim_logical_delegation_launch,
+            commit_logical_delegation_result,
+        )
+        if not claim_logical_delegation_launch(
+            logical_dispatch_key, logical_input_digest
+        ):
+            return json.dumps(
+                {"status": "quarantined", "error": "logical launch claim failed"}
+            )
+        _sync_result = _execute_and_aggregate()
+        commit_logical_delegation_result(
+            logical_dispatch_key, logical_input_digest, _sync_result
+        )
+        return json.dumps(_sync_result, ensure_ascii=False)
     return json.dumps(_execute_and_aggregate(), ensure_ascii=False)
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2438,6 +2438,7 @@ def delegate_task(
     background: Optional[bool] = None,
     logical_dispatch_key: Optional[str] = None,
     logical_input_digest: Optional[str] = None,
+    bridge_authority_context: Any = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2562,6 +2563,25 @@ def delegate_task(
     # but before transcript IDs, child sessions, or execution identities exist.
     _logical_bridge = None
     if is_truthy_value(cfg.get("workflow_bridge_enabled", False)):
+        if bridge_authority_context is not None:
+            from tools.async_delegation import (
+                canonical_json_digest,
+                canonical_logical_key,
+            )
+
+            logical_dispatch_key = canonical_logical_key(bridge_authority_context)
+            logical_input_digest = canonical_json_digest(
+                {
+                    "tasks": [
+                        {
+                            "goal": task["goal"],
+                            "context": task.get("context"),
+                            "role": _normalize_role(task.get("role") or top_role),
+                        }
+                        for task in task_list
+                    ]
+                }
+            )
         if bool(logical_dispatch_key) != bool(logical_input_digest):
             return tool_error(
                 "logical_dispatch_key and logical_input_digest must be provided together."
@@ -2581,6 +2601,7 @@ def delegate_task(
                 model=creds["model"],
                 session_key="",
                 parent_session_id=getattr(parent_agent, "session_id", None),
+                authority_context=bridge_authority_context,
             )
             if _logical_bridge.get("status") != "reserved":
                 return json.dumps(_logical_bridge, ensure_ascii=False)
@@ -2935,6 +2956,11 @@ def delegate_task(
         update_manifest_statuses(live_deleg_id, results)
 
         combined: Dict[str, Any] = {
+            "status": (
+                "PASS"
+                if results and all(entry.get("status") == "completed" for entry in results)
+                else "FAILED"
+            ),
             "results": results,
             "total_duration_seconds": total_duration,
         }
@@ -3746,6 +3772,89 @@ def _model_background_value(args: dict, parent_agent=None) -> bool:
 _MODEL_HIDDEN_TASK_FIELDS = {"acp_command", "acp_args"}
 
 
+def _kernel_bridge_authority_context(parent_agent=None):
+    """Capture immutable bridge authority from the dispatcher-owned worker scope."""
+    worker_marker_present = (
+        "KANBAN_WORKER" in os.environ or "HERMES_KANBAN_TASK" in os.environ
+    )
+    if not worker_marker_present:
+        return None
+    if "KANBAN_WORKER" in os.environ and os.environ["KANBAN_WORKER"] != "1":
+        raise ValueError("delegate bridge requires KANBAN_WORKER=1")
+
+    task_id = os.environ.get("HERMES_KANBAN_TASK")
+    if not task_id or task_id != task_id.strip():
+        raise ValueError("delegate bridge requires an exact worker task scope")
+
+    def _identity(canonical: str, compatibility: str, label: str) -> Optional[str]:
+        canonical_present = canonical in os.environ
+        compatibility_present = compatibility in os.environ
+        if (
+            canonical_present
+            and compatibility_present
+            and os.environ[canonical] != os.environ[compatibility]
+        ):
+            raise ValueError(f"delegate bridge {label} aliases conflict")
+        return (
+            os.environ[canonical]
+            if canonical_present
+            else os.environ.get(compatibility)
+        )
+
+    raw_run_id = _identity("KANBAN_TASK_RUN_ID", "HERMES_KANBAN_RUN_ID", "run id")
+    claim_token = _identity("KANBAN_CLAIM_TOKEN", "HERMES_KANBAN_CLAIM_LOCK", "claim")
+    if not raw_run_id or not raw_run_id.isascii() or not raw_run_id.isdecimal():
+        raise ValueError("delegate bridge requires a valid worker run id")
+    run_id = int(raw_run_id)
+    if run_id <= 0 or run_id > 0x7FFF_FFFF_FFFF_FFFF:
+        raise ValueError("delegate bridge requires a positive worker run id")
+    if (
+        not claim_token
+        or claim_token != claim_token.strip()
+        or not claim_token.isprintable()
+        or len(claim_token.encode("utf-8")) > 512
+    ):
+        raise ValueError("delegate bridge requires a valid worker claim token")
+
+    from hermes_cli import kanban_db as kb
+    from tools.async_delegation import BridgeAuthorityContext
+
+    db_path = kb.kanban_db_path().expanduser().resolve()
+    with kb.connect_closing(db_path) as conn:
+        row = conn.execute(
+            """SELECT t.workflow_template_id, t.current_step_key, t.assignee,
+                      t.model_override
+                 FROM tasks AS t
+                 JOIN task_runs AS r
+                   ON r.id=t.current_run_id AND r.task_id=t.id
+                WHERE t.id=? AND t.status='running' AND t.current_run_id=?
+                  AND t.claim_lock=? AND r.status='running'
+                  AND r.ended_at IS NULL AND r.claim_lock=?""",
+            (task_id, run_id, claim_token, claim_token),
+        ).fetchone()
+    if row is None:
+        raise ValueError("delegate bridge worker authority is stale or mismatched")
+    workflow_id = row["workflow_template_id"]
+    step_key = row["current_step_key"]
+    if not workflow_id or not step_key:
+        return None
+    lane = row["assignee"] or os.environ.get("HERMES_PROFILE", "")
+    route = row["model_override"] or str(getattr(parent_agent, "model", "") or "")
+    owner_id = str(getattr(parent_agent, "session_id", "") or "")
+    return BridgeAuthorityContext(
+        kanban_db_path=str(db_path),
+        workflow_id=workflow_id,
+        step_key=step_key,
+        step_attempt_id=f"{workflow_id}/{step_key}/{run_id}",
+        task_id=task_id,
+        run_id=run_id,
+        claim_token=claim_token,
+        lane=lane,
+        route=route,
+        owner_id=owner_id,
+    )
+
+
 def _strip_model_hidden_task_fields(tasks: Any) -> Any:
     if not isinstance(tasks, list):
         return tasks
@@ -3776,6 +3885,9 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
+        bridge_authority_context=_kernel_bridge_authority_context(
+            kw.get("parent_agent")
+        ),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -28,10 +28,11 @@ through the board.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 import logging
 import os
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from agent.redact import redact_sensitive_text
 from hermes_cli.goals import judge_goal
@@ -151,11 +152,144 @@ def _worker_run_id(task_id: str) -> Optional[int]:
         return None
 
 
+@dataclass(frozen=True)
+class _CompletionContext:
+    """One parsed authority decision for a completion attempt."""
+
+    authority_mode: Literal["worker", "orchestrator"]
+    task_id: Optional[str] = None
+    run_id: Optional[int] = None
+    claim_token: Optional[str] = None
+    error: Optional[str] = None
+
+
+def _parse_completion_context(task_id: str) -> _CompletionContext:
+    """Parse worker scope and identity once, failing closed on ambiguity.
+
+    Either the canonical marker or the compatibility task marker declares a
+    worker context.  A declared worker must have one exact task scope and one
+    unambiguous run/claim identity before completion can reach the database.
+    Raw alias values are compared and validated without normalization.
+    """
+    canonical_marker_present = "KANBAN_WORKER" in os.environ
+    task_marker_present = "HERMES_KANBAN_TASK" in os.environ
+    if not canonical_marker_present and not task_marker_present:
+        return _CompletionContext(authority_mode="orchestrator")
+
+    if canonical_marker_present and os.environ["KANBAN_WORKER"] != "1":
+        return _CompletionContext(
+            authority_mode="worker",
+            error="worker completion requires KANBAN_WORKER=1",
+        )
+
+    scoped_task_id = os.environ.get("HERMES_KANBAN_TASK")
+    if (
+        not scoped_task_id
+        or scoped_task_id != scoped_task_id.strip()
+    ):
+        return _CompletionContext(
+            authority_mode="worker",
+            error=(
+                "worker completion requires a non-empty, stripped "
+                "HERMES_KANBAN_TASK scope"
+            ),
+        )
+    if scoped_task_id != task_id:
+        return _CompletionContext(
+            authority_mode="worker",
+            task_id=scoped_task_id,
+            error=(
+                f"worker is scoped to task {scoped_task_id}; refusing to mutate "
+                f"{task_id}. Use kanban_comment to hand off information to other "
+                f"tasks, or kanban_create to spawn follow-up work."
+            ),
+        )
+
+    canonical_run_present = "KANBAN_TASK_RUN_ID" in os.environ
+    legacy_run_present = "HERMES_KANBAN_RUN_ID" in os.environ
+    if (
+        canonical_run_present
+        and legacy_run_present
+        and os.environ["KANBAN_TASK_RUN_ID"]
+        != os.environ["HERMES_KANBAN_RUN_ID"]
+    ):
+        return _CompletionContext(
+            authority_mode="worker",
+            task_id=scoped_task_id,
+            error="worker completion run id aliases conflict",
+        )
+    raw_run_id = (
+        os.environ["KANBAN_TASK_RUN_ID"]
+        if canonical_run_present
+        else os.environ.get("HERMES_KANBAN_RUN_ID")
+    )
+    if not raw_run_id or not raw_run_id.isascii() or not raw_run_id.isdecimal():
+        return _CompletionContext(
+            authority_mode="worker",
+            task_id=scoped_task_id,
+            error="worker completion requires a valid current run id",
+        )
+    run_id = int(raw_run_id)
+    if run_id <= 0 or run_id > 0x7FFF_FFFF_FFFF_FFFF:
+        return _CompletionContext(
+            authority_mode="worker",
+            task_id=scoped_task_id,
+            error="worker completion requires a positive current run id",
+        )
+
+    canonical_claim_present = "KANBAN_CLAIM_TOKEN" in os.environ
+    legacy_claim_present = "HERMES_KANBAN_CLAIM_LOCK" in os.environ
+    if (
+        canonical_claim_present
+        and legacy_claim_present
+        and os.environ["KANBAN_CLAIM_TOKEN"]
+        != os.environ["HERMES_KANBAN_CLAIM_LOCK"]
+    ):
+        return _CompletionContext(
+            authority_mode="worker",
+            task_id=scoped_task_id,
+            run_id=run_id,
+            error="worker completion claim token aliases conflict",
+        )
+    claim_token = (
+        os.environ["KANBAN_CLAIM_TOKEN"]
+        if canonical_claim_present
+        else os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
+    )
+    if not claim_token:
+        return _CompletionContext(
+            authority_mode="worker",
+            task_id=scoped_task_id,
+            run_id=run_id,
+            error="worker completion requires a non-empty current claim token",
+        )
+    if (
+        claim_token != claim_token.strip()
+        or not claim_token.isprintable()
+        or len(claim_token.encode("utf-8")) > 512
+    ):
+        return _CompletionContext(
+            authority_mode="worker",
+            task_id=scoped_task_id,
+            run_id=run_id,
+            error=(
+                "worker completion requires a valid claim token: no surrounding "
+                "whitespace or control characters, maximum 512 UTF-8 bytes"
+            ),
+        )
+    return _CompletionContext(
+        authority_mode="worker",
+        task_id=scoped_task_id,
+        run_id=run_id,
+        claim_token=claim_token,
+    )
+
+
 def _stamp_worker_session_metadata(
-    task_id: str, metadata: Optional[dict]
+    context: _CompletionContext, metadata: Optional[dict]
 ) -> Optional[dict]:
     """Add trusted worker session id metadata for this worker's own task."""
-    if os.environ.get("HERMES_KANBAN_TASK") != task_id:
+    if context.authority_mode != "worker":
         return metadata
     session_id = os.environ.get("HERMES_SESSION_ID")
     if not session_id:
@@ -546,9 +680,9 @@ def _handle_complete(args: dict, **kw) -> str:
         return tool_error(
             "task_id is required (or set HERMES_KANBAN_TASK in the env)"
         )
-    ownership_err = _enforce_worker_task_ownership(tid)
-    if ownership_err:
-        return ownership_err
+    context = _parse_completion_context(tid)
+    if context.error:
+        return tool_error(context.error)
     summary = args.get("summary")
     metadata = args.get("metadata")
     result = args.get("result")
@@ -625,7 +759,7 @@ def _handle_complete(args: dict, **kw) -> str:
         return tool_error(
             f"metadata must be an object/dict, got {type(metadata).__name__}"
         )
-    metadata = _stamp_worker_session_metadata(tid, metadata)
+    metadata = _stamp_worker_session_metadata(context, metadata)
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -671,7 +805,9 @@ def _handle_complete(args: dict, **kw) -> str:
                     conn, tid,
                     result=result, summary=summary, metadata=metadata,
                     created_cards=created_cards,
-                    expected_run_id=_worker_run_id(tid),
+                    expected_run_id=context.run_id,
+                    expected_claim_token=context.claim_token,
+                    authority_mode=kb.CompletionAuthority(context.authority_mode),
                 )
             except kb.ArtifactPreservationError as artifact_err:
                 return tool_error(


### PR DESCRIPTION
## What changed

- fail closed when a Kanban worker completion lacks the immutable task, run, claim, workflow, step, lane, route, or owner identity required for authority
- gate workflow successors on verifier-backed receipts instead of task state alone
- add a replay-safe logical delegation bridge with canonical input and result digests
- require exact lowercase `sha256:<64 hex>` values that match the canonical recomputation
- preserve cross-board compare-and-set behavior, per-destination correlation, and duplicate/replay idempotency
- protect pending async evidence from incompatible deletion and retain upstream's guaranteed SQLite connection cleanup

## Why

The direct-dispatch compatibility path could previously create authoritative receipt and continuation state without a current immutable run and claim. It also accepted noncanonical digest values and allowed task state alone to stand in for receipt authority. This made stale, replayed, or context-free evidence capable of advancing a workflow.

## Impact

Authoritative continuation now requires current, internally consistent evidence. Invalid or stale evidence fails closed without creating a receipt, committed attachment, target pin, event, or accepted continuation. Valid logical dispatches remain replay-safe and preserve their existing concurrency behavior.

## Validation

- `scripts/run_tests.sh` across seven delegation, receipt, verifier, and Kanban files: **222 passed**
- additional file-descriptor, CLI delivery, and gateway session-binding regressions: **22 passed**
- Python byte-compilation of all changed production modules
- `git diff --check`

The branch was replayed onto current `origin/main`. Its one upstream overlap was resolved by keeping both the newer `_transaction()` connection-closing behavior and the authority schema/trigger additions.
