### PR TITLE
fix(insights): guard against non-numeric DB values in _compute_model_breakdown (#71026)

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -72,6 +72,21 @@ def _estimate_cost(
     return float(result.amount_usd or 0.0), result.status
 
 
+def _safe_int(val) -> int:
+    """Cast *val* to int, returning 0 on any unparseable or None value.
+
+    Guards against corrupted DB rows that store non-numeric strings
+    (e.g. Chinese text) in numeric columns such as ``api_call_count``
+    or ``input_tokens`` — the ``or 0`` idiom alone does not help because
+    a truthy string short-circuits to itself before ``int()`` gets a
+    chance to fail cleanly.
+    """
+    try:
+        return int(val) if val is not None else 0
+    except (ValueError, TypeError):
+        return 0
+
+
 
 
 def _bar_chart(values: List[int], max_width: int = 20) -> List[str]:
@@ -623,13 +638,18 @@ class InsightsEngine:
         # double-counting already-attributed route deltas.
         for s in sessions:
             totals = usage_totals[s["id"]]
-            inp = max(0, (s.get("input_tokens") or 0) - totals["input_tokens"])
-            out = max(0, (s.get("output_tokens") or 0) - totals["output_tokens"])
+            inp = max(
+                0, _safe_int(s.get("input_tokens")) - totals["input_tokens"]
+            )
+            out = max(
+                0, _safe_int(s.get("output_tokens")) - totals["output_tokens"]
+            )
             cache_read = max(
-                0, (s.get("cache_read_tokens") or 0) - totals["cache_read_tokens"]
+                0, _safe_int(s.get("cache_read_tokens")) - totals["cache_read_tokens"]
             )
             cache_write = max(
-                0, (s.get("cache_write_tokens") or 0) - totals["cache_write_tokens"]
+                0,
+                _safe_int(s.get("cache_write_tokens")) - totals["cache_write_tokens"],
             )
             residual_cost = max(
                 0.0, float(s.get("estimated_cost_usd") or 0.0)
@@ -640,7 +660,7 @@ class InsightsEngine:
                 - totals["actual_cost_usd"],
             )
             residual_calls = max(
-                0, (s.get("api_call_count") or 0) - totals["api_call_count"]
+                0, _safe_int(s.get("api_call_count")) - totals["api_call_count"]
             )
             if not (
                 inp or out or cache_read or cache_write or residual_cost


### PR DESCRIPTION
## Symptom

```
$ hermes insights --days 30
Error generating insights: unsupported operand type(s) for -: 'str' and 'int'
```

## Root cause

In `agent/insights.py:_compute_model_breakdown`, the reconciliation loop does:

```python
residual_calls = max(0, (s.get("api_call_count") or 0) - totals["api_call_count"])
```

When the session DB contains a non-numeric string in `api_call_count` (e.g. corrupted Chinese text), `s.get("api_call_count")` returns the truthy string. `"string" or 0` evaluates to `"string"` (not `0`), so `"string" - int` fails with `TypeError`.

Same risk affects `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`.

## Fix

Add a `_safe_int()` helper that catches `ValueError`/`TypeError` and returns `0` for unparseable values:

```python
def _safe_int(val) -> int:
    try:
        return int(val) if val is not None else 0
    except (ValueError, TypeError):
        return 0
```

Applied to all five numeric fields in the reconciliation loop.

Fixes #71026