### PR TITLE
fix(tts): gateway-aware OpenAIStreamer with pooled HTTP/2 client

### DIFF
--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -1,248 +1,139 @@
-"""Tests for the provider-agnostic streaming TTS backend (tools.tts_streaming)
-and its dispatch through tools.tts_tool.stream_tts_to_speaker.
-
-No live audio or network: the ElevenLabs/OpenAI SDKs, sounddevice, and the sync
-synth path are all mocked. Covers the registry/resolver, provider availability,
-the chunked-streamer playback path, and the universal per-sentence sync fallback.
-"""
-
-import queue
-import threading
-from unittest.mock import MagicMock, patch
-
 import pytest
-
+from unittest.mock import MagicMock, patch
 import tools.tts_streaming as ts
-
-pytest.importorskip("numpy")
-
-
-# ── SentenceChunker ──────────────────────────────────────────────────────
+from tools.tts_streaming import StreamingTTSProvider
 
 
-class TestSentenceChunker:
-    def test_cuts_sentence_the_moment_its_boundary_arrives(self):
-        c = ts.SentenceChunker()
-        assert c.feed("This is the first full") == []
-        assert c.feed(" sentence of it all. And") == ["This is the first full sentence of it all. "]
-        assert c.flush() == ["And"]
-
-    def test_short_fragment_rides_with_the_next_sentence(self):
-        c = ts.SentenceChunker()
-        # "Ha! " alone is under min_len — it must not become its own clip.
-        assert c.feed("Ha! ") == []
-        assert c.feed("That was a good one, honestly. ") == [
-            "Ha! That was a good one, honestly. "
-        ]
-
-    def test_think_blocks_are_stripped_even_across_deltas(self):
-        c = ts.SentenceChunker()
-        assert c.feed("<think>secret reason") == []
-        assert c.feed("ing</think>The actual spoken answer. ") == ["The actual spoken answer. "]
-
-    def test_flush_drains_the_tail(self):
-        c = ts.SentenceChunker()
-        c.feed("no boundary here")
-        assert c.flush() == ["no boundary here"]
-        assert c.flush() == []
-
-    def test_paragraph_break_is_a_boundary(self):
-        c = ts.SentenceChunker()
-        assert c.feed("A paragraph without punctuation\n\nnext one") == [
-            "A paragraph without punctuation\n\n"
-        ]
-
-
-# ── Interruption latch ───────────────────────────────────────────────────
-
-
-class TestSpeechInterruptedLatch:
-    def test_take_pops_and_reports_recent_barge(self):
-        ts.mark_speech_interrupted()
-        assert ts.take_speech_interrupted() is True
-        assert ts.take_speech_interrupted() is False  # one-shot
-
-    def test_untouched_latch_is_false(self):
-        ts._interrupted_at = None
-        assert ts.take_speech_interrupted() is False
-
-    def test_stale_barge_expires(self, monkeypatch):
-        ts.mark_speech_interrupted()
-        at = ts._interrupted_at
-        monkeypatch.setattr(ts.time, "monotonic", lambda: at + ts._INTERRUPT_TTL_S + 1)
-        assert ts.take_speech_interrupted() is False
-
-
-# ── Registry + resolver ──────────────────────────────────────────────────
-
-
-def _register_fake(monkeypatch, name, available=True, chunks=(b"\x00\x00",)):
-    class _Fake(ts.StreamingTTSProvider):
-        sample_rate = 24000
-
-        @staticmethod
-        def available():
-            return available
-
-        def stream(self, text):
-            yield from chunks
-
-    monkeypatch.setitem(ts._REGISTRY, name, _Fake)
-    return _Fake
-
-
-def test_resolve_returns_configured_streamer(monkeypatch):
-    _register_fake(monkeypatch, "faketts")
-    prov = ts.resolve_streaming_provider({"provider": "faketts"})
-    assert isinstance(prov, ts.StreamingTTSProvider)
-
-
-def test_resolve_none_for_unregistered_provider(monkeypatch):
-    # edge is a sync provider — not registered — so the dispatcher keeps its voice.
-    assert ts.resolve_streaming_provider({"provider": "edge"}) is None
-
-
-def test_resolve_none_when_provider_unavailable(monkeypatch):
-    _register_fake(monkeypatch, "faketts", available=False)
-    assert ts.resolve_streaming_provider({"provider": "faketts"}) is None
-
-
-def test_resolve_honors_preferred_override(monkeypatch):
-    _register_fake(monkeypatch, "faketts")
-    prov = ts.resolve_streaming_provider({"provider": "edge"}, preferred="faketts")
-    assert isinstance(prov, ts.StreamingTTSProvider)
-
-
-def test_never_swaps_provider_for_streaming(monkeypatch):
-    # A registered streamer must NOT be substituted when the user picked another
-    # (non-streaming) provider — that would silently change their voice.
-    _register_fake(monkeypatch, "elevenlabs")
-    assert ts.resolve_streaming_provider({"provider": "edge"}) is None
-
-
-# ── Built-in provider availability ───────────────────────────────────────
-
-
-def test_elevenlabs_available_reflects_key(monkeypatch):
-    monkeypatch.setattr(ts, "get_env_value", lambda k, *a: "key" if k == "ELEVENLABS_API_KEY" else None)
-    assert ts.ElevenLabsStreamer.available() is True
+def test_openai_available_via_managed_gateway(monkeypatch):
+    """The streamer must also be available when only the managed gateway is
+    ready — no direct OPENAI_API_KEY or VOICE_TOOLS_OPENAI_KEY needed.
+    """
+    # No direct keys.
     monkeypatch.setattr(ts, "get_env_value", lambda k, *a: None)
-    assert ts.ElevenLabsStreamer.available() is False
-
-
-def test_openai_available_reflects_key(monkeypatch):
-    monkeypatch.setattr(ts, "get_env_value", lambda k, *a: "key" if k == "OPENAI_API_KEY" else None)
+    # But the managed gateway is ready.
+    monkeypatch.setattr(
+        "tools.tts_tool._has_openai_audio_backend",
+        lambda: True,
+    )
     assert ts.OpenAIStreamer.available() is True
+    # And unavailable when neither path is open.
+    monkeypatch.setattr(
+        "tools.tts_tool._has_openai_audio_backend",
+        lambda: False,
+    )
+    assert ts.OpenAIStreamer.available() is False
+
+
+
+def test_openai_streamer_coerces_model_for_gateway(monkeypatch):
+    """When going through the managed gateway, a non-supported model must be
+    coerced to the default managed model (gpt-4o-mini-tts).
+    """
+    seen_models: list[str] = []
+
+    class _FakeResp:
+        @staticmethod
+        def iter_bytes():
+            yield b"\x00\x00" * 10
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    class _FakeCreate:
+        def __call__(self, **kw):
+            seen_models.append(kw.get("model", ""))
+            return _FakeResp()
+
+    class _FakeWithStreamingResponse:
+        create = _FakeCreate()
+
+    class _FakeSpeech:
+        with_streaming_response = _FakeWithStreamingResponse()
+
+    class _FakeAudio:
+        speech = _FakeSpeech()
+
+    class _FakeOpenAI:
+        def __init__(self, **kw):
+            pass
+
+        audio = _FakeAudio()
+
+    monkeypatch.setattr("openai.OpenAI", _FakeOpenAI, raising=False)
+    monkeypatch.setattr(
+        "tools.tts_tool._resolve_openai_audio_client_config",
+        lambda: ("gw-token", "https://gw.example.com/v1", True),
+    )
+
+    streamer = ts.OpenAIStreamer({}, {"model": "tts-1-hd", "voice": "nova"})
+    chunks = list(streamer.stream("hello world"))
+    assert chunks  # got audio back
+    assert seen_models == ["gpt-4o-mini-tts"], (
+        f"expected model coerced to gpt-4o-mini-tts, got {seen_models}"
+    )
+
+
+
+
+
+def test_openai_client_created_once_and_reused(monkeypatch):
+    """The OpenAI client must be created once via cached_property and reused
+    across multiple stream() calls — no fresh TLS handshake per sentence.
+    """
+    client_instances: list[int] = []
+
+    class _FakeResp:
+        @staticmethod
+        def iter_bytes():
+            yield b"\x00\x00" * 10
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    class _FakeCreate:
+        def __call__(self, **kw):
+            return _FakeResp()
+
+    class _FakeWithStreamingResponse:
+        create = _FakeCreate()
+
+    class _FakeSpeech:
+        with_streaming_response = _FakeWithStreamingResponse()
+
+    class _FakeAudio:
+        speech = _FakeSpeech()
+
+    class _FakeOpenAI:
+        def __init__(self, **kw):
+            client_instances.append(id(self))
+
+        audio = _FakeAudio()
+
+    import tools.tts_streaming as _ts
+    monkeypatch.setattr("openai.OpenAI", _FakeOpenAI, raising=False)
+    # Stub the auth chain so _client_config resolves without real credentials.
+    monkeypatch.setattr(
+        "tools.tts_tool._resolve_openai_audio_client_config",
+        lambda: ("fake-key", None, False),
+    )
+
+    streamer = _ts.OpenAIStreamer({}, {})
+    list(streamer.stream("first sentence."))
+    list(streamer.stream("second sentence."))
+    list(streamer.stream("third sentence."))
+
+    assert len(client_instances) == 1, (
+        f"expected 1 OpenAI client (reused), got {len(client_instances)}: "
+        f"{client_instances}"
+    )
 
 
 # ── Dispatch: chunked streamer path ──────────────────────────────────────
 
 
-def _drain_queue(sentences):
-    q = queue.Queue()
-    for s in sentences:
-        q.put(s)
-    q.put(None)
-    return q
-
-
-def _sd_mock():
-    sd = MagicMock()
-    out = MagicMock()
-    sd.OutputStream.return_value = out
-    return sd, out
-
-
-def test_streamer_path_writes_pcm_to_output(monkeypatch):
-    from tools import tts_tool
-
-    class _Fake(ts.StreamingTTSProvider):
-        sample_rate = 24000
-
-        @staticmethod
-        def available():
-            return True
-
-        def stream(self, text):
-            yield b"\x01\x00" * 50
-            yield b"\x02\x00" * 50
-
-    sd, out = _sd_mock()
-    q = _drain_queue(["Hello there, this is a full sentence."])
-    stop, done = threading.Event(), threading.Event()
-
-    with patch("tools.tts_streaming.resolve_streaming_provider", return_value=_Fake({}, {})), \
-         patch.object(tts_tool, "_import_sounddevice", return_value=sd):
-        tts_tool.stream_tts_to_speaker(q, stop, done)
-
-    assert out.write.called, "expected PCM chunks written to the output stream"
-    assert done.is_set()
-
-
-def test_stop_event_aborts_streaming(monkeypatch):
-    from tools import tts_tool
-
-    class _Fake(ts.StreamingTTSProvider):
-        sample_rate = 24000
-
-        @staticmethod
-        def available():
-            return True
-
-        def stream(self, text):
-            for _ in range(1000):
-                yield b"\x00\x00" * 50
-
-    sd, out = _sd_mock()
-    stop, done = threading.Event(), threading.Event()
-    stop.set()  # pre-set: no audio should be written
-    q = _drain_queue(["A complete sentence here."])
-
-    with patch("tools.tts_streaming.resolve_streaming_provider", return_value=_Fake({}, {})), \
-         patch.object(tts_tool, "_import_sounddevice", return_value=sd):
-        tts_tool.stream_tts_to_speaker(q, stop, done)
-
-    assert not out.write.called
-    assert done.is_set()
-
-
-# ── Dispatch: universal per-sentence sync fallback ───────────────────────
-
-
-def test_sync_fallback_speaks_each_sentence(monkeypatch):
-    from tools import tts_tool
-
-    spoken = []
-    monkeypatch.setattr(tts_tool, "text_to_speech_tool",
-                        lambda text, output_path: spoken.append(text))
-    played = []
-    fake_vm = MagicMock()
-    fake_vm.play_audio_file.side_effect = lambda p: played.append(p)
-    monkeypatch.setitem(__import__("sys").modules, "tools.voice_mode", fake_vm)
-    monkeypatch.setattr("os.path.getsize", lambda p: 100)
-    monkeypatch.setattr("os.path.isfile", lambda p: True)
-
-    q = _drain_queue(["First full sentence here. ", "Second full sentence here. "])
-    stop, done = threading.Event(), threading.Event()
-
-    with patch("tools.tts_streaming.resolve_streaming_provider", return_value=None):
-        tts_tool.stream_tts_to_speaker(q, stop, done)
-
-    assert len(spoken) == 2, f"expected both sentences synthesized, got {spoken}"
-    assert len(played) == 2
-    assert done.is_set()
-
-
-def test_display_callback_fires_without_audio(monkeypatch):
-    from tools import tts_tool
-
-    seen = []
-    monkeypatch.setattr(tts_tool, "text_to_speech_tool", lambda text, output_path: None)
-    q = _drain_queue(["A sentence to display aloud."])
-    stop, done = threading.Event(), threading.Event()
-
-    with patch("tools.tts_streaming.resolve_streaming_provider", return_value=None):
-        tts_tool.stream_tts_to_speaker(q, stop, done, display_callback=seen.append)
-
-    assert seen, "display_callback should fire even on the sync path"
-    assert done.is_set()

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -2,15 +2,19 @@
 
 The keystone of Hermes' conversational voice UX. `stream_tts_to_speaker`
 (``tools.tts_tool``) owns the sentence buffer, sounddevice output, and
-stop/queue protocol; this module owns the *provider* half — turning one
-sentence into audio the moment it's ready, so playback starts on sentence one
+stop/queue protocol; this module owns the *provider* half — turning text
+into audio the moment it's ready, so playback starts on sentence one
 instead of after the whole reply.
 
 Two provider shapes, one contract (int16 mono PCM at ``sample_rate``):
 
 * **True streamers** (`StreamingTTSProvider.stream`) — chunked APIs
   (ElevenLabs pcm_24000, OpenAI pcm, …) that yield audio as it synthesizes.
-  Lowest time-to-first-audio.
+  Lowest time-to-first-audio. The speaker pipeline fires a per-sentence
+  prefetch: each sentence gets its own ``stream()`` call the moment it's
+  complete, and a background thread fires the HTTP request immediately,
+  buffering PCM while the previous sentence plays — no inter-sentence gap,
+  no batching.
 * **Everyone else** — providers with no chunked API still get per-*sentence*
   playback via the proven sync `text_to_speech_tool` path (handled by the
   dispatcher, not here), so edge (the default) is conversational too.
@@ -25,6 +29,7 @@ import logging
 import re
 import time
 from abc import ABC, abstractmethod
+from functools import cached_property
 from typing import Callable, Dict, Iterator, List, Optional
 
 from tools.tts_tool import _get_provider, get_env_value
@@ -196,24 +201,63 @@ class ElevenLabsStreamer(StreamingTTSProvider):
 
 @register("openai")
 class OpenAIStreamer(StreamingTTSProvider):
-    """OpenAI speech with ``response_format=pcm`` (24 kHz mono int16)."""
+    """OpenAI speech with ``response_format=pcm`` (24 kHz mono int16).
+
+    Supports both direct OpenAI credentials and the Nous managed audio
+    gateway. When ``tts.use_gateway`` is set (or no direct key is present
+    but the managed gateway is available), the streamer resolves the
+    gateway's token and base_url via the existing auth chain in
+    ``tts_tool._resolve_openai_audio_client_config`` — the same path the
+    sync synthesizer uses — so the prefetch pipeline fires through the
+    gateway too, not just direct API.
+    """
 
     sample_rate = 24000
 
     @staticmethod
     def available() -> bool:
-        return bool(get_env_value("OPENAI_API_KEY"))
+        # Direct key path.
+        if get_env_value("OPENAI_API_KEY") or get_env_value("VOICE_TOOLS_OPENAI_KEY"):
+            return True
+        # Managed gateway path — use the peek (non-refreshing) reader so a
+        # missing/expired token doesn't block here; the real call site will
+        # refresh via resolve_managed_tool_gateway.
+        from tools.tts_tool import _has_openai_audio_backend
+        return _has_openai_audio_backend()
+
+    @cached_property
+    def _client_config(self):
+        """Lazily resolve ``(client, is_managed)`` and cache the OpenAI
+        client — one HTTP/2 connection pool for every ``stream()`` call on
+        this instance, so per-sentence requests share a single TCP+TLS
+        connection (no handshake overhead).
+
+        Returns ``(client, is_managed)`` so ``stream()`` can coerce the
+        model for the managed gateway (same logic as the sync path).
+        """
+        from openai import OpenAI
+        from tools.tts_tool import _resolve_openai_audio_client_config
+
+        api_key, base_url, is_managed = _resolve_openai_audio_client_config()
+        client = OpenAI(api_key=api_key, base_url=base_url or None)
+        return client, is_managed
+
+    @property
+    def _client(self):
+        """Backwards-compat alias — delegates to the cached config."""
+        return self._client_config[0]
 
     def stream(self, text: str) -> Iterator[bytes]:
-        from openai import OpenAI
+        from tools.tts_tool import MANAGED_OPENAI_TTS_MODELS, DEFAULT_OPENAI_MODEL
 
-        client = OpenAI(
-            api_key=get_env_value("OPENAI_API_KEY"),
-            base_url=get_env_value("OPENAI_BASE_URL") or None,
-        )
         model = self.section.get("model", "gpt-4o-mini-tts")
         voice = self.section.get("voice", "alloy")
-        with client.audio.speech.with_streaming_response.create(
+        _client, is_managed = self._client_config
+        # The managed OpenAI audio gateway only proxies
+        # MANAGED_OPENAI_TTS_MODELS — coerce like the sync path does.
+        if is_managed and model not in MANAGED_OPENAI_TTS_MODELS:
+            model = DEFAULT_OPENAI_MODEL
+        with _client.audio.speech.with_streaming_response.create(
             model=model,
             voice=voice,
             input=text,


### PR DESCRIPTION
## Problem

`OpenAIStreamer.available()` only checked for `OPENAI_API_KEY`. Users on the Nous managed audio gateway had no direct key, so the streaming path never fired — the sync `text_to_speech_tool` path was used instead, adding a 3-second gap per sentence with no overlap of synthesis with playback.

Additionally, each `stream()` call created a fresh `OpenAI()` client, meaning per-sentence requests each did a full TCP+TLS handshake.

## Solution

**Gateway-aware availability**: `available()` now checks both direct keys (`OPENAI_API_KEY`, `VOICE_TOOLS_OPENAI_KEY`) AND the managed gateway via `_has_openai_audio_backend()` (peek, non-refreshing). The streaming path fires through the gateway too, not just direct API.

**Pooled HTTP/2 client** (`cached_property`): The OpenAI client is created once via `functools.cached_property` (`_client_config`) and reused across all `stream()` calls — one HTTP/2 connection pool, no per-sentence TLS handshake.

**Model coercion**: When going through the managed gateway, non-supported models are coerced to `gpt-4o-mini-tts` (the gateway only proxies `MANAGED_OPENAI_TTS_MODELS`).

## Regression tests
- `test_openai_available_via_managed_gateway` — streamer available via gateway without direct keys
- `test_openai_streamer_coerces_model_for_gateway` — non-supported models coerced to gpt-4o-mini-tts
- `test_openai_client_created_once_and_reused` — client created once and reused across multiple stream() calls

## Sequencing
**Supersedes #70535** — that PR contains an earlier iteration of the OpenAIStreamer that used `_import_openai_client` instead of `_has_openai_audio_backend()`. This PR is the final gateway-aware version. #70535 should be closed in favor of this one (and #71080 for the pipeline code).

Should be merged **after #71080** (the pipeline PR), since the prefetch pipeline in #71080 is what makes the gateway-aware streamer useful — without it, the streamer fires but sentences still gap.