### PR TITLE
fix(skills): separate origin from curator ownership

### DIFF
--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -58,14 +58,14 @@ function toolset(overrides: Record<string, unknown> = {}) {
   }
 }
 
-async function renderSkills() {
+async function renderSkills(initialEntry = '/skills?tab=toolsets') {
   const { SkillsView } = await import('./index')
   let result: ReturnType<typeof render>
   await act(async () => {
     result = render(
       // SkillsView reads skills/toolsets via useQuery, so it needs a provider.
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={['/skills?tab=toolsets']}>
+        <MemoryRouter initialEntries={[initialEntry]}>
           <SkillsView />
         </MemoryRouter>
       </QueryClientProvider>
@@ -152,5 +152,36 @@ describe('SkillsView toolset management', () => {
     // Internal route change into the Models section with the aux slot target —
     // consumed by ModelSettings' deep-link highlight. Never an external URL.
     await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith('/settings?tab=config:model&aux=vision'))
+  })
+})
+
+describe('SkillsView skill provenance', () => {
+  it('distinguishes local and background-learned skills', async () => {
+    getSkills.mockResolvedValue([
+      {
+        name: 'manual-skill',
+        description: 'Written by the user',
+        category: 'demo',
+        enabled: true,
+        usage: 1,
+        provenance: 'agent'
+      },
+      {
+        name: 'learned-skill',
+        description: 'Created by background review',
+        category: 'demo',
+        enabled: true,
+        usage: 1,
+        provenance: 'agent',
+        origin: 'background_review'
+      }
+    ])
+
+    await renderSkills('/skills?tab=skills')
+
+    expect((await screen.findAllByText(/local/i)).length).toBeGreaterThan(0)
+    expect((await screen.findAllByText(/learned/i)).length).toBeGreaterThan(0)
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Archive' })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -105,22 +105,41 @@ const usageOf = (skill: SkillInfo): number => (typeof skill.usage === 'number' ?
 
 const categoryFor = (skill: SkillInfo): string => asText(skill.category) || 'general'
 
+type SkillOrigin = NonNullable<SkillInfo['origin']>
+
+function skillOrigin(skill: SkillInfo): SkillOrigin {
+  if (skill.origin) {
+    return skill.origin
+  }
+
+  if (skill.provenance === 'hub' || skill.provenance === 'bundled') {
+    return skill.provenance
+  }
+
+  return 'local'
+}
+
 // Row subtitle: category, with non-default origins badged.
-function skillSubtitle(skill: SkillInfo): React.ReactNode {
+function skillSubtitle(skill: SkillInfo, labels: Record<SkillOrigin, string>): React.ReactNode {
   const category = prettyName(categoryFor(skill))
-  const provenance = skill.provenance
+  const origin = skillOrigin(skill)
 
   return (
     <>
       <span className="truncate">{category}</span>
-      {provenance === 'agent' && (
+      {origin === 'background_review' && (
         <Badge className="shrink-0 normal-case" variant="default">
-          learned
+          {labels[origin]}
         </Badge>
       )}
-      {provenance === 'hub' && (
+      {origin === 'local' && (
         <Badge className="shrink-0 normal-case" variant="muted">
-          hub
+          {labels[origin]}
+        </Badge>
+      )}
+      {origin === 'hub' && (
+        <Badge className="shrink-0 normal-case" variant="muted">
+          {labels[origin]}
         </Badge>
       )}
     </>
@@ -603,7 +622,7 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
                   meta={usageOf(skill) > 0 ? `×${compactNumber(usageOf(skill))}` : undefined}
                   onSelect={() => setSelectedSkill(skill.name)}
                   onToggle={enabled => void handleToggleSkill(skill, enabled)}
-                  subtitle={skillSubtitle(skill)}
+                  subtitle={skillSubtitle(skill, t.skills.provenance)}
                   title={skill.name}
                   toggleLabel={skill.name}
                 />
@@ -718,9 +737,11 @@ function DetailHeader({
 
 function SkillDetail({ onArchive, onEdit, skill }: { onArchive: () => void; onEdit: () => void; skill: SkillInfo }) {
   const { t } = useI18n()
-  // Only learned/local skills are the user's to rewrite or archive — bundled
-  // and hub skills are managed by their sources.
-  const editable = skill.provenance === 'agent'
+  const origin = skillOrigin(skill)
+
+  // Local and background-created skills are user-owned. Bundled and Hub skills
+  // remain source-managed. Legacy backends classify local ownership as agent.
+  const editable = skill.provenance === 'agent' || origin === 'local' || origin === 'background_review'
 
   return (
     <>
@@ -729,9 +750,9 @@ function SkillDetail({ onArchive, onEdit, skill }: { onArchive: () => void; onEd
         pills={
           <>
             <PanelPill>{prettyName(categoryFor(skill))}</PanelPill>
-            {skill.provenance && skill.provenance !== 'bundled' && (
-              <PanelPill tone={skill.provenance === 'agent' ? 'good' : 'muted'}>
-                {t.skills.provenance[skill.provenance]}
+            {origin !== 'bundled' && (
+              <PanelPill tone={origin === 'background_review' ? 'good' : 'muted'}>
+                {t.skills.provenance[origin]}
               </PanelPill>
             )}
           </>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -983,7 +983,8 @@ export const en: Translations = {
     bulkNoChange: 'Nothing to change.',
     usageCount: count => `used ${count}×`,
     provenance: {
-      agent: 'Learned',
+      background_review: 'Learned',
+      local: 'Local',
       bundled: 'Built-in',
       hub: 'Hub'
     },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1023,7 +1023,8 @@ export const ja = defineLocale({
     bulkNoChange: '変更するものはありません。',
     usageCount: count => `${count} 回使用`,
     provenance: {
-      agent: '学習済み',
+      background_review: '学習済み',
+      local: 'ローカル',
       bundled: '組み込み',
       hub: 'ハブ'
     },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -858,7 +858,7 @@ export interface Translations {
     bulkUpdated: (count: number) => string
     bulkNoChange: string
     usageCount: (count: number | string) => string
-    provenance: Record<'agent' | 'bundled' | 'hub', string>
+    provenance: Record<'background_review' | 'local' | 'bundled' | 'hub', string>
     emptyNoneFound: (noun: string) => string
     emptyNothingMatches: (query: string) => string
     emptyNoneAvailable: (noun: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -991,7 +991,8 @@ export const zhHant = defineLocale({
     bulkNoChange: '沒有需要變更的內容。',
     usageCount: count => `已使用 ${count} 次`,
     provenance: {
-      agent: '已學習',
+      background_review: '已學習',
+      local: '本機',
       bundled: '內建',
       hub: '技能中心'
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1180,7 +1180,8 @@ export const zh: Translations = {
     bulkNoChange: '没有需要更改的内容。',
     usageCount: count => `已使用 ${count} 次`,
     provenance: {
-      agent: '习得',
+      background_review: '已学习',
+      local: '本地',
       bundled: '内置',
       hub: '技能中心'
     },

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -835,8 +835,10 @@ export interface SkillInfo {
   name: string
   /** Total observed activity (use + view + patch). Absent on older backends. */
   usage?: number
-  /** 'agent' = learned/local (editable), 'bundled' = ships with Hermes, 'hub' = installed. */
+  /** Legacy ownership class retained for older Desktop clients. */
   provenance?: 'agent' | 'bundled' | 'hub'
+  /** Explicit human-facing provenance. Absent on older backends. */
+  origin?: 'background_review' | 'local' | 'bundled' | 'hub'
 }
 
 export interface ToolsetInfo {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15444,25 +15444,33 @@ async def get_skills(profile: Optional[str] = None):
         _read_hub_installed_names,
         activity_count,
         load_usage,
+        origin,
+        provenance,
     )
     with _profile_scope(profile):
         config = load_config()
         disabled = get_disabled_skills(config)
         skills = _find_all_skills(skip_disabled=True)
         usage = load_usage()
-        # Set-based provenance (same classification as skill_usage.provenance,
-        # without a per-skill manifest read): hub > bundled > agent, where
-        # "agent" covers agent-authored AND local hand-made skills — the ones
-        # the user may edit/delete from the UI.
+        # Set-based classification avoids per-skill manifest reads. The legacy
+        # ``provenance`` field preserves broad local ownership for older Desktop
+        # clients; ``origin`` carries the explicit human-facing source.
         bundled_names = _read_bundled_manifest_names()
         hub_names = _read_hub_installed_names()
     for s in skills:
+        usage_record = usage.get(s["name"], {})
         s["enabled"] = s["name"] not in disabled
-        s["usage"] = activity_count(usage.get(s["name"], {}))
-        s["provenance"] = (
-            "hub" if s["name"] in hub_names
-            else "bundled" if s["name"] in bundled_names
-            else "agent"
+        s["usage"] = activity_count(usage_record)
+        s["provenance"] = provenance(
+            s["name"],
+            bundled_names=bundled_names,
+            hub_names=hub_names,
+        )
+        s["origin"] = origin(
+            s["name"],
+            usage_record,
+            bundled_names=bundled_names,
+            hub_names=hub_names,
         )
     return skills
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5856,6 +5856,7 @@ class TestNewEndpoints:
 
     def test_skills_list_includes_disabled_skills(self, monkeypatch):
         import tools.skills_tool as skills_tool
+        import tools.skill_usage as skill_usage
         import hermes_cli.skills_config as skills_config
         import hermes_cli.web_server as web_server
 
@@ -5870,6 +5871,16 @@ class TestNewEndpoints:
             ]
 
         monkeypatch.setattr(skills_tool, "_find_all_skills", _fake_find_all_skills)
+        monkeypatch.setattr(
+            skill_usage,
+            "load_usage",
+            lambda: {
+                "active-skill": {
+                    "created_by": "agent",
+                    "origin": "background_review",
+                }
+            },
+        )
         monkeypatch.setattr(skills_config, "get_disabled_skills", lambda config: {"disabled-skill"})
         monkeypatch.setattr(web_server, "load_config", lambda: {"skills": {"disabled": ["disabled-skill"]}})
 
@@ -5884,6 +5895,7 @@ class TestNewEndpoints:
                 "enabled": True,
                 "usage": 0,
                 "provenance": "agent",
+                "origin": "background_review",
             },
             {
                 "name": "disabled-skill",
@@ -5892,6 +5904,7 @@ class TestNewEndpoints:
                 "enabled": False,
                 "usage": 0,
                 "provenance": "agent",
+                "origin": "local",
             },
         ]
 

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -626,6 +626,7 @@ class TestSkillManageDispatcher:
         # entirely (telemetry best-effort) or present with created_by unset.
         rec = usage.get("test-skill") or {}
         assert rec.get("created_by") in {None, "", False}
+        assert rec.get("origin") in {None, ""}
 
     def test_create_from_background_review_marks_agent_created(self, tmp_path):
         """Background-review fork creates ARE marked as agent-created."""
@@ -644,6 +645,7 @@ class TestSkillManageDispatcher:
         result = json.loads(raw)
         assert result["success"] is True
         assert usage["review-sediment"]["created_by"] == "agent"
+        assert usage["review-sediment"]["origin"] == "background_review"
 
     def test_delete_via_dispatcher_threads_absorbed_into(self, tmp_path):
         # Dispatcher must plumb absorbed_into through to _delete_skill so the

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -788,27 +788,33 @@ def test_usage_report_covers_all_provenance(skills_home):
     """usage_report() surfaces every skill with provenance, unlike the
     curator-scoped agent_created_report()."""
     from tools.skill_usage import (
-        bump_use, usage_report, mark_agent_created,
+        bump_use, usage_report, mark_background_review_created,
     )
     skills_dir = skills_home / "skills"
     _write_skill(skills_dir, "bundled-one")
     _write_skill(skills_dir, "hub-one")
     _write_skill(skills_dir, "mine")
+    _write_skill(skills_dir, "manual")
     (skills_dir / ".bundled_manifest").write_text("bundled-one:abc\n", encoding="utf-8")
     hub = skills_dir / ".hub"
     hub.mkdir()
     (hub / "lock.json").write_text(
         json.dumps({"installed": {"hub-one": {}}}), encoding="utf-8",
     )
-    mark_agent_created("mine")
-    for n in ("bundled-one", "hub-one", "mine"):
+    mark_background_review_created("mine")
+    for n in ("bundled-one", "hub-one", "mine", "manual"):
         bump_use(n)
 
     rows = {r["name"]: r for r in usage_report()}
-    assert set(rows) == {"bundled-one", "hub-one", "mine"}
+    assert set(rows) == {"bundled-one", "hub-one", "mine", "manual"}
     assert rows["bundled-one"]["provenance"] == "bundled"
     assert rows["hub-one"]["provenance"] == "hub"
     assert rows["mine"]["provenance"] == "agent"
+    assert rows["manual"]["provenance"] == "agent"
+    assert rows["bundled-one"]["origin"] == "bundled"
+    assert rows["hub-one"]["origin"] == "hub"
+    assert rows["mine"]["origin"] == "background_review"
+    assert rows["manual"]["origin"] == "local"
     # All carry real usage now.
     for n in rows:
         assert rows[n]["use_count"] == 1

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1455,11 +1455,11 @@ def skill_manage(
         # user-directed, and those skills belong to the user (the curator must
         # not touch them). Best-effort; telemetry failures never break the tool.
         try:
-            from tools.skill_usage import bump_patch, forget, mark_agent_created
+            from tools.skill_usage import bump_patch, forget, mark_background_review_created
             from tools.skill_provenance import is_background_review
             if action == "create":
                 if is_background_review():
-                    mark_agent_created(name)
+                    mark_background_review_created(name)
             elif action in {"patch", "edit", "write_file", "remove_file"}:
                 bump_patch(name)
             elif action == "delete":

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -492,6 +492,7 @@ def _is_curator_managed_record(record: Any) -> bool:
 def _empty_record() -> Dict[str, Any]:
     return {
         "created_by": None,
+        "origin": None,
         "use_count": 0,
         "view_count": 0,
         "last_used_at": None,
@@ -654,11 +655,20 @@ def bump_patch(skill_name: str) -> None:
 def mark_agent_created(skill_name: str) -> None:
     """Opt a skill created by skill_manage into curator management.
 
-    Viewing or invoking a manually authored skill may still create telemetry,
-    but only this explicit marker makes it eligible for automatic curation.
+    This field is curator eligibility, not human-facing provenance. Viewing or
+    invoking a manually authored skill may still create telemetry, but only
+    this explicit marker makes it eligible for automatic curation.
     """
     def _apply(rec: Dict[str, Any]) -> None:
         rec["created_by"] = "agent"
+    _mutate(skill_name, _apply, require_curation_eligible=True)
+
+
+def mark_background_review_created(skill_name: str) -> None:
+    """Record immutable provenance for background self-improvement sediment."""
+    def _apply(rec: Dict[str, Any]) -> None:
+        rec["created_by"] = "agent"
+        rec["origin"] = "background_review"
     _mutate(skill_name, _apply, require_curation_eligible=True)
 
 
@@ -901,17 +911,56 @@ def agent_created_report() -> List[Dict[str, Any]]:
     return rows
 
 
-def provenance(skill_name: str) -> str:
-    """Classify a skill's origin: 'hub', 'bundled', or 'agent'.
+def provenance(
+    skill_name: str,
+    *,
+    bundled_names: Optional[Set[str]] = None,
+    hub_names: Optional[Set[str]] = None,
+) -> str:
+    """Return the legacy ownership class used by older Desktop clients.
 
-    'agent' covers both agent-authored and local manually-authored skills —
-    anything not seeded from the bundled repo or installed via the hub.
+    ``agent`` intentionally means any local/user-owned skill here. The separate
+    :func:`origin` field carries human-facing provenance without breaking older
+    clients that rely on ``agent`` to keep local skills editable.
     """
-    if is_hub_installed(skill_name):
+    is_hub = skill_name in hub_names if hub_names is not None else is_hub_installed(skill_name)
+    if is_hub:
         return "hub"
-    if is_bundled(skill_name):
+    is_bundled_skill = (
+        skill_name in bundled_names
+        if bundled_names is not None
+        else is_bundled(skill_name)
+    )
+    if is_bundled_skill:
         return "bundled"
     return "agent"
+
+
+def origin(
+    skill_name: str,
+    usage_record: Any = None,
+    *,
+    bundled_names: Optional[Set[str]] = None,
+    hub_names: Optional[Set[str]] = None,
+) -> str:
+    """Return explicit human-facing origin for a skill.
+
+    Ambiguous and legacy local records are classified conservatively as
+    ``local``. Only the immutable marker written by the background-review fork
+    may produce ``background_review``.
+    """
+    legacy = provenance(
+        skill_name,
+        bundled_names=bundled_names,
+        hub_names=hub_names,
+    )
+    if legacy in {"hub", "bundled"}:
+        return legacy
+    if usage_record is None:
+        usage_record = load_usage().get(skill_name)
+    if isinstance(usage_record, dict) and usage_record.get("origin") == "background_review":
+        return "background_review"
+    return "local"
 
 
 def usage_report() -> List[Dict[str, Any]]:
@@ -921,13 +970,17 @@ def usage_report() -> List[Dict[str, Any]]:
     candidates), this surfaces all skills — bundled built-ins and
     hub-installed included — so callers can answer "how often is this skill
     used" independent of whether it's ever curated. Rows carry a
-    ``provenance`` field ('agent' | 'bundled' | 'hub') and ``_persisted``
-    (whether a real ``.usage.json`` record backs the row).
+    ``provenance`` field ('agent' | 'bundled' | 'hub') for legacy ownership,
+    an explicit ``origin`` field ('background_review' | 'local' | 'bundled' |
+    'hub') for human-facing labels, and ``_persisted`` (whether a real
+    ``.usage.json`` record backs the row).
     """
     base = _skills_dir()
     if not base.exists():
         return []
     data = load_usage()
+    bundled_names = _read_bundled_manifest_names()
+    hub_names = _read_hub_installed_names()
     rows: List[Dict[str, Any]] = []
     seen: set = set()
     for skill_md in base.rglob("SKILL.md"):
@@ -946,7 +999,17 @@ def usage_report() -> List[Dict[str, Any]]:
         row = {
             "name": name,
             **rec,
-            "provenance": provenance(name),
+            "provenance": provenance(
+                name,
+                bundled_names=bundled_names,
+                hub_names=hub_names,
+            ),
+            "origin": origin(
+                name,
+                rec,
+                bundled_names=bundled_names,
+                hub_names=hub_names,
+            ),
             "_persisted": persisted,
         }
         row["last_activity_at"] = latest_activity_at(row)


### PR DESCRIPTION
## Summary
- add an explicit skill `origin` field so human-facing provenance is independent of curator eligibility
- record `background_review` only for skills created by the background self-improvement fork; ambiguous and legacy local records fall back conservatively to `local`
- preserve the legacy `provenance` ownership field so older Desktop clients keep local skills editable
- render localized Local/Learned/Hub labels from `origin`, including a safe fallback when a new Desktop connects to an older backend
- cover foreground creation, background-review creation, API serialization, and Desktop labels/editability

## Test plan
- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/tools/test_skill_usage.py tests/tools/test_skill_manager_tool.py tests/hermes_cli/test_web_server.py -q` (668 passed)
- `cd apps/desktop && npm run test:ui -- src/app/skills/index.test.tsx` (5 passed)
- `cd apps/desktop && npm run typecheck`
- `cd apps/desktop && npx eslint src/app/skills/index.tsx src/app/skills/index.test.tsx src/types/hermes.ts src/i18n/types.ts src/i18n/en.ts src/i18n/ja.ts src/i18n/zh.ts src/i18n/zh-hant.ts`
- `cd apps/desktop && npx prettier --check src/app/skills/index.tsx src/app/skills/index.test.tsx src/types/hermes.ts src/i18n/types.ts src/i18n/en.ts src/i18n/ja.ts src/i18n/zh.ts src/i18n/zh-hant.ts`
- `.venv/bin/ruff check tools/skill_usage.py tools/skill_manager_tool.py hermes_cli/web_server.py tests/tools/test_skill_usage.py tests/tools/test_skill_manager_tool.py tests/hermes_cli/test_web_server.py`
- `git diff --check`

Fixes #70712
