### PR TITLE
fix(config): show model_routes, mcp_servers and plugins in config show

### DIFF
--- a/contributors/emails/git@accounts.watergard.com
+++ b/contributors/emails/git@accounts.watergard.com
@@ -1,0 +1,1 @@
+Watergard

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8660,6 +8660,37 @@ def show_config():
     except Exception:
         pass
 
+    # Integrations
+    #
+    # These are the keys an operator reaches for when an integration misbehaves,
+    # and previously they were readable only by opening config.yaml.  Print names
+    # and counts ONLY — a route's ``api_key`` and an MCP server's command/env are
+    # upstream credentials, so no per-entry value is iterated except each route's
+    # ``model`` target (never a secret).  This is the explicit regression guard
+    # for suffix-shaped-secret leakage (#68040).
+    routes = cfg_get(config, "platforms", "api_server", "extra", "model_routes", default={})
+    mcp_servers = config.get("mcp_servers") or {}
+    plugins_cfg = config.get("plugins") or {}
+    plugins_enabled = plugins_cfg.get("enabled") or []
+    plugins_disabled = plugins_cfg.get("disabled") or []
+
+    if (isinstance(routes, dict) and routes) or (isinstance(mcp_servers, dict) and mcp_servers) \
+            or plugins_enabled or plugins_disabled:
+        print()
+        print(color("◆ Integrations", Colors.CYAN, Colors.BOLD))
+        if isinstance(routes, dict) and routes:
+            print(f"  Model routes: {len(routes)}")
+            for alias in sorted(routes):
+                route_cfg = routes[alias]
+                target = route_cfg.get("model", "") if isinstance(route_cfg, dict) else ""
+                print(f"    {alias} → {target or color('(no model — ignored at load)', Colors.YELLOW)}")
+        if isinstance(mcp_servers, dict) and mcp_servers:
+            print(f"  MCP servers:  {len(mcp_servers)} ({', '.join(sorted(mcp_servers))})")
+        if plugins_enabled:
+            print(f"  Plugins on:   {', '.join(sorted(map(str, plugins_enabled)))}")
+        if plugins_disabled:
+            print(f"  Plugins off:  {', '.join(sorted(map(str, plugins_disabled)))}")
+
     print()
     print(color("─" * 60, Colors.DIM))
     print(color("  hermes config edit     # Edit config file", Colors.DIM))

--- a/tests/hermes_cli/test_config_show_integrations.py
+++ b/tests/hermes_cli/test_config_show_integrations.py
@@ -1,0 +1,85 @@
+"""Tests for the Integrations section of ``hermes config show``.
+
+``show_config`` previously omitted ``model_routes``, ``mcp_servers`` and
+``plugins`` entirely — the three surfaces an operator most needs when an
+integration misbehaves. The section prints NAMES and COUNTS only: no per-entry
+value is iterated except each route's ``model`` target, so no secret can leak
+(regression guard for the suffix-shaped-secret leakage of #68040).
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from hermes_cli.config import show_config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path):
+    (tmp_path / ".env").touch()
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        yield tmp_path
+
+
+def _write_config(tmp_path, data):
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def test_shows_route_mcp_and_plugin_names(_isolated_hermes_home, capsys):
+    _write_config(_isolated_hermes_home, {
+        "platforms": {"api_server": {"extra": {"model_routes": {
+            "gpt-5.6-sol": {"model": "openai/gpt-5.6"},
+        }}}},
+        "mcp_servers": {"my-server": {"command": "run-it"}},
+        "plugins": {"enabled": ["kanban"], "disabled": ["spotify"]},
+    })
+    show_config()
+    out = capsys.readouterr().out
+    assert "Integrations" in out
+    assert "gpt-5.6-sol" in out
+    assert "openai/gpt-5.6" in out
+    assert "my-server" in out
+    assert "kanban" in out
+    assert "spotify" in out
+
+
+def test_section_omitted_when_nothing_configured(_isolated_hermes_home, capsys):
+    _write_config(_isolated_hermes_home, {"model": "hermes"})
+    show_config()
+    out = capsys.readouterr().out
+    assert "Integrations" not in out
+
+
+def test_does_not_print_route_api_key_or_mcp_env(_isolated_hermes_home, capsys):
+    # The #68040 regression guard: a secret planted in BOTH a route api_key and
+    # an mcp_server env must never appear in the output.
+    _write_config(_isolated_hermes_home, {
+        "platforms": {"api_server": {"extra": {"model_routes": {
+            "gpt-5.6-sol": {"model": "openai/gpt-5.6", "api_key": "sk-ROUTE-SECRET"},
+        }}}},
+        "mcp_servers": {"my-server": {
+            "command": "run-it",
+            "env": {"TOKEN": "sk-MCP-SECRET"},
+        }},
+    })
+    show_config()
+    out = capsys.readouterr().out
+    assert "sk-ROUTE-SECRET" not in out
+    assert "sk-MCP-SECRET" not in out
+    # The non-secret names/targets are still shown.
+    assert "gpt-5.6-sol" in out
+    assert "my-server" in out
+
+
+def test_route_with_no_model_is_flagged(_isolated_hermes_home, capsys):
+    _write_config(_isolated_hermes_home, {
+        "platforms": {"api_server": {"extra": {"model_routes": {
+            "broken-route": {"provider": "openai"},
+        }}}},
+    })
+    show_config()
+    out = capsys.readouterr().out
+    assert "broken-route" in out
+    assert "no model" in out


### PR DESCRIPTION
## What does this PR do?

`hermes config show` walks the operator through Paths, API Keys, Model, Display, Terminal, Timezone, Context Compression, Auxiliary Models, Messaging Platforms and Skill Settings — and then stops. Three configured integrations are never shown:

- `platforms.api_server.extra.model_routes` — per-alias model routing
- `mcp_servers` — configured MCP servers
- `plugins.enabled` / `plugins.disabled`

An operator who has configured any of them cannot confirm it from the CLI; `config show` reports a state that looks like "not configured". This adds the three sections.

Same class of defect as #34653 (`config show` omits `display.*` keys) — that issue establishes "config show omits X" as a bug worth fixing; this covers a different, and arguably more surprising, set of omissions.

## Related Issue

Related: #34653 (same defect class, different keys). Not a duplicate — disjoint key sets.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — `show_config()` gains three sections, inserted after Skill Settings and before the closing footer
- `tests/hermes_cli/test_config_show_integrations.py` — new; covers each section rendering when configured, and being omitted entirely when not

## Secret safety

This matters here because route entries legitimately carry `api_key` / `base_url`, and `config show` already redacts (#50245).

**The new output prints names, counts, and the `model` target only — no credential-shaped value is read.** For `mcp_servers` and `plugins` it prints names and enabled/disabled state. Nothing here widens the surface #68040 is concerned with.

## How to Test

1. Configure any of: an `api_server` model route, an MCP server, an enabled plugin
2. `hermes config show` → each configured integration now appears
3. With none configured, `hermes config show` output is unchanged (sections omitted, not shown empty)
4. Confirm no route `api_key` is echoed

Tests: verified green under `scripts/run_tests.sh tests/hermes_cli/test_config_show_integrations.py` (per-file isolation), with no new failures versus the pre-change baseline.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the changed test file green under `scripts/run_tests.sh` (per-file isolation); no new failures versus baseline
- [x] I've added tests for my changes
- [x] I've verified the change under `scripts/run_tests.sh` per-file isolation on the changed test file

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (surfaces existing config, adds no keys)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — terminal output only
- [x] I've updated tool descriptions/schemas — N/A
