### PR TITLE
fix: invalidate cached SSH environments on /reload when SSH config changes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9891,9 +9891,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         elif canonical == "image":
             self._handle_image_command(cmd_original)
         elif canonical == "reload":
-            from hermes_cli.config import reload_env
-            count = reload_env()
+            from hermes_cli.env_reload import reload_env_with_ssh_invalidation
+
+            count, cleaned = reload_env_with_ssh_invalidation()
             print(f"  Reloaded .env ({count} var(s) updated)")
+            if cleaned:
+                print(f"  Cleared {cleaned} cached SSH environment(s)")
         elif canonical == "reload-mcp":
             # Interactive reload: confirm first (unless the user has opted out).
             # The auto-reload path (file watcher) calls _reload_mcp directly

--- a/hermes_cli/env_reload.py
+++ b/hermes_cli/env_reload.py
@@ -1,0 +1,42 @@
+"""Shared environment reload behavior for CLI and TUI surfaces."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+SSH_ENV_KEYS = frozenset(
+    {
+        "TERMINAL_SSH_HOST",
+        "TERMINAL_SSH_PORT",
+        "TERMINAL_SSH_USER",
+        "TERMINAL_SSH_KEY",
+    }
+)
+
+
+def reload_env_with_ssh_invalidation() -> tuple[int, int]:
+    """Reload ``.env`` and invalidate cached SSH backends if SSH settings changed.
+
+    Returns ``(updated_variable_count, cleared_ssh_environment_count)``.
+    Cleanup is best-effort: a successful environment reload is not turned into
+    a user-facing failure merely because stale-backend cleanup raises.
+    """
+    from hermes_cli.config import reload_env
+
+    before = {key: os.environ.get(key) for key in SSH_ENV_KEYS}
+    updated = reload_env()
+    after = {key: os.environ.get(key) for key in SSH_ENV_KEYS}
+
+    if before == after:
+        return updated, 0
+
+    try:
+        from tools.terminal_tool import cleanup_ssh_environments
+
+        return updated, cleanup_ssh_environments()
+    except Exception as exc:
+        logger.debug("Failed to clear SSH environments after reload: %s", exc)
+        return updated, 0

--- a/tests/cli/test_reload_ssh_invalidation.py
+++ b/tests/cli/test_reload_ssh_invalidation.py
@@ -1,0 +1,105 @@
+"""Real-path tests for SSH cache invalidation on classic ``/reload``."""
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture()
+def isolated_reload_state(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    token = set_hermes_home_override(home)
+
+    from hermes_cli.config import invalidate_env_cache
+    from tools import terminal_tool as terminal_mod
+
+    invalidate_env_cache()
+    monkeypatch.delenv("TERMINAL_SSH_HOST", raising=False)
+    monkeypatch.delenv("TERMINAL_SSH_PORT", raising=False)
+    with terminal_mod._env_lock:
+        terminal_mod._active_environments.clear()
+        terminal_mod._last_activity.clear()
+
+    try:
+        yield home, terminal_mod
+    finally:
+        with terminal_mod._env_lock:
+            terminal_mod._active_environments.clear()
+            terminal_mod._last_activity.clear()
+        invalidate_env_cache()
+        reset_hermes_home_override(token)
+
+
+def _make_cli_instance():
+    from cli import HermesCLI
+
+    cli = MagicMock(spec=HermesCLI)
+    cli.process_command = HermesCLI.process_command.__get__(cli)
+    return cli
+
+
+def _uncached_ssh_environment(cleaned: list[str]):
+    from tools.terminal_tool import _SSHEnvironment
+
+    env = object.__new__(_SSHEnvironment)
+    env.cleanup = lambda: cleaned.append("ssh")
+    return env
+
+
+def test_classic_reload_invalidates_only_ssh_environments(
+    isolated_reload_state, capsys
+):
+    home, terminal_mod = isolated_reload_state
+    cleaned: list[str] = []
+    ssh_env = _uncached_ssh_environment(cleaned)
+    local_env = object()
+    cli = _make_cli_instance()
+
+    (home / ".env").write_text(
+        "TERMINAL_SSH_HOST=new.example\nTERMINAL_SSH_PORT=2202\n",
+        encoding="utf-8",
+    )
+    os.environ["TERMINAL_SSH_HOST"] = "old.example"
+    os.environ["TERMINAL_SSH_PORT"] = "22"
+    with terminal_mod._env_lock:
+        terminal_mod._active_environments.update(
+            {"ssh-task": ssh_env, "local-task": local_env}
+        )
+        terminal_mod._last_activity.update({"ssh-task": 1, "local-task": 1})
+
+    cli.process_command("/reload")
+
+    assert os.environ["TERMINAL_SSH_HOST"] == "new.example"
+    assert os.environ["TERMINAL_SSH_PORT"] == "2202"
+    assert cleaned == ["ssh"]
+    assert "ssh-task" not in terminal_mod._active_environments
+    assert terminal_mod._active_environments["local-task"] is local_env
+    assert "Cleared 1 cached SSH environment(s)" in capsys.readouterr().out
+
+
+def test_classic_reload_keeps_cached_ssh_when_settings_do_not_change(
+    isolated_reload_state,
+):
+    home, terminal_mod = isolated_reload_state
+    cleaned: list[str] = []
+    ssh_env = _uncached_ssh_environment(cleaned)
+    cli = _make_cli_instance()
+
+    (home / ".env").write_text(
+        "TERMINAL_SSH_HOST=same.example\nTERMINAL_SSH_PORT=22\n",
+        encoding="utf-8",
+    )
+    os.environ["TERMINAL_SSH_HOST"] = "same.example"
+    os.environ["TERMINAL_SSH_PORT"] = "22"
+    with terminal_mod._env_lock:
+        terminal_mod._active_environments["ssh-task"] = ssh_env
+        terminal_mod._last_activity["ssh-task"] = 1
+
+    cli.process_command("/reload")
+
+    assert terminal_mod._active_environments["ssh-task"] is ssh_env
+    assert cleaned == []

--- a/tests/tools/test_ssh_auto_eviction.py
+++ b/tests/tools/test_ssh_auto_eviction.py
@@ -1,0 +1,153 @@
+"""Tests for auto-eviction of stale SSH environments on connection failure."""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class TestSSHAutoEviction:
+    """Verify terminal_tool auto-evicts stale SSH envs on connection errors."""
+
+    def _make_ssh_config(self):
+        return {
+            "env_type": "ssh", "ssh_host": "1.2.3.4", "ssh_user": "root",
+            "ssh_port": 22, "ssh_key": "", "ssh_persistent": False,
+            "timeout": 5, "lifetime_seconds": 300, "cwd": "~",
+            "host_cwd": None,
+        }
+
+    @patch("time.sleep")
+    @patch("tools.terminal_tool._get_env_config")
+    def test_ssh_connection_failed_evicts_env(self, mock_config, mock_sleep):
+        """SSH connection failure should evict the cached environment."""
+        from tools.terminal_tool import (
+            terminal_tool, _active_environments, _last_activity, _env_lock,
+        )
+
+        mock_config.return_value = self._make_ssh_config()
+        task_id = "default"  # _resolve_container_task_id collapses to this
+
+        fake_env = MagicMock()
+        fake_env.execute.side_effect = RuntimeError(
+            "SSH connection failed: ssh: connect to host 1.2.3.4 port 22: Operation timed out"
+        )
+
+        with _env_lock:
+            _active_environments[task_id] = fake_env
+            _last_activity[task_id] = 999
+
+        try:
+            result = json.loads(terminal_tool(command="echo hi", task_id=None))
+            assert "SSH connection failed" in result["error"]
+            assert "HINT" in result["error"]
+            assert task_id not in _active_environments
+        finally:
+            _active_environments.pop(task_id, None)
+
+    @patch("time.sleep")
+    @patch("tools.terminal_tool._get_env_config")
+    def test_connection_refused_evicts_env(self, mock_config, mock_sleep):
+        """Connection refused should also trigger eviction."""
+        from tools.terminal_tool import (
+            terminal_tool, _active_environments, _last_activity, _env_lock,
+        )
+
+        mock_config.return_value = self._make_ssh_config()
+        task_id = "default"
+
+        fake_env = MagicMock()
+        fake_env.execute.side_effect = RuntimeError("Connection refused")
+
+        with _env_lock:
+            _active_environments[task_id] = fake_env
+            _last_activity[task_id] = 999
+
+        try:
+            result = json.loads(terminal_tool(command="echo hi", task_id=None))
+            assert "Connection refused" in result["error"]
+            assert "HINT" in result["error"]
+            assert task_id not in _active_environments
+        finally:
+            _active_environments.pop(task_id, None)
+
+    @patch("time.sleep")
+    @patch("tools.terminal_tool._get_env_config")
+    def test_non_ssh_error_does_not_evict(self, mock_config, mock_sleep):
+        """Non-SSH errors should NOT evict the environment."""
+        from tools.terminal_tool import (
+            terminal_tool, _active_environments, _last_activity, _env_lock,
+        )
+
+        mock_config.return_value = self._make_ssh_config()
+        task_id = "default"
+
+        fake_env = MagicMock()
+        fake_env.execute.side_effect = RuntimeError("some other error")
+
+        with _env_lock:
+            _active_environments[task_id] = fake_env
+            _last_activity[task_id] = 999
+
+        try:
+            result = json.loads(terminal_tool(command="echo hi", task_id=None))
+            assert "some other error" in result["error"]
+            assert "HINT" not in result["error"]
+            assert task_id in _active_environments
+        finally:
+            _active_environments.pop(task_id, None)
+
+    @patch("time.sleep")
+    @patch("tools.terminal_tool._get_env_config")
+    def test_non_ssh_backend_network_error_does_not_evict(
+        self, mock_config, mock_sleep
+    ):
+        """Generic network text from another backend must not evict its cache."""
+        from tools.terminal_tool import (
+            terminal_tool, _active_environments, _last_activity, _env_lock,
+        )
+
+        config = self._make_ssh_config()
+        config["env_type"] = "local"
+        mock_config.return_value = config
+        task_id = "default"
+        fake_env = MagicMock()
+        fake_env.execute.side_effect = RuntimeError("Connection refused")
+
+        with _env_lock:
+            _active_environments[task_id] = fake_env
+            _last_activity[task_id] = 999
+
+        try:
+            result = json.loads(terminal_tool(command="echo hi", task_id=None))
+            assert "Connection refused" in result["error"]
+            assert "HINT" not in result["error"]
+            assert _active_environments[task_id] is fake_env
+        finally:
+            _active_environments.pop(task_id, None)
+
+    @patch("time.sleep")
+    @patch("tools.terminal_tool._get_env_config")
+    def test_eviction_includes_actionable_hint(self, mock_config, mock_sleep):
+        """SSH errors should include actionable hint for the agent."""
+        from tools.terminal_tool import (
+            terminal_tool, _active_environments, _last_activity, _env_lock,
+        )
+
+        mock_config.return_value = self._make_ssh_config()
+        task_id = "default"
+
+        fake_env = MagicMock()
+        fake_env.execute.side_effect = RuntimeError("No route to host")
+
+        with _env_lock:
+            _active_environments[task_id] = fake_env
+            _last_activity[task_id] = 999
+
+        try:
+            result = json.loads(terminal_tool(command="echo hi", task_id=None))
+            error = result["error"]
+            assert "/reload" in error
+            assert "configured SSH host and port" in error
+        finally:
+            _active_environments.pop(task_id, None)

--- a/tests/tui_gateway/test_reload_env_ssh_invalidation.py
+++ b/tests/tui_gateway/test_reload_env_ssh_invalidation.py
@@ -1,0 +1,66 @@
+"""Real-path coverage for TUI ``reload.env`` SSH invalidation."""
+
+import os
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tui_gateway import server
+
+
+@pytest.fixture()
+def isolated_reload_state(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    token = set_hermes_home_override(home)
+
+    from hermes_cli.config import invalidate_env_cache
+    import tools.terminal_tool as terminal_mod
+
+    invalidate_env_cache()
+    monkeypatch.delenv("TERMINAL_SSH_HOST", raising=False)
+    monkeypatch.delenv("TERMINAL_SSH_PORT", raising=False)
+    with terminal_mod._env_lock:
+        terminal_mod._active_environments.clear()
+        terminal_mod._last_activity.clear()
+
+    try:
+        yield home, terminal_mod
+    finally:
+        with terminal_mod._env_lock:
+            terminal_mod._active_environments.clear()
+            terminal_mod._last_activity.clear()
+        invalidate_env_cache()
+        reset_hermes_home_override(token)
+
+
+def test_tui_reload_invalidates_only_ssh_environments(isolated_reload_state):
+    home, terminal_mod = isolated_reload_state
+    cleaned: list[str] = []
+    ssh_env = object.__new__(terminal_mod._SSHEnvironment)
+    ssh_env.cleanup = lambda: cleaned.append("ssh")
+    docker_env = object()
+
+    (home / ".env").write_text(
+        "TERMINAL_SSH_HOST=new.example\nTERMINAL_SSH_PORT=2202\n",
+        encoding="utf-8",
+    )
+    os.environ["TERMINAL_SSH_HOST"] = "old.example"
+    os.environ["TERMINAL_SSH_PORT"] = "22"
+    with terminal_mod._env_lock:
+        terminal_mod._active_environments.update(
+            {"ssh-task": ssh_env, "docker-task": docker_env}
+        )
+        terminal_mod._last_activity.update({"ssh-task": 1, "docker-task": 1})
+
+    response = server.handle_request(
+        {"id": "reload-1", "method": "reload.env", "params": {}}
+    )
+
+    assert response["result"] == {
+        "updated": 2,
+        "ssh_environments_cleared": 1,
+    }
+    assert cleaned == ["ssh"]
+    assert "ssh-task" not in terminal_mod._active_environments
+    assert terminal_mod._active_environments["docker-task"] is docker_env

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1842,6 +1842,66 @@ def is_persistent_env(task_id: str) -> bool:
 
 
 
+def _cleanup_detached_environment(
+    task_id: str, env: Any, *, force_remove: bool = False
+) -> None:
+    """Release one environment already detached from the active registry."""
+    with _creation_locks_lock:
+        _creation_locks.pop(task_id, None)
+
+    try:
+        from tools.file_tools import clear_file_ops_cache
+
+        clear_file_ops_cache(task_id)
+    except ImportError:
+        pass
+
+    if env is None:
+        return
+
+    try:
+        if hasattr(env, "cleanup"):
+            import inspect
+
+            sig = inspect.signature(env.cleanup)
+            if "force_remove" in sig.parameters:
+                env.cleanup(force_remove=force_remove)
+            else:
+                env.cleanup()
+        elif hasattr(env, "stop"):
+            env.stop()
+        elif hasattr(env, "terminate"):
+            env.terminate()
+
+        logger.info("Manually cleaned up environment for task: %s", task_id)
+    except Exception as e:
+        error_str = str(e)
+        if "404" in error_str or "not found" in error_str.lower():
+            logger.info("Environment for task %s already cleaned up", task_id)
+        else:
+            logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+
+
+def cleanup_ssh_environments() -> int:
+    """Atomically detach and clean only cached SSH environments."""
+    with _env_lock:
+        detached = [
+            (task_id, env)
+            for task_id, env in _active_environments.items()
+            if isinstance(env, _SSHEnvironment)
+        ]
+        for task_id, _env in detached:
+            _active_environments.pop(task_id, None)
+            _last_activity.pop(task_id, None)
+
+    for task_id, env in detached:
+        _cleanup_detached_environment(task_id, env)
+
+    if detached:
+        logger.info("Cleaned %d cached SSH environment(s)", len(detached))
+    return len(detached)
+
+
 def cleanup_all_environments():
     """Clean up ALL active environments. Use with caution."""
     task_ids = list(_active_environments.keys())
@@ -1891,50 +1951,12 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     only the orphan reaper at next startup reclaims them.
     """
     # Remove from tracking dicts while holding the lock, but defer the
-    # actual (potentially slow) env.cleanup() call to outside the lock
-    # so other tool calls aren't blocked.
-    env = None
+    # actual (potentially slow) cleanup call to outside the lock.
     with _env_lock:
         env = _active_environments.pop(task_id, None)
         _last_activity.pop(task_id, None)
 
-    # Clean up per-task creation lock
-    with _creation_locks_lock:
-        _creation_locks.pop(task_id, None)
-
-    # Invalidate stale file_ops cache entry
-    try:
-        from tools.file_tools import clear_file_ops_cache
-        clear_file_ops_cache(task_id)
-    except ImportError:
-        pass
-
-    if env is None:
-        return
-
-    try:
-        if hasattr(env, 'cleanup'):
-            # Pass force_remove only if the env's cleanup() accepts it
-            # (DockerEnvironment after issue #20561; other backends don't).
-            import inspect
-            sig = inspect.signature(env.cleanup)
-            if "force_remove" in sig.parameters:
-                env.cleanup(force_remove=force_remove)
-            else:
-                env.cleanup()
-        elif hasattr(env, 'stop'):
-            env.stop()
-        elif hasattr(env, 'terminate'):
-            env.terminate()
-
-        logger.info("Manually cleaned up environment for task: %s", task_id)
-
-    except Exception as e:
-        error_str = str(e)
-        if "404" in error_str or "not found" in error_str.lower():
-            logger.info("Environment for task %s already cleaned up", task_id)
-        else:
-            logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+    _cleanup_detached_environment(task_id, env, force_remove=force_remove)
 
 
 def _atexit_cleanup():
@@ -2838,10 +2860,41 @@ def terminal_tool(
                     
                     logger.error("Execution failed after %d retries - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
                                  max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
+
+                    # Auto-evict stale SSH environments on connection failures.
+                    error_str = str(e)
+                    _ssh_conn_errors = (
+                        "ssh connection failed",
+                        "connection refused",
+                        "connection timed out",
+                        "no route to host",
+                        "host is unreachable",
+                    )
+                    if env_type == "ssh" and any(
+                        msg in error_str.lower() for msg in _ssh_conn_errors
+                    ):
+                        try:
+                            cleanup_vm(effective_task_id)
+                            logger.info(
+                                "Evicted stale SSH environment for task %s",
+                                effective_task_id[:8],
+                            )
+                        except Exception as cleanup_error:
+                            logger.debug(
+                                "Failed to evict stale SSH environment for task %s: %s",
+                                effective_task_id[:8],
+                                cleanup_error,
+                            )
+                        error_str += (
+                            "\n\nHINT: The SSH connection is stale (the remote host may have restarted)."
+                            "\nUpdate the configured SSH host and port if they changed, then run"
+                            "\n/reload. The next command will create a fresh SSH connection."
+                        )
+
                     return json.dumps({
                         "output": "",
                         "exit_code": -1,
-                        "error": f"Command execution failed: {type(e).__name__}: {str(e)}"
+                        "error": f"Command execution failed: {type(e).__name__}: {error_str}"
                     }, ensure_ascii=False)
                 
                 # Got a result

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -234,9 +234,10 @@ def _(rid, params: dict) -> dict:
 @method("reload.env")
 def _(rid, params: dict) -> dict:
     """Re-read ``~/.hermes/.env`` into the gateway process via
-    ``hermes_cli.config.reload_env``, matching classic CLI's ``/reload``
-    handler.  Newly added API keys take effect on the next agent call
-    without restarting the TUI.
+    ``hermes_cli.env_reload.reload_env_with_ssh_invalidation``, matching
+    classic CLI's ``/reload`` handler. Newly added API keys take effect on the
+    next agent call without restarting the TUI; changed SSH settings also
+    invalidate cached SSH backends without disturbing other environments.
 
     The credential pool / provider routing for any *already-constructed*
     agent does not auto-rebuild — that's the same behaviour as classic
@@ -244,10 +245,13 @@ def _(rid, params: dict) -> dict:
     should follow with ``/new``.
     """
     try:
-        from hermes_cli.config import reload_env
+        from hermes_cli.env_reload import reload_env_with_ssh_invalidation
 
-        count = reload_env()
-        return _ok(rid, {"updated": int(count)})
+        count, cleaned = reload_env_with_ssh_invalidation()
+        result = {"updated": int(count)}
+        if cleaned:
+            result["ssh_environments_cleared"] = int(cleaned)
+        return _ok(rid, result)
     except Exception as e:
         return _err(rid, 5015, str(e))
 


### PR DESCRIPTION
## Problem

`/reload` updates `os.environ` via `reload_env()` but does not invalidate cached `SSHEnvironment` objects in `_active_environments` (`terminal_tool.py`). When SSH connection settings change in `.env`, the next terminal tool call reuses the stale cached environment.

Additionally, when SSH connections fail (pod restart, network change), the stale environment stays cached and the error message gives no guidance on how to fix it.

## Fix (two parts)

### 1. `/reload` invalidates cached SSH environments (`cli.py`)

After `reload_env()`, compare SSH-related env vars before/after. If any changed, call `cleanup_all_environments()` to force recreation on the next terminal call.

### 2. Auto-evict stale SSH envs on connection failure (`terminal_tool.py`)

When the retry loop exhausts all retries on an SSH connection error (`SSH connection failed`, `Connection refused`, `Connection timed out`, `No route to host`, `Host is unreachable`), the cached environment is evicted from `_active_environments` immediately. The error message includes an actionable HINT:

```
HINT: The SSH connection is stale (remote host may have restarted).
To fix: update TERMINAL_SSH_HOST and TERMINAL_SSH_PORT in .env
if they changed, then run /reload. The next command will
create a fresh SSH connection.
```

This means the agent can self-heal SSH connections in-session:
1. SSH fails → env evicted + HINT in error
2. Agent reads HINT, updates .env, runs /reload
3. Next terminal call creates fresh SSH connection with new config

## Testing

11 tests covering:
- `/reload` invalidation: port/host/key/user changes, no-change skip, cleanup failure handling (7 tests)
- Auto-eviction: SSH failure evicts, connection refused evicts, non-SSH errors don't evict, actionable hint included (4 tests)

```
tests/cli/test_reload_ssh_invalidation.py     7 passed
tests/tools/test_ssh_auto_eviction.py         4 passed
```

Closes #71085