### PR TITLE
feat(cron): persist transport receipts with delivery outcome contract (#70945)

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -72,21 +72,6 @@ def _estimate_cost(
     return float(result.amount_usd or 0.0), result.status
 
 
-def _safe_int(val) -> int:
-    """Cast *val* to int, returning 0 on any unparseable or None value.
-
-    Guards against corrupted DB rows that store non-numeric strings
-    (e.g. Chinese text) in numeric columns such as ``api_call_count``
-    or ``input_tokens`` — the ``or 0`` idiom alone does not help because
-    a truthy string short-circuits to itself before ``int()`` gets a
-    chance to fail cleanly.
-    """
-    try:
-        return int(val) if val is not None else 0
-    except (ValueError, TypeError):
-        return 0
-
-
 
 
 def _bar_chart(values: List[int], max_width: int = 20) -> List[str]:
@@ -638,18 +623,13 @@ class InsightsEngine:
         # double-counting already-attributed route deltas.
         for s in sessions:
             totals = usage_totals[s["id"]]
-            inp = max(
-                0, _safe_int(s.get("input_tokens")) - totals["input_tokens"]
-            )
-            out = max(
-                0, _safe_int(s.get("output_tokens")) - totals["output_tokens"]
-            )
+            inp = max(0, (s.get("input_tokens") or 0) - totals["input_tokens"])
+            out = max(0, (s.get("output_tokens") or 0) - totals["output_tokens"])
             cache_read = max(
-                0, _safe_int(s.get("cache_read_tokens")) - totals["cache_read_tokens"]
+                0, (s.get("cache_read_tokens") or 0) - totals["cache_read_tokens"]
             )
             cache_write = max(
-                0,
-                _safe_int(s.get("cache_write_tokens")) - totals["cache_write_tokens"],
+                0, (s.get("cache_write_tokens") or 0) - totals["cache_write_tokens"]
             )
             residual_cost = max(
                 0.0, float(s.get("estimated_cost_usd") or 0.0)
@@ -660,7 +640,7 @@ class InsightsEngine:
                 - totals["actual_cost_usd"],
             )
             residual_calls = max(
-                0, _safe_int(s.get("api_call_count")) - totals["api_call_count"]
+                0, (s.get("api_call_count") or 0) - totals["api_call_count"]
             )
             if not (
                 inp or out or cache_read or cache_write or residual_cost

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -72,6 +72,21 @@ def _estimate_cost(
     return float(result.amount_usd or 0.0), result.status
 
 
+def _safe_int(val) -> int:
+    """Cast *val* to int, returning 0 on any unparseable or None value.
+
+    Guards against corrupted DB rows that store non-numeric strings
+    (e.g. Chinese text) in numeric columns such as ``api_call_count``
+    or ``input_tokens`` — the ``or 0`` idiom alone does not help because
+    a truthy string short-circuits to itself before ``int()`` gets a
+    chance to fail cleanly.
+    """
+    try:
+        return int(val) if val is not None else 0
+    except (ValueError, TypeError):
+        return 0
+
+
 
 
 def _bar_chart(values: List[int], max_width: int = 20) -> List[str]:
@@ -623,13 +638,18 @@ class InsightsEngine:
         # double-counting already-attributed route deltas.
         for s in sessions:
             totals = usage_totals[s["id"]]
-            inp = max(0, (s.get("input_tokens") or 0) - totals["input_tokens"])
-            out = max(0, (s.get("output_tokens") or 0) - totals["output_tokens"])
+            inp = max(
+                0, _safe_int(s.get("input_tokens")) - totals["input_tokens"]
+            )
+            out = max(
+                0, _safe_int(s.get("output_tokens")) - totals["output_tokens"]
+            )
             cache_read = max(
-                0, (s.get("cache_read_tokens") or 0) - totals["cache_read_tokens"]
+                0, _safe_int(s.get("cache_read_tokens")) - totals["cache_read_tokens"]
             )
             cache_write = max(
-                0, (s.get("cache_write_tokens") or 0) - totals["cache_write_tokens"]
+                0,
+                _safe_int(s.get("cache_write_tokens")) - totals["cache_write_tokens"],
             )
             residual_cost = max(
                 0.0, float(s.get("estimated_cost_usd") or 0.0)
@@ -640,7 +660,7 @@ class InsightsEngine:
                 - totals["actual_cost_usd"],
             )
             residual_calls = max(
-                0, (s.get("api_call_count") or 0) - totals["api_call_count"]
+                0, _safe_int(s.get("api_call_count")) - totals["api_call_count"]
             )
             if not (
                 inp or out or cache_read or cache_write or residual_cost

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -3,11 +3,19 @@
 The ledger records what is known about each attempt; it is not a retry queue.
 Interrupted attempts become ``unknown`` only after their exact owner process is
 proved gone. Terminal states are immutable.
+
+The ledger also records structured delivery outcomes per target per execution,
+so ``last_delivery_error: null`` is no longer the only signal — callers can
+query whether a platform sent a transport acknowledgement, whether delivery was
+ambiguous (e.g. write-timeout after a possible dispatch), or whether a definite
+pre-dispatch rejection occurred.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
+import logging
 import os
 import sqlite3
 import threading
@@ -19,9 +27,18 @@ from typing import Any, Dict, Iterator, List, Optional
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
+logger = logging.getLogger(__name__)
+
 EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
 MAX_TERMINAL_EXECUTIONS = 1000
 _TERMINAL_STATES = ("completed", "failed", "unknown")
+# Delivery outcome statuses: ordered by precedence for aggregation.
+# Confirmation outranks ambiguity; ambiguity outranks failure.
+DELIVERY_CONFIRMED = "delivered_confirmed"
+DELIVERY_UNKNOWN = "delivery_unknown"
+DELIVERY_FAILED = "delivery_failed"
+_DELIVERY_STATES = (DELIVERY_CONFIRMED, DELIVERY_UNKNOWN, DELIVERY_FAILED)
+_DELIVERY_STATE_SQL = "','".join(_DELIVERY_STATES)
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
 
@@ -61,6 +78,32 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_executions_status_claimed "
         "ON executions(status, claimed_at DESC, id DESC)"
+    )
+    conn.execute(
+        f"""CREATE TABLE IF NOT EXISTS delivery_outcomes (
+             id TEXT PRIMARY KEY,
+             execution_id TEXT NOT NULL REFERENCES executions(id),
+             target TEXT NOT NULL,
+             platform TEXT NOT NULL,
+             chat_id TEXT,
+             thread_id TEXT,
+             actual_platform TEXT,
+             actual_chat_id TEXT,
+             actual_thread_id TEXT,
+             status TEXT NOT NULL CHECK(status IN ('{_DELIVERY_STATE_SQL}')),
+             provider_message_id TEXT,
+             content_hash TEXT,
+             confirmed_at TEXT,
+             created_at TEXT NOT NULL
+           )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_delivery_outcomes_exec "
+        "ON delivery_outcomes(execution_id, target)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_delivery_outcomes_exec_status "
+        "ON delivery_outcomes(execution_id, status)"
     )
 
 
@@ -119,6 +162,11 @@ def _prune_unlocked(conn: sqlite3.Connection) -> None:
              ORDER BY claimed_at DESC, id DESC LIMIT -1 OFFSET ?
            )""",
         (limit,),
+    )
+    # Prune orphaned delivery_outcomes whose parent execution was pruned.
+    conn.execute(
+        """DELETE FROM delivery_outcomes
+           WHERE execution_id NOT IN (SELECT id FROM executions)"""
     )
 
 
@@ -252,3 +300,152 @@ def latest_executions(job_ids: List[str]) -> Dict[str, Dict[str, Any]]:
             clean,
         ).fetchall()
     return {row["job_id"]: dict(row) for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# Delivery-outcome storage
+# ---------------------------------------------------------------------------
+
+def register_delivery_target(
+    execution_id: str,
+    *,
+    target: str,
+    platform: str,
+    chat_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Pre-register one expected delivery target before the send attempt.
+
+    Every fan-out target is pre-registered so that an exception during
+    delivery never silently omits a target from the audit record.
+
+    Raises a constraint violation if the same ``(execution_id, target)``
+    pair is registered twice (content-hash conflict guard — each target
+    row must represent exactly one send attempt per execution).
+    """
+    now = _hermes_now().isoformat()
+    outcome_id = uuid.uuid4().hex
+    with _transaction() as conn:
+        conn.execute(
+            """INSERT INTO delivery_outcomes
+               (id, execution_id, target, platform, chat_id, thread_id,
+                status, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, 'delivery_unknown', ?)""",
+            (outcome_id, execution_id, target, platform, chat_id, thread_id, now),
+        )
+        row = conn.execute(
+            "SELECT * FROM delivery_outcomes WHERE id=?", (outcome_id,)
+        ).fetchone()
+    return _record(row)  # type: ignore[return-value]
+
+
+def confirm_delivery_outcome(
+    execution_id: str,
+    target: str,
+    *,
+    status: str,
+    provider_message_id: Optional[str] = None,
+    actual_platform: Optional[str] = None,
+    actual_chat_id: Optional[str] = None,
+    actual_thread_id: Optional[str] = None,
+    content: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Record the outcome for a previously-registered delivery target.
+
+    The status must be one of ``DELIVERY_CONFIRMED``, ``DELIVERY_UNKNOWN``,
+    or ``DELIVERY_FAILED`` (constants defined at module level).
+
+    ``content``, when provided, is hashed (SHA-256) and stored as
+    ``content_hash`` — the message body itself is never persisted.
+
+    Confirmation outranks ambiguity: if the row already has a higher-precedence
+    status, this update is silently skipped (no-op).  Ambiguity outranks
+    failure, so a ``delivery_failed`` write is skipped if the row is already
+    ``delivery_unknown`` or ``delivered_confirmed``.
+    """
+    now = _hermes_now().isoformat()
+    content_hash = hashlib.sha256(content.encode()).hexdigest() if content else None
+
+    # Precedence: confirmed > unknown > failed.
+    # Only update if the new status outranks the existing one.
+    precedence = {DELIVERY_CONFIRMED: 3, DELIVERY_UNKNOWN: 2, DELIVERY_FAILED: 1}
+    new_rank = precedence.get(status, 0)
+
+    with _transaction() as conn:
+        existing = conn.execute(
+            "SELECT * FROM delivery_outcomes WHERE execution_id=? AND target=?",
+            (execution_id, target),
+        ).fetchone()
+        if existing is None:
+            logger.warning(
+                "No delivery_outcome row for execution=%s target=%s — "
+                "did pre-registration succeed?",
+                execution_id, target,
+            )
+            return None
+        old_rank = precedence.get(existing["status"], 0)
+        if new_rank <= old_rank:
+            # Current row has equal or higher precedence; keep it.
+            logger.debug(
+                "Skipping delivery_outcome update for %s/%s: "
+                "existing=%s (rank %d) >= new=%s (rank %d)",
+                execution_id, target,
+                existing["status"], old_rank, status, new_rank,
+            )
+            return _record(existing)
+
+        cur = conn.execute(
+            """UPDATE delivery_outcomes
+               SET status=?, provider_message_id=?,
+                   actual_platform=COALESCE(?, actual_platform),
+                   actual_chat_id=COALESCE(?, actual_chat_id),
+                   actual_thread_id=COALESCE(?, actual_thread_id),
+                   content_hash=COALESCE(?, content_hash),
+                   confirmed_at=?
+               WHERE execution_id=? AND target=?""",
+            (status, provider_message_id,
+             actual_platform, actual_chat_id, actual_thread_id,
+             content_hash, now,
+             execution_id, target),
+        )
+        if cur.rowcount < 1:
+            return None
+        row = conn.execute(
+            "SELECT * FROM delivery_outcomes WHERE execution_id=? AND target=?",
+            (execution_id, target),
+        ).fetchone()
+    return _record(row)
+
+
+def get_delivery_outcomes(
+    execution_id: str,
+) -> List[Dict[str, Any]]:
+    """Return all delivery outcomes for one execution, one per target."""
+    with _transaction() as conn:
+        rows = conn.execute(
+            "SELECT * FROM delivery_outcomes WHERE execution_id=? "
+            "ORDER BY created_at ASC",
+            (execution_id,),
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def get_delivery_outcomes_for_job(job_id: str) -> Dict[str, List[Dict[str, Any]]]:
+    """Return delivery outcomes grouped by execution for a job.
+
+    Useful for CLI/API display: returns ``{execution_id: [outcome, ...]}``
+    for the latest executions of the given job.
+    """
+    with _transaction() as conn:
+        rows = conn.execute(
+            """SELECT do.* FROM delivery_outcomes do
+                INNER JOIN executions e ON e.id = do.execution_id
+                WHERE e.job_id=?
+                ORDER BY e.claimed_at DESC, do.created_at ASC""",
+            (str(job_id),),
+        ).fetchall()
+    result: Dict[str, List[Dict[str, Any]]] = {}
+    for row in rows:
+        d = dict(row)
+        result.setdefault(d["execution_id"], []).append(d)
+    return result

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -278,7 +278,16 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 }
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
-from cron.executions import create_execution, finish_execution, mark_execution_running
+from cron.executions import (
+    create_execution,
+    finish_execution,
+    mark_execution_running,
+    register_delivery_target,
+    confirm_delivery_outcome,
+    DELIVERY_CONFIRMED,
+    DELIVERY_UNKNOWN,
+    DELIVERY_FAILED,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -1459,7 +1468,62 @@ def _is_channel_dm_topic(
     return is_channel
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _format_target_key(target: dict) -> str:
+    """Return a stable string key for a delivery target dict.
+
+    Used as the ``target`` column value in the delivery-outcomes table to
+    identify which logical target an outcome corresponds to.
+    """
+    platform = str(target.get("platform", "?"))
+    chat_id = target.get("chat_id") or ""
+    thread_id = target.get("thread_id") or ""
+    parts = [platform]
+    if chat_id:
+        parts.append(chat_id)
+        if thread_id:
+            parts.append(thread_id)
+    return ":".join(parts)
+
+
+def _record_delivery_outcome(
+    execution_id: str,
+    target_key: str,
+    content: str,
+    *,
+    status: str,
+    provider_message_id: Optional[str] = None,
+    actual_platform: Optional[str] = None,
+    actual_chat_id: Optional[str] = None,
+    actual_thread_id: Optional[str] = None,
+) -> None:
+    """Best-effort helper to record a delivery outcome in the executions ledger.
+
+    Silently swallows exceptions so a failed outcome write never crashes the
+    delivery or the cron run.  No-op when ``execution_id`` is not provided
+    (caller opted out of outcome tracking).
+    """
+    if not execution_id:
+        return
+    try:
+        confirm_delivery_outcome(
+            execution_id,
+            target_key,
+            status=status,
+            provider_message_id=provider_message_id,
+            actual_platform=actual_platform,
+            actual_chat_id=actual_chat_id,
+            actual_thread_id=actual_thread_id,
+            content=content,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to record delivery outcome for %s/%s: status=%s",
+            execution_id, target_key, status, exc_info=True,
+        )
+
+
+def _deliver_result(job: dict, content: str, adapters=None, loop=None,
+                    execution_id: Optional[str] = None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -1468,9 +1532,31 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     the standalone HTTP path cannot encrypt.  Falls back to standalone send if
     the adapter path fails or is unavailable.
 
+    When ``execution_id`` is provided, each delivery target is pre-registered
+    in the delivery-outcomes ledger before sending, and the resulting outcome
+    (confirmed / unknown / failed) is recorded after each send.
+
     Returns None on success, or an error string on failure.
     """
     targets = _resolve_delivery_targets(job)
+    # Pre-register every fan-out target before any send attempt.
+    # This guarantees that an exception during delivery never silently
+    # omits a target from the delivery-outcomes audit trail.
+    if execution_id and targets:
+        for t in targets:
+            try:
+                register_delivery_target(
+                    execution_id,
+                    target=_format_target_key(t),
+                    platform=str(t["platform"]),
+                    chat_id=t.get("chat_id"),
+                    thread_id=t.get("thread_id"),
+                )
+            except Exception:
+                logger.warning(
+                    "Job '%s': failed to pre-register delivery target %s",
+                    job["id"], t, exc_info=True,
+                )
     if not targets:
         deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
         if deliver_value == "local":
@@ -1550,6 +1636,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
+        # Stable identifier for delivery-outcome ledger — computed from original
+        # target values before any inline thread_id modifications below.
+        target_key = _format_target_key(target)
 
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
@@ -1867,6 +1956,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     "to avoid duplicate)",
                                     job["id"], platform_name, chat_id,
                                 )
+                                _record_delivery_outcome(
+                                    execution_id, target_key, content,
+                                    status=DELIVERY_UNKNOWN,
+                                )
                         except Exception as ex:
                             # A real send error (not a slow confirmation) — fall
                             # through to the standalone path so the message is
@@ -1971,6 +2064,23 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
+                    # Record delivery outcome: extract provider_message_id from
+                    # the send result when available.
+                    provider_message_id = None
+                    if isinstance(send_result, dict):
+                        provider_message_id = send_result.get("message_id") or send_result.get("provider_message_id")
+                    elif send_result is not None:
+                        provider_message_id = getattr(send_result, "message_id", None)
+                        if not provider_message_id:
+                            provider_message_id = getattr(send_result, "provider_message_id", None)
+                    # Track actual thread after potential fallback/creation
+                    actual_thread_id = str(opened_thread_id) if opened_thread_id else (str(thread_id) if thread_id else None)
+                    _record_delivery_outcome(
+                        execution_id, target_key, content,
+                        status=DELIVERY_CONFIRMED,
+                        provider_message_id=provider_message_id,
+                        actual_thread_id=actual_thread_id,
+                    )
                     # Seed the thread session only now that delivery into it
                     # succeeded (deferred from thread-open above).
                     if opened_thread_id and not thread_seeded:
@@ -2018,6 +2128,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         f"relay delivery to {platform_name}:{chat_id} failed"
                     )
                 delivery_errors.extend(target_errors)
+                _record_delivery_outcome(
+                    execution_id, target_key, content,
+                    status=DELIVERY_FAILED,
+                    actual_platform=str(transport.transport_platform.value) if transport else None,
+                    actual_chat_id=chat_id,
+                )
                 continue
             # If the interpreter is finalizing (gateway SIGTERM / restart /
             # OOM), scheduling any new delivery is futile — asyncio.run and a
@@ -2030,6 +2146,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 logger.warning("Job '%s': %s", job["id"], msg)
                 target_errors.append(msg)
                 delivery_errors.extend(target_errors)
+                _record_delivery_outcome(
+                    execution_id, target_key, content,
+                    status=DELIVERY_UNKNOWN,
+                )
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
             coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
@@ -2049,6 +2169,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     logger.warning("Job '%s': %s", job["id"], msg)
                     target_errors.append(msg)
                     delivery_errors.extend(target_errors)
+                    _record_delivery_outcome(
+                        execution_id, target_key, content,
+                        status=DELIVERY_UNKNOWN,
+                    )
                     continue
                 # The thread-pool fallback can itself raise (SMTP ConnectionError,
                 # future.result timeout, etc.). An exception raised inside this
@@ -2073,17 +2197,29 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         logger.warning("Job '%s': %s", job["id"], msg)
                         target_errors.append(msg)
                         delivery_errors.extend(target_errors)
+                        _record_delivery_outcome(
+                            execution_id, target_key, content,
+                            status=DELIVERY_UNKNOWN,
+                        )
                         continue
                     msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                     logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
                     target_errors.extend([msg])
                     delivery_errors.extend(target_errors)
+                    _record_delivery_outcome(
+                        execution_id, target_key, content,
+                        status=DELIVERY_FAILED,
+                    )
                     continue
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                 logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)
+                _record_delivery_outcome(
+                    execution_id, target_key, content,
+                    status=DELIVERY_FAILED,
+                )
                 continue
 
             if result and result.get("error"):
@@ -2091,9 +2227,25 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 logger.error("Job '%s': %s", job["id"], msg)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)
+                _record_delivery_outcome(
+                    execution_id, target_key, content,
+                    status=DELIVERY_FAILED,
+                )
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
+            # Extract provider_message_id from standalone send result
+            provider_message_id = None
+            if result:
+                if isinstance(result, dict):
+                    provider_message_id = result.get("message_id") or result.get("provider_message_id")
+                else:
+                    provider_message_id = getattr(result, "message_id", None) or getattr(result, "provider_message_id", None)
+            _record_delivery_outcome(
+                execution_id, target_key, content,
+                status=DELIVERY_CONFIRMED,
+                provider_message_id=provider_message_id,
+            )
             _maybe_mirror_cron_delivery(
                 job, platform_name, chat_id, mirror_text,
                 thread_id=thread_id, user_id=origin_user_id,
@@ -3981,7 +4133,11 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
 
             if should_deliver:
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    delivery_error = _deliver_result(
+                        job, deliver_content,
+                        adapters=adapters, loop=loop,
+                        execution_id=execution_id,
+                    )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -27,7 +27,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("save", jid))
         return f"/tmp/{jid}.txt"
 
-    def fake_deliver(job, content, adapters=None, loop=None):
+    def fake_deliver(job, content, adapters=None, loop=None, execution_id=None):
         calls.append(("deliver", job["id"]))
         return None
 
@@ -184,7 +184,7 @@ def test_run_one_job_delivers_before_agent_teardown(monkeypatch):
         defer_agent_teardown.append(FakeAgent())
         return (True, "out", "final response", None)
 
-    def fake_deliver(job, content, adapters=None, loop=None):
+    def fake_deliver(job, content, adapters=None, loop=None, execution_id=None):
         order.append("deliver")
         return None
 
@@ -219,7 +219,7 @@ def test_run_one_job_tears_down_deferred_agent_when_delivery_raises(monkeypatch)
         defer_agent_teardown.append(FakeAgent())
         return (True, "out", "final response", None)
 
-    def boom_deliver(job, content, adapters=None, loop=None):
+    def boom_deliver(job, content, adapters=None, loop=None, execution_id=None):
         order.append("deliver-raise")
         raise RuntimeError("send blew up")
 


### PR DESCRIPTION
## Summary

Add a structured send-outcome contract to cron delivery, stored in the existing `cron/executions.db` ledger with transactional integrity. Each fan-out target is pre-registered before the send attempt and updated with the actual outcome afterwards.

## Changes

### `cron/executions.py`
- New `delivery_outcomes` table with columns for execution_id, target, platform, chat_id, thread_id, actual_* (after fallback), status, provider_message_id, content_hash (SHA-256 - message bodies are never persisted), and timestamps.
- `register_delivery_target()` - pre-register expected targets before any send attempt, so an exception during delivery never silently omits a target.
- `confirm_delivery_outcome()` - record the result with precedence ordering: delivered_confirmed > delivery_unknown > delivery_failed. A lower-precedence write is silently skipped.
- `get_delivery_outcomes()` and `get_delivery_outcomes_for_job()` for inspection.
- `_prune_unlocked()` now cascades to prune orphaned delivery_outcomes rows.

### `cron/scheduler.py`
- `_format_target_key()` - stable target string identifier.
- `_record_delivery_outcome()` - best-effort helper that silently swallows exceptions.
- Pre-register all fan-out targets in `_deliver_result()` before sending.
- Outcome recording at every resolution point: live adapter confirmed, timeout in-flight, relay failure, interpreter shutdown skip, standalone failure, standalone success.

### `tests/cron/test_run_one_job.py`
- Update mock deliver functions to accept optional execution_id kwarg.

Closes #70945