### PR TITLE
feat(approval): require approval for docker/podman daemon-redirect commands (Claude Code 2.1.214-inspired)

### DIFF
--- a/tests/tools/test_docker_daemon_redirect.py
+++ b/tests/tools/test_docker_daemon_redirect.py
@@ -1,0 +1,155 @@
+"""Docker/Podman daemon-redirect and lifecycle flag-insertion detection.
+
+Inspired by Claude Code 2.1.214, which added permission prompts for docker
+commands (including the Podman ``docker`` shim) carrying daemon-redirect
+flags (``--url``, ``--connection``, ``--identity``, and Podman's remote
+mode) that previously ran without one.
+
+A daemon redirect makes a local-looking command operate on a different
+(often remote) daemon, so any docker/podman invocation carrying one
+requires approval regardless of subcommand.
+"""
+
+from tools.approval import detect_dangerous_command
+
+
+class TestDockerDaemonRedirect:
+    def test_docker_dash_h_remote_host(self):
+        is_dangerous, key, desc = detect_dangerous_command(
+            "docker -H ssh://prod-host stop app")
+        assert is_dangerous is True
+        assert key is not None
+        assert "daemon redirect" in desc
+
+    def test_docker_long_host_flag_equals_form(self):
+        is_dangerous, _, desc = detect_dangerous_command(
+            "docker --host=tcp://10.0.0.5:2375 ps")
+        assert is_dangerous is True
+        assert "daemon redirect" in desc
+
+    def test_docker_host_flag_after_other_global_flags(self):
+        is_dangerous, _, desc = detect_dangerous_command(
+            "docker --log-level debug -H tcp://10.0.0.5:2375 images")
+        assert is_dangerous is True
+        assert "daemon redirect" in desc
+
+    def test_docker_context_flag(self):
+        is_dangerous, _, desc = detect_dangerous_command(
+            "docker --context production rm -f db")
+        assert is_dangerous is True
+        assert "daemon redirect" in desc
+
+    def test_docker_context_use(self):
+        is_dangerous, _, desc = detect_dangerous_command(
+            "docker context use production")
+        assert is_dangerous is True
+        assert "context use" in desc
+
+    def test_docker_host_env_prefix(self):
+        is_dangerous, _, _ = detect_dangerous_command(
+            "DOCKER_HOST=ssh://prod docker stop app")
+        assert is_dangerous is True
+
+    def test_docker_context_env_prefix(self):
+        is_dangerous, _, _ = detect_dangerous_command(
+            "DOCKER_CONTEXT=production docker ps")
+        assert is_dangerous is True
+
+    def test_container_host_env_prefix(self):
+        is_dangerous, _, _ = detect_dangerous_command(
+            "CONTAINER_HOST=ssh://root@prod:22/run/podman/podman.sock podman ps")
+        assert is_dangerous is True
+
+    def test_podman_url_flag(self):
+        is_dangerous, _, desc = detect_dangerous_command(
+            "podman --url ssh://core@remote:22/run/podman.sock ps")
+        assert is_dangerous is True
+        assert "daemon redirect" in desc
+
+    def test_podman_connection_flag(self):
+        is_dangerous, _, _ = detect_dangerous_command(
+            "podman --connection prod rm -f web")
+        assert is_dangerous is True
+
+    def test_podman_identity_flag(self):
+        is_dangerous, _, _ = detect_dangerous_command(
+            "podman --identity ~/.ssh/id_ed25519 --url ssh://x ps")
+        assert is_dangerous is True
+
+    def test_podman_remote_mode(self):
+        is_dangerous, _, desc = detect_dangerous_command("podman --remote ps")
+        assert is_dangerous is True
+        assert "remote mode" in desc
+
+    def test_podman_short_remote_flag(self):
+        is_dangerous, _, _ = detect_dangerous_command("podman -r images")
+        assert is_dangerous is True
+
+    # -- negatives: local docker usage stays out of the deny ----------------
+
+    def test_plain_docker_ps_not_flagged(self):
+        assert detect_dangerous_command("docker ps -a") == (False, None, None)
+
+    def test_docker_run_not_flagged(self):
+        assert detect_dangerous_command(
+            "docker run --rm -it alpine sh") == (False, None, None)
+
+    def test_docker_bare_help_flag_not_flagged(self):
+        # `docker -h` alone is help; the redirect rule requires a value token.
+        assert detect_dangerous_command("docker -h") == (False, None, None)
+
+    def test_docker_run_hostname_flag_not_flagged(self):
+        # `-h` in the subcommand position is `docker run --hostname`.
+        assert detect_dangerous_command(
+            "docker run -h myhost alpine") == (False, None, None)
+
+    def test_docker_build_not_flagged(self):
+        assert detect_dangerous_command(
+            "docker build -t myimage .") == (False, None, None)
+
+    def test_docker_context_ls_not_flagged(self):
+        assert detect_dangerous_command(
+            "docker context ls") == (False, None, None)
+
+    def test_podman_local_ps_not_flagged(self):
+        assert detect_dangerous_command("podman ps") == (False, None, None)
+
+    def test_podman_local_rm_not_misattributed_to_redirect(self):
+        is_dangerous, _, desc = detect_dangerous_command(
+            "podman rm old-container")
+        if is_dangerous:
+            assert "remote" not in desc
+
+
+class TestDockerLifecycleFlagInsertion:
+    """Global flags must not slip a lifecycle verb past the docker guard."""
+
+    def test_docker_stop_still_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command("docker stop app")
+        assert is_dangerous is True
+        assert "container lifecycle" in desc
+
+    def test_docker_stop_with_global_flag_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command(
+            "docker --log-level debug stop app")
+        assert is_dangerous is True
+        assert "container lifecycle" in desc
+
+    def test_docker_compose_down_with_file_flag_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command(
+            "docker compose -f docker-compose.prod.yml down")
+        assert is_dangerous is True
+        assert "container lifecycle" in desc
+
+    def test_legacy_docker_compose_binary_down_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command("docker-compose down")
+        assert is_dangerous is True
+        assert "container lifecycle" in desc
+
+    def test_docker_compose_up_not_flagged(self):
+        assert detect_dangerous_command(
+            "docker compose -f dev.yml up -d") == (False, None, None)
+
+    def test_docker_run_restart_policy_not_flagged(self):
+        assert detect_dangerous_command(
+            "docker run --restart=always -d nginx") == (False, None, None)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -690,8 +690,40 @@ DANGEROUS_PATTERNS = [
     # containers without approval.  These are agent-initiated lifecycle operations
     # that should always require user consent, just like `hermes gateway restart`
     # already does for the gateway process.
-    (r'\bdocker\s+compose\s+(restart|stop|kill|down)\b', "docker compose restart/stop/kill/down (container lifecycle)"),
-    (r'\bdocker\s+(restart|stop|kill)\b', "docker restart/stop/kill (container lifecycle)"),
+    # Docker/Podman daemon redirect — global flags or env prefixes that point
+    # the CLI at a DIFFERENT daemon, often a remote host over ssh/tcp.  A
+    # command that looks local (`docker -H ssh://prod stop app`) silently
+    # operates on remote infrastructure, so any docker/podman invocation
+    # carrying a redirect requires approval regardless of subcommand.  The
+    # redirect flag must appear in the global-flag position (before the
+    # subcommand) and -H/--host/--context must carry a value, which keeps
+    # `docker -h` (help) and subcommand flags like `docker run -h <hostname>`
+    # out of the deny.  Listed BEFORE the lifecycle rules so a redirected
+    # lifecycle command surfaces the more specific "remote daemon" reason.
+    # Inspired by Claude Code 2.1.214, which added permission prompts for
+    # docker/podman commands carrying daemon-redirect flags (--url,
+    # --connection, --identity, remote mode).
+    (r'\bdocker\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(?:-h|--host)[=\s]+\S+',
+     "docker with remote daemon redirect (-H/--host)"),
+    (r'\bdocker\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(?:-c|--context)[=\s]+\S+',
+     "docker with daemon redirect (--context: alternate daemon)"),
+    (r'\bdocker\s+context\s+use\b',
+     "docker context use (switches default daemon for future commands)"),
+    (r'\bpodman\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(?:--url|--connection|--identity)[=\s]+\S+',
+     "podman with remote daemon redirect (--url/--connection/--identity)"),
+    (r'\bpodman\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(?:-r\b|--remote\b)',
+     "podman remote mode (-r/--remote: remote daemon)"),
+    (r'\b(?:docker_host|docker_context|container_host|container_connection)=\S+',
+     "docker/podman daemon redirect via environment (DOCKER_HOST/CONTAINER_HOST)"),
+    # Allow global flags between `docker`/`compose` and the verb (e.g.
+    # `docker compose -f prod.yml down`, `docker --log-level debug stop app`)
+    # and the legacy hyphenated `docker-compose` binary, so a flag can't slip
+    # a lifecycle command past the guard — same treatment as the `hermes ...
+    # gateway` pattern above.
+    (r'\bdocker(?:-compose|\s+compose)\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(restart|stop|kill|down)\b',
+     "docker compose restart/stop/kill/down (container lifecycle)"),
+    (r'\bdocker\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(restart|stop|kill)\b',
+     "docker restart/stop/kill (container lifecycle)"),
     # Gateway protection: never start gateway outside systemd management
     (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -182,6 +182,10 @@ The following patterns trigger approval prompts (defined in `tools/approval.py`)
 | `sed -i` / `sed --in-place` on `/etc/` | In-place edit of system config |
 | `pkill`/`killall` hermes/gateway | Self-termination prevention |
 | `gateway run` with `&`/`disown`/`nohup`/`setsid` | Prevents starting gateway outside service manager |
+| `docker stop/kill/restart`, `docker compose down/stop/kill/restart` | Container lifecycle (also catches global flags and `docker-compose`) |
+| `docker -H`/`--host`/`--context`, `DOCKER_HOST=`/`DOCKER_CONTEXT=` | Docker daemon redirect — the command targets a different (often remote) daemon |
+| `docker context use` | Switches the default daemon for all future docker commands |
+| `podman --remote`/`-r`/`--url`/`--connection`/`--identity`, `CONTAINER_HOST=` | Podman remote daemon redirect |
 
 :::info
 **Container bypass**: When running in `docker`, `singularity`, `modal`, or `daytona` backends, dangerous command checks are **skipped** because the container itself is the security boundary. Destructive commands inside a container can't harm the host.


### PR DESCRIPTION
## Summary
Docker/Podman commands carrying a daemon redirect — global flags or env prefixes that point the CLI at a different, often remote, daemon — now require approval regardless of subcommand. Inspired by Claude Code 2.1.214 (July 2026), which added permission prompts for docker commands carrying daemon-redirect flags (`--url`, `--connection`, `--identity`, and Podman's remote mode) that previously ran without one.

**Source:** [Claude Code changelog, v2.1.214](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21214)

## Why
`docker -H ssh://prod-host stop app` looks like a local container operation but silently stops a container on production infrastructure. The existing guard only matched local lifecycle verbs directly adjacent to `docker`, so every redirected command — and even `docker --log-level debug stop app` — ran approval-free.

## Changes
- `tools/approval.py`: new DANGEROUS_PATTERNS entries —
  - `docker -H/--host <value>`, `docker --context <value>` (global-flag position only; value required so bare `docker -h` help and `docker run -h <hostname>` stay allowed)
  - `docker context use` (persistently switches the default daemon)
  - `podman --url/--connection/--identity <value>`, `podman -r/--remote`
  - `DOCKER_HOST=` / `DOCKER_CONTEXT=` / `CONTAINER_HOST=` / `CONTAINER_CONNECTION=` env prefixes
- Sibling-site widening: the docker lifecycle rules now tolerate global flags (same treatment as the `hermes ... gateway` rule) and cover `docker compose -f <file> down` and the legacy `docker-compose` binary, closing the flag-insertion evasion.
- Redirect rules are ordered before lifecycle rules so a redirected lifecycle command surfaces the more specific "remote daemon" reason.
- `tests/tools/test_docker_daemon_redirect.py`: 33 new tests (12 dangerous, 17 safe/negative + description-precedence checks).
- `website/docs/user-guide/security.md`: "What Triggers Approval" table rows for the docker/podman rules (the pre-existing lifecycle rules were also undocumented).

## How our implementation differs from Claude Code
| | Claude Code 2.1.214 | hermes-agent |
|---|---|---|
| Mechanism | permission-analyzer prompt | `DANGEROUS_PATTERNS` regex → approval flow (smart/manual/yolo aware) |
| Coverage | `--url`, `--connection`, `--identity`, podman remote mode | those + docker `-H/--host/--context`, `docker context use`, and `DOCKER_HOST=`-family env prefixes |
| Extra | — | closes the pre-existing flag-insertion evasion of the docker lifecycle rules (`docker --log-level debug stop app`, `docker compose -f prod.yml down`, `docker-compose down`) |

## Validation
| Check | Result |
|---|---|
| `tests/tools/test_docker_daemon_redirect.py` + `test_approval.py` | 339 passed |
| Adjacent guard suites (yolo, hardline, shell-bypass, gnu-long-option, execution-flag, cron-approval) | 442 passed, 1 skipped |
| E2E (real imports, temp HERMES_HOME): 12 dangerous flagged with correct descriptions, 17 safe commands untouched, none hardline | pass |
| Hot-path timing (pathological flag-heavy command) | ~330 µs/call |
| `ruff check` + `py_compile` on touched files | clean |

Not included (noted for scope): podman *local* lifecycle verbs (`podman stop/kill/restart`) remain un-gated, matching the pre-existing docker-only scope decision — flagging that separately rather than widening here.

## Infographic

![docker-daemon-redirect-guard](https://v3b.fal.media/files/b/0aa39985/bS9ow8EgdmLCViyVw_Hc6_p7ZxKUWk.png)
