### PR TITLE
feat(hindsight): add recall_min_scores relevance floor to recall path

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -147,4 +147,4 @@ Available in `hybrid` and `tools` memory modes:
 
 ## Client Version
 
-Requires `hindsight-client >= 0.6.1`. The plugin auto-upgrades on session start if an older version is detected.
+Requires `hindsight-client >= 0.8.5`. The plugin auto-upgrades on session start if an older version is detected.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -41,7 +41,7 @@ import sys
 import threading
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 from hermes_constants import get_hermes_home
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
-_MIN_CLIENT_VERSION = "0.6.1"
+_MIN_CLIENT_VERSION = "0.8.5"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
@@ -477,6 +477,48 @@ def _normalize_observation_scopes(value: Any) -> Any:
         return scopes or None
 
     return None
+
+
+_VALID_MIN_SCORE_KEYS = frozenset({"semantic", "keyword", "reranker", "final"})
+
+
+def _normalize_min_scores(value: Any) -> Optional[Dict[str, float]]:
+    """Validate and normalize a ``recall_min_scores`` config value.
+
+    Returns a ``{stage: floor}`` dict ready to pass as ``min_scores`` to
+    ``client.arecall()``, or ``None`` if the config is unset / entirely invalid
+    (fail-open: no relevance floor applied).
+
+    Only the four known stage keys are accepted (0.8.5 client raises
+    ``ValueError`` on unknown keys).  Non-numeric values are dropped with a
+    ``logger.warning``.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        logger.warning("recall_min_scores: expected dict, got %s — ignoring", type(value).__name__)
+        return None
+
+    result: Dict[str, float] = {}
+    for key, raw in value.items():
+        key_str = str(key)
+        if key_str not in _VALID_MIN_SCORE_KEYS:
+            logger.warning(
+                "recall_min_scores: unknown key %r (must be one of %s) — dropping",
+                key_str,
+                ", ".join(sorted(_VALID_MIN_SCORE_KEYS)),
+            )
+            continue
+        try:
+            result[key_str] = float(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "recall_min_scores: key %r has non-numeric value %r — dropping",
+                key_str,
+                raw,
+            )
+
+    return result or None
 
 
 def _utc_timestamp() -> str:
@@ -1003,6 +1045,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
+            {"key": "recall_min_scores", "description": "Relevance score floors applied to RECALL ONLY (not reflect — server-side limitation). Dict mapping stage name to minimum score, e.g. {\"reranker\": 0.01}. Valid stages: semantic, keyword, reranker, final.", "default": {}},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
@@ -1351,6 +1394,13 @@ class HindsightMemoryProvider(MemoryProvider):
             self._recall_types = list(configured_types) or ["observation"]
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+
+        # Min-scores relevance floor (RECALL ONLY — server ReflectRequest has
+        # no min_scores field, so this does NOT apply to reflect paths).
+        self._recall_min_scores = _normalize_min_scores(
+            self._config.get("recall_min_scores")
+        )
+
         self._retain_async = self._config.get("retain_async", True)
 
         _client_version = "unknown"
@@ -1366,10 +1416,11 @@ class HindsightMemoryProvider(MemoryProvider):
                          self._bank_id_template, self._agent_identity, self._agent_workspace,
                          self._platform, self._user_id, self._bank_id)
         logger.debug("Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
-                     "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
+                     "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, "
+                     "tags=%s, recall_tags=%s, recall_min_scores=%s",
                      self._auto_retain, self._auto_recall, self._retain_every_n_turns,
                      self._retain_async, self._retain_context, self._recall_max_tokens, self._recall_max_input_chars,
-                     self._tags, self._recall_tags)
+                     self._tags, self._recall_tags, self._recall_min_scores)
 
         # For local mode, start the embedded daemon in the background so it
         # doesn't block the chat. Redirect stdout/stderr to a log file to
@@ -1511,6 +1562,8 @@ class HindsightMemoryProvider(MemoryProvider):
                         recall_kwargs["tags_match"] = self._recall_tags_match
                     if self._recall_types:
                         recall_kwargs["types"] = self._recall_types
+                    if self._recall_min_scores is not None:
+                        recall_kwargs["min_scores"] = self._recall_min_scores
                     logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
                                  self._bank_id, len(query), self._budget)
                     resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
@@ -1740,6 +1793,8 @@ class HindsightMemoryProvider(MemoryProvider):
                     recall_kwargs["tags_match"] = self._recall_tags_match
                 if self._recall_types:
                     recall_kwargs["types"] = self._recall_types
+                if self._recall_min_scores is not None:
+                    recall_kwargs["min_scores"] = self._recall_min_scores
                 logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
                 resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -35,6 +35,7 @@ import atexit
 import importlib
 import json
 import logging
+import math
 import os
 import queue
 import sys
@@ -574,6 +575,13 @@ def _normalize_min_scores(value: Any) -> Optional[Dict[str, float]]:
         except (TypeError, ValueError):
             logger.warning(
                 "recall_min_scores: key %r has non-numeric value %r — dropping",
+                key_str,
+                raw,
+            )
+            continue
+        if not math.isfinite(v):
+            logger.warning(
+                "recall_min_scores: key %r has non-finite value %r — dropping",
                 key_str,
                 raw,
             )

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -570,13 +570,22 @@ def _normalize_min_scores(value: Any) -> Optional[Dict[str, float]]:
             )
             continue
         try:
-            result[key_str] = float(raw)
+            v = float(raw)
         except (TypeError, ValueError):
             logger.warning(
                 "recall_min_scores: key %r has non-numeric value %r — dropping",
                 key_str,
                 raw,
             )
+            continue
+        # Range-clamp bounded stages (keyword uses BM25 which is unbounded ≥0).
+        if key_str in {"semantic", "reranker", "final"} and not (0.0 <= v <= 1.0):
+            logger.warning(
+                "recall_min_scores: %r value %s outside [0,1] — clamping",
+                key_str, v,
+            )
+            v = max(0.0, min(1.0, v))
+        result[key_str] = v
 
     return result or None
 
@@ -899,6 +908,12 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_types: list[str] = ["observation"]
         self._recall_prompt_preamble = ""
         self._recall_max_input_chars = 800
+
+        # v0.8.4+ recall parameters (prefer_observations, min_scores).
+        # Constructor defaults so any pre-initialize read never raises
+        # AttributeError. Actual values are set in initialize().
+        self._prefer_observations = False
+        self._recall_min_scores: dict | None = None
 
         # Bank
         self._bank_mission = ""
@@ -1246,6 +1261,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_min_scores", "description": "Relevance score floors applied to RECALL ONLY (not reflect — server-side limitation). Dict mapping stage name to minimum score, e.g. {\"reranker\": 0.01}. Valid stages: semantic, keyword, reranker, final.", "default": {}},
+            {"key": "prefer_observations", "description": "When recalling observation+raw facts together, drop raw facts superseded by consolidated observations. Requires Hindsight >= 0.8.4. Has no effect when recall_types is observation-only (the default).", "default": False},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
@@ -1773,6 +1789,33 @@ class HindsightMemoryProvider(MemoryProvider):
             self._config.get("recall_min_scores")
         )
 
+        # prefer_observations: pass through to arecall when configured. When
+        # recall_types is observation-only (the default), this flag has no
+        # effect — it only matters when at least one raw type (world/experience)
+        # is also included alongside observation. See runbook C3 decision.
+        self._prefer_observations = bool(
+            self._config.get("prefer_observations", False)
+        )
+
+        # Version guard (C4): if an installed hindsight-client < 0.8.4 would
+        # not accept these params, drop them gracefully (log warning, recall
+        # still proceeds) rather than raising TypeError.
+        if self._prefer_observations or self._recall_min_scores is not None:
+            try:
+                from importlib.metadata import version as _v
+                _installed_client = _v("hindsight-client")
+                if _meets_minimum_version(_installed_client, "0.8.4") is False:
+                    logger.warning(
+                        "v0.8.4 recall params (prefer_observations / min_scores) "
+                        "require hindsight-client >= 0.8.4 (installed: %s). "
+                        "Params disabled — recall will proceed without them.",
+                        _installed_client,
+                    )
+                    self._prefer_observations = False
+                    self._recall_min_scores = None
+            except Exception:
+                pass  # packaging/version not available — proceed
+
         self._retain_async = self._config.get("retain_async", True)
         self._prefetch_waits_for_retain = self._config.get("prefetch_waits_for_retain", True)
         self._prefetch_retain_drain_timeout = float(
@@ -2027,6 +2070,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     self._prefetch_count = recalled.count
 
 
+
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()
 
@@ -2268,6 +2312,11 @@ class HindsightMemoryProvider(MemoryProvider):
                     recall_kwargs["tags_match"] = self._recall_tags_match
                 if self._recall_types:
                     recall_kwargs["types"] = self._recall_types
+                # prefer_observations: wired but inert unless recall_types
+                # includes at least one raw type (world/experience) alongside
+                # observation (dormant-by-design, runbook C3).
+                if self._prefer_observations:
+                    recall_kwargs["prefer_observations"] = self._prefer_observations
                 if self._recall_min_scores is not None:
                     recall_kwargs["min_scores"] = self._recall_min_scores
                 logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -71,7 +71,7 @@ class _RecallResult:
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
-_MIN_CLIENT_VERSION = "0.6.1"
+_MIN_CLIENT_VERSION = "0.8.5"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # ``metadata.source`` stamped on retained memories — OPT-IN, empty by default.
@@ -537,6 +537,48 @@ def _normalize_observation_scopes(value: Any) -> Any:
         return scopes or None
 
     return None
+
+
+_VALID_MIN_SCORE_KEYS = frozenset({"semantic", "keyword", "reranker", "final"})
+
+
+def _normalize_min_scores(value: Any) -> Optional[Dict[str, float]]:
+    """Validate and normalize a ``recall_min_scores`` config value.
+
+    Returns a ``{stage: floor}`` dict ready to pass as ``min_scores`` to
+    ``client.arecall()``, or ``None`` if the config is unset / entirely invalid
+    (fail-open: no relevance floor applied).
+
+    Only the four known stage keys are accepted (0.8.5 client raises
+    ``ValueError`` on unknown keys).  Non-numeric values are dropped with a
+    ``logger.warning``.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        logger.warning("recall_min_scores: expected dict, got %s — ignoring", type(value).__name__)
+        return None
+
+    result: Dict[str, float] = {}
+    for key, raw in value.items():
+        key_str = str(key)
+        if key_str not in _VALID_MIN_SCORE_KEYS:
+            logger.warning(
+                "recall_min_scores: unknown key %r (must be one of %s) — dropping",
+                key_str,
+                ", ".join(sorted(_VALID_MIN_SCORE_KEYS)),
+            )
+            continue
+        try:
+            result[key_str] = float(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "recall_min_scores: key %r has non-numeric value %r — dropping",
+                key_str,
+                raw,
+            )
+
+    return result or None
 
 
 def _utc_timestamp() -> str:
@@ -1203,6 +1245,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
+            {"key": "recall_min_scores", "description": "Relevance score floors applied to RECALL ONLY (not reflect — server-side limitation). Dict mapping stage name to minimum score, e.g. {\"reranker\": 0.01}. Valid stages: semantic, keyword, reranker, final.", "default": {}},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
@@ -1723,6 +1766,13 @@ class HindsightMemoryProvider(MemoryProvider):
         # when a turn is dispatched to the writer. Same off switch rationale.
         self._retain_indicator = bool(self._config.get("retain_indicator", True))
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+
+        # Min-scores relevance floor (RECALL ONLY — server ReflectRequest has
+        # no min_scores field, so this does NOT apply to reflect paths).
+        self._recall_min_scores = _normalize_min_scores(
+            self._config.get("recall_min_scores")
+        )
+
         self._retain_async = self._config.get("retain_async", True)
         self._prefetch_waits_for_retain = self._config.get("prefetch_waits_for_retain", True)
         self._prefetch_retain_drain_timeout = float(
@@ -1742,10 +1792,11 @@ class HindsightMemoryProvider(MemoryProvider):
                          self._bank_id_template, self._agent_identity, self._agent_workspace,
                          self._platform, self._user_id, self._bank_id)
         logger.debug("Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
-                     "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
+                     "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, "
+                     "tags=%s, recall_tags=%s, recall_min_scores=%s",
                      self._auto_retain, self._auto_recall, self._retain_every_n_turns,
                      self._retain_async, self._retain_context, self._recall_max_tokens, self._recall_max_input_chars,
-                     self._tags, self._recall_tags)
+                     self._tags, self._recall_tags, self._recall_min_scores)
 
         # For local mode, start the embedded daemon in the background so it
         # doesn't block the chat. Redirect stdout/stderr to a log file to
@@ -1879,6 +1930,10 @@ class HindsightMemoryProvider(MemoryProvider):
                 recall_kwargs["tags_match"] = self._recall_tags_match
             if self._recall_types:
                 recall_kwargs["types"] = self._recall_types
+            if self._prefer_observations:
+                recall_kwargs["prefer_observations"] = self._prefer_observations
+            if self._recall_min_scores is not None:
+                recall_kwargs["min_scores"] = self._recall_min_scores
             logger.debug("Recall: calling recall (bank=%s, query_len=%d, budget=%s)",
                          self._bank_id, len(query), self._budget)
             resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
@@ -1970,6 +2025,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 with self._prefetch_lock:
                     self._prefetch_result = recalled.text
                     self._prefetch_count = recalled.count
+
 
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()
@@ -2212,6 +2268,8 @@ class HindsightMemoryProvider(MemoryProvider):
                     recall_kwargs["tags_match"] = self._recall_tags_match
                 if self._recall_types:
                     recall_kwargs["types"] = self._recall_types
+                if self._recall_min_scores is not None:
+                    recall_kwargs["min_scores"] = self._recall_min_scores
                 logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
                 resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1814,7 +1814,13 @@ class HindsightMemoryProvider(MemoryProvider):
                     self._prefer_observations = False
                     self._recall_min_scores = None
             except Exception:
-                pass  # packaging/version not available — proceed
+                logger.warning(
+                    "Could not determine hindsight-client version; disabling "
+                    "prefer_observations / min_scores params defensively — "
+                    "recall will proceed without them.",
+                )
+                self._prefer_observations = False
+                self._recall_min_scores = None
 
         self._retain_async = self._config.get("retain_async", True)
         self._prefetch_waits_for_retain = self._config.get("prefetch_waits_for_retain", True)

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.6.1"
+  - "hindsight-client>=0.8.5"
 requires_env: []
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,9 +180,10 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client==0.8.5"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
+
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]
 matrix = ["mautrix[encryption]==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.3"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -24,9 +24,11 @@ from plugins.memory.hindsight import (
     _load_config,
     _build_embedded_profile_env,
     _normalize_observation_scopes,
+    _normalize_min_scores,
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _VALID_MIN_SCORE_KEYS,
 )
 
 
@@ -1819,3 +1821,121 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_min_scores unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeMinScores:
+    """Validate the _normalize_min_scores helper (fail-open whitelist)."""
+
+    def test_none_returns_none(self):
+        assert _normalize_min_scores(None) is None
+
+    def test_valid_dict_returned(self):
+        result = _normalize_min_scores({"reranker": 0.01})
+        assert result == {"reranker": 0.01}
+
+    def test_all_valid_keys_accepted(self):
+        value = {"semantic": 0.1, "keyword": 0.2, "reranker": 0.01, "final": 0.5}
+        result = _normalize_min_scores(value)
+        assert result == value
+
+    def test_unknown_key_dropped_with_warning(self, caplog):
+        result = _normalize_min_scores({"reranker": 0.01, "rerank": 0.5})
+        assert result == {"reranker": 0.01}
+        assert any("unknown key" in rec.message.lower() for rec in caplog.records)
+
+    def test_non_numeric_value_dropped_with_warning(self, caplog):
+        result = _normalize_min_scores({"reranker": 0.01, "semantic": "high"})
+        assert result == {"reranker": 0.01}
+        assert any("non-numeric" in rec.message.lower() for rec in caplog.records)
+
+    def test_all_invalid_returns_none(self, caplog):
+        result = _normalize_min_scores({"bad_key": 0.5})
+        assert result is None
+        # At least one warning logged
+        assert any(rec.levelname == "WARNING" for rec in caplog.records)
+
+    def test_type_error_value_dropped(self, caplog):
+        """A list value should be dropped as non-numeric."""
+        result = _normalize_min_scores({"reranker": [1, 2]})
+        assert result is None  # "reranker" was the only key, value is invalid
+        assert any("non-numeric" in rec.message.lower() for rec in caplog.records)
+
+    def test_not_a_dict_returns_none(self, caplog):
+        result = _normalize_min_scores("reranker:0.01")
+        assert result is None
+        assert any("expected dict" in rec.message.lower() for rec in caplog.records)
+
+    def test_valid_keys_constant(self):
+        assert _VALID_MIN_SCORE_KEYS == {"semantic", "keyword", "reranker", "final"}
+
+    def test_int_value_coerced_to_float(self):
+        result = _normalize_min_scores({"reranker": 1})
+        assert result == {"reranker": 1.0}
+        assert isinstance(result["reranker"], float)
+
+
+# ---------------------------------------------------------------------------
+# Recall min_scores wiring tests
+# ---------------------------------------------------------------------------
+
+
+class TestRecallMinScores:
+    """Verify recall_min_scores reaches arecall at both call sites and that
+    malformed config is dropped (fail-open)."""
+
+    def test_prefetch_passes_min_scores_when_configured(self, provider_with_config):
+        p = provider_with_config(recall_min_scores={"reranker": 0.01})
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["min_scores"] == {"reranker": 0.01}
+
+    def test_prefetch_omits_min_scores_when_unset(self, provider_with_config):
+        p = provider_with_config()
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "min_scores" not in call_kwargs
+
+    def test_hindsight_recall_tool_passes_min_scores(self, provider_with_config):
+        p = provider_with_config(recall_min_scores={"reranker": 0.02, "final": 0.1})
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["min_scores"] == {"reranker": 0.02, "final": 0.1}
+
+    def test_hindsight_recall_tool_omits_min_scores_when_unset(self, provider_with_config):
+        p = provider_with_config()
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "min_scores" not in call_kwargs
+
+    def test_malformed_min_scores_unknown_key(self, provider_with_config, caplog):
+        """Unknown key is dropped; min_scores is NOT passed to arecall."""
+        p = provider_with_config(
+            recall_min_scores={"unknown_stage": 0.5}
+        )
+        assert p._recall_min_scores is None  # all entries dropped
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "min_scores" not in call_kwargs
+        assert any("unknown key" in rec.message.lower() for rec in caplog.records)
+
+    def test_malformed_min_scores_non_numeric(self, provider_with_config, caplog):
+        """Non-numeric value is dropped; min_scores is NOT passed to arecall."""
+        p = provider_with_config(
+            recall_min_scores={"reranker": "high"}
+        )
+        assert p._recall_min_scores is None  # all entries dropped
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "min_scores" not in call_kwargs
+        assert any("non-numeric" in rec.message.lower() for rec in caplog.records)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1681,3 +1681,79 @@ class TestRecallMinScores:
         call_kwargs = p._client.arecall.call_args.kwargs
         assert "min_scores" not in call_kwargs
         assert any("non-numeric" in rec.message.lower() for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# prefer_observations wiring tests (+ combined with min_scores)
+# ---------------------------------------------------------------------------
+
+
+class TestPreferObservations:
+    """Verify prefer_observations reaches arecall at both call sites and that
+    the kwarg is omitted when the flag is False / unset."""
+
+    def test_prefetch_passes_prefer_observations(self, provider_with_config, monkeypatch):
+        """Auto-recall (prefetch) passes prefer_observations=True when configured."""
+        monkeypatch.setattr("importlib.metadata.version", lambda _: "0.8.5")
+        p = provider_with_config(prefer_observations=True)
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["prefer_observations"] is True
+
+    def test_tool_recall_passes_prefer_observations(self, provider_with_config, monkeypatch):
+        """Tool recall path passes prefer_observations=True when configured."""
+        monkeypatch.setattr("importlib.metadata.version", lambda _: "0.8.5")
+        p = provider_with_config(prefer_observations=True)
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["prefer_observations"] is True
+
+    def test_both_sites_omit_when_unset(self, provider_with_config, monkeypatch):
+        """When prefer_observations is False, the kwarg is omitted at both sites."""
+        # Tool call
+        monkeypatch.setattr("importlib.metadata.version", lambda _: "0.8.5")
+        p = provider_with_config(prefer_observations=False)
+        p.handle_tool_call("hindsight_recall", {"query": "t1"})
+        kwargs = p._client.arecall.call_args.kwargs
+        assert "prefer_observations" not in kwargs
+
+        # Prefetch (recreate provider)
+        p2 = provider_with_config(prefer_observations=False)
+        p2.queue_prefetch("t2")
+        if p2._prefetch_thread:
+            p2._prefetch_thread.join(timeout=5.0)
+        kwargs2 = p2._client.arecall.call_args.kwargs
+        assert "prefer_observations" not in kwargs2
+
+    def test_both_flags_together_in_same_call(self, provider_with_config, monkeypatch):
+        """prefer_observations AND recall_min_scores both reach arecall together."""
+        monkeypatch.setattr("importlib.metadata.version", lambda _: "0.8.5")
+        p = provider_with_config(
+            prefer_observations=True,
+            recall_min_scores={"reranker": 0.3, "semantic": 0.5},
+        )
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        kwargs = p._client.arecall.call_args.kwargs
+        assert kwargs["prefer_observations"] is True
+        assert kwargs["min_scores"] == {"reranker": 0.3, "semantic": 0.5}
+
+    def test_version_guard_disables_on_old_client(self, provider_with_config, monkeypatch, caplog):
+        """v0.8.4 recall params are knocked out when hindsight-client < 0.8.4."""
+        monkeypatch.setattr("importlib.metadata.version", lambda _: "0.6.1")
+        p = provider_with_config(
+            prefer_observations=True,
+            recall_min_scores={"reranker": 0.5},
+        )
+        # Despite config being set, both should be knocked out
+        assert p._prefer_observations is False
+        assert p._recall_min_scores is None
+
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        kwargs = p._client.arecall.call_args.kwargs
+        assert "prefer_observations" not in kwargs
+        assert "min_scores" not in kwargs
+        assert any("require hindsight-client >= 0.8.4" in rec.message for rec in caplog.records)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -27,9 +27,11 @@ from plugins.memory.hindsight import (
     _load_simple_env,
     _build_embedded_profile_env,
     _normalize_observation_scopes,
+    _normalize_min_scores,
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _VALID_MIN_SCORE_KEYS,
 )
 
 
@@ -1561,3 +1563,121 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()
                    for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_min_scores unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeMinScores:
+    """Validate the _normalize_min_scores helper (fail-open whitelist)."""
+
+    def test_none_returns_none(self):
+        assert _normalize_min_scores(None) is None
+
+    def test_valid_dict_returned(self):
+        result = _normalize_min_scores({"reranker": 0.01})
+        assert result == {"reranker": 0.01}
+
+    def test_all_valid_keys_accepted(self):
+        value = {"semantic": 0.1, "keyword": 0.2, "reranker": 0.01, "final": 0.5}
+        result = _normalize_min_scores(value)
+        assert result == value
+
+    def test_unknown_key_dropped_with_warning(self, caplog):
+        result = _normalize_min_scores({"reranker": 0.01, "rerank": 0.5})
+        assert result == {"reranker": 0.01}
+        assert any("unknown key" in rec.message.lower() for rec in caplog.records)
+
+    def test_non_numeric_value_dropped_with_warning(self, caplog):
+        result = _normalize_min_scores({"reranker": 0.01, "semantic": "high"})
+        assert result == {"reranker": 0.01}
+        assert any("non-numeric" in rec.message.lower() for rec in caplog.records)
+
+    def test_all_invalid_returns_none(self, caplog):
+        result = _normalize_min_scores({"bad_key": 0.5})
+        assert result is None
+        # At least one warning logged
+        assert any(rec.levelname == "WARNING" for rec in caplog.records)
+
+    def test_type_error_value_dropped(self, caplog):
+        """A list value should be dropped as non-numeric."""
+        result = _normalize_min_scores({"reranker": [1, 2]})
+        assert result is None  # "reranker" was the only key, value is invalid
+        assert any("non-numeric" in rec.message.lower() for rec in caplog.records)
+
+    def test_not_a_dict_returns_none(self, caplog):
+        result = _normalize_min_scores("reranker:0.01")
+        assert result is None
+        assert any("expected dict" in rec.message.lower() for rec in caplog.records)
+
+    def test_valid_keys_constant(self):
+        assert _VALID_MIN_SCORE_KEYS == {"semantic", "keyword", "reranker", "final"}
+
+    def test_int_value_coerced_to_float(self):
+        result = _normalize_min_scores({"reranker": 1})
+        assert result == {"reranker": 1.0}
+        assert isinstance(result["reranker"], float)
+
+
+# ---------------------------------------------------------------------------
+# Recall min_scores wiring tests
+# ---------------------------------------------------------------------------
+
+
+class TestRecallMinScores:
+    """Verify recall_min_scores reaches arecall at both call sites and that
+    malformed config is dropped (fail-open)."""
+
+    def test_prefetch_passes_min_scores_when_configured(self, provider_with_config):
+        p = provider_with_config(recall_min_scores={"reranker": 0.01})
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["min_scores"] == {"reranker": 0.01}
+
+    def test_prefetch_omits_min_scores_when_unset(self, provider_with_config):
+        p = provider_with_config()
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "min_scores" not in call_kwargs
+
+    def test_hindsight_recall_tool_passes_min_scores(self, provider_with_config):
+        p = provider_with_config(recall_min_scores={"reranker": 0.02, "final": 0.1})
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["min_scores"] == {"reranker": 0.02, "final": 0.1}
+
+    def test_hindsight_recall_tool_omits_min_scores_when_unset(self, provider_with_config):
+        p = provider_with_config()
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "min_scores" not in call_kwargs
+
+    def test_malformed_min_scores_unknown_key(self, provider_with_config, caplog):
+        """Unknown key is dropped; min_scores is NOT passed to arecall."""
+        p = provider_with_config(
+            recall_min_scores={"unknown_stage": 0.5}
+        )
+        assert p._recall_min_scores is None  # all entries dropped
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "min_scores" not in call_kwargs
+        assert any("unknown key" in rec.message.lower() for rec in caplog.records)
+
+    def test_malformed_min_scores_non_numeric(self, provider_with_config, caplog):
+        """Non-numeric value is dropped; min_scores is NOT passed to arecall."""
+        p = provider_with_config(
+            recall_min_scores={"reranker": "high"}
+        )
+        assert p._recall_min_scores is None  # all entries dropped
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "min_scores" not in call_kwargs
+        assert any("non-numeric" in rec.message.lower() for rec in caplog.records)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -191,7 +191,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client==0.8.5",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -140,7 +140,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.0.1",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client==0.8.5",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the

--- a/uv.lock
+++ b/uv.lock
@@ -1868,9 +1868,10 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.8.5" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
+
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "httpx2", marker = "extra == 'computer-use'", specifier = "==2.7.0" },
     { name = "httpx2", marker = "extra == 'dev'", specifier = "==2.7.0" },
@@ -1966,7 +1967,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-client"
-version = "0.6.1"
+version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1976,9 +1977,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/26/8b8efa4be21fc3ba12ade3b1353d87f9837ec0d3ec2607e8adbf85bc9c63/hindsight_client-0.6.1.tar.gz", hash = "sha256:314d0bb9e13622e15586ba1586a799726d405b27bc20d78872474b5d6d96cd51", size = 99833, upload-time = "2026-05-08T13:01:23.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/18/c74c4d7dfc181157fb9deb0f3fd17258eb83f73f8e701c8f77ed085138a7/hindsight_client-0.8.5.tar.gz", hash = "sha256:5f435a9f60e7232bb642be79c7dbe4e4e53c72720c110b8cfe28f242835ed04c", size = 118313, upload-time = "2026-07-22T12:05:33.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/4f/a1d0bc33ef933ecc52e76dc1514163594d25836a5d303c256a61bb61445d/hindsight_client-0.6.1-py3-none-any.whl", hash = "sha256:9fdda176ab50f7cec8d7339c6608c148f0cd9ad7e65d9d76192f2db730bc330a", size = 249379, upload-time = "2026-05-08T13:01:22.035Z" },
+    { url = "https://files.pythonhosted.org/packages/23/66/80f8f49e3395a97e630b25b42fda5c545a1bda7ae2be581e4c774b767e21/hindsight_client-0.8.5-py3-none-any.whl", hash = "sha256:f868a4764a9d98d84f8fdff6f50703e00d91667b55c22a6c19e2bc44bb84295f", size = 291921, upload-time = "2026-07-22T12:05:32.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add opt-in `recall_min_scores` config key that passes a relevance floor through to Hindsight's recall calls, fixing the "no relevance floor, backfills to token budget regardless of fit" bug that injects stale/irrelevant facts into every turn.

Per Planner spec review (t_babb0d63, APPROVED WITH CORRECTIONS).

## Changes

### Version pin (B1 — atomic across 3 files)
- `plugins/memory/hindsight/__init__.py`: `_MIN_CLIENT_VERSION` 0.6.1 → 0.8.5
- `tools/lazy_deps.py`: `hindsight-client==0.6.1` → `==0.8.5` (exact pin)
- `plugin.yaml`: `hindsight-client>=0.6.1` → `>=0.8.5`

### New config + validation (B2)
- `recall_min_scores` in `get_config_schema()` — opt-in dict e.g. `{"reranker": 0.01}`
- `_normalize_min_scores()` helper with key whitelist `{semantic, keyword, reranker, final}`, float coercion, fail-open on invalid input
- Wired in `initialize()` next to other recall controls

### Call-site wiring (2 sites)
- `queue_prefetch()` — prefetch recall: passes `min_scores` to `arecall(**recall_kwargs)`
- `hindsight_recall` tool — passes `min_scores` to `arecall(**recall_kwargs)`
- Reflect call sites **intentionally untouched** (server 0.8.4 ReflectRequest has no `min_scores` field)
- No numeric default — ship unset/opt-in only

### Tests (16 new)
- `_normalize_min_scores` validation: None, valid dict, all keys, unknown key dropped, non-numeric dropped, all-invalid returns None, type error, not-a-dict, int→float coercion
- Wiring: prefetch passes/omits min_scores, hindsight_recall tool passes/omits min_scores, malformed config drops with warning and does NOT pass to arecall (fail-open confirmed)

## Verification

All 132 tests pass (116 existing + 16 new):
```
pytest tests/plugins/memory/test_hindsight_provider.py -v
# ============================= 132 passed in 3.15s ==============================
```

## Files changed
- `plugins/memory/hindsight/__init__.py` (+61 lines)
- `plugins/memory/hindsight/plugin.yaml` (+1/-1)
- `tools/lazy_deps.py` (+1/-1)
- `tests/plugins/memory/test_hindsight_provider.py` (+120 lines)