### PR TITLE
fix(mcp): re-read server config from disk on every respawn

### DIFF
--- a/tests/tools/test_mcp_config_refresh.py
+++ b/tests/tools/test_mcp_config_refresh.py
@@ -1,0 +1,83 @@
+"""Regression test: MCP server respawns re-read config from disk.
+
+External tooling can rotate credentials in ``config.yaml`` between spawns
+(e.g. a cron pre-run script rewriting ``BW_SESSION`` for the Bitwarden MCP
+server). Previously ``MCPServerTask.run()`` captured the server config once
+at first connect and reused that snapshot for every subsequent respawn in
+the reconnect loop, so rotated values never reached the child process.
+The fix re-reads ``_load_mcp_config()`` at the top of every (re)spawn
+iteration; this test locks that behaviour in.
+"""
+
+import asyncio
+
+import tools.mcp_tool as mcp_tool
+
+
+def test_respawn_uses_refreshed_config(monkeypatch):
+    """After a transport death, the respawn must use the on-disk config,
+    not the snapshot captured at first connect."""
+    spawn_markers = []
+
+    async def fake_run_stdio(self, config):
+        # Record the env marker this spawn was given, "die" once, then
+        # shut the loop down on the second entry.
+        spawn_markers.append((config.get("env") or {}).get("MARKER"))
+        if len(spawn_markers) == 1:
+            raise RuntimeError("simulated transport death")
+        self._shutdown_event.set()
+        return "shutdown"
+
+    monkeypatch.setattr(mcp_tool.MCPServerTask, "_run_stdio", fake_run_stdio)
+    # Keep backoff sleeps negligible.
+    monkeypatch.setattr(mcp_tool, "_MAX_BACKOFF_SECONDS", 0.01)
+    monkeypatch.setattr(mcp_tool, "_CONNECT_RETRY_BASE_BACKOFF_SEC", 0.01)
+
+    # On-disk config evolves between spawns: MARKER=one, then MARKER=two.
+    disk_configs = iter([
+        {"fake": {"command": "cat", "env": {"MARKER": "one"}}},
+        {"fake": {"command": "cat", "env": {"MARKER": "two"}}},
+    ])
+    monkeypatch.setattr(
+        mcp_tool,
+        "_load_mcp_config",
+        lambda: next(
+            disk_configs,
+            {"fake": {"command": "cat", "env": {"MARKER": "two"}}},
+        ),
+    )
+
+    async def main():
+        task = mcp_tool.MCPServerTask("fake")
+        task._ready.set()  # simulate a previously-healthy connection
+        await task.run({"command": "cat", "env": {"MARKER": "one"}})
+
+    asyncio.run(main())
+
+    assert spawn_markers == ["one", "two"], (
+        "respawn after transport death did not pick up the refreshed "
+        f"on-disk config: {spawn_markers}"
+    )
+
+
+def test_respawn_keeps_last_config_when_server_removed(monkeypatch):
+    """If the server disappears from config.yaml, the reconnect loop must
+    not crash — it keeps using the last known config."""
+    spawn_count = []
+
+    async def fake_run_stdio(self, config):
+        spawn_count.append(1)
+        self._shutdown_event.set()
+        return "shutdown"
+
+    monkeypatch.setattr(mcp_tool.MCPServerTask, "_run_stdio", fake_run_stdio)
+    monkeypatch.setattr(mcp_tool, "_load_mcp_config", lambda: {})
+
+    async def main():
+        task = mcp_tool.MCPServerTask("fake")
+        task._ready.set()
+        await task.run({"command": "cat", "env": {"MARKER": "one"}})
+
+    asyncio.run(main())
+
+    assert spawn_count == [1]

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3099,6 +3099,28 @@ class MCPServerTask:
 
         while True:
             try:
+                # Refresh this server's config from disk on every (re)spawn.
+                # External tooling can rotate credentials in config.yaml
+                # (e.g. a pre-run script rewriting BW_SESSION); without this,
+                # every respawn reused the stale snapshot captured at first
+                # connect and the running child never saw the new values.
+                # _load_mcp_config() -> load_config() is mtime-aware, so this
+                # is cheap when the file is unchanged.
+                try:
+                    fresh_config = _load_mcp_config().get(self.name)
+                    if isinstance(fresh_config, dict) and fresh_config:
+                        if fresh_config != config:
+                            logger.info(
+                                "MCP server '%s': config changed on disk, "
+                                "(re)spawning with fresh config",
+                                self.name,
+                            )
+                        config = fresh_config
+                        self._config = fresh_config
+                except Exception:
+                    # Never let a config-refresh failure break the reconnect
+                    # loop — fall back to the last known config.
+                    pass
                 if self._is_http():
                     lifecycle_reason = await self._run_http(config)
                 else:


### PR DESCRIPTION
## Symptom

An MCP stdio server whose credentials are rotated in `config.yaml` by external tooling never receives the new values. Concrete case: a cron pre-run script unlocks a Bitwarden vault and writes a fresh `BW_SESSION` into `mcp_servers.bitwarden.env.BW_SESSION`, then kills the stale `mcp-server-bitwarden` child so the gateway respawns it. The respawned child still comes up with the **old** token — verified live via `ps eww` on three independent long-lived hosts (gateway, webui, desktop-serve), each holding a different stale token, none matching the just-written config value. The only escapes were a full process restart or `/reload-mcp`.

## Root cause

`MCPServerTask.run()` captures `config` once (`self._config = config`) and the reconnect loop's `while True:` respawns via `_run_stdio(config)` / `_run_http(config)` using that same snapshot forever. `_load_mcp_config()` (and the mtime-aware `load_config()` beneath it) is only called from `discover_mcp_tools()` / status paths — never on the respawn path. Killing the child therefore can't propagate rotated env vars, because the auto-reconnect reuses the first-connect snapshot.

## Fix

Re-read `_load_mcp_config()` at the top of every (re)spawn iteration inside the reconnect loop, and adopt the fresh config when it differs. This one site covers every respawn path (auto-reconnect after failure, parked revival, lazy stdio recycle, auth-recovery rebuild) because they all funnel through this loop. `load_config()` is mtime-aware, so the refresh is cheap when the file is unchanged. If the refresh raises or the server was removed from config, the loop falls back to the last known config — a config-refresh failure can never break reconnection.

## Test

`tests/tools/test_mcp_config_refresh.py` (2 tests):
- respawn after simulated transport death receives the refreshed on-disk env (`MARKER` one → two)
- a server removed from config keeps its last known config and the loop doesn't crash

Existing MCP suites still pass: `test_mcp_tool.py`, `test_mcp_bridge_single_failure.py`, `test_mcp_reload_rev.py` — 231 passed.