### PR TITLE
fix(kanban): scope default assignee fallback by board

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1256,6 +1256,16 @@ delegation:
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
 
 # =============================================================================
+# Kanban Dispatch
+# =============================================================================
+# The singleton dispatcher scans every board for explicitly assigned cards.
+# Scope only the fallback that assigns otherwise-unassigned Ready cards:
+# kanban:
+#   default_assignee: ""                     # Profile used as the fallback
+#   default_assignee_boards:                 # Default: only the legacy default board
+#     - default                              # Use [] to disable or ["*"] for every board
+
+# =============================================================================
 # Honcho Integration (Cross-Session User Modeling)
 # =============================================================================
 # AI-native persistent memory via Honcho (https://honcho.dev/).

--- a/docs/kanban/multi-gateway.md
+++ b/docs/kanban/multi-gateway.md
@@ -19,7 +19,10 @@ same flag means exactly one process touches the kanban DBs.
 ## Configuration
 
 On the dispatch-owning gateway (typically the `default` profile), no change is
-needed. On every other profile gateway, add to `~/.hermes/config.yaml`:
+needed for explicitly assigned cards. Its profile-local
+`kanban.default_assignee` is authorized only on the legacy `default` board
+unless `kanban.default_assignee_boards` opts in named boards. On every other
+profile gateway, add to that profile's `config.yaml`:
 
 ```yaml
 kanban:
@@ -27,6 +30,20 @@ kanban:
 ```
 
 Or set the env var: `HERMES_KANBAN_DISPATCH_IN_GATEWAY=false`
+
+If the dispatch owner should apply its fallback to named boards, list them
+explicitly:
+
+```yaml
+kanban:
+  default_assignee: default
+  default_assignee_boards: [project-a, project-b]
+```
+
+Use `default_assignee_boards: ["*"]` only when the dispatcher profile is
+deliberately trusted to assign unowned Ready cards on every board. An empty
+list disables fallback assignment without stopping dispatch of cards that
+already have an assignee.
 
 ## What each gateway does
 

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1195,11 +1195,6 @@ class GatewayKanbanWatchersMixin:
             connection handle or accidentally claim across each other.
             """
             conn = None
-            fallback_rule = _kb.default_assignee_routing_rule(
-                slug,
-                default_assignee_boards,
-            )
-            board_default_assignee = default_assignee if fallback_rule else None
             fingerprint = _board_db_fingerprint(slug)
             disabled_entry = disabled_corrupt_boards.get(slug)
             if disabled_entry is not None:
@@ -1238,9 +1233,9 @@ class GatewayKanbanWatchersMixin:
                     max_in_progress=max_in_progress,
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,
-                    default_assignee=board_default_assignee,
+                    default_assignee=default_assignee,
                     default_assignee_dispatcher_profile=dispatcher_profile,
-                    default_assignee_routing_rule=fallback_rule,
+                    default_assignee_boards=default_assignee_boards,
                     max_in_progress_per_profile=max_in_progress_per_profile,
                 )
             except sqlite3.DatabaseError as exc:

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1089,18 +1089,28 @@ class GatewayKanbanWatchersMixin:
             )
             stale_timeout_seconds = 0
 
-        # Read kanban.default_assignee — fallback profile for tasks
-        # created without an explicit assignee (e.g. via the dashboard).
-        # When set, the dispatcher applies it to unassigned ready tasks
-        # instead of skipping them indefinitely (#27145). Empty string
-        # (the schema default) means "no fallback, keep skipping" —
-        # backward-compatible with existing installs.
+        # Read kanban.default_assignee — fallback profile for tasks created
+        # without an explicit assignee (e.g. via the dashboard). Boards are
+        # shared across profiles, so the profile-local fallback is applied only
+        # on boards authorized by default_assignee_boards.  The default board
+        # remains authorized for compatibility with the original single-board
+        # feature (#27145); named boards require an explicit slug or wildcard.
         default_assignee = (kanban_cfg.get("default_assignee") or "").strip() or None
+        default_assignee_boards = kanban_cfg.get(
+            "default_assignee_boards",
+            [_kb.DEFAULT_BOARD],
+        )
+        try:
+            dispatcher_profile = getattr(self, "_active_profile_name")()
+        except Exception:
+            dispatcher_profile = "unknown"
         if default_assignee:
             logger.info(
-                "kanban dispatcher: default_assignee=%r (unassigned ready tasks "
-                "will route to this profile)",
+                "kanban dispatcher: default_assignee=%r profile=%s "
+                "authorized_boards=%r",
                 default_assignee,
+                dispatcher_profile,
+                default_assignee_boards,
             )
 
         # Read kanban.max_in_progress_per_profile — per-profile concurrency
@@ -1185,6 +1195,11 @@ class GatewayKanbanWatchersMixin:
             connection handle or accidentally claim across each other.
             """
             conn = None
+            fallback_rule = _kb.default_assignee_routing_rule(
+                slug,
+                default_assignee_boards,
+            )
+            board_default_assignee = default_assignee if fallback_rule else None
             fingerprint = _board_db_fingerprint(slug)
             disabled_entry = disabled_corrupt_boards.get(slug)
             if disabled_entry is not None:
@@ -1223,7 +1238,9 @@ class GatewayKanbanWatchersMixin:
                     max_in_progress=max_in_progress,
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,
-                    default_assignee=default_assignee,
+                    default_assignee=board_default_assignee,
+                    default_assignee_dispatcher_profile=dispatcher_profile,
+                    default_assignee_routing_rule=fallback_rule,
                     max_in_progress_per_profile=max_in_progress_per_profile,
                 )
             except sqlite3.DatabaseError as exc:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2176,6 +2176,13 @@ DEFAULT_CONFIG = {
         # assignee to any installed profile. When unset, falls back to the
         # default profile. A task never ends up with assignee=None.
         "default_assignee": "",
+        # Boards on which this profile's dispatcher may apply
+        # kanban.default_assignee to an otherwise unassigned Ready card.
+        # The singleton dispatcher still scans every board for explicitly
+        # assigned work. ["default"] preserves the original single-board
+        # behavior; [] disables fallback assignment; named slugs opt in
+        # those boards; ["*"] deliberately restores legacy all-board fallback.
+        "default_assignee_boards": ["default"],
         # Per-profile concurrency cap (#21582). When set to a positive int,
         # no single profile can have more than N workers running at once,
         # even if the global max_in_progress / max_spawn caps would allow

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2445,7 +2445,17 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         from hermes_cli.config import load_config
         _cfg = load_config()
         _kanban_cfg = _cfg.get("kanban", {}) if isinstance(_cfg, dict) else {}
-        default_assignee = (_kanban_cfg.get("default_assignee") or "").strip() or None
+        configured_default_assignee = (
+            (_kanban_cfg.get("default_assignee") or "").strip() or None
+        )
+        default_assignee_rule = kb.default_assignee_routing_rule(
+            kb.get_current_board(),
+            _kanban_cfg.get("default_assignee_boards", [kb.DEFAULT_BOARD]),
+        )
+        default_assignee = (
+            configured_default_assignee if default_assignee_rule else None
+        )
+        default_assignee_dispatcher_profile = _profile_author()
 
         def _coerce_positive_int(value):
             if value is None:
@@ -2468,6 +2478,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         )
     except Exception:
         default_assignee = None
+        default_assignee_rule = None
+        default_assignee_dispatcher_profile = None
         max_in_progress_per_profile = None
         max_in_progress = None
         max_spawn = getattr(args, "max", None)
@@ -2479,6 +2491,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             max_in_progress=max_in_progress,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             default_assignee=default_assignee,
+            default_assignee_dispatcher_profile=default_assignee_dispatcher_profile,
+            default_assignee_routing_rule=default_assignee_rule,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
     if getattr(args, "json", False):

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2448,12 +2448,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         configured_default_assignee = (
             (_kanban_cfg.get("default_assignee") or "").strip() or None
         )
-        default_assignee_rule = kb.default_assignee_routing_rule(
-            kb.get_current_board(),
-            _kanban_cfg.get("default_assignee_boards", [kb.DEFAULT_BOARD]),
-        )
-        default_assignee = (
-            configured_default_assignee if default_assignee_rule else None
+        default_assignee_boards = _kanban_cfg.get(
+            "default_assignee_boards",
+            [kb.DEFAULT_BOARD],
         )
         default_assignee_dispatcher_profile = _profile_author()
 
@@ -2477,8 +2474,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             _kanban_cfg.get("max_spawn")
         )
     except Exception:
-        default_assignee = None
-        default_assignee_rule = None
+        configured_default_assignee = None
+        default_assignee_boards = []
         default_assignee_dispatcher_profile = None
         max_in_progress_per_profile = None
         max_in_progress = None
@@ -2490,9 +2487,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             max_spawn=max_spawn,
             max_in_progress=max_in_progress,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
-            default_assignee=default_assignee,
+            default_assignee=configured_default_assignee,
             default_assignee_dispatcher_profile=default_assignee_dispatcher_profile,
-            default_assignee_routing_rule=default_assignee_rule,
+            default_assignee_boards=default_assignee_boards,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
     if getattr(args, "json", False):
@@ -2536,7 +2533,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(f"  - {tid}  ->  {who}  @ {ws or '-'}{tag}")
     if res.auto_assigned_default:
         print(
-            f"Auto-assigned to kanban.default_assignee={default_assignee!r}: "
+            "Auto-assigned to "
+            f"kanban.default_assignee={configured_default_assignee!r}: "
             f"{', '.join(res.auto_assigned_default)}"
         )
     if res.skipped_unassigned:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -400,8 +400,8 @@ def default_assignee_routing_rule(
     ``kanban.default_assignee`` belongs to the profile hosting the singleton
     dispatcher, while boards are shared across profiles.  The fallback must
     therefore be explicitly board-scoped before it may mutate an unassigned
-    card.  A missing setting keeps the original single-board behavior by
-    authorizing only ``default``; an explicit empty list disables fallback
+    card.  Callers supply ``["default"]`` for a missing setting to keep the
+    original single-board behavior; an explicit empty list disables fallback
     assignment everywhere; and ``["*"]`` deliberately restores the historical
     all-board behavior.
 
@@ -410,7 +410,7 @@ def default_assignee_routing_rule(
     authorized for this board.
     """
     slug = _normalize_board_slug(board) or DEFAULT_BOARD
-    entries = [DEFAULT_BOARD] if configured_boards is None else configured_boards
+    entries = configured_boards
     if not isinstance(entries, (list, tuple, set, frozenset)):
         return None
 
@@ -8108,7 +8108,7 @@ def dispatch_once(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     default_assignee_dispatcher_profile: Optional[str] = None,
-    default_assignee_routing_rule: Optional[str] = None,
+    default_assignee_boards: object = (DEFAULT_BOARD,),
     max_in_progress_per_profile: Optional[int] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
@@ -8125,6 +8125,12 @@ def dispatch_once(
     The lock is keyed off the board's resolved DB path, so unrelated
     boards tick in parallel. See :func:`_dispatch_tick_lock` for the
     cross-process / cross-platform mechanics.
+
+    Fallback authorization is also enforced here, at the mutation boundary:
+    ``default_assignee`` is ignored unless the resolved board matches
+    ``default_assignee_boards`` (or its explicit ``"*"`` wildcard). Keeping
+    this check below gateway/CLI orchestration prevents sibling callers from
+    bypassing board scope.
     """
     try:
         db_path = kanban_db_path(board=board)
@@ -8144,7 +8150,7 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             default_assignee_dispatcher_profile=default_assignee_dispatcher_profile,
-            default_assignee_routing_rule=default_assignee_routing_rule,
+            default_assignee_boards=default_assignee_boards,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
     with _dispatch_tick_lock(db_path) as held:
@@ -8162,7 +8168,7 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             default_assignee_dispatcher_profile=default_assignee_dispatcher_profile,
-            default_assignee_routing_rule=default_assignee_routing_rule,
+            default_assignee_boards=default_assignee_boards,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
         # Still under the dispatch lock: opportunistically truncate the WAL
@@ -8184,7 +8190,7 @@ def _dispatch_once_locked(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     default_assignee_dispatcher_profile: Optional[str] = None,
-    default_assignee_routing_rule: Optional[str] = None,
+    default_assignee_boards: object = (DEFAULT_BOARD,),
     max_in_progress_per_profile: Optional[int] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
@@ -8302,7 +8308,14 @@ def _dispatch_once_locked(
     # Normalize default_assignee once: empty/whitespace string → None so the
     # rest of the loop can use ``if default_assignee:`` as a single check.
     # We also resolve profile_exists once here for the same reason.
-    _default_assignee = (default_assignee or "").strip() or None
+    effective_board = _normalize_board_slug(board) or get_current_board()
+    default_assignee_rule = default_assignee_routing_rule(
+        effective_board,
+        default_assignee_boards,
+    )
+    _default_assignee = (
+        (default_assignee or "").strip() or None
+    ) if default_assignee_rule else None
     _default_assignee_resolved = False
     if _default_assignee:
         try:
@@ -8331,6 +8344,7 @@ def _dispatch_once_locked(
             # by ``kanban.default_assignee``, not "unassigned but secretly
             # routed".
             if _default_assignee and _default_assignee_resolved:
+                assert default_assignee_rule is not None
                 # Dry-run: show what WOULD happen (auto-assign + spawn) without
                 # mutating the DB. Real run: mutate the row + emit the
                 # 'assigned' event so the board state matches what just happened.
@@ -8350,10 +8364,9 @@ def _dispatch_once_locked(
                                 assignment_payload["dispatcher_profile"] = (
                                     default_assignee_dispatcher_profile
                                 )
-                            if default_assignee_routing_rule:
-                                assignment_payload["routing_rule"] = (
-                                    default_assignee_routing_rule
-                                )
+                            assignment_payload["routing_rule"] = (
+                                default_assignee_rule
+                            )
                             _append_event(
                                 conn,
                                 row["id"],

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -391,6 +391,85 @@ def _normalize_board_slug(slug: Optional[str]) -> Optional[str]:
     return s
 
 
+def _main_db_path_for_connection(conn: sqlite3.Connection) -> Optional[Path]:
+    """Return the resolved path of SQLite's main database, when file-backed."""
+    try:
+        rows = conn.execute("PRAGMA database_list").fetchall()
+    except Exception:
+        return None
+
+    filename = ""
+    for row in rows:
+        try:
+            name, row_filename = row["name"], row["file"]
+        except (IndexError, KeyError, TypeError):
+            try:
+                name, row_filename = row[1], row[2]
+            except (IndexError, TypeError):
+                continue
+        if name == "main":
+            filename = str(row_filename or "").strip()
+            break
+    if not filename:
+        return None
+
+    try:
+        return Path(filename).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
+def _dispatch_board_for_connection(
+    conn: sqlite3.Connection,
+    requested_board: Optional[str],
+) -> Optional[str]:
+    """Resolve the board actually backing ``conn`` for fallback authorization.
+
+    ``requested_board`` is not authoritative: a caller can accidentally open
+    one board and pass another slug (or omit the slug while the ambient current
+    board points elsewhere). Authorization therefore follows SQLite's main DB
+    path. Unknown/custom paths fail closed unless ``HERMES_KANBAN_DB`` explicitly
+    pins that exact path, in which case the requested/current board supplies the
+    legacy override's otherwise-unavailable slug.
+    """
+    actual_path = _main_db_path_for_connection(conn)
+    if actual_path is None:
+        return None
+    try:
+        default_path = (kanban_home() / "kanban.db").expanduser().resolve()
+    except (OSError, RuntimeError):
+        return None
+    if actual_path == default_path:
+        return DEFAULT_BOARD
+
+    try:
+        relative = actual_path.relative_to(boards_root().expanduser().resolve())
+    except (OSError, RuntimeError, ValueError):
+        relative = None
+    if relative is not None and len(relative.parts) == 2:
+        slug_part, db_filename = relative.parts
+        if db_filename == "kanban.db":
+            try:
+                slug = _normalize_board_slug(slug_part)
+            except ValueError:
+                slug = None
+            if slug:
+                return slug
+
+    override = os.environ.get("HERMES_KANBAN_DB", "").strip()
+    if override:
+        try:
+            override_path = Path(override).expanduser().resolve()
+        except (OSError, RuntimeError):
+            return None
+        if actual_path == override_path:
+            try:
+                return _normalize_board_slug(requested_board) or get_current_board()
+            except ValueError:
+                return None
+    return None
+
+
 def default_assignee_routing_rule(
     board: Optional[str],
     configured_boards: object | None,
@@ -8132,8 +8211,11 @@ def dispatch_once(
     this check below gateway/CLI orchestration prevents sibling callers from
     bypassing board scope.
     """
+    connection_db_path = _main_db_path_for_connection(conn)
+    connection_board = _dispatch_board_for_connection(conn, board)
+    effective_board = connection_board if connection_board is not None else board
     try:
-        db_path = kanban_db_path(board=board)
+        db_path = connection_db_path or kanban_db_path(board=board)
     except Exception:
         # Path resolution should never fail, but if it somehow does we
         # must not lose the tick — fall through to an unguarded dispatch
@@ -8147,7 +8229,7 @@ def dispatch_once(
             max_in_progress=max_in_progress,
             failure_limit=failure_limit,
             stale_timeout_seconds=stale_timeout_seconds,
-            board=board,
+            board=effective_board,
             default_assignee=default_assignee,
             default_assignee_dispatcher_profile=default_assignee_dispatcher_profile,
             default_assignee_boards=default_assignee_boards,
@@ -8165,7 +8247,7 @@ def dispatch_once(
             max_in_progress=max_in_progress,
             failure_limit=failure_limit,
             stale_timeout_seconds=stale_timeout_seconds,
-            board=board,
+            board=effective_board,
             default_assignee=default_assignee,
             default_assignee_dispatcher_profile=default_assignee_dispatcher_profile,
             default_assignee_boards=default_assignee_boards,
@@ -8308,10 +8390,10 @@ def _dispatch_once_locked(
     # Normalize default_assignee once: empty/whitespace string → None so the
     # rest of the loop can use ``if default_assignee:`` as a single check.
     # We also resolve profile_exists once here for the same reason.
-    effective_board = _normalize_board_slug(board) or get_current_board()
+    effective_board = _dispatch_board_for_connection(conn, board)
     default_assignee_rule = default_assignee_routing_rule(
         effective_board,
-        default_assignee_boards,
+        default_assignee_boards if effective_board is not None else (),
     )
     _default_assignee = (
         (default_assignee or "").strip() or None

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -391,6 +391,47 @@ def _normalize_board_slug(slug: Optional[str]) -> Optional[str]:
     return s
 
 
+def default_assignee_routing_rule(
+    board: Optional[str],
+    configured_boards: object | None,
+) -> Optional[str]:
+    """Return the config rule authorizing fallback assignment on ``board``.
+
+    ``kanban.default_assignee`` belongs to the profile hosting the singleton
+    dispatcher, while boards are shared across profiles.  The fallback must
+    therefore be explicitly board-scoped before it may mutate an unassigned
+    card.  A missing setting keeps the original single-board behavior by
+    authorizing only ``default``; an explicit empty list disables fallback
+    assignment everywhere; and ``["*"]`` deliberately restores the historical
+    all-board behavior.
+
+    Invalid values fail closed.  The returned string is suitable for the
+    assignment event audit trail; ``None`` means the fallback is not
+    authorized for this board.
+    """
+    slug = _normalize_board_slug(board) or DEFAULT_BOARD
+    entries = [DEFAULT_BOARD] if configured_boards is None else configured_boards
+    if not isinstance(entries, (list, tuple, set, frozenset)):
+        return None
+
+    normalized: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, str):
+            continue
+        value = entry.strip().lower()
+        if value == "*":
+            return "kanban.default_assignee_boards:*"
+        try:
+            routed_slug = _normalize_board_slug(value)
+        except ValueError:
+            continue
+        if routed_slug:
+            normalized.add(routed_slug)
+    if slug in normalized:
+        return f"kanban.default_assignee_boards:{slug}"
+    return None
+
+
 def kanban_home() -> Path:
     """Return the shared Hermes root that anchors the kanban board.
 
@@ -8066,6 +8107,8 @@ def dispatch_once(
     stale_timeout_seconds: int = 0,
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
+    default_assignee_dispatcher_profile: Optional[str] = None,
+    default_assignee_routing_rule: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
@@ -8100,6 +8143,8 @@ def dispatch_once(
             stale_timeout_seconds=stale_timeout_seconds,
             board=board,
             default_assignee=default_assignee,
+            default_assignee_dispatcher_profile=default_assignee_dispatcher_profile,
+            default_assignee_routing_rule=default_assignee_routing_rule,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
     with _dispatch_tick_lock(db_path) as held:
@@ -8116,6 +8161,8 @@ def dispatch_once(
             stale_timeout_seconds=stale_timeout_seconds,
             board=board,
             default_assignee=default_assignee,
+            default_assignee_dispatcher_profile=default_assignee_dispatcher_profile,
+            default_assignee_routing_rule=default_assignee_routing_rule,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
         # Still under the dispatch lock: opportunistically truncate the WAL
@@ -8136,6 +8183,8 @@ def _dispatch_once_locked(
     stale_timeout_seconds: int = 0,
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
+    default_assignee_dispatcher_profile: Optional[str] = None,
+    default_assignee_routing_rule: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
@@ -8293,12 +8342,23 @@ def _dispatch_once_locked(
                                 "AND (assignee IS NULL OR assignee = '')",
                                 (_default_assignee, row["id"]),
                             )
+                            assignment_payload = {
+                                "assignee": _default_assignee,
+                                "source": "kanban.default_assignee",
+                            }
+                            if default_assignee_dispatcher_profile:
+                                assignment_payload["dispatcher_profile"] = (
+                                    default_assignee_dispatcher_profile
+                                )
+                            if default_assignee_routing_rule:
+                                assignment_payload["routing_rule"] = (
+                                    default_assignee_routing_rule
+                                )
                             _append_event(
-                                conn, row["id"], "assigned",
-                                {
-                                    "assignee": _default_assignee,
-                                    "source": "kanban.default_assignee",
-                                },
+                                conn,
+                                row["id"],
+                                "assigned",
+                                assignment_payload,
                             )
                     except Exception:
                         _log.debug(

--- a/tests/gateway/test_kanban_default_assignee_routing.py
+++ b/tests/gateway/test_kanban_default_assignee_routing.py
@@ -1,0 +1,167 @@
+"""Production-path coverage for profile-scoped Kanban fallback routing."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import yaml
+
+
+def test_profile_dispatchers_scope_fallback_but_keep_explicit_dispatch(
+    tmp_path,
+    monkeypatch,
+):
+    """The singleton winner's profile fallback cannot bleed across boards.
+
+    Both profile gateway configs coexist in the same installation.  Each is
+    exercised as the singleton-lock winner because the production contract
+    intentionally permits only one dispatcher loop at a time.
+    """
+    root = tmp_path / "hermes"
+    profile_a_home = root / "profiles" / "profile-a"
+    profile_b_home = root / "profiles" / "profile-b"
+    profile_a_home.mkdir(parents=True)
+    profile_b_home.mkdir(parents=True)
+
+    def _write_profile_config(home, assignee, boards):
+        (home / "config.yaml").write_text(
+            yaml.safe_dump({
+                "kanban": {
+                    "dispatch_in_gateway": True,
+                    "dispatch_interval_seconds": 1,
+                    "auto_decompose": False,
+                    "default_assignee": assignee,
+                    "default_assignee_boards": boards,
+                }
+            }),
+            encoding="utf-8",
+        )
+
+    _write_profile_config(profile_a_home, "profile-a", ["board-a"])
+    _write_profile_config(profile_b_home, "profile-b", ["board-b"])
+
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    from gateway import kanban_watchers
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.profiles import get_active_profile_name
+
+    kb.create_board("board-a", name="Board A")
+    kb.create_board("board-b", name="Board B")
+    with kb.connect_closing(board="board-a") as conn:
+        board_a_unassigned = kb.create_task(
+            conn,
+            title="Board A unassigned",
+            assignee=None,
+        )
+        board_a_explicit = kb.create_task(
+            conn,
+            title="Board A explicitly assigned to B",
+            assignee="profile-b",
+        )
+    with kb.connect_closing(board="board-b") as conn:
+        board_b_unassigned = kb.create_task(
+            conn,
+            title="Board B unassigned",
+            assignee=None,
+        )
+
+    spawned: list[tuple[str, str, str]] = []
+
+    def _fake_spawn(task, _workspace, *, board=None):
+        spawned.append((board or kb.DEFAULT_BOARD, task.id, task.assignee or ""))
+        return None
+
+    monkeypatch.setattr(kb, "_default_spawn", _fake_spawn)
+    monkeypatch.setattr(kb, "reap_worker_zombies", lambda: [])
+
+    class _Runner(kanban_watchers.GatewayKanbanWatchersMixin):
+        def __init__(self):
+            self._running = True
+
+        @staticmethod
+        def _active_profile_name():
+            return get_active_profile_name()
+
+    async def _no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(kanban_watchers.asyncio, "sleep", _no_sleep)
+
+    def _run_one_tick(profile_home):
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        runner = _Runner()
+
+        async def _inline_to_thread(fn, *args, **kwargs):
+            result = fn(*args, **kwargs)
+            if getattr(fn, "__name__", "") == "_tick_once":
+                runner._running = False
+            return result
+
+        monkeypatch.setattr(
+            kanban_watchers.asyncio,
+            "to_thread",
+            _inline_to_thread,
+        )
+        asyncio.run(runner._kanban_dispatcher_watcher())
+
+    # Profile B wins the singleton lock.  It may dispatch explicit work on
+    # every board, but its fallback is authorized only on Board B.
+    _run_one_tick(profile_b_home)
+
+    with kb.connect_closing(board="board-a") as conn:
+        denied = kb.get_task(conn, board_a_unassigned)
+        explicit = kb.get_task(conn, board_a_explicit)
+    with kb.connect_closing(board="board-b") as conn:
+        allowed_b = kb.get_task(conn, board_b_unassigned)
+        event_b = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'assigned'",
+            (board_b_unassigned,),
+        ).fetchone()
+
+    assert denied is not None and denied.assignee is None and denied.status == "ready"
+    assert explicit is not None and explicit.assignee == "profile-b"
+    assert explicit.status == "running"
+    assert allowed_b is not None and allowed_b.assignee == "profile-b"
+    assert allowed_b.status == "running"
+    assert ("board-a", board_a_explicit, "profile-b") in spawned
+    assert ("board-b", board_b_unassigned, "profile-b") in spawned
+    payload_b = json.loads(event_b["payload"])
+    assert payload_b["dispatcher_profile"] == "profile-b"
+    assert payload_b["routing_rule"] == "kanban.default_assignee_boards:board-b"
+
+    # When A is the singleton winner, the same production path can claim the
+    # card only because A's config explicitly authorizes Board A.
+    _run_one_tick(profile_a_home)
+    with kb.connect_closing(board="board-a") as conn:
+        allowed_a = kb.get_task(conn, board_a_unassigned)
+        event_a = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'assigned'",
+            (board_a_unassigned,),
+        ).fetchone()
+    assert allowed_a is not None and allowed_a.assignee == "profile-a"
+    assert allowed_a.status == "running"
+    payload_a = json.loads(event_a["payload"])
+    assert payload_a["dispatcher_profile"] == "profile-a"
+    assert payload_a["routing_rule"] == "kanban.default_assignee_boards:board-a"
+
+    # Wildcard is an explicit migration escape hatch for operators who
+    # deliberately want the singleton winner's fallback on every board.
+    with kb.connect_closing(board="board-a") as conn:
+        wildcard_task = kb.create_task(
+            conn,
+            title="Legacy all-board fallback",
+            assignee=None,
+        )
+    _write_profile_config(profile_b_home, "profile-b", ["*"])
+    _run_one_tick(profile_b_home)
+    with kb.connect_closing(board="board-a") as conn:
+        wildcard = kb.get_task(conn, wildcard_task)
+        wildcard_event = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'assigned'",
+            (wildcard_task,),
+        ).fetchone()
+    assert wildcard is not None and wildcard.assignee == "profile-b"
+    wildcard_payload = json.loads(wildcard_event["payload"])
+    assert wildcard_payload["dispatcher_profile"] == "profile-b"
+    assert wildcard_payload["routing_rule"] == "kanban.default_assignee_boards:*"

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -94,3 +94,46 @@ def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypat
     )
 
 
+@pytest.mark.parametrize(
+    ("configured_boards", "expected_assignee", "expected_rule"),
+    [
+        (None, None, None),
+        ([], None, None),
+        (["project-a"], "default", "kanban.default_assignee_boards:project-a"),
+        (["*"], "default", "kanban.default_assignee_boards:*"),
+    ],
+)
+def test_cli_dispatch_scopes_default_assignee_to_current_board(
+    isolated_kanban_home,
+    monkeypatch,
+    configured_boards,
+    expected_assignee,
+    expected_rule,
+):
+    """Direct CLI dispatch enforces the same board fallback policy as gateway."""
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    kanban_db.create_board("project-a")
+    fake_kanban_config = {"default_assignee": "default"}
+    if configured_boards is not None:
+        fake_kanban_config["default_assignee_boards"] = configured_boards
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": fake_kanban_config},
+    )
+
+    captured = {}
+    monkeypatch.setattr(
+        kanban_db,
+        "dispatch_once",
+        lambda conn, **kw: (captured.update(kw), kanban_db.DispatchResult())[1],
+    )
+
+    args = argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=False)
+    with kanban_db.scoped_current_board("project-a"):
+        kb_cli._cmd_dispatch(args)
+
+    assert captured["default_assignee"] == expected_assignee
+    assert captured["default_assignee_routing_rule"] == expected_rule
+

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -95,22 +95,21 @@ def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypat
 
 
 @pytest.mark.parametrize(
-    ("configured_boards", "expected_assignee", "expected_rule"),
+    ("configured_boards", "expected_boards"),
     [
-        (None, None, None),
-        ([], None, None),
-        (["project-a"], "default", "kanban.default_assignee_boards:project-a"),
-        (["*"], "default", "kanban.default_assignee_boards:*"),
+        (None, ["default"]),
+        ([], []),
+        (["project-a"], ["project-a"]),
+        (["*"], ["*"]),
     ],
 )
-def test_cli_dispatch_scopes_default_assignee_to_current_board(
+def test_cli_dispatch_passes_default_assignee_policy_to_dispatch_boundary(
     isolated_kanban_home,
     monkeypatch,
     configured_boards,
-    expected_assignee,
-    expected_rule,
+    expected_boards,
 ):
-    """Direct CLI dispatch enforces the same board fallback policy as gateway."""
+    """The database dispatcher, not the CLI, owns fallback authorization."""
     from hermes_cli import kanban as kb_cli
     from hermes_cli import kanban_db
 
@@ -134,6 +133,6 @@ def test_cli_dispatch_scopes_default_assignee_to_current_board(
     with kanban_db.scoped_current_board("project-a"):
         kb_cli._cmd_dispatch(args)
 
-    assert captured["default_assignee"] == expected_assignee
-    assert captured["default_assignee_routing_rule"] == expected_rule
+    assert captured["default_assignee"] == "default"
+    assert captured["default_assignee_boards"] == expected_boards
 

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -10,8 +10,10 @@ import json
 import os
 import sys
 import tempfile
+from pathlib import Path
 
 import pytest
+import yaml
 
 
 @pytest.fixture()
@@ -49,6 +51,8 @@ def test_unassigned_task_auto_assigned_with_default_assignee(isolated_kanban_hom
         res = kb.dispatch_once(
             conn, spawn_fn=_fake_spawn, dry_run=False,
             default_assignee="default",
+            default_assignee_dispatcher_profile="default",
+            default_assignee_routing_rule="kanban.default_assignee_boards:default",
         )
     assert res.auto_assigned_default == [task_id]
     assert not res.skipped_unassigned
@@ -70,6 +74,8 @@ def test_unassigned_task_auto_assigned_with_default_assignee(isolated_kanban_hom
     payload = json.loads(evs[0][1])
     assert payload["assignee"] == "default"
     assert payload["source"] == "kanban.default_assignee"
+    assert payload["dispatcher_profile"] == "default"
+    assert payload["routing_rule"] == "kanban.default_assignee_boards:default"
 
 
 
@@ -92,4 +98,55 @@ def test_explicitly_assigned_task_untouched_by_default_assignee(isolated_kanban_
     assert task_id not in res.auto_assigned_default
     assert any(s[0] == task_id and s[1] == "default" for s in res.spawned)
 
+
+@pytest.mark.parametrize(
+    ("board", "configured_boards", "expected"),
+    [
+        ("default", None, "kanban.default_assignee_boards:default"),
+        ("project-a", None, None),
+        ("default", [], None),
+        ("project-a", ["project-a"], "kanban.default_assignee_boards:project-a"),
+        ("project-a", ["PROJECT-A"], "kanban.default_assignee_boards:project-a"),
+        ("project-a", ["*"], "kanban.default_assignee_boards:*"),
+        ("project-a", "project-a", None),
+        ("none", [None], None),
+        ("123", [123], None),
+        ("project-a", ["../project-a"], None),
+    ],
+)
+def test_default_assignee_board_routing_contract(
+    isolated_kanban_home,
+    board,
+    configured_boards,
+    expected,
+):
+    """Fallback routing is explicit, with a narrow legacy-default migration."""
+    kb, _home = isolated_kanban_home
+    assert kb.default_assignee_routing_rule(board, configured_boards) == expected
+
+
+def test_default_config_preserves_legacy_default_board_only(isolated_kanban_home):
+    """Missing user config keeps #27145 on default without authorizing names."""
+    _kb, home = isolated_kanban_home
+    from hermes_cli.config import load_config
+
+    config_path = Path(home) / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({"kanban": {"default_assignee": "default"}}),
+        encoding="utf-8",
+    )
+    assert load_config()["kanban"]["default_assignee_boards"] == ["default"]
+
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "kanban": {
+                    "default_assignee": "default",
+                    "default_assignee_boards": [],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert load_config()["kanban"]["default_assignee_boards"] == []
 

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -52,7 +52,6 @@ def test_unassigned_task_auto_assigned_with_default_assignee(isolated_kanban_hom
             conn, spawn_fn=_fake_spawn, dry_run=False,
             default_assignee="default",
             default_assignee_dispatcher_profile="default",
-            default_assignee_routing_rule="kanban.default_assignee_boards:default",
         )
     assert res.auto_assigned_default == [task_id]
     assert not res.skipped_unassigned
@@ -102,7 +101,7 @@ def test_explicitly_assigned_task_untouched_by_default_assignee(isolated_kanban_
 @pytest.mark.parametrize(
     ("board", "configured_boards", "expected"),
     [
-        ("default", None, "kanban.default_assignee_boards:default"),
+        ("default", None, None),
         ("project-a", None, None),
         ("default", [], None),
         ("project-a", ["project-a"], "kanban.default_assignee_boards:project-a"),
@@ -150,3 +149,48 @@ def test_default_config_preserves_legacy_default_board_only(isolated_kanban_home
     )
     assert load_config()["kanban"]["default_assignee_boards"] == []
 
+def test_dispatch_enforces_board_routing_at_assignment_boundary(
+    isolated_kanban_home,
+):
+    """A direct caller cannot bypass named-board fallback authorization."""
+    kb, _home = isolated_kanban_home
+    kb.create_board("project-a")
+    with kb.connect_closing(board="project-a") as conn:
+        task_id = kb.create_task(conn, title="named-board task", assignee=None)
+
+        denied = kb.dispatch_once(
+            conn,
+            board="project-a",
+            spawn_fn=_fake_spawn,
+            default_assignee="default",
+        )
+        assert denied.skipped_unassigned == [task_id]
+        untouched = kb.get_task(conn, task_id)
+        assert untouched is not None and untouched.assignee is None
+        assert conn.execute(
+            "SELECT 1 FROM task_events "
+            "WHERE task_id = ? AND kind = 'assigned'",
+            (task_id,),
+        ).fetchone() is None
+
+        allowed = kb.dispatch_once(
+            conn,
+            board="project-a",
+            spawn_fn=_fake_spawn,
+            default_assignee="default",
+            default_assignee_dispatcher_profile="default",
+            default_assignee_boards=["project-a"],
+        )
+
+        task = kb.get_task(conn, task_id)
+        event = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'assigned'",
+            (task_id,),
+        ).fetchone()
+
+    assert allowed.auto_assigned_default == [task_id]
+    assert task is not None and task.assignee == "default"
+    payload = json.loads(event["payload"])
+    assert payload["dispatcher_profile"] == "default"
+    assert payload["routing_rule"] == "kanban.default_assignee_boards:project-a"

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -152,15 +152,16 @@ def test_default_config_preserves_legacy_default_board_only(isolated_kanban_home
 def test_dispatch_enforces_board_routing_at_assignment_boundary(
     isolated_kanban_home,
 ):
-    """A direct caller cannot bypass named-board fallback authorization."""
+    """Authorization follows the connection, not an optional caller hint."""
     kb, _home = isolated_kanban_home
     kb.create_board("project-a")
     with kb.connect_closing(board="project-a") as conn:
         task_id = kb.create_task(conn, title="named-board task", assignee=None)
 
+        # Omitting board= must not make this named-board connection inherit the
+        # ambient default board's fallback authorization.
         denied = kb.dispatch_once(
             conn,
-            board="project-a",
             spawn_fn=_fake_spawn,
             default_assignee="default",
         )
@@ -175,7 +176,6 @@ def test_dispatch_enforces_board_routing_at_assignment_boundary(
 
         allowed = kb.dispatch_once(
             conn,
-            board="project-a",
             spawn_fn=_fake_spawn,
             default_assignee="default",
             default_assignee_dispatcher_profile="default",
@@ -194,3 +194,75 @@ def test_dispatch_enforces_board_routing_at_assignment_boundary(
     payload = json.loads(event["payload"])
     assert payload["dispatcher_profile"] == "default"
     assert payload["routing_rule"] == "kanban.default_assignee_boards:project-a"
+
+
+def test_dispatch_ignores_mismatched_board_hint_for_fallback_authorization(
+    isolated_kanban_home,
+):
+    """Connection identity governs authorization and downstream spawn routing."""
+    kb, _home = isolated_kanban_home
+    kb.create_board("project-a")
+    spawned_boards = []
+
+    def _recording_spawn(*_args, board=None, **_kwargs):
+        spawned_boards.append(board)
+        return 12345
+
+    with kb.connect_closing(board="project-a") as conn:
+        task_id = kb.create_task(conn, title="mismatched board hint", assignee=None)
+        result = kb.dispatch_once(
+            conn,
+            board="default",
+            spawn_fn=_fake_spawn,
+            default_assignee="default",
+        )
+        task = kb.get_task(conn, task_id)
+
+        assert result.skipped_unassigned == [task_id]
+        assert result.auto_assigned_default == []
+        assert task is not None and task.assignee is None
+
+        allowed = kb.dispatch_once(
+            conn,
+            board="default",
+            spawn_fn=_recording_spawn,
+            default_assignee="default",
+            default_assignee_boards=["project-a"],
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert allowed.auto_assigned_default == [task_id]
+    assert task is not None and task.assignee == "default"
+    assert spawned_boards == ["project-a"]
+
+
+def test_custom_db_path_requires_explicit_legacy_pin_for_fallback(
+    isolated_kanban_home,
+    monkeypatch,
+    tmp_path,
+):
+    """Unknown DB paths fail closed, while HERMES_KANBAN_DB stays compatible."""
+    kb, _home = isolated_kanban_home
+    custom_db = tmp_path / "custom-board.sqlite"
+    with kb.connect(db_path=custom_db) as conn:
+        task_id = kb.create_task(conn, title="custom DB fallback", assignee=None)
+
+        denied = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            default_assignee="default",
+        )
+        task = kb.get_task(conn, task_id)
+        assert denied.skipped_unassigned == [task_id]
+        assert task is not None and task.assignee is None
+
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(custom_db))
+        allowed = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            default_assignee="default",
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert allowed.auto_assigned_default == [task_id]
+    assert task is not None and task.assignee == "default"

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -226,7 +226,19 @@ up on the next tick (60s by default).
 kanban:
   dispatch_in_gateway: true        # default
   dispatch_interval_seconds: 60    # default
+  default_assignee: ""             # fallback for unassigned Ready cards
+  default_assignee_boards:         # where that profile-local fallback may act
+    - default
 ```
+
+The embedded dispatcher remains a machine-wide singleton and continues to
+sweep every active board for cards that already have an explicit assignee.
+`default_assignee_boards` scopes only the mutating fallback for unassigned
+Ready cards: the default `["default"]` preserves the original single-board
+behavior, `[]` disables dispatcher fallback everywhere, named slugs opt those
+boards in, and `["*"]` deliberately restores the historical all-board
+fallback. Assignment events record both the dispatcher profile and the
+matching routing rule.
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`
 for debugging. Standard gateway supervision applies: run `hermes gateway
@@ -579,6 +591,7 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
+| `default_assignee_boards` | `["default"]` | Boards where the singleton dispatcher may apply this profile's `default_assignee` to an unassigned Ready card. Use named slugs to opt in, `[]` to disable, or `["*"]` for every board. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
 
 And the two auxiliary LLM slots:


### PR DESCRIPTION
## What does this PR do?

Scopes the gateway and CLI `kanban.default_assignee` fallback to explicitly
authorized Kanban boards.

The machine-wide singleton dispatcher still scans every active board for cards
that already have an explicit assignee. Only the mutating fallback for
otherwise-unassigned Ready cards is restricted.

`kanban.default_assignee_boards` supports:

- `["default"]` — compatibility default
- named board slugs — explicit opt-in
- `[]` — disable fallback assignment
- `["*"]` — deliberately allow fallback on every board

Fallback assignment events now record the responsible dispatcher profile and
the matching routing rule.

## Related Issue

Fixes #70805

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Enforce board-scoped fallback routing at the shared database mutation boundary.
- Derive authorization, dispatch locking, and worker board routing from the
  connection's actual SQLite database instead of trusting an ambient or caller hint.
- Pass the same policy through gateway and direct CLI dispatch.
- Fail closed for malformed scope and unpinned custom database paths while
  preserving the existing `HERMES_KANBAN_DB` compatibility override.
- Preserve explicitly assigned cross-board dispatch.
- Record dispatcher profile and routing-rule provenance on fallback assignments.
- Add production-path two-profile routing coverage and focused boundary tests.
- Document configuration and migration behavior.

## How to Test

1. Configure two profiles with different `default_assignee` values and board
   lists.
2. Create unassigned Ready cards on each board.
3. Verify a singleton winner applies its fallback only to authorized boards.
4. Verify explicitly assigned cards continue dispatching on every board.
5. Run the focused routing and sibling Kanban suites.

## Validation

- Focused routing suite: 23 passed.
- Config loader/validation suites: 76 passed.
- Full Kanban sweep on this branch: 171 passed, 1 skipped, with 8
  order-dependent failures that reproduce as the exact same 8 failures on
  current `main`; all 8 pass when rerun in isolation.
- Repository Ruff checks for every changed Python file passed.
- `git diff --check` and Python bytecode compilation passed.
- Clean merge simulation against current `origin/main`; GitHub reports the PR
  mergeable.
- Tested on macOS.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commits follow Conventional Commits.
- [x] I searched existing issues and PRs for duplicates.
- [x] The PR contains only changes related to this fix.
- [x] I added regression and production-path tests.

### Documentation & Housekeeping

- [x] Updated the Kanban documentation and `cli-config.yaml.example`.
- [x] Considered Windows, macOS, and Linux path behavior.
- [x] No tool schema changes are required.
