### PR TITLE
fix(billing): persist NULL estimated_cost_usd for unpriced models

### DIFF
--- a/contributors/emails/git@accounts.watergard.com
+++ b/contributors/emails/git@accounts.watergard.com
@@ -1,0 +1,1 @@
+Watergard

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4162,7 +4162,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    cache_read_tokens = ?,
                    cache_write_tokens = ?,
                    reasoning_tokens = ?,
-                   estimated_cost_usd = COALESCE(?, 0),
+                   estimated_cost_usd = CASE
+                       WHEN ? IS NULL THEN estimated_cost_usd
+                       ELSE ?
+                   END,
                    actual_cost_usd = CASE
                        WHEN ? IS NULL THEN actual_cost_usd
                        ELSE ?
@@ -4183,7 +4186,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    cache_read_tokens = cache_read_tokens + ?,
                    cache_write_tokens = cache_write_tokens + ?,
                    reasoning_tokens = reasoning_tokens + ?,
-                   estimated_cost_usd = COALESCE(estimated_cost_usd, 0) + COALESCE(?, 0),
+                   estimated_cost_usd = CASE
+                       WHEN ? IS NULL THEN estimated_cost_usd
+                       ELSE COALESCE(estimated_cost_usd, 0) + ?
+                   END,
                    actual_cost_usd = CASE
                        WHEN ? IS NULL THEN actual_cost_usd
                        ELSE COALESCE(actual_cost_usd, 0) + ?
@@ -4208,6 +4214,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             cache_read_tokens,
             cache_write_tokens,
             reasoning_tokens,
+            estimated_cost_usd,
             estimated_cost_usd,
             actual_cost_usd,
             actual_cost_usd,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -186,6 +186,120 @@ class TestSessionLifecycle:
 
 
 
+    def test_update_token_counts_preserves_null_cost_for_unpriced_model(self, db):
+        """An unpriced turn (estimated_cost_usd=None) must leave the column
+        NULL, not coerce it to 0.0.
+
+        The pricing layer returns amount_usd=None ("unknown") for a model it
+        has no rate for; the persisted row must stay NULL so a client can tell
+        "cost unknown" from a genuine measured zero. Regression guard for the
+        COALESCE(?, 0) coercion on the incremental branch.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts(
+            "s1", input_tokens=1000, output_tokens=200,
+            estimated_cost_usd=None, cost_status="unknown", cost_source="none",
+            api_call_count=1,
+        )
+
+        session = db.get_session("s1")
+        assert session["estimated_cost_usd"] is None
+        assert session["cost_status"] == "unknown"
+        assert session["cost_source"] == "none"
+
+    def test_update_token_counts_records_explicit_zero_for_included_route(self, db):
+        """A genuine zero (subscription-included) must persist as 0.0, not NULL.
+
+        Guards against "fixing" the unpriced case by treating a falsy cost as
+        unknown, which would erase the distinction between "included" and
+        "no price available".
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts(
+            "s1", input_tokens=1000, output_tokens=200,
+            estimated_cost_usd=0.0, cost_status="included",
+            cost_source="subscription", api_call_count=1,
+        )
+
+        session = db.get_session("s1")
+        assert session["estimated_cost_usd"] == 0.0
+        assert session["cost_status"] == "included"
+
+    def test_update_token_counts_null_delta_does_not_reset_accumulated_cost(self, db):
+        """A later unpriced turn must not zero out an already-accumulated cost.
+
+        A priced call establishes a positive total; a subsequent unpriced call
+        (None delta) must leave that total intact rather than resetting it.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts(
+            "s1", input_tokens=1000, output_tokens=200,
+            estimated_cost_usd=0.25, cost_status="metered", api_call_count=1,
+        )
+        db.update_token_counts(
+            "s1", input_tokens=500, output_tokens=100,
+            estimated_cost_usd=None, cost_status="unknown", api_call_count=1,
+        )
+
+        session = db.get_session("s1")
+        assert session["estimated_cost_usd"] == 0.25
+
+    def test_update_token_counts_absolute_preserves_null_cost_for_unpriced_model(self, db):
+        """absolute=True: None means "no price information", never zero.
+
+        The gateway path writes cumulative totals with absolute=True, which is
+        a separate SQL branch from the CLI's incremental one. An unpriced
+        cumulative write must leave the column NULL on a fresh session, and
+        must not overwrite an already-priced total on a later one -- while the
+        token counters it carries are still set absolutely.
+        """
+        db.create_session(session_id="s1", source="gateway")
+        db.update_token_counts(
+            "s1", input_tokens=1000, output_tokens=200,
+            estimated_cost_usd=None, cost_status="unknown", cost_source="none",
+            api_call_count=1, absolute=True,
+        )
+        assert db.get_session("s1")["estimated_cost_usd"] is None
+
+        db.update_token_counts(
+            "s1", input_tokens=1500, output_tokens=300,
+            estimated_cost_usd=0.25, cost_status="metered",
+            api_call_count=2, absolute=True,
+        )
+        assert db.get_session("s1")["estimated_cost_usd"] == 0.25
+
+        db.update_token_counts(
+            "s1", input_tokens=2000, output_tokens=400,
+            estimated_cost_usd=None, cost_status="unknown",
+            api_call_count=3, absolute=True,
+        )
+        session = db.get_session("s1")
+        assert session["estimated_cost_usd"] == 0.25
+        # The overwrite semantics of the absolute branch are untouched.
+        assert session["input_tokens"] == 2000
+        assert session["api_call_count"] == 3
+
+    def test_update_token_counts_absolute_records_explicit_zero_for_included_route(self, db):
+        """absolute=True: an explicit 0.0 still overwrites a priced total.
+
+        The absolute branch must keep *setting* the column, so a session that
+        turns out to be subscription-included lands on 0.0 rather than keeping
+        an earlier estimate. Pins the zero/None split on this branch too.
+        """
+        db.create_session(session_id="s1", source="gateway")
+        db.update_token_counts(
+            "s1", input_tokens=1000, estimated_cost_usd=0.25,
+            cost_status="metered", api_call_count=1, absolute=True,
+        )
+        db.update_token_counts(
+            "s1", input_tokens=1500, estimated_cost_usd=0.0,
+            cost_status="included", cost_source="subscription",
+            api_call_count=2, absolute=True,
+        )
+
+        session = db.get_session("s1")
+        assert session["estimated_cost_usd"] == 0.0
+        assert session["cost_status"] == "included"
 
     def test_update_session_model_clears_browser_lock_and_preserves_lineage(self, db):
         """A later /model switch must replace, not compete with, a Browser lock."""


### PR DESCRIPTION
## What does this PR do?

`sessions.estimated_cost_usd` cannot currently represent "we have no price for this model". An unpriced model's cost is coerced to `0`, so **"this genuinely cost nothing" and "we don't know what this cost" are stored identically.**

The caller already expresses the distinction correctly — `agent/conversation_loop.py` passes `estimated_cost_usd=None` when the turn has no resolvable price. The SQL then throws it away:

```sql
estimated_cost_usd = COALESCE(?, 0),
```
```sql
estimated_cost_usd = COALESCE(estimated_cost_usd, 0) + COALESCE(?, 0),
```

Three facts make this a defect rather than a design choice:

1. **The column is nullable.** `sessions.estimated_cost_usd REAL` — no `NOT NULL`, no `DEFAULT`. NULL is representable and a fresh row starts NULL.
2. **The adjacent line already does it right.** `actual_cost_usd`, two lines away in the same statement, uses `CASE WHEN ? IS NULL THEN actual_cost_usd ELSE ? END` — the exact idiom this PR applies to `estimated_cost_usd`. This is in-file precedent, not a new pattern.
3. **The import path already round-trips NULL.** `import_sessions` writes `self._float_or_none(raw.get("estimated_cost_usd"))`, so a NULL can be imported into a column the write path can never produce.

This changes both branches to the `actual_cost_usd` idiom, so an unpriced turn leaves the value untouched (NULL for a never-priced session) instead of asserting `0`.

**Scope note (deliberate):** `session_model_usage.estimated_cost_usd` is declared `REAL NOT NULL DEFAULT 0`, so the coercion in `_record_model_usage` is required by that table's schema and is left alone. `gateway/session.py`'s `SessionEntry.estimated_cost_usd: float = 0.0` is an in-memory dataclass on a different layer and is also untouched.

**Blast radius:** every SQL consumer already wraps this column in `COALESCE(SUM(...), 0)` and every Python consumer uses `or 0.0`, so NULL is safe downstream today. `absolute=True` has no non-test callers at present; it is fixed alongside the incremental branch for symmetry rather than because it is the observed symptom.

Companion PR exposing the fields that make a `0` legible to API clients: see the linked `cost_status`/`cost_source` PR.

## Related Issue

Related: #18304 (`usage cost always 0 even when tokens are recorded`). That issue is broader — it also covers missing pricing entries — so this does not close it, but "estimated_cost_usd is always 0" is exactly the symptom here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` — `SessionDB.update_token_counts`: both the absolute and incremental `UPDATE` statements now preserve NULL for `estimated_cost_usd` using the same `CASE WHEN ? IS NULL` form already used by `actual_cost_usd`
- `tests/test_hermes_state.py` — coverage for the unpriced case on both branches

## How to Test

1. Run a turn with a model that has no pricing entry
2. `SELECT estimated_cost_usd FROM sessions WHERE id = ...` → `NULL`, not `0.0`
3. Run a turn with a priced model → the value accumulates exactly as before
4. Mixed session (priced turn, then unpriced turn) → the priced total is preserved, not zeroed

Verify with the canonical runner (per-file isolation): `scripts/run_tests.sh tests/test_hermes_state.py`. Expected: the three new unpriced-cost cases pass and the file shows no new failures versus the pre-patch baseline on the same file (Python 3.11).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] Ran `tests/test_hermes_state.py` via `scripts/run_tests.sh` — green, no new failures vs the pre-patch baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (WSL2 Ubuntu 24.04, Python 3.11) via `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no schema change; the column is already nullable)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — SQL only
- [x] I've updated tool descriptions/schemas — N/A
