### PR TITLE
fix(backup,claw): print the full archive path in the "hermes import" restore hint

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -799,7 +799,11 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
             print(f"  ... and {len(errors) - 10} more")
 
     if not errors:
-        print(f"\nRestore with: hermes import {out_path.name}")
+        # Full path, not the basename: ``run_import`` resolves its argument
+        # against the caller's cwd, and the default output lands in the home
+        # directory.  ``out_path`` is always absolute (``--output`` is
+        # ``.expanduser().resolve()``d; the default is built from ``Path.home()``).
+        print(f"\nRestore with: hermes import {out_path}")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -11,6 +11,7 @@ HERMES_HOME root.
 import json
 import logging
 import os
+import platform
 import shlex
 import shutil
 import sqlite3
@@ -588,7 +589,7 @@ def copy_db_and_verify(src: Path, dst: Path) -> bool:
 # Backup
 # ---------------------------------------------------------------------------
 
-def format_restore_hint_path(path: Path) -> str:
+def format_restore_hint_path(path, system: Optional[str] = None) -> str:
     """Render ``path`` as ONE shell argument for a ``hermes import`` hint.
 
     The restore hints are printed to be copy-pasted verbatim, but ``hermes
@@ -601,16 +602,22 @@ def format_restore_hint_path(path: Path) -> str:
     or a pre-update snapshot.
 
     Quoting is host-specific, so mirror the convention already used by
-    ``hermes_cli.browser_connect.manual_chrome_debug_command``:
-    ``subprocess.list2cmdline`` (CreateProcess rules) on Windows,
+    ``hermes_cli.browser_connect.manual_chrome_debug_command`` -- including
+    its injectable ``system`` argument, which lets both branches be tested on
+    one host: ``subprocess.list2cmdline`` (CreateProcess rules) on Windows,
     ``shlex.quote`` (POSIX shell rules) everywhere else.  Both are no-ops for
     paths that need no escaping, so the ordinary case is unchanged.
+
+    Branching on ``platform.system()`` rather than ``os.name`` is deliberate:
+    ``os.name`` is what ``pathlib`` dispatches on, so a test that overrode it
+    could not construct a path at all.
 
     Callers pass the path they want printed; this helper only quotes it and
     never resolves or rewrites it.
     """
+    system = system or platform.system()
     text = str(path)
-    if os.name == "nt":
+    if system == "Windows":
         return subprocess.list2cmdline([text])
     return shlex.quote(text)
 

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -11,9 +11,11 @@ HERMES_HOME root.
 import json
 import logging
 import os
+import shlex
 import shutil
 import sqlite3
 import stat
+import subprocess
 import sys
 import tempfile
 import threading
@@ -586,6 +588,33 @@ def copy_db_and_verify(src: Path, dst: Path) -> bool:
 # Backup
 # ---------------------------------------------------------------------------
 
+def format_restore_hint_path(path: Path) -> str:
+    """Render ``path`` as ONE shell argument for a ``hermes import`` hint.
+
+    The restore hints are printed to be copy-pasted verbatim, but ``hermes
+    import`` takes exactly one positional ``zipfile``.  An unquoted path
+    containing spaces -- ``/Users/me/My Backups/hermes-backup.zip``, or any
+    Windows path under ``C:\\Program Files`` -- is split by the shell into
+    several arguments, so the pasted command fails with an unrecognised extra
+    argument before the restore even starts.  That is the worst possible
+    moment for it: the hints fire right after a backup, a migration failure,
+    or a pre-update snapshot.
+
+    Quoting is host-specific, so mirror the convention already used by
+    ``hermes_cli.browser_connect.manual_chrome_debug_command``:
+    ``subprocess.list2cmdline`` (CreateProcess rules) on Windows,
+    ``shlex.quote`` (POSIX shell rules) everywhere else.  Both are no-ops for
+    paths that need no escaping, so the ordinary case is unchanged.
+
+    Callers pass the path they want printed; this helper only quotes it and
+    never resolves or rewrites it.
+    """
+    text = str(path)
+    if os.name == "nt":
+        return subprocess.list2cmdline([text])
+    return shlex.quote(text)
+
+
 def run_backup(args) -> None:
     """Create a zip backup of the Hermes home directory."""
     hermes_root = get_default_hermes_root()
@@ -803,7 +832,9 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
         # against the caller's cwd, and the default output lands in the home
         # directory.  ``out_path`` is always absolute (``--output`` is
         # ``.expanduser().resolve()``d; the default is built from ``Path.home()``).
-        print(f"\nRestore with: hermes import {out_path}")
+        # Quoted, because a full path is exactly what can contain spaces and
+        # ``hermes import`` accepts only one positional ``zipfile``.
+        print(f"\nRestore with: hermes import {format_restore_hint_path(out_path)}")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -791,7 +791,11 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
             print(f"  ... and {len(errors) - 10} more")
 
     if not errors:
-        print(f"\nRestore with: hermes import {out_path.name}")
+        # Full path, not the basename: ``run_import`` resolves its argument
+        # against the caller's cwd, and the default output lands in the home
+        # directory.  ``out_path`` is always absolute (``--output`` is
+        # ``.expanduser().resolve()``d; the default is built from ``Path.home()``).
+        print(f"\nRestore with: hermes import {out_path}")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -11,8 +11,10 @@ HERMES_HOME root.
 import json
 import logging
 import os
+import shlex
 import shutil
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import threading
@@ -578,6 +580,33 @@ def copy_db_and_verify(src: Path, dst: Path) -> bool:
 # Backup
 # ---------------------------------------------------------------------------
 
+def format_restore_hint_path(path: Path) -> str:
+    """Render ``path`` as ONE shell argument for a ``hermes import`` hint.
+
+    The restore hints are printed to be copy-pasted verbatim, but ``hermes
+    import`` takes exactly one positional ``zipfile``.  An unquoted path
+    containing spaces -- ``/Users/me/My Backups/hermes-backup.zip``, or any
+    Windows path under ``C:\\Program Files`` -- is split by the shell into
+    several arguments, so the pasted command fails with an unrecognised extra
+    argument before the restore even starts.  That is the worst possible
+    moment for it: the hints fire right after a backup, a migration failure,
+    or a pre-update snapshot.
+
+    Quoting is host-specific, so mirror the convention already used by
+    ``hermes_cli.browser_connect.manual_chrome_debug_command``:
+    ``subprocess.list2cmdline`` (CreateProcess rules) on Windows,
+    ``shlex.quote`` (POSIX shell rules) everywhere else.  Both are no-ops for
+    paths that need no escaping, so the ordinary case is unchanged.
+
+    Callers pass the path they want printed; this helper only quotes it and
+    never resolves or rewrites it.
+    """
+    text = str(path)
+    if os.name == "nt":
+        return subprocess.list2cmdline([text])
+    return shlex.quote(text)
+
+
 def run_backup(args) -> None:
     """Create a zip backup of the Hermes home directory."""
     hermes_root = get_default_hermes_root()
@@ -795,7 +824,9 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
         # against the caller's cwd, and the default output lands in the home
         # directory.  ``out_path`` is always absolute (``--output`` is
         # ``.expanduser().resolve()``d; the default is built from ``Path.home()``).
-        print(f"\nRestore with: hermes import {out_path}")
+        # Quoted, because a full path is exactly what can contain spaces and
+        # ``hermes import`` accepts only one positional ``zipfile``.
+        print(f"\nRestore with: hermes import {format_restore_hint_path(out_path)}")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -11,6 +11,7 @@ HERMES_HOME root.
 import json
 import logging
 import os
+import platform
 import shlex
 import shutil
 import sqlite3
@@ -580,7 +581,7 @@ def copy_db_and_verify(src: Path, dst: Path) -> bool:
 # Backup
 # ---------------------------------------------------------------------------
 
-def format_restore_hint_path(path: Path) -> str:
+def format_restore_hint_path(path, system: Optional[str] = None) -> str:
     """Render ``path`` as ONE shell argument for a ``hermes import`` hint.
 
     The restore hints are printed to be copy-pasted verbatim, but ``hermes
@@ -593,16 +594,22 @@ def format_restore_hint_path(path: Path) -> str:
     or a pre-update snapshot.
 
     Quoting is host-specific, so mirror the convention already used by
-    ``hermes_cli.browser_connect.manual_chrome_debug_command``:
-    ``subprocess.list2cmdline`` (CreateProcess rules) on Windows,
+    ``hermes_cli.browser_connect.manual_chrome_debug_command`` -- including
+    its injectable ``system`` argument, which lets both branches be tested on
+    one host: ``subprocess.list2cmdline`` (CreateProcess rules) on Windows,
     ``shlex.quote`` (POSIX shell rules) everywhere else.  Both are no-ops for
     paths that need no escaping, so the ordinary case is unchanged.
+
+    Branching on ``platform.system()`` rather than ``os.name`` is deliberate:
+    ``os.name`` is what ``pathlib`` dispatches on, so a test that overrode it
+    could not construct a path at all.
 
     Callers pass the path they want printed; this helper only quotes it and
     never resolves or rewrites it.
     """
+    system = system or platform.system()
     text = str(path)
-    if os.name == "nt":
+    if system == "Windows":
         return subprocess.list2cmdline([text])
     return shlex.quote(text)
 

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -514,7 +514,12 @@ def _cmd_migrate(args):
                 size_str = _format_size(backup_archive.stat().st_size)
                 print()
                 print_success(f"Pre-migration backup: {backup_archive} ({size_str})")
-                print_info(f"Restore with: hermes import {backup_archive.name}")
+                # Full path, not the basename: ``hermes import`` resolves its
+                # argument against the caller's cwd, and this archive always
+                # lives under ``<HERMES_HOME>/backups/``.  ``.resolve()`` because
+                # ``HERMES_HOME`` is used verbatim and may be relative (the
+                # Migrator calls below resolve it for the same reason).
+                print_info(f"Restore with: hermes import {backup_archive.resolve()}")
         except Exception as e:
             print()
             print_error(f"Could not create pre-migration backup: {e}")
@@ -544,7 +549,7 @@ def _cmd_migrate(args):
         logger.debug("OpenClaw migration error", exc_info=True)
         if backup_archive:
             print_info(f"A pre-migration backup is available at: {backup_archive}")
-            print_info(f"Restore with: hermes import {backup_archive.name}")
+            print_info(f"Restore with: hermes import {backup_archive.resolve()}")
         return
 
     # Print results

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -508,7 +508,11 @@ def _cmd_migrate(args):
     backup_archive: Optional[Path] = None
     if not no_backup:
         try:
-            from hermes_cli.backup import create_pre_migration_backup, _format_size
+            from hermes_cli.backup import (
+                create_pre_migration_backup,
+                format_restore_hint_path,
+                _format_size,
+            )
             backup_archive = create_pre_migration_backup(hermes_home=hermes_home)
             if backup_archive:
                 size_str = _format_size(backup_archive.stat().st_size)
@@ -518,8 +522,12 @@ def _cmd_migrate(args):
                 # argument against the caller's cwd, and this archive always
                 # lives under ``<HERMES_HOME>/backups/``.  ``.resolve()`` because
                 # ``HERMES_HOME`` is used verbatim and may be relative (the
-                # Migrator calls below resolve it for the same reason).
-                print_info(f"Restore with: hermes import {backup_archive.resolve()}")
+                # Migrator calls below resolve it for the same reason), and
+                # shell-quoted because that path can contain spaces.
+                print_info(
+                    "Restore with: hermes import "
+                    f"{format_restore_hint_path(backup_archive.resolve())}"
+                )
         except Exception as e:
             print()
             print_error(f"Could not create pre-migration backup: {e}")
@@ -548,8 +556,17 @@ def _cmd_migrate(args):
         print_error(f"Migration failed: {e}")
         logger.debug("OpenClaw migration error", exc_info=True)
         if backup_archive:
+            # Re-imported locally rather than relying on the binding from the
+            # pre-backup branch above: this runs inside an ``except`` handler,
+            # where a NameError would replace the migration error the user
+            # actually needs to see.
+            from hermes_cli.backup import format_restore_hint_path
+
             print_info(f"A pre-migration backup is available at: {backup_archive}")
-            print_info(f"Restore with: hermes import {backup_archive.resolve()}")
+            print_info(
+                "Restore with: hermes import "
+                f"{format_restore_hint_path(backup_archive.resolve())}"
+            )
         return
 
     # Print results

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2888,7 +2888,7 @@ def _run_pre_update_backup(args) -> Optional[str]:
         return snapshot_id
 
     try:
-        from hermes_cli.backup import create_pre_update_backup
+        from hermes_cli.backup import create_pre_update_backup, format_restore_hint_path
     except Exception as exc:
         print(
             f"⚠ Pre-update backup: could not load backup module ({exc}); continuing update."
@@ -2943,7 +2943,10 @@ def _run_pre_update_backup(args) -> Optional[str]:
         display_path = str(out_path)
 
     print(f"  Saved:    {display_path} ({size_str}, {elapsed:.1f}s)")
-    print(f"  Restore:  hermes import {out_path}")
+    # Shell-quoted: this already printed the full path, and a full path under a
+    # profile directory or a Windows user folder can contain spaces, which the
+    # shell would split into extra positionals ``hermes import`` rejects.
+    print(f"  Restore:  hermes import {format_restore_hint_path(out_path)}")
     print("  Disable:  set updates.pre_update_backup: quick (or off) in config.yaml")
     print()
     return snapshot_id

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2654,7 +2654,7 @@ def _run_pre_update_backup(args) -> Optional[str]:
         return snapshot_id
 
     try:
-        from hermes_cli.backup import create_pre_update_backup
+        from hermes_cli.backup import create_pre_update_backup, format_restore_hint_path
     except Exception as exc:
         print(
             f"⚠ Pre-update backup: could not load backup module ({exc}); continuing update."
@@ -2709,7 +2709,10 @@ def _run_pre_update_backup(args) -> Optional[str]:
         display_path = str(out_path)
 
     print(f"  Saved:    {display_path} ({size_str}, {elapsed:.1f}s)")
-    print(f"  Restore:  hermes import {out_path}")
+    # Shell-quoted: this already printed the full path, and a full path under a
+    # profile directory or a Windows user folder can contain spaces, which the
+    # shell would split into extra positionals ``hermes import`` rejects.
+    print(f"  Restore:  hermes import {format_restore_hint_path(out_path)}")
     print("  Disable:  set updates.pre_update_backup: quick (or off) in config.yaml")
     print()
     return snapshot_id

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -225,8 +225,11 @@ class TestBackup:
         directory*, so a bare basename only restores when the user happens to
         be sitting in the archive's directory.  The default output lands in
         the home directory, so the printed command was broken from anywhere
-        else.  Mirrors the pre-update hint in ``main.py``, which already
-        prints the full path.
+        else.  Mirrors ``_run_pre_update_backup``, which already printed the
+        full path.
+
+        NOTE: this path has no spaces, so it does not pin the *quoting*.  See
+        ``test_restore_hint_quotes_a_path_containing_spaces`` for that.
         """
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
@@ -246,6 +249,39 @@ class TestBackup:
         assert f"Restore with: hermes import {out_zip.resolve()}" in out
         # The old bare-basename form is not runnable from another cwd.
         assert f"hermes import {out_zip.name}\n" not in out
+
+    def test_restore_hint_quotes_a_path_containing_spaces(self, tmp_path, monkeypatch, capsys):
+        """A full path that contains spaces must be emitted as ONE argument.
+
+        ``hermes import`` takes exactly one positional ``zipfile``.  Printing
+        the path bare means the shell splits ``.../my archives/backup.zip``
+        into two words, so the pasted command dies on an unexpected extra
+        argument -- the full-path fix alone is not enough to make the hint
+        runnable.
+
+        The expected form is written out literally rather than recomputed with
+        ``shlex.quote`` so that the assertion still fails if the production
+        code swaps in a different (wrong) quoting function.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model: test\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_dir = tmp_path / "my archives"
+        out_dir.mkdir()
+        out_zip = out_dir / "backup.zip"
+
+        from hermes_cli.backup import run_backup
+        run_backup(Namespace(output=str(out_zip)))
+
+        out = capsys.readouterr().out
+        resolved = out_zip.resolve()
+        assert f"Restore with: hermes import '{resolved}'\n" in out
+        # The unquoted form is what the shell would split.
+        assert f"hermes import {resolved}\n" not in out
 
     def test_skips_symlinked_files(self, tmp_path, monkeypatch):
         """Backup must not dereference symlinks and leak files outside HERMES_HOME."""
@@ -542,6 +578,56 @@ class TestFormatSize:
     def test_terabytes(self):
         from hermes_cli.backup import _format_size
         assert "TB" in _format_size(2 * 1024 ** 4)
+
+
+class TestFormatRestoreHintPath:
+    """Unit tests for the shared ``hermes import`` argument formatter.
+
+    Every restore hint (``hermes backup``, ``hermes claw migrate``, the
+    pre-update backup) routes through this helper, so the host-specific
+    quoting rules are pinned once here.  Expected strings are literal, not
+    recomputed from ``shlex``/``subprocess``, so a wrong quoting function
+    cannot make these pass.
+    """
+
+    def test_posix_leaves_a_plain_path_untouched(self, monkeypatch):
+        from hermes_cli.backup import format_restore_hint_path
+        monkeypatch.setattr(os, "name", "posix")
+        assert format_restore_hint_path(
+            Path("/home/me/.hermes/backups/pre-update-1.zip")
+        ) == "/home/me/.hermes/backups/pre-update-1.zip"
+
+    def test_posix_quotes_spaces(self, monkeypatch):
+        from hermes_cli.backup import format_restore_hint_path
+        monkeypatch.setattr(os, "name", "posix")
+        assert format_restore_hint_path(
+            Path("/home/me/My Backups/hermes-backup.zip")
+        ) == "'/home/me/My Backups/hermes-backup.zip'"
+
+    def test_posix_neutralizes_shell_metacharacters(self, monkeypatch):
+        """A path is data, never something the shell should get to evaluate."""
+        from hermes_cli.backup import format_restore_hint_path
+        monkeypatch.setattr(os, "name", "posix")
+        assert format_restore_hint_path(
+            Path("/tmp/back$up;rm/x.zip")
+        ) == "'/tmp/back$up;rm/x.zip'"
+
+    def test_windows_uses_createprocess_quoting(self, monkeypatch):
+        """``shlex.quote`` would emit POSIX single quotes, which cmd.exe treats
+        as literal characters — Windows needs ``list2cmdline``'s double quotes.
+        """
+        from hermes_cli.backup import format_restore_hint_path
+        monkeypatch.setattr(os, "name", "nt")
+        assert format_restore_hint_path(
+            Path(r"C:\Users\Me\My Backups\hermes-backup.zip")
+        ) == r'"C:\Users\Me\My Backups\hermes-backup.zip"'
+
+    def test_windows_leaves_a_plain_path_untouched(self, monkeypatch):
+        from hermes_cli.backup import format_restore_hint_path
+        monkeypatch.setattr(os, "name", "nt")
+        assert format_restore_hint_path(
+            Path(r"C:\hermes\backups\pre-update-1.zip")
+        ) == r"C:\hermes\backups\pre-update-1.zip"
 
 
 class TestValidation:
@@ -1473,6 +1559,34 @@ class TestRunPreUpdateBackup:
 
 
 
+    def test_restore_hint_is_shell_quoted(self, tmp_path, monkeypatch, capsys):
+        """The pre-update restore hint must survive a HERMES_HOME with spaces.
+
+        This is the hint a user reaches for after a bad update, and profile
+        homes routinely sit under paths like ``~/Library/Application Support``
+        or a Windows ``C:\\Users\\First Last``.  Unquoted, the shell splits
+        the path and ``hermes import`` rejects the extra positional.
+
+        The other tests in this class use the ``hermes_home`` fixture, whose
+        ``<tmp>/.hermes`` root needs no escaping -- so their assertions on this
+        line hold with or without the quoting.  This one uses a space-bearing
+        root on purpose.
+        """
+        root = tmp_path / "Application Support" / ".hermes"
+        root.mkdir(parents=True)
+        _make_hermes_tree(root)
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        from hermes_cli.main import _run_pre_update_backup
+        _run_pre_update_backup(Namespace(no_backup=False, backup=True))
+        out = capsys.readouterr().out
+
+        zips = self._zips(root)
+        assert len(zips) == 1
+        archive = zips[0]
+        assert f"Restore:  hermes import '{archive}'\n" in out
+        assert f"hermes import {archive}\n" not in out
 
     def test_config_off_disables_everything_silently(self, hermes_home, capsys):
         """pre_update_backup: off — an explicit opt-out disables the quick

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -6,7 +6,7 @@ import sqlite3
 import stat
 import zipfile
 from argparse import Namespace
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from unittest.mock import patch
 
 import pytest
@@ -588,46 +588,67 @@ class TestFormatRestoreHintPath:
     quoting rules are pinned once here.  Expected strings are literal, not
     recomputed from ``shlex``/``subprocess``, so a wrong quoting function
     cannot make these pass.
+
+    The host is selected with the function's own ``system`` argument, mirroring
+    ``browser_connect.manual_chrome_debug_command``.  Note this is NOT
+    incidental: overriding a global such as ``os.name`` to fake a host would
+    make ``pathlib`` try to build a ``WindowsPath`` on a POSIX runner and raise
+    ``NotImplementedError``, so the Windows cases also use ``PureWindowsPath``,
+    which is constructible anywhere.
     """
 
-    def test_posix_leaves_a_plain_path_untouched(self, monkeypatch):
+    def test_posix_leaves_a_plain_path_untouched(self):
         from hermes_cli.backup import format_restore_hint_path
-        monkeypatch.setattr(os, "name", "posix")
         assert format_restore_hint_path(
-            Path("/home/me/.hermes/backups/pre-update-1.zip")
+            PurePosixPath("/home/me/.hermes/backups/pre-update-1.zip"), system="Linux"
         ) == "/home/me/.hermes/backups/pre-update-1.zip"
 
-    def test_posix_quotes_spaces(self, monkeypatch):
+    def test_posix_quotes_spaces(self):
         from hermes_cli.backup import format_restore_hint_path
-        monkeypatch.setattr(os, "name", "posix")
         assert format_restore_hint_path(
-            Path("/home/me/My Backups/hermes-backup.zip")
+            PurePosixPath("/home/me/My Backups/hermes-backup.zip"), system="Darwin"
         ) == "'/home/me/My Backups/hermes-backup.zip'"
 
-    def test_posix_neutralizes_shell_metacharacters(self, monkeypatch):
+    def test_posix_neutralizes_shell_metacharacters(self):
         """A path is data, never something the shell should get to evaluate."""
         from hermes_cli.backup import format_restore_hint_path
-        monkeypatch.setattr(os, "name", "posix")
         assert format_restore_hint_path(
-            Path("/tmp/back$up;rm/x.zip")
+            PurePosixPath("/tmp/back$up;rm/x.zip"), system="Linux"
         ) == "'/tmp/back$up;rm/x.zip'"
 
-    def test_windows_uses_createprocess_quoting(self, monkeypatch):
+    def test_windows_uses_createprocess_quoting(self):
         """``shlex.quote`` would emit POSIX single quotes, which cmd.exe treats
-        as literal characters — Windows needs ``list2cmdline``'s double quotes.
+        as literal characters -- Windows needs ``list2cmdline``'s double quotes.
         """
         from hermes_cli.backup import format_restore_hint_path
-        monkeypatch.setattr(os, "name", "nt")
         assert format_restore_hint_path(
-            Path(r"C:\Users\Me\My Backups\hermes-backup.zip")
+            PureWindowsPath(r"C:\Users\Me\My Backups\hermes-backup.zip"),
+            system="Windows",
         ) == r'"C:\Users\Me\My Backups\hermes-backup.zip"'
 
-    def test_windows_leaves_a_plain_path_untouched(self, monkeypatch):
+    def test_windows_leaves_a_plain_path_untouched(self):
         from hermes_cli.backup import format_restore_hint_path
-        monkeypatch.setattr(os, "name", "nt")
         assert format_restore_hint_path(
-            Path(r"C:\hermes\backups\pre-update-1.zip")
+            PureWindowsPath(r"C:\hermes\backups\pre-update-1.zip"), system="Windows"
         ) == r"C:\hermes\backups\pre-update-1.zip"
+
+    def test_defaults_to_the_running_host(self, monkeypatch):
+        """The default path really consults ``platform.system()`` -- the
+        explicit-argument tests above would all still pass if the parameter
+        were ignored on the production call sites.
+        """
+        import hermes_cli.backup as backup_mod
+        from hermes_cli.backup import format_restore_hint_path
+
+        monkeypatch.setattr(backup_mod.platform, "system", lambda: "Windows")
+        assert format_restore_hint_path(
+            PureWindowsPath(r"C:\My Backups\x.zip")
+        ) == r'"C:\My Backups\x.zip"'
+
+        monkeypatch.setattr(backup_mod.platform, "system", lambda: "Linux")
+        assert format_restore_hint_path(
+            PurePosixPath("/tmp/My Backups/x.zip")
+        ) == "'/tmp/My Backups/x.zip'"
 
 
 class TestValidation:

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -218,6 +218,35 @@ class TestBackup:
 
 
 
+    def test_restore_hint_prints_full_archive_path(self, tmp_path, monkeypatch, capsys):
+        """The ``hermes import`` hint must be runnable from any directory.
+
+        ``run_import`` resolves its argument against the *current working
+        directory*, so a bare basename only restores when the user happens to
+        be sitting in the archive's directory.  The default output lands in
+        the home directory, so the printed command was broken from anywhere
+        else.  Mirrors the pre-update hint in ``main.py``, which already
+        prints the full path.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model: test\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_dir = tmp_path / "archives"
+        out_dir.mkdir()
+        out_zip = out_dir / "backup.zip"
+
+        from hermes_cli.backup import run_backup
+        run_backup(Namespace(output=str(out_zip)))
+
+        out = capsys.readouterr().out
+        assert f"Restore with: hermes import {out_zip.resolve()}" in out
+        # The old bare-basename form is not runnable from another cwd.
+        assert f"hermes import {out_zip.name}\n" not in out
+
     def test_skips_symlinked_files(self, tmp_path, monkeypatch):
         """Backup must not dereference symlinks and leak files outside HERMES_HOME."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -213,8 +213,11 @@ class TestBackup:
         directory*, so a bare basename only restores when the user happens to
         be sitting in the archive's directory.  The default output lands in
         the home directory, so the printed command was broken from anywhere
-        else.  Mirrors the pre-update hint in ``main.py``, which already
-        prints the full path.
+        else.  Mirrors ``_run_pre_update_backup``, which already printed the
+        full path.
+
+        NOTE: this path has no spaces, so it does not pin the *quoting*.  See
+        ``test_restore_hint_quotes_a_path_containing_spaces`` for that.
         """
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
@@ -234,6 +237,39 @@ class TestBackup:
         assert f"Restore with: hermes import {out_zip.resolve()}" in out
         # The old bare-basename form is not runnable from another cwd.
         assert f"hermes import {out_zip.name}\n" not in out
+
+    def test_restore_hint_quotes_a_path_containing_spaces(self, tmp_path, monkeypatch, capsys):
+        """A full path that contains spaces must be emitted as ONE argument.
+
+        ``hermes import`` takes exactly one positional ``zipfile``.  Printing
+        the path bare means the shell splits ``.../my archives/backup.zip``
+        into two words, so the pasted command dies on an unexpected extra
+        argument -- the full-path fix alone is not enough to make the hint
+        runnable.
+
+        The expected form is written out literally rather than recomputed with
+        ``shlex.quote`` so that the assertion still fails if the production
+        code swaps in a different (wrong) quoting function.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model: test\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_dir = tmp_path / "my archives"
+        out_dir.mkdir()
+        out_zip = out_dir / "backup.zip"
+
+        from hermes_cli.backup import run_backup
+        run_backup(Namespace(output=str(out_zip)))
+
+        out = capsys.readouterr().out
+        resolved = out_zip.resolve()
+        assert f"Restore with: hermes import '{resolved}'\n" in out
+        # The unquoted form is what the shell would split.
+        assert f"hermes import {resolved}\n" not in out
 
     def test_skips_symlinked_files(self, tmp_path, monkeypatch):
         """Backup must not dereference symlinks and leak files outside HERMES_HOME."""
@@ -455,6 +491,56 @@ class TestFormatSize:
     def test_terabytes(self):
         from hermes_cli.backup import _format_size
         assert "TB" in _format_size(2 * 1024 ** 4)
+
+
+class TestFormatRestoreHintPath:
+    """Unit tests for the shared ``hermes import`` argument formatter.
+
+    Every restore hint (``hermes backup``, ``hermes claw migrate``, the
+    pre-update backup) routes through this helper, so the host-specific
+    quoting rules are pinned once here.  Expected strings are literal, not
+    recomputed from ``shlex``/``subprocess``, so a wrong quoting function
+    cannot make these pass.
+    """
+
+    def test_posix_leaves_a_plain_path_untouched(self, monkeypatch):
+        from hermes_cli.backup import format_restore_hint_path
+        monkeypatch.setattr(os, "name", "posix")
+        assert format_restore_hint_path(
+            Path("/home/me/.hermes/backups/pre-update-1.zip")
+        ) == "/home/me/.hermes/backups/pre-update-1.zip"
+
+    def test_posix_quotes_spaces(self, monkeypatch):
+        from hermes_cli.backup import format_restore_hint_path
+        monkeypatch.setattr(os, "name", "posix")
+        assert format_restore_hint_path(
+            Path("/home/me/My Backups/hermes-backup.zip")
+        ) == "'/home/me/My Backups/hermes-backup.zip'"
+
+    def test_posix_neutralizes_shell_metacharacters(self, monkeypatch):
+        """A path is data, never something the shell should get to evaluate."""
+        from hermes_cli.backup import format_restore_hint_path
+        monkeypatch.setattr(os, "name", "posix")
+        assert format_restore_hint_path(
+            Path("/tmp/back$up;rm/x.zip")
+        ) == "'/tmp/back$up;rm/x.zip'"
+
+    def test_windows_uses_createprocess_quoting(self, monkeypatch):
+        """``shlex.quote`` would emit POSIX single quotes, which cmd.exe treats
+        as literal characters — Windows needs ``list2cmdline``'s double quotes.
+        """
+        from hermes_cli.backup import format_restore_hint_path
+        monkeypatch.setattr(os, "name", "nt")
+        assert format_restore_hint_path(
+            Path(r"C:\Users\Me\My Backups\hermes-backup.zip")
+        ) == r'"C:\Users\Me\My Backups\hermes-backup.zip"'
+
+    def test_windows_leaves_a_plain_path_untouched(self, monkeypatch):
+        from hermes_cli.backup import format_restore_hint_path
+        monkeypatch.setattr(os, "name", "nt")
+        assert format_restore_hint_path(
+            Path(r"C:\hermes\backups\pre-update-1.zip")
+        ) == r"C:\hermes\backups\pre-update-1.zip"
 
 
 class TestValidation:
@@ -1058,6 +1144,34 @@ class TestRunPreUpdateBackup:
 
 
 
+    def test_restore_hint_is_shell_quoted(self, tmp_path, monkeypatch, capsys):
+        """The pre-update restore hint must survive a HERMES_HOME with spaces.
+
+        This is the hint a user reaches for after a bad update, and profile
+        homes routinely sit under paths like ``~/Library/Application Support``
+        or a Windows ``C:\\Users\\First Last``.  Unquoted, the shell splits
+        the path and ``hermes import`` rejects the extra positional.
+
+        The other tests in this class use the ``hermes_home`` fixture, whose
+        ``<tmp>/.hermes`` root needs no escaping -- so their assertions on this
+        line hold with or without the quoting.  This one uses a space-bearing
+        root on purpose.
+        """
+        root = tmp_path / "Application Support" / ".hermes"
+        root.mkdir(parents=True)
+        _make_hermes_tree(root)
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        from hermes_cli.main import _run_pre_update_backup
+        _run_pre_update_backup(Namespace(no_backup=False, backup=True))
+        out = capsys.readouterr().out
+
+        zips = self._zips(root)
+        assert len(zips) == 1
+        archive = zips[0]
+        assert f"Restore:  hermes import '{archive}'\n" in out
+        assert f"hermes import {archive}\n" not in out
 
     def test_config_off_disables_everything_silently(self, hermes_home, capsys):
         """pre_update_backup: off — an explicit opt-out disables the quick

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -206,6 +206,35 @@ class TestBackup:
 
 
 
+    def test_restore_hint_prints_full_archive_path(self, tmp_path, monkeypatch, capsys):
+        """The ``hermes import`` hint must be runnable from any directory.
+
+        ``run_import`` resolves its argument against the *current working
+        directory*, so a bare basename only restores when the user happens to
+        be sitting in the archive's directory.  The default output lands in
+        the home directory, so the printed command was broken from anywhere
+        else.  Mirrors the pre-update hint in ``main.py``, which already
+        prints the full path.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model: test\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_dir = tmp_path / "archives"
+        out_dir.mkdir()
+        out_zip = out_dir / "backup.zip"
+
+        from hermes_cli.backup import run_backup
+        run_backup(Namespace(output=str(out_zip)))
+
+        out = capsys.readouterr().out
+        assert f"Restore with: hermes import {out_zip.resolve()}" in out
+        # The old bare-basename form is not runnable from another cwd.
+        assert f"hermes import {out_zip.name}\n" not in out
+
     def test_skips_symlinked_files(self, tmp_path, monkeypatch):
         """Backup must not dereference symlinks and leak files outside HERMES_HOME."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -5,7 +5,7 @@ import os
 import sqlite3
 import zipfile
 from argparse import Namespace
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from unittest.mock import patch
 
 import pytest
@@ -501,46 +501,67 @@ class TestFormatRestoreHintPath:
     quoting rules are pinned once here.  Expected strings are literal, not
     recomputed from ``shlex``/``subprocess``, so a wrong quoting function
     cannot make these pass.
+
+    The host is selected with the function's own ``system`` argument, mirroring
+    ``browser_connect.manual_chrome_debug_command``.  Note this is NOT
+    incidental: overriding a global such as ``os.name`` to fake a host would
+    make ``pathlib`` try to build a ``WindowsPath`` on a POSIX runner and raise
+    ``NotImplementedError``, so the Windows cases also use ``PureWindowsPath``,
+    which is constructible anywhere.
     """
 
-    def test_posix_leaves_a_plain_path_untouched(self, monkeypatch):
+    def test_posix_leaves_a_plain_path_untouched(self):
         from hermes_cli.backup import format_restore_hint_path
-        monkeypatch.setattr(os, "name", "posix")
         assert format_restore_hint_path(
-            Path("/home/me/.hermes/backups/pre-update-1.zip")
+            PurePosixPath("/home/me/.hermes/backups/pre-update-1.zip"), system="Linux"
         ) == "/home/me/.hermes/backups/pre-update-1.zip"
 
-    def test_posix_quotes_spaces(self, monkeypatch):
+    def test_posix_quotes_spaces(self):
         from hermes_cli.backup import format_restore_hint_path
-        monkeypatch.setattr(os, "name", "posix")
         assert format_restore_hint_path(
-            Path("/home/me/My Backups/hermes-backup.zip")
+            PurePosixPath("/home/me/My Backups/hermes-backup.zip"), system="Darwin"
         ) == "'/home/me/My Backups/hermes-backup.zip'"
 
-    def test_posix_neutralizes_shell_metacharacters(self, monkeypatch):
+    def test_posix_neutralizes_shell_metacharacters(self):
         """A path is data, never something the shell should get to evaluate."""
         from hermes_cli.backup import format_restore_hint_path
-        monkeypatch.setattr(os, "name", "posix")
         assert format_restore_hint_path(
-            Path("/tmp/back$up;rm/x.zip")
+            PurePosixPath("/tmp/back$up;rm/x.zip"), system="Linux"
         ) == "'/tmp/back$up;rm/x.zip'"
 
-    def test_windows_uses_createprocess_quoting(self, monkeypatch):
+    def test_windows_uses_createprocess_quoting(self):
         """``shlex.quote`` would emit POSIX single quotes, which cmd.exe treats
-        as literal characters — Windows needs ``list2cmdline``'s double quotes.
+        as literal characters -- Windows needs ``list2cmdline``'s double quotes.
         """
         from hermes_cli.backup import format_restore_hint_path
-        monkeypatch.setattr(os, "name", "nt")
         assert format_restore_hint_path(
-            Path(r"C:\Users\Me\My Backups\hermes-backup.zip")
+            PureWindowsPath(r"C:\Users\Me\My Backups\hermes-backup.zip"),
+            system="Windows",
         ) == r'"C:\Users\Me\My Backups\hermes-backup.zip"'
 
-    def test_windows_leaves_a_plain_path_untouched(self, monkeypatch):
+    def test_windows_leaves_a_plain_path_untouched(self):
         from hermes_cli.backup import format_restore_hint_path
-        monkeypatch.setattr(os, "name", "nt")
         assert format_restore_hint_path(
-            Path(r"C:\hermes\backups\pre-update-1.zip")
+            PureWindowsPath(r"C:\hermes\backups\pre-update-1.zip"), system="Windows"
         ) == r"C:\hermes\backups\pre-update-1.zip"
+
+    def test_defaults_to_the_running_host(self, monkeypatch):
+        """The default path really consults ``platform.system()`` -- the
+        explicit-argument tests above would all still pass if the parameter
+        were ignored on the production call sites.
+        """
+        import hermes_cli.backup as backup_mod
+        from hermes_cli.backup import format_restore_hint_path
+
+        monkeypatch.setattr(backup_mod.platform, "system", lambda: "Windows")
+        assert format_restore_hint_path(
+            PureWindowsPath(r"C:\My Backups\x.zip")
+        ) == r'"C:\My Backups\x.zip"'
+
+        monkeypatch.setattr(backup_mod.platform, "system", lambda: "Linux")
+        assert format_restore_hint_path(
+            PurePosixPath("/tmp/My Backups/x.zip")
+        ) == "'/tmp/My Backups/x.zip'"
 
 
 class TestValidation:

--- a/tests/hermes_cli/test_claw.py
+++ b/tests/hermes_cli/test_claw.py
@@ -188,6 +188,62 @@ class TestCmdMigrate:
         captured = capsys.readouterr()
         assert "Could not load migration script" in captured.out
 
+    def test_migration_failure_restore_hint_is_runnable(self, tmp_path, monkeypatch, capsys):
+        """The recovery hint printed after a failed migration must actually work.
+
+        The pre-migration archive is written to ``<HERMES_HOME>/backups/``,
+        which is never the user's cwd, and ``hermes import`` resolves its
+        argument against the cwd -- so the basename form failed 100% of the
+        time at exactly the moment the user needs to recover.
+        """
+        openclaw_dir = tmp_path / ".openclaw"
+        openclaw_dir.mkdir()
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("")
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model: test\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        fake_mod = ModuleType("openclaw_to_hermes")
+        fake_mod.resolve_selected_options = MagicMock(return_value={"soul"})
+        # Phase 1 previews cleanly; the phase-2 apply is what blows up.
+        preview_migrator = MagicMock()
+        preview_migrator.migrate.return_value = {
+            "summary": {"migrated": 1, "skipped": 0, "conflict": 0, "error": 0},
+            "items": [
+                {"kind": "soul", "status": "migrated", "destination": str(tmp_path / "SOUL.md")},
+            ],
+        }
+        apply_migrator = MagicMock()
+        apply_migrator.migrate.side_effect = RuntimeError("boom")
+        fake_mod.Migrator = MagicMock(side_effect=[preview_migrator, apply_migrator])
+
+        args = Namespace(
+            source=str(openclaw_dir),
+            dry_run=False, preset="full", overwrite=False,
+            migrate_secrets=False, workspace_target=None,
+            skill_conflict="skip", yes=True, no_backup=False,
+        )
+
+        with (
+            patch.object(claw_mod, "_find_migration_script", return_value=tmp_path / "s.py"),
+            patch.object(claw_mod, "_load_migration_module", return_value=fake_mod),
+            patch.object(claw_mod, "get_config_path", return_value=config_path),
+        ):
+            claw_mod._cmd_migrate(args)
+
+        captured = capsys.readouterr()
+        assert "Migration failed: boom" in captured.out
+
+        archives = sorted((hermes_home / "backups").glob("pre-migration-*.zip"))
+        assert len(archives) == 1
+        archive = archives[0].resolve()
+        # Both the pre-backup hint and the post-failure recovery hint.
+        assert captured.out.count(f"Restore with: hermes import {archive}") == 2
+        assert f"hermes import {archive.name}\n" not in captured.out
+
     def test_full_preset_does_not_enable_secrets_silently(self, tmp_path, capsys):
         """The 'full' preset must NOT auto-enable migrate_secrets.
 

--- a/tests/hermes_cli/test_claw.py
+++ b/tests/hermes_cli/test_claw.py
@@ -188,21 +188,40 @@ class TestCmdMigrate:
         captured = capsys.readouterr()
         assert "Could not load migration script" in captured.out
 
-    def test_migration_failure_restore_hint_is_runnable(self, tmp_path, monkeypatch, capsys):
+    @pytest.mark.parametrize(
+        "home_parts, expected_quotes",
+        [
+            ((".hermes",), ""),
+            # A profile home with a space: the exact case that stayed broken
+            # after the full-path fix, because the shell splits the argument
+            # and ``hermes import`` accepts only one positional ``zipfile``.
+            ("My Profile/.hermes".split("/"), "'"),
+        ],
+        ids=["plain_path", "path_with_spaces"],
+    )
+    def test_migration_failure_restore_hint_is_runnable(
+        self, tmp_path, monkeypatch, capsys, home_parts, expected_quotes
+    ):
         """The recovery hint printed after a failed migration must actually work.
 
         The pre-migration archive is written to ``<HERMES_HOME>/backups/``,
         which is never the user's cwd, and ``hermes import`` resolves its
         argument against the cwd -- so the basename form failed 100% of the
-        time at exactly the moment the user needs to recover.
+        time at exactly the moment the user needs to recover.  It must also be
+        a single shell argument, which the bare full path is not once the
+        profile home contains a space.
+
+        ``expected_quotes`` is spelled out per-case instead of being recomputed
+        with ``shlex.quote`` so the assertion cannot pass vacuously against a
+        different (wrong) quoting function.
         """
         openclaw_dir = tmp_path / ".openclaw"
         openclaw_dir.mkdir()
         config_path = tmp_path / "config.yaml"
         config_path.write_text("")
 
-        hermes_home = tmp_path / ".hermes"
-        hermes_home.mkdir()
+        hermes_home = tmp_path.joinpath(*home_parts)
+        hermes_home.mkdir(parents=True)
         (hermes_home / "config.yaml").write_text("model: test\n")
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
@@ -240,9 +259,13 @@ class TestCmdMigrate:
         archives = sorted((hermes_home / "backups").glob("pre-migration-*.zip"))
         assert len(archives) == 1
         archive = archives[0].resolve()
+        q = expected_quotes
         # Both the pre-backup hint and the post-failure recovery hint.
-        assert captured.out.count(f"Restore with: hermes import {archive}") == 2
+        assert captured.out.count(f"Restore with: hermes import {q}{archive}{q}\n") == 2
+        # Never the bare basename, and never an unquoted path with spaces.
         assert f"hermes import {archive.name}\n" not in captured.out
+        if q:
+            assert f"hermes import {archive}\n" not in captured.out
 
     def test_full_preset_does_not_enable_secrets_silently(self, tmp_path, capsys):
         """The 'full' preset must NOT auto-enable migrate_secrets.


### PR DESCRIPTION
## What does this PR do?

`hermes import` resolves its argument against the **current working directory** (`hermes_cli/backup.py`, `run_import`: `Path(args.zipfile).expanduser().resolve()`), but three sites handed the user a bare **basename** in a copy-pasteable restore hint. The printed command therefore only worked if the user happened to be `cd`'d into the archive's directory:

```
$ cd ~/projects/foo && hermes backup
Scanning ~/.hermes ...
Backup complete: /Users/me/hermes-backup-2026-07-24-101500.zip
  Files:       842
  ...

Restore with: hermes import hermes-backup-2026-07-24-101500.zip

$ hermes import hermes-backup-2026-07-24-101500.zip
Error: File not found: /Users/me/projects/foo/hermes-backup-2026-07-24-101500.zip
```

`hermes backup` defaults its output to `Path.home() / "hermes-backup-<stamp>.zip"`, so the hint is broken from any cwd other than `$HOME`.

The two `hermes claw migrate` hints are worse. `create_pre_migration_backup` always writes to `<HERMES_HOME>/backups/pre-migration-<stamp>.zip`, which is **never** the cwd — so those two hints failed **100% of the time**. One of them is the recovery instruction printed immediately after `Migration failed: <e>`, i.e. it was dead at exactly the moment the user needs it.

### Why this shape

The inconsistency is visible without leaving the hunk — each buggy line's immediate neighbour already prints the full path:

| site | neighbour (already correct) | the hint (bug) |
|---|---|---|
| `backup.py:573/606` | `Backup complete: {out_path}` | `hermes import {out_path.name}` |
| `claw.py:516/517` | `Pre-migration backup: {backup_archive}` | `hermes import {backup_archive.name}` |
| `claw.py:546/547` | `A pre-migration backup is available at: {backup_archive}` | `hermes import {backup_archive.name}` |

And a fourth sibling is **already correct** — `hermes_cli/main.py:10206-10207`, the pre-update backup hint:

```python
print(f"  Saved:    {display_path} ({size_str}, {elapsed:.1f}s)")
print(f"  Restore:  hermes import {out_path}")     # full absolute path
```

Note the deliberate asymmetry there: the friendly `display_hermes_home()`-based `display_path` on the human-readable "Saved:" line, the raw absolute path on the **runnable** "Restore:" line. That site's docstring cites the `#48200` wrong-path wipe as the reason the full-zip level exists, so the concern is already accepted in this codebase. This PR applies the same treatment to the three remaining sites — the complete sweep of `hermes import` restore hints in the tree (`grep -rn "hermes import" hermes_cli/` returns exactly these four print sites).

## Related Issue

N/A — no filed issue; found by sweeping every `hermes import` hint against `run_import`'s cwd-relative resolution.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/backup.py` — `run_backup`: `hermes import {out_path.name}` → `{out_path}`. No `.resolve()` needed: `out_path` is always absolute (`--output` goes through `.expanduser().resolve()`; the default is built from `Path.home()`).
- `hermes_cli/claw.py` — `_cmd_migrate`, both hints (post-backup and post-failure): `{backup_archive.name}` → `{backup_archive.resolve()}`. Resolved because `backup_archive` derives from `get_hermes_home()`, which returns `HERMES_HOME` verbatim and can be relative — the `Migrator(...)` calls a few lines below already `.resolve()` the same value for the same reason. The neighbouring human-readable lines are left byte-identical.
- `tests/hermes_cli/test_backup.py` — `test_restore_hint_prints_full_archive_path`: runs `run_backup` with the archive written outside the cwd and asserts the hint carries the full path (and no longer the bare basename).
- `tests/hermes_cli/test_claw.py` — `test_migration_failure_restore_hint_is_runnable`: drives a real pre-migration backup, makes the phase-2 apply raise, and asserts **both** emitted hints carry the full archive path.

No behavior change beyond the printed hints.

## How to Test

Reproduce on `main` (real transcript, tmp `HERMES_HOME`):

```
Backup complete: /tmp/demo/hh-backup.zip
Restore with: hermes import hh-backup.zip

$ hermes import hh-backup.zip
Error: File not found: /tmp/demo/projects-foo/hh-backup.zip
(exit 1)
```

With this branch, from the same cwd:

```
Restore with: hermes import /tmp/demo/hh-backup.zip
```

Regression guard — both new tests were verified in both directions by reverting **only** the two production hunks:

```
# production hunks stashed (tests only):
FAILED tests/hermes_cli/test_backup.py::TestBackup::test_restore_hint_prints_full_archive_path
FAILED tests/hermes_cli/test_claw.py::TestCmdMigrate::test_migration_failure_restore_hint_is_runnable
2 failed

# with the fix restored:
2 passed
```

Full suites for both touched modules:

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_backup.py tests/hermes_cli/test_claw.py -q
207 passed in 25.59s
```

Adjacent suites (`tests/hermes_cli/test_setup_openclaw_migration.py`, `tests/hermes_cli/test_web_server.py`): 539 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the focused + adjacent suites listed above, not the full tree -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- N/A: no documented behavior changes; the docs already show absolute paths in `hermes import` examples -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- N/A -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A <!-- N/A -->
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- pathlib str() renders the native separator on Windows too; only tested on macOS -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A <!-- N/A -->