### PR TITLE
docs(cron): fix stale verifier path — plugins/cron → plugins/cron_providers

### DIFF
--- a/docs/chronos-managed-cron-contract.md
+++ b/docs/chronos-managed-cron-contract.md
@@ -132,7 +132,7 @@ public HTTP surface on hosted deployments (the gateway may be idle/scaled down);
 it is in `PUBLIC_API_PATHS` so the dashboard cookie gate lets the bearer-JWT
 callback through to the verifier. (Also registered on the optional
 `APIServerAdapter` for self-host API-server deployments.) The verifier is
-`plugins/cron/chronos/verify.py`.
+`plugins/cron_providers/chronos/verify.py`.
 
 - **Auth:** `Authorization: Bearer <NAS-minted JWT>`. The agent verifies:
   - signature against the NAS JWKS (`cron.chronos.nas_jwks_url`),

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -114,7 +114,7 @@ The active provider is chosen by the `cron.provider` config key:
   historical in-process loop calling `scheduler.tick()` every 60 seconds. This
   is byte-identical to the pre-provider behavior.
 - **a named provider** (e.g. `chronos`, a managed-cron provider for
-  scale-to-zero deployments) → discovered from `plugins/cron/<name>/` or
+  scale-to-zero deployments) → discovered from `plugins/cron_providers/<name>/` or
   `$HERMES_HOME/plugins/<name>/`.
 
 If a named provider is missing, fails to load, or reports `is_available() ==

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -560,7 +560,7 @@ The cron **trigger** is pluggable via the `cron.provider` config key. Empty
 (the default) uses the built-in in-process ticker. Set it to `chronos` (the
 NAS-managed provider for scale-to-zero hosted gateways) — configured via the
 `cron.chronos.*` keys (`portal_url`, `callback_url`, `expected_audience`,
-`nas_jwks_url`) — or name a custom provider under `plugins/cron/<name>/` or
+`nas_jwks_url`) — or name a custom provider under `plugins/cron_providers/<name>/` or
 `$HERMES_HOME/plugins/<name>/`. An unknown or unavailable provider falls back to
 the built-in, so cron is never left without a trigger. See the
 [cron internals](../developer-guide/cron-internals.md#gateway-integration) doc.


### PR DESCRIPTION
## Problem

`docs/chronos-managed-cron-contract.md` line 135 references `plugins/cron/chronos/verify.py` as the inbound fire verifier. This path no longer exists — the directory was renamed from `plugins/cron` to `plugins/cron_providers` in the merged PR [#51702](https://github.com/NousResearch/hermes-agent/pull/51702), but this docs file was not updated in that rename.

## Triage / Root cause

Leftover reference from the `plugins/cron` → `plugins/cron_providers` package rename. The code moved correctly; the wire-contract doc was missed.

## Fix

- Updated `plugins/cron/chronos/verify.py` → `plugins/cron_providers/chronos/verify.py` (one-line change)
- Verified the corrected path `plugins/cron_providers/chronos/verify.py` exists on `upstream/main`

## Verification

```bash
git show upstream/main:plugins/cron_providers/chronos/verify.py  # exists
grep -r "plugins/cron/" docs/*.md  # no other stale references
```

## Notes / Risks

- This is a docs-only change; no runtime impact.
- Self-sourced (no associated issue).