### PR TITLE
fix(gateway): force reconnect stale Signal SSE streams

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -503,22 +503,34 @@ class SignalAdapter(BasePlatformAdapter):
 
             elapsed = time.time() - self._last_sse_activity
             if elapsed > HEALTH_CHECK_STALE_THRESHOLD:
-                logger.warning("Signal: SSE idle for %.0fs, checking daemon health", elapsed)
+                # Keepalives (":" comments ~every 15s) and data events both
+                # refresh _last_sse_activity. Crossing this threshold means the
+                # SSE stream itself is hung — daemon HTTP health is not proof
+                # the receive path is alive (see #3316). Reconnect first; /check
+                # is diagnostics only and must not delay cutting the hung stream.
+                logger.warning(
+                    "Signal: SSE idle for %.0fs (no events/keepalives); forcing reconnect",
+                    elapsed,
+                )
+                self._force_reconnect()
                 try:
                     resp = await self.client.get(
                         f"{self.http_url}/api/v1/check", timeout=10.0
                     )
                     if resp.status_code == 200:
-                        # Daemon is alive but SSE is idle — update activity to
-                        # avoid repeated warnings (connection may just be quiet)
-                        self._last_sse_activity = time.time()
-                        logger.debug("Signal: daemon healthy, SSE idle")
+                        logger.debug(
+                            "Signal: daemon healthy but SSE was stale "
+                            "(reconnect already requested)"
+                        )
                     else:
-                        logger.warning("Signal: health check failed (%d), forcing reconnect", resp.status_code)
-                        self._force_reconnect()
+                        logger.warning(
+                            "Signal: health check failed (%d) during SSE stale reconnect",
+                            resp.status_code,
+                        )
                 except Exception as e:
-                    logger.warning("Signal: health check error: %s, forcing reconnect", e)
-                    self._force_reconnect()
+                    logger.warning(
+                        "Signal: health check error during SSE stale reconnect: %s", e
+                    )
 
     def _force_reconnect(self) -> None:
         """Force SSE reconnection by closing the current response."""

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -2587,3 +2587,107 @@ class TestRecentSentTimestampRing:
         adapter._track_sent_timestamp({"timestamp": 3})
         # Both 1 and 2 should be evicted on TTL, only 3 remains
         assert list(adapter._recent_sent_timestamps.keys()) == [3]
+
+
+# ---------------------------------------------------------------------------
+# SSE health monitor — hung stream vs daemon HTTP
+# ---------------------------------------------------------------------------
+
+class TestSignalSseHealthMonitor:
+    """Stale SSE must force reconnect even when daemon /check is still 200."""
+
+    @staticmethod
+    async def _run_one_health_cycle(adapter):
+        """Drive one monitor iteration then stop the loop."""
+        sleep_calls = {"n": 0}
+
+        async def fake_sleep(_):
+            sleep_calls["n"] += 1
+            if sleep_calls["n"] >= 2:
+                adapter._running = False
+
+        with patch("gateway.platforms.signal.asyncio.sleep", fake_sleep), \
+             patch.object(adapter, "_force_reconnect") as mock_reconnect:
+            await adapter._health_monitor()
+        return mock_reconnect
+
+    @pytest.mark.asyncio
+    async def test_forces_reconnect_when_daemon_healthy_but_sse_stale(self, monkeypatch):
+        import time as time_module
+
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.client = AsyncMock()
+        call_order = []
+
+        async def fake_get(*args, **kwargs):
+            call_order.append("get")
+            return MagicMock(status_code=200)
+
+        def tracking_reconnect():
+            call_order.append("reconnect")
+
+        adapter.client.get = AsyncMock(side_effect=fake_get)
+        adapter._running = True
+        adapter._last_sse_activity = time_module.time() - 200
+        stale_at = adapter._last_sse_activity
+
+        sleep_calls = {"n": 0}
+
+        async def fake_sleep(_):
+            sleep_calls["n"] += 1
+            if sleep_calls["n"] >= 2:
+                adapter._running = False
+
+        with patch("gateway.platforms.signal.asyncio.sleep", fake_sleep), \
+             patch.object(adapter, "_force_reconnect", side_effect=tracking_reconnect) as mock_reconnect:
+            await adapter._health_monitor()
+
+        adapter.client.get.assert_awaited_once_with(
+            "http://localhost:8080/api/v1/check", timeout=10.0
+        )
+        mock_reconnect.assert_called_once()
+        assert adapter._last_sse_activity == stale_at
+        assert call_order == ["reconnect", "get"]
+
+    @pytest.mark.asyncio
+    async def test_forces_reconnect_when_health_check_unhealthy(self, monkeypatch):
+        import time as time_module
+
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.client = AsyncMock()
+        adapter.client.get = AsyncMock(return_value=MagicMock(status_code=500))
+        adapter._running = True
+        adapter._last_sse_activity = time_module.time() - 200
+
+        mock_reconnect = await self._run_one_health_cycle(adapter)
+
+        mock_reconnect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_forces_reconnect_when_health_check_raises(self, monkeypatch):
+        import time as time_module
+
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.client = AsyncMock()
+        adapter.client.get = AsyncMock(side_effect=OSError("connection refused"))
+        adapter._running = True
+        adapter._last_sse_activity = time_module.time() - 200
+
+        mock_reconnect = await self._run_one_health_cycle(adapter)
+
+        mock_reconnect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_does_not_reconnect_when_sse_activity_is_fresh(self, monkeypatch):
+        import time as time_module
+
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.client = AsyncMock()
+        adapter.client.get = AsyncMock(return_value=MagicMock(status_code=200))
+        adapter._running = True
+        adapter._last_sse_activity = time_module.time()
+
+        mock_reconnect = await self._run_one_health_cycle(adapter)
+
+        adapter.client.get.assert_not_awaited()
+        mock_reconnect.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Fixes a Signal gateway bug where inbound messages could stop permanently while the adapter still looked connected. When the SSE receive stream stalled for more than 120 seconds, the health monitor refreshed the idle clock if the daemon HTTP check returned 200 instead of forcing a reconnect.

### Bug Cause

In `gateway/platforms/signal.py`, `_health_monitor()` treated a 200 from `GET /api/v1/check` as proof the receive path was healthy and reset `_last_sse_activity`. After #3316, signal-cli sends SSE `:` keepalive comments about every 15 seconds, so crossing `HEALTH_CHECK_STALE_THRESHOLD` (120s) means the stream itself is hung, not merely quiet. Resetting the idle clock left the dead SSE connection open and `_sse_listener()` never entered its reconnect/backoff loop.

### Reproduction Steps

1. Start the Hermes gateway with Signal enabled and confirm inbound messages work.
2. Stall the SSE stream to `/api/v1/events` (for example proxy drops further bytes, half-open TCP, or a stuck daemon event thread) while `GET /api/v1/check` still returns 200.
3. Wait more than 120 seconds without SSE keepalives or data events.
4. Send a Signal message to the bot.

Expected: the health monitor forces an SSE reconnect and inbound messages resume.
Before fix: logs show repeated "daemon healthy, SSE idle" debug lines, `_last_sse_activity` keeps getting refreshed, and inbound messages never resume until process restart.

### Fix

When SSE activity is stale, call `_force_reconnect()` immediately. The daemon `/check` probe runs afterward for diagnostics only and no longer refreshes `_last_sse_activity`. Added `TestSignalSseHealthMonitor` to lock reconnect-on-stale behavior, call order (reconnect before probe), and the no-clock-refresh invariant.

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/signal.py` - force reconnect on stale SSE before the diagnostic daemon health probe
- `tests/gateway/test_signal.py` - add `TestSignalSseHealthMonitor` coverage for stale/fresh/unhealthy/error paths

## How to Test

1. Manual: reproduce the stalled SSE scenario above and confirm the gateway logs a stale SSE warning, calls `_force_reconnect()`, and inbound messages resume without restarting the process.
2. Automated (already run locally, 141 passed):

```bash
scripts/run_tests.sh tests/gateway/test_signal.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A
