### PR TITLE
Fix Desktop status readiness without loading platform adapters

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -13,11 +13,19 @@ import os
 import json
 from pathlib import Path
 from dataclasses import asdict, dataclass, field, is_dataclass
-from typing import Dict, List, Optional, Any, Callable
+from typing import Dict, List, Optional, Any
 from enum import Enum
 
 from hermes_cli.config import get_hermes_home
+from hermes_cli.secret_validation import has_usable_secret
 from agent.secret_scope import current_secret_scope, get_secret as _get_secret
+from gateway.platform_configuration import (
+    BUILTIN_PLATFORM_SPECS,
+    StaticConfigurationState,
+    deep_merge,
+    evaluate_static_configuration,
+    load_static_platform_states,
+)
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -371,6 +379,58 @@ class Platform(Enum):
 # Snapshot of built-in platform values before any dynamic _missing_ lookups.
 # Used to distinguish real platforms from arbitrary strings.
 _BUILTIN_PLATFORM_VALUES = frozenset(m.value for m in Platform.__members__.values())
+
+
+def load_status_platform_states(
+    candidate_names: Any,
+) -> dict[str, StaticConfigurationState]:
+    """Classify persisted runtime names without resolving platform plugins.
+
+    Bundled platforms use the same pure specs as ``GatewayConfig``.  A
+    third-party platform can opt in by registering a complete declarative spec
+    on its ``PlatformEntry``; this lookup only inspects entries that are
+    already concrete and never runs deferred loaders or entry points.
+    """
+    candidates = tuple(
+        dict.fromkeys(
+            str(name).strip()
+            for name in candidate_names
+            if str(name).strip()
+        )
+    )
+    specs = dict(BUILTIN_PLATFORM_SPECS)
+    try:
+        from gateway.platform_registry import platform_registry
+
+        for name in candidates:
+            entry = platform_registry.get_concrete_entry(name)
+            if entry is None:
+                continue
+            if entry.static_configuration is None:
+                # A concrete third-party override owns this name but has not
+                # supplied enough pure metadata. Do not apply the unrelated
+                # shipped adapter's built-in contract.
+                specs.pop(name, None)
+            else:
+                specs[name] = entry.static_configuration
+    except Exception:
+        pass
+    return load_static_platform_states(
+        get_hermes_home(),
+        candidates,
+        specs=specs,
+        getenv=_getenv,
+    )
+
+
+def load_status_configured_platforms(candidate_names: Any) -> frozenset[str]:
+    """Return only candidates whose static configuration is proven."""
+    states = load_status_platform_states(candidate_names)
+    return frozenset(
+        name
+        for name, state in states.items()
+        if state is StaticConfigurationState.CONFIGURED
+    )
 
 
 # Platforms that bind a host TCP port (HTTP/webhook listeners). In a profile
@@ -812,13 +872,6 @@ class StreamingConfig:
         )
 
 
-# -----------------------------------------------------------------------------
-# Built-in platform connection checkers
-# -----------------------------------------------------------------------------
-# Each callable receives a ``PlatformConfig`` and returns ``True`` when the
-# platform is sufficiently configured to be considered "connected".  Platforms
-# that rely on the generic ``token or api_key`` check (Telegram, Discord,
-# Slack, Matrix, Mattermost, HomeAssistant) do not need an entry here.
 def _has_usable_api_server_key(key: object) -> bool:
     """True when API_SERVER_KEY is present and strong enough to be usable.
 
@@ -826,47 +879,7 @@ def _has_usable_api_server_key(key: object) -> bool:
     (``has_usable_secret`` with ``min_length=16``) so the platform is only
     enrolled at load time when the adapter would actually agree to start.
     """
-    if not key:
-        return False
-    try:
-        from hermes_cli.auth import has_usable_secret
-    except ImportError:
-        return len(str(key).strip()) >= 16
     return has_usable_secret(key, min_length=16)
-
-
-_PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] = {
-    Platform.WEIXIN: lambda cfg: bool(
-        cfg.extra.get("account_id") and (cfg.token or cfg.extra.get("token"))
-    ),
-    Platform.WHATSAPP_CLOUD: lambda cfg: bool(
-        cfg.extra.get("phone_number_id") and cfg.extra.get("access_token")
-    ),
-    Platform.SIGNAL: lambda cfg: bool(cfg.extra.get("http_url")),
-    Platform.API_SERVER: lambda cfg: _has_usable_api_server_key(
-        cfg.extra.get("key") if cfg else None
-    ),
-    Platform.WEBHOOK: lambda cfg: True,
-    Platform.MSGRAPH_WEBHOOK: lambda cfg: bool(
-        str(cfg.extra.get("client_state") or "").strip()
-    ),
-    Platform.BLUEBUBBLES: lambda cfg: bool(
-        cfg.extra.get("server_url") and cfg.extra.get("password")
-    ),
-    Platform.QQBOT: lambda cfg: bool(
-        cfg.extra.get("app_id") and cfg.extra.get("client_secret")
-    ),
-    Platform.YUANBAO: lambda cfg: bool(
-        cfg.extra.get("app_id") and cfg.extra.get("app_secret")
-    ),
-    # Relay dials OUT to a connector; it is "connected" once an endpoint URL is
-    # configured (extra["relay_url"] or extra["url"]). The capability descriptor
-    # is negotiated at handshake time, so the URL is the only config-level
-    # signal in the experimental phase. EXPERIMENTAL — may change.
-    Platform.RELAY: lambda cfg: bool(
-        cfg.extra.get("relay_url") or cfg.extra.get("url")
-    ),
-}
 
 
 @dataclass
@@ -979,22 +992,41 @@ class GatewayConfig:
 
     def _is_platform_connected(self, platform: Platform, config: PlatformConfig) -> bool:
         """Check whether a single platform is sufficiently configured."""
-        # Weixin requires both a token and an account_id (checked first so
-        # the generic token branch doesn't let it through without account_id).
-        if platform == Platform.WEIXIN:
-            return bool(
-                config.extra.get("account_id")
-                and (config.token or config.extra.get("token"))
+        concrete_entry = None
+        try:
+            from gateway.platform_registry import platform_registry
+
+            concrete_entry = platform_registry.get_concrete_entry(platform.value)
+        except Exception:
+            pass
+
+        if concrete_entry is not None:
+            state = evaluate_static_configuration(
+                config,
+                concrete_entry.static_configuration,
+                getenv=_getenv,
+                home=get_hermes_home(),
             )
+            if state is not StaticConfigurationState.UNKNOWN:
+                return state is StaticConfigurationState.CONFIGURED
+            if concrete_entry.is_connected is not None:
+                return concrete_entry.is_connected(config)
+            if concrete_entry.validate_config is not None:
+                return concrete_entry.validate_config(config)
+            return False
 
-        # Generic token/api_key auth covers Telegram, Discord, Slack, etc.
-        if config.token or config.api_key:
-            return True
-
-        # Platform-specific check
-        checker = _PLATFORM_CONNECTED_CHECKERS.get(platform)
-        if checker is not None:
-            return checker(config)
+        # Built-ins and bundled adapters share one pure declarative semantic
+        # oracle with core readiness.  This prevents /api/status from growing
+        # a parallel interpretation that drifts from Gateway enrollment.
+        spec = BUILTIN_PLATFORM_SPECS.get(platform.value)
+        if spec is not None:
+            state = evaluate_static_configuration(
+                config,
+                spec,
+                getenv=_getenv,
+                home=get_hermes_home(),
+            )
+            return state is StaticConfigurationState.CONFIGURED
 
         # Plugin-registered platforms.  Force plugin discovery first so this
         # works even when GatewayConfig is constructed directly (e.g. in tests
@@ -1009,11 +1041,19 @@ class GatewayConfig:
                 pass
             entry = platform_registry.get(platform.value)
             if entry:
+                state = evaluate_static_configuration(
+                    config,
+                    entry.static_configuration,
+                    getenv=_getenv,
+                    home=get_hermes_home(),
+                )
+                if state is not StaticConfigurationState.UNKNOWN:
+                    return state is StaticConfigurationState.CONFIGURED
                 if entry.is_connected is not None:
                     return entry.is_connected(config)
                 if entry.validate_config is not None:
                     return entry.validate_config(config)
-                return True
+                return False
         except Exception:
             pass  # Registry not yet initialised during early import
 
@@ -1266,6 +1306,17 @@ def load_gateway_config() -> GatewayConfig:
         try:
             with open(gateway_json_path, "r", encoding="utf-8") as f:
                 gw_data = json.load(f) or {}
+            legacy_platforms = gw_data.get("platforms")
+            if isinstance(legacy_platforms, dict):
+                for legacy_block in legacy_platforms.values():
+                    if not isinstance(legacy_block, dict) or "enabled" not in legacy_block:
+                        continue
+                    legacy_extra = legacy_block.setdefault("extra", {})
+                    if not isinstance(legacy_extra, dict):
+                        legacy_extra = {}
+                        legacy_block["extra"] = legacy_extra
+                    legacy_extra["_enabled_explicit"] = True
+                    legacy_extra["_enabled_declared"] = legacy_block["enabled"]
             logger.info(
                 "Loaded legacy %s — consider moving settings to config.yaml",
                 gateway_json_path,
@@ -1437,13 +1488,18 @@ def load_gateway_config() -> GatewayConfig:
                     existing = platforms_data.get(plat_name, {})
                     if not isinstance(existing, dict):
                         existing = {}
-                    # Deep-merge extra dicts so gateway.json defaults survive
-                    merged_extra = {**existing.get("extra", {}), **plat_block.get("extra", {})}
+                    # The full loader and import-free readiness share the same
+                    # recursive precedence semantics. Nested adapter settings
+                    # from gateway.json remain unless a higher source replaces
+                    # the exact leaf.
+                    merged = deep_merge(existing, plat_block)
                     if "enabled" in plat_block:
+                        merged_extra = merged.get("extra")
+                        if not isinstance(merged_extra, dict):
+                            merged_extra = {}
+                            merged["extra"] = merged_extra
                         merged_extra["_enabled_explicit"] = True
-                    merged = {**existing, **plat_block}
-                    if merged_extra:
-                        merged["extra"] = merged_extra
+                        merged_extra["_enabled_declared"] = plat_block["enabled"]
                     platforms_data[plat_name] = merged
 
             _merge_platform_map(gateway_platforms)
@@ -1636,6 +1692,7 @@ def load_gateway_config() -> GatewayConfig:
                     # (slack, telegram, matrix, dingtalk, whatsapp, feishu …)
                     # instead of re-enabling them on token/SDK presence. #41112.
                     extra["_enabled_explicit"] = True
+                    extra["_enabled_declared"] = platform_cfg["enabled"]
                 extra.update(bridged)
 
             # Plugin-owned YAML→env config bridges (#24836).  See
@@ -1736,6 +1793,22 @@ def load_gateway_config() -> GatewayConfig:
             _home / "config.yaml",
             e,
         )
+
+    # Platform-owned YAML bridges may have revisited a lower-precedence source
+    # while translating adapter settings. Re-anchor enable/disable provenance
+    # once, at the final raw-data boundary, so the effective merged declaration
+    # is what environment overrides must respect.
+    _final_platforms = gw_data.get("platforms")
+    if isinstance(_final_platforms, dict):
+        for _final_block in _final_platforms.values():
+            if not isinstance(_final_block, dict) or "enabled" not in _final_block:
+                continue
+            _final_extra = _final_block.setdefault("extra", {})
+            if not isinstance(_final_extra, dict):
+                _final_extra = {}
+                _final_block["extra"] = _final_extra
+            _final_extra["_enabled_explicit"] = True
+            _final_extra["_enabled_declared"] = _final_block["enabled"]
 
     config = GatewayConfig.from_dict(gw_data)
 
@@ -2573,37 +2646,39 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             # enabled=True means the user wrote it themselves or another
             # env-var bridge enabled it — keep that decision).
             if existing_cfg is None or not existing_cfg.enabled:
-                if entry.is_connected is not None:
+                # Probe with ``enabled=True`` since the question is whether
+                # this candidate has enough evidence to be enabled.  Layer
+                # env-seeded extras onto a copy so the existing config is not
+                # mutated during classification.
+                if existing_cfg is not None:
+                    probe_cfg = PlatformConfig(
+                        enabled=True,
+                        token=existing_cfg.token,
+                        api_key=existing_cfg.api_key,
+                        extra=dict(existing_cfg.extra or {}),
+                    )
+                else:
+                    probe_cfg = PlatformConfig(enabled=True)
+                if isinstance(seed_for_probe, dict) and seed_for_probe:
+                    probe_extra = dict(probe_cfg.extra or {})
+                    for k, v in seed_for_probe.items():
+                        if k == "home_channel":
+                            continue
+                        probe_extra.setdefault(k, v)
+                    probe_cfg.extra = probe_extra
+
+                static_state = evaluate_static_configuration(
+                    probe_cfg,
+                    entry.static_configuration,
+                    getenv=_getenv,
+                    home=get_hermes_home(),
+                )
+                if static_state is not StaticConfigurationState.UNKNOWN:
+                    configured = (
+                        static_state is StaticConfigurationState.CONFIGURED
+                    )
+                elif entry.is_connected is not None:
                     try:
-                        # Probe with ``enabled=True`` since we're asking
-                        # "would this plugin BE configured if we enabled
-                        # it?" not "is it currently enabled?". Google
-                        # Chat's ``_is_connected`` short-circuits on
-                        # ``config.enabled`` being False, which on the
-                        # default ``PlatformConfig()`` would fail the
-                        # gate even with proper env vars set.
-                        if existing_cfg is not None:
-                            probe_cfg = existing_cfg
-                            if not probe_cfg.enabled:
-                                probe_cfg = PlatformConfig(
-                                    enabled=True,
-                                    extra=dict(probe_cfg.extra or {}),
-                                )
-                        else:
-                            probe_cfg = PlatformConfig(enabled=True)
-                        if isinstance(seed_for_probe, dict) and seed_for_probe:
-                            # Don't mutate ``existing_cfg``; the probe gets
-                            # a transient view with env-seeded extras layered
-                            # on top of whatever's already there.
-                            probe_extra = dict(getattr(probe_cfg, "extra", {}) or {})
-                            for k, v in seed_for_probe.items():
-                                if k == "home_channel":
-                                    continue
-                                probe_extra.setdefault(k, v)
-                            probe_cfg = PlatformConfig(
-                                enabled=True,
-                                extra=probe_extra,
-                            )
                         configured = bool(entry.is_connected(probe_cfg))
                     except Exception as exc:
                         logger.debug(
@@ -2611,13 +2686,15 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                             entry.name, exc,
                         )
                         configured = False
-                    if not configured:
-                        logger.debug(
-                            "Plugin platform '%s' available but not configured "
-                            "(is_connected returned False) — skipping enable",
-                            entry.name,
-                        )
-                        continue
+                else:
+                    configured = False
+                if not configured:
+                    logger.debug(
+                        "Plugin platform '%s' available but not statically "
+                        "configured — skipping enable",
+                        entry.name,
+                    )
+                    continue
             # Verify dependencies LAST — only for platforms that are already
             # enabled or passed the credential gate above.  For adapter plugins
             # ``check_fn`` lazy-INSTALLS the platform SDK (pip) as a side
@@ -2681,4 +2758,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         relay_config.extra["relay_url"] = relay_url_val.rstrip("/")
 
     for platform_config in config.platforms.values():
-        platform_config.extra.pop("_enabled_explicit", None)
+        enabled_explicit = platform_config.extra.pop("_enabled_explicit", False)
+        enabled_declared = platform_config.extra.pop("_enabled_declared", None)
+        if enabled_explicit and not _coerce_bool(enabled_declared, False):
+            platform_config.enabled = False

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1325,7 +1325,6 @@ def load_gateway_config() -> GatewayConfig:
                         legacy_extra = {}
                         legacy_block["extra"] = legacy_extra
                     legacy_extra["_enabled_explicit"] = True
-                    legacy_extra["_enabled_declared"] = legacy_block["enabled"]
             logger.info(
                 "Loaded legacy %s — consider moving settings to config.yaml",
                 gateway_json_path,
@@ -1508,7 +1507,6 @@ def load_gateway_config() -> GatewayConfig:
                             merged_extra = {}
                             merged["extra"] = merged_extra
                         merged_extra["_enabled_explicit"] = True
-                        merged_extra["_enabled_declared"] = plat_block["enabled"]
                     platforms_data[plat_name] = merged
 
             _merge_platform_map(gateway_platforms)
@@ -1701,7 +1699,6 @@ def load_gateway_config() -> GatewayConfig:
                     # (slack, telegram, matrix, dingtalk, whatsapp, feishu …)
                     # instead of re-enabling them on token/SDK presence. #41112.
                     extra["_enabled_explicit"] = True
-                    extra["_enabled_declared"] = platform_cfg["enabled"]
                 extra.update(bridged)
 
             # Plugin-owned YAML→env config bridges (#24836).  See
@@ -1817,7 +1814,6 @@ def load_gateway_config() -> GatewayConfig:
                 _final_extra = {}
                 _final_block["extra"] = _final_extra
             _final_extra["_enabled_explicit"] = True
-            _final_extra["_enabled_declared"] = _final_block["enabled"]
 
     config = GatewayConfig.from_dict(gw_data)
 
@@ -2696,8 +2692,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                         )
                         configured = False
                 else:
-                    configured = False
-                if not configured:
+                    # Parent contract: when neither static_configuration nor
+                    # is_connected is available, check_fn alone decides
+                    # enablement.  Do not tighten Gateway enrollment here.
+                    configured = None
+                if configured is False:
                     logger.debug(
                         "Plugin platform '%s' available but not statically "
                         "configured — skipping enable",
@@ -2767,7 +2766,4 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         relay_config.extra["relay_url"] = relay_url_val.rstrip("/")
 
     for platform_config in config.platforms.values():
-        enabled_explicit = platform_config.extra.pop("_enabled_explicit", False)
-        enabled_declared = platform_config.extra.pop("_enabled_declared", None)
-        if enabled_explicit and not _coerce_bool(enabled_declared, False):
-            platform_config.enabled = False
+        platform_config.extra.pop("_enabled_explicit", None)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -13,7 +13,7 @@ import os
 import json
 from pathlib import Path
 from dataclasses import asdict, dataclass, field, is_dataclass
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 
 from hermes_cli.config import get_hermes_home
@@ -406,7 +406,12 @@ def load_status_platform_states(
             entry = platform_registry.get_concrete_entry(name)
             if entry is None:
                 continue
-            if entry.static_configuration is None:
+            if name in BUILTIN_PLATFORM_SPECS and not entry.readiness_trusted:
+                # An unbundled override may own the runtime adapter, but it
+                # cannot replace Hermes' trusted static contract on the
+                # import-free path. Dynamic verification belongs to Gateway.
+                specs.pop(name, None)
+            elif entry.static_configuration is None:
                 # A concrete third-party override owns this name but has not
                 # supplied enough pure metadata. Do not apply the unrelated
                 # shipped adapter's built-in contract.
@@ -882,6 +887,38 @@ def _has_usable_api_server_key(key: object) -> bool:
     return has_usable_secret(key, min_length=16)
 
 
+# Full Gateway enrollment predicates retained from the parent contract. The
+# readiness table deliberately does not participate in this decision.
+_PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] = {
+    Platform.WEIXIN: lambda cfg: bool(
+        cfg.extra.get("account_id") and (cfg.token or cfg.extra.get("token"))
+    ),
+    Platform.WHATSAPP_CLOUD: lambda cfg: bool(
+        cfg.extra.get("phone_number_id") and cfg.extra.get("access_token")
+    ),
+    Platform.SIGNAL: lambda cfg: bool(cfg.extra.get("http_url")),
+    Platform.API_SERVER: lambda cfg: _has_usable_api_server_key(
+        cfg.extra.get("key") if cfg else None
+    ),
+    Platform.WEBHOOK: lambda cfg: True,
+    Platform.MSGRAPH_WEBHOOK: lambda cfg: bool(
+        str(cfg.extra.get("client_state") or "").strip()
+    ),
+    Platform.BLUEBUBBLES: lambda cfg: bool(
+        cfg.extra.get("server_url") and cfg.extra.get("password")
+    ),
+    Platform.QQBOT: lambda cfg: bool(
+        cfg.extra.get("app_id") and cfg.extra.get("client_secret")
+    ),
+    Platform.YUANBAO: lambda cfg: bool(
+        cfg.extra.get("app_id") and cfg.extra.get("app_secret")
+    ),
+    Platform.RELAY: lambda cfg: bool(
+        cfg.extra.get("relay_url") or cfg.extra.get("url")
+    ),
+}
+
+
 @dataclass
 class GatewayConfig:
     """
@@ -992,41 +1029,21 @@ class GatewayConfig:
 
     def _is_platform_connected(self, platform: Platform, config: PlatformConfig) -> bool:
         """Check whether a single platform is sufficiently configured."""
-        concrete_entry = None
-        try:
-            from gateway.platform_registry import platform_registry
-
-            concrete_entry = platform_registry.get_concrete_entry(platform.value)
-        except Exception:
-            pass
-
-        if concrete_entry is not None:
-            state = evaluate_static_configuration(
-                config,
-                concrete_entry.static_configuration,
-                getenv=_getenv,
-                home=get_hermes_home(),
+        # Keep the full Gateway lane compatible with the parent implementation.
+        # Static metadata is for import-free readiness only; it must never
+        # preempt these established enrollment predicates or plugin callbacks.
+        if platform == Platform.WEIXIN:
+            return bool(
+                config.extra.get("account_id")
+                and (config.token or config.extra.get("token"))
             )
-            if state is not StaticConfigurationState.UNKNOWN:
-                return state is StaticConfigurationState.CONFIGURED
-            if concrete_entry.is_connected is not None:
-                return concrete_entry.is_connected(config)
-            if concrete_entry.validate_config is not None:
-                return concrete_entry.validate_config(config)
-            return False
 
-        # Built-ins and bundled adapters share one pure declarative semantic
-        # oracle with core readiness.  This prevents /api/status from growing
-        # a parallel interpretation that drifts from Gateway enrollment.
-        spec = BUILTIN_PLATFORM_SPECS.get(platform.value)
-        if spec is not None:
-            state = evaluate_static_configuration(
-                config,
-                spec,
-                getenv=_getenv,
-                home=get_hermes_home(),
-            )
-            return state is StaticConfigurationState.CONFIGURED
+        if config.token or config.api_key:
+            return True
+
+        checker = _PLATFORM_CONNECTED_CHECKERS.get(platform)
+        if checker is not None:
+            return checker(config)
 
         # Plugin-registered platforms.  Force plugin discovery first so this
         # works even when GatewayConfig is constructed directly (e.g. in tests
@@ -1041,19 +1058,11 @@ class GatewayConfig:
                 pass
             entry = platform_registry.get(platform.value)
             if entry:
-                state = evaluate_static_configuration(
-                    config,
-                    entry.static_configuration,
-                    getenv=_getenv,
-                    home=get_hermes_home(),
-                )
-                if state is not StaticConfigurationState.UNKNOWN:
-                    return state is StaticConfigurationState.CONFIGURED
                 if entry.is_connected is not None:
                     return entry.is_connected(config)
                 if entry.validate_config is not None:
                     return entry.validate_config(config)
-                return False
+                return True
         except Exception:
             pass  # Registry not yet initialised during early import
 

--- a/gateway/platform_configuration.py
+++ b/gateway/platform_configuration.py
@@ -106,21 +106,11 @@ def _alternatives(
 BUILTIN_PLATFORM_SPECS: dict[str, PlatformConfigurationSpec] = {
     "telegram": _one(_e("token", "extra.token", env=("TELEGRAM_BOT_TOKEN",))),
     "discord": _one(_e("token", env=("DISCORD_BOT_TOKEN",))),
-    "whatsapp": PlatformConfigurationSpec(
-        any_of=(
-            (
-                _e(
-                    "extra.session_credentials",
-                    files=(
-                        "platforms/whatsapp/session/creds.json",
-                        "whatsapp/session/creds.json",
-                    ),
-                ),
-            ),
-        ),
-        implicit_enable=False,
-        enable_env_var="WHATSAPP_ENABLED",
-    ),
+    # WhatsApp's historical enrollment decision belongs to its bundled
+    # callback (enabled-with-extras or WHATSAPP_ENABLED). There is no complete
+    # declarative equivalent for the YAML "any extras" branch, so readiness
+    # stays conservative rather than redefining that callback's contract.
+    "whatsapp": PlatformConfigurationSpec(complete=False),
     "whatsapp_cloud": _one(
         _e(
             "extra.phone_number_id",
@@ -134,10 +124,7 @@ BUILTIN_PLATFORM_SPECS: dict[str, PlatformConfigurationSpec] = {
         ),
     ),
     "slack": _one(_e("token", env=("SLACK_BOT_TOKEN",))),
-    "signal": _one(
-        _e("extra.http_url", "http_url", env=("SIGNAL_HTTP_URL",)),
-        _e("extra.account", "account", env=("SIGNAL_ACCOUNT",)),
-    ),
+    "signal": _one(_e("extra.http_url", "http_url", env=("SIGNAL_HTTP_URL",))),
     "mattermost": _one(
         _e("token", env=("MATTERMOST_TOKEN",)),
         _e("extra.url", "url", env=("MATTERMOST_URL",)),
@@ -152,12 +139,7 @@ BUILTIN_PLATFORM_SPECS: dict[str, PlatformConfigurationSpec] = {
         ),
     ),
     "homeassistant": _one(_e("token", env=("HASS_TOKEN",))),
-    "email": _one(
-        _e("extra.address", "address", env=("EMAIL_ADDRESS",)),
-        _e("extra.password", "password", env=("EMAIL_PASSWORD",)),
-        _e("extra.imap_host", "imap_host", env=("EMAIL_IMAP_HOST",)),
-        _e("extra.smtp_host", "smtp_host", env=("EMAIL_SMTP_HOST",)),
-    ),
+    "email": _one(_e("extra.address", "address", env=("EMAIL_ADDRESS",))),
     "sms": _one(
         _e("extra.account_sid", "account_sid", env=("TWILIO_ACCOUNT_SID",)),
         _e("api_key", "extra.auth_token", env=("TWILIO_AUTH_TOKEN",)),

--- a/gateway/platform_configuration.py
+++ b/gateway/platform_configuration.py
@@ -1,0 +1,616 @@
+"""Pure platform-configuration semantics shared by Gateway and readiness.
+
+This module intentionally imports no platform adapter, plugin module, optional
+SDK, or plugin entry point.  It answers one narrow question: whether static
+configuration and credential *presence* are sufficient to prove that a
+platform is configured.  Runtime observation and runtime connection remain
+separate facts owned by ``gateway_state.json`` and the running Gateway.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from hermes_cli.secret_validation import has_usable_secret
+
+
+logger = logging.getLogger(__name__)
+
+
+class StaticConfigurationState(str, Enum):
+    """Import-free result for a platform configuration declaration."""
+
+    CONFIGURED = "configured"
+    DISABLED = "disabled"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ConfigurationEvidence:
+    """One required value, available from config paths or environment aliases."""
+
+    config_paths: tuple[str, ...] = ()
+    env_vars: tuple[str, ...] = ()
+    relative_files: tuple[str, ...] = ()
+    json_file_paths: tuple[tuple[str, str], ...] = ()
+    min_length: int = 1
+    truthy: bool = False
+    usable_secret: bool = False
+
+
+@dataclass(frozen=True)
+class PlatformConfigurationSpec:
+    """Declarative static requirements for one platform.
+
+    ``any_of`` is a tuple of alternatives.  Every evidence item inside one
+    alternative must be satisfied; satisfying any complete alternative proves
+    configuration.  A spec with no alternatives represents a credentialless
+    platform whose explicit enable declaration is sufficient.
+    """
+
+    any_of: tuple[tuple[ConfigurationEvidence, ...], ...] = ()
+    complete: bool = True
+    implicit_enable: bool = True
+    enable_env_var: str = ""
+
+
+@dataclass(frozen=True)
+class PlatformBlocks:
+    """Merged platform declarations plus independently recoverable read errors."""
+
+    blocks: dict[str, dict[str, Any]]
+    source_errors: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _e(
+    *config_paths: str,
+    env: tuple[str, ...] = (),
+    files: tuple[str, ...] = (),
+    json_files: tuple[tuple[str, str], ...] = (),
+    min_length: int = 1,
+    truthy: bool = False,
+    usable_secret: bool = False,
+) -> ConfigurationEvidence:
+    return ConfigurationEvidence(
+        config_paths=tuple(config_paths),
+        env_vars=env,
+        relative_files=files,
+        json_file_paths=json_files,
+        min_length=min_length,
+        truthy=truthy,
+        usable_secret=usable_secret,
+    )
+
+
+def _one(*evidence: ConfigurationEvidence) -> PlatformConfigurationSpec:
+    return PlatformConfigurationSpec(any_of=(tuple(evidence),))
+
+
+def _alternatives(
+    *groups: tuple[ConfigurationEvidence, ...],
+) -> PlatformConfigurationSpec:
+    return PlatformConfigurationSpec(any_of=tuple(groups))
+
+
+# This is not a second status-only heuristic table.  GatewayConfig and the
+# import-free status reader both consume these same immutable requirements.
+# Adapter-specific runtime checks remain in adapters; static credential
+# presence and non-secret shape live here.
+BUILTIN_PLATFORM_SPECS: dict[str, PlatformConfigurationSpec] = {
+    "telegram": _one(_e("token", "extra.token", env=("TELEGRAM_BOT_TOKEN",))),
+    "discord": _one(_e("token", env=("DISCORD_BOT_TOKEN",))),
+    "whatsapp": PlatformConfigurationSpec(
+        any_of=(
+            (
+                _e(
+                    "extra.session_credentials",
+                    files=(
+                        "platforms/whatsapp/session/creds.json",
+                        "whatsapp/session/creds.json",
+                    ),
+                ),
+            ),
+        ),
+        implicit_enable=False,
+        enable_env_var="WHATSAPP_ENABLED",
+    ),
+    "whatsapp_cloud": _one(
+        _e(
+            "extra.phone_number_id",
+            "phone_number_id",
+            env=("WHATSAPP_CLOUD_PHONE_NUMBER_ID",),
+        ),
+        _e(
+            "extra.access_token",
+            "access_token",
+            env=("WHATSAPP_CLOUD_ACCESS_TOKEN",),
+        ),
+    ),
+    "slack": _one(_e("token", env=("SLACK_BOT_TOKEN",))),
+    "signal": _one(
+        _e("extra.http_url", "http_url", env=("SIGNAL_HTTP_URL",)),
+        _e("extra.account", "account", env=("SIGNAL_ACCOUNT",)),
+    ),
+    "mattermost": _one(
+        _e("token", env=("MATTERMOST_TOKEN",)),
+        _e("extra.url", "url", env=("MATTERMOST_URL",)),
+    ),
+    "matrix": _one(
+        _e("extra.homeserver", "homeserver", env=("MATRIX_HOMESERVER",)),
+        _e(
+            "token",
+            "extra.password",
+            "password",
+            env=("MATRIX_ACCESS_TOKEN", "MATRIX_PASSWORD"),
+        ),
+    ),
+    "homeassistant": _one(_e("token", env=("HASS_TOKEN",))),
+    "email": _one(
+        _e("extra.address", "address", env=("EMAIL_ADDRESS",)),
+        _e("extra.password", "password", env=("EMAIL_PASSWORD",)),
+        _e("extra.imap_host", "imap_host", env=("EMAIL_IMAP_HOST",)),
+        _e("extra.smtp_host", "smtp_host", env=("EMAIL_SMTP_HOST",)),
+    ),
+    "sms": _one(
+        _e("extra.account_sid", "account_sid", env=("TWILIO_ACCOUNT_SID",)),
+        _e("api_key", "extra.auth_token", env=("TWILIO_AUTH_TOKEN",)),
+    ),
+    "dingtalk": _one(
+        _e("extra.client_id", "client_id", env=("DINGTALK_CLIENT_ID",)),
+        _e(
+            "extra.client_secret",
+            "client_secret",
+            env=("DINGTALK_CLIENT_SECRET",),
+        ),
+    ),
+    "api_server": _one(
+        _e(
+            "extra.key",
+            "key",
+            env=("API_SERVER_KEY",),
+            min_length=16,
+            usable_secret=True,
+        )
+    ),
+    "webhook": PlatformConfigurationSpec(
+        implicit_enable=False,
+        enable_env_var="WEBHOOK_ENABLED",
+    ),
+    "msgraph_webhook": PlatformConfigurationSpec(
+        any_of=(
+            (
+                _e(
+                    "extra.client_state",
+                    "client_state",
+                    env=("MSGRAPH_WEBHOOK_CLIENT_STATE",),
+                ),
+            ),
+        ),
+        implicit_enable=False,
+        enable_env_var="MSGRAPH_WEBHOOK_ENABLED",
+    ),
+    "feishu": _one(
+        _e("extra.app_id", "app_id", env=("FEISHU_APP_ID",)),
+        _e("extra.app_secret", "app_secret", env=("FEISHU_APP_SECRET",)),
+    ),
+    "wecom": _one(
+        _e("extra.bot_id", "bot_id", env=("WECOM_BOT_ID",)),
+        _e("extra.secret", "secret", env=("WECOM_SECRET",)),
+    ),
+    "wecom_callback": _alternatives(
+        (
+            _e(
+                "extra.corp_id",
+                "corp_id",
+                env=("WECOM_CALLBACK_CORP_ID",),
+            ),
+            _e(
+                "extra.corp_secret",
+                "corp_secret",
+                env=("WECOM_CALLBACK_CORP_SECRET",),
+            ),
+        ),
+        (_e("extra.apps", "apps"),),
+    ),
+    "weixin": _one(
+        _e("extra.account_id", "account_id", env=("WEIXIN_ACCOUNT_ID",)),
+        _e("token", "extra.token", env=("WEIXIN_TOKEN",)),
+    ),
+    "bluebubbles": _one(
+        _e(
+            "extra.server_url",
+            "server_url",
+            env=("BLUEBUBBLES_SERVER_URL",),
+        ),
+        _e("extra.password", "password", env=("BLUEBUBBLES_PASSWORD",)),
+    ),
+    "qqbot": _one(
+        _e("extra.app_id", "app_id", env=("QQ_APP_ID",)),
+        _e(
+            "extra.client_secret",
+            "client_secret",
+            env=("QQ_CLIENT_SECRET",),
+        ),
+    ),
+    "yuanbao": _one(
+        _e(
+            "extra.app_id",
+            "app_id",
+            env=("YUANBAO_APP_ID", "YUANBAO_APP_KEY"),
+        ),
+        _e(
+            "extra.app_secret",
+            "app_secret",
+            env=("YUANBAO_APP_SECRET",),
+        ),
+    ),
+    "relay": _one(
+        _e("extra.relay_url", "extra.url", "relay_url", "url", env=("GATEWAY_RELAY_URL",))
+    ),
+    "irc": _one(
+        _e("extra.server", "server", env=("IRC_SERVER",)),
+        _e("extra.channel", "channel", env=("IRC_CHANNEL",)),
+    ),
+    "line": _one(
+        _e(
+            "extra.channel_access_token",
+            "channel_access_token",
+            env=("LINE_CHANNEL_ACCESS_TOKEN",),
+        ),
+        _e(
+            "extra.channel_secret",
+            "channel_secret",
+            env=("LINE_CHANNEL_SECRET",),
+        ),
+    ),
+    "teams": _one(
+        _e("extra.client_id", "client_id", env=("TEAMS_CLIENT_ID",)),
+        _e(
+            "extra.client_secret",
+            "client_secret",
+            env=("TEAMS_CLIENT_SECRET",),
+        ),
+        _e("extra.tenant_id", "tenant_id", env=("TEAMS_TENANT_ID",)),
+    ),
+    "ntfy": _one(_e("extra.topic", "topic", env=("NTFY_TOPIC",))),
+    "simplex": _one(_e("extra.ws_url", "ws_url", env=("SIMPLEX_WS_URL",))),
+    "google_chat": _alternatives(
+        (
+            _e(
+                "extra.http_events_url",
+                "http_events_url",
+                env=("GOOGLE_CHAT_HTTP_EVENTS_URL",),
+            ),
+        ),
+        (
+            _e(
+                "extra.project_id",
+                "project_id",
+                env=("GOOGLE_CHAT_PROJECT_ID", "GOOGLE_CLOUD_PROJECT"),
+            ),
+            _e(
+                "extra.subscription_name",
+                "subscription_name",
+                env=(
+                    "GOOGLE_CHAT_SUBSCRIPTION_NAME",
+                    "GOOGLE_CHAT_SUBSCRIPTION",
+                ),
+            ),
+        ),
+    ),
+    "photon": _one(
+        _e(
+            "extra.project_id",
+            "project_id",
+            env=("PHOTON_PROJECT_ID",),
+            json_files=(
+                (
+                    "auth.json",
+                    "credential_pool.photon_project.0.spectrum_project_id",
+                ),
+                (
+                    "auth.json",
+                    "credential_pool.photon_project.0.project_id",
+                ),
+            ),
+        ),
+        _e(
+            "extra.project_secret",
+            "project_secret",
+            env=("PHOTON_PROJECT_SECRET",),
+            json_files=(
+                (
+                    "auth.json",
+                    "credential_pool.photon_project.0.project_secret",
+                ),
+            ),
+        ),
+    ),
+    "raft": _alternatives(
+        (_e("extra.bridge_token", "bridge_token"),),
+        (_e("extra.profile", "profile", env=("RAFT_PROFILE",)),),
+    ),
+}
+
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSY = frozenset({"", "0", "false", "no", "off", "none", "null"})
+_MISSING = object()
+
+
+def _mapping_or_attrs_get(value: Any, path: str) -> Any:
+    current = value
+    for part in path.split("."):
+        if isinstance(current, (list, tuple)):
+            try:
+                current = current[int(part)]
+            except (IndexError, TypeError, ValueError):
+                return _MISSING
+            continue
+        if isinstance(current, Mapping):
+            if part not in current:
+                return _MISSING
+            current = current[part]
+        else:
+            current = getattr(current, part, _MISSING)
+            if current is _MISSING:
+                return _MISSING
+    return current
+
+
+def _present(value: Any, evidence: ConfigurationEvidence) -> bool:
+    if value is _MISSING or value is None:
+        return False
+    if isinstance(value, str):
+        text = value.strip()
+        if evidence.usable_secret:
+            return has_usable_secret(text, min_length=evidence.min_length)
+        if evidence.truthy:
+            return text.lower() in _TRUTHY
+        return len(text) >= evidence.min_length
+    if evidence.truthy:
+        return bool(value)
+    if isinstance(value, (Mapping, list, tuple, set)):
+        return bool(value)
+    return len(str(value).strip()) >= evidence.min_length
+
+
+def _evidence_is_present(
+    config: Any,
+    evidence: ConfigurationEvidence,
+    getenv: Callable[[str], Any],
+    home: Path | None,
+) -> bool:
+    for path in evidence.config_paths:
+        if _present(_mapping_or_attrs_get(config, path), evidence):
+            return True
+    for name in evidence.env_vars:
+        if _present(getenv(name), evidence):
+            return True
+    if home is not None:
+        for relative in evidence.relative_files:
+            try:
+                if (home / relative).is_file():
+                    return True
+            except OSError:
+                continue
+        loaded_json: dict[Path, Any] = {}
+        for relative, path in evidence.json_file_paths:
+            file_path = home / relative
+            if file_path not in loaded_json:
+                try:
+                    with file_path.open(encoding="utf-8") as handle:
+                        loaded_json[file_path] = json.load(handle)
+                except Exception:
+                    loaded_json[file_path] = _MISSING
+            if _present(
+                _mapping_or_attrs_get(loaded_json[file_path], path),
+                evidence,
+            ):
+                return True
+    return False
+
+
+def _explicit_enabled(config: Any) -> tuple[bool, bool]:
+    """Return ``(was_explicit, enabled)`` for raw blocks or PlatformConfig."""
+    if isinstance(config, Mapping):
+        if "enabled" not in config:
+            return False, False
+        value = config.get("enabled")
+    else:
+        value = getattr(config, "enabled", False)
+        return True, bool(value)
+
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in _TRUTHY:
+            return True, True
+        if token in _FALSY:
+            return True, False
+        return True, False
+    return True, bool(value)
+
+
+def evaluate_static_configuration(
+    config: Any,
+    spec: PlatformConfigurationSpec | None,
+    *,
+    getenv: Callable[[str], Any] = os.getenv,
+    home: Path | None = None,
+) -> StaticConfigurationState:
+    """Evaluate one declaration without executing plugin or adapter code."""
+    if spec is None or not spec.complete:
+        return StaticConfigurationState.UNKNOWN
+
+    was_explicit, enabled = _explicit_enabled(config)
+    if was_explicit and not enabled:
+        return StaticConfigurationState.DISABLED
+    if not was_explicit and spec.enable_env_var:
+        raw_enable = getenv(spec.enable_env_var)
+        if raw_enable is not None:
+            token = str(raw_enable).strip().lower()
+            if token in _FALSY:
+                return StaticConfigurationState.DISABLED
+            if token in _TRUTHY:
+                was_explicit, enabled = True, True
+
+    if not spec.any_of:
+        if was_explicit and enabled:
+            return StaticConfigurationState.CONFIGURED
+        return StaticConfigurationState.DISABLED
+
+    configured = any(
+        all(_evidence_is_present(config, item, getenv, home) for item in group)
+        for group in spec.any_of
+    )
+    if not configured:
+        return StaticConfigurationState.DISABLED
+    if was_explicit and enabled:
+        return StaticConfigurationState.CONFIGURED
+    if spec.implicit_enable:
+        return StaticConfigurationState.CONFIGURED
+    return StaticConfigurationState.DISABLED
+
+
+def deep_merge(base: Mapping[str, Any], overlay: Mapping[str, Any]) -> dict[str, Any]:
+    """Recursively merge mappings; overlay values win at every leaf."""
+    merged: dict[str, Any] = dict(base)
+    for key, value in overlay.items():
+        previous = merged.get(key)
+        if isinstance(previous, Mapping) and isinstance(value, Mapping):
+            merged[key] = deep_merge(previous, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _merge_platform_map(
+    target: dict[str, dict[str, Any]],
+    source: Any,
+) -> None:
+    if not isinstance(source, Mapping):
+        return
+    for raw_name, raw_block in source.items():
+        if not isinstance(raw_name, str) or not isinstance(raw_block, Mapping):
+            continue
+        name = raw_name.strip()
+        if not name:
+            continue
+        target[name] = deep_merge(target.get(name, {}), raw_block)
+
+
+def _load_json_source(path: Path) -> tuple[dict[str, Any], str | None]:
+    if not path.exists():
+        return {}, None
+    try:
+        with path.open(encoding="utf-8") as handle:
+            loaded = json.load(handle) or {}
+        if not isinstance(loaded, dict):
+            raise TypeError("root must be a mapping")
+        return loaded, None
+    except Exception as exc:
+        logger.warning("Failed to load %s for platform status: %s", path, exc)
+        return {}, path.name
+
+
+def _load_yaml_source(path: Path) -> tuple[dict[str, Any], str | None]:
+    if not path.exists():
+        return {}, None
+    try:
+        import yaml
+
+        with path.open(encoding="utf-8") as handle:
+            loaded = yaml.safe_load(handle) or {}
+        if not isinstance(loaded, dict):
+            raise TypeError("root must be a mapping")
+        from hermes_cli import managed_scope
+
+        overlaid = managed_scope.apply_managed_overlay(loaded)
+        if not isinstance(overlaid, dict):
+            raise TypeError("managed overlay root must be a mapping")
+        return overlaid, None
+    except Exception as exc:
+        logger.warning("Failed to load %s for platform status: %s", path, exc)
+        return {}, path.name
+
+
+def load_platform_blocks(
+    home: Path,
+    *,
+    candidate_names: Iterable[str] = (),
+) -> PlatformBlocks:
+    """Load and deep-merge platform declarations without plugin resolution."""
+    legacy, legacy_error = _load_json_source(home / "gateway.json")
+    yaml_cfg, yaml_error = _load_yaml_source(home / "config.yaml")
+    blocks: dict[str, dict[str, Any]] = {}
+
+    _merge_platform_map(blocks, legacy.get("platforms"))
+
+    gateway_cfg = yaml_cfg.get("gateway")
+    if isinstance(gateway_cfg, Mapping):
+        _merge_platform_map(blocks, gateway_cfg.get("platforms"))
+    _merge_platform_map(blocks, yaml_cfg.get("platforms"))
+
+    names = set(BUILTIN_PLATFORM_SPECS)
+    names.update(name for name in candidate_names if isinstance(name, str))
+    if isinstance(gateway_cfg, Mapping):
+        for name in names:
+            nested = gateway_cfg.get(name)
+            if isinstance(nested, Mapping):
+                _merge_platform_map(blocks, {name: nested})
+    for name in names:
+        direct = yaml_cfg.get(name)
+        # Top-level ``telegram:``, ``matrix:``, etc. sections are adapter
+        # policy/config-bridge inputs in the canonical loader, not arbitrary
+        # PlatformConfig blocks.  The one shared enrollment field consumed
+        # there is ``enabled``; credential/extra evidence must come from
+        # gateway.json, platforms.*, gateway.platforms.*, gateway.<name>, or
+        # environment.  Merging the whole direct block here would let status
+        # recognize shapes that the full loader discards.
+        if isinstance(direct, Mapping) and "enabled" in direct:
+            _merge_platform_map(blocks, {name: {"enabled": direct["enabled"]}})
+
+    errors = tuple(
+        error for error in (legacy_error, yaml_error) if error is not None
+    )
+    return PlatformBlocks(blocks=blocks, source_errors=errors)
+
+
+def load_static_platform_states(
+    home: Path,
+    candidate_names: Iterable[str],
+    *,
+    specs: Mapping[str, PlatformConfigurationSpec] = BUILTIN_PLATFORM_SPECS,
+    getenv: Callable[[str], Any] = os.getenv,
+) -> dict[str, StaticConfigurationState]:
+    """Classify runtime candidate names from static configuration evidence."""
+    candidates = tuple(dict.fromkeys(str(name).strip() for name in candidate_names))
+    loaded = load_platform_blocks(home, candidate_names=candidates)
+    states: dict[str, StaticConfigurationState] = {}
+    for name in candidates:
+        spec = specs.get(name)
+        if spec is None:
+            states[name] = StaticConfigurationState.UNKNOWN
+            continue
+        block = loaded.blocks.get(name, {})
+        state = evaluate_static_configuration(
+            block,
+            spec,
+            getenv=getenv,
+            home=home,
+        )
+        if (
+            state is StaticConfigurationState.DISABLED
+            and loaded.source_errors
+            and not block
+        ):
+            state = StaticConfigurationState.UNKNOWN
+        states[name] = state
+    return states

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -63,6 +63,12 @@ class PlatformEntry:
     # If None, falls back to ``validate_config`` or ``check_fn``.
     is_connected: Optional[Callable[[Any], bool]] = None
 
+    # Optional pure declarative configuration requirements.  Core readiness
+    # may inspect this object without invoking callbacks or resolving deferred
+    # adapter loaders.  Incomplete/absent metadata means UNKNOWN, never
+    # implicitly configured.
+    static_configuration: Any = None
+
     # Env vars this platform needs (for ``hermes setup`` display).
     required_env: list = field(default_factory=list)
 
@@ -256,6 +262,20 @@ class PlatformRegistry:
         """Look up a platform entry by name."""
         if name not in self._entries:
             self._resolve(name)
+        return self._entries.get(name)
+
+    def get_static_configuration(self, name: str) -> Any:
+        """Return already-registered declarative metadata without resolution.
+
+        This accessor deliberately never calls ``_resolve``.  It is safe for
+        readiness and other import-boundary paths that must not import an
+        adapter merely to classify persisted runtime state.
+        """
+        entry = self._entries.get(name)
+        return entry.static_configuration if entry is not None else None
+
+    def get_concrete_entry(self, name: str) -> Optional[PlatformEntry]:
+        """Return an already-registered entry without resolving a loader."""
         return self._entries.get(name)
 
     def all_entries(self) -> list[PlatformEntry]:

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -69,6 +69,10 @@ class PlatformEntry:
     # implicitly configured.
     static_configuration: Any = None
 
+    # Only the in-tree bundled-plugin registration path may set this. Status
+    # uses it to avoid trusting a third-party replacement of a built-in name.
+    readiness_trusted: bool = False
+
     # Env vars this platform needs (for ``hermes setup`` display).
     required_env: list = field(default_factory=list)
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -49,6 +49,7 @@ from hermes_cli.config import (
     read_raw_config,
     require_readable_config_before_write,
 )
+from hermes_cli.secret_validation import has_usable_secret
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
 from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
@@ -546,34 +547,6 @@ def _resolve_kimi_base_url(api_key: str, default_url: str, env_override: str) ->
         return KIMI_CODE_BASE_URL
     return default_url
 
-
-
-_PLACEHOLDER_SECRET_VALUES = {
-    "*",
-    "**",
-    "***",
-    "changeme",
-    "your_api_key",
-    "your_api_key_here",
-    "your-api-key",
-    "placeholder",
-    "example",
-    "dummy",
-    "null",
-    "none",
-}
-
-
-def has_usable_secret(value: Any, *, min_length: int = 4) -> bool:
-    """Return True when a configured secret looks usable, not empty/placeholder."""
-    if not isinstance(value, str):
-        return False
-    cleaned = value.strip()
-    if len(cleaned) < min_length:
-        return False
-    if cleaned.lower() in _PLACEHOLDER_SECRET_VALUES:
-        return False
-    return True
 
 
 def _resolve_api_key_provider_secret(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -963,6 +963,10 @@ class PluginContext:
         from gateway.platform_registry import platform_registry, PlatformEntry
 
         entry_kwargs.setdefault("plugin_name", self.manifest.name)
+        # Manifest provenance is established by the plugin manager, not by a
+        # plugin's registration arguments. Do not let arbitrary plugin code
+        # bless an override of a built-in readiness contract.
+        entry_kwargs["readiness_trusted"] = self.manifest.source == "bundled"
         if (
             "static_configuration" not in entry_kwargs
             and self.manifest.source == "bundled"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -963,6 +963,20 @@ class PluginContext:
         from gateway.platform_registry import platform_registry, PlatformEntry
 
         entry_kwargs.setdefault("plugin_name", self.manifest.name)
+        if (
+            "static_configuration" not in entry_kwargs
+            and self.manifest.source == "bundled"
+        ):
+            # Shipped platform adapters consume the same pure enrollment
+            # contract as GatewayConfig and core readiness. User/project/
+            # entry-point plugins must opt in explicitly: assigning a built-in
+            # spec to a third-party override with the same name would turn an
+            # unproven plugin into a false CONFIGURED result.
+            from gateway.platform_configuration import BUILTIN_PLATFORM_SPECS
+
+            bundled_spec = BUILTIN_PLATFORM_SPECS.get(name)
+            if bundled_spec is not None:
+                entry_kwargs["static_configuration"] = bundled_spec
         entry = PlatformEntry(
             name=name,
             label=label,

--- a/hermes_cli/secret_validation.py
+++ b/hermes_cli/secret_validation.py
@@ -1,0 +1,33 @@
+"""Pure secret-presence validation shared by auth and readiness."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+PLACEHOLDER_SECRET_VALUES = frozenset(
+    {
+        "*",
+        "**",
+        "***",
+        "changeme",
+        "your_api_key",
+        "your_api_key_here",
+        "your-api-key",
+        "placeholder",
+        "example",
+        "dummy",
+        "null",
+        "none",
+    }
+)
+
+
+def has_usable_secret(value: Any, *, min_length: int = 4) -> bool:
+    """Return True when a configured secret looks usable, not a placeholder."""
+    if not isinstance(value, str):
+        return False
+    cleaned = value.strip()
+    if len(cleaned) < min_length:
+        return False
+    return cleaned.lower() not in PLACEHOLDER_SECRET_VALUES

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3098,16 +3098,6 @@ async def get_status(profile: Optional[str] = None):
         gateway_platforms: dict = {}
         gateway_exit_reason = None
         gateway_updated_at = None
-        configured_gateway_platforms: set[str] | None = None
-        try:
-            from gateway.config import load_gateway_config
-
-            gateway_config = load_gateway_config()
-            configured_gateway_platforms = {
-                platform.value for platform in gateway_config.get_connected_platforms()
-            }
-        except Exception:
-            configured_gateway_platforms = None
 
         # Prefer the detailed health endpoint response (has full state) when the
         # local runtime status file is absent or stale (cross-container).
@@ -3148,12 +3138,23 @@ async def get_status(profile: Optional[str] = None):
         if runtime:
             gateway_state = runtime.get("gateway_state")
             gateway_platforms = runtime.get("platforms") or {}
-            if configured_gateway_platforms is not None:
-                gateway_platforms = {
-                    key: value
-                    for key, value in gateway_platforms.items()
-                    if key in configured_gateway_platforms
-                }
+            configured_gateway_platforms: frozenset[str] = frozenset()
+            try:
+                from gateway.config import load_status_configured_platforms
+
+                configured_gateway_platforms = load_status_configured_platforms(
+                    gateway_platforms
+                )
+            except Exception:
+                # Readiness stays available, but an unprovable candidate is
+                # never promoted to configured merely because runtime observed
+                # a stale record.
+                configured_gateway_platforms = frozenset()
+            gateway_platforms = {
+                key: value
+                for key, value in gateway_platforms.items()
+                if key in configured_gateway_platforms
+            }
             gateway_exit_reason = runtime.get("exit_reason")
             # Contract: gateway_updated_at is RFC3339 string | null, never a
             # number. ``runtime`` here may be the local gateway_state.json

--- a/tests/gateway/test_platform_connected_checkers.py
+++ b/tests/gateway/test_platform_connected_checkers.py
@@ -1,153 +1,52 @@
-"""
-Verify that every gateway platform — built-in and plugin — has a connection
-checker so ``GatewayConfig.get_connected_platforms()`` doesn't silently drop
-platforms with bespoke auth requirements.
-"""
+"""Shared declarative configuration coverage for every Gateway platform."""
 
-from unittest.mock import MagicMock
+from __future__ import annotations
 
-import pytest
+from gateway.config import Platform
+from gateway.platform_configuration import (
+    BUILTIN_PLATFORM_SPECS,
+    StaticConfigurationState,
+    evaluate_static_configuration,
+)
 
-from gateway.config import Platform, _PLATFORM_CONNECTED_CHECKERS, _BUILTIN_PLATFORM_VALUES
+
+def test_all_builtins_have_shared_pure_configuration_semantics():
+    """Every shipped platform must be classified without adapter imports."""
+    expected = {
+        member.value
+        for member in Platform.__members__.values()
+        if member is not Platform.LOCAL
+    }
+    expected.update(Platform._scan_bundled_plugin_platforms())
+
+    assert expected <= BUILTIN_PLATFORM_SPECS.keys()
 
 
-def test_all_builtins_have_checker_or_generic_token_path():
-    """Every built-in Platform member must be reachable by either:
+def test_every_builtin_spec_handles_minimal_config():
+    for name, spec in BUILTIN_PLATFORM_SPECS.items():
+        state = evaluate_static_configuration(
+            {"enabled": True},
+            spec,
+            getenv={}.get,
+        )
+        assert isinstance(state, StaticConfigurationState), name
 
-    1. The generic ``config.token or config.api_key`` check, OR
-    2. A platform-specific entry in ``_PLATFORM_CONNECTED_CHECKERS``.
 
-    This guarantees ``get_connected_platforms()`` doesn't silently ignore
-    a built-in just because nobody added it to the checker dict.
-    """
-    # Platforms covered by the generic token/api_key branch
-    generic_token_values = {p.value for p in {
-        Platform.TELEGRAM,
-        Platform.DISCORD,
-        Platform.SLACK,
-        Platform.MATRIX,
-        Platform.MATTERMOST,
-        Platform.HOMEASSISTANT,
-    }}
+def test_api_server_shared_key_validity():
+    spec = BUILTIN_PLATFORM_SPECS["api_server"]
 
-    # Platforms with a bespoke checker
-    checker_values = {p.value for p in set(_PLATFORM_CONNECTED_CHECKERS.keys())}
+    for invalid in (None, "", "changeme", "shortkey"):
+        block = {"enabled": True, "extra": {"key": invalid}}
+        assert (
+            evaluate_static_configuration(block, spec, getenv={}.get)
+            is StaticConfigurationState.DISABLED
+        )
 
-    # Platforms whose connection check now comes from a registered plugin entry
-    # (is_connected / validate_config).  Several adapters migrated out of core
-    # into bundled plugins (#41112); their checker moved with them to the
-    # platform registry, so get_connected_platforms() resolves them via the
-    # registry fallback rather than _PLATFORM_CONNECTED_CHECKERS.
-    plugin_checker_values: set[str] = set()
-    try:
-        from hermes_cli.plugins import discover_plugins
-        from gateway.platform_registry import platform_registry
-        discover_plugins()
-        for _entry in platform_registry.all_entries():
-            if _entry.is_connected is not None or _entry.validate_config is not None:
-                plugin_checker_values.add(_entry.name)
-    except Exception:
-        pass
-
-    # Every built-in should be in one of the sets
-    all_builtins = set(_BUILTIN_PLATFORM_VALUES)
-    missing = (
-        all_builtins
-        - generic_token_values
-        - checker_values
-        - plugin_checker_values
-        - {"local"}
+    assert (
+        evaluate_static_configuration(
+            {"enabled": True, "extra": {"key": "opensslrandhex32strongkey"}},
+            spec,
+            getenv={}.get,
+        )
+        is StaticConfigurationState.CONFIGURED
     )
-
-    assert not missing, (
-        f"Built-in platforms missing a connection checker: "
-        f"{sorted(missing)}.  "
-        f"Add them to _PLATFORM_CONNECTED_CHECKERS or generic_token_platforms."
-    )
-
-
-@pytest.mark.parametrize("platform, checker", list(_PLATFORM_CONNECTED_CHECKERS.items()))
-def test_checker_handles_minimal_config(platform, checker):
-    """Each bespoke checker must not crash on a minimal PlatformConfig."""
-    mock_config = MagicMock()
-    mock_config.extra = {}
-    mock_config.token = None
-    mock_config.api_key = None
-    mock_config.enabled = True
-
-    # Should return a bool without raising
-    result = checker(mock_config)
-    assert isinstance(result, bool)
-
-
-@pytest.mark.parametrize("platform, checker", list(_PLATFORM_CONNECTED_CHECKERS.items()))
-def test_checker_returns_true_when_configured(platform, checker, monkeypatch):
-    """Each bespoke checker must return True when the config looks valid."""
-    mock_config = MagicMock()
-    mock_config.token = None
-    mock_config.api_key = None
-    mock_config.enabled = True
-
-    # Set up platform-specific mock extra fields so the checker succeeds
-    if platform == Platform.WEIXIN:
-        mock_config.extra = {"account_id": "123", "token": "***"}
-    elif platform == Platform.SIGNAL:
-        mock_config.extra = {"http_url": "http://signal:8080"}
-    elif platform == Platform.EMAIL:
-        mock_config.extra = {"address": "hermes@example.com"}
-    elif platform == Platform.SMS:
-        monkeypatch.setenv("TWILIO_ACCOUNT_SID", "ACtest")
-        mock_config.extra = {}
-    elif platform == Platform.API_SERVER:
-        mock_config.extra = {"key": "opensslrandhex32strongkey"}
-    elif platform in {
-        Platform.WEBHOOK,
-        Platform.WHATSAPP,
-    }:
-        mock_config.extra = {}
-    elif platform == Platform.MSGRAPH_WEBHOOK:
-        mock_config.extra = {"client_state": "expected-client-state"}
-    elif platform == Platform.FEISHU:
-        mock_config.extra = {"app_id": "app"}
-    elif platform == Platform.WECOM:
-        mock_config.extra = {"bot_id": "bot"}
-    elif platform == Platform.WECOM_CALLBACK:
-        mock_config.extra = {"corp_id": "corp"}
-    elif platform == Platform.BLUEBUBBLES:
-        mock_config.extra = {"server_url": "http://bb:1234", "password": "pw"}
-    elif platform == Platform.QQBOT:
-        mock_config.extra = {"app_id": "app", "client_secret": "sec"}
-    elif platform == Platform.YUANBAO:
-        mock_config.extra = {"app_id": "app", "app_secret": "sec"}
-    elif platform == Platform.DINGTALK:
-        mock_config.extra = {"client_id": "id", "client_secret": "sec"}
-    elif platform == Platform.RELAY:
-        mock_config.extra = {"relay_url": "wss://connector.example/relay"}
-    else:
-        pytest.skip(f"No synthetic config defined for {platform.value}")
-
-    result = checker(mock_config)
-    assert result is True, f"{platform.value} checker should return True with valid-looking config"
-
-
-def test_api_server_checker_key_validity():
-    """API_SERVER checker: missing, placeholder, short, and strong keys."""
-    checker = _PLATFORM_CONNECTED_CHECKERS[Platform.API_SERVER]
-
-    cfg = MagicMock()
-
-    # Missing
-    cfg.extra = {}
-    assert checker(cfg) is False
-
-    # Placeholder
-    cfg.extra = {"key": "changeme"}
-    assert checker(cfg) is False
-
-    # Too short (<16 chars)
-    cfg.extra = {"key": "shortkey"}
-    assert checker(cfg) is False
-
-    # Strong key (>=16 chars, not a placeholder)
-    cfg.extra = {"key": "opensslrandhex32strongkey"}
-    assert checker(cfg) is True

--- a/tests/gateway/test_platform_connected_checkers.py
+++ b/tests/gateway/test_platform_connected_checkers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from gateway.config import Platform
 from gateway.platform_configuration import (
     BUILTIN_PLATFORM_SPECS,
     StaticConfigurationState,
@@ -12,14 +11,10 @@ from gateway.platform_configuration import (
 
 def test_all_builtins_have_shared_pure_configuration_semantics():
     """Every shipped platform must be classified without adapter imports."""
-    expected = {
-        member.value
-        for member in Platform.__members__.values()
-        if member is not Platform.LOCAL
-    }
-    expected.update(Platform._scan_bundled_plugin_platforms())
+    from gateway.config import _BUILTIN_PLATFORM_VALUES
+    from gateway.platform_configuration import BUILTIN_PLATFORM_SPECS
 
-    assert expected <= BUILTIN_PLATFORM_SPECS.keys()
+    assert _BUILTIN_PLATFORM_VALUES - {"local"} <= BUILTIN_PLATFORM_SPECS.keys()
 
 
 def test_every_builtin_spec_handles_minimal_config():

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -790,10 +790,17 @@ class TestPluginEnablementGate:
         finally:
             _reg.unregister("myconfiguredplat")
 
-    def test_plugin_without_declarative_metadata_is_not_auto_enabled(
+    def test_plugin_without_declarative_metadata_falls_back_to_check_fn(
         self, tmp_path, monkeypatch
     ):
-        """Dependency presence is not proof of third-party configuration."""
+        """Legacy plugins without is_connected or static_configuration keep
+        working through the dependency-presence fallback (check_fn).
+
+        The parent contract: when neither static_configuration nor
+        is_connected is available, check_fn alone decides enablement.
+        Readiness may return UNKNOWN for the same plugin, but the full
+        Gateway enrollment path must not tighten this behavior.
+        """
         from gateway.platform_registry import platform_registry as _reg
 
         _reg.register(PlatformEntry(
@@ -812,9 +819,40 @@ class TestPluginEnablementGate:
             cfg = load_gateway_config()
 
             plat = Platform("mylegacyplat")
-            assert plat not in cfg.platforms
+            assert plat in cfg.platforms
+            assert cfg.platforms[plat].enabled is True
         finally:
             _reg.unregister("mylegacyplat")
+
+    def test_plugin_without_is_connected_or_check_fn_is_not_auto_enabled(
+        self, tmp_path, monkeypatch
+    ):
+        """A plugin that provides neither is_connected nor check_fn must not
+        be auto-enabled.  This is the same as the parent behavior: no
+        check_fn means no dependency-presence proof, so the plugin stays
+        disabled.
+        """
+        from gateway.platform_registry import platform_registry as _reg
+
+        _reg.register(PlatformEntry(
+            name="mynocheckplat",
+            label="MyNoCheck",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: False,
+            # is_connected intentionally omitted (None)
+            source="plugin",
+        ))
+        try:
+            home = self._write_config(tmp_path)
+            monkeypatch.setenv("HERMES_HOME", str(home))
+
+            from gateway.config import load_gateway_config, Platform
+            cfg = load_gateway_config()
+
+            plat = Platform("mynocheckplat")
+            assert plat not in cfg.platforms
+        finally:
+            _reg.unregister("mynocheckplat")
 
     def test_is_connected_raises_does_not_enable(self, tmp_path, monkeypatch):
         """A buggy is_connected must not silently enable the platform.

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -790,15 +790,10 @@ class TestPluginEnablementGate:
         finally:
             _reg.unregister("myconfiguredplat")
 
-    def test_plugin_without_is_connected_falls_back_to_check_fn(
+    def test_plugin_without_declarative_metadata_is_not_auto_enabled(
         self, tmp_path, monkeypatch
     ):
-        """Legacy plugins that don't register is_connected keep working.
-
-        For plugins where ``is_connected is None``, gating on ``check_fn``
-        alone remains the contract — that's what callers without a
-        credential probe have always done.
-        """
+        """Dependency presence is not proof of third-party configuration."""
         from gateway.platform_registry import platform_registry as _reg
 
         _reg.register(PlatformEntry(
@@ -817,8 +812,7 @@ class TestPluginEnablementGate:
             cfg = load_gateway_config()
 
             plat = Platform("mylegacyplat")
-            assert plat in cfg.platforms
-            assert cfg.platforms[plat].enabled is True
+            assert plat not in cfg.platforms
         finally:
             _reg.unregister("mylegacyplat")
 

--- a/tests/gateway/test_status_platform_configuration.py
+++ b/tests/gateway/test_status_platform_configuration.py
@@ -1,0 +1,699 @@
+"""Parity and safety contracts for import-free status platform evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+
+import pytest
+import yaml
+
+
+def _write_yaml(home, data) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(data, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _write_json(home, data) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "gateway.json").write_text(
+        json.dumps(data),
+        encoding="utf-8",
+    )
+
+
+def _set_path(target: dict, path: str, value) -> None:
+    current = target
+    parts = path.split(".")
+    for part in parts[:-1]:
+        current = current.setdefault(part, {})
+    current[parts[-1]] = value
+
+
+def _synthetic_block(spec, *, enabled=True) -> dict:
+    block: dict = {"enabled": enabled}
+    if spec.any_of:
+        for evidence in spec.any_of[0]:
+            assert evidence.config_paths
+            value = "x" * max(1, evidence.min_length)
+            _set_path(block, evidence.config_paths[0], value)
+    return block
+
+
+def test_builtin_specs_cover_every_current_builtin_platform():
+    from gateway.config import Platform
+    from gateway.platform_configuration import BUILTIN_PLATFORM_SPECS
+
+    expected = {
+        member.value for member in Platform.__members__.values()
+        if member is not Platform.LOCAL
+    }
+    expected.update(Platform._scan_bundled_plugin_platforms())
+
+    assert expected <= BUILTIN_PLATFORM_SPECS.keys()
+
+
+@pytest.mark.parametrize(
+    ("name", "block", "env", "expected"),
+    [
+        ("telegram", {"enabled": True}, {}, "disabled"),
+        ("telegram", {"enabled": True, "token": "token"}, {}, "configured"),
+        (
+            "telegram",
+            {"enabled": False, "token": "token"},
+            {"TELEGRAM_BOT_TOKEN": "env-token"},
+            "disabled",
+        ),
+        (
+            "telegram",
+            {"enabled": True, "extra": {"require_mention": True}},
+            {},
+            "disabled",
+        ),
+        (
+            "matrix",
+            {
+                "enabled": True,
+                "extra": {"homeserver": "https://matrix.example", "password": "pw"},
+            },
+            {},
+            "configured",
+        ),
+        (
+            "api_server",
+            {"enabled": True, "extra": {"key": "short"}},
+            {},
+            "disabled",
+        ),
+        (
+            "api_server",
+            {"enabled": True, "extra": {"key": "0123456789abcdef"}},
+            {},
+            "configured",
+        ),
+        (
+            "api_server",
+            {"enabled": True, "extra": {"key": "your_api_key_here"}},
+            {},
+            "disabled",
+        ),
+    ],
+)
+def test_static_contract_rejects_declarations_without_required_evidence(
+    name, block, env, expected
+):
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+        evaluate_static_configuration,
+    )
+
+    state = evaluate_static_configuration(
+        block,
+        BUILTIN_PLATFORM_SPECS[name],
+        getenv=env.get,
+    )
+
+    assert state is StaticConfigurationState(expected)
+
+
+def test_status_sources_deep_merge_extra_with_canonical_precedence(
+    tmp_path, monkeypatch
+):
+    from gateway.config import Platform, load_gateway_config
+    from gateway.platform_configuration import load_platform_blocks
+
+    _write_json(
+        tmp_path,
+        {
+            "platforms": {
+                "matrix": {
+                    "enabled": True,
+                    "extra": {
+                        "homeserver": "https://json.example",
+                        "nested": {"json": 1, "winner": "json"},
+                    },
+                }
+            }
+        },
+    )
+    _write_yaml(
+        tmp_path,
+        {
+            "gateway": {
+                "platforms": {
+                    "matrix": {
+                        "extra": {
+                            "nested": {"gateway": 2, "winner": "gateway"},
+                        }
+                    }
+                }
+            },
+            "platforms": {
+                "matrix": {
+                    "extra": {
+                        "nested": {"top": 3, "winner": "top"},
+                        "password": "pw",
+                    }
+                }
+            },
+        },
+    )
+
+    loaded = load_platform_blocks(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    full = load_gateway_config()
+
+    assert loaded.blocks["matrix"] == {
+        "enabled": True,
+        "extra": {
+            "homeserver": "https://json.example",
+            "password": "pw",
+            "nested": {
+                "json": 1,
+                "gateway": 2,
+                "top": 3,
+                "winner": "top",
+            },
+        },
+    }
+    assert full.platforms[Platform.MATRIX].extra["nested"] == {
+        "json": 1,
+        "gateway": 2,
+        "top": 3,
+        "winner": "top",
+    }
+
+
+@pytest.mark.parametrize("broken_name", ["gateway.json", "config.yaml"])
+def test_malformed_source_does_not_hide_valid_fallback(tmp_path, broken_name):
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+        load_static_platform_states,
+    )
+
+    if broken_name == "gateway.json":
+        (tmp_path / "gateway.json").write_text("{not-json", encoding="utf-8")
+        _write_yaml(
+            tmp_path,
+            {"platforms": {"telegram": {"enabled": True, "token": "yaml-token"}}},
+        )
+    else:
+        _write_json(
+            tmp_path,
+            {"platforms": {"telegram": {"enabled": True, "token": "json-token"}}},
+        )
+        (tmp_path / "config.yaml").write_text("platforms: [unterminated", encoding="utf-8")
+
+    states = load_static_platform_states(
+        tmp_path,
+        ["telegram"],
+        specs=BUILTIN_PLATFORM_SPECS,
+        getenv={}.get,
+    )
+
+    assert states["telegram"] is StaticConfigurationState.CONFIGURED
+
+
+def test_unknown_third_party_is_not_promoted_from_runtime_observation(tmp_path):
+    from gateway.platform_configuration import (
+        StaticConfigurationState,
+        load_static_platform_states,
+    )
+
+    states = load_static_platform_states(
+        tmp_path,
+        ["third_party_chat"],
+        specs={},
+        getenv={}.get,
+    )
+
+    assert states == {"third_party_chat": StaticConfigurationState.UNKNOWN}
+
+
+def test_third_party_requires_complete_declarative_metadata():
+    from gateway.platform_configuration import (
+        ConfigurationEvidence,
+        PlatformConfigurationSpec,
+        StaticConfigurationState,
+        evaluate_static_configuration,
+    )
+
+    complete = PlatformConfigurationSpec(
+        any_of=(
+            (
+                ConfigurationEvidence(
+                    config_paths=("extra.endpoint",),
+                    env_vars=("THIRD_PARTY_ENDPOINT",),
+                ),
+                ConfigurationEvidence(
+                    config_paths=("api_key",),
+                    env_vars=("THIRD_PARTY_API_KEY",),
+                ),
+            ),
+        ),
+    )
+    incomplete = replace(complete, complete=False)
+    block = {
+        "enabled": True,
+        "api_key": "secret",
+        "extra": {"endpoint": "https://plugin.example"},
+    }
+
+    assert (
+        evaluate_static_configuration(block, complete, getenv={}.get)
+        is StaticConfigurationState.CONFIGURED
+    )
+    assert (
+        evaluate_static_configuration(block, incomplete, getenv={}.get)
+        is StaticConfigurationState.UNKNOWN
+    )
+
+
+def test_registered_third_party_metadata_is_shared_without_callback_resolution(
+    tmp_path, monkeypatch
+):
+    from gateway.config import Platform, load_gateway_config, load_status_platform_states
+    from gateway.platform_configuration import (
+        ConfigurationEvidence,
+        PlatformConfigurationSpec,
+        StaticConfigurationState,
+    )
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    spec = PlatformConfigurationSpec(
+        any_of=(
+            (
+                ConfigurationEvidence(env_vars=("THIRD_PARTY_ENDPOINT",)),
+                ConfigurationEvidence(env_vars=("THIRD_PARTY_API_KEY",)),
+            ),
+        ),
+    )
+    platform_registry.register(
+        PlatformEntry(
+            name="third_party_chat",
+            label="Third Party Chat",
+            adapter_factory=lambda config: None,
+            check_fn=lambda: True,
+            static_configuration=spec,
+            source="plugin",
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("THIRD_PARTY_ENDPOINT", "https://plugin.example")
+    monkeypatch.setenv("THIRD_PARTY_API_KEY", "secret")
+    try:
+        full = load_gateway_config()
+        states = load_status_platform_states(["third_party_chat"])
+        platform = Platform("third_party_chat")
+
+        assert full.get_connected_platforms() == [platform]
+        assert states["third_party_chat"] is StaticConfigurationState.CONFIGURED
+    finally:
+        platform_registry.unregister("third_party_chat")
+
+
+def test_case_variant_and_removed_plugin_records_remain_unknown(tmp_path):
+    from gateway.platform_configuration import (
+        StaticConfigurationState,
+        load_static_platform_states,
+    )
+
+    states = load_static_platform_states(
+        tmp_path,
+        ["Telegram", "removed_plugin"],
+        specs={},
+        getenv={}.get,
+    )
+
+    assert states == {
+        "Telegram": StaticConfigurationState.UNKNOWN,
+        "removed_plugin": StaticConfigurationState.UNKNOWN,
+    }
+
+
+def test_builtin_full_loader_and_pure_evaluator_share_semantics(monkeypatch):
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+        evaluate_static_configuration,
+    )
+
+    env = {
+        "SIGNAL_HTTP_URL": "http://127.0.0.1:8080",
+        "SIGNAL_ACCOUNT": "+15555550100",
+    }
+    monkeypatch.setattr("gateway.config._getenv", env.get)
+    config = PlatformConfig(
+        enabled=True,
+        extra={"http_url": env["SIGNAL_HTTP_URL"], "account": env["SIGNAL_ACCOUNT"]},
+    )
+    gateway_config = GatewayConfig(platforms={Platform.SIGNAL: config})
+
+    static_state = evaluate_static_configuration(
+        config,
+        BUILTIN_PLATFORM_SPECS["signal"],
+        getenv=env.get,
+    )
+
+    assert static_state is StaticConfigurationState.CONFIGURED
+    assert gateway_config.get_connected_platforms() == [Platform.SIGNAL]
+
+
+def test_every_builtin_full_loader_decision_matches_shared_spec():
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+        evaluate_static_configuration,
+    )
+
+    for name, spec in BUILTIN_PLATFORM_SPECS.items():
+        block = _synthetic_block(spec)
+
+        platform = Platform(name)
+        platform_config = PlatformConfig.from_dict(block)
+        full = GatewayConfig(platforms={platform: platform_config})
+        pure = evaluate_static_configuration(
+            platform_config,
+            spec,
+            getenv={}.get,
+        )
+
+        assert pure is StaticConfigurationState.CONFIGURED, name
+        assert full.get_connected_platforms() == [platform], name
+
+
+def test_every_builtin_rejects_credentialless_and_policy_only_declarations():
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+        evaluate_static_configuration,
+    )
+
+    for name, spec in BUILTIN_PLATFORM_SPECS.items():
+        expected = (
+            StaticConfigurationState.CONFIGURED
+            if not spec.any_of
+            else StaticConfigurationState.DISABLED
+        )
+        for block in (
+            {"enabled": True},
+            {"enabled": True, "extra": {"require_mention": True}},
+        ):
+            assert (
+                evaluate_static_configuration(block, spec, getenv={}.get)
+                is expected
+            ), name
+
+
+def test_every_builtin_explicit_disable_wins_with_valid_evidence():
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+        evaluate_static_configuration,
+    )
+
+    for name, spec in BUILTIN_PLATFORM_SPECS.items():
+        block = _synthetic_block(spec, enabled=False)
+        assert (
+            evaluate_static_configuration(block, spec, getenv={}.get)
+            is StaticConfigurationState.DISABLED
+        ), name
+
+
+def test_environment_only_evidence_matches_full_loader(monkeypatch):
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+        evaluate_static_configuration,
+    )
+
+    covered = set()
+    for name, spec in BUILTIN_PLATFORM_SPECS.items():
+        if not spec.any_of:
+            continue
+        group = next(
+            (
+                candidate
+                for candidate in spec.any_of
+                if all(evidence.env_vars for evidence in candidate)
+            ),
+            None,
+        )
+        if group is None:
+            continue
+        env = {}
+        for evidence in group:
+            env[evidence.env_vars[0]] = "x" * max(1, evidence.min_length)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+
+        platform = Platform(name)
+        config = PlatformConfig(enabled=True)
+        pure = evaluate_static_configuration(config, spec, getenv=env.get)
+        full = GatewayConfig(platforms={platform: config})
+
+        assert pure is StaticConfigurationState.CONFIGURED, name
+        assert full.get_connected_platforms() == [platform], name
+        covered.add(name)
+        for key in env:
+            monkeypatch.delenv(key)
+
+    assert {
+        "telegram",
+        "matrix",
+        "email",
+        "teams",
+        "google_chat",
+        "photon",
+    } <= covered
+
+
+def test_managed_overlay_and_direct_source_follow_full_loader_precedence(
+    tmp_path, monkeypatch
+):
+    from gateway.config import Platform, load_gateway_config
+    from gateway.platform_configuration import load_platform_blocks
+    from hermes_cli import managed_scope
+
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    (managed_dir / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "platforms": {
+                    "matrix": {
+                        "extra": {
+                            "password": "managed-password",
+                            "nested": {"managed": 4, "winner": "managed"},
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_json(
+        tmp_path,
+        {
+            "platforms": {
+                "matrix": {
+                    "enabled": True,
+                    "extra": {
+                        "homeserver": "https://json.example",
+                        "nested": {"json": 1, "winner": "json"},
+                    },
+                }
+            }
+        },
+    )
+    _write_yaml(
+        tmp_path,
+        {
+            "gateway": {
+                "platforms": {
+                    "matrix": {
+                        "extra": {"nested": {"gateway": 2, "winner": "gateway"}}
+                    }
+                }
+            },
+            "platforms": {
+                "matrix": {
+                    "extra": {"nested": {"top": 3, "winner": "top"}}
+                }
+            },
+            "matrix": {
+                "extra": {"nested": {"direct": 5, "winner": "direct"}}
+            },
+        },
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    managed_scope.invalidate_managed_cache()
+
+    blocks = load_platform_blocks(tmp_path)
+    full = load_gateway_config()
+    expected_nested = {
+        "json": 1,
+        "gateway": 2,
+        "top": 3,
+        "managed": 4,
+        "winner": "managed",
+    }
+
+    assert blocks.blocks["matrix"]["extra"]["nested"] == expected_nested
+    assert full.platforms[Platform.MATRIX].extra["nested"] == expected_nested
+    assert blocks.blocks["matrix"]["extra"]["password"] == "managed-password"
+    assert full.platforms[Platform.MATRIX].extra["password"] == "managed-password"
+
+
+def test_status_never_resolves_deferred_plugin_callback(tmp_path):
+    from gateway.config import load_status_platform_states
+    from gateway.platform_configuration import StaticConfigurationState
+    from gateway.platform_registry import platform_registry
+
+    def forbidden_loader():
+        raise AssertionError("readiness resolved a deferred plugin callback")
+
+    platform_registry.register_deferred("callback_plugin", forbidden_loader)
+    try:
+        states = load_status_platform_states(["callback_plugin"])
+    finally:
+        platform_registry.unregister("callback_plugin")
+
+    assert states["callback_plugin"] is StaticConfigurationState.UNKNOWN
+
+
+def test_third_party_override_of_builtin_without_metadata_is_unknown():
+    from gateway.config import load_status_platform_states
+    from gateway.platform_configuration import StaticConfigurationState
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    original = platform_registry.get_concrete_entry("telegram")
+    platform_registry.register(
+        PlatformEntry(
+            name="telegram",
+            label="Custom Telegram Override",
+            adapter_factory=lambda config: None,
+            check_fn=lambda: True,
+            is_connected=lambda config: True,
+            source="plugin",
+        )
+    )
+    try:
+        states = load_status_platform_states(["telegram"])
+    finally:
+        platform_registry.unregister("telegram")
+        if original is not None:
+            platform_registry.register(original)
+
+    assert states["telegram"] is StaticConfigurationState.UNKNOWN
+
+
+def test_bundled_plugin_registration_inherits_shared_static_spec():
+    from gateway.platform_configuration import BUILTIN_PLATFORM_SPECS
+    from gateway.platform_registry import platform_registry
+    from hermes_cli.plugins import PluginContext, PluginManifest
+
+    class _Manager:
+        _plugin_platform_names: set[str] = set()
+
+    original = platform_registry.get_concrete_entry("telegram")
+    context = PluginContext(
+        PluginManifest(name="telegram-platform", source="bundled"),
+        _Manager(),
+    )
+    try:
+        context.register_platform(
+            name="telegram",
+            label="Telegram",
+            adapter_factory=lambda config: None,
+            check_fn=lambda: True,
+        )
+        entry = platform_registry.get_concrete_entry("telegram")
+
+        assert entry is not None
+        assert entry.static_configuration is BUILTIN_PLATFORM_SPECS["telegram"]
+    finally:
+        platform_registry.unregister("telegram")
+        if original is not None:
+            platform_registry.register(original)
+
+
+def test_status_uses_secret_scope_instead_of_process_environment(monkeypatch):
+    from agent.secret_scope import (
+        reset_secret_scope,
+        set_multiplex_active,
+        set_secret_scope,
+    )
+    from gateway.config import load_status_platform_states
+    from gateway.platform_configuration import StaticConfigurationState
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "wrong-profile-token")
+    set_multiplex_active(True)
+    token = set_secret_scope({"TELEGRAM_BOT_TOKEN": "scoped-token"})
+    try:
+        states = load_status_platform_states(["telegram"])
+    finally:
+        reset_secret_scope(token)
+        set_multiplex_active(False)
+
+    assert states["telegram"] is StaticConfigurationState.CONFIGURED
+
+
+@pytest.mark.parametrize("truthy", ["1", "true", "yes", "on", " TRUE "])
+def test_platform_enable_env_accepts_shared_truthy_values(truthy):
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+        evaluate_static_configuration,
+    )
+
+    state = evaluate_static_configuration(
+        {},
+        BUILTIN_PLATFORM_SPECS["webhook"],
+        getenv={"WEBHOOK_ENABLED": truthy}.get,
+    )
+
+    assert state is StaticConfigurationState.CONFIGURED
+
+
+def test_explicit_disable_wins_over_environment_enablement():
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+        evaluate_static_configuration,
+    )
+
+    state = evaluate_static_configuration(
+        {"enabled": False},
+        BUILTIN_PLATFORM_SPECS["webhook"],
+        getenv={"WEBHOOK_ENABLED": "true"}.get,
+    )
+
+    assert state is StaticConfigurationState.DISABLED
+
+
+def test_full_loader_preserves_explicit_disable_against_env(
+    tmp_path, monkeypatch
+):
+    from gateway.config import Platform, load_gateway_config
+
+    _write_yaml(
+        tmp_path,
+        {"platforms": {"webhook": {"enabled": False}}},
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("WEBHOOK_ENABLED", "true")
+
+    loaded = load_gateway_config()
+
+    assert loaded.platforms[Platform.WEBHOOK].enabled is False
+    assert Platform.WEBHOOK not in loaded.get_connected_platforms()

--- a/tests/gateway/test_status_platform_configuration.py
+++ b/tests/gateway/test_status_platform_configuration.py
@@ -44,16 +44,10 @@ def _synthetic_block(spec, *, enabled=True) -> dict:
 
 
 def test_builtin_specs_cover_every_current_builtin_platform():
-    from gateway.config import Platform
+    from gateway.config import _BUILTIN_PLATFORM_VALUES
     from gateway.platform_configuration import BUILTIN_PLATFORM_SPECS
 
-    expected = {
-        member.value for member in Platform.__members__.values()
-        if member is not Platform.LOCAL
-    }
-    expected.update(Platform._scan_bundled_plugin_platforms())
-
-    assert expected <= BUILTIN_PLATFORM_SPECS.keys()
+    assert _BUILTIN_PLATFORM_VALUES - {"local"} <= BUILTIN_PLATFORM_SPECS.keys()
 
 
 @pytest.mark.parametrize(
@@ -654,24 +648,6 @@ def test_explicit_disable_wins_over_environment_enablement():
     )
 
     assert state is StaticConfigurationState.DISABLED
-
-
-def test_full_loader_preserves_explicit_disable_against_env(
-    tmp_path, monkeypatch
-):
-    from gateway.config import Platform, load_gateway_config
-
-    _write_yaml(
-        tmp_path,
-        {"platforms": {"webhook": {"enabled": False}}},
-    )
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("WEBHOOK_ENABLED", "true")
-
-    loaded = load_gateway_config()
-
-    assert loaded.platforms[Platform.WEBHOOK].enabled is False
-    assert Platform.WEBHOOK not in loaded.get_connected_platforms()
 
 
 def test_full_loader_preserves_parent_signal_http_url_contract():

--- a/tests/gateway/test_status_platform_configuration.py
+++ b/tests/gateway/test_status_platform_configuration.py
@@ -365,30 +365,6 @@ def test_builtin_full_loader_and_pure_evaluator_share_semantics(monkeypatch):
     assert gateway_config.get_connected_platforms() == [Platform.SIGNAL]
 
 
-def test_every_builtin_full_loader_decision_matches_shared_spec():
-    from gateway.config import GatewayConfig, Platform, PlatformConfig
-    from gateway.platform_configuration import (
-        BUILTIN_PLATFORM_SPECS,
-        StaticConfigurationState,
-        evaluate_static_configuration,
-    )
-
-    for name, spec in BUILTIN_PLATFORM_SPECS.items():
-        block = _synthetic_block(spec)
-
-        platform = Platform(name)
-        platform_config = PlatformConfig.from_dict(block)
-        full = GatewayConfig(platforms={platform: platform_config})
-        pure = evaluate_static_configuration(
-            platform_config,
-            spec,
-            getenv={}.get,
-        )
-
-        assert pure is StaticConfigurationState.CONFIGURED, name
-        assert full.get_connected_platforms() == [platform], name
-
-
 def test_every_builtin_rejects_credentialless_and_policy_only_declarations():
     from gateway.platform_configuration import (
         BUILTIN_PLATFORM_SPECS,
@@ -397,6 +373,8 @@ def test_every_builtin_rejects_credentialless_and_policy_only_declarations():
     )
 
     for name, spec in BUILTIN_PLATFORM_SPECS.items():
+        if not spec.complete:
+            continue
         expected = (
             StaticConfigurationState.CONFIGURED
             if not spec.any_of
@@ -420,6 +398,8 @@ def test_every_builtin_explicit_disable_wins_with_valid_evidence():
     )
 
     for name, spec in BUILTIN_PLATFORM_SPECS.items():
+        if not spec.complete:
+            continue
         block = _synthetic_block(spec, enabled=False)
         assert (
             evaluate_static_configuration(block, spec, getenv={}.get)
@@ -427,8 +407,7 @@ def test_every_builtin_explicit_disable_wins_with_valid_evidence():
         ), name
 
 
-def test_environment_only_evidence_matches_full_loader(monkeypatch):
-    from gateway.config import GatewayConfig, Platform, PlatformConfig
+def test_environment_only_evidence_is_a_static_readiness_projection(monkeypatch):
     from gateway.platform_configuration import (
         BUILTIN_PLATFORM_SPECS,
         StaticConfigurationState,
@@ -455,13 +434,9 @@ def test_environment_only_evidence_matches_full_loader(monkeypatch):
         for key, value in env.items():
             monkeypatch.setenv(key, value)
 
-        platform = Platform(name)
-        config = PlatformConfig(enabled=True)
-        pure = evaluate_static_configuration(config, spec, getenv=env.get)
-        full = GatewayConfig(platforms={platform: config})
+        pure = evaluate_static_configuration({"enabled": True}, spec, getenv=env.get)
 
         assert pure is StaticConfigurationState.CONFIGURED, name
-        assert full.get_connected_platforms() == [platform], name
         covered.add(name)
         for key in env:
             monkeypatch.delenv(key)
@@ -697,3 +672,109 @@ def test_full_loader_preserves_explicit_disable_against_env(
 
     assert loaded.platforms[Platform.WEBHOOK].enabled is False
     assert Platform.WEBHOOK not in loaded.get_connected_platforms()
+
+
+def test_full_loader_preserves_parent_signal_http_url_contract():
+    """Parent accepted enabled Signal with a URL; account was not required."""
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+    config = GatewayConfig(
+        platforms={Platform.SIGNAL: PlatformConfig(enabled=True, extra={"http_url": "http://signal"})}
+    )
+
+    assert config.get_connected_platforms() == [Platform.SIGNAL]
+
+
+def test_readiness_uses_parent_compatible_signal_and_email_minima():
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+        evaluate_static_configuration,
+    )
+
+    assert evaluate_static_configuration(
+        {"enabled": True, "extra": {"http_url": "http://signal"}},
+        BUILTIN_PLATFORM_SPECS["signal"],
+        getenv={}.get,
+    ) is StaticConfigurationState.CONFIGURED
+    assert evaluate_static_configuration(
+        {"enabled": True, "extra": {"address": "user@example.test"}},
+        BUILTIN_PLATFORM_SPECS["email"],
+        getenv={}.get,
+    ) is StaticConfigurationState.CONFIGURED
+
+
+def test_readiness_returns_unknown_for_whatsapp_callback_contract():
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+        evaluate_static_configuration,
+    )
+
+    assert evaluate_static_configuration(
+        {"enabled": True, "extra": {"seeded": "value"}},
+        BUILTIN_PLATFORM_SPECS["whatsapp"],
+        getenv={}.get,
+    ) is StaticConfigurationState.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "extra"),
+    [
+        ("email", {"address": "user@example.test"}),
+        ("whatsapp", {"seeded": "value"}),
+    ],
+)
+def test_full_loader_never_allows_static_metadata_to_preempt_callback(
+    platform_name, extra
+):
+    """The parent lane invokes its registered callback after built-in checks."""
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from gateway.platform_configuration import PlatformConfigurationSpec
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    original = platform_registry.get_concrete_entry(platform_name)
+    platform_registry.register(
+        PlatformEntry(
+            name=platform_name, label="Callback contract", adapter_factory=lambda cfg: None,
+            check_fn=lambda: True, is_connected=lambda cfg: bool(cfg.extra),
+            static_configuration=PlatformConfigurationSpec(complete=False),
+        )
+    )
+    try:
+        loaded = GatewayConfig(
+            platforms={Platform(platform_name): PlatformConfig(enabled=True, extra=extra)}
+        )
+        assert loaded.get_connected_platforms() == [Platform(platform_name)]
+    finally:
+        platform_registry.unregister(platform_name)
+        if original is not None:
+            platform_registry.register(original)
+
+
+def test_forged_unbundled_builtin_metadata_is_unknown(tmp_path, monkeypatch):
+    from gateway.config import load_status_platform_states
+    from gateway.platform_configuration import (
+        BUILTIN_PLATFORM_SPECS,
+        StaticConfigurationState,
+    )
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    _write_yaml(tmp_path, {"platforms": {"telegram": {"enabled": True, "token": "token"}}})
+    monkeypatch.setattr("gateway.config.get_hermes_home", lambda: tmp_path)
+    original = platform_registry.get_concrete_entry("telegram")
+    platform_registry.register(
+        PlatformEntry(
+            name="telegram", label="Forged", adapter_factory=lambda cfg: None,
+            check_fn=lambda: True, static_configuration=BUILTIN_PLATFORM_SPECS["telegram"],
+            source="plugin", readiness_trusted=False,
+        )
+    )
+    try:
+        states = load_status_platform_states(["telegram"])
+    finally:
+        platform_registry.unregister("telegram")
+        if original is not None:
+            platform_registry.register(original)
+
+    assert states["telegram"] is StaticConfigurationState.UNKNOWN

--- a/tests/hermes_cli/test_status_readiness_imports.py
+++ b/tests/hermes_cli/test_status_readiness_imports.py
@@ -1,0 +1,222 @@
+"""Readiness must not activate platform plugins or optional platform SDKs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+
+from fastapi.testclient import TestClient
+
+
+def test_status_does_not_enter_gateway_or_plugin_resolution(monkeypatch):
+    import gateway.config as gateway_config
+    from gateway.platform_registry import platform_registry
+    from hermes_cli import plugins, web_server
+
+    calls: list[str] = []
+
+    def forbidden(name):
+        def _record(*_args, **_kwargs):
+            calls.append(name)
+            raise AssertionError(f"/api/status called forbidden resolver: {name}")
+
+        return _record
+
+    monkeypatch.setattr(
+        gateway_config,
+        "load_gateway_config",
+        forbidden("load_gateway_config"),
+    )
+    monkeypatch.setattr(
+        plugins,
+        "discover_plugins",
+        forbidden("discover_plugins"),
+    )
+    monkeypatch.setattr(
+        platform_registry,
+        "plugin_entries",
+        forbidden("plugin_entries"),
+    )
+    monkeypatch.setattr(
+        platform_registry,
+        "all_entries",
+        forbidden("all_entries"),
+    )
+    monkeypatch.setattr(
+        platform_registry,
+        "_resolve_all",
+        forbidden("_resolve_all"),
+    )
+    monkeypatch.setattr(
+        platform_registry,
+        "get",
+        forbidden("adapter_lookup"),
+    )
+
+    response = TestClient(web_server.app).get("/api/status")
+
+    assert response.status_code == 200
+    assert calls == []
+
+
+def test_status_is_independent_of_concurrent_plugin_discovery(monkeypatch):
+    from hermes_cli import plugins, web_server
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    def slow_discovery():
+        entered.set()
+        release.wait(timeout=5)
+
+    monkeypatch.setattr(plugins, "discover_plugins", slow_discovery)
+    worker = threading.Thread(target=plugins.discover_plugins)
+    worker.start()
+    assert entered.wait(timeout=1)
+
+    started = time.perf_counter()
+    response = TestClient(web_server.app).get("/api/status")
+    elapsed = time.perf_counter() - started
+    release.set()
+    worker.join(timeout=1)
+
+    assert response.status_code == 200
+    assert elapsed < 1
+    assert not worker.is_alive()
+
+
+def test_status_request_installs_import_guard_before_application_import(tmp_path):
+    """A fresh request must not import adapters, SDKs, or entry-point payloads."""
+
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    (home / "gateway_state.json").write_text(
+        json.dumps(
+            {
+                "gateway_state": "running",
+                "platforms": {
+                    "telegram": {"state": "connected"},
+                    "removed_plugin": {"state": "disconnected"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    script = textwrap.dedent(
+        """
+        import importlib.metadata
+        import json
+        import sys
+
+        forbidden_prefixes = (
+            "gateway.platforms.",
+            "plugins.platforms.",
+            "hermes_plugins.platforms__",
+        )
+        forbidden_roots = {
+            "aioimaplib",
+            "aiosmtplib",
+            "botbuilder",
+            "discord",
+            "dingtalk_stream",
+            "google",
+            "googleapiclient",
+            "lark_oapi",
+            "mattermostdriver",
+            "msal",
+            "nio",
+            "slack_bolt",
+            "slack_sdk",
+            "telegram",
+            "twilio",
+        }
+
+        class RejectPlatformImports:
+            def find_spec(self, fullname, path=None, target=None):
+                if (
+                    fullname.startswith(forbidden_prefixes)
+                    or fullname.split(".", 1)[0] in forbidden_roots
+                ):
+                    raise AssertionError("forbidden readiness import: " + fullname)
+                return None
+
+        sys.meta_path.insert(0, RejectPlatformImports())
+        before = set(sys.modules)
+
+        original_entry_point_load = importlib.metadata.EntryPoint.load
+        def reject_entry_point_load(self):
+            raise AssertionError("readiness loaded entry point: " + self.name)
+        importlib.metadata.EntryPoint.load = reject_entry_point_load
+
+        from fastapi.testclient import TestClient
+        from hermes_cli import web_server
+
+        response = TestClient(web_server.app).get("/api/status")
+        imported = sorted(set(sys.modules) - before)
+        forbidden = [
+            name
+            for name in imported
+            if name.startswith(forbidden_prefixes)
+            or name.split(".", 1)[0] in forbidden_roots
+        ]
+        print(
+            "STATUS_IMPORT_RESULT="
+            + json.dumps(
+                {
+                    "status_code": response.status_code,
+                    "forbidden": forbidden,
+                },
+                sort_keys=True,
+            )
+        )
+        importlib.metadata.EntryPoint.load = original_entry_point_load
+        """
+    )
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not (
+            key.endswith(("_TOKEN", "_SECRET", "_PASSWORD", "_API_KEY"))
+            or key
+            in {
+                "API_SERVER_KEY",
+                "EMAIL_ADDRESS",
+                "GOOGLE_APPLICATION_CREDENTIALS",
+                "HASS_TOKEN",
+                "IRC_CHANNEL",
+                "IRC_SERVER",
+                "MATRIX_HOMESERVER",
+                "PHOTON_PROJECT_ID",
+                "RAFT_PROFILE",
+                "SIGNAL_ACCOUNT",
+                "SIGNAL_HTTP_URL",
+                "SIMPLEX_WS_URL",
+            }
+        )
+    }
+    env["HERMES_HOME"] = str(home)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=90,
+        check=False,
+    )
+
+    marker = "STATUS_IMPORT_RESULT="
+    payload_line = next(
+        (line for line in result.stdout.splitlines() if line.startswith(marker)),
+        None,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert payload_line is not None, result.stdout + result.stderr
+    payload = json.loads(payload_line[len(marker) :])
+    assert payload == {"status_code": 200, "forbidden": []}

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2747,14 +2747,6 @@ class TestWebServerEndpoints:
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server
 
-        class _Platform:
-            def __init__(self, value):
-                self.value = value
-
-        class _GatewayConfig:
-            def get_connected_platforms(self):
-                return [_Platform("telegram")]
-
         monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: 1234)
         monkeypatch.setattr(
             web_server,
@@ -2770,7 +2762,11 @@ class TestWebServerEndpoints:
             },
         )
         monkeypatch.setattr(web_server, "check_config_version", lambda: (1, 1))
-        monkeypatch.setattr(gateway_config, "load_gateway_config", lambda: _GatewayConfig())
+        monkeypatch.setattr(
+            gateway_config,
+            "load_status_configured_platforms",
+            lambda candidates: frozenset({"telegram"}),
+        )
 
         resp = self.client.get("/api/status")
 
@@ -2782,10 +2778,6 @@ class TestWebServerEndpoints:
     def test_get_status_hides_stale_platforms_when_gateway_not_running(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server
-
-        class _GatewayConfig:
-            def get_connected_platforms(self):
-                return []
 
         monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: None)
         monkeypatch.setattr(
@@ -2801,7 +2793,11 @@ class TestWebServerEndpoints:
             },
         )
         monkeypatch.setattr(web_server, "check_config_version", lambda: (1, 1))
-        monkeypatch.setattr(gateway_config, "load_gateway_config", lambda: _GatewayConfig())
+        monkeypatch.setattr(
+            gateway_config,
+            "load_status_configured_platforms",
+            lambda candidates: frozenset(),
+        )
 
         resp = self.client.get("/api/status")
 

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -579,14 +579,9 @@ class TestProfileScopedGateway:
             lambda payload, **k: 4242,
         )
         monkeypatch.setattr(web_server, "_GATEWAY_HEALTH_URL", None)
-        from gateway.config import Platform
-
-        class _FakeGatewayConfig:
-            def get_connected_platforms(self):
-                return [Platform.TELEGRAM]
-
         monkeypatch.setattr(
-            "gateway.config.load_gateway_config", lambda: _FakeGatewayConfig()
+            "gateway.config.load_status_configured_platforms",
+            lambda candidates: frozenset({"telegram"}),
         )
 
         resp = client.get("/api/status", params={"profile": "worker_beta"})


### PR DESCRIPTION
## Problem

Hermes Desktop waits for `/api/status` during startup. That endpoint reused the full Gateway configuration path, which could synchronously discover platform plugins, resolve adapters, and import optional SDKs on the main event-loop thread.

On cold starts this caused long stalls and repeated Desktop readiness timeouts even though the backend eventually became healthy.

## Root cause

The readiness path crossed this heavyweight call chain:

```text
/api/status
  -> load_gateway_config()
  -> plugin discovery / registry resolution
  -> platform adapter imports
  -> optional SDK imports
```

Core liveness does not require adapter classes, authentication, network access, or deep integration discovery.

## Changes

- Added a pure, import-free platform configuration evaluator for readiness.
- Rewired `/api/status` to use static configuration state instead of the full Gateway loader.
- Preserved existing full Gateway enrollment, callback, validation, and fallback behavior.
- Separated statically configured, disabled, runtime-observed, runtime-connected, and unknown platform states internally.
- Treats unprovable third-party readiness metadata as `UNKNOWN` rather than configured.
- Prevents untrusted plugins from overriding bundled built-in readiness contracts.
- Extracted shared secret validation used by both auth and static configuration checks.
- Preserved the existing public `/api/status` response schema.

Readiness now performs no platform adapter resolution, optional SDK imports, entry-point loading, arbitrary plugin callbacks, authentication calls, or network activity.

## Verification

Rebased and revalidated against upstream `8dc99787418e5b10720c0a7a432addc02deef322`.

- 94 focused platform/readiness tests passed.
- 70 web-server status, dashboard, component, and health tests passed.
- 116 plugin tests passed.
- 27 Telegram and Discord connection tests passed.
- Desktop Vitest: 2,133 tests across 252 files passed.
- Desktop TypeScript check and renderer/Electron build passed.
- Python `compileall` and `git diff --check` passed.
- Five fresh DrvFS readiness samples:
  - cold maximum: **147.0 ms**
  - warm p95: **5.7 ms**
- Forbidden readiness imports: **zero**.
- Rebase conflicts: **zero**.
- No dependency or lockfile changes.

## Compatibility

The full Gateway path still owns dynamic plugin resolution and platform-specific callback behavior. The static evaluator is used only for readiness and returns `UNKNOWN` when it cannot safely prove configuration without imports or callbacks.

Parent behavior was explicitly preserved for plugin-backed platforms including Signal, Email, and WhatsApp.

## Scope

13 files changed, 3 commits:

1. `Fix status readiness without configuration drift`
2. `Preserve Gateway platform contracts in status fix`
3. `Restore Gateway plugin enrollment compatibility`

## Limitations / follow-ups

- A display-capable packaged Desktop E2E launch was not rerun after the final rebase; Desktop E2E CI should verify the packaged application path.
- Windows packaged Desktop was not tested locally.
- Existing dependency audit findings were not introduced or modified by this branch.

## Expected result

Desktop startup can query core readiness quickly and deterministically without importing the platform integration stack, while full Gateway behavior remains unchanged outside readiness.