### PR TITLE
fix(profiles): strip platform bot tokens from cloned .env (#71143)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -20,6 +20,7 @@ Usage::
 """
 
 import json
+import logging
 import os
 import re
 import shlex
@@ -31,6 +32,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 from agent.skill_utils import is_excluded_skill_path
 
@@ -71,6 +74,71 @@ _CLONE_SUBDIR_FILES = [
 # Runtime files stripped after --clone-all (shouldn't carry over).
 # Kept as a post-copy step rather than in the ignore filter because they
 # are created dynamically during normal use and may be absent at copy time.
+
+# Platform bot-token env vars that must NOT survive a profile clone.
+# If the cloned .env contains any of these, the new profile's gateway
+# would connect to the same bot account as the source, causing duplicate
+# message delivery and endless pairing challenges (#71143).
+_PLATFORM_BOT_TOKEN_KEYS: set[str] = {
+    "TELEGRAM_BOT_TOKEN",
+    "DISCORD_BOT_TOKEN",
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+    "MATRIX_ACCESS_TOKEN",
+    "MATRIX_HOMESERVER_URL",
+    "WEIXIN_TOKEN",
+    "WEIXIN_ACCOUNT_ID",
+    "WEIXIN_BASE_URL",
+    "FEISHU_APP_ID",
+    "FEISHU_APP_SECRET",
+    "FEISHU_ENCRYPT_KEY",
+    "FEISHU_VERIFICATION_TOKEN",
+    "SIGNAL_PHONE_NUMBER",
+    "WHATSAPP_PHONE_NUMBER_ID",
+    "WHATSAPP_ACCESS_TOKEN",
+    "WHATSAPP_BUSINESS_ACCOUNT_ID",
+    "QQ_APP_ID",
+    "QQ_APP_SECRET",
+}
+
+
+def _strip_platform_bot_tokens(env_path: Path) -> None:
+    """Remove platform bot-token lines from a cloned .env file.
+
+    After ``shutil.copy2`` copies the source profile's ``.env``, this
+    strips every line whose key matches :data:`_PLATFORM_BOT_TOKEN_KEYS`
+    so the new profile doesn't silently connect to the same bot accounts.
+    API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) are preserved.
+    """
+    try:
+        text = env_path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return
+    kept: list[str] = []
+    stripped: list[str] = []
+    for line in text.splitlines(keepends=True):
+        stripped_line = line.strip()
+        if stripped_line.startswith("#") or "=" not in stripped_line:
+            kept.append(line)
+            continue
+        key = stripped_line.split("=", 1)[0].strip().upper()
+        if key in _PLATFORM_BOT_TOKEN_KEYS:
+            stripped.append(key)
+        else:
+            kept.append(line)
+    if stripped:
+        try:
+            env_path.write_text("".join(kept), encoding="utf-8")
+            os.chmod(str(env_path), 0o600)
+        except OSError:
+            pass
+        logger.info(
+            "Stripped %d platform bot token(s) from cloned .env: %s",
+            len(stripped),
+            ", ".join(stripped),
+        )
+
+
 _CLONE_ALL_STRIP: list[str] = [
     "gateway.pid",
     "gateway_state.json",
@@ -1089,6 +1157,13 @@ def create_profile(
                             os.chmod(str(dst), 0o600)
                         except OSError:
                             pass
+                        # Strip platform bot tokens from the cloned .env so
+                        # the new profile doesn't silently connect to the
+                        # same bot accounts as the source (#71143).  Without
+                        # this, two gateways serve the same Telegram / Discord
+                        # / Weixin bot and the clone's empty pairing store
+                        # produces endless "I don't recognize you" challenges.
+                        _strip_platform_bot_tokens(dst)
 
             # Clone installed skills from the source profile. The dashboard's
             # "clone from default" flow is expected to preserve both bundled

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -390,6 +390,37 @@ class TestCreateProfile:
         # SOUL.md is always seeded with the default even when clone source lacks it
         assert (profile_dir / "SOUL.md").exists()
 
+    def test_clone_strips_platform_bot_tokens(self, profile_env):
+        """Cloned .env must not contain platform bot tokens (#71143)."""
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        # Create source .env with both API keys and bot tokens
+        (default_home / ".env").write_text(
+            "OPENAI_API_KEY=sk-test123\n"
+            "TELEGRAM_BOT_TOKEN=123:ABC\n"
+            "DISCORD_BOT_TOKEN=MTIzNA\n"
+            "SLACK_BOT_TOKEN=xoxb-123\n"
+            "WEIXIN_TOKEN=ilink-token\n"
+            "FEISHU_APP_SECRET=feishu_secret\n"
+            "ANTHROPIC_API_KEY=sk-ant-test\n"
+            "MATRIX_ACCESS_TOKEN=syt_matrix\n",
+            encoding="utf-8",
+        )
+
+        profile_dir = create_profile("coder", clone_config=True, no_alias=True)
+
+        cloned_env = (profile_dir / ".env").read_text(encoding="utf-8")
+        # API keys preserved
+        assert "OPENAI_API_KEY=sk-test123" in cloned_env
+        assert "ANTHROPIC_API_KEY=sk-ant-test" in cloned_env
+        # Bot tokens stripped
+        assert "TELEGRAM_BOT_TOKEN" not in cloned_env
+        assert "DISCORD_BOT_TOKEN" not in cloned_env
+        assert "SLACK_BOT_TOKEN" not in cloned_env
+        assert "WEIXIN_TOKEN" not in cloned_env
+        assert "FEISHU_APP_SECRET" not in cloned_env
+        assert "MATRIX_ACCESS_TOKEN" not in cloned_env
+
 
 # ===================================================================
 # TestNoSkillsOptOut


### PR DESCRIPTION
## Problem

Creating a profile by cloning (`hermes profile create <name> --clone` or Desktop "New Profile") copies the source profile's `.env` as-is, including platform bot tokens (`TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, `WEIXIN_TOKEN`, etc.). When both profiles run their own gateway, both connect to the same bot account — causing duplicate message delivery and endless pairing challenges because the clone's per-profile pairing store is empty.

## Fix

After `shutil.copy2` copies the `.env` during clone, call `_strip_platform_bot_tokens()` which reads the file and removes lines whose key matches a known set of platform bot-token env vars. API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) are preserved.

The stripped keys include all platform connectors: Telegram, Discord, Slack, Matrix, Weixin, Feishu, Signal, WhatsApp, QQ.

## Regression test

`TestCreateProfile.test_clone_strips_platform_bot_tokens` — creates a source `.env` with both API keys and bot tokens, clones the profile, verifies API keys are preserved and bot tokens are stripped.

Fixes #71143
