### PR TITLE
fix(install): resolve Playwright command on Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -622,6 +622,49 @@ function Resolve-NpmCmd {
     return $npmExe
 }
 
+function Resolve-PlaywrightInvocation {
+    param(
+        [string]$InstallDir,
+        [string]$NpxExe
+    )
+
+    # npm workspaces may install Playwright only inside apps/desktop. A bare
+    # `npx playwright ...` can select that nested package without exposing its
+    # nested .bin directory to the child PATH (#70787), producing
+    # "playwright is not recognized".
+    # Prefer an installed binary, then make the fallback package explicit so
+    # npm exec always injects Playwright's bin directory.
+    $binDirs = @(
+        (Join-Path $InstallDir "node_modules/.bin"),
+        (Join-Path $InstallDir "apps/desktop/node_modules/.bin")
+    )
+    foreach ($binDir in $binDirs) {
+        foreach ($name in @("playwright.cmd", "playwright.exe", "playwright")) {
+            $candidate = Join-Path $binDir $name
+            if (Test-Path -LiteralPath $candidate) {
+                return [pscustomobject]@{
+                    Command = $candidate
+                    Arguments = @("install", "chromium")
+                }
+            }
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($NpxExe)) {
+        return [pscustomobject]@{
+            Command = $NpxExe
+            Arguments = @(
+                "--yes",
+                "--package=playwright",
+                "playwright",
+                "install",
+                "chromium"
+            )
+        }
+    }
+    return $null
+}
+
 function Find-SystemBrowser {
     # Honor ONLY an explicit, user-set AGENT_BROWSER_EXECUTABLE_PATH override.
     #
@@ -3072,10 +3115,13 @@ function Install-NodeDeps {
                 $npxCmd = Get-Command npx -ErrorAction SilentlyContinue
                 if ($npxCmd) { $npxExe = $npxCmd.Source }
             }
-            if (-not $npxExe) {
-                Write-Warn "npx not found -- cannot install Playwright Chromium."
-                Write-Info "Run manually later: cd `"$InstallDir`"; npx playwright install chromium"
+            $playwrightInvocation = Resolve-PlaywrightInvocation -InstallDir $InstallDir -NpxExe $npxExe
+            if (-not $playwrightInvocation) {
+                Write-Warn "Playwright command not found and npx is unavailable -- cannot install Chromium."
+                Write-Info "Run manually later: cd `"$InstallDir`"; npx --yes --package=playwright playwright install chromium"
             } else {
+                $pwCommand = $playwrightInvocation.Command
+                $pwArgs = @($playwrightInvocation.Arguments)
                 $pwLog = "$env:TEMP\hermes-playwright-install-$(Get-Random).log"
                 Push-Location $InstallDir
                 # Capture EAP outside the try block so the catch's restore call
@@ -3091,13 +3137,11 @@ function Install-NodeDeps {
                     # _Run-NpmInstall above for the same pattern and
                     # the rationale behind 2>&1 before the pipe.
                     Write-Info "(this can take several minutes -- streaming progress below)"
-                    # --yes auto-accepts npx's "Need to install playwright@X.Y.Z"
-                    # confirmation prompt.  Without it, npx 7+ blocks on stdin
-                    # waiting for a y/N answer that never comes when this is
-                    # invoked through a pipeline (Tee-Object disconnects stdin
-                    # from the user's TTY), and the install hangs indefinitely
-                    # after printing "Need to install the following packages:
-                    # playwright@X.Y.Z".
+                    # The resolver prefers the workspace-local Playwright
+                    # binary. Its npx fallback uses --package=playwright explicitly,
+                    # which both auto-injects the binary into PATH and avoids the
+                    # workspace inference failure from #70787. --yes suppresses
+                    # the package-install confirmation in the non-interactive pipeline.
                     #
                     # Relax EAP around the playwright invocation: playwright
                     # emits a "Chromium downloaded to ..." success banner to
@@ -3116,7 +3160,7 @@ function Install-NodeDeps {
                     # the user sees clean playwright output instead of the
                     # alarming-looking error formatting.
                     $ErrorActionPreference = "Continue"
-                    & $npxExe --yes playwright install chromium 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $pwLog
+                    & $pwCommand @pwArgs 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $pwLog
                     $pwCode = $LASTEXITCODE
                     $ErrorActionPreference = $prevEAP
                     if ($pwCode -eq 0) {
@@ -3136,12 +3180,12 @@ function Install-NodeDeps {
                                 Write-Info "  Full log: $pwLog"
                             }
                         }
-                        Write-Info "Run manually later: cd `"$InstallDir`"; npx playwright install chromium"
+                        Write-Info "Run manually later: cd `"$InstallDir`"; npx --yes --package=playwright playwright install chromium"
                     }
                 } catch {
                     if ($prevEAP) { $ErrorActionPreference = $prevEAP }
                     Write-Warn "Playwright Chromium install could not be launched: $_"
-                    Write-Info "Run manually later: cd `"$InstallDir`"; npx playwright install chromium"
+                    Write-Info "Run manually later: cd `"$InstallDir`"; npx --yes --package=playwright playwright install chromium"
                 } finally {
                     Pop-Location
                 }

--- a/scripts/tests/test-install-ps1-playwright-resolution.ps1
+++ b/scripts/tests/test-install-ps1-playwright-resolution.ps1
@@ -1,0 +1,85 @@
+# Unit tests for install.ps1's Playwright command resolution.
+# The installer itself is never executed: the helper is extracted through the
+# PowerShell AST so tests do not download packages or browsers.
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$installScript = Join-Path $repoRoot "scripts/install.ps1"
+
+$failures = 0
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Label)
+    if ($Expected -ne $Actual) {
+        Write-Host "FAIL: $Label" -ForegroundColor Red
+        Write-Host "  expected: $Expected"
+        Write-Host "  actual:   $Actual"
+        $script:failures++
+    } else {
+        Write-Host "OK: $Label" -ForegroundColor Green
+    }
+}
+function Assert-True {
+    param($Condition, [string]$Label)
+    if (-not $Condition) {
+        Write-Host "FAIL: $Label" -ForegroundColor Red
+        $script:failures++
+    } else {
+        Write-Host "OK: $Label" -ForegroundColor Green
+    }
+}
+
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $installScript, [ref]$tokens, [ref]$parseErrors
+)
+if ($parseErrors.Count -gt 0) {
+    throw "install.ps1 has parse errors: $($parseErrors -join '; ')"
+}
+
+$fnAst = $ast.FindAll(
+    {
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq "Resolve-PlaywrightInvocation"
+    }, $true
+) | Select-Object -First 1
+if (-not $fnAst) {
+    throw "Resolve-PlaywrightInvocation not found in install.ps1"
+}
+. ([scriptblock]::Create($fnAst.Extent.Text))
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("hermes-pw-test-" + [guid]::NewGuid())
+try {
+    $workspaceBin = Join-Path $tempRoot "apps/desktop/node_modules/.bin"
+    New-Item -ItemType Directory -Force -Path $workspaceBin | Out-Null
+    $localPlaywright = Join-Path $workspaceBin "playwright.cmd"
+    Set-Content -Path $localPlaywright -Value "@echo off" -Encoding Ascii
+
+    $local = Resolve-PlaywrightInvocation -InstallDir $tempRoot -NpxExe "C:\Node\npx.cmd"
+    Assert-Equal $localPlaywright $local.Command "prefers installed Desktop workspace binary"
+    Assert-Equal "install|chromium" ($local.Arguments -join "|") "local binary receives install args"
+
+    Remove-Item -Force $localPlaywright
+    $fallback = Resolve-PlaywrightInvocation -InstallDir $tempRoot -NpxExe "C:\Node\npx.cmd"
+    Assert-Equal "C:\Node\npx.cmd" $fallback.Command "falls back to resolved npx"
+    Assert-Equal "--yes|--package=playwright|playwright|install|chromium" `
+        ($fallback.Arguments -join "|") `
+        "fallback explicitly injects the Playwright package bin"
+
+    $missing = Resolve-PlaywrightInvocation -InstallDir $tempRoot -NpxExe $null
+    Assert-Equal $null $missing "returns null when neither local binary nor npx exists"
+
+    $source = Get-Content $installScript -Raw
+    Assert-True ($source.Contains("Resolve-PlaywrightInvocation -InstallDir `$InstallDir -NpxExe `$npxExe")) `
+        "Install-NodeDeps uses the shared resolver"
+} finally {
+    Remove-Item -Recurse -Force $tempRoot -ErrorAction SilentlyContinue
+}
+
+if ($failures -gt 0) {
+    Write-Host "FAILED: $failures assertion(s) failed" -ForegroundColor Red
+    exit 1
+}
+Write-Host "All Playwright resolution tests passed." -ForegroundColor Green
+exit 0

--- a/scripts/tests/test-install-ps1-playwright-resolution.ps1
+++ b/scripts/tests/test-install-ps1-playwright-resolution.ps1
@@ -18,16 +18,6 @@ function Assert-Equal {
         Write-Host "OK: $Label" -ForegroundColor Green
     }
 }
-function Assert-True {
-    param($Condition, [string]$Label)
-    if (-not $Condition) {
-        Write-Host "FAIL: $Label" -ForegroundColor Red
-        $script:failures++
-    } else {
-        Write-Host "OK: $Label" -ForegroundColor Green
-    }
-}
-
 $tokens = $null
 $parseErrors = $null
 $ast = [System.Management.Automation.Language.Parser]::ParseFile(
@@ -51,14 +41,23 @@ if (-not $fnAst) {
 
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("hermes-pw-test-" + [guid]::NewGuid())
 try {
+    $rootBin = Join-Path $tempRoot "node_modules/.bin"
     $workspaceBin = Join-Path $tempRoot "apps/desktop/node_modules/.bin"
+    New-Item -ItemType Directory -Force -Path $rootBin | Out-Null
     New-Item -ItemType Directory -Force -Path $workspaceBin | Out-Null
+    $rootPlaywright = Join-Path $rootBin "playwright.cmd"
     $localPlaywright = Join-Path $workspaceBin "playwright.cmd"
+    Set-Content -Path $rootPlaywright -Value "@echo off" -Encoding Ascii
     Set-Content -Path $localPlaywright -Value "@echo off" -Encoding Ascii
 
+    $hoisted = Resolve-PlaywrightInvocation -InstallDir $tempRoot -NpxExe "C:\Node\npx.cmd"
+    Assert-Equal $rootPlaywright $hoisted.Command "prefers root-hoisted Playwright binary"
+    Assert-Equal "install|chromium" ($hoisted.Arguments -join "|") "hoisted binary receives install args"
+
+    Remove-Item -Force $rootPlaywright
     $local = Resolve-PlaywrightInvocation -InstallDir $tempRoot -NpxExe "C:\Node\npx.cmd"
-    Assert-Equal $localPlaywright $local.Command "prefers installed Desktop workspace binary"
-    Assert-Equal "install|chromium" ($local.Arguments -join "|") "local binary receives install args"
+    Assert-Equal $localPlaywright $local.Command "falls back to nested Desktop workspace binary"
+    Assert-Equal "install|chromium" ($local.Arguments -join "|") "nested binary receives install args"
 
     Remove-Item -Force $localPlaywright
     $fallback = Resolve-PlaywrightInvocation -InstallDir $tempRoot -NpxExe "C:\Node\npx.cmd"
@@ -70,9 +69,6 @@ try {
     $missing = Resolve-PlaywrightInvocation -InstallDir $tempRoot -NpxExe $null
     Assert-Equal $null $missing "returns null when neither local binary nor npx exists"
 
-    $source = Get-Content $installScript -Raw
-    Assert-True ($source.Contains("Resolve-PlaywrightInvocation -InstallDir `$InstallDir -NpxExe `$npxExe")) `
-        "Install-NodeDeps uses the shared resolver"
 } finally {
     Remove-Item -Recurse -Force $tempRoot -ErrorAction SilentlyContinue
 }

--- a/tests/test_install_ps1_playwright_resolution.py
+++ b/tests/test_install_ps1_playwright_resolution.py
@@ -1,0 +1,31 @@
+"""Regression coverage for Windows Playwright command resolution (#70787)."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+PS_TEST = REPO_ROOT / "scripts" / "tests" / "test-install-ps1-playwright-resolution.ps1"
+
+
+def test_installer_uses_explicit_playwright_package_fallback() -> None:
+    source = INSTALL_PS1.read_text(encoding="ascii")
+
+    assert "Resolve-PlaywrightInvocation -InstallDir $InstallDir -NpxExe $npxExe" in source
+    assert '"apps/desktop/node_modules/.bin"' in source
+    assert '"--package=playwright"' in source
+    assert "& $pwCommand @pwArgs" in source
+    assert "& $npxExe --yes playwright install chromium" not in source
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="PowerShell is unavailable")
+def test_playwright_resolver_behavior() -> None:
+    subprocess.run(
+        ["pwsh", "-NoProfile", "-File", str(PS_TEST)],
+        cwd=REPO_ROOT,
+        check=True,
+    )

--- a/tests/test_install_ps1_playwright_resolution.py
+++ b/tests/test_install_ps1_playwright_resolution.py
@@ -8,18 +8,7 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
 PS_TEST = REPO_ROOT / "scripts" / "tests" / "test-install-ps1-playwright-resolution.ps1"
-
-
-def test_installer_uses_explicit_playwright_package_fallback() -> None:
-    source = INSTALL_PS1.read_text(encoding="ascii")
-
-    assert "Resolve-PlaywrightInvocation -InstallDir $InstallDir -NpxExe $npxExe" in source
-    assert '"apps/desktop/node_modules/.bin"' in source
-    assert '"--package=playwright"' in source
-    assert "& $pwCommand @pwArgs" in source
-    assert "& $npxExe --yes playwright install chromium" not in source
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason="PowerShell is unavailable")


### PR DESCRIPTION
## Summary

Fix the Windows PowerShell install path that can reach the Playwright step and then fail with:

```text
'playwright' is not recognized as an internal or external command
```

The root npm install is workspace-aware, so Playwright may be hoisted at the repository root or remain under `apps/desktop/node_modules/.bin`. A bare `npx playwright ...` can also select a nested package without making its executable available to the child `PATH`.

## Changes

- prefer an already-installed Playwright executable from either:
  - `node_modules/.bin`
  - `apps/desktop/node_modules/.bin`
- when no local binary exists, use an explicit npx package context:
  - `npx --yes --package=playwright playwright install chromium`
- retain the existing streamed output, exit-code handling, logs, and non-fatal browser-install behavior;
- update the manual recovery command to use the same reliable invocation;
- remove Python source-string assertions and the analogous PowerShell `Get-Content`/source-shape assertion;
- retain behavior-level resolver fixtures for root-hoisted, nested-workspace, explicit npx-package fallback, and unavailable-command outcomes.

No dependency manifest, global npm install, or installer stage protocol changes.

Fixes #70787.

## Regression coverage

The PowerShell fixture invokes the resolver behavior with temporary workspace layouts and asserts:

- a root-hoisted `playwright.cmd` wins when present;
- the nested `apps/desktop/node_modules/.bin/playwright.cmd` is selected when the root executable is absent;
- no local executable yields `npx.cmd --yes --package=playwright playwright install chromium`;
- no local executable and no npx yields `$null`, preserving non-fatal unavailable-command handling.

The pytest wrapper executes that fixture under `pwsh`; it no longer reads `install.ps1` or asserts implementation strings.

## Verification

- rebased cleanly onto current `main` (`f51aa6a9`);
- PowerShell resolver fixture: **7 behavior assertions passed**;
- all `tests/test_install_ps1_*.py` files: **18 passed, 1 skipped across 8 files**;
- full `install.ps1` AST parse: clean;
- focused Ruff: passed;
- `git diff --check`: clean.
- upstream `All required checks pass`: green, including the PowerShell installer lane.


