### PR TITLE
fix(gateway): dingtalk cronjob send correct MARKDOWN message

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -1716,9 +1716,18 @@ async def _standalone_send(
         if not webhook_url:
             return {"error": "DingTalk not configured. Set DINGTALK_WEBHOOK_URL env var or webhook_url in dingtalk platform extra config."}
         async with httpx.AsyncClient(timeout=30.0) as client:
+            # A static robot webhook accepts DingTalk Markdown too.  Cron uses
+            # this fallback whenever no per-message session webhook is cached;
+            # sending plain text here would expose Markdown markers literally.
+            normalized = DingTalkAdapter._normalize_markdown(
+                message[: DingTalkAdapter.MAX_MESSAGE_LENGTH]
+            )
             resp = await client.post(
                 webhook_url,
-                json={"msgtype": "text", "text": {"content": message}},
+                json={
+                    "msgtype": "markdown",
+                    "markdown": {"title": "Hermes", "text": normalized},
+                },
             )
             resp.raise_for_status()
             data = resp.json()

--- a/tests/tools/test_send_message_missing_platforms.py
+++ b/tests/tools/test_send_message_missing_platforms.py
@@ -254,13 +254,21 @@ class TestSendDingtalk:
 
         with patch("httpx.AsyncClient", return_value=client_ctx):
             extra = {"webhook_url": "https://oapi.dingtalk.com/robot/send?access_token=abc"}
-            result = asyncio.run(_send_dingtalk(extra, "ignored", "hello dingtalk"))
+            result = asyncio.run(
+                _send_dingtalk(extra, "ignored", "# Daily report\n\n**Done**: yes")
+            )
 
         assert result == {"success": True, "platform": "dingtalk", "chat_id": "ignored"}
         client.post.assert_awaited_once()
         call_kwargs = client.post.await_args
         assert call_kwargs[0][0] == "https://oapi.dingtalk.com/robot/send?access_token=abc"
-        assert call_kwargs[1]["json"] == {"msgtype": "text", "text": {"content": "hello dingtalk"}}
+        assert call_kwargs[1]["json"] == {
+            "msgtype": "markdown",
+            "markdown": {
+                "title": "Hermes",
+                "text": "# Daily report\n\n**Done**: yes",
+            },
+        }
 
 
     def test_http_error_redacts_access_token_in_exception_text(self):


### PR DESCRIPTION
## What does this PR do?

Fix cronjob markdown messages through dingtalk channel can't display correctly.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)


