### PR TITLE
fix(config): give config edit an actionable hint when no editor is found

### DIFF
--- a/contributors/emails/git@accounts.watergard.com
+++ b/contributors/emails/git@accounts.watergard.com
@@ -1,0 +1,1 @@
+Watergard

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4448,10 +4448,20 @@ def edit_config():
                 break
     
     if not editor:
+        # Reached only after the candidate probe above ran, so ``candidates`` is
+        # in scope.  Failing here is fine — there genuinely is no editor — but a
+        # bare "No editor found" is a dead end, so name the four cheap exits.
         print("No editor found. Config file is at:")
         print(f"  {config_path}")
+        print()
+        print(f"  Tried: {', '.join(candidates)} (none found on PATH).")
+        print()
+        print("  Next steps:")
+        print("    • Set an editor:    EDITOR=vi hermes config edit")
+        print("    • Edit without one: hermes config set <key> <value>")
+        print("    • Print the path:   hermes config path")
         return
-    
+
     print(f"Opening {config_path} in {editor}...")
     subprocess.run([editor, str(config_path)])
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4450,14 +4450,14 @@ def edit_config():
     if not editor:
         # Reached only after the candidate probe above ran, so ``candidates`` is
         # in scope.  Failing here is fine — there genuinely is no editor — but a
-        # bare "No editor found" is a dead end, so name the four cheap exits.
+        # bare "No editor found" is a dead end, so name the three cheap exits.
         print("No editor found. Config file is at:")
         print(f"  {config_path}")
         print()
         print(f"  Tried: {', '.join(candidates)} (none found on PATH).")
         print()
         print("  Next steps:")
-        print("    • Set an editor:    EDITOR=vi hermes config edit")
+        print("    • Set an editor:    install one, then set EDITOR to <its command>")
         print("    • Edit without one: hermes config set <key> <value>")
         print("    • Print the path:   hermes config path")
         return

--- a/tests/hermes_cli/test_config_edit_no_editor.py
+++ b/tests/hermes_cli/test_config_edit_no_editor.py
@@ -34,8 +34,11 @@ def test_no_editor_message_is_actionable(_isolated_hermes_home, capsys):
     assert "No editor found" in out
     # Names the editors it tried…
     assert "Tried:" in out
-    # …and each of the four documented next steps.
-    assert "EDITOR=" in out
+    # …and each of the three documented next steps.  Assert only the ``EDITOR``
+    # variable name: the hint must not pin shell-specific ``VAR=value`` syntax,
+    # nor name a concrete editor — every plausible one is a probed candidate, so
+    # reaching this branch proves it is absent.
+    assert "EDITOR" in out
     assert "hermes config set" in out
     assert "hermes config path" in out
 

--- a/tests/hermes_cli/test_config_edit_no_editor.py
+++ b/tests/hermes_cli/test_config_edit_no_editor.py
@@ -1,0 +1,47 @@
+"""Tests for the actionable hint ``hermes config edit`` prints when no editor
+is found.
+
+On a minimal container (no ``nano``/``vim``/``code`` and no ``$EDITOR``) the
+command used to print a two-line dead end. It now names the editors it tried
+and the cheap non-interactive alternatives.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import edit_config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path):
+    (tmp_path / ".env").touch()
+    # Pre-create config.yaml so edit_config goes straight to editor resolution.
+    (tmp_path / "config.yaml").write_text("model: hermes\n", encoding="utf-8")
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+        # Ensure neither EDITOR nor VISUAL is set.
+        os.environ.pop("EDITOR", None)
+        os.environ.pop("VISUAL", None)
+        yield tmp_path
+
+
+def test_no_editor_message_is_actionable(_isolated_hermes_home, capsys):
+    # No editor on PATH and no $EDITOR / $VISUAL.
+    with patch("shutil.which", return_value=None):
+        edit_config()
+    out = capsys.readouterr().out
+    assert "No editor found" in out
+    # Names the editors it tried…
+    assert "Tried:" in out
+    # …and each of the four documented next steps.
+    assert "EDITOR=" in out
+    assert "hermes config set" in out
+    assert "hermes config path" in out
+
+
+def test_no_editor_does_not_launch_subprocess(_isolated_hermes_home):
+    with patch("shutil.which", return_value=None), \
+            patch("subprocess.run") as run:
+        edit_config()
+    run.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

When `hermes config edit` cannot find an editor, it prints a two-line dead end:

```
No editor found. Config file is at:
  /path/to/config.yaml
```

It has just probed a known list of candidates (`nano`, `vim`, `vi`, `code`, `notepad`, ordered per-platform) and knows `$EDITOR`/`$VISUAL` were unset — but tells the user none of that. The user is left to guess why, and what to do.

This replaces the dead end with the information the function already has in scope: what was tried, and the two ways to fix it (set `$EDITOR`, or install one of the candidates).

Pure output change — no behavioural change, `subprocess.run` is still not called on this path.

## Related Issue

No existing issue — no PR or issue covers this message.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — `edit_config()`'s no-editor branch now reports the probed candidates and the two remedies alongside the config path
- `tests/hermes_cli/test_config_edit_no_editor.py` — new; asserts the hint content and that no editor subprocess is launched

Note: there is currently no upstream test that calls `edit_config()`, so these are the first.

## How to Test

1. Unset `EDITOR` and `VISUAL`
2. Run `hermes config edit` on a machine with none of the candidates on `PATH` (or temporarily shadow `PATH`)
3. The output now names what was probed and how to fix it, instead of only the path

Tests: `scripts/run_tests.sh tests/hermes_cli/test_config_edit_no_editor.py` (the canonical per-file runner). Both cases pass with the fix — every asserted string is printed on the no-editor path and `subprocess.run` is unreachable there. The file is new, so it adds no regressions to the existing `tests/hermes_cli/` baseline.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] The new test file is green under `scripts/run_tests.sh` (per-file isolation) and adds no new failures relative to the pre-change `tests/hermes_cli/` baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (WSL2 Ubuntu 24.04, Python 3.11) via `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (error-message wording)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the candidate list is already platform-ordered; the hint reports whichever list ran
- [x] I've updated tool descriptions/schemas — N/A
