### PR TITLE
fix(compression): prune stale codex_reasoning_items during compaction (#71058)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -189,6 +189,49 @@ def _strip_persistence_markers(messages: List[Dict[str, Any]]) -> None:
             msg.pop(_DB_PERSISTED_MARKER, None)
 
 
+def _prune_stale_reasoning_replay(messages: List[Dict[str, Any]]) -> int:
+    """Strip stale replay fields (``codex_reasoning_items``) from retained
+    assistant messages older than the most recent assistant turn.
+
+    During Codex/Responses sessions, every retained assistant message carries
+    encrypted reasoning blobs (``codex_reasoning_items``) that are only needed
+    for replaying the *current* turn's reasoning chain.  Prior-turn items are
+    pure re-billed weight: the compaction boundary has already invalidated the
+    prompt-cache prefix, and ``conversation_loop.py`` already drops these
+    wholesale when ``api_mode != "codex_responses"``.
+
+    Operates in place on the fully assembled compacted message list.  Returns
+    the number of messages that were pruned (for diagnostics).  #71058.
+
+    The pruning rule is conservative: everything up to (but not including) the
+    *last* assistant message in the list gets its stale replay fields stripped.
+    The final assistant message retains its items because it is the most recent
+    turn and its replay chain may still be active.  When there is no assistant
+    message at all (shouldn't happen in practice, but defensive) nothing is
+    stripped.
+    """
+    # Find the last assistant message index — everything before it is stale.
+    last_asst_idx = -1
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            last_asst_idx = i
+            break
+    if last_asst_idx <= 0:
+        # No assistant message, or only one (nothing to prune).
+        return 0
+
+    pruned = 0
+    for i in range(last_asst_idx):
+        msg = messages[i]
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        for key in _STALE_REPLAY_PRUNE_KEYS:
+            if msg.pop(key, None) is not None:
+                pruned += 1
+    return pruned
+
+
 # Appended to every standalone summary message (and to the merged-into-tail
 # prefix) so the model has an unambiguous "summary ends here" boundary.
 # Without it, weak models read the verbatim "## Active Task" quote as fresh
@@ -732,6 +775,17 @@ _REPLAY_BUDGET_KEYS = (
     "codex_message_items",
 )
 
+# Replay keys that can be safely pruned from stale assistant messages during
+# compaction.  ``codex_reasoning_items`` carries encrypted reasoning blobs that
+# are only needed for the current turn's replay — prior-turn items are pure
+# re-billed weight.  Stripping stale items at compaction time is a safe, cheap
+# pre-pass: the compaction boundary has already invalidated the prompt-cache
+# prefix, and the conversation_loop already drops these wholesale when
+# ``api_mode != "codex_responses"`` (#71058).
+_STALE_REPLAY_PRUNE_KEYS = (
+    "codex_reasoning_items",
+)
+
 
 def _estimate_msg_budget_tokens(msg: dict) -> int:
     """Token estimate for one message in the tail-protection budget walks.
@@ -750,8 +804,11 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
     same size class; otherwise an assistant message with tiny visible
     content but large hidden replay blobs is protected as if it were small,
     the post-compression session stays near the context limit, and
-    compaction re-fires continuously (#55572).  Accounting-only: replay
-    fields are never mutated or pruned here.
+    compaction re-fires continuously (#55572).  Stale replay fields from
+    prior assistant turns are stripped during the compaction assembly pass
+    (``_prune_stale_reasoning_replay``, #71058).  Accounting-only here: this
+    budget walk does not mutate or prune — it counts so the tail-protection
+    boundary does not undershoot due to invisible replay payload.
     """
     content = msg.get("content") or ""
     if isinstance(content, str):
@@ -5498,6 +5555,21 @@ This compaction should PRIORITISE preserving all information related to the focu
         # are positional; this single terminal sweep makes it structural so a
         # future copy site cannot re-leak the marker into the child-session flush.
         _strip_persistence_markers(compressed)
+        # Prune stale codex_reasoning_items from retained assistant messages
+        # older than the most recent assistant turn (#71058).  These encrypted
+        # reasoning blobs are only needed for the *current* turn's replay;
+        # prior-turn items are pure re-billed weight that keeps compaction from
+        # reaching its target ratio.  The compaction boundary has already
+        # invalidated the prompt-cache prefix, so stripping them here costs
+        # nothing extra cache-wise.  conversation_loop.py already drops these
+        # wholesale when api_mode != "codex_responses", so this is a scoped
+        # strip consistent with existing semantics.
+        _pruned_replay = _prune_stale_reasoning_replay(compressed)
+        if _pruned_replay and not self.quiet_mode:
+            logger.info(
+                "Pruned stale replay items from %d assistant message(s) during compaction",
+                _pruned_replay,
+            )
         self._last_compression_made_progress = True
 
         return compressed


### PR DESCRIPTION
## Summary

Fixes #71058. Compaction never pruned `codex_reasoning_items` — encrypted reasoning blobs from Codex/Responses that ride on every retained assistant message. On long-lived sessions these blobs become the largest incompressible component (~36% of the payload), causing compaction to bottom out at ~2× the configured `target_ratio` and re-fire every 30–60 minutes.

## Changes

**`agent/context_compressor.py`** — 3 additive changes, no behavioral change to non-Codex sessions:

1. **`_prune_stale_reasoning_replay(messages)`** — New module-level function that scans the fully-assembled compacted message list right-to-left, locates the *last* assistant turn, and strips `codex_reasoning_items` (and any future keys in `_STALE_REPLAY_PRUNE_KEYS`) from all assistant messages before it. The final assistant message retains its items because its replay chain may still be active.

2. **`_STALE_REPLAY_PRUNE_KEYS`** — New tuple alongside `_REPLAY_BUDGET_KEYS`, listing fields safe to strip from stale turns. Currently: `codex_reasoning_items` only.

3. **Wired into `compress()`** — Called after `_strip_persistence_markers(compressed)`, just before the return. Logs pruned count at INFO when non-zero and not in quiet mode.

## Safety

- **Compaction already invalidates the prompt-cache prefix** — stripping blobs at this point costs nothing extra cache-wise.
- **`conversation_loop.py` already drops these wholesale** when `api_mode != "codex_responses"` — this is a scoped strip consistent with existing semantics.
- **Conservative boundary** — only items older than the *last* assistant turn are pruned; the most recent assistant message keeps its replay items for the current turn.
- **No config knob needed** — the behavior is always correct and safe during compaction. A config option would add complexity for no benefit given the cache-invalidation guarantee above.

## Testing

- Unit tests of `_prune_stale_reasoning_replay` pass (empty list, single asst, multi-asst, no asst, three-asst cases).
- All 43 existing `test_context_compressor.py` tests pass (including `TestCompress` full integration tests).
- `from agent.context_compressor import _prune_stale_reasoning_replay, _STALE_REPLAY_PRUNE_KEYS` succeeds.

Closes #71058.