### PR TITLE
fix(dashboard): add tested deselect-all profile skill action

### DIFF
--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -574,11 +574,10 @@ class ProfileCreate(BaseModel):
     # create (the user can fix it from the relevant dashboard page afterward).
     # MCP servers to write into the new profile's config.yaml.
     mcp_servers: List["MCPServerCreate"] = []
-    # Built-in / optional skills to KEEP active. When this list is non-empty,
-    # the builder uses "replace" semantics: the bundle is seeded, then every
-    # seeded skill NOT in this list is added to the profile's disabled list.
-    # Empty list = leave the seeded bundle untouched (legacy behaviour).
-    keep_skills: List[str] = []
+    # Built-in / optional skills to KEEP active. Omission preserves the seeded
+    # bundle; an explicitly supplied list uses replace semantics, including []
+    # to disable every seeded skill.
+    keep_skills: Optional[List[str]] = None
     # Skills-hub identifiers to install into the new profile. Installed async
     # via a subprocess scoped to the profile (`hermes -p <name> skills install`)
     # because skills_hub.SKILLS_DIR is import-time-bound and the HERMES_HOME

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -692,11 +692,10 @@ async def create_profile_endpoint(body: ProfileCreate):
         except Exception:
             _log.exception("Writing MCP servers for new profile %s failed", body.name)
 
-    # Optional "keep" skill selection — replace semantics. When the builder
-    # sends an explicit keep list, disable every seeded skill not in it.
-    # Best-effort. Skipped when keep_skills is empty (legacy: keep the bundle).
+    # Optional "keep" skill selection — replace semantics. Omission preserves
+    # the seeded bundle; explicit [] disables every seeded skill.
     skills_disabled = 0
-    if body.keep_skills:
+    if body.keep_skills is not None:
         try:
             skills_disabled = _disable_unselected_skills(path, body.keep_skills)
         except Exception:

--- a/tests/hermes_cli/test_web_profile_create_skills.py
+++ b/tests/hermes_cli/test_web_profile_create_skills.py
@@ -1,0 +1,84 @@
+"""Route-level contract for Profile Builder seeded-skill selection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+SEEDED_SKILLS = ("alpha-skill", "beta-skill")
+
+
+def _seed_profile_skills(
+    profile_dir: Path, quiet: bool = False
+) -> dict[str, list[str]]:
+    del quiet
+    for skill_name in SEEDED_SKILLS:
+        skill_dir = profile_dir / "skills" / "custom" / skill_name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {skill_name}\n---\n\n# {skill_name}\n",
+            encoding="utf-8",
+        )
+    return {"copied": list(SEEDED_SKILLS)}
+
+
+@pytest.fixture()
+def profile_create_client(tmp_path, monkeypatch, _isolate_hermes_home):
+    from hermes_constants import get_hermes_home
+    from hermes_cli import profiles as profiles_mod
+    from hermes_cli import web_server
+
+    home = get_hermes_home()
+    profiles_root = home / "profiles"
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(profiles_mod, "_get_default_hermes_home", lambda: home)
+    monkeypatch.setattr(profiles_mod, "_get_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(profiles_mod, "seed_profile_skills", _seed_profile_skills)
+    monkeypatch.setattr(profiles_mod, "check_alias_collision", lambda _name: "test")
+
+    with TestClient(web_server.app) as client:
+        client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+        yield client, profiles_root
+
+
+def _disabled_skills(profile_dir: Path) -> set[str]:
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from hermes_cli.config import load_config
+    from hermes_cli.skills_config import get_disabled_skills
+
+    token = set_hermes_home_override(str(profile_dir))
+    try:
+        return get_disabled_skills(load_config())
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_omitted_keep_skills_preserves_seeded_bundle(profile_create_client):
+    client, profiles_root = profile_create_client
+
+    response = client.post("/api/profiles", json={"name": "defaults-kept"})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["skills_disabled"] == 0
+    profile_dir = profiles_root / "defaults-kept"
+    assert _disabled_skills(profile_dir).isdisjoint(SEEDED_SKILLS)
+    for skill_name in SEEDED_SKILLS:
+        assert (profile_dir / "skills" / "custom" / skill_name / "SKILL.md").is_file()
+
+
+def test_explicit_empty_keep_skills_disables_seeded_bundle(profile_create_client):
+    client, profiles_root = profile_create_client
+
+    response = client.post(
+        "/api/profiles",
+        json={"name": "defaults-disabled", "keep_skills": []},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["skills_disabled"] == len(SEEDED_SKILLS)
+    assert _disabled_skills(profiles_root / "defaults-disabled") == set(SEEDED_SKILLS)

--- a/web/src/lib/profile-builder-skills.test.ts
+++ b/web/src/lib/profile-builder-skills.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildKeepSkillsPayload,
+  profileSkillSelectionSummary,
+} from "./profile-builder-skills";
+
+describe("profileSkillSelectionSummary", () => {
+  it("reports the full skill set even when the visible list is filtered", () => {
+    const skills = [{ name: "alpha" }, { name: "beta" }, { name: "gamma" }];
+    const kept = new Set(["alpha", "beta", "gamma"]);
+
+    expect(profileSkillSelectionSummary(skills, kept)).toEqual({
+      selected: 3,
+      total: 3,
+    });
+  });
+
+  it("ignores stale selections that are no longer in the loaded skill set", () => {
+    const skills = [{ name: "alpha" }, { name: "beta" }];
+    const kept = new Set(["alpha", "removed-skill"]);
+
+    expect(profileSkillSelectionSummary(skills, kept)).toEqual({
+      selected: 1,
+      total: 2,
+    });
+  });
+});
+
+describe("buildKeepSkillsPayload", () => {
+  it("preserves the full-bundle sentinel", () => {
+    expect(buildKeepSkillsPayload(true, new Set(["alpha"]))).toBeUndefined();
+  });
+
+  it("emits an empty keep list after deselect all", () => {
+    expect(buildKeepSkillsPayload(false, new Set())).toEqual([]);
+  });
+});

--- a/web/src/lib/profile-builder-skills.ts
+++ b/web/src/lib/profile-builder-skills.ts
@@ -1,0 +1,21 @@
+type NamedSkill = { name: string };
+
+export function profileSkillSelectionSummary(
+  skills: readonly NamedSkill[],
+  keptSkills: ReadonlySet<string>,
+): { selected: number; total: number } {
+  return {
+    selected: skills.reduce(
+      (count, skill) => count + Number(keptSkills.has(skill.name)),
+      0,
+    ),
+    total: skills.length,
+  };
+}
+
+export function buildKeepSkillsPayload(
+  keepAll: boolean,
+  keptSkills: ReadonlySet<string>,
+): string[] | undefined {
+  return keepAll ? undefined : Array.from(keptSkills);
+}

--- a/web/src/pages/ProfileBuilderPage.tsx
+++ b/web/src/pages/ProfileBuilderPage.tsx
@@ -22,6 +22,10 @@ import {
   type McpServerDraft,
   type McpTransport,
 } from "@/lib/mcp-server-create";
+import {
+  buildKeepSkillsPayload,
+  profileSkillSelectionSummary,
+} from "@/lib/profile-builder-skills";
 import { cn } from "@/lib/utils";
 
 // Profile name rule mirrors the backend (`^[a-z0-9][a-z0-9_-]{0,63}$`).
@@ -230,6 +234,11 @@ export default function ProfileBuilderPage() {
     );
   }, [skills, skillFilter]);
 
+  const skillSelectionSummary = useMemo(
+    () => profileSkillSelectionSummary(skills ?? [], keptSkills),
+    [skills, keptSkills],
+  );
+
   const pickedModel = useMemo(
     () =>
       modelChoice
@@ -256,7 +265,7 @@ export default function ProfileBuilderPage() {
         provider: pickedModel?.provider,
         model: pickedModel?.model,
         mcp_servers: mcpServers.length ? mcpServers : undefined,
-        keep_skills: keepAll ? undefined : Array.from(keptSkills),
+        keep_skills: buildKeepSkillsPayload(keepAll, keptSkills),
         hub_skills: hubSkills.length
           ? hubSkills.map((s) => s.identifier)
           : undefined,
@@ -418,16 +427,22 @@ export default function ProfileBuilderPage() {
                   />
                   {skills !== null && skills.length > 0 && (
                     <div className="flex items-center justify-between">
-                      <span className="text-xs text-muted-foreground">
-                        {keptSkills.size} of {filteredSkills.length} selected
+                      <span
+                        className="text-xs text-muted-foreground"
+                        aria-live="polite"
+                      >
+                        {skillSelectionSummary.selected} of{" "}
+                        {skillSelectionSummary.total} selected
                       </span>
-                      <button
+                      <Button
                         type="button"
-                        onClick={() => setKeptSkills(new Set())}
-                        className="text-xs text-muted-foreground underline hover:text-foreground"
+                        size="sm"
+                        ghost
+                        onClick={() => setKeptSkills(new Set<string>())}
+                        disabled={skillSelectionSummary.selected === 0}
                       >
                         Deselect all
-                      </button>
+                      </Button>
                     </div>
                   )}
                   {skills === null ? (

--- a/web/src/pages/ProfileBuilderPage.tsx
+++ b/web/src/pages/ProfileBuilderPage.tsx
@@ -416,6 +416,20 @@ export default function ProfileBuilderPage() {
                       setSkillFilter(e.target.value)
                     }
                   />
+                  {skills !== null && skills.length > 0 && (
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">
+                        {keptSkills.size} of {filteredSkills.length} selected
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setKeptSkills(new Set())}
+                        className="text-xs text-muted-foreground underline hover:text-foreground"
+                      >
+                        Deselect all
+                      </button>
+                    </div>
+                  )}
                   {skills === null ? (
                     <p className="text-sm text-muted-foreground">
                       Loading skills…


### PR DESCRIPTION
## Summary

- add a one-click **Deselect all** action to the Profile Builder's built-in/optional skills step;
- keep the selection counter global rather than comparing retained skills against only filtered rows;
- exclude stale skill names from the displayed selected count;
- disable the action once the selection is empty;
- distinguish the create-profile request contract at the API boundary:
  - omitted `keep_skills` preserves the seeded/default skill bundle;
  - explicit `keep_skills: []` applies replace semantics and disables every seeded skill;
  - a non-empty list keeps only the selected seeded skills active.

## Contributor credit / relationship to #71072

This preserves @webtecnica's original focused implementation commit and authorship. #71072 was contributor-author closed as superseded; this branch retains that UI work and completes the backend contract plus route-level regression coverage.

Closes #71052.

## Regression coverage

- frontend helper coverage preserves the full-list counter, stale-name filtering, omitted payload sentinel, and explicit-empty payload;
- route-level profile creation with omitted `keep_skills` proves seeded skills remain active;
- route-level profile creation with explicit `keep_skills: []` proves every seeded skill is disabled.

The explicit-empty route regression fails before `4d4fb75cc` and passes with it.

## Verification

- rebased cleanly onto current `main` (`f51aa6a9`);
- route-level omitted-versus-explicit-empty outcomes: **2 passed**;
- `vitest` profile-builder helper suite: **4 passed**;
- web TypeScript typecheck: passed;
- focused ESLint: passed;
- production web build: passed;
- focused Ruff and `py_compile`: passed;
- `git diff --check`: passed.
- upstream `All required checks pass`: green.


