### PR TITLE
fix(dashboard): read SPA gating from the mounted app, not the module global

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15815,7 +15815,13 @@ def mount_spa(application: FastAPI):
                 status_code=404,
             )
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
-        gated = bool(getattr(app.state, "auth_required", False))
+        # Read gating from the app this SPA was mounted on, not the module
+        # global. Production calls ``mount_spa(app)`` so the two are the same
+        # object and behaviour is unchanged, but every route above registers
+        # on ``application`` — deciding the auth scheme from a different app
+        # than the one serving the request is how a gated mount could end up
+        # emitting the long-lived token that gated mode exists to withhold.
+        gated = bool(getattr(application.state, "auth_required", False))
         gated_js = "true" if gated else "false"
         if gated:
             bootstrap_script = (

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3517,4 +3517,52 @@ class TestDashboardComponentHealth:
         assert self.ws.DASHBOARD_HEALTH.selftest_http_status == 500
         assert self.ws.DASHBOARD_HEALTH.snapshot()["status"] == "degraded"
 
+class TestMountSpaGatingIsAppScoped:
+    """`mount_spa(application)` must read gating from the app it is given.
 
+    Every route in `mount_spa` registers on the `application` parameter, but
+    `_serve_index` read `auth_required` from the MODULE-LEVEL `app`. Production
+    passes the global (`mount_spa(app)`), so the two coincide and nothing
+    breaks today - but the SPA's auth scheme is then decided by an object it
+    was not mounted on. Any second mount (an embedded/test/sub-app) silently
+    inherits the global's gating, and picking the wrong branch here decides
+    whether the long-lived session token is injected into the HTML.
+    """
+
+    @staticmethod
+    def _mount(tmp_path, monkeypatch, *, app_gated: bool, global_gated: bool):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        dist = tmp_path / "web_dist"
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text(
+            "<html><head><title>t</title></head><body>SPA</body></html>",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(ws, "WEB_DIST", dist)
+        monkeypatch.setattr(ws, "load_config", lambda: {"dashboard": {"theme": "default"}})
+        monkeypatch.setattr(ws, "_SESSION_TOKEN", "scope-probe-token")
+        # The global says one thing, the mounted app says another.
+        monkeypatch.setattr(ws.app.state, "auth_required", global_gated, raising=False)
+
+        spa_app = FastAPI()
+        spa_app.state.auth_required = app_gated
+        ws.mount_spa(spa_app)
+        return TestClient(spa_app).get("/chat")
+
+    def test_gated_app_is_gated_even_when_global_is_not(self, tmp_path, monkeypatch):
+        resp = self._mount(tmp_path, monkeypatch, app_gated=True, global_gated=False)
+
+        assert resp.status_code == 200
+        # Gated: cookie auth, so the long-lived token must NOT be in the HTML.
+        assert "scope-probe-token" not in resp.text
+        assert "window.__HERMES_AUTH_REQUIRED__=true" in resp.text
+
+    def test_ungated_app_is_ungated_even_when_global_is_gated(self, tmp_path, monkeypatch):
+        resp = self._mount(tmp_path, monkeypatch, app_gated=False, global_gated=True)
+
+        assert resp.status_code == 200
+        assert "scope-probe-token" in resp.text
+        assert "window.__HERMES_AUTH_REQUIRED__=false" in resp.text


### PR DESCRIPTION
## The problem

Every route in `mount_spa(application)` registers on the `application` parameter, but `_serve_index` decided the auth scheme from the module-level `app`:

```python
gated = bool(getattr(app.state, "auth_required", False))   # module global
```

Production calls `mount_spa(app)`, so the two are the same object and today's behaviour is correct. But the SPA's auth scheme was being read from an object it was not mounted on.

## Why it matters

That flag decides whether the long-lived `_SESSION_TOKEN` is injected into `index.html`. Gated mode withholds it and the browser authenticates with a cookie session instead; ungated mode injects it — which is exactly the property that makes it safe to put the dashboard behind a reverse proxy.

So a second mount (an embedded host, a test harness, any future sub-app) inherits the global's gating rather than its own. A gated app whose global is ungated would emit the very token gated mode exists to withhold.

Found while writing a test for that no-token invariant: setting `auth_required` on the app under test had no effect, because the code was reading a different app.

## The fix

Read from `application` — the app the SPA was actually mounted on.

One line. Behaviour-identical in production (single caller, `mount_spa(app)`), correct for every other mount.

## Tests

Two, with the app and the global deliberately **disagreeing**, which is the only way to tell the seams apart:

- gated app + ungated global → stays gated, no token in HTML (the security-relevant direction)
- ungated app + gated global → stays ungated, token present

Both fail before the change and pass after. `tests/hermes_cli/test_web_server.py`: **508 passed**.
