### PR TITLE
fix(config): address dotted config keys whose segments contain a dot

### DIFF
--- a/contributors/emails/git@accounts.watergard.com
+++ b/contributors/emails/git@accounts.watergard.com
@@ -1,0 +1,1 @@
+Watergard

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -981,6 +981,38 @@ def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     return missing
 
 
+def _split_dotted_key(dotted_key: str) -> list:
+    """Split a dotted config path into segments, honouring double-quoted spans.
+
+    A double-quoted span is taken literally, so a key segment that legitimately
+    contains a dot can be addressed.  Every real model id contains one
+    (``gpt-5.6-sol``, ``claude-sonnet-4.5``), which is what otherwise makes
+    ``platforms.api_server.extra.model_routes.<model-id>`` unreachable::
+
+        platforms.api_server.extra.model_routes."gpt-5.6-sol".model
+        -> ['platforms', 'api_server', 'extra', 'model_routes',
+            'gpt-5.6-sol', 'model']
+
+    Input without quotes tokenizes byte-for-byte identically to
+    ``dotted_key.split(".")``, so this is fully backward compatible.
+    """
+    parts: list = []
+    buf: list = []
+    in_quotes = False
+    for ch in dotted_key:
+        if ch == '"':
+            in_quotes = not in_quotes
+        elif ch == "." and not in_quotes:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    if in_quotes:
+        raise ValueError(f"unterminated quote in config key {dotted_key!r}")
+    parts.append("".join(buf))
+    return parts
+
+
 def _set_nested(config, dotted_key: str, value):
     """Set a value at an arbitrarily nested dotted key path.
 
@@ -1003,7 +1035,7 @@ def _set_nested(config, dotted_key: str, value):
     destroying list-typed config like ``custom_providers`` whenever a
     caller used an indexed path.
     """
-    parts = dotted_key.split(".")
+    parts = _split_dotted_key(dotted_key)
     current = config
     for part in parts[:-1]:
         if isinstance(current, list):
@@ -1065,7 +1097,7 @@ _MISSING = object()
 def _get_nested(config, dotted_key: str):
     """Return a dotted-path value from nested dict/list config data."""
     current = config
-    for part in dotted_key.split("."):
+    for part in _split_dotted_key(dotted_key):
         if isinstance(current, list):
             try:
                 current = current[int(part)]
@@ -1082,7 +1114,7 @@ def _get_nested(config, dotted_key: str):
 
 def _unset_nested(config, dotted_key: str) -> bool:
     """Remove a dotted-path value from nested dict/list config data."""
-    parts = dotted_key.split(".")
+    parts = _split_dotted_key(dotted_key)
     if not parts:
         return False
 
@@ -4592,7 +4624,7 @@ def _default_value_for_key(dotted_key: str):
     best-effort coercion used by ``config set``.
     """
     node = DEFAULT_CONFIG
-    for part in dotted_key.split("."):
+    for part in _split_dotted_key(dotted_key):
         if not isinstance(node, dict) or part not in node:
             return None
         node = node[part]
@@ -4698,7 +4730,7 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     if not key:
         return False, None
 
-    segments = key.split(".")
+    segments = _split_dotted_key(key)
     top = segments[0]
 
     # ── Underscore-prefixed keys are internal/test markers ───────────
@@ -4783,6 +4815,14 @@ def set_config_value(key: str, value: str, force: bool = False):
             writes of keys the running version doesn't recognize yet. The CLI
             exposes this via ``hermes config set --force``.
     """
+    # Reject a malformed key (e.g. an unterminated quote) cleanly, before any
+    # validation or I/O runs — every dotted-key consumer below tokenizes too, so
+    # a late guard would only turn the same error into a traceback.
+    try:
+        _split_dotted_key(key)
+    except ValueError as e:
+        print(f"Invalid config key: {e}", file=sys.stderr)
+        sys.exit(1)
     if is_managed():
         managed_error("set configuration values")
         return
@@ -4921,6 +4961,11 @@ def set_config_value(key: str, value: str, force: bool = False):
 
 def get_config_value(key: str, *, as_json: bool = False):
     """Print a resolved configuration value."""
+    try:
+        _split_dotted_key(key)
+    except ValueError as e:
+        print(f"Invalid config key: {e}", file=sys.stderr)
+        sys.exit(1)
     if _is_env_config_key(key):
         env_value = get_env_value(key.upper())
         value = _MISSING if env_value is None else env_value
@@ -4936,6 +4981,11 @@ def get_config_value(key: str, *, as_json: bool = False):
 
 def unset_config_value(key: str):
     """Remove a user-set configuration or .env value."""
+    try:
+        _split_dotted_key(key)
+    except ValueError as e:
+        print(f"Invalid config key: {e}", file=sys.stderr)
+        sys.exit(1)
     if is_managed():
         managed_error("unset configuration values")
         return

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple, Set
 
+from hermes_cli.dotted_path import split_dotted_key
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.secret_prompt import masked_secret_prompt
 
@@ -981,36 +982,12 @@ def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     return missing
 
 
-def _split_dotted_key(dotted_key: str) -> list:
-    """Split a dotted config path into segments, honouring double-quoted spans.
-
-    A double-quoted span is taken literally, so a key segment that legitimately
-    contains a dot can be addressed.  Every real model id contains one
-    (``gpt-5.6-sol``, ``claude-sonnet-4.5``), which is what otherwise makes
-    ``platforms.api_server.extra.model_routes.<model-id>`` unreachable::
-
-        platforms.api_server.extra.model_routes."gpt-5.6-sol".model
-        -> ['platforms', 'api_server', 'extra', 'model_routes',
-            'gpt-5.6-sol', 'model']
-
-    Input without quotes tokenizes byte-for-byte identically to
-    ``dotted_key.split(".")``, so this is fully backward compatible.
-    """
-    parts: list = []
-    buf: list = []
-    in_quotes = False
-    for ch in dotted_key:
-        if ch == '"':
-            in_quotes = not in_quotes
-        elif ch == "." and not in_quotes:
-            parts.append("".join(buf))
-            buf = []
-        else:
-            buf.append(ch)
-    if in_quotes:
-        raise ValueError(f"unterminated quote in config key {dotted_key!r}")
-    parts.append("".join(buf))
-    return parts
+# The canonical dotted-path representation lives in ``hermes_cli.dotted_path``
+# so ``managed_scope`` can share it: ``config`` imports ``managed_scope``, never
+# the reverse, so the helper cannot live here without inverting that dependency.
+# ``_split_dotted_key`` stays as the in-module name — every call site below, and
+# the CLI's malformed-key guards, already use it.
+_split_dotted_key = split_dotted_key
 
 
 def _set_nested(config, dotted_key: str, value):
@@ -2488,10 +2465,20 @@ def _strip_dotted_keys(cfg: dict, dotted_keys: set) -> Tuple[dict, set]:
     ``save_config`` to drop managed-scope leaves before persisting, so a bulk
     write never writes a user value that would lose to the managed layer on the
     next load. Only keys actually present in ``cfg`` are reported as stripped.
+
+    Keys arrive in the canonical representation (``managed_config_keys()``), so
+    they are tokenized with ``split_dotted_key`` — a raw ``.split(".")`` here
+    would walk into ``model_routes`` → ``gpt-5`` → ``6-sol"`` and silently strip
+    nothing, letting a user bulk-write persist a value the managed overlay then
+    overrides. A malformed key can only come from a caller that built it by
+    hand; skip it rather than aborting the whole save.
     """
     stripped: set = set()
     for dotted in dotted_keys:
-        parts = dotted.split(".")
+        try:
+            parts = split_dotted_key(dotted)
+        except ValueError:
+            continue
         node = cfg
         for p in parts[:-1]:
             if not isinstance(node, dict) or p not in node:

--- a/hermes_cli/dotted_path.py
+++ b/hermes_cli/dotted_path.py
@@ -1,0 +1,103 @@
+"""Canonical parse/serialize for dotted config-key paths.
+
+One representation, used everywhere a config path is tokenized or rendered:
+the CLI helpers in ``hermes_cli/config.py``, the managed-scope key flattening
+and comparison in ``hermes_cli/managed_scope.py``, and ``_strip_dotted_keys``.
+
+Why this is its own module: ``managed_scope`` deliberately imports nothing
+from ``config`` (``config`` imports ``managed_scope``, not the other way
+round), so the shared helper cannot live in ``config`` without inverting that
+dependency.  This module is a leaf — stdlib only, no ``hermes_cli`` imports.
+
+The representation is dot-separated segments, where a segment that contains a
+dot is wrapped in double quotes::
+
+    platforms.api_server.extra.model_routes."gpt-5.6-sol".model
+    -> ['platforms', 'api_server', 'extra', 'model_routes',
+        'gpt-5.6-sol', 'model']
+
+Backward compatibility is the load-bearing property: a key with no dot-bearing
+segment tokenizes exactly as ``key.split(".")`` did, and serializes back
+byte-for-byte unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+
+def split_dotted_key(dotted_key: str) -> List[str]:
+    """Split a dotted config path into segments, honouring double-quoted spans.
+
+    A double-quoted span is taken literally, so a key segment that legitimately
+    contains a dot can be addressed.  Every real model id contains one
+    (``gpt-5.6-sol``, ``claude-sonnet-4.5``), which is what otherwise makes
+    ``platforms.api_server.extra.model_routes.<model-id>`` unreachable::
+
+        platforms.api_server.extra.model_routes."gpt-5.6-sol".model
+        -> ['platforms', 'api_server', 'extra', 'model_routes',
+            'gpt-5.6-sol', 'model']
+
+    Input without quotes tokenizes byte-for-byte identically to
+    ``dotted_key.split(".")``, so this is fully backward compatible.
+
+    Raises ``ValueError`` on an unterminated quote.  Note that the quote
+    characters are structural and never appear in the output, so there is no
+    way to express a literal ``"`` inside a segment — see ``join_dotted_key``.
+    """
+    parts: List[str] = []
+    buf: List[str] = []
+    in_quotes = False
+    for ch in dotted_key:
+        if ch == '"':
+            in_quotes = not in_quotes
+        elif ch == "." and not in_quotes:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    if in_quotes:
+        raise ValueError(f"unterminated quote in config key {dotted_key!r}")
+    parts.append("".join(buf))
+    return parts
+
+
+def join_dotted_key(parts: Iterable[object]) -> str:
+    """Serialize path segments into the canonical dotted key.
+
+    A segment is double-quoted iff it contains a dot; every other segment is
+    emitted bare.  So a path with no dot-bearing segment serializes exactly as
+    ``".".join(parts)`` did, which is what keeps every existing managed key
+    byte-for-byte stable.
+
+    Segments are coerced with ``str()`` to match what ``managed_scope``'s
+    flattening did with non-string YAML keys (ints, bools).  One deliberate
+    consequence: a YAML float key (``4.5:``) now serializes as ``"4.5"``
+    rather than bare ``4.5``.  That is the same defect this representation
+    exists to fix — bare ``4.5`` addresses ``4`` → ``5``, a different path.
+
+    This function never raises.  A segment containing a ``"`` cannot be
+    represented (the tokenizer treats quotes as structure and strips them, so
+    there is no escape), and is emitted bare — byte-identical to the previous
+    behaviour, i.e. still not addressable, but no worse and no new failure.
+    ``_flatten_keys`` walks whatever YAML an administrator wrote, and
+    ``doctor.py`` calls it outside its ``try``: a raise here would be a new
+    crash surface in ``hermes doctor``.
+    """
+    out: List[str] = []
+    for part in parts:
+        text = str(part)
+        out.append(f'"{text}"' if "." in text else text)
+    return ".".join(out)
+
+
+def normalize_dotted_key(key: str) -> str:
+    """Round-trip a dotted key through the canonical representation.
+
+    Lets two spellings of the same path compare equal — e.g. a CLI-supplied
+    ``model_routes."gpt-5.6-sol".model`` and the same path flattened out of
+    managed YAML.  Redundant quoting on a dot-free segment is dropped.
+
+    Raises ``ValueError`` on an unterminated quote (from ``split_dotted_key``).
+    """
+    return join_dotted_key(split_dotted_key(key))

--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -26,6 +26,11 @@ from typing import Dict, Optional
 
 import yaml
 
+# ``dotted_path`` is a stdlib-only leaf module — importing it keeps this
+# module's rule intact (managed_scope depends on nothing in hermes_cli.config;
+# config depends on managed_scope).
+from hermes_cli.dotted_path import join_dotted_key, normalize_dotted_key
+
 logger = logging.getLogger(__name__)
 
 # POSIX default. Other-platform locations are a deliberate v2 item; when added,
@@ -188,25 +193,60 @@ def _parse_env(f) -> Dict[str, str]:
     return out
 
 
-def _flatten_keys(d: dict, prefix: str = "") -> set:
+def _flatten_keys(d: dict, prefix: tuple = ()) -> set:
+    """Flatten a nested managed config into canonical dotted leaf keys.
+
+    Serialization goes through ``join_dotted_key``, so a segment that contains a
+    dot is quoted — which every real model id does, making
+    ``platforms.api_server.extra.model_routes."gpt-5.6-sol".model`` the only
+    spelling that addresses that leaf.  The previous plain ``f"{prefix}.{k}"``
+    join emitted a string that re-tokenizes to a *different* path (``gpt-5`` →
+    ``6-sol``), so ``is_key_managed`` never matched the CLI's key and
+    ``_strip_dotted_keys`` never found the leaf: a user ``config set`` of such a
+    managed key was neither refused nor stripped, persisted into config.yaml,
+    and was then silently overridden by the managed overlay on load.
+
+    A tree with no dot-bearing key serializes byte-for-byte as before.
+    """
     keys: set = set()
     for k, v in d.items():
-        dotted = f"{prefix}.{k}" if prefix else str(k)
+        path = prefix + (k,)
         if isinstance(v, dict) and v:
-            keys |= _flatten_keys(v, dotted)
+            keys |= _flatten_keys(v, path)
         else:
-            keys.add(dotted)
+            keys.add(join_dotted_key(path))
     return keys
 
 
 def managed_config_keys() -> set:
-    """Dotted leaf keys pinned by the managed config (e.g. {'model.default'})."""
+    """Dotted leaf keys pinned by the managed config (e.g. {'model.default'}).
+
+    Keys are in the canonical representation, so a dot-bearing segment comes
+    back quoted.  Callers that display these (``hermes config show``,
+    ``save_config``'s "not saved" note) therefore render the exact string the
+    user must type to address that key.
+    """
     return _flatten_keys(load_managed_config())
 
 
 def is_key_managed(dotted_key: str) -> bool:
-    """True if the exact dotted config key is pinned by the managed layer."""
-    return dotted_key in managed_config_keys()
+    """True if the exact dotted config key is pinned by the managed layer.
+
+    The argument is normalized into the canonical representation first, so the
+    CLI's spelling and the flattened managed key are compared in one form.  The
+    comparison itself stays exact set membership — this is a config-authority
+    check, never a prefix or fuzzy match.
+    """
+    try:
+        candidate = normalize_dotted_key(dotted_key)
+    except ValueError:
+        # Unterminated quote — unrepresentable, so it cannot equal any canonical
+        # key.  Fall back to the raw exact test: that is precisely the previous
+        # behaviour, and it keeps an authority check from gaining a new raise.
+        # The CLI validators reject a malformed key before it reaches here, so
+        # this is defence in depth rather than a live path.
+        candidate = dotted_key
+    return candidate in managed_config_keys()
 
 
 def is_env_managed(name: str) -> bool:

--- a/tests/hermes_cli/test_config_dotted_keys.py
+++ b/tests/hermes_cli/test_config_dotted_keys.py
@@ -1,0 +1,146 @@
+"""Tests for double-quote-aware dotted config-key addressing (`_split_dotted_key`).
+
+A key segment that legitimately contains a dot — every real model id does
+(``gpt-5.6-sol``) — must be addressable so ``model_routes.<model-id>`` can be
+written, read and removed from the CLI. Unquoted keys must keep tokenizing
+exactly as ``str.split(".")`` did.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import (
+    _split_dotted_key,
+    _get_nested,
+    _unset_nested,
+    _default_value_for_key,
+    set_config_value,
+    get_config_value,
+    unset_config_value,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path):
+    """Point HERMES_HOME at a temp dir so tests never touch real config."""
+    (tmp_path / ".env").touch()
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        yield tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+
+class TestSplitDottedKey:
+    def test_unquoted_matches_str_split(self):
+        assert _split_dotted_key("a.b.c") == ["a", "b", "c"]
+
+    def test_quoted_span_kept_literal(self):
+        assert _split_dotted_key('a."b.c".d') == ["a", "b.c", "d"]
+
+    def test_model_id_route_path(self):
+        assert _split_dotted_key(
+            'platforms.api_server.extra.model_routes."gpt-5.6-sol".model'
+        ) == [
+            "platforms", "api_server", "extra", "model_routes",
+            "gpt-5.6-sol", "model",
+        ]
+
+    def test_numeric_list_segment_preserved(self):
+        # The #17876 list-navigation guard must be unaffected.
+        assert _split_dotted_key("custom_providers.0.api_key") == [
+            "custom_providers", "0", "api_key",
+        ]
+
+    def test_unterminated_quote_raises(self):
+        with pytest.raises(ValueError):
+            _split_dotted_key('a."b')
+
+
+# ---------------------------------------------------------------------------
+# Round trip through set/get/unset on a dotted model-id leaf
+# ---------------------------------------------------------------------------
+
+class TestDottedRouteRoundTrip:
+    KEY = 'platforms.api_server.extra.model_routes."gpt-5.6-sol".model'
+
+    def test_set_get_unset_addresses_single_key(self, capsys):
+        set_config_value(self.KEY, "openai/gpt-5.6")
+        capsys.readouterr()
+
+        from hermes_cli.config import load_config
+        routes = (
+            load_config()
+            .get("platforms", {})
+            .get("api_server", {})
+            .get("extra", {})
+            .get("model_routes", {})
+        )
+        # The route lands under the SINGLE key "gpt-5.6-sol", not a nested
+        # "gpt-5" -> "6-sol" mangling.
+        assert routes == {"gpt-5.6-sol": {"model": "openai/gpt-5.6"}}
+
+        get_config_value(self.KEY)
+        assert "openai/gpt-5.6" in capsys.readouterr().out
+
+        unset_config_value(self.KEY)
+        capsys.readouterr()
+        routes_after = (
+            load_config()
+            .get("platforms", {})
+            .get("api_server", {})
+            .get("extra", {})
+            .get("model_routes", {})
+        )
+        # Unset removes the addressed leaf (`.model`), and hermes' existing
+        # empty-container cleanup then collapses the route entry and its now
+        # empty ancestors — the same behaviour `config unset` already has for
+        # any other key. Quoting changes only how the path is addressed.
+        assert routes_after == {}
+
+    def test_get_nested_directly(self):
+        cfg = {"model_routes": {"gpt-5.6-sol": {"model": "x"}}}
+        assert _get_nested(cfg, 'model_routes."gpt-5.6-sol".model') == "x"
+
+    def test_unset_nested_directly(self):
+        cfg = {"model_routes": {"gpt-5.6-sol": {"model": "x"}}}
+        assert _unset_nested(cfg, 'model_routes."gpt-5.6-sol"') is True
+        # The quoted segment is removed, then the existing empty-container
+        # cleanup drops the emptied `model_routes` parent.
+        assert cfg == {}
+
+
+# ---------------------------------------------------------------------------
+# A quoted model-id leaf must not be coerced away from a string
+# ---------------------------------------------------------------------------
+
+def test_quoted_key_does_not_mis_coerce_default_lookup():
+    # A quoted model-id path misses DEFAULT_CONFIG, so the default lookup
+    # returns None and the value keeps its historical best-effort coercion —
+    # a model-id string stays a string.
+    key = 'platforms.api_server.extra.model_routes."gpt-5.6-sol".model'
+    assert _default_value_for_key(key) is None
+
+
+# ---------------------------------------------------------------------------
+# Malformed key is rejected cleanly (no traceback, non-zero exit)
+# ---------------------------------------------------------------------------
+
+class TestMalformedKeyGuard:
+    def test_set_exits_on_unterminated_quote(self):
+        with pytest.raises(SystemExit) as exc:
+            set_config_value('model_routes."gpt-5.6-sol', "x")
+        assert exc.value.code == 1
+
+    def test_get_exits_on_unterminated_quote(self):
+        with pytest.raises(SystemExit) as exc:
+            get_config_value('model_routes."gpt-5.6-sol')
+        assert exc.value.code == 1
+
+    def test_unset_exits_on_unterminated_quote(self):
+        with pytest.raises(SystemExit) as exc:
+            unset_config_value('model_routes."gpt-5.6-sol')
+        assert exc.value.code == 1

--- a/tests/hermes_cli/test_config_dotted_keys.py
+++ b/tests/hermes_cli/test_config_dotted_keys.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hermes_cli.dotted_path import join_dotted_key, normalize_dotted_key
 from hermes_cli.config import (
     _split_dotted_key,
     _get_nested,
@@ -144,3 +145,99 @@ class TestMalformedKeyGuard:
         with pytest.raises(SystemExit) as exc:
             unset_config_value('model_routes."gpt-5.6-sol')
         assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Serializer + round-trip invariants
+#
+# The tokenizer and the serializer are one representation, shared with
+# ``managed_scope`` via ``hermes_cli.dotted_path``. These pin the contract that
+# lets a managed key and a CLI key compare equal.
+# ---------------------------------------------------------------------------
+
+class TestJoinDottedKey:
+    def test_dot_free_segments_join_exactly_as_str_join(self):
+        """Backward compat, stated as an equality against the old behaviour.
+
+        If ``join_dotted_key`` ever quoted unconditionally, every one of these
+        would gain quotes and fail — this is what makes the invariant proven
+        rather than assumed.
+        """
+        for parts in (
+            ["a"],
+            ["a", "b", "c"],
+            ["model", "default"],
+            ["platforms", "api_server", "extra", "model_routes", "alias", "model"],
+            ["providers", "0", "name"],
+            ["a", "", "b"],
+            ["a-b", "a_b", "a b"],
+        ):
+            assert join_dotted_key(parts) == ".".join(parts)
+
+    def test_dot_bearing_segment_is_quoted(self):
+        assert join_dotted_key(["model_routes", "gpt-5.6-sol", "model"]) == (
+            'model_routes."gpt-5.6-sol".model'
+        )
+
+    def test_non_string_segments_are_str_coerced(self):
+        # Matches what managed_scope's flattening did with non-string YAML keys.
+        assert join_dotted_key(["a", 0, True]) == "a.0.True"
+        # A float key contains a dot, so it is quoted — deliberate: bare 4.5
+        # addresses 4 -> 5, a different path.
+        assert join_dotted_key([4.5, "a"]) == '"4.5".a'
+
+    def test_quote_bearing_segment_is_emitted_bare_and_never_raises(self):
+        """A ``"`` cannot be represented — the tokenizer treats quotes as
+        structure and strips them, so there is no escape. Emitting bare is
+        byte-identical to the pre-fix behaviour; raising would add a new crash
+        surface to ``hermes doctor``, which calls managed_config_keys()
+        outside its try/except.
+        """
+        assert join_dotted_key(['a"b', "c"]) == 'a"b.c'
+
+
+class TestRoundTrip:
+    def test_split_of_join_recovers_the_segments(self):
+        """split(join(parts)) == parts for any segments containing no quote."""
+        for parts in (
+            ["a", "b"],
+            ["model", "default"],
+            ["platforms", "api_server", "extra", "model_routes", "gpt-5.6-sol", "model"],
+            ["claude-sonnet-4.5"],
+            ["a.b", "c.d"],
+            ["a", "", "b"],
+            ["4.5", "a"],
+            ["only-one-segment"],
+        ):
+            assert _split_dotted_key(join_dotted_key(parts)) == parts
+
+    def test_join_of_split_is_the_identity_on_dot_free_keys(self):
+        """join(split(k)) == k byte-for-byte for any key with no dot-bearing
+        segment. This is the backward-compatibility guarantee: every existing
+        managed key in the wild is of this shape and must not change spelling.
+        """
+        for key in (
+            "a",
+            "a.b.c",
+            "model.default",
+            "platforms.api_server.extra.model_routes.alias.model",
+            "toolsets.enabled",
+            "providers.0.name",
+            "",
+            "a..b",
+        ):
+            assert join_dotted_key(_split_dotted_key(key)) == key
+
+    def test_normalize_is_join_of_split(self):
+        assert normalize_dotted_key("model.default") == "model.default"
+        assert normalize_dotted_key('model."default"') == "model.default"
+        assert normalize_dotted_key('a."b.c".d') == 'a."b.c".d'
+        # Two spellings of the same path normalize to one string — this is what
+        # lets is_key_managed compare a CLI key against a flattened managed key.
+        assert normalize_dotted_key('"model".default') == normalize_dotted_key(
+            "model.default"
+        )
+
+    def test_normalize_raises_on_unterminated_quote(self):
+        with pytest.raises(ValueError):
+            normalize_dotted_key('model."default')

--- a/tests/hermes_cli/test_managed_scope_dotted_keys.py
+++ b/tests/hermes_cli/test_managed_scope_dotted_keys.py
@@ -1,0 +1,274 @@
+"""Managed scope must speak the same dotted-key representation as the CLI.
+
+Regression: a managed model-route alias contains a dot (every real model id
+does — ``gpt-5.6-sol``). ``_flatten_keys`` used to join segments with a plain
+``f"{prefix}.{k}"``, producing a string that re-tokenizes to a *different* path
+(``gpt-5`` → ``6-sol``). So ``is_key_managed`` never matched the key the CLI
+builds, and ``_strip_dotted_keys`` never found the leaf: a user ``config set``
+of that managed key was neither refused nor stripped. It persisted into
+config.yaml and was then silently overridden by the managed overlay on load.
+
+That is a "the user is misled" bug, not a privilege escalation — the managed
+layer still wins at load time. What broke was the user's ability to know it.
+"""
+import textwrap
+
+import pytest
+
+QUOTED_KEY = 'platforms.api_server.extra.model_routes."gpt-5.6-sol".model'
+# The same characters without quotes are NOT the same path: they address
+# model_routes → gpt-5 → 6-sol → model. Asserting False on this is the point;
+# a prefix or fuzzy match in is_key_managed would make it True.
+UNQUOTED_KEY = "platforms.api_server.extra.model_routes.gpt-5.6-sol.model"
+
+MANAGED_YAML = """
+    platforms:
+      api_server:
+        extra:
+          model_routes:
+            "gpt-5.6-sol":
+              model: managed/route-target
+            plain-alias:
+              model: managed/plain-target
+    model:
+      default: managed/model
+"""
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    import hermes_cli.config as cfg
+    from hermes_cli import managed_scope
+
+    cfg._LOAD_CONFIG_CACHE.clear()
+    cfg._RAW_CONFIG_CACHE.clear()
+    managed_scope.invalidate_managed_cache()
+    (managed / "config.yaml").write_text(
+        textwrap.dedent(MANAGED_YAML), encoding="utf-8"
+    )
+    managed_scope.invalidate_managed_cache()
+    return home, managed
+
+
+# ---------------------------------------------------------------------------
+# Flattening emits the canonical (quoted) form
+# ---------------------------------------------------------------------------
+
+def test_managed_config_keys_quotes_the_dot_bearing_alias(homes):
+    from hermes_cli import managed_scope
+
+    keys = managed_scope.managed_config_keys()
+    assert QUOTED_KEY in keys
+    # The old unquoted join must be gone, not merely accompanied.
+    assert UNQUOTED_KEY not in keys
+
+
+def test_dot_free_keys_flatten_byte_for_byte_as_before(homes):
+    """Backward compat: the quoting rule must fire ONLY on a dot-bearing segment.
+
+    Reference implementation is the pre-fix join, inlined. If ``join_dotted_key``
+    ever quoted unconditionally (or dropped quoting entirely), this diverges.
+    """
+    from hermes_cli import managed_scope
+
+    def reference_flatten(d, prefix=""):
+        keys = set()
+        for k, v in d.items():
+            dotted = f"{prefix}.{k}" if prefix else str(k)
+            if isinstance(v, dict) and v:
+                keys |= reference_flatten(v, dotted)
+            else:
+                keys.add(dotted)
+        return keys
+
+    dot_free = {
+        "model": {"default": "x", "planner": "y"},
+        "toolsets": {"enabled": ["a", "b"]},
+        "platforms": {
+            "api_server": {"extra": {"model_routes": {"plain-alias": {"model": "z"}}}}
+        },
+        "empty": {},
+        1: {"numeric_parent": True},
+    }
+    assert managed_scope._flatten_keys(dot_free) == reference_flatten(dot_free)
+
+    # And the dot-free siblings of the real fixture are untouched by the fix.
+    keys = managed_scope.managed_config_keys()
+    assert "model.default" in keys
+    assert (
+        "platforms.api_server.extra.model_routes.plain-alias.model" in keys
+    )
+
+
+def test_yaml_float_key_is_quoted(homes):
+    """A YAML float key (``4.5:``) is the same defect class and is now quoted.
+
+    Pinned deliberately: bare ``4.5`` addresses ``4`` → ``5``. This is an
+    intentional behaviour change, not a regression to revert.
+    """
+    from hermes_cli import managed_scope
+
+    assert managed_scope._flatten_keys({4.5: {"a": 1}}) == {'"4.5".a'}
+
+
+# ---------------------------------------------------------------------------
+# Comparison is exact, on the canonical form
+# ---------------------------------------------------------------------------
+
+def test_is_key_managed_matches_the_quoted_key(homes):
+    from hermes_cli import managed_scope
+
+    assert managed_scope.is_key_managed(QUOTED_KEY) is True
+
+
+def test_is_key_managed_rejects_the_unquoted_key(homes):
+    """The correct negative. ``...model_routes.gpt-5.6-sol.model`` genuinely
+    addresses a different path (``gpt-5`` → ``6-sol``), which the managed layer
+    does NOT pin. If this ever returns True, ``is_key_managed`` has been
+    weakened into a prefix/fuzzy match — it is a config-authority check and
+    must stay exact.
+    """
+    from hermes_cli import managed_scope
+
+    assert managed_scope.is_key_managed(UNQUOTED_KEY) is False
+
+
+def test_is_key_managed_normalizes_redundant_quoting(homes):
+    """Quoting a segment that needs no quotes addresses the same path."""
+    from hermes_cli import managed_scope
+
+    assert managed_scope.is_key_managed('model."default"') is True
+
+
+def test_is_key_managed_still_false_for_unmanaged_key(homes):
+    from hermes_cli import managed_scope
+
+    assert managed_scope.is_key_managed("model.planner") is False
+    assert managed_scope.is_key_managed(
+        'platforms.api_server.extra.model_routes."claude-sonnet-4.5".model'
+    ) is False
+
+
+def test_is_key_managed_does_not_raise_on_a_malformed_key(homes):
+    """``doctor``/authority paths must not gain a new crash surface."""
+    from hermes_cli import managed_scope
+
+    assert managed_scope.is_key_managed('model."unterminated') is False
+
+
+# ---------------------------------------------------------------------------
+# The write guard now actually fires
+# ---------------------------------------------------------------------------
+
+def test_save_config_strips_the_dot_bearing_managed_leaf(homes, capsys):
+    """A bulk write must not persist a value the overlay would override.
+
+    Positive control in the same test: ``model.planner`` sits under a managed
+    parent but is NOT itself managed, and must survive. Without it, this test
+    would also pass if ``save_config`` had bailed out entirely or written an
+    empty document.
+    """
+    from hermes_cli.config import save_config, get_config_path
+    from utils import fast_safe_load
+
+    home, _managed = homes
+    save_config(
+        {
+            "model": {"default": "user/override", "planner": "user/planner"},
+            "platforms": {
+                "api_server": {
+                    "extra": {
+                        "model_routes": {
+                            "gpt-5.6-sol": {"model": "user/route-override"},
+                        }
+                    }
+                }
+            },
+        },
+        strip_defaults=False,
+    )
+
+    written = fast_safe_load(get_config_path().read_text(encoding="utf-8")) or {}
+
+    # Positive control — the unmanaged leaf landed, so the save really ran.
+    assert written["model"]["planner"] == "user/planner"
+
+    # Managed leaves are gone.
+    assert "default" not in written.get("model", {})
+    routes = (
+        written.get("platforms", {})
+        .get("api_server", {})
+        .get("extra", {})
+        .get("model_routes", {})
+    )
+    assert "model" not in routes.get("gpt-5.6-sol", {})
+
+    # And the user was told, using the canonical spelling they must type.
+    err = capsys.readouterr().err
+    assert "managed setting(s) were not saved" in err
+    assert QUOTED_KEY in err
+
+
+def test_strip_dotted_keys_reports_the_quoted_key_as_stripped(homes):
+    """Assert the returned set, not just the absence — absence alone passes
+    vacuously if the nesting were wrong and the leaf never existed."""
+    from hermes_cli.config import _strip_dotted_keys
+
+    cfg = {
+        "platforms": {
+            "api_server": {
+                "extra": {"model_routes": {"gpt-5.6-sol": {"model": "user/x"}}}
+            }
+        }
+    }
+    pruned, stripped = _strip_dotted_keys(cfg, {QUOTED_KEY})
+    assert stripped == {QUOTED_KEY}
+    assert pruned["platforms"]["api_server"]["extra"]["model_routes"][
+        "gpt-5.6-sol"
+    ] == {}
+
+
+def test_strip_dotted_keys_ignores_a_malformed_key(homes):
+    """A hand-built malformed key must not abort the whole save."""
+    from hermes_cli.config import _strip_dotted_keys
+
+    cfg = {"model": {"default": "x"}}
+    pruned, stripped = _strip_dotted_keys(cfg, {'model."unterminated', "model.default"})
+    assert stripped == {"model.default"}
+    assert pruned == {"model": {}}
+
+
+def test_config_set_of_the_dot_bearing_managed_key_is_refused(homes, capsys):
+    """The user-facing half of the bug: this used to be accepted silently."""
+    from hermes_cli.config import set_config_value
+
+    with pytest.raises(SystemExit) as exc:
+        set_config_value(QUOTED_KEY, "user/override")
+    assert exc.value.code != 0
+    captured = capsys.readouterr()
+    assert "managed" in (captured.out + captured.err).lower()
+
+
+def test_config_show_renders_the_typeable_spelling(homes, capsys):
+    """`hermes config show` lists managed keys — it must print the exact string
+    the user has to type to address the leaf.
+
+    Without this, the "Managed config keys:" banner would advertise
+    ``...model_routes.gpt-5.6-sol.model``, and a user copying it straight back
+    into `config set` would address a different path and get no warning at all.
+    The existing surfacing tests only assert the banner is ABSENT when no
+    managed scope exists, so nothing else covers the rendered strings.
+    """
+    from hermes_cli.config import show_config
+
+    show_config()
+    out = capsys.readouterr().out
+    assert "managed by your administrator" in out.lower()
+    assert QUOTED_KEY in out
+    assert UNQUOTED_KEY not in out


### PR DESCRIPTION
## What does this PR do?

`hermes config set/get/unset` tokenizes a dotted key with a bare `str.split(".")`, so a config path whose **segment legitimately contains a dot** cannot be addressed at all.

The concrete casualty is model-route configuration. `platforms.api_server.extra.model_routes` is keyed by model id, and essentially every real model id contains a dot (`gpt-5.6-sol`, `claude-sonnet-4.5`). Today:

```
hermes config set platforms.api_server.extra.model_routes.gpt-5.6-sol.model openai/gpt-5.6
```

silently creates a nested `gpt-5` → `6-sol` mangling instead of the single key the reader expects (`gateway/platforms/api_server.py` reads `model_routes` as a flat dict keyed by alias). The feature is only reachable by hand-editing YAML.

This adds `_split_dotted_key()`, which honours a double-quoted span so a dot-bearing segment can be addressed:

```
hermes config set 'platforms.api_server.extra.model_routes."gpt-5.6-sol".model' openai/gpt-5.6
```

**Unquoted keys tokenize byte-for-byte identically to the old `dotted_key.split(".")`**, so every existing key keeps its meaning. The only new-facing behavior is that a malformed key with an unbalanced `"` now raises a clear error instead of being mis-parsed.

## Related Issue

No existing issue — found while configuring `model_routes` by hand.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — new `_split_dotted_key()`; the five existing consumers now call it instead of `str.split(".")`:
  - `_set_nested`, `_get_nested`, `_unset_nested`, `_default_value_for_key`, `_validate_config_key`
- `hermes_cli/config.py` — `set_config_value` / `get_config_value` / `unset_config_value` reject a malformed key (unterminated quote) with a clean message before any validation or I/O, rather than letting it surface as a traceback
- `tests/hermes_cli/test_config_dotted_keys.py` — new (12 tests)

**Deliberately unchanged:** the empty-container cleanup in `_unset_nested` is preserved exactly. Unsetting a quoted leaf collapses the emptied ancestors the same way it already does for any other key — quoting changes only how a path is *addressed*, never what `unset` does afterwards. The tests assert this explicitly.

## How to Test

1. `hermes config set 'platforms.api_server.extra.model_routes."gpt-5.6-sol".model' openai/gpt-5.6`
2. Inspect `config.yaml` — the route is under the single key `gpt-5.6-sol`, not nested `gpt-5` → `6-sol`
3. `hermes config get 'platforms.api_server.extra.model_routes."gpt-5.6-sol".model'` → `openai/gpt-5.6`
4. `hermes config unset 'platforms.api_server.extra.model_routes."gpt-5.6-sol"'` → the route and its now-empty ancestors are removed
5. Regression: any unquoted key behaves exactly as before

Tests: the new `tests/hermes_cli/test_config_dotted_keys.py` (12 cases) was verified green under the repo's own `scripts/run_tests.sh` (per-file isolation — each file in its own `python -m pytest` subprocess, TZ/LANG/PYTHONHASHSEED pinned), which is the canonical runner. No new failures were introduced versus the pre-change baseline for the changed test file. (A bare `pytest tests/` on this tree has pre-existing, unrelated failures; `scripts/run_tests.sh` is the supported way to run a file in isolation.)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the changed test file under `scripts/run_tests.sh` (per-file isolation) — green, no new failures vs baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (WSL2 Ubuntu 24.04, Python 3.11) via `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no new config keys; the key *syntax* is additive and backward compatible)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure string tokenization, no platform surface
- [x] I've updated tool descriptions/schemas — N/A

