### PR TITLE
fix(streaming): never close OpenAI shared client from watchdog

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3440,17 +3440,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         )
                         _cancel_current_stream_attempt("stream_mid_tool_retry_cleanup")
                         _close_request_client_once("stream_mid_tool_retry_cleanup")
-                        # #67142: anthropic streams on a request-local client,
-                        # already worker-owned-closed by _close_request_client_once
-                        # above; the next attempt builds a fresh one. The shared
-                        # _anthropic_client is never closed from inside a request.
-                        if agent.api_mode != "anthropic_messages":
-                            try:
-                                agent._replace_primary_openai_client(
-                                    reason="stream_mid_tool_retry_pool_cleanup"
-                                )
-                            except Exception:
-                                pass
+                        # #70773 / #67142: every stream (anthropic OR OpenAI-wire)
+                        # runs on a request-local client, already worker-owned-
+                        # closed by _close_request_client_once above; the next
+                        # attempt builds a fresh one. The shared client
+                        # (_anthropic_client / agent.client) is never closed from
+                        # inside a request — closing the shared OpenAI-wire pool
+                        # here (formerly _replace_primary_openai_client) could
+                        # release a TLS FD that a sibling in-flight request still
+                        # holds, recycling it onto a SQLite header (#70773).
                         continue
 
                     # SSE error events from proxies (e.g. OpenRouter sends
@@ -3503,19 +3501,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             # Close the stale request client before retry
                             _cancel_current_stream_attempt("stream_retry_cleanup")
                             _close_request_client_once("stream_retry_cleanup")
-                            # Also rebuild the primary client to purge any dead
-                            # connections from the pool. #67142: anthropic uses a
-                            # request-local client (already worker-owned-closed
-                            # above; next attempt builds fresh), so the shared
-                            # _anthropic_client is never closed from inside a
-                            # request — only the OpenAI-wire primary is refreshed.
-                            if agent.api_mode != "anthropic_messages":
-                                try:
-                                    agent._replace_primary_openai_client(
-                                        reason="stream_retry_pool_cleanup"
-                                    )
-                                except Exception:
-                                    pass
+                            # #70773 / #67142: every stream (anthropic OR
+                            # OpenAI-wire) uses a request-local client, already
+                            # worker-owned-closed above; the next attempt builds a
+                            # fresh one, so there are no dead connections to purge
+                            # from a shared pool. The shared client
+                            # (_anthropic_client / agent.client) is never closed
+                            # from inside a request — replacing the shared
+                            # OpenAI-wire client here (formerly
+                            # _replace_primary_openai_client) closed a pool that a
+                            # sibling in-flight request could still hold, releasing
+                            # a TLS FD the kernel recycled onto a SQLite header
+                            # (#70773; #67142 was the anthropic instance).
                             continue
                         # Retries exhausted. Log the final failure with
                         # full diagnostic detail (chain, headers,
@@ -3746,22 +3743,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Circuit breaker (#58962): count the stale kill.  See the
             # canonical comment block above ``_stale_streak()``.
             _bump_stale_streak(agent)
-            # Rebuild the primary client too — its connection pool
-            # may hold dead sockets from the same provider outage.
-            if agent.api_mode == "anthropic_messages":
-                # #67142: the stale stream ran on a request-local anthropic
-                # client, already socket-aborted above via
-                # _close_request_client_once (which unblocks the worker and
-                # preserves the #28161 no-hang guarantee). The shared
-                # _anthropic_client is NOT the in-flight transport, so we must
-                # not close it from this poll (stranger) thread — that was the
-                # FD-recycle corruption vector. Nothing further is needed.
-                pass
-            else:
-                try:
-                    agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
-                except Exception:
-                    pass
+            # #70773 / #67142: the stale stream ran on a *request-local* client
+            # (anthropic OR OpenAI-wire), already socket-aborted above via
+            # _close_request_client_once from this poll (stranger) thread, which
+            # unblocks the worker and preserves the #28161 no-hang guarantee.
+            # The shared client (agent._anthropic_client / agent.client) is NOT
+            # this stream's transport, so we must not close/replace it from this
+            # poll thread: doing so releases a TLS FD that a still-unwinding
+            # worker from a prior stale-killed attempt can write into after the
+            # kernel recycles it onto an unrelated SQLite handle (#70773 was the
+            # OpenAI-wire instance of this; #67142 the anthropic one). The next
+            # retry attempt builds a fresh request-local client, so there is no
+            # stale shared pool to purge here. Nothing further is needed.
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()

--- a/tests/run_agent/test_70773_openai_wire_stream_pool_cleanup.py
+++ b/tests/run_agent/test_70773_openai_wire_stream_pool_cleanup.py
@@ -1,0 +1,229 @@
+"""OpenAI-wire stream cleanup must NOT close/replace the shared OpenAI client
+from the stale/interrupt/retry watchdog — the request-local client (#29507)
+is the only thing that may be torn down from a request (#70773).
+
+#67142 fixed this exact bug class for the Anthropic path (the stale watchdog
+closing the shared _anthropic_client from the poll/stranger thread released a
+live TLS FD that the kernel recycled onto a SQLite header, corrupting the DB).
+But the OpenAI-wire path kept calling _replace_primary_openai_client() at three
+cleanup sites (stale_stream / stream_retry / stream_mid_tool_retry), which swaps
+self.client and closes the *old shared pool* — from the watchdog thread for the
+stale site, and from a request worker for the retry sites — while sibling/
+prior-attempt workers may still hold sockets from that pool. #70773 is the
+production forensic report of that OpenAI-wire instance corrupting kanban.db.
+
+Since the fix, every OpenAI-wire stream runs on a per-request client that the
+watchdog aborts (stranger thread) or the owning worker closes — the shared
+client is never closed from inside a request. These tests assert
+_replace_primary_openai_client is never called from any of the three cleanup
+sites, while the request-local abort/close still fires (no #28161 hang).
+
+Fixes #70773. Extends #67142.
+"""
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_openai_agent(**kwargs):
+    from run_agent import AIAgent
+
+    defaults = dict(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    defaults.update(kwargs)
+    agent = AIAgent(**defaults)
+    # OpenAI-wire (chat_completions) — the custom-provider path in #70773.
+    agent.api_mode = "chat_completions"
+    return agent
+
+
+def _chunk(content=None, tool_calls=None, finish_reason=None, model=None):
+    delta = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model=model, usage=None)
+
+
+def _tool_call_delta(index=0, tc_id=None, name=None, arguments=None):
+    func = SimpleNamespace(name=name, arguments=arguments)
+    return SimpleNamespace(index=index, id=tc_id, function=func)
+
+
+class _Stream:
+    """Minimal OpenAI-wire stream: an iterable with a .response (for diag
+    header snapshotting). Deliberately NOT a MagicMock so it exposes no
+    ``choices`` attribute (which would trip the non-iterator fast path)."""
+
+    def __init__(self, chunks_or_gen):
+        self.response = SimpleNamespace(headers={})
+        self._src = chunks_or_gen
+
+    def __iter__(self):
+        src = self._src
+        return src() if callable(src) else iter(src)
+
+
+def _good_chunks():
+    return [
+        _chunk(content="ok final"),
+        _chunk(finish_reason="stop", model="test/model"),
+    ]
+
+
+class TestOpenAIWireStreamPoolCleanup:
+    """OpenAI-wire cleanup must never close/replace the shared OpenAI client;
+    only the request-local client is torn down (#70773 / #67142 / #29507)."""
+
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+    )
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    def test_stream_retry_does_not_replace_shared_client(
+        self, mock_create, mock_close, mock_abort, mock_replace, monkeypatch
+    ):
+        """Transient ConnectError on a fresh stream → retry on a new
+        request-local client; the shared client is NEVER replaced (that was the
+        stream_retry_pool_cleanup FD-recycle vector), and the worker closes its
+        own request client from its own thread."""
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+
+        agent = _make_openai_agent()
+        mock_client = MagicMock()
+        mock_create.return_value = mock_client
+
+        attempt = [0]
+
+        def _create_side_effect(**kwargs):
+            attempt[0] += 1
+            if attempt[0] == 1:
+                raise httpx.ConnectError("connection reset by peer")
+            return _Stream(_good_chunks())
+
+        mock_client.chat.completions.create.side_effect = _create_side_effect
+
+        agent._interrupt_requested = False
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response is not None
+        assert attempt[0] == 2  # failed once, retried, succeeded
+        # THE fix: shared OpenAI client never swapped/closed from the retry site.
+        mock_replace.assert_not_called()
+        # The stale request client is closed by its owning worker thread.
+        mock_close.assert_called()
+
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+    )
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    def test_stale_stream_aborts_request_client_not_shared(
+        self, mock_create, mock_close, mock_abort, mock_replace, monkeypatch
+    ):
+        """Stale-stream outer-poll detector → aborts the request-local client's
+        socket from the poll (stranger) thread and retries; it must NEVER call
+        _replace_primary_openai_client (the #70773 corruption vector: closing
+        the shared pool from the watchdog thread while a worker unwinds)."""
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.1")
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+
+        agent = _make_openai_agent()
+        mock_client = MagicMock()
+        mock_create.return_value = mock_client
+        unblock = threading.Event()
+        attempt = [0]
+
+        def _create_side_effect(**kwargs):
+            attempt[0] += 1
+            if attempt[0] == 1:
+                def _blocking_gen():
+                    # Yields nothing → trips the stale detector; unblocks only
+                    # when the poll thread aborts the request client's socket.
+                    unblock.wait(timeout=5.0)
+                    raise httpx.ConnectError("connection dropped after abort")
+                    yield  # make this a generator
+                return _Stream(_blocking_gen)
+            return _Stream(_good_chunks())
+
+        mock_client.chat.completions.create.side_effect = _create_side_effect
+        # Poll thread aborts the request-local client's socket (not close() on
+        # the shared client); simulate the shutdown waking the blocked read.
+        mock_abort.side_effect = lambda *a, **k: unblock.set()
+
+        agent._interrupt_requested = False
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response is not None
+        assert attempt[0] >= 2  # stale-killed once, then retried
+        mock_replace.assert_not_called()
+        # The poll (stranger) thread aborted the request-local client's socket.
+        assert mock_abort.called
+
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+    )
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    def test_mid_tool_retry_does_not_replace_shared_client(
+        self, mock_create, mock_close, mock_abort, mock_replace, monkeypatch
+    ):
+        """A mid-tool-call transient drop (deltas already sent + tool in-flight)
+        triggers the stream_mid_tool_retry cleanup + silent retry. That site
+        must NOT replace the shared OpenAI client either (#70773)."""
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+
+        agent = _make_openai_agent()
+        mock_client = MagicMock()
+        mock_create.return_value = mock_client
+        attempt = [0]
+
+        def _create_side_effect(**kwargs):
+            attempt[0] += 1
+            if attempt[0] == 1:
+                def _gen():
+                    # Deliver a tool-call delta (marks a tool in-flight and
+                    # sets deltas_were_sent), then drop the connection.
+                    yield _chunk(
+                        tool_calls=[
+                            _tool_call_delta(index=0, tc_id="call_1", name="terminal")
+                        ]
+                    )
+                    raise httpx.RemoteProtocolError("peer closed connection")
+                return _Stream(_gen)
+            return _Stream(_good_chunks())
+
+        mock_client.chat.completions.create.side_effect = _create_side_effect
+
+        agent._interrupt_requested = False
+        agent._interruptible_streaming_api_call({})
+
+        assert attempt[0] == 2  # mid-tool drop, then silent retry
+        mock_replace.assert_not_called()
+        mock_close.assert_called()
+
+


### PR DESCRIPTION
## Summary
Fixes #70773 - OpenAI-wire watchdog closes shared client from non-owner thread

## Changes
- Extend #67142's owner-thread discipline to OpenAI-wire else-branch
- Remove shared-client close from 3 streaming cleanup sites
- Add regression test for OpenAI-wire streaming pool cleanup
- Update existing tests asserting old behavior

## Testing
- ✅ Added test_70773_openai_wire_stream_pool_cleanup.py
- ✅ Updated existing streaming tests
- ✅ Test suite passed

## Related
Fixes #70773