### PR TITLE
fix(compression): log why the aux-provider warning fired, not a generic line

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -740,10 +740,13 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 )
             agent._compression_warning = msg
             agent._emit_status(msg)
-            logger.warning(
-                "No auxiliary LLM provider for compression — "
-                "summaries will be unavailable."
-            )
+            # Log the SAME message the user gets, not a generic restatement.
+            # This branch is where compression drops middle turns without a
+            # summary, and on a long-running gateway the log is the only
+            # record. A generic line cannot distinguish a configured provider
+            # that failed auth (reauthenticate it) from an install that never
+            # had one (run setup) — which is the whole diagnosis.
+            logger.warning("%s", msg.lstrip("⚠").strip())
             return
 
         aux_base_url = str(getattr(client, "base_url", ""))

--- a/tests/agent/test_compression_aux_warning_detail.py
+++ b/tests/agent/test_compression_aux_warning_detail.py
@@ -1,0 +1,94 @@
+"""The aux-provider compression warning must log WHY it fired.
+
+``check_compression_model_feasibility`` computes a specific, actionable
+message - either "configured provider 'X' is unavailable, reauthenticate" or
+"no provider configured, run hermes setup" - stores it on the agent, emits it
+to the user, and then logs a GENERIC line that carries neither.
+
+That branch is the one where compression "will drop middle turns without a
+summary", i.e. silent context loss. When it fires on a long-running gateway
+the operator has only the log, and the log cannot distinguish a transient
+auth failure on a configured provider (reauthenticate) from an unconfigured
+install (run setup). Observed 21 times on a live install that HAD a provider
+configured, with no way to tell which case it was.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent import conversation_compression as cc
+
+
+@pytest.fixture()
+def agent():
+    return SimpleNamespace(
+        compression_enabled=True,
+        _compression_warning=None,
+        _emitted=[],
+        _emit_status=lambda msg: None,
+        _current_main_runtime=lambda: None,
+    )
+
+
+def _force_unavailable_aux(monkeypatch, configured_provider: str):
+    """Make aux-client resolution fail so the warning branch runs.
+
+    Patches the ``agent.auxiliary_client`` seam the function imports locally.
+    """
+    import agent.auxiliary_client as aux
+
+    monkeypatch.setattr(
+        aux, "get_text_auxiliary_client", lambda *a, **k: (None, ""), raising=False
+    )
+    monkeypatch.setattr(
+        aux,
+        "_try_configured_fallback_for_unavailable_client",
+        lambda *a, **k: (None, "", ""),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        aux,
+        "_resolve_task_provider_model",
+        lambda task: (configured_provider, None, None, None, None),
+        raising=False,
+    )
+
+
+class TestAuxWarningCarriesTheReason:
+    def test_configured_but_unavailable_provider_is_named_in_the_log(
+        self, agent, monkeypatch, caplog
+    ):
+        _force_unavailable_aux(monkeypatch, "xai-oauth")
+
+        with caplog.at_level("WARNING"):
+            cc.check_compression_model_feasibility(agent)
+
+        assert agent._compression_warning, "warning should be set on the agent"
+        logged = " ".join(r.getMessage() for r in caplog.records)
+        # The operator must be able to tell WHICH failure this was from the log
+        # alone: a configured-but-unavailable provider needs reauthentication,
+        # not `hermes setup`.
+        assert "xai-oauth" in logged
+
+    def test_unconfigured_case_logs_the_setup_remedy(self, agent, monkeypatch, caplog):
+        _force_unavailable_aux(monkeypatch, "")
+
+        with caplog.at_level("WARNING"):
+            cc.check_compression_model_feasibility(agent)
+
+        logged = " ".join(r.getMessage() for r in caplog.records)
+        assert "hermes setup" in logged or "OPENROUTER_API_KEY" in logged
+
+    def test_logged_text_matches_the_user_facing_warning(
+        self, agent, monkeypatch, caplog
+    ):
+        """One message, two sinks. Divergence is how the log went generic."""
+        _force_unavailable_aux(monkeypatch, "xai-oauth")
+
+        with caplog.at_level("WARNING"):
+            cc.check_compression_model_feasibility(agent)
+
+        logged = " ".join(r.getMessage() for r in caplog.records)
+        stored = (agent._compression_warning or "").lstrip("⚠").strip()
+        assert stored and stored in logged


### PR DESCRIPTION
## The problem

`check_compression_model_feasibility` builds a specific, actionable warning and then logs a generic one that contains none of it.

It computes either:

> ⚠ Configured auxiliary compression provider **'xai-oauth'** is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and **reauthenticate that provider**.

or:

> ⚠ **No auxiliary LLM provider configured** — context compression will drop middle turns without a summary. **Run `hermes setup`** or set `OPENROUTER_API_KEY`.

stores it on the agent, emits it to the user, and then logs:

```
No auxiliary LLM provider for compression — summaries will be unavailable.
```

## Why it matters

This is the branch where compression **drops middle turns without a summary** — silent context loss, not graceful degradation.

On a long-running gateway the operator usually isn't watching the chat surface when it fires; the log is the only record. And the generic line cannot distinguish the two cases, which have opposite remedies: a configured provider that failed auth needs reauthenticating, an install that never had one needs `hermes setup`. The second message even says "no provider configured" when a provider *is* configured and merely unreachable, which points at the wrong fix.

Found while investigating token spend on a live install: 21 occurrences in the gateway log, provider configured throughout, and no way to tell from the log whether the configured provider had an auth blip or the config wasn't being read at all.

## The fix

Log the same message the user already gets.

No behaviour change, no new config, no new message to translate — the string was already built one line above. Strictly more information on a path that silently loses conversation history.

## Tests

Three, covering both branches and the invariant:

- configured-but-unavailable → the provider name appears in the log
- unconfigured → the `hermes setup` / `OPENROUTER_API_KEY` remedy appears in the log
- the logged text matches the user-facing warning (one message, two sinks — divergence is how it went generic in the first place)

`tests/agent -k compress`: 624 passed. Nothing asserted the old generic wording.
