### PR TITLE
fix(cron): deliver manual runs on profile-owned gateway loop

### DIFF
--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -7,6 +7,8 @@ last_run_at stayed null forever. Now action='run' claims the job (at-most-once,
 blocking a concurrent tick) and fires it inline via the shared run_one_job body.
 """
 import json
+import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from tools.cronjob_tools import cronjob, _execute_job_now
@@ -109,6 +111,39 @@ class TestCronjobRunExecutesImmediately:
         assert res["claimed"] is False
         assert res["success"] is False
         m_run.assert_not_called()
+
+    def test_execute_job_now_passes_live_gateway_context_to_delivery(self):
+        """Manual runs must deliver on the live gateway adapter's owning loop."""
+        adapters = {"matrix": object()}
+        gateway_loop = object()
+        runner = SimpleNamespace(adapters=adapters, _gateway_loop=gateway_loop)
+        completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("gateway.run._gateway_runner_ref", return_value=runner), \
+             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=completed):
+            res = _execute_job_now(dict(_JOB))
+
+        assert res["success"] is True
+        m_run.assert_called_once_with(
+            _JOB,
+            adapters=adapters,
+            loop=gateway_loop,
+        )
+
+    def test_execute_job_now_remains_standalone_without_gateway(self):
+        """CLI-only runs retain the standalone delivery path."""
+        completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+
+        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch.dict(sys.modules, {"gateway.run": None}), \
+             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=completed):
+            res = _execute_job_now(dict(_JOB))
+
+        assert res["success"] is True
+        m_run.assert_called_once_with(_JOB, adapters=None, loop=None)
 
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -7,9 +7,10 @@ last_run_at stayed null forever. Now action='run' claims the job (at-most-once,
 blocking a concurrent tick) and fires it inline via the shared run_one_job body.
 """
 import json
-import sys
 from types import SimpleNamespace
 from unittest.mock import patch
+
+import pytest
 
 from tools.cronjob_tools import cronjob, _execute_job_now
 
@@ -33,6 +34,179 @@ class TestCronjobRunExecutesImmediately:
         assert out["job"]["execution_success"] is True
         m_claim.assert_called_once_with("job-run-1")   # at-most-once claim taken
         m_run.assert_called_once()                       # fired via the shared body
+
+    def test_execute_job_now_reuses_live_gateway_delivery_context(self):
+        """An in-gateway manual run must deliver on the gateway-owned loop."""
+        loop = SimpleNamespace(is_running=lambda: True, is_closed=lambda: False)
+        adapters = {"matrix": object()}
+        runner = SimpleNamespace(
+            _running=True,
+            _gateway_loop=loop,
+            adapters=adapters,
+        )
+        ran = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+
+        with patch("gateway.run._gateway_runner_ref", return_value=runner), \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=ran):
+            result = _execute_job_now(dict(_JOB))
+
+        assert result["success"] is True
+        m_run.assert_called_once_with(dict(_JOB), adapters=adapters, loop=loop)
+
+    def test_execute_job_now_uses_active_multiplex_profile_adapters(self, tmp_path):
+        """A secondary-profile run must never inherit the primary bot adapter."""
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        loop = SimpleNamespace(is_running=lambda: True, is_closed=lambda: False)
+        primary_adapters = {"matrix": object()}
+        secondary_adapters = {"matrix": object()}
+        runner = SimpleNamespace(
+            _running=True,
+            _gateway_loop=loop,
+            adapters=primary_adapters,
+            _profile_adapters={"coder": secondary_adapters},
+            config=SimpleNamespace(multiplex_profiles=True),
+        )
+        ran = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+        profiles_root = tmp_path / "hermes-root" / "profiles"
+        profile_home = profiles_root / "coder"
+        profile_home.mkdir(parents=True)
+        home_token = set_hermes_home_override(str(profile_home))
+
+        try:
+            with patch("gateway.run._gateway_runner_ref", return_value=runner), \
+                 patch("hermes_cli.profiles._get_profiles_root", return_value=profiles_root), \
+                 patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+                 patch("tools.cronjob_tools.get_job", return_value=ran):
+                result = _execute_job_now(dict(_JOB))
+        finally:
+            reset_hermes_home_override(home_token)
+
+        assert result["success"] is True
+        m_run.assert_called_once_with(
+            dict(_JOB), adapters=secondary_adapters, loop=loop
+        )
+
+    @pytest.mark.parametrize(
+        "multiplex_metadata",
+        [True, False, None],
+        ids=["enabled", "disabled", "missing"],
+    )
+    @pytest.mark.parametrize(
+        "registry_present",
+        [False, True],
+        ids=["registry-absent", "registry-lacks-matrix"],
+    )
+    def test_secondary_context_never_borrows_primary_transport(
+        self, tmp_path, multiplex_metadata, registry_present
+    ):
+        """Scoped secondary turns fail closed regardless of runner metadata."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.delivery import resolve_delivery_transport
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from tools.cronjob_tools import _get_live_gateway_delivery_context
+
+        loop = SimpleNamespace(is_running=lambda: True, is_closed=lambda: False)
+        primary_adapter = object()
+        secondary_adapters = (
+            {Platform.TELEGRAM: object()} if registry_present else None
+        )
+        runner = SimpleNamespace(
+            _running=True,
+            _gateway_loop=loop,
+            adapters={Platform.MATRIX: primary_adapter},
+            _profile_adapters=(
+                {"coder": secondary_adapters} if registry_present else {}
+            ),
+        )
+        if multiplex_metadata is not None:
+            runner.config = SimpleNamespace(
+                multiplex_profiles=multiplex_metadata
+            )
+        profiles_root = tmp_path / "hermes-root" / "profiles"
+        profile_home = profiles_root / "coder"
+        profile_home.mkdir(parents=True)
+        home_token = set_hermes_home_override(str(profile_home))
+
+        try:
+            with patch("gateway.run._gateway_runner_ref", return_value=runner), \
+                 patch(
+                     "hermes_cli.profiles._get_profiles_root",
+                     return_value=profiles_root,
+                 ):
+                context = _get_live_gateway_delivery_context()
+        finally:
+            reset_hermes_home_override(home_token)
+
+        config = GatewayConfig(
+            platforms={Platform.MATRIX: PlatformConfig(enabled=True)}
+        )
+        transport = resolve_delivery_transport(
+            Platform.MATRIX,
+            config,
+            context[0] if context is not None else None,
+        )
+        if registry_present:
+            assert context is not None
+            assert context[0] is secondary_adapters
+            assert context[1] is loop
+        else:
+            assert context is None
+        assert transport is None
+
+    def test_execute_job_now_preserves_standalone_call_without_live_gateway(self):
+        """CLI-only execution keeps the existing standalone delivery path."""
+        ran = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+
+        with patch("gateway.run._gateway_runner_ref", return_value=None), \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=ran):
+            result = _execute_job_now(dict(_JOB))
+
+        assert result["success"] is True
+        m_run.assert_called_once_with(dict(_JOB))
+
+    @pytest.mark.parametrize(
+        ("runner_running", "loop_running", "loop_closed"),
+        [
+            (False, True, False),
+            (True, False, False),
+            (True, True, True),
+        ],
+    )
+    def test_execute_job_now_rejects_stale_gateway_delivery_context(
+        self, runner_running, loop_running, loop_closed
+    ):
+        """Startup/shutdown races must fall back instead of crossing loops."""
+        loop = SimpleNamespace(
+            is_running=lambda: loop_running,
+            is_closed=lambda: loop_closed,
+        )
+        runner = SimpleNamespace(
+            _running=runner_running,
+            _gateway_loop=loop,
+            adapters={"matrix": object()},
+        )
+        ran = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+
+        with patch("gateway.run._gateway_runner_ref", return_value=runner), \
+             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+             patch("tools.cronjob_tools.get_job", return_value=ran):
+            result = _execute_job_now(dict(_JOB))
+
+        assert result["success"] is True
+        m_run.assert_called_once_with(dict(_JOB))
 
     def test_run_reconciles_external_provider_after_claimed_execution(self):
         """A direct run must re-arm Chronos after it advances next_run_at.
@@ -111,39 +285,6 @@ class TestCronjobRunExecutesImmediately:
         assert res["claimed"] is False
         assert res["success"] is False
         m_run.assert_not_called()
-
-    def test_execute_job_now_passes_live_gateway_context_to_delivery(self):
-        """Manual runs must deliver on the live gateway adapter's owning loop."""
-        adapters = {"matrix": object()}
-        gateway_loop = object()
-        runner = SimpleNamespace(adapters=adapters, _gateway_loop=gateway_loop)
-        completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
-
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
-             patch("gateway.run._gateway_runner_ref", return_value=runner), \
-             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
-             patch("tools.cronjob_tools.get_job", return_value=completed):
-            res = _execute_job_now(dict(_JOB))
-
-        assert res["success"] is True
-        m_run.assert_called_once_with(
-            _JOB,
-            adapters=adapters,
-            loop=gateway_loop,
-        )
-
-    def test_execute_job_now_remains_standalone_without_gateway(self):
-        """CLI-only runs retain the standalone delivery path."""
-        completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
-
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
-             patch.dict(sys.modules, {"gateway.run": None}), \
-             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
-             patch("tools.cronjob_tools.get_job", return_value=completed):
-            res = _execute_job_now(dict(_JOB))
-
-        assert res["success"] is True
-        m_run.assert_called_once_with(_JOB, adapters=None, loop=None)
 
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -638,7 +638,20 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
 
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
-        processed = run_one_job(job)
+        # Manual runs invoked from a gateway agent execute outside the scheduler
+        # ticker, but they still share the process with the live platform
+        # adapters.  Pass the gateway-owned adapter map and event loop through to
+        # run_one_job so delivery is scheduled on the loop that owns clients such
+        # as Matrix/aiohttp.  Calling those clients from run_one_job's standalone
+        # asyncio.run() loop raises errors like "Timeout context manager should be
+        # used inside a task" and can break encrypted Matrix delivery.
+        gateway_module = sys.modules.get("gateway.run")
+        runner_ref = getattr(gateway_module, "_gateway_runner_ref", None)
+        runner = runner_ref() if callable(runner_ref) else None
+        adapters = getattr(runner, "adapters", None) if runner is not None else None
+        gateway_loop = getattr(runner, "_gateway_loop", None) if runner is not None else None
+
+        processed = run_one_job(job, adapters=adapters, loop=gateway_loop)
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
         return {

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -12,7 +12,11 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from hermes_constants import display_hermes_home
+from hermes_constants import (
+    display_hermes_home,
+    get_hermes_home,
+    get_process_hermes_home,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -601,6 +605,52 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
+def _get_live_gateway_delivery_context() -> Optional[tuple[Any, Any]]:
+    """Return the active gateway's adapter map and owning event loop.
+
+    Manual cron runs execute inside the synchronous tool worker, not the cron
+    ticker thread.  Reusing a live async adapter without also scheduling on its
+    gateway-owned loop crosses event-loop ownership (notably for Matrix's
+    aiohttp client).  Keep standalone callers lightweight by consulting the
+    already-imported gateway module rather than importing the gateway stack.
+    """
+    gateway_run = sys.modules.get("gateway.run")
+    if gateway_run is None:
+        return None
+
+    try:
+        runner_ref = getattr(gateway_run, "_gateway_runner_ref")
+        runner = runner_ref()
+        if runner is None or not getattr(runner, "_running", False):
+            return None
+
+        loop = getattr(runner, "_gateway_loop", None)
+        if loop is None or loop.is_closed() or not loop.is_running():
+            return None
+
+        adapters = getattr(runner, "adapters", None)
+        # The per-turn HERMES_HOME ContextVar survives tool-thread dispatch,
+        # while get_process_hermes_home() identifies the gateway-owned primary
+        # home. A scoped secondary must have its own registry entry regardless
+        # of potentially stale/missing multiplex config metadata; otherwise fail
+        # closed instead of borrowing primary credentials.
+        if get_hermes_home().resolve() != get_process_hermes_home().resolve():
+            from hermes_cli.profiles import get_active_profile_name
+
+            profile_name = get_active_profile_name() or "default"
+            profile_maps = getattr(runner, "_profile_adapters", None) or {}
+            adapters = profile_maps.get(profile_name)
+            if adapters is None:
+                return None
+        if adapters is None:
+            return None
+        return adapters, loop
+    except Exception:
+        # A stale weakref or a loop racing gateway shutdown must preserve the
+        # pre-existing standalone delivery path rather than break manual runs.
+        return None
+
+
 def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
     """Execute a cron job immediately, outside the scheduler tick.
 
@@ -638,20 +688,15 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
 
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
-        # Manual runs invoked from a gateway agent execute outside the scheduler
-        # ticker, but they still share the process with the live platform
-        # adapters.  Pass the gateway-owned adapter map and event loop through to
-        # run_one_job so delivery is scheduled on the loop that owns clients such
-        # as Matrix/aiohttp.  Calling those clients from run_one_job's standalone
-        # asyncio.run() loop raises errors like "Timeout context manager should be
-        # used inside a task" and can break encrypted Matrix delivery.
-        gateway_module = sys.modules.get("gateway.run")
-        runner_ref = getattr(gateway_module, "_gateway_runner_ref", None)
-        runner = runner_ref() if callable(runner_ref) else None
-        adapters = getattr(runner, "adapters", None) if runner is not None else None
-        gateway_loop = getattr(runner, "_gateway_loop", None) if runner is not None else None
-
-        processed = run_one_job(job, adapters=adapters, loop=gateway_loop)
+        # Inside a running gateway, forward the live adapters together with
+        # their owning loop so async delivery stays on the same loop as the
+        # connected clients. CLI-only callers retain the standalone path.
+        delivery_context = _get_live_gateway_delivery_context()
+        if delivery_context is None:
+            processed = run_one_job(job)
+        else:
+            adapters, loop = delivery_context
+            processed = run_one_job(job, adapters=adapters, loop=loop)
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
         return {


### PR DESCRIPTION
## What does this PR do?

Manual `cronjob(action="run")` executions inside a live gateway currently call `run_one_job(job)` without the gateway adapter map or the event loop that owns those adapters. Matrix then may await its live mautrix/aiohttp client from a fresh `asyncio.run()` loop and fail with:

```text
Timeout context manager should be used inside a task
```

This PR passes the live, profile-owned adapter map and its owning gateway loop into the existing scheduler delivery path. Unsafe or unavailable gateway context preserves the exact standalone `run_one_job(job)` behavior.

This carries forward Fly's original commit from #63586, preserving authorship, and adds the multiplex-profile isolation requested in that PR's maintainer review. Unlike the original revision, a secondary profile can never inherit the primary profile's adapter credentials when its own registry entry is missing or partial.

## Related Issue

Fixes #61495

- Supersedes #63586 with its requested multiplex-profile hardening while preserving the original commit and author.
- Complements #68359, which protects the separate second-stage fallback after a live delivery attempt has already failed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/cronjob_tools.py`
  - Resolve the existing `gateway.run._gateway_runner_ref` without adding another registry or a Matrix-specific branch.
  - Reuse context only when the runner is active and its loop is present, open, and running.
  - Compare context-scoped `get_hermes_home()` with process-owned `get_process_hermes_home()` unconditionally.
  - For a scoped secondary profile, require the exact `_profile_adapters[get_active_profile_name()]` map; missing provenance fails closed instead of borrowing `runner.adapters`.
  - Pass adapters and their owning loop together to `run_one_job`; otherwise retain the exact one-argument standalone call.
- `tests/tools/test_cronjob_run_immediate.py`
  - Cover live gateway context, exact standalone compatibility, stale runner/loop states, real `HERMES_HOME` profile resolution, metadata enabled/disabled/missing, absent registries, and partial secondary maps.
  - Feed selected maps into the real delivery resolver to assert adapter identity rather than only inspecting mocks.

## How to Test

1. Run the focused and adjacent cron suites:

   ```bash
   HERMES_PYTHON=/usr/local/lib/hermes-agent/venv/bin/python \
     HERMES_TEST_FILE_RETRIES=0 \
     scripts/run_tests.sh \
       tests/tools/test_cronjob_run_immediate.py \
       tests/tools/test_cronjob_tools.py \
       tests/cron/test_run_one_job.py \
       tests/cron/test_ticker_stall_60703.py \
       tests/cron/test_scheduler_provider.py -q
   ```

   Result: **155 passed, 0 failed**.

2. Run static checks:

   ```bash
   python -m ruff check tools/cronjob_tools.py tests/tools/test_cronjob_run_immediate.py
   python -m py_compile tools/cronjob_tools.py tests/tools/test_cronjob_run_immediate.py
   git diff --check origin/main...HEAD
   ```

   Result: all passed.

3. Causal regressions were also verified during development:
   - the original live-context assertion failed on base because manual execution used the one-argument path;
   - the multiplex assertion failed when the primary map was selected;
   - the absent-registry resolver assertion failed when primary Matrix credentials were selected;
   - all pass on this branch.

Full-suite note: `scripts/run_tests.sh tests/ -q` was attempted locally but exceeded the 600-second execution cap at 29% of roughly 43,000 collected tests. Thirteen path-completion failures observed before timeout reproduce on untouched `origin/main` in this agent worktree environment. One unrelated routing assertion sees the configured Matrix home because this worktree sits beneath the live `HERMES_HOME`; it is outside the changed paths. I therefore leave the full-suite checklist item unchecked and rely on CI for the clean-environment full run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs; this preserves and extends #63586 rather than discarding its contributor credit
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see the bounded full-suite note above
- [x] I've added tests for my changes
- [x] I've tested on Linux (`7.0.14-4-pve`, Python 3.11)

### Documentation & Housekeeping

- [x] Relevant documentation update — N/A; no user-facing behavior or configuration changes
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update — N/A; no workflow or architectural contract changed
- [x] Cross-platform impact considered; implementation uses `pathlib`, existing runtime APIs, and no platform-specific branches
- [x] Tool descriptions/schemas update — N/A; tool schema is unchanged

## Screenshots / Logs

Not applicable. The failure and fix are covered by causal unit/integration regressions and real delivery-resolver identity checks.
