### PR TITLE
fix(mcp): clean up stale OAuth cache when auth type changes (#60313)

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -5,7 +5,7 @@ import os
 import stat
 import sys
 from io import BytesIO
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
@@ -135,39 +135,6 @@ class TestHermesTokenStorage:
 
         assert storage.has_cached_tokens()
 
-    def test_cleanup_stale_cache_when_auth_type_not_oauth(self, tmp_path, monkeypatch):
-        """When auth type changes from oauth to non-oauth, stale cache is cleaned."""
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        storage = HermesTokenStorage("cloudflare")
-
-        # Simulate previous OAuth usage: create client.json and tokens
-        d = tmp_path / "mcp-tokens"
-        d.mkdir(parents=True)
-        (d / "cloudflare.json").write_text('{"access_token": "old", "token_type": "Bearer"}')
-        (d / "cloudflare.client.json").write_text('{"client_id": "some-id"}')
-        (d / "cloudflare.meta.json").write_text('{"token_endpoint": "https://example.com/token"}')
-
-        assert storage.has_cached_tokens()
-        assert storage._client_info_path().exists()
-
-        # This simulates the cleanup path in MCPServerTask._connect()
-        # when _auth_type != "oauth": check for stale client.json, then remove all
-        storage.remove()
-
-        # All three OAuth cache files should be gone
-        assert not (d / "cloudflare.json").exists()
-        assert not (d / "cloudflare.client.json").exists()
-        assert not (d / "cloudflare.meta.json").exists()
-
-    def test_cleanup_stale_cache_noop_when_no_files(self, tmp_path, monkeypatch):
-        """Cleanup is a no-op when no stale cache files exist."""
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        storage = HermesTokenStorage("new-server")
-
-        # No files exist — remove() should not raise
-        assert not storage._client_info_path().exists()
-        storage.remove()  # Should not raise
-
     def test_corrupt_tokens_returns_none(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         storage = HermesTokenStorage("bad-server")
@@ -189,6 +156,113 @@ class TestHermesTokenStorage:
 
         import asyncio
         assert asyncio.run(storage.get_client_info()) is None
+
+
+class TestNonOAuthStaleCacheCleanup:
+    """Regression coverage for #60313 — ``MCPServerTask._run_http()`` must
+    remove the orphaned OAuth cache files when the server's auth type is not
+    ``oauth`` (e.g. a user switched ``auth: oauth`` to headers or removed it).
+
+    These tests drive the real production branch (the ``else`` in
+    ``_run_http``) with the transport mocked, rather than calling
+    ``HermesTokenStorage.remove()`` directly, so they fail if the cleanup
+    branch is ever dropped.
+    """
+
+    @staticmethod
+    def _drive_non_oauth_run_http(tmp_path, monkeypatch, *, auth_type: str = "headers"):
+        """Run ``MCPServerTask._run_http`` with non-OAuth auth against a temp
+        HERMES_HOME, with the SSE transport and session lifecycle mocked."""
+        from tools.mcp_tool import MCPServerTask
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        server = MCPServerTask("cf-server")
+        server._auth_type = auth_type
+        server._sampling = None
+
+        class _FakeStream:
+            def __init__(self):
+                self._read = AsyncMock()
+                self._write = AsyncMock()
+
+            async def __aenter__(self):
+                return (self._read, self._write)
+
+            async def __aexit__(self, *a):
+                return False
+
+        def fake_sse_client(**kwargs):
+            return _FakeStream()
+
+        class _FakeSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                mock_session = MagicMock()
+                mock_session.initialize = AsyncMock()
+                return mock_session
+
+            async def __aexit__(self, *a):
+                return False
+
+        async def drive():
+            with patch("tools.mcp_tool.sse_client", new=fake_sse_client), \
+                 patch("tools.mcp_tool.ClientSession", new=_FakeSession), \
+                 patch.object(MCPServerTask, "_wait_for_lifecycle_event",
+                              new=AsyncMock(return_value="shutdown")), \
+                 patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()):
+                await asyncio.wait_for(
+                    server._run_http({
+                        "url": "https://example.com/mcp/sse",
+                        "transport": "sse",
+                        "timeout": 60,
+                    }),
+                    timeout=2.0,
+                )
+
+        try:
+            asyncio.run(drive())
+        except Exception:
+            # The fakes only exist to get past transport setup; the cleanup
+            # under test has already run by the time transport starts, so
+            # transport teardown noise must not fail the assertions below.
+            pass
+        return server
+
+    def test_run_http_non_oauth_removes_stale_oauth_cache(self, tmp_path, monkeypatch):
+        """Switching from oauth to headers auth must delete token, client, and
+        metadata files through the real ``_run_http`` cleanup branch."""
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        (d / "cf-server.json").write_text('{"access_token": "old", "token_type": "Bearer"}')
+        (d / "cf-server.client.json").write_text('{"client_id": "some-id"}')
+        (d / "cf-server.meta.json").write_text('{"token_endpoint": "https://example.com/token"}')
+
+        server = self._drive_non_oauth_run_http(tmp_path, monkeypatch)
+
+        # The connect must have reached the ready state — proving the cleanup
+        # branch executed and the transport completed, not just that no files
+        # were created (a pre-cleanup _run_http failure must fail this test).
+        assert server._ready.is_set()
+
+        # All three OAuth cache files must be gone after the non-OAuth connect
+        assert not (d / "cf-server.json").exists()
+        assert not (d / "cf-server.client.json").exists()
+        assert not (d / "cf-server.meta.json").exists()
+
+    def test_run_http_non_oauth_cleanup_is_noop_without_cache(self, tmp_path, monkeypatch):
+        """Cleanup is a no-op when no stale cache exists — the connect must
+        succeed and leave nothing behind."""
+        server = self._drive_non_oauth_run_http(tmp_path, monkeypatch)
+
+        # Same ready-state proof as the stale-cache test: if _run_http failed
+        # before the transport, the test must fail rather than pass vacuously.
+        assert server._ready.is_set()
+
+        assert not (tmp_path / "mcp-tokens" / "cf-server.json").exists()
+        assert not (tmp_path / "mcp-tokens" / "cf-server.client.json").exists()
+        assert not (tmp_path / "mcp-tokens" / "cf-server.meta.json").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -135,6 +135,39 @@ class TestHermesTokenStorage:
 
         assert storage.has_cached_tokens()
 
+    def test_cleanup_stale_cache_when_auth_type_not_oauth(self, tmp_path, monkeypatch):
+        """When auth type changes from oauth to non-oauth, stale cache is cleaned."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("cloudflare")
+
+        # Simulate previous OAuth usage: create client.json and tokens
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        (d / "cloudflare.json").write_text('{"access_token": "old", "token_type": "Bearer"}')
+        (d / "cloudflare.client.json").write_text('{"client_id": "some-id"}')
+        (d / "cloudflare.meta.json").write_text('{"token_endpoint": "https://example.com/token"}')
+
+        assert storage.has_cached_tokens()
+        assert storage._client_info_path().exists()
+
+        # This simulates the cleanup path in MCPServerTask._connect()
+        # when _auth_type != "oauth": check for stale client.json, then remove all
+        storage.remove()
+
+        # All three OAuth cache files should be gone
+        assert not (d / "cloudflare.json").exists()
+        assert not (d / "cloudflare.client.json").exists()
+        assert not (d / "cloudflare.meta.json").exists()
+
+    def test_cleanup_stale_cache_noop_when_no_files(self, tmp_path, monkeypatch):
+        """Cleanup is a no-op when no stale cache files exist."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("new-server")
+
+        # No files exist — remove() should not raise
+        assert not storage._client_info_path().exists()
+        storage.remove()  # Should not raise
+
     def test_corrupt_tokens_returns_none(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         storage = HermesTokenStorage("bad-server")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2760,6 +2760,21 @@ class MCPServerTask:
             except Exception as exc:
                 logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
                 raise
+        else:
+            # Clean up stale OAuth cache when the auth type is not "oauth"
+            # (e.g. user switched from auth: oauth to headers or no-auth).
+            # Orphaned mcp-tokens/<name>.client.json files confuse debugging
+            # because their presence suggests OAuth is still in use (#60313).
+            # Best-effort: failures here should never block server startup.
+            from tools.mcp_oauth import HermesTokenStorage
+            storage = HermesTokenStorage(self.name)
+            try:
+                storage.remove()
+            except OSError as exc:
+                logger.debug(
+                    "MCP '%s': could not clean stale OAuth cache: %s",
+                    self.name, exc,
+                )
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
         if self._elicitation:


### PR DESCRIPTION
## Summary

When a user switches an MCP server from `auth: oauth` to `headers`-based auth (or removes auth entirely), the cached `mcp-tokens/<name>.client.json` files are left as orphaned disk cruft. These files don't independently trigger OAuth (the flow is correctly gated by `self._auth_type == "oauth"` in `MCPServerTask._connect()`), but their presence confuses debugging — as reported in #60313.

## What this does

Adds a best-effort cleanup step in `MCPServerTask._connect()`. When `_auth_type != "oauth"`, any stale OAuth cache files (tokens, client info, metadata) are removed. The cleanup is wrapped in `try/except OSError` so permission errors never block server startup.

## Changes

- **`tools/mcp_tool.py`**: In the `else` branch of `if self._auth_type == "oauth"`, call `HermesTokenStorage.remove()` to clean up any stale cache
- **`tests/tools/test_mcp_oauth.py`**: Two new tests — one verifying cleanup removes all three cache files, one verifying cleanup is a no-op when no files exist

## Testing

```
$ python -m pytest tests/tools/test_mcp_oauth.py -q
107 passed in 3.22s
```

## Notes

- The stale cache files do **not** independently trigger OAuth browser popups — the OAuth flow is correctly gated by the `auth: oauth` config field
- The dual-config situation (#60313 Issue 1) is a separate documentation/UX concern and is not addressed here

Closes #60313