### PR TITLE
fix(matrix): fallback to homeserver query for room encryption detection (#71067)

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -809,17 +809,43 @@ class _CryptoStateStore:
     state.
     """
 
-    def __init__(self, client_state_store: Any, joined_rooms: set):
+    def __init__(self, client_state_store: Any, joined_rooms: set, client=None):
         self._ss = client_state_store
         self._joined_rooms = joined_rooms
+        self._client = client
 
     async def is_encrypted(self, room_id: str) -> bool:
         return (await self.get_encryption_info(room_id)) is not None
 
     async def get_encryption_info(self, room_id: str):
+        info = None
         if hasattr(self._ss, "get_encryption_info"):
-            return await self._ss.get_encryption_info(room_id)
-        return None
+            info = await self._ss.get_encryption_info(room_id)
+        if info is not None:
+            return info
+        client = self._client
+        if client is None:
+            return None
+        try:
+            from mautrix.types import (
+                EventType as _ET,
+                RoomEncryptionStateEventContent as _Enc,
+                RoomID as _RID,
+            )
+            raw = await client.get_state_event(_RID(room_id), _ET.ROOM_ENCRYPTION)
+        except Exception:
+            return None
+        if not raw:
+            return None
+        content = raw if isinstance(raw, _Enc) else _Enc.deserialize(
+            raw.serialize() if hasattr(raw, "serialize") else raw
+        )
+        if hasattr(self._ss, "set_encryption_info"):
+            try:
+                await self._ss.set_encryption_info(_RID(room_id), content)
+            except Exception:
+                pass
+        return content
 
     async def find_shared_rooms(self, user_id: str) -> list:
         # Return all joined rooms — simple but correct for a single-user bot.
@@ -1410,7 +1436,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     if client.device_id:
                         await crypto_store.put_device_id(client.device_id)
 
-                    crypto_state = _CryptoStateStore(state_store, self._joined_rooms)
+                    crypto_state = _CryptoStateStore(state_store, self._joined_rooms, client)
                     olm = OlmMachine(client, crypto_store, crypto_state)
                     olm.share_keys_min_trust = TrustState.UNVERIFIED
                     olm.send_keys_min_trust = TrustState.UNVERIFIED


### PR DESCRIPTION
## Summary

Fixes #71067. With E2EE enabled and a fresh crypto store, the Matrix bot silently drops ALL inbound messages in encrypted rooms it already joined — no device tracking, no Olm sessions, no decryption.

## Root cause

`_CryptoStateStore.get_encryption_info` only consulted mautrix's in-memory `MemoryStateStore`, which has no record of `m.room.encryption` for rooms the bot joined in the past (the raw-sync path never fed those state events through `set_encryption_info`). On a fresh crypto store this returns `None` for all previously-joined rooms, so `OlmMachine.is_encrypted` returns `False`, `handle_member_event` early-returns, device tracking is skipped, and every inbound `m.room.encrypted` event fails to decrypt.

## Fix

1. **Pass `client` into `_CryptoStateStore`** — the mautrix `Client` instance is now stored as `self._client`.
2. **Fallback to homeserver query** — when `get_encryption_info` returns `None` from the in-memory store, make a live `GET /_matrix/client/v3/rooms/{room_id}/state/m.room.encryption` call via `client.get_state_event`.
3. **Cache the result** — write back via `set_encryption_info` so subsequent lookups (and `OlmMachine` device tracking) hit the fast path.

## Changes

Single file: `plugins/platforms/matrix/adapter.py` (+30 / −4)

- `_CryptoStateStore.__init__`: added optional `client=None` parameter
- `_CryptoStateStore.get_encryption_info`: fallback to homeserver GET when in-memory returns `None`, cache result
- Call site: `_CryptoStateStore(state_store, self._joined_rooms, client)`