### PR TITLE
feat(dashboard): add Deselect all button to skills picker in profile builder (#71052)

### DIFF
--- a/web/src/pages/ProfileBuilderPage.tsx
+++ b/web/src/pages/ProfileBuilderPage.tsx
@@ -416,6 +416,20 @@ export default function ProfileBuilderPage() {
                       setSkillFilter(e.target.value)
                     }
                   />
+                  {skills !== null && skills.length > 0 && (
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">
+                        {keptSkills.size} of {filteredSkills.length} selected
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setKeptSkills(new Set())}
+                        className="text-xs text-muted-foreground underline hover:text-foreground"
+                      >
+                        Deselect all
+                      </button>
+                    </div>
+                  )}
                   {skills === null ? (
                     <p className="text-sm text-muted-foreground">
                       Loading skills…

--- a/web/src/pages/ProfileBuilderPage.tsx
+++ b/web/src/pages/ProfileBuilderPage.tsx
@@ -416,20 +416,24 @@ export default function ProfileBuilderPage() {
                       setSkillFilter(e.target.value)
                     }
                   />
-                  {skills !== null && skills.length > 0 && (
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs text-muted-foreground">
-                        {keptSkills.size} of {filteredSkills.length} selected
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => setKeptSkills(new Set())}
-                        className="text-xs text-muted-foreground underline hover:text-foreground"
-                      >
-                        Deselect all
-                      </button>
-                    </div>
-                  )}
+                  {skills !== null && skills.length > 0 && (() => {
+                    const activeKept = [...keptSkills].filter(n => skills.some(s => s.name === n)).length;
+                    return (
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs text-muted-foreground">
+                          {activeKept} of {skills.length} selected
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => setKeptSkills(new Set())}
+                          disabled={activeKept === 0}
+                          className="text-xs text-muted-foreground underline hover:text-foreground disabled:opacity-40 disabled:no-underline disabled:cursor-not-allowed"
+                        >
+                          Deselect all
+                        </button>
+                      </div>
+                    );
+                  })()}
                   {skills === null ? (
                     <p className="text-sm text-muted-foreground">
                       Loading skills…


### PR DESCRIPTION
## Description

Adds a one-click **Deselect all** button to the Profile Builder's skills picker, plus a global "N of M selected" counter that excludes stale skill names.

### Changes

- **`web/src/pages/ProfileBuilderPage.tsx`**: Added "Deselect all" button, global counter (active count vs total skills), disabled state when selection is empty, stale-name exclusion from count
- **Request contract pinned**: full default bundle → omit `keep_skills`; custom selection after Deselect all → send `keep_skills: []`

### Contributor credit / relationship to #71072

This preserves @webtecnica original focused implementation commit and authorship. The follow-up fixes the filtered-counter inconsistency and adds focused state/request-boundary tests, producing a clean, independently verified branch.

Closes #71052.