### PR TITLE
fix(compression): fall back to replace_messages when archive_and_compact fails (#71097)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1837,7 +1837,27 @@ def compress_context(
                     # for search/recovery (Teknium review — keep one durable id
                     # WITHOUT destroying history, unlike a hard replace_messages).
                     # See #38763.
-                    agent._session_db.archive_and_compact(agent.session_id, compressed)
+                    try:
+                        agent._session_db.archive_and_compact(
+                            agent.session_id, compressed
+                        )
+                    except Exception as _archive_err:
+                        # archive_and_compact can fail on contended writes
+                        # or schema-migration races.  Fall back to a
+                        # destructive active-only replace so the compressed
+                        # transcript is still persisted for the gateway to
+                        # consume — losing the soft-archive history is
+                        # preferable to silently dropping the compaction
+                        # result (#71097).
+                        logger.warning(
+                            "archive_and_compact failed for session %s, "
+                            "falling back to replace_messages: %s",
+                            agent.session_id or "?",
+                            _archive_err,
+                        )
+                        agent._session_db.replace_messages(
+                            agent.session_id, compressed, active_only=True,
+                        )
                     split_status = "in_place_committed"
                     # Reset the flush identity set so the next turn's appends are
                     # diffed against the COMPACTED transcript: the compacted dicts

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -323,3 +323,45 @@ class TestCompactedTurnsStaySearchable:
                 "ZEBRAWORD", role_filter=["user", "assistant"], include_inactive=True
             )
             assert len(recovered) == 1
+
+
+class TestInPlaceArchiveFailureFallback:
+    """Regression for #71097: when archive_and_compact raises (e.g. contended
+    write or schema-migration race), compress_context must fall back to
+    replace_messages so the compressed transcript is still persisted and
+    _last_compaction_in_place remains True for the gateway."""
+
+    def test_archive_and_compact_failure_falls_back_to_replace(self):
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260725_71097_fb"
+            _seed(db, sid, "archive-fail", n=8)
+            agent = _make_agent(db, sid, in_place=True)
+
+            # Make archive_and_compact raise to simulate a contended write.
+            _original = db.archive_and_compact
+
+            def _boom(*a, **kw):
+                raise RuntimeError("database is locked")
+
+            db.archive_and_compact = _boom
+
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(8)]
+            compressed, _sp = compress_context(
+                agent, messages, approx_tokens=100_000, system_message="sys"
+            )
+
+            # The fallback persisted via replace_messages so the live
+            # transcript is the compacted set.
+            live = db.get_messages_as_conversation(sid)
+            assert len(live) == 2
+            assert [m.get("content") for m in live] == [
+                "[CONTEXT COMPACTION] summary of prior turns",
+                "recent reply",
+            ]
+            # The gateway signal must be True so the hygiene path consumes
+            # the result instead of discarding it.
+            assert agent._last_compaction_in_place is True


### PR DESCRIPTION
## Problem

When `archive_and_compact()` raises during in-place compaction (contended write, schema-migration race, etc.), the broad `except Exception` at the end of the `compress_context` try block swallows the error. `compacted_in_place` stays `False`, so `_last_compaction_in_place` is never set. The gateway then enters the `else` branch and discards the successfully-produced summary with the "no session_db on the hygiene agent" warning.

## Fix

Wrap the `archive_and_compact()` call in its own try/except. When it raises, fall back to `replace_messages(active_only=True)` so the compressed transcript is still persisted. This is destructive relative to `archive_and_compact` (loses soft-archived pre-compaction history) but is strictly better than silently dropping the compression result.

## Regression test

`TestInPlaceArchiveFailureFallback.test_archive_and_compact_failure_falls_back_to_replace` — patches `archive_and_compact` to raise `RuntimeError("database is locked")`, runs `compress_context`, verifies:
- Live transcript is the compacted 2-message set
- `_last_compaction_in_place` is `True`

Fixes #71097
