### PR TITLE
fix(terminal): re-pin running install's bin dir after shell rc sourcing

### DIFF
--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -97,8 +97,25 @@ class TestResolveShellInitFiles:
 
 
 class TestPrependShellInit:
-    def test_empty_list_returns_command_unchanged(self):
-        assert _prepend_shell_init("echo hi", []) == "echo hi"
+    def test_empty_list_without_bin_dir_returns_unchanged(self):
+        with patch(
+            "tools.environments.local._resolve_hermes_bin_dir",
+            return_value=None,
+        ):
+            assert _prepend_shell_init("echo hi", []) == "echo hi"
+
+    def test_empty_list_still_repins_hermes_bin_dir(self):
+        """Strict-login / empty init list must still re-pin: bash -l can
+        rewrite PATH via native login rc before -c runs.
+        """
+        with patch(
+            "tools.environments.local._resolve_hermes_bin_dir",
+            return_value="/opt/hermes-venv/bin",
+        ):
+            wrapped = _prepend_shell_init("echo hi", [])
+
+        assert "export PATH='/opt/hermes-venv/bin':\"$PATH\"" in wrapped
+        assert wrapped.rstrip().endswith("echo hi")
 
     def test_prepends_guarded_source_lines(self):
         wrapped = _prepend_shell_init("echo hi", ["/tmp/a.sh", "/tmp/b.sh"])
@@ -285,6 +302,45 @@ class TestSnapshotEndToEnd:
         with patch(
             "tools.environments.local._read_terminal_shell_init_config",
             return_value=([], True),
+        ), patch(
+            "tools.environments.local._resolve_hermes_bin_dir",
+            return_value=str(ours),
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+            try:
+                result = env.execute('command -v hermes; hermes')
+            finally:
+                env.cleanup()
+
+        output = result.get("output", "")
+        assert "OURS" in output
+        assert "THEIRS" not in output
+
+    def test_strict_login_empty_init_list_still_repins_against_login_rc(
+        self, tmp_path, monkeypatch
+    ):
+        """Strict-login path: no Hermes-sourced init files, but ``bash -l``
+        still reads ``~/.bash_profile`` and can prepend a competing install.
+
+        ``auto_source_bashrc=False`` + empty ``shell_init_files`` leaves the
+        resolved init list empty; the re-pin must still run after login rc.
+        """
+        ours = tmp_path / "ours" / "bin"
+        theirs = tmp_path / "theirs" / "bin"
+        for bin_dir, tag in ((ours, "OURS"), (theirs, "THEIRS")):
+            bin_dir.mkdir(parents=True)
+            shim = bin_dir / "hermes"
+            shim.write_text(f"#!/bin/sh\necho {tag}\n")
+            shim.chmod(0o755)
+
+        # bash -l prefers ~/.bash_profile over ~/.profile / ~/.bashrc.
+        bash_profile = tmp_path / ".bash_profile"
+        bash_profile.write_text(f'export PATH="{theirs}:$PATH"\n')
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], False),
         ), patch(
             "tools.environments.local._resolve_hermes_bin_dir",
             return_value=str(ours),

--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -116,6 +116,39 @@ class TestPrependShellInit:
         # quote is escaped as '\'' rather than breaking the outer quoting.
         assert "o'\\''malley" in wrapped
 
+    def test_repins_hermes_bin_dir_after_rc_sources(self):
+        """The re-pin export must come AFTER the source lines so it wins
+        over any PATH prepend an rc file performed (first-occurrence-wins).
+        """
+        with patch(
+            "tools.environments.local._resolve_hermes_bin_dir",
+            return_value="/opt/hermes-venv/bin",
+        ):
+            wrapped = _prepend_shell_init("echo hi", ["/tmp/a.sh"])
+
+        assert "export PATH='/opt/hermes-venv/bin':\"$PATH\"" in wrapped
+        assert wrapped.index("/tmp/a.sh") < wrapped.index("/opt/hermes-venv/bin")
+        # The command itself still follows the prelude.
+        assert wrapped.rstrip().endswith("echo hi")
+
+    def test_repin_skipped_when_bin_dir_unresolved(self):
+        with patch(
+            "tools.environments.local._resolve_hermes_bin_dir",
+            return_value=None,
+        ):
+            wrapped = _prepend_shell_init("echo hi", ["/tmp/a.sh"])
+
+        assert "export PATH=" not in wrapped
+
+    def test_repin_escapes_single_quotes_in_bin_dir(self):
+        with patch(
+            "tools.environments.local._resolve_hermes_bin_dir",
+            return_value="/opt/o'malley/bin",
+        ):
+            wrapped = _prepend_shell_init("echo hi", ["/tmp/a.sh"])
+
+        assert "o'\\''malley" in wrapped
+
 
 @pytest.mark.skipif(
     os.environ.get("CI") == "true" and not os.path.isfile("/bin/bash"),
@@ -224,3 +257,44 @@ class TestSnapshotEndToEnd:
         assert str(fake_n_bin) in output
         # bashrc short-circuited on the interactive guard — its export never ran
         assert "FROM_BASHRC=bashrc-should-not-appear" not in output
+
+    def test_rc_path_prepend_cannot_shadow_running_hermes(
+        self, tmp_path, monkeypatch
+    ):
+        """Reproduces the multi-instance shadowing case.
+
+        Two fake installs each ship a ``hermes`` shim. The gateway runs from
+        install A while ``~/.bashrc`` prepends install B's bin dir — a common
+        leftover on machines that ran an older per-instance install (e.g.
+        ``export PATH="$HOME/.hermes/hermes-agent/venv/bin:$PATH"``). Without
+        the post-source re-pin, the login snapshot captures B first and bare
+        ``hermes`` resolves to the wrong install for every terminal call.
+        """
+        ours = tmp_path / "ours" / "bin"
+        theirs = tmp_path / "theirs" / "bin"
+        for bin_dir, tag in ((ours, "OURS"), (theirs, "THEIRS")):
+            bin_dir.mkdir(parents=True)
+            shim = bin_dir / "hermes"
+            shim.write_text(f"#!/bin/sh\necho {tag}\n")
+            shim.chmod(0o755)
+
+        bashrc = tmp_path / ".bashrc"
+        bashrc.write_text(f'export PATH="{theirs}:$PATH"\n')
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], True),
+        ), patch(
+            "tools.environments.local._resolve_hermes_bin_dir",
+            return_value=str(ours),
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+            try:
+                result = env.execute('command -v hermes; hermes')
+            finally:
+                env.cleanup()
+
+        output = result.get("output", "")
+        assert "OURS" in output
+        assert "THEIRS" not in output

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1396,31 +1396,35 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
     Each file is wrapped so a failing rc file doesn't abort the whole
     bootstrap: ``set +e`` keeps going on errors, ``2>/dev/null`` hides
     noisy prompts, and ``|| true`` neutralises the exit status.
+
+    Even when ``files`` is empty (strict-login / auto-source disabled), still
+    emit the running-install PATH re-pin: ``bash -l`` continues to read
+    login rc files natively, and those can prepend a competing install.
     """
-    if not files:
-        return cmd_string
+    prelude_parts: list[str] = []
+    if files:
+        prelude_parts.append("set +e")
+        for path in files:
+            # shlex.quote isn't available here without an import; the files list
+            # comes from os.path.expanduser output so it's a concrete absolute
+            # path.  Escape single quotes defensively anyway.
+            safe = path.replace("'", "'\\''")
+            prelude_parts.append(f"[ -r '{safe}' ] && . '{safe}' 2>/dev/null || true")
 
-    prelude_parts = ["set +e"]
-    for path in files:
-        # shlex.quote isn't available here without an import; the files list
-        # comes from os.path.expanduser output so it's a concrete absolute
-        # path.  Escape single quotes defensively anyway.
-        safe = path.replace("'", "'\\''")
-        prelude_parts.append(f"[ -r '{safe}' ] && . '{safe}' 2>/dev/null || true")
-
-    # Re-pin the running install's bin dir AFTER the rc files have run.
+    # Re-pin the running install's bin dir AFTER optional rc sources.
     #
-    # A sourced rc may prepend a *different* Hermes install's bin dir —
-    # multi-HERMES_HOME machines commonly carry a stale
+    # A sourced rc (or a native login rc when Hermes does not auto-source)
+    # may prepend a *different* Hermes install's bin dir — multi-HERMES_HOME
+    # machines commonly carry a stale
     # ``export PATH="$HOME/.hermes/hermes-agent/venv/bin:$PATH"`` in
-    # ~/.bashrc from an older per-instance install. That rewrite happens
-    # inside the login shell, i.e. *after* the process-env pin applied by
-    # ``_prepend_hermes_bin_dir`` in ``_make_run_env``, so the environment
-    # snapshot captures the interloper first and every subsequent terminal
-    # call resolves bare ``hermes`` to the wrong install (wrong version,
-    # wrong venv). Prepend-if-missing semantics wouldn't help here either:
-    # our dir is usually already on PATH, just at a lower position — so we
-    # prepend unconditionally and rely on first-occurrence-wins.
+    # ~/.bashrc / ~/.bash_profile from an older per-instance install. That
+    # rewrite happens inside the login shell, i.e. *after* the process-env
+    # pin applied by ``_prepend_hermes_bin_dir`` in ``_make_run_env``, so the
+    # environment snapshot captures the interloper first and every subsequent
+    # terminal call resolves bare ``hermes`` to the wrong install (wrong
+    # version, wrong venv). Prepend-if-missing semantics wouldn't help here
+    # either: our dir is usually already on PATH, just at a lower position —
+    # so we prepend unconditionally and rely on first-occurrence-wins.
     #
     # POSIX-only: on Windows the bin dir is a native path that would need
     # MSYS translation before it could be embedded in a bash export, and
@@ -1430,6 +1434,9 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
         if bin_dir:
             safe_bin = bin_dir.replace("'", "'\\''")
             prelude_parts.append(f"export PATH='{safe_bin}':\"$PATH\"")
+
+    if not prelude_parts:
+        return cmd_string
 
     prelude = "\n".join(prelude_parts) + "\n"
     return prelude + cmd_string
@@ -1518,9 +1525,11 @@ class LocalEnvironment(BaseEnvironment):
         # Non-login invocations are already sourcing the snapshot and
         # don't need this.
         if login:
+            # Always run through the wrapper on login snapshots — even when
+            # the resolved init-file list is empty — so the running-install
+            # PATH re-pin still fires after native ``bash -l`` login rc.
             init_files = _resolve_shell_init_files()
-            if init_files:
-                cmd_string = _prepend_shell_init(cmd_string, init_files)
+            cmd_string = _prepend_shell_init(cmd_string, init_files)
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1407,6 +1407,30 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
         # path.  Escape single quotes defensively anyway.
         safe = path.replace("'", "'\\''")
         prelude_parts.append(f"[ -r '{safe}' ] && . '{safe}' 2>/dev/null || true")
+
+    # Re-pin the running install's bin dir AFTER the rc files have run.
+    #
+    # A sourced rc may prepend a *different* Hermes install's bin dir —
+    # multi-HERMES_HOME machines commonly carry a stale
+    # ``export PATH="$HOME/.hermes/hermes-agent/venv/bin:$PATH"`` in
+    # ~/.bashrc from an older per-instance install. That rewrite happens
+    # inside the login shell, i.e. *after* the process-env pin applied by
+    # ``_prepend_hermes_bin_dir`` in ``_make_run_env``, so the environment
+    # snapshot captures the interloper first and every subsequent terminal
+    # call resolves bare ``hermes`` to the wrong install (wrong version,
+    # wrong venv). Prepend-if-missing semantics wouldn't help here either:
+    # our dir is usually already on PATH, just at a lower position — so we
+    # prepend unconditionally and rely on first-occurrence-wins.
+    #
+    # POSIX-only: on Windows the bin dir is a native path that would need
+    # MSYS translation before it could be embedded in a bash export, and
+    # the auto-source path is disabled there anyway.
+    if not _IS_WINDOWS:
+        bin_dir = _resolve_hermes_bin_dir()
+        if bin_dir:
+            safe_bin = bin_dir.replace("'", "'\\''")
+            prelude_parts.append(f"export PATH='{safe_bin}':\"$PATH\"")
+
     prelude = "\n".join(prelude_parts) + "\n"
     return prelude + cmd_string
 


### PR DESCRIPTION
## What does this PR do?

Fixes the terminal tool resolving bare `hermes` to the **wrong install** on multi-`HERMES_HOME` machines.

The login-shell environment snapshot (`LocalEnvironment.init_session`) sources `~/.profile` / `~/.bash_profile` / `~/.bashrc` before capturing env. If an rc file prepends a *different* Hermes install's bin dir — a common leftover such as `export PATH="$HOME/.hermes/hermes-agent/venv/bin:$PATH"` from an older per-instance install — the rewrite happens *inside* the shell, i.e. **after** the process-env pin from `_prepend_hermes_bin_dir()` in `_make_run_env()`. The snapshot captures the interloper first and every terminal call thereafter runs the wrong `hermes` (wrong version, wrong venv).

The existing pin can't defend against this: it adjusts the process env (which the rc rewrite overrides), and its prepend-**if-missing** semantics skip when the running install's dir is already on PATH just at a lower position.

**Fix:** after the guarded `source` lines in `_prepend_shell_init()`, unconditionally re-export the running install's bin dir (from `_resolve_hermes_bin_dir()`) at the front of `PATH` *inside the shell*, so first-occurrence-wins restores the correct `hermes`. POSIX-only: on Windows the auto-source path is disabled anyway and the native path would need MSYS translation before it could be embedded in a bash export.

Hit in production: a gateway upgraded to 0.19.0 kept reporting `hermes` 0.16.0 in-chat because a stale bashrc line pointed at a sibling install.

## Related Issue

Fixes #71069

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/local.py` — `_prepend_shell_init()`: append a `PATH` re-pin export after the rc `source` lines (guarded by `_resolve_hermes_bin_dir()` returning a dir; single quotes in the path escaped; skipped on Windows).
- `tests/tools/test_local_shell_init.py`:
  - `TestPrependShellInit`: re-pin comes *after* the source lines; skipped when the bin dir is unresolved; single-quote escaping.
  - `TestSnapshotEndToEnd::test_rc_path_prepend_cannot_shadow_running_hermes`: end-to-end repro with two fake installs where `~/.bashrc` shadows the running one — **fails before this change, passes after** (verified red/green by stashing the fix).

## How to Test

1. `pytest tests/tools/test_local_shell_init.py -v` — 20 pass (16 existing + 4 new).
2. Red check: revert `tools/environments/local.py` only and re-run — the new tests fail, with the e2e repro resolving `hermes` to the interloper install.
3. Manual: on a POSIX box, add `export PATH="/some/other/hermes/bin:$PATH"` (containing a fake `hermes`) to `~/.bashrc`, start a gateway from another install, run `which hermes` via the terminal tool — resolves to the running install with this patch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted suites: `tests/tools/test_local_shell_init.py` (20/20), plus neighbors `test_local_env_blocklist.py`, `test_terminal_config_env_sync.py`, `test_terminal_task_cwd.py` — all green. `test_execution_flag_detection.py` has 3 failures on my host (`man`/`sort` real-binary behavior) that reproduce identically on a clean tree, i.e. pre-existing environment issues unrelated to this change.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
