### PR TITLE
fix(gateway): stop /undo from leaving next reply on pre-rewind context

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -37,7 +37,6 @@ from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
 from gateway.session import (
     AsyncSessionStore,
     SessionSource,
-    build_session_key,
     is_shared_multi_user_session,
 )
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
@@ -2585,11 +2584,11 @@ class GatewaySlashCommandsMixin:
         session_entry.last_prompt_tokens = 0
         # Evict the cached agent so the next turn rebuilds from the active-only
         # transcript and memory providers refresh their per-session caches.
-        try:
-            session_key = build_session_key(source)
-            self._evict_cached_agent(session_key)
-        except Exception as e:
-            logger.debug("undo: cached-agent eviction skipped: %s", e)
+        # Must use _session_key_for_source (not bare build_session_key) so the
+        # key matches agent-cache / SessionStore routing under
+        # group_sessions_per_user, thread_sessions_per_user, and multiplex
+        # profile namespaces.
+        self._evict_cached_agent(self._session_key_for_source(source))
 
         target_text = result["target_text"]
         preview = target_text[:200] + "..." if len(target_text) > 200 else target_text

--- a/tests/gateway/test_undo_session_key_eviction.py
+++ b/tests/gateway/test_undo_session_key_eviction.py
@@ -1,0 +1,106 @@
+""" /undo must evict the agent cache under the real routing session key.
+
+Bare ``build_session_key(source)`` ignores gateway config
+(``group_sessions_per_user``, multiplex profile namespace, etc.). When that
+diverges from ``_session_key_for_source`` / SessionStore, /undo would leave
+the live cache entry in place and the next turn would reuse a stale agent.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _group_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="g1",
+        user_name="alice",
+        chat_type="group",
+    )
+
+
+def _make_event() -> MessageEvent:
+    return MessageEvent(text="/undo", source=_group_source(), message_id="m1")
+
+
+def _make_runner(*, group_sessions_per_user: bool) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+        group_sessions_per_user=group_sessions_per_user,
+    )
+    # Bind the real resolver so config kwargs are honored (no session_store
+    # short-circuit path needed — fall through to build_session_key with config).
+    runner.session_store = None
+    runner._session_key_for_source = GatewayRunner._session_key_for_source.__get__(
+        runner, GatewayRunner
+    )
+
+    source = _group_source()
+    real_key = runner._session_key_for_source(source)
+    session_entry = SessionEntry(
+        session_key=real_key,
+        session_id="sess-undo-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+        last_prompt_tokens=1234,
+    )
+
+    # async_session_store is a property; install the mock behind the private
+    # cache attribute and keep facade._store identical to session_store so the
+    # property does not rebuild over None.
+    store = MagicMock()
+    store._store = None
+    store.get_or_create_session = AsyncMock(return_value=session_entry)
+    store.rewind_session = AsyncMock(
+        return_value={
+            "rewound_count": 2,
+            "turns_undone": 1,
+            "target_text": "previous user turn",
+        }
+    )
+    runner._async_session_store = store
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._running_agents = {}
+    runner._evict_cached_agent = MagicMock(
+        wraps=GatewayRunner._evict_cached_agent.__get__(runner, GatewayRunner)
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_undo_evicts_store_key_when_group_sessions_shared():
+    """With group_sessions_per_user=False, bare build_session_key diverges."""
+    runner = _make_runner(group_sessions_per_user=False)
+    source = _group_source()
+    bare_key = build_session_key(source)
+    real_key = runner._session_key_for_source(source)
+    assert bare_key != real_key
+
+    stale_agent = MagicMock(name="stale-agent")
+    runner._agent_cache[real_key] = (stale_agent, "sig")
+    # Also plant a decoy under the bare key so a wrong eviction would "succeed"
+    # at the mock call site while leaving the live entry.
+    runner._agent_cache[bare_key] = (MagicMock(name="decoy"), "sig")
+
+    result = await runner._handle_undo_command(_make_event())
+
+    assert isinstance(result, str) and result
+    runner._evict_cached_agent.assert_called_once_with(real_key)
+    # Live cache entry under the routing key must be gone; the bare-key decoy
+    # must remain (proves we did not only evict the wrong key).
+    assert real_key not in runner._agent_cache
+    assert bare_key in runner._agent_cache


### PR DESCRIPTION
## What does this PR do?

Gateway `/undo` rewound the transcript by `session_id` but evicted the cached agent with bare `build_session_key(source)`, which ignores gateway routing config. When that key diverged from `_session_key_for_source` / SessionStore, the live cache entry was left in place and the next turn reused a stale agent against the rewound transcript.

### Bug Cause

Almost every other slash handler evicts via `self._session_key_for_source(source)`. `/undo` alone called `build_session_key(source)` with default kwargs, so keys diverged when `group_sessions_per_user` was false (or under multiplex profile / `thread_sessions_per_user` settings).

### Reproduction Steps

1. Configure `group_sessions_per_user: false` so the shared group routing key differs from bare `build_session_key` defaults.
2. Run a turn so `_agent_cache` is populated under the store / routing key.
3. Run `/undo`.
4. Observe that the store-key cache entry remains; the next message reuses pre-undo agent state.

Expected: cached agent under the routing key is evicted; next turn rebuilds from the active-only transcript.
Before fix: eviction targeted the bare key; the live routing-key entry survived.

### Fix

- Evict with `self._session_key_for_source(source)`, matching `/reset` and other handlers.
- Drop the broad try/except around eviction so a failed eviction cannot silently leave a stale agent after a successful rewind.
- Remove the now-unused `build_session_key` import from `gateway/slash_commands.py`.
- Add a regression test that plants cache entries under both keys and asserts only the routing key is evicted.

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py` - `/undo` eviction uses `_session_key_for_source`; remove swallow-all try/except and unused import
- `tests/gateway/test_undo_session_key_eviction.py` - regression for `group_sessions_per_user=False` key divergence

## How to Test

1. Manual: with `group_sessions_per_user: false`, chat in a group, `/undo`, then send a follow-up that would only make sense with the undone turn; agent should not retain that context from cache.
2. Automated (already run locally, 13 passed):

```bash
scripts/run_tests.sh \
  tests/gateway/test_undo_session_key_eviction.py \
  tests/gateway/test_undo_rewind_session.py \
  tests/gateway/test_destructive_slash_confirm.py \
  -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (WSL test runner)

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - N/A (gateway session-key logic only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
