### PR TITLE
fix(cron): anchor kill branch so "skill" is not a gateway lifecycle command

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -73,9 +73,12 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # Branch C: systemctl ops on a hermes-gateway unit.
     r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both
-    # token orders because real reproductions show both.
-    r"|(?:p?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
-    r"|(?:p?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
+    # token orders because real reproductions show both. The leading \b is
+    # required: without it `p?kill` matches the tail of any word ending in
+    # "kill" — most importantly "skill", so ordinary text mentioning a
+    # skill alongside hermes and gateway was blocked as a kill command.
+    r"|(?:\bp?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
+    r"|(?:\bp?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
 )
 
 

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -77,6 +77,10 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # required: without it `p?kill` matches the tail of any word ending in
     # "kill" — most importantly "skill", so ordinary text mentioning a
     # skill alongside hermes and gateway was blocked as a kill command.
+    # Deliberately scoped to `kill`/`pkill` only: `killall` and Windows
+    # `taskkill` are real ways to stop the process but aren't matched here.
+    # The overall pattern is compiled with `(?i)` above, so this branch is
+    # case-insensitive like the others despite its own `\b` anchors.
     r"|(?:\bp?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
     r"|(?:\bp?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
 )

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -68,6 +68,27 @@ class TestGatewayLifecyclePattern:
 
 
     @pytest.mark.parametrize("text", [
+        # Regression: `p?kill` had no leading \b, so it matched the "kill"
+        # tail of any word — notably "skill". Combined with the permissive
+        # [^\n]* bridges, ordinary text/commands mentioning a skill plus
+        # "hermes" plus "gateway" were blocked as kill commands. Real report:
+        # an agent running a read-only health check inside the gateway had
+        # this command rejected:
+        #   echo "=== thermal skill intact ==="; ls -la ~/.hermes/skills/...;
+        #   echo "=== gateway still healthy ==="
+        'echo "thermal skill intact"; ls -la /home/u/.hermes/skills/; echo "gateway healthy"',
+        "the skill is fine, hermes gateway is healthy",
+        "reinstall skill for hermes, check gateway",
+        "my skill list for hermes gateway",
+        "load the obsidian skill then report hermes gateway status",
+        # Same class, other words ending in "kill":
+        "roadkill on the hermes gateway dashboard",
+        "overkill: hermes gateway has three health checks",
+    ])
+    def test_words_ending_in_kill_are_not_kill_commands(self, text):
+        assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
+
+    @pytest.mark.parametrize("text", [
         "restart the server application",
         "hermes cron list",
         "hermes update",

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -89,6 +89,22 @@ class TestGatewayLifecyclePattern:
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
 
     @pytest.mark.parametrize("text", [
+        # Paired positive case for the anchor change above: the true
+        # positives `kill`/`pkill` (as their own token, both orderings)
+        # must still match after adding the leading \b.
+        "kill hermes gateway",
+        "kill the hermes gateway process",
+        "pkill -f hermes.*gateway",
+        "pkill -f gateway.*hermes",
+        # Case-insensitivity: the whole pattern compiles with `(?i)`, so
+        # this must still match — confirms Branch D isn't accidentally
+        # case-sensitive despite having its own `\b` anchors now.
+        "Kill Hermes Gateway",
+    ])
+    def test_kill_and_pkill_still_match_after_anchor(self, text):
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
+
+    @pytest.mark.parametrize("text", [
         "restart the server application",
         "hermes cron list",
         "hermes update",


### PR DESCRIPTION
## Summary

The gateway-lifecycle guard blocks the word **"skill"** as if it were a `kill` command.

Both kill branches of `_GATEWAY_LIFECYCLE_PATTERN` in `cron/lifecycle_guard.py` are written as:

```python
r"|(?:p?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
r"|(?:p?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
```

`p?kill` makes the `p` optional but has **no leading word boundary**, so it matches the trailing `kill` of any word — most importantly **`skill`**. Combined with the two permissive `[^\n]*` bridges, any text pairing a singular "skill" with "hermes" and "gateway" is rejected as a kill command.

## Reproduction

A read-only health check run inside the gateway:

```bash
echo "=== thermal skill intact ==="; ls -la ~/.hermes/skills/hardware/
echo "=== gateway still healthy ==="; systemctl --user is-active hermes-gateway
```

is blocked with:

> Blocked: cannot restart or stop the gateway from inside the gateway process. The gateway would kill this command before it could complete…

The regex matched:

```
'kill intact, dupe gone ==="; ls -la /home/u/.hermes/skills/hardware/; echo; echo "=== ar'
```

Nothing in that command mutates gateway state, so the SIGTERM-respawn warning is inapplicable and misleading.

Minimal cases, all currently blocked on `main`:

```
BLOCK  the skill is fine, hermes gateway is healthy
BLOCK  reinstall skill for hermes, check gateway
BLOCK  load the obsidian skill then report hermes gateway status
BLOCK  roadkill on the hermes gateway dashboard
BLOCK  overkill: hermes gateway has three health checks
```

Note that **`skills` (plural) escapes the match** — the trailing `s` breaks the `\b` after `kill`. So whether the guard fires depends on whether the word happens to be singular, which is not a distinction anything should rely on.

## Why this matters beyond terminal commands

`contains_gateway_lifecycle_command` is also the predicate behind `check_gateway_lifecycle`, enforced at `cron.jobs.create_job` — scanning both cron **prompts** and **script bodies**. So a legitimate scheduled job like:

> "report hermes gateway status and note which skill fired"

is rejected at creation time with a `#30719` SIGTERM-loop error.

That directly contradicts the module's own docstring, which states the pattern is *"intentionally command-shaped: it anchors on a concrete command identifier … so it cannot fire on prose"*, and that an over-broad match on English *"would produce a high false-positive rate without preventing the actual foot-gun."* The `\b` omission is exactly that failure mode.

## Fix

Add a leading `\b` to both kill alternatives. One character each; no behavioral change to the true positives.

## Verification

All 11 true-positive foot-guns still block:

```
BLOCK  kill hermes gateway process
BLOCK  pkill -f hermes.*gateway
BLOCK  pkill -f gateway.*hermes
BLOCK  pkill hermes gateway
BLOCK  kill -9 the hermes gateway
BLOCK  hermes gateway restart
BLOCK  hermes gateway stop
BLOCK  systemctl --user restart hermes-gateway
BLOCK  systemctl stop hermes-gateway.service
BLOCK  launchctl kickstart gui/501/ai.hermes.gateway
BLOCK  echo start; pkill -f "hermes.*gateway"; echo done
```

Read-only / benign forms still pass:

```
allow  systemctl --user is-active hermes-gateway
allow  systemctl --user status hermes-gateway
allow  journalctl --user -u hermes-gateway -n 20
allow  hermes gateway start
```

Test suite:

```
$ python -m pytest tests/hermes_cli/test_gateway_restart_loop.py -o 'addopts=' -q
72 passed in 0.48s
```

Added `test_words_ending_in_kill_are_not_kill_commands` to the existing
`TestGatewayLifecyclePattern` class, following the false-positive-regression
convention already established there for the `#30728` follow-up cases.

Wider run of `tests/hermes_cli/test_gateway_restart_loop.py tests/gateway/ tests/cron/`:
11,845 passed. The failures present in that run (Telegram markdown escaping,
`test_mirror`, `test_send_multiple_images`) are **pre-existing test-pollution
failures unrelated to this change** — confirmed by running the identical
selection on unmodified `main`, which produces a superset (15 failures), and by
running those same tests in isolation both with and without this patch, where
all 104 pass.
