### PR TITLE
fix(api): make session forks atomic

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3244,23 +3244,10 @@ class APIServerAdapter(BasePlatformAdapter):
         fork_id = str(body.get("id") or body.get("session_id") or f"api_{int(time.time())}_{uuid.uuid4().hex[:8]}").strip()
         if not fork_id or re.search(r'[\r\n\x00]', fork_id):
             return web.json_response(_openai_error("Invalid session ID", code="invalid_session_id"), status=400)
-        if await asyncio.to_thread(db.get_session, fork_id):
-            return web.json_response(_openai_error(f"Session already exists: {fork_id}", code="session_exists"), status=409)
 
-        # Match the CLI /branch semantics: mark the original as branched, then
-        # create a child session that carries the transcript forward. This uses
-        # SessionDB's native parent_session_id/end_reason visibility model rather
-        # than inventing a parallel fork store.
-        await asyncio.to_thread(db.end_session, source_id, "branched")
-        await asyncio.to_thread(db.create_session,
-            fork_id,
-            "api_server",
-            model=source.get("model"),
-            system_prompt=source.get("system_prompt"),
-            parent_session_id=source_id,
-        )
-        messages = await asyncio.to_thread(db.get_messages, source_id)
-        await asyncio.to_thread(db.replace_messages, fork_id, messages)
+        # Match the CLI /branch semantics using one DB transaction: copy the
+        # transcript into a child and mark the original as branched together,
+        # so a rejected title or copy failure cannot leave a partial fork.
         title = body.get("title")
         if title is None:
             base = source.get("title") or "fork"
@@ -3269,10 +3256,31 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 title = f"{base} fork"
         try:
-            await asyncio.to_thread(db.set_session_title, fork_id, str(title))
+            fork = await asyncio.to_thread(
+                db.fork_session,
+                source_id,
+                fork_id,
+                source="api_server",
+                title=str(title),
+            )
+        except FileExistsError:
+            return web.json_response(
+                _openai_error(
+                    f"Session already exists: {fork_id}",
+                    code="session_exists",
+                ),
+                status=409,
+            )
+        except KeyError:
+            return web.json_response(
+                _openai_error(
+                    f"Session not found: {source_id}",
+                    code="session_not_found",
+                ),
+                status=404,
+            )
         except ValueError as exc:
             return web.json_response(_openai_error(str(exc), code="invalid_title"), status=400)
-        fork = await asyncio.to_thread(db.get_session, fork_id) or {"id": fork_id, "parent_session_id": source_id}
         return web.json_response({"object": "hermes.session", "session": self._session_response(fork)}, status=201)
 
     @_admit_api_agent_request

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3508,6 +3508,126 @@ class SessionDB:
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
 
+    def fork_session(
+        self,
+        source_session_id: str,
+        fork_session_id: str,
+        *,
+        source: str,
+        title: str,
+    ) -> Dict[str, Any]:
+        """Atomically fork a session and its active transcript.
+
+        The source end marker, child row, transcript copy, and title assignment
+        are one write transaction. A duplicate id/title or a copy failure
+        therefore leaves the source untouched and no partial child behind.
+        """
+        clean_title = self.sanitize_title(title)
+
+        def _do(conn):
+            source_row = conn.execute(
+                "SELECT * FROM sessions WHERE id = ?",
+                (source_session_id,),
+            ).fetchone()
+            if source_row is None:
+                raise KeyError(source_session_id)
+            if conn.execute(
+                "SELECT 1 FROM sessions WHERE id = ?",
+                (fork_session_id,),
+            ).fetchone():
+                raise FileExistsError(fork_session_id)
+            if clean_title:
+                conflict = conn.execute(
+                    "SELECT id FROM sessions WHERE title = ? AND id != ?",
+                    (clean_title, fork_session_id),
+                ).fetchone()
+                if conflict:
+                    raise ValueError(
+                        f"Title '{clean_title}' is already in use by session "
+                        f"{conflict['id']}"
+                    )
+
+            now = time.time()
+            conn.execute(
+                """INSERT INTO sessions (
+                   id, source, model, system_prompt, parent_session_id,
+                   cwd, git_branch, git_repo_root, profile_name, title,
+                   started_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    fork_session_id,
+                    source,
+                    source_row["model"],
+                    source_row["system_prompt"],
+                    source_session_id,
+                    source_row["cwd"],
+                    source_row["git_branch"],
+                    source_row["git_repo_root"],
+                    source_row["profile_name"],
+                    clean_title,
+                    now,
+                ),
+            )
+            conn.execute(
+                """INSERT INTO messages (
+                   session_id, role, content, tool_call_id, tool_calls,
+                   tool_name, effect_disposition, timestamp, token_count,
+                   finish_reason, reasoning, reasoning_content,
+                   reasoning_details, codex_reasoning_items,
+                   codex_message_items, platform_message_id, observed,
+                   active, compacted, api_content, display_kind,
+                   display_metadata
+                )
+                SELECT ?, role, content, tool_call_id, tool_calls,
+                       tool_name, effect_disposition, timestamp, token_count,
+                       finish_reason, reasoning, reasoning_content,
+                       reasoning_details, codex_reasoning_items,
+                       codex_message_items, platform_message_id, observed,
+                       1, 0, api_content, display_kind, display_metadata
+                FROM messages
+                WHERE session_id = ? AND active = 1
+                ORDER BY timestamp, id""",
+                (fork_session_id, source_session_id),
+            )
+            counts = conn.execute(
+                """SELECT COUNT(*) AS message_count,
+                          COALESCE(SUM(
+                              CASE
+                                  WHEN tool_calls IS NULL THEN 0
+                                  WHEN json_valid(tool_calls) = 0 THEN 0
+                                  WHEN json_type(tool_calls) = 'array'
+                                      THEN json_array_length(tool_calls)
+                                  ELSE 1
+                              END
+                          ), 0) AS tool_call_count
+                   FROM messages
+                   WHERE session_id = ? AND active = 1""",
+                (fork_session_id,),
+            ).fetchone()
+            conn.execute(
+                """UPDATE sessions
+                   SET message_count = ?, tool_call_count = ?
+                   WHERE id = ?""",
+                (
+                    counts["message_count"],
+                    counts["tool_call_count"],
+                    fork_session_id,
+                ),
+            )
+            conn.execute(
+                """UPDATE sessions
+                   SET ended_at = ?, end_reason = 'branched'
+                   WHERE id = ?""",
+                (now, source_session_id),
+            )
+            row = conn.execute(
+                "SELECT * FROM sessions WHERE id = ?",
+                (fork_session_id,),
+            ).fetchone()
+            return dict(row)
+
+        return self._execute_write(_do)
+
     def record_gateway_session_peer(
         self,
         session_id: str,

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -215,6 +215,32 @@ async def test_session_fork_uses_current_sessiondb_branch_primitives(adapter, se
 
 
 @pytest.mark.asyncio
+async def test_session_fork_title_conflict_leaves_source_unchanged(adapter, session_db):
+    """A rejected fork must not end the source or leave an unreported child."""
+    source_id = session_db.create_session("source-session", "api_server")
+    session_db.set_session_title(source_id, "Original")
+    session_db.append_message(source_id, "user", "keep this conversation live")
+    other_id = session_db.create_session("other-session", "api_server")
+    session_db.set_session_title(other_id, "Already used")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={"id": "rejected-fork", "title": "Already used"},
+        )
+
+    assert resp.status == 400
+    assert session_db.get_session("rejected-fork") is None
+    source = session_db.get_session(source_id)
+    assert source["ended_at"] is None
+    assert source["end_reason"] is None
+    assert [m["content"] for m in session_db.get_messages(source_id)] == [
+        "keep this conversation live"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_session_chat_loads_history_and_preserves_session_headers(auth_adapter, session_db):
     session_id = session_db.create_session("chat-session", "api_server")
     session_db.set_session_title(session_id, "Chat")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -131,6 +131,38 @@ class TestSessionLifecycle:
         assert session["model"] == "real-model"
         assert session["source"] == "cli"
 
+    def test_fork_session_rolls_back_every_mutation_when_copy_fails(self, db):
+        """A transcript-copy failure must not end the source or leave a child."""
+        db.create_session("source", source="api_server")
+        db.append_message("source", "user", "durable message")
+
+        db._execute_write(
+            lambda conn: conn.execute(
+                """CREATE TRIGGER fail_test_fork_copy
+                   BEFORE INSERT ON messages
+                   WHEN NEW.session_id = 'failed-fork'
+                   BEGIN
+                       SELECT RAISE(ABORT, 'copy failed');
+                   END"""
+            )
+        )
+
+        with pytest.raises(sqlite3.IntegrityError, match="copy failed"):
+            db.fork_session(
+                "source",
+                "failed-fork",
+                source="api_server",
+                title="Failed fork",
+            )
+
+        assert db.get_session("failed-fork") is None
+        source = db.get_session("source")
+        assert source["ended_at"] is None
+        assert source["end_reason"] is None
+        assert [m["content"] for m in db.get_messages("source")] == [
+            "durable message"
+        ]
+
     def test_update_session_cwd_persists_git_branch(self, db):
         db.create_session(session_id="s1", source="cli")
         db.update_session_cwd("s1", "/work/repo", git_branch="pets-feature")


### PR DESCRIPTION
## What does this PR do?

`POST /api/sessions/{session_id}/fork` performed a fork as four independent writes:

1. mark the source session as `branched`
2. create the child session
3. copy the transcript
4. assign the requested title

A normal validation failure during step 4 returned HTTP 400 while leaving the
source ended and an unreported child session persisted. Failures during
transcript copying could likewise leave a partial child behind.

This change moves source finalization, child creation, active-transcript copying,
counter updates, and title assignment into one `SessionDB` write transaction.
Any duplicate id/title or copy failure now rolls the entire fork back.

## Related Issue

No existing issue found after searching open and closed issues and pull requests.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: add an atomic `SessionDB.fork_session()` operation.
- `gateway/platforms/api_server.py`: route API forks through the atomic DB operation while preserving 400/404/409 error responses.
- `tests/gateway/test_session_api.py`: prove a rejected title collision leaves the source active and creates no child.
- `tests/test_hermes_state.py`: inject a transcript-copy failure and prove every fork mutation rolls back.

## How to Test

1. Create a source session containing a message and another session titled `Already used`.
2. POST a fork with `{"id": "rejected-fork", "title": "Already used"}`.
3. On current main, the request returns 400 but `rejected-fork` exists and the source is marked `branched`.
4. With this change, the request still returns 400, but the child does not exist and the source remains active.

Validation:

    463 passed
    253 passed, 1 skipped
    ruff: passed
    compileall: passed
    Windows footgun scan: passed
    git diff --check: passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit follows Conventional Commits
- [x] I searched open and closed PRs/issues for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` — focused state/session/API suites were run instead
- [x] I've added tests for my changes
- [x] I've tested on my local

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered; implementation uses SQLite transactions
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

Before:

    400 response
    rejected-fork still exists
    source.end_reason == "branched"

After:

    400 response
    rejected-fork does not exist
    source.ended_at is None
    source.end_reason is None