### PR TITLE
fix(bedrock): route Mantle Claude through Messages API

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -674,12 +674,17 @@ def init_agent(
         pass  # Non-fatal — transport may not exist for all modes yet
 
     try:
+        from agent.anthropic_adapter import _is_bedrock_mantle_endpoint
         from hermes_cli.model_normalize import (
             _AGGREGATOR_PROVIDERS,
             normalize_model_for_provider,
         )
 
-        if agent.provider not in _AGGREGATOR_PROVIDERS:
+        is_mantle_anthropic = (
+            agent.provider == "anthropic"
+            and _is_bedrock_mantle_endpoint(agent.base_url)
+        )
+        if agent.provider not in _AGGREGATOR_PROVIDERS and not is_mantle_anthropic:
             agent.model = normalize_model_for_provider(agent.model, agent.provider)
     except Exception:
         pass
@@ -1007,7 +1012,9 @@ def init_agent(
             # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
             # Falling back would send Anthropic credentials to third-party endpoints (Fixes #1739, #minimax-401).
             _is_native_anthropic = agent.provider == "anthropic"
-            effective_key = (api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or "")
+            effective_key = (
+                api_key or resolve_anthropic_token(base_url) or ""
+            ) if _is_native_anthropic else (api_key or "")
 
             # MiniMax OAuth issues short-lived (~15-min) access tokens. The
             # Anthropic SDK caches ``api_key`` as a static string at client

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2207,7 +2207,15 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own
             # API key — falling back would send Anthropic credentials to third-party endpoints.
             _is_native_anthropic = new_provider == "anthropic"
-            effective_key = (api_key or agent.api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or agent.api_key or "")
+            effective_base_url = base_url or getattr(
+                agent, "_anthropic_base_url", None
+            )
+            effective_key = (
+                api_key
+                or agent.api_key
+                or resolve_anthropic_token(effective_base_url)
+                or ""
+            ) if _is_native_anthropic else (api_key or agent.api_key or "")
 
             # MiniMax OAuth: swap static string for a per-request callable token
             # provider so the rebuilt client survives 15-min token expiry. See
@@ -2226,7 +2234,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
             agent.api_key = effective_key
             agent._anthropic_api_key = effective_key
-            agent._anthropic_base_url = base_url or getattr(agent, "_anthropic_base_url", None)
+            agent._anthropic_base_url = effective_base_url
             agent._anthropic_client = build_anthropic_client(
                 effective_key, agent._anthropic_base_url,
                 timeout=get_provider_request_timeout(agent.provider, agent.model),

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -561,12 +561,43 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     normalized = normalized.rstrip("/").lower()
     return (
         normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
+        or _is_bedrock_mantle_endpoint(normalized)
         or "azure.com" in normalized
         # Palantir Foundry LLM proxy (<org>.palantirfoundry.com/api/v2/llm/proxy/anthropic)
         # rejects x-api-key with 401 and requires Authorization: Bearer.
         # Hostname match (not substring) so e.g. evil.com/palantirfoundry
         # paths don't trigger Bearer auth.
         or base_url_host_matches(normalized, "palantirfoundry.com")
+    )
+
+
+def _is_bedrock_mantle_endpoint(base_url: str | None) -> bool:
+    """Return True only for AWS Bedrock Mantle Anthropic endpoints.
+
+    Mantle API keys are bearer credentials that must never share the native
+    Anthropic credential chain. Keep the match host- and path-scoped so an
+    attacker-controlled URL containing ``bedrock-mantle`` cannot receive the
+    Bedrock credential.
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(normalized)
+    except Exception:
+        return False
+    hostname = (parsed.hostname or "").lower()
+    path = (parsed.path or "").rstrip("/").lower()
+    labels = hostname.split(".")
+    return (
+        parsed.scheme == "https"
+        and len(labels) == 4
+        and labels[0] == "bedrock-mantle"
+        and bool(labels[1])
+        and labels[2:] == ["api", "aws"]
+        and path in {"", "/anthropic"}
     )
 
 
@@ -1295,8 +1326,13 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
     return None
 
 
-def resolve_anthropic_token() -> Optional[str]:
+def resolve_anthropic_token(base_url: str | None = None) -> Optional[str]:
     """Resolve an Anthropic token from all available sources.
+
+    Bedrock Mantle endpoints are a separate credential boundary. For those
+    endpoints, resolve only ``AWS_BEARER_TOKEN_BEDROCK`` and never inspect
+    Anthropic OAuth, Claude Code credentials, credential pools, or
+    ``ANTHROPIC_API_KEY``.
 
     Priority:
       1. ANTHROPIC_TOKEN env var (OAuth/setup token saved by Hermes)
@@ -1308,6 +1344,9 @@ def resolve_anthropic_token() -> Optional[str]:
 
     Returns the token string or None.
     """
+    if _is_bedrock_mantle_endpoint(base_url):
+        return os.getenv("AWS_BEARER_TOKEN_BEDROCK", "").strip() or None
+
     creds = read_claude_code_credentials()
 
     # 1. Hermes-managed OAuth/setup token env var

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -755,6 +755,37 @@ def _build_anthropic_client_with_bearer_hook(
     return _anthropic_sdk.Anthropic(**kwargs)
 
 
+def _resolve_bedrock_mantle_workspace_id(base_url: Optional[str]) -> str:
+    """Resolve the optional Bedrock Mantle workspace for Anthropic requests.
+
+    The Anthropic Messages endpoint accepts ``anthropic-workspace-id``.
+    ``anthropic-workspace`` is not equivalent and is silently ignored.
+    """
+    if not _is_bedrock_mantle_endpoint(base_url):
+        return ""
+
+    workspace_id = os.environ.get("BEDROCK_MANTLE_WORKSPACE_ID", "").strip()
+    if not workspace_id:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config() or {}
+            bedrock = config.get("bedrock") or {}
+            workspace_id = str(bedrock.get("mantle_workspace_id") or "").strip()
+        except Exception:
+            workspace_id = ""
+
+    if workspace_id and (
+        not workspace_id.startswith("proj_")
+        or not workspace_id.removeprefix("proj_").isalnum()
+    ):
+        raise ValueError(
+            "Invalid Bedrock Mantle workspace ID. "
+            "Expected a project ID beginning with 'proj_'."
+        )
+    return workspace_id
+
+
 def build_anthropic_client(
     api_key,
     base_url: str = None,
@@ -880,6 +911,12 @@ def build_anthropic_client(
         kwargs["api_key"] = api_key
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+
+    workspace_id = _resolve_bedrock_mantle_workspace_id(normalized_base_url)
+    if workspace_id:
+        headers = dict(kwargs.get("default_headers") or {})
+        headers["anthropic-workspace-id"] = workspace_id
+        kwargs["default_headers"] = headers
 
     return _anthropic_sdk.Anthropic(**kwargs)
 

--- a/cli.py
+++ b/cli.py
@@ -5601,12 +5601,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         changed = False
 
         try:
+            from agent.anthropic_adapter import _is_bedrock_mantle_endpoint
             from hermes_cli.model_normalize import (
                 _AGGREGATOR_PROVIDERS,
                 normalize_model_for_provider,
             )
 
-            if resolved_provider not in _AGGREGATOR_PROVIDERS:
+            is_mantle_anthropic = (
+                resolved_provider == "anthropic"
+                and _is_bedrock_mantle_endpoint(self.base_url)
+            )
+            if (
+                resolved_provider not in _AGGREGATOR_PROVIDERS
+                and not is_mantle_anthropic
+            ):
                 normalized_model = normalize_model_for_provider(current_model, resolved_provider)
                 if normalized_model and normalized_model != current_model:
                     if not self._model_is_default:

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2133,10 +2133,11 @@ def _model_flow_stepfun(config, current_model=""):
         print("No change.")
 
 def _model_flow_bedrock_api_key(config, region, current_model=""):
-    """Bedrock API Key mode — uses the OpenAI-compatible bedrock-mantle endpoint.
+    """Configure a Bedrock API Key against the bedrock-mantle endpoints.
 
-    For developers who don't have an AWS account but received a Bedrock API Key
-    from their AWS admin. Works like any OpenAI-compatible endpoint.
+    Claude models use Mantle's Anthropic Messages endpoint so Hermes keeps its
+    native streaming, tool-use, and prompt-caching path. Other models continue
+    to use Mantle's OpenAI-compatible endpoint.
     """
     from hermes_cli.auth import (
         _prompt_model_selection,
@@ -2149,9 +2150,12 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
         get_env_value,
         save_env_value,
     )
-    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.models import _PROVIDER_MODELS, fetch_api_models
 
     mantle_base_url = f"https://bedrock-mantle.{region}.api.aws/v1"
+    mantle_anthropic_base_url = (
+        f"https://bedrock-mantle.{region}.api.aws/anthropic"
+    )
 
     # Prompt for API key
     existing_key = get_env_value("AWS_BEARER_TOKEN_BEDROCK") or ""
@@ -2177,9 +2181,17 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
         print("  ✓ API key saved.")
     print()
 
-    # Model selection — use static list (mantle doesn't need boto3 for discovery)
-    model_list = _PROVIDER_MODELS.get("bedrock", [])
-    print(f"  Showing {len(model_list)} curated models")
+    # The Mantle catalog uses different IDs from native Bedrock Converse.
+    # Probe it first and fall back to the curated list only when unavailable.
+    model_list = fetch_api_models(existing_key, mantle_base_url)
+    if model_list:
+        print(f"  Found {len(model_list)} model(s) from Bedrock Mantle")
+    else:
+        model_list = _PROVIDER_MODELS.get("bedrock", [])
+        print(
+            "  ⚠ Could not auto-detect models from Bedrock Mantle — "
+            f"showing {len(model_list)} curated models"
+        )
 
     if model_list:
         selected = _prompt_model_selection(
@@ -2198,16 +2210,22 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
     if selected:
         _save_model_choice(selected)
 
-        # Save as custom provider pointing to bedrock-mantle
         cfg = load_config()
         model = cfg.get("model")
         if not isinstance(model, dict):
             model = {"default": model} if model else {}
             cfg["model"] = model
-        model["provider"] = "custom"
-        model["base_url"] = mantle_base_url
-        model.pop("api_mode", None)  # chat_completions is the default
+        is_mantle_claude = selected.lower().startswith("anthropic.claude-")
         clear_model_endpoint_credentials(model, clear_api_mode=False)
+        if is_mantle_claude:
+            model["provider"] = "anthropic"
+            model["base_url"] = mantle_anthropic_base_url
+            model["api_mode"] = "anthropic_messages"
+            model["key_env"] = "AWS_BEARER_TOKEN_BEDROCK"
+        else:
+            model["provider"] = "custom"
+            model["base_url"] = mantle_base_url
+            model.pop("api_mode", None)  # chat_completions is the default
 
         # Also save region in bedrock config for reference
         bedrock_cfg = cfg.get("bedrock", {})
@@ -2216,15 +2234,21 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
         bedrock_cfg["region"] = region
         cfg["bedrock"] = bedrock_cfg
 
-        # Save the API key env var name so hermes knows where to find it
-        save_env_value("OPENAI_API_KEY", existing_key)
-        save_env_value("OPENAI_BASE_URL", mantle_base_url)
+        # Non-Claude models still use the OpenAI-compatible Mantle transport.
+        # Claude resolves the Bedrock key directly and must not duplicate it
+        # into ANTHROPIC_API_KEY or OPENAI_API_KEY.
+        if not is_mantle_claude:
+            save_env_value("OPENAI_API_KEY", existing_key)
+            save_env_value("OPENAI_BASE_URL", mantle_base_url)
 
         save_config(cfg)
         deactivate_provider()
 
         print(f"  Default model set to: {selected} (via Bedrock API Key, {region})")
-        print(f"  Endpoint: {mantle_base_url}")
+        print(
+            "  Endpoint: "
+            f"{mantle_anthropic_base_url if is_mantle_claude else mantle_base_url}"
+        )
     else:
         print("  No change.")
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1343,6 +1343,15 @@ def switch_model(
     api_key = current_api_key
     base_url = current_base_url
     api_mode = ""
+    direct_alias = None
+    if resolved_alias:
+        _ensure_direct_aliases()
+        direct_alias = DIRECT_ALIASES.get(resolved_alias)
+    direct_alias_base_url = (
+        direct_alias.base_url
+        if direct_alias is not None and direct_alias.base_url
+        else None
+    )
 
     if provider_changed or explicit_provider:
         import os
@@ -1389,6 +1398,7 @@ def switch_model(
             try:
                 runtime = resolve_runtime_provider(
                     requested=target_provider,
+                    explicit_base_url=direct_alias_base_url,
                     target_model=new_model,
                 )
                 api_key = runtime.get("api_key", "")
@@ -1409,6 +1419,7 @@ def switch_model(
         try:
             runtime = resolve_runtime_provider(
                 requested=current_provider,
+                explicit_base_url=direct_alias_base_url,
                 target_model=new_model,
             )
             # If resolution fell through to "custom" (e.g. named custom provider like
@@ -1422,11 +1433,9 @@ def switch_model(
             pass
 
     # --- Direct alias override: use exact base_url from the alias if set ---
-    if resolved_alias:
-        _ensure_direct_aliases()
-        _da = DIRECT_ALIASES.get(resolved_alias)
-        if _da is not None and _da.base_url:
-            base_url = _da.base_url
+    if direct_alias is not None:
+        if direct_alias.base_url:
+            base_url = direct_alias.base_url
             api_mode = ""  # clear so determine_api_mode re-detects from URL
             if not api_key:
                 api_key = "no-key-required"
@@ -1447,7 +1456,12 @@ def switch_model(
         api_mode = determine_api_mode(target_provider, base_url)
 
     # --- Normalize model name for target provider ---
-    new_model = normalize_model_for_provider(new_model, target_provider)
+    # Direct aliases are exact endpoint/model mappings. Preserve their model ID
+    # verbatim instead of applying provider normalization.
+    if direct_alias is not None:
+        new_model = direct_alias.model
+    else:
+        new_model = normalize_model_for_provider(new_model, target_provider)
 
     # --- Validate ---
     try:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -452,6 +452,16 @@ def _resolve_runtime_from_pool_entry(
             if not _anthropic_base_url_override_ok(cfg_base_url):
                 cfg_base_url = ""
         base_url = cfg_base_url or base_url or "https://api.anthropic.com"
+        from agent.anthropic_adapter import (
+            _is_bedrock_mantle_endpoint,
+            resolve_anthropic_token,
+        )
+        if _is_bedrock_mantle_endpoint(base_url):
+            api_key = resolve_anthropic_token(base_url)
+            if not api_key:
+                raise AuthError(
+                    "No Bedrock API key found. Set AWS_BEARER_TOKEN_BEDROCK."
+                )
     elif provider == "openrouter":
         base_url = base_url or OPENROUTER_BASE_URL
     elif provider == "xai":
@@ -1482,12 +1492,22 @@ def _resolve_explicit_runtime(
             if not _anthropic_base_url_override_ok(cfg_base_url):
                 cfg_base_url = ""
         base_url = explicit_base_url or cfg_base_url or "https://api.anthropic.com"
-        api_key = explicit_api_key
+        from agent.anthropic_adapter import (
+            _is_bedrock_mantle_endpoint,
+            resolve_anthropic_token,
+        )
+        api_key = (
+            resolve_anthropic_token(base_url)
+            if _is_bedrock_mantle_endpoint(base_url)
+            else explicit_api_key
+        )
         if not api_key:
-            from agent.anthropic_adapter import resolve_anthropic_token
-
-            api_key = resolve_anthropic_token()
+            api_key = resolve_anthropic_token(base_url)
             if not api_key:
+                if _is_bedrock_mantle_endpoint(base_url):
+                    raise AuthError(
+                        "No Bedrock API key found. Set AWS_BEARER_TOKEN_BEDROCK."
+                    )
                 raise AuthError(
                     "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
                     "run 'claude setup-token', or authenticate with 'claude /login'."
@@ -2013,10 +2033,21 @@ def resolve_runtime_provider(
         # would find the Claude Code OAuth token first (priority 3) and return
         # that instead, causing 401s. Detect Azure endpoints and use the env
         # key directly to bypass the OAuth priority chain.
+        from agent.anthropic_adapter import _is_bedrock_mantle_endpoint
+
+        _is_mantle_endpoint = _is_bedrock_mantle_endpoint(base_url)
         _is_azure_endpoint = "azure.com" in base_url.lower() or (
             cfg_base_url and "azure.com" in cfg_base_url.lower()
         )
-        if _is_azure_endpoint:
+        if _is_mantle_endpoint:
+            from agent.anthropic_adapter import resolve_anthropic_token
+
+            token = resolve_anthropic_token(base_url)
+            if not token:
+                raise AuthError(
+                    "No Bedrock API key found. Set AWS_BEARER_TOKEN_BEDROCK."
+                )
+        elif _is_azure_endpoint:
             # Honor user-specified env var hints on the model config before
             # falling back to the built-in AZURE_ANTHROPIC_KEY / ANTHROPIC_API_KEY
             # chain.  Accept both `key_env` (Hermes canonical — matches the
@@ -2048,7 +2079,7 @@ def resolve_runtime_provider(
                 )
         else:
             from agent.anthropic_adapter import resolve_anthropic_token
-            token = resolve_anthropic_token()
+            token = resolve_anthropic_token(base_url)
             if not token:
                 raise AuthError(
                     "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "

--- a/run_agent.py
+++ b/run_agent.py
@@ -4838,7 +4838,7 @@ class AIAgent:
         try:
             from agent.anthropic_adapter import resolve_anthropic_token, build_anthropic_client
 
-            new_token = resolve_anthropic_token()
+            new_token = resolve_anthropic_token(_base)
         except Exception as exc:
             logger.debug("Anthropic credential refresh failed: %s", exc)
             return False

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -147,6 +147,42 @@ class TestBuildAnthropicClient:
             "http://bedrock-mantle.ap-northeast-1.api.aws/anthropic"
         ) is False
 
+    def test_bedrock_mantle_adds_workspace_header(self, monkeypatch):
+        monkeypatch.setenv("BEDROCK_MANTLE_WORKSPACE_ID", "proj_test123")
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "bedrock-key",
+                base_url="https://bedrock-mantle.us-east-1.api.aws/anthropic",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert (
+                kwargs["default_headers"]["anthropic-workspace-id"]
+                == "proj_test123"
+            )
+            assert "anthropic-workspace" not in kwargs["default_headers"]
+
+    def test_workspace_header_is_not_added_outside_bedrock_mantle(self, monkeypatch):
+        monkeypatch.setenv("BEDROCK_MANTLE_WORKSPACE_ID", "proj_test123")
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "anthropic-key",
+                base_url="https://api.anthropic.com",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert "anthropic-workspace-id" not in kwargs.get("default_headers", {})
+
+    def test_invalid_bedrock_mantle_workspace_id_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("BEDROCK_MANTLE_WORKSPACE_ID", "workspace-test")
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            with pytest.raises(
+                ValueError, match="Invalid Bedrock Mantle workspace ID"
+            ):
+                build_anthropic_client(
+                    "bedrock-key",
+                    base_url="https://bedrock-mantle.us-east-1.api.aws/anthropic",
+                )
+            mock_sdk.Anthropic.assert_not_called()
+
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
             build_anthropic_client(

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -10,6 +10,7 @@ import pytest
 
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
+    _is_bedrock_mantle_endpoint,
     _is_azure_anthropic_endpoint,
     _is_oauth_token,
     _refresh_oauth_token,
@@ -121,6 +122,30 @@ class TestBuildAnthropicClient:
             )
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert kwargs["base_url"] == "https://proxy.example.com/anthropic"
+
+    def test_bedrock_mantle_uses_bearer_auth(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "bedrock-long-term-key",
+                base_url="https://bedrock-mantle.ap-northeast-1.api.aws/anthropic",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["auth_token"] == "bedrock-long-term-key"
+            assert "api_key" not in kwargs
+
+    def test_bedrock_mantle_detection_is_host_and_path_scoped(self):
+        assert _is_bedrock_mantle_endpoint(
+            "https://bedrock-mantle.ap-northeast-1.api.aws/anthropic"
+        ) is True
+        assert _is_bedrock_mantle_endpoint(
+            "https://bedrock-mantle.us-west-2.api.aws/anthropic/v1"
+        ) is False
+        assert _is_bedrock_mantle_endpoint(
+            "https://bedrock-mantle.ap-northeast-1.api.aws.evil.example/anthropic"
+        ) is False
+        assert _is_bedrock_mantle_endpoint(
+            "http://bedrock-mantle.ap-northeast-1.api.aws/anthropic"
+        ) is False
 
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
@@ -331,6 +356,23 @@ class TestIsClaudeCodeTokenValid:
 
 
 class TestResolveAnthropicToken:
+    def test_mantle_resolves_only_bedrock_key(self, monkeypatch):
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bedrock-key")
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "must-not-leak")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "must-not-leak-either")
+
+        assert resolve_anthropic_token(
+            "https://bedrock-mantle.ap-northeast-1.api.aws/anthropic"
+        ) == "bedrock-key"
+
+    def test_mantle_fails_closed_without_bedrock_key(self, monkeypatch):
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "must-not-leak")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "must-not-leak-either")
+
+        assert resolve_anthropic_token(
+            "https://bedrock-mantle.ap-northeast-1.api.aws/anthropic"
+        ) is None
     def test_prefers_oauth_token_over_api_key(self, monkeypatch, tmp_path):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-mykey")
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")

--- a/tests/hermes_cli/test_bedrock_mantle_anthropic.py
+++ b/tests/hermes_cli/test_bedrock_mantle_anthropic.py
@@ -1,0 +1,100 @@
+"""Bedrock Mantle Claude routing and credential-boundary regression tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import runtime_provider as rp
+
+
+MANTLE_BASE = "https://bedrock-mantle.ap-northeast-1.api.aws/anthropic"
+
+
+def test_runtime_uses_bedrock_key_for_mantle_anthropic(monkeypatch):
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bedrock-key")
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "native-anthropic-token")
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "anthropic",
+            "base_url": MANTLE_BASE,
+            "api_mode": "anthropic_messages",
+            "default": "anthropic.claude-opus-4-8",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda *a, **k: None)
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == MANTLE_BASE
+    assert resolved["api_key"] == "bedrock-key"
+
+
+def test_runtime_mantle_does_not_fall_back_to_anthropic_credentials(monkeypatch):
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "native-anthropic-token")
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "anthropic",
+            "base_url": MANTLE_BASE,
+            "default": "anthropic.claude-opus-4-8",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda *a, **k: None)
+
+    with pytest.raises(rp.AuthError, match="AWS_BEARER_TOKEN_BEDROCK"):
+        rp.resolve_runtime_provider(requested="anthropic")
+
+
+def test_bedrock_api_key_flow_routes_claude_to_messages(monkeypatch):
+    config = {}
+    saved_config = {}
+    saved_env = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_value",
+        lambda name: "bedrock-key" if name == "AWS_BEARER_TOKEN_BEDROCK" else "",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.save_env_value",
+        lambda name, value: saved_env.__setitem__(name, value),
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr(
+        "hermes_cli.config.save_config",
+        lambda value: saved_config.update(value),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda key, base: [
+            "anthropic.claude-opus-4-8",
+            "openai.gpt-5.6",
+        ],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda *a, **k: "anthropic.claude-opus-4-8",
+    )
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+
+    from hermes_cli.model_setup_flows import _model_flow_bedrock_api_key
+
+    _model_flow_bedrock_api_key(config, "ap-northeast-1")
+
+    model = saved_config["model"]
+    assert model == {
+        "provider": "anthropic",
+        "base_url": MANTLE_BASE,
+        "api_mode": "anthropic_messages",
+        "key_env": "AWS_BEARER_TOKEN_BEDROCK",
+    }
+    assert "ANTHROPIC_API_KEY" not in saved_env
+    assert "OPENAI_API_KEY" not in saved_env

--- a/tests/hermes_cli/test_bedrock_mantle_anthropic.py
+++ b/tests/hermes_cli/test_bedrock_mantle_anthropic.py
@@ -53,6 +53,85 @@ def test_runtime_mantle_does_not_fall_back_to_anthropic_credentials(monkeypatch)
         rp.resolve_runtime_provider(requested="anthropic")
 
 
+DIRECT_MANTLE_ALIASES = [
+    ("fable", "anthropic.claude-fable-5"),
+    ("sonnet", "anthropic.claude-sonnet-5"),
+    ("opus", "anthropic.claude-opus-5"),
+]
+
+
+def _switch_from_codex_to_direct_mantle_alias(
+    monkeypatch,
+    alias,
+    model,
+):
+    import hermes_cli.model_switch as ms
+
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bedrock-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "native-anthropic-key")
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "native-anthropic-token")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "native-anthropic-oauth")
+    monkeypatch.setattr(
+        ms,
+        "DIRECT_ALIASES",
+        {
+            alias: ms.DirectAlias(
+                model,
+                "anthropic",
+                MANTLE_BASE,
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *args, **kwargs: {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "message": None,
+        },
+    )
+    monkeypatch.setattr(ms, "get_model_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ms, "get_model_capabilities", lambda *args, **kwargs: None)
+
+    return ms.switch_model(
+        raw_input=alias,
+        current_provider="openai-codex",
+        current_model="gpt-5.5",
+        current_base_url="https://chatgpt.com/backend-api/codex",
+        current_api_key="codex-key",
+    )
+
+
+@pytest.mark.parametrize(("alias", "model"), DIRECT_MANTLE_ALIASES)
+def test_model_switch_direct_mantle_alias_uses_bedrock_credentials(
+    monkeypatch,
+    alias,
+    model,
+):
+    """Mantle aliases select Bedrock credentials before native Anthropic auth."""
+    result = _switch_from_codex_to_direct_mantle_alias(monkeypatch, alias, model)
+
+    assert result.success is True
+    assert result.target_provider == "anthropic"
+    assert result.base_url == MANTLE_BASE
+    assert result.api_mode == "anthropic_messages"
+    assert result.api_key == "bedrock-key"
+
+
+@pytest.mark.parametrize(("alias", "model"), DIRECT_MANTLE_ALIASES)
+def test_model_switch_direct_alias_preserves_exact_model_id(
+    monkeypatch,
+    alias,
+    model,
+):
+    """Direct aliases keep their exact endpoint model ID."""
+    result = _switch_from_codex_to_direct_mantle_alias(monkeypatch, alias, model)
+
+    assert result.success is True
+    assert result.new_model == model
+
+
 def test_bedrock_api_key_flow_routes_claude_to_messages(monkeypatch):
     config = {}
     saved_config = {}


### PR DESCRIPTION
## Summary

Add first-class support for Claude models exposed by the AWS Bedrock Mantle Anthropic Messages endpoint.

- Discover the current Bedrock API-key model catalog instead of relying only on a static list.
- Route `anthropic.claude-*` model IDs through `provider: anthropic` and `/anthropic`.
- Authenticate Mantle requests exclusively with `AWS_BEARER_TOKEN_BEDROCK`.
- Preserve exact Mantle model IDs through startup, CLI, refresh, and model-switch paths.
- Keep non-Claude Bedrock models on the existing OpenAI-compatible `/v1` path.

## Why

The existing Bedrock API-key setup stores every selected model as a custom OpenAI-compatible provider. That works for non-Claude models, but Claude then bypasses Hermes' Anthropic Messages path and its existing `cache_control` behavior.

The credential resolver also needs a strict boundary: a Bedrock bearer key must be sent only to an HTTPS `bedrock-mantle.<region>.api.aws[/anthropic]` endpoint and must never fall back to native Anthropic credentials.

## Validation

- `9 passed, 199 deselected` for the focused Mantle regression suite.
- Python compilation completed for all changed runtime modules.
- `git diff --check` passed.
- Live Mantle validation from a local profile succeeded for normal response, streaming, and tool use.
- Prompt-cache proof with an unchanged prefix:

```text
first:  cache_creation_input_tokens=61204, cache_read_input_tokens=0
second: cache_creation_input_tokens=0,     cache_read_input_tokens=61204
```

The live validation used the clean PR worktree and did not expose or commit the API key.
