### PR TITLE
fix(gateway): forward MoA fan-out events on api_server SSE streams

### DIFF
--- a/contributors/emails/git@accounts.watergard.com
+++ b/contributors/emails/git@accounts.watergard.com
@@ -1,0 +1,1 @@
+Watergard

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3554,6 +3554,12 @@ class APIServerAdapter(BasePlatformAdapter):
         def _tool_progress(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs) -> None:
             if event_type == "reasoning.available":
                 _enqueue("tool.progress", {"message_id": message_id, "tool_name": tool_name or "_thinking", "delta": preview or ""})
+            elif event_type == "moa.reference":
+                # MoA fan-out: one labelled block per reference model, forwarded so
+                # an HTTP client sees the same progress the CLI/TUI already show.
+                _enqueue("moa.reference", {"message_id": message_id, "label": tool_name, "text": preview or "", "index": kwargs.get("moa_index"), "count": kwargs.get("moa_count")})
+            elif event_type == "moa.aggregating":
+                _enqueue("moa.aggregating", {"message_id": message_id, "aggregator": tool_name, "ref_count": kwargs.get("moa_ref_count")})
             elif event_type in {"tool.started", "tool.completed", "tool.failed"}:
                 event_name = event_type.replace("tool.", "tool.")
                 _enqueue(event_name, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
@@ -6029,6 +6035,26 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": ts,
                     "text": preview or "",
                 })
+            elif event_type == "moa.reference":
+                # MoA fan-out: one event per reference model before the aggregator
+                # acts, mirroring the CLI/TUI so /v1/runs clients can show it too.
+                _push({
+                    "event": "moa.reference",
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "label": tool_name,
+                    "text": preview or "",
+                    "index": kwargs.get("moa_index"),
+                    "count": kwargs.get("moa_count"),
+                })
+            elif event_type == "moa.aggregating":
+                _push({
+                    "event": "moa.aggregating",
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "aggregator": tool_name,
+                    "ref_count": kwargs.get("moa_ref_count"),
+                })
             elif event_type in {"subagent.start", "subagent.complete"}:
                 event = {
                     "event": event_type,
@@ -6077,6 +6103,9 @@ class APIServerAdapter(BasePlatformAdapter):
             # not forwarded on the /v1/runs stream: they are high-volume UI
             # noise. Lifecycle boundaries (start/complete) still need to land
             # so clients can observe delegate_task timeouts and failures.
+            # ``moa.progress``/``moa.phase`` are dropped for the same reason:
+            # they are per-reference progress ticks, while the two MoA events
+            # above are the content-bearing fan-out boundaries.
 
         return _callback
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3560,6 +3560,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 _enqueue("moa.reference", {"message_id": message_id, "label": tool_name, "text": preview or "", "index": kwargs.get("moa_index"), "count": kwargs.get("moa_count")})
             elif event_type == "moa.aggregating":
                 _enqueue("moa.aggregating", {"message_id": message_id, "aggregator": tool_name, "ref_count": kwargs.get("moa_ref_count")})
+            elif event_type == "moa.progress":
+                # Per-reference completion tick. ``refs_done``/``refs_total``
+                # count references ATTEMPTED, as ``count``/``ref_count`` do.
+                _enqueue("moa.progress", {"message_id": message_id, "label": tool_name or "", "refs_done": kwargs.get("moa_refs_done"), "refs_total": kwargs.get("moa_refs_total")})
+            elif event_type == "moa.phase":
+                _enqueue("moa.phase", {"message_id": message_id, "phase": kwargs.get("moa_phase"), "refs_done": kwargs.get("moa_refs_done"), "refs_total": kwargs.get("moa_refs_total"), "aggregator": tool_name or ""})
             elif event_type in {"tool.started", "tool.completed", "tool.failed"}:
                 event_name = event_type.replace("tool.", "tool.")
                 _enqueue(event_name, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
@@ -6055,6 +6061,34 @@ class APIServerAdapter(BasePlatformAdapter):
                     "aggregator": tool_name,
                     "ref_count": kwargs.get("moa_ref_count"),
                 })
+            elif event_type == "moa.progress":
+                # Fires as each reference completes, so a client can show
+                # "N/M refs done" during the fan-out rather than waiting for
+                # the content-bearing events. ``refs_done``/``refs_total``
+                # count references ATTEMPTED, matching ``count``/``ref_count``
+                # above — a reference that failed still advances them.
+                _push({
+                    "event": "moa.progress",
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "label": tool_name or "",
+                    "refs_done": kwargs.get("moa_refs_done"),
+                    "refs_total": kwargs.get("moa_refs_total"),
+                })
+            elif event_type == "moa.phase":
+                # Phase transition; currently only ``phase="aggregator"``,
+                # emitted once the fan-out is done. Clients that prefer one
+                # event family for phase tracking switch on ``phase`` instead
+                # of subscribing to ``moa.aggregating`` separately.
+                _push({
+                    "event": "moa.phase",
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "phase": kwargs.get("moa_phase"),
+                    "refs_done": kwargs.get("moa_refs_done"),
+                    "refs_total": kwargs.get("moa_refs_total"),
+                    "aggregator": tool_name or "",
+                })
             elif event_type in {"subagent.start", "subagent.complete"}:
                 event = {
                     "event": event_type,
@@ -6103,9 +6137,9 @@ class APIServerAdapter(BasePlatformAdapter):
             # not forwarded on the /v1/runs stream: they are high-volume UI
             # noise. Lifecycle boundaries (start/complete) still need to land
             # so clients can observe delegate_task timeouts and failures.
-            # ``moa.progress``/``moa.phase`` are dropped for the same reason:
-            # they are per-reference progress ticks, while the two MoA events
-            # above are the content-bearing fan-out boundaries.
+            # The MoA family is forwarded whole — the four events above are
+            # every event ``moa_loop`` emits, and they are bounded by the
+            # reference count rather than by tool volume.
 
         return _callback
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -815,6 +815,85 @@ class TestChatCompletionsEndpoint:
 
 
     @pytest.mark.asyncio
+    async def test_session_chat_stream_forwards_moa_fanout_events(self, adapter):
+        """MoA fan-out must reach the session SSE client as real frames.
+
+        ``build_moa_facade`` (``agent/moa_loop.py``) relays ``moa.reference`` /
+        ``moa.aggregating`` onto ``tool_progress_callback``. The session stream
+        used to match only ``reasoning.available`` and the ``tool.*`` family, so
+        a council run went silent between ``message.started`` and
+        ``run.completed``. Assert on the serialized SSE frames — a mock-level
+        check would pass even if nothing were written to the wire.
+        """
+        app = _create_app(adapter)
+
+        async def _mock_run_agent(**kwargs):
+            cb = kwargs.get("tool_progress_callback")
+            assert cb is not None, "session stream must pass tool_progress_callback"
+            # Positional signature is fixed by the relay in agent/moa_loop.py:
+            # (event, label, text, args, **kwargs).
+            cb("moa.reference", "openrouter:ref-a", "Answer A.", None, moa_index=1, moa_count=2)
+            cb("moa.reference", "openrouter:ref-b", "Answer B.", None, moa_index=2, moa_count=2)
+            cb("moa.aggregating", "nous:aggregator", None, None, moa_ref_count=2)
+            return (
+                {"final_response": "merged", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_get_existing_session_or_404", return_value=({"id": "s1"}, None)),
+                patch.object(adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/api/sessions/s1/chat/stream",
+                    json={"message": "ask the council"},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        # Parse the wire bytes into (event name, payload) pairs rather than
+        # substring-matching: JSON separator spacing must not decide the result.
+        frames = []
+        for block in body.split("\n\n"):
+            name = data = None
+            for line in block.splitlines():
+                if line.startswith("event: "):
+                    name = line[len("event: "):].strip()
+                elif line.startswith("data: "):
+                    data = line[len("data: "):]
+            if name and data is not None:
+                frames.append((name, json.loads(data)))
+
+        names = [name for name, _ in frames]
+        assert names.count("moa.reference") == 2, names
+        assert names.count("moa.aggregating") == 1, names
+        # Fan-out lands after the message opens and before the turn closes.
+        assert names.index("message.started") < names.index("moa.reference")
+        assert names.index("moa.reference") < names.index("moa.aggregating")
+        assert names.index("moa.aggregating") < names.index("run.completed")
+
+        started = next(p for n, p in frames if n == "message.started")
+        message_id = started["message"]["id"]
+
+        refs = [p for n, p in frames if n == "moa.reference"]
+        assert [r["label"] for r in refs] == ["openrouter:ref-a", "openrouter:ref-b"]
+        assert [r["text"] for r in refs] == ["Answer A.", "Answer B."]
+        assert [r["index"] for r in refs] == [1, 2]
+        assert [r["count"] for r in refs] == [2, 2]
+        for ref in refs:
+            assert ref["message_id"] == message_id
+            assert ref["session_id"] == "s1"
+
+        agg = next(p for n, p in frames if n == "moa.aggregating")
+        assert agg["aggregator"] == "nous:aggregator"
+        assert agg["ref_count"] == 2
+        assert agg["message_id"] == message_id
+        assert agg["session_id"] == "s1"
+
+
+    @pytest.mark.asyncio
     async def test_stream_task_done_callback_enqueues_eos_for_chat_completions(self, adapter):
         """Regression guard for #24451: completion callback must signal SSE EOS."""
         app = _create_app(adapter)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -816,14 +816,14 @@ class TestChatCompletionsEndpoint:
 
     @pytest.mark.asyncio
     async def test_session_chat_stream_forwards_moa_fanout_events(self, adapter):
-        """MoA fan-out must reach the session SSE client as real frames.
+        """The whole MoA family must reach the session SSE client as real frames.
 
-        ``build_moa_facade`` (``agent/moa_loop.py``) relays ``moa.reference`` /
-        ``moa.aggregating`` onto ``tool_progress_callback``. The session stream
-        used to match only ``reasoning.available`` and the ``tool.*`` family, so
-        a council run went silent between ``message.started`` and
-        ``run.completed``. Assert on the serialized SSE frames — a mock-level
-        check would pass even if nothing were written to the wire.
+        ``build_moa_facade`` (``agent/moa_loop.py``) relays all four MoA events
+        onto ``tool_progress_callback``. The session stream used to match only
+        ``reasoning.available`` and the ``tool.*`` family, so a council run went
+        silent between ``message.started`` and ``run.completed``. Assert on the
+        serialized SSE frames — a mock-level check would pass even if nothing
+        were written to the wire.
         """
         app = _create_app(adapter)
 
@@ -832,8 +832,18 @@ class TestChatCompletionsEndpoint:
             assert cb is not None, "session stream must pass tool_progress_callback"
             # Positional signature is fixed by the relay in agent/moa_loop.py:
             # (event, label, text, args, **kwargs).
+            #
+            # Emission ORDER is fixed there too, and is not interleaved: every
+            # moa.progress fires from the progress_callback while
+            # _run_references_parallel is still running, and the moa.reference
+            # blocks are only emitted once it returns. Then the phase
+            # transition, then moa.aggregating. Mirrored here so the ordering
+            # assertion below tests the real contract.
+            cb("moa.progress", "openrouter:ref-a", None, None, moa_refs_done=1, moa_refs_total=2)
+            cb("moa.progress", "openrouter:ref-b", None, None, moa_refs_done=2, moa_refs_total=2)
             cb("moa.reference", "openrouter:ref-a", "Answer A.", None, moa_index=1, moa_count=2)
             cb("moa.reference", "openrouter:ref-b", "Answer B.", None, moa_index=2, moa_count=2)
+            cb("moa.phase", "nous:aggregator", None, None, moa_phase="aggregator", moa_refs_done=2, moa_refs_total=2)
             cb("moa.aggregating", "nous:aggregator", None, None, moa_ref_count=2)
             return (
                 {"final_response": "merged", "messages": [], "api_calls": 1},
@@ -867,11 +877,19 @@ class TestChatCompletionsEndpoint:
                 frames.append((name, json.loads(data)))
 
         names = [name for name, _ in frames]
-        assert names.count("moa.reference") == 2, names
-        assert names.count("moa.aggregating") == 1, names
+        # One assertion for counts AND relative order: a subsequence check
+        # catches a dropped event and a reordered one, which two separate
+        # index() comparisons would not.
+        assert [n for n in names if n.startswith("moa.")] == [
+            "moa.progress",
+            "moa.progress",
+            "moa.reference",
+            "moa.reference",
+            "moa.phase",
+            "moa.aggregating",
+        ], names
         # Fan-out lands after the message opens and before the turn closes.
-        assert names.index("message.started") < names.index("moa.reference")
-        assert names.index("moa.reference") < names.index("moa.aggregating")
+        assert names.index("message.started") < names.index("moa.progress")
         assert names.index("moa.aggregating") < names.index("run.completed")
 
         started = next(p for n, p in frames if n == "message.started")
@@ -882,15 +900,28 @@ class TestChatCompletionsEndpoint:
         assert [r["text"] for r in refs] == ["Answer A.", "Answer B."]
         assert [r["index"] for r in refs] == [1, 2]
         assert [r["count"] for r in refs] == [2, 2]
-        for ref in refs:
-            assert ref["message_id"] == message_id
-            assert ref["session_id"] == "s1"
+
+        progress = [p for n, p in frames if n == "moa.progress"]
+        assert [p["label"] for p in progress] == ["openrouter:ref-a", "openrouter:ref-b"]
+        assert [p["refs_done"] for p in progress] == [1, 2]
+        assert [p["refs_total"] for p in progress] == [2, 2]
+
+        phase = next(p for n, p in frames if n == "moa.phase")
+        assert phase["phase"] == "aggregator"
+        assert phase["aggregator"] == "nous:aggregator"
+        assert phase["refs_done"] == 2
+        assert phase["refs_total"] == 2
 
         agg = next(p for n, p in frames if n == "moa.aggregating")
         assert agg["aggregator"] == "nous:aggregator"
         assert agg["ref_count"] == 2
-        assert agg["message_id"] == message_id
-        assert agg["session_id"] == "s1"
+
+        # Every MoA frame is attributable to the turn that produced it.
+        for _name, payload in frames:
+            if not _name.startswith("moa."):
+                continue
+            assert payload["message_id"] == message_id, _name
+            assert payload["session_id"] == "s1", _name
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -820,7 +820,7 @@ class TestChatCompletionsEndpoint:
 
         ``build_moa_facade`` (``agent/moa_loop.py``) relays all four MoA events
         onto ``tool_progress_callback``. The session stream used to match only
-        ``reasoning.available`` and the ``tool.*`` family, so a council run went
+        ``reasoning.available`` and the ``tool.*`` family, so a MoA run went
         silent between ``message.started`` and ``run.completed``. Assert on the
         serialized SSE frames — a mock-level check would pass even if nothing
         were written to the wire.
@@ -858,7 +858,7 @@ class TestChatCompletionsEndpoint:
             ):
                 resp = await cli.post(
                     "/api/sessions/s1/chat/stream",
-                    json={"message": "ask the council"},
+                    json={"message": "run this through the preset"},
                 )
                 assert resp.status == 200
                 body = await resp.text()

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -637,3 +637,67 @@ class TestRunsProviderAuthFailure:
                 assert status["status"] == "failed"
                 assert status["error"] == "⚠️ Provider authentication failed: No credentials found for provider 'nous'"
                 assert status["last_event"] == "run.failed"
+
+
+# ---------------------------------------------------------------------------
+# MoA fan-out events on the /v1/runs SSE callback
+# ---------------------------------------------------------------------------
+
+
+class TestRunCallbackMoAEvents:
+    """MoA progress events must reach /v1/runs SSE clients.
+
+    The relay ``build_moa_facade`` installs (``agent/moa_loop.py``) forwards
+    ``moa.reference`` / ``moa.aggregating`` onto the agent's
+    ``tool_progress_callback`` — the same callback the CLI and TUI already
+    consume. The run callback must forward them rather than drop them on the
+    closed match set.
+    """
+
+    @pytest.mark.asyncio
+    async def test_run_callback_forwards_moa_reference(self, adapter):
+        run_id = "run_moa_ref"
+        q: asyncio.Queue = asyncio.Queue()
+        adapter._run_streams[run_id] = q
+        callback = adapter._make_run_event_callback(run_id, asyncio.get_running_loop())
+
+        # Positional mapping matches the relay: label in tool_name, text in preview.
+        callback("moa.reference", "reference-1", "an answer", None, moa_index=1, moa_count=3)
+        await asyncio.sleep(0.05)
+
+        event = q.get_nowait()
+        assert event["event"] == "moa.reference"
+        assert event["run_id"] == run_id
+        assert event["label"] == "reference-1"
+        assert event["text"] == "an answer"
+        assert event["index"] == 1
+        assert event["count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_run_callback_forwards_moa_aggregating(self, adapter):
+        run_id = "run_moa_agg"
+        q: asyncio.Queue = asyncio.Queue()
+        adapter._run_streams[run_id] = q
+        callback = adapter._make_run_event_callback(run_id, asyncio.get_running_loop())
+
+        callback("moa.aggregating", "aggregator-model", None, None, moa_ref_count=3)
+        await asyncio.sleep(0.05)
+
+        event = q.get_nowait()
+        assert event["event"] == "moa.aggregating"
+        assert event["run_id"] == run_id
+        assert event["aggregator"] == "aggregator-model"
+        assert event["ref_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_run_callback_ignores_unknown_event_types(self, adapter):
+        """The no-else contract still holds: an unrecognized event enqueues nothing."""
+        run_id = "run_moa_unknown"
+        q: asyncio.Queue = asyncio.Queue()
+        adapter._run_streams[run_id] = q
+        callback = adapter._make_run_event_callback(run_id, asyncio.get_running_loop())
+
+        callback("subagent_progress", "sub", "x", None)
+        await asyncio.sleep(0.05)
+
+        assert q.empty()

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -648,10 +648,10 @@ class TestRunCallbackMoAEvents:
     """MoA progress events must reach /v1/runs SSE clients.
 
     The relay ``build_moa_facade`` installs (``agent/moa_loop.py``) forwards
-    ``moa.reference`` / ``moa.aggregating`` onto the agent's
-    ``tool_progress_callback`` — the same callback the CLI and TUI already
-    consume. The run callback must forward them rather than drop them on the
-    closed match set.
+    all four MoA events — ``moa.progress``, ``moa.reference``, ``moa.phase``
+    and ``moa.aggregating`` — onto the agent's ``tool_progress_callback``, the
+    same callback the CLI and TUI already consume. The run callback must
+    forward them rather than drop them on the closed match set.
     """
 
     @pytest.mark.asyncio
@@ -688,6 +688,54 @@ class TestRunCallbackMoAEvents:
         assert event["run_id"] == run_id
         assert event["aggregator"] == "aggregator-model"
         assert event["ref_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_run_callback_forwards_moa_progress(self, adapter):
+        """The tick that lets a client show N/M during the fan-out."""
+        run_id = "run_moa_progress"
+        q: asyncio.Queue = asyncio.Queue()
+        adapter._run_streams[run_id] = q
+        callback = adapter._make_run_event_callback(run_id, asyncio.get_running_loop())
+
+        # Relay puts the finished slot label in tool_name, counters in kwargs.
+        callback("moa.progress", "reference-1", None, None, moa_refs_done=1, moa_refs_total=3)
+        await asyncio.sleep(0.05)
+
+        event = q.get_nowait()
+        assert event["event"] == "moa.progress"
+        assert event["run_id"] == run_id
+        assert event["label"] == "reference-1"
+        assert event["refs_done"] == 1
+        assert event["refs_total"] == 3
+
+    @pytest.mark.asyncio
+    async def test_run_callback_forwards_moa_phase(self, adapter):
+        """The aggregator transition, for clients tracking one event family."""
+        run_id = "run_moa_phase"
+        q: asyncio.Queue = asyncio.Queue()
+        adapter._run_streams[run_id] = q
+        callback = adapter._make_run_event_callback(run_id, asyncio.get_running_loop())
+
+        # Here the second positional carries the AGGREGATOR slot, not a
+        # reference label — the relay reuses the same argument for both events.
+        callback(
+            "moa.phase",
+            "aggregator-model",
+            None,
+            None,
+            moa_phase="aggregator",
+            moa_refs_done=3,
+            moa_refs_total=3,
+        )
+        await asyncio.sleep(0.05)
+
+        event = q.get_nowait()
+        assert event["event"] == "moa.phase"
+        assert event["run_id"] == run_id
+        assert event["phase"] == "aggregator"
+        assert event["aggregator"] == "aggregator-model"
+        assert event["refs_done"] == 3
+        assert event["refs_total"] == 3
 
     @pytest.mark.asyncio
     async def test_run_callback_ignores_unknown_event_types(self, adapter):

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -386,6 +386,28 @@ redaction before leaving the process. Per-tool child events
 are high-volume UI noise; use the per-child live transcript files for
 play-by-play.
 
+When the run uses a mixture-of-agents preset, the stream also carries the MoA
+fan-out so a council run is not silent while the references work.
+`moa.reference` fires once per reference model, before the aggregator acts, and
+carries `label` (the reference model slot), `text` (that reference's output —
+a reference that failed still emits a frame), and `index` / `count` (its
+1-based position in the fan-out, out of the references attempted).
+`moa.aggregating` fires once afterwards with `aggregator` (the aggregator model
+slot) and `ref_count`, the same attempted-reference total. Both carry the usual
+`event`, `run_id` and `timestamp` fields. When a MoA privacy mode is
+configured, reference text is redacted at the point of emission, so these
+streams see exactly what the CLI and TUI see.
+Per-reference progress ticks (`moa.progress`, `moa.phase`) are intentionally
+**not** forwarded, for the same reason per-tool child events are not.
+
+```
+event: moa.reference
+data: {"event": "moa.reference", "run_id": "run_abc123", "timestamp": 1717171717.5, "label": "openrouter:anthropic/claude-opus-4.8", "text": "Answer A.", "index": 1, "count": 3}
+
+event: moa.aggregating
+data: {"event": "moa.aggregating", "run_id": "run_abc123", "timestamp": 1717171718.1, "aggregator": "nous:hermes-4-405b", "ref_count": 3}
+```
+
 Unconsumed event buffers expire after five minutes so a detached client cannot
 grow memory indefinitely. This expires transport state only: a run that is
 still executing remains visible to status polling, approval, stop control, and
@@ -453,7 +475,24 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `GET` | `/api/sessions/{id}/messages` | Message history for a session |
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
 | `POST` | `/api/sessions/{id}/chat` | Run one synchronous agent turn |
-| `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
+| `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `moa.reference`, `moa.aggregating`, `run.completed` events |
+
+On a mixture-of-agents run this stream carries the same fan-out events the
+`/v1/runs` stream does, so an external UI shows the council working instead of a
+silent pause. `moa.reference` fires once per reference model attempted, with
+`label`, `text`, `index` and `count`; `moa.aggregating` fires once afterwards
+with `aggregator` and `ref_count`. Both also carry the `message_id` of the
+assistant message being streamed, plus the `session_id`, `run_id`, `seq` and `ts` fields
+every event on this stream carries — so a client can attribute the fan-out to
+the turn that produced it.
+
+```
+event: moa.reference
+data: {"message_id": "msg_9f2c8ab1e4", "label": "openrouter:anthropic/claude-opus-4.8", "text": "Answer A.", "index": 1, "count": 3, "session_id": "space-session", "run_id": "run_abc123", "seq": 3, "ts": 1717171717.5}
+
+event: moa.aggregating
+data: {"message_id": "msg_9f2c8ab1e4", "aggregator": "nous:hermes-4-405b", "ref_count": 3, "session_id": "space-session", "run_id": "run_abc123", "seq": 6, "ts": 1717171718.1}
+```
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -387,7 +387,7 @@ are high-volume UI noise; use the per-child live transcript files for
 play-by-play.
 
 When the run uses a mixture-of-agents preset, the stream also carries the MoA
-fan-out so a council run is not silent while the references work.
+fan-out so a MoA run is not silent while the references work.
 `moa.reference` fires once per reference model, before the aggregator acts, and
 carries `label` (the reference model slot), `text` (that reference's output —
 a reference that failed still emits a frame), and `index` / `count` (its
@@ -493,7 +493,7 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `moa.progress`, `moa.reference`, `moa.phase`, `moa.aggregating`, `run.completed` events |
 
 On a mixture-of-agents run this stream carries the same four fan-out events the
-`/v1/runs` stream does, so an external UI shows the council working instead of a
+`/v1/runs` stream does, so an external UI shows the fan-out working instead of a
 silent pause. `moa.progress` ticks as each reference completes, with `label` and
 `refs_done` / `refs_total`; `moa.reference` fires once per reference model
 attempted, with `label`, `text`, `index` and `count`; `moa.phase` marks the

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -397,12 +397,27 @@ slot) and `ref_count`, the same attempted-reference total. Both carry the usual
 `event`, `run_id` and `timestamp` fields. When a MoA privacy mode is
 configured, reference text is redacted at the point of emission, so these
 streams see exactly what the CLI and TUI see.
-Per-reference progress ticks (`moa.progress`, `moa.phase`) are intentionally
-**not** forwarded, for the same reason per-tool child events are not.
+
+Two lifecycle events accompany them, so the wait between content frames is not
+silent. `moa.progress` fires as each reference completes, carrying `label` (the
+slot that just finished) and `refs_done` / `refs_total` — render it as
+`MOA: N/M refs done`. `moa.phase` fires on a phase transition, currently only
+`phase="aggregator"` once the fan-out is done, and carries `aggregator` plus the
+same two counters; a client that prefers a single event family for phase
+tracking can switch on `phase` instead of subscribing to `moa.aggregating`
+separately. `refs_done` and `refs_total` count the references **attempted**,
+exactly as `count` and `ref_count` do — a reference that failed still advances
+them, so `3/3` does not promise three usable answers.
 
 ```
+event: moa.progress
+data: {"event": "moa.progress", "run_id": "run_abc123", "timestamp": 1717171717.2, "label": "openrouter:anthropic/claude-opus-4.8", "refs_done": 1, "refs_total": 3}
+
 event: moa.reference
 data: {"event": "moa.reference", "run_id": "run_abc123", "timestamp": 1717171717.5, "label": "openrouter:anthropic/claude-opus-4.8", "text": "Answer A.", "index": 1, "count": 3}
+
+event: moa.phase
+data: {"event": "moa.phase", "run_id": "run_abc123", "timestamp": 1717171718.0, "phase": "aggregator", "refs_done": 3, "refs_total": 3, "aggregator": "nous:hermes-4-405b"}
 
 event: moa.aggregating
 data: {"event": "moa.aggregating", "run_id": "run_abc123", "timestamp": 1717171718.1, "aggregator": "nous:hermes-4-405b", "ref_count": 3}
@@ -475,20 +490,29 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `GET` | `/api/sessions/{id}/messages` | Message history for a session |
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
 | `POST` | `/api/sessions/{id}/chat` | Run one synchronous agent turn |
-| `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `moa.reference`, `moa.aggregating`, `run.completed` events |
+| `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `moa.progress`, `moa.reference`, `moa.phase`, `moa.aggregating`, `run.completed` events |
 
-On a mixture-of-agents run this stream carries the same fan-out events the
+On a mixture-of-agents run this stream carries the same four fan-out events the
 `/v1/runs` stream does, so an external UI shows the council working instead of a
-silent pause. `moa.reference` fires once per reference model attempted, with
-`label`, `text`, `index` and `count`; `moa.aggregating` fires once afterwards
-with `aggregator` and `ref_count`. Both also carry the `message_id` of the
-assistant message being streamed, plus the `session_id`, `run_id`, `seq` and `ts` fields
-every event on this stream carries — so a client can attribute the fan-out to
-the turn that produced it.
+silent pause. `moa.progress` ticks as each reference completes, with `label` and
+`refs_done` / `refs_total`; `moa.reference` fires once per reference model
+attempted, with `label`, `text`, `index` and `count`; `moa.phase` marks the
+transition to the aggregator, with `phase`, `aggregator` and the same two
+counters; `moa.aggregating` fires last with `aggregator` and `ref_count`. All
+four also carry the `message_id` of the assistant message being streamed, plus
+the `session_id`, `run_id`, `seq` and `ts` fields every event on this stream
+carries — so a client can attribute the fan-out to the turn that produced it.
+Every count here is of references **attempted**, matching `/v1/runs`.
 
 ```
+event: moa.progress
+data: {"message_id": "msg_9f2c8ab1e4", "label": "openrouter:anthropic/claude-opus-4.8", "refs_done": 1, "refs_total": 3, "session_id": "space-session", "run_id": "run_abc123", "seq": 2, "ts": 1717171717.2}
+
 event: moa.reference
 data: {"message_id": "msg_9f2c8ab1e4", "label": "openrouter:anthropic/claude-opus-4.8", "text": "Answer A.", "index": 1, "count": 3, "session_id": "space-session", "run_id": "run_abc123", "seq": 3, "ts": 1717171717.5}
+
+event: moa.phase
+data: {"message_id": "msg_9f2c8ab1e4", "phase": "aggregator", "refs_done": 3, "refs_total": 3, "aggregator": "nous:hermes-4-405b", "session_id": "space-session", "run_id": "run_abc123", "seq": 5, "ts": 1717171718.0}
 
 event: moa.aggregating
 data: {"message_id": "msg_9f2c8ab1e4", "aggregator": "nous:hermes-4-405b", "ref_count": 3, "session_id": "space-session", "run_id": "run_abc123", "seq": 6, "ts": 1717171718.1}


### PR DESCRIPTION
## What does this PR do?

MoA fan-out events never reach API-server SSE clients. `grep -i moa` over `gateway/platforms/api_server.py` on `main` returns **zero hits** — the module has no MoA handling at all. A client watching a MoA run over HTTP sees nothing while the references work, then a final answer from nowhere.

This forwards all four MoA events on both API-server SSE paths — the session chat stream and `/v1/runs`:

| event | fields |
|---|---|
| `moa.progress` | `label`, `refs_done`, `refs_total` |
| `moa.reference` | `label`, `text`, `index`, `count` |
| `moa.phase` | `phase`, `aggregator`, `refs_done`, `refs_total` |
| `moa.aggregating` | `aggregator`, `ref_count` |

Field names match what `tui_gateway/server.py` already emits, so a desktop client needs no change. On the session stream each event additionally carries the `message_id` of the assistant message, plus the `session_id`, `run_id`, `seq` and `ts` every event on that stream carries.

Payload shapes were derived from the live relay in `agent/moa_loop.py`, **not** from `agent/agent_init.py::_relay_moa_reference_event` — that one has no production callers (its only importer is `tests/agent/test_moa_quiet_reference_output.py`). The kwargs contract is byte-identical between the two, so the premise holds either way, but the live emitter is the one to read.

**The counts are of references attempted.** `index`/`count` and `refs_done`/`refs_total` all come from `len(reference_outputs)`, evaluated before `_successful_references` filters anything — so a reference that *failed* still advances them and still emits a frame whose `text` is not an answer. `3/3` does not promise three usable answers. Stated at both doc sites.

**Emission order is not interleaved.** Every `moa.progress` fires from `progress_callback` while `_run_references_parallel` is still running; the `moa.reference` blocks only follow once it returns, then `moa.phase`, then `moa.aggregating`.

When a MoA privacy mode is configured, reference text passes `_redact_reference_text` at the point of emission, so these streams see exactly what the CLI and TUI see.

`moa.progress` and `moa.phase` come from @iHeyTang's [fix(api): forward MoA progress events on /v1/runs](https://github.com/NousResearch/hermes-agent/pull/80767), folded in here so the four-event contract lands atomically instead of two events on one surface and four on the other. Their field mapping was verified against the re-emission layer in `moa_loop.py` and adopted unchanged; credited with `Co-authored-by:` on the commit.

No allowlist change was needed on the SSE side: the writer emits `event: <name>` unfiltered, so new event names pass through once forwarded.

## Related Issue

Extends [PR 53793](https://github.com/NousResearch/hermes-agent/pull/53793) (merged), which made each reference model's output visible as a labelled block; this brings that to the HTTP surface. Supersedes [PR 80767](https://github.com/NousResearch/hermes-agent/pull/80767) by folding it in.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` — `_tool_progress` (session chat stream) and `_make_run_event_callback` (`/v1/runs`) forward all four MoA events
- `website/docs/user-guide/features/api-server.md` — both event lists describe all four, each with a literal SSE frame; the session-stream table row names them
- `tests/gateway/test_api_server.py` — endpoint-level coverage driving all four through `POST /api/sessions/{id}/chat/stream`
- `tests/gateway/test_api_server_runs.py` — callback-level coverage for each event on the runs surface

## How to Test

1. Configure a Mixture of Agents preset and start the API server
2. Open an SSE stream: `POST /api/sessions/{id}/chat/stream` or `GET /v1/runs/{run_id}/events`
3. Send a prompt that routes to the MoA preset
4. `moa.progress` ticks as each reference finishes, each reference's labelled answer arrives as `moa.reference`, `moa.phase` marks the aggregator transition, and `moa.aggregating` closes the fan-out

## Testing

```
scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py
  112 -> 114 passed, 0 failed

scripts/run_tests.sh tests/gateway/
  4421 -> 4423 passed, 4 failed on both sides
```

The 4 are pre-existing and unrelated — `test_shutdown_forensics`, `test_systemd_notify`, `test_wecom_callback`, all platform or optional-dependency. I diffed the failing **file lists** between the two trees rather than comparing counts; they are identical.

Verified by removing the fix rather than by inspection. With the production hunks reverted and the existing `moa.reference`/`moa.aggregating` branches left intact, all three new/extended tests go red and the other 111 stay green:

```
FAILED test_api_server_runs.py::TestRunCallbackMoAEvents::test_run_callback_forwards_moa_progress
FAILED test_api_server_runs.py::TestRunCallbackMoAEvents::test_run_callback_forwards_moa_phase
FAILED test_api_server.py::...::test_session_chat_stream_forwards_moa_fanout_events
E  assert ['moa.referen....aggregating'] == ['moa.progres....aggregating']
```

The session-stream test parses the serialized SSE body into `(event-name, payload)` pairs and asserts on those — not on the callback having been invoked — covering frame ordering and `message_id` correlation against the id from `message.started`. Emission order in the mock mirrors `moa_loop` rather than being guessed, and a single subsequence assertion covers count and order together, which separate `index()` comparisons would not.

`ruff` and `scripts/check-windows-footguns.py` are clean on all three touched source files.

Two caveats I would rather state than leave implied:

- Run on Python 3.13.7 / macOS arm64. **Pre-existing failure counts are environment-dependent** — the same commit reports 43 failures under `tests/gateway/` on another host and 4 here, because optional-dependency tests that fail on one machine never collect on the other. That is why the file lists are diffed rather than the numbers compared.
- The docs gate was **not** run. `website/package.json` has `lint:diagrams` → `ascii-guard`, but `ascii-guard` is declared in neither its dependencies nor devDependencies and is not on the public registry, so it is unavailable outside the Nix devShell. Checked directly instead: the additions introduce no box-drawing characters and no non-ASCII character the file does not already use.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `scripts/run_tests.sh` on the touched files and on the whole of `tests/gateway/`; results and baseline comparison above
- [x] I've added tests for my changes
- [x] I've considered cross-platform impact — event forwarding only, no platform-specific code paths

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/user-guide/features/api-server.md`, both the `/v1/runs` and session-stream sections
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've updated tool descriptions/schemas — N/A
