### PR TITLE
fix(gateway): expose cost_status and cost_source in session response

### DIFF
--- a/contributors/emails/git@accounts.watergard.com
+++ b/contributors/emails/git@accounts.watergard.com
@@ -1,0 +1,1 @@
+Watergard

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2968,8 +2968,8 @@ class APIServerAdapter(BasePlatformAdapter):
             "end_reason", "message_count", "tool_call_count", "input_tokens",
             "output_tokens", "cache_read_tokens", "cache_write_tokens",
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
-            "api_call_count", "parent_session_id", "last_active", "preview",
-            "_lineage_root_id",
+            "cost_status", "cost_source", "api_call_count", "parent_session_id",
+            "last_active", "preview", "_lineage_root_id",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
         # Avoid exposing full system prompts/model_config through the client API;

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -4549,6 +4549,40 @@ class TestConversationParameter:
 
 
 # ---------------------------------------------------------------------------
+# _session_response field allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestSessionResponse:
+    """_session_response is the funnel for every session-shaped API payload."""
+
+    def test_session_response_exposes_cost_status_and_source(self):
+        """cost_status / cost_source are the discriminators that tell a known
+        cost from an unknown one; the client-safe view must include them."""
+        row = {
+            "id": "s1",
+            "model": "hermes-agent",
+            "estimated_cost_usd": 0.0,
+            "actual_cost_usd": None,
+            "cost_status": "unknown",
+            "cost_source": "none",
+        }
+        payload = APIServerAdapter._session_response(row)
+        assert payload["cost_status"] == "unknown"
+        assert payload["cost_source"] == "none"
+        # The numbers they qualify are still present.
+        assert payload["estimated_cost_usd"] == 0.0
+
+    def test_session_response_omits_cost_fields_when_absent_from_row(self):
+        """An older row without the columns simply omits them (the `if key in
+        session` guard), rather than emitting None — forward/backward compatible."""
+        row = {"id": "s1", "model": "hermes-agent", "estimated_cost_usd": 0.5}
+        payload = APIServerAdapter._session_response(row)
+        assert "cost_status" not in payload
+        assert "cost_source" not in payload
+
+
+# ---------------------------------------------------------------------------
 # X-Hermes-Session-Id header (session continuity)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

The API server's session payload omits `cost_status` and `cost_source`, so an API client can see a cost but cannot tell **what kind of cost it is** — real, estimated, included in a subscription, or simply unknown.

Both fields already exist and are already populated in the DB and agent layers (`hermes_state.py`, `agent/insights.py`, `agent/turn_finalizer.py`, `gateway/session.py`). They are dropped at exactly one place — the `safe_keys` allowlist in `APIServerAdapter._session_response`:

```python
safe_keys = (
    "id", "source", "user_id", "model", ...
    "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
    "api_call_count", "parent_session_id", "last_active", "preview",
    "_lineage_root_id",
)
```

`cost_status` / `cost_source` appear nowhere else in that module. Because this one funnel feeds all five session-shaped endpoints (list, create, get, patch, fork), **every one of them is missing the discriminators.**

Consequence for a client: a reported `0` is uninterpretable. This is the reader-facing half of the same problem as the linked `estimated_cost_usd` NULL-preservation PR — that one makes "unknown" *storable*, this one makes it *legible*.

**Forward-compatible by construction:** the patch passes the stored string through unmodified rather than enumerating an allowed set, so it does not pin the vocabulary. Any refinement of the `cost_status` ladder flows through without touching this code.

Adding a field to this tuple is the established pattern for this surface — the same one-line addition is used by open PRs adding `session_key`/`chat_id` and `archived`.

## Related Issue

No existing issue describes this omission.

Related: the companion `estimated_cost_usd` NULL PR (linked below). Each is useful alone; together they close the loop.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` — `_session_response` now includes `cost_status` and `cost_source` in `safe_keys`
- `tests/gateway/test_api_server.py` — coverage for the two fields being surfaced (present when the row carries them, omitted when it doesn't)

Purely additive to the response shape: existing clients that ignore unknown keys are unaffected.

## How to Test

1. Start the API server and run a turn
2. `GET /api/sessions/{id}` → the payload now carries `cost_status` and `cost_source`
3. Same for the list, create, patch and fork responses (all share `_session_response`)
4. Cross-check the values against the `sessions` row

Tests: reproduce with the canonical per-file runner — `scripts/run_tests.sh tests/gateway/test_api_server.py`. The change is purely additive to the response shape; the two added cases in `TestSessionResponse` are the only behavioral delta, and the patch adds no new failures against the pre-change baseline of that file.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant suite (`scripts/run_tests.sh tests/gateway/test_api_server.py`); the added cases pass and the additive change introduces no new failures against the pre-change baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (WSL2 Ubuntu 24.04, Python 3.11) via `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] I've updated relevant documentation — happy to add the two fields to `website/docs/user-guide/features/api-server.md` if preferred; say the word
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — response serialization only
- [x] I've updated tool descriptions/schemas — N/A
